### PR TITLE
Add provider types, provider registry, and provider-model listing endpoint

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -83,6 +83,7 @@ Upsert a model profile.
 Request:
 ```json
 {
+  "provider": "openai_compatible",
   "model": "gpt-4o-mini",
   "base_url": "https://api.openai.com/v1",
   "api_key": "***",
@@ -90,6 +91,24 @@ Request:
   "top_p": 1.0,
   "max_tokens": 4096
 }
+```
+
+### `GET /system/configs/model/providers/models`
+Returns queryable provider model metadata generated from runtime profiles.
+
+Optional query parameter:
+- `provider`: provider type filter (`openai_compatible`, `echo`)
+
+Response:
+```json
+[
+  {
+    "profile": "default",
+    "provider": "openai_compatible",
+    "model": "gpt-4o-mini",
+    "base_url": "https://api.openai.com/v1"
+  }
+]
 ```
 
 ### `DELETE /system/configs/model/profiles/{name}`

--- a/src/agent_teams/env/config_manager.py
+++ b/src/agent_teams/env/config_manager.py
@@ -33,6 +33,7 @@ class ConfigManager:
             if not isinstance(profile, dict):
                 continue
             result[name] = {
+                "provider": profile.get("provider", "openai_compatible"),
                 "model": profile.get("model", ""),
                 "base_url": profile.get("base_url", ""),
                 "has_api_key": bool(profile.get("api_key")),

--- a/src/agent_teams/env/runtime_config.py
+++ b/src/agent_teams/env/runtime_config.py
@@ -9,7 +9,11 @@ from pydantic import BaseModel, ConfigDict
 
 from agent_teams.env import load_merged_env_vars
 from agent_teams.paths import get_project_config_dir
-from agent_teams.providers.model_config import ModelEndpointConfig, SamplingConfig
+from agent_teams.providers.model_config import (
+    ModelEndpointConfig,
+    ProviderType,
+    SamplingConfig,
+)
 
 
 class RuntimePaths(BaseModel):
@@ -84,9 +88,14 @@ def load_llm_configs(
 
     profiles: dict[str, ModelEndpointConfig] = {}
     for name, cfg in data.items():
+        if not isinstance(cfg, dict):
+            raise ValueError(f"Invalid profile '{name}': expected an object.")
+
         model = cfg.get("model")
         base_url = cfg.get("base_url")
         api_key = _resolve_env_var(cfg.get("api_key", ""), env_values)
+        provider_raw = cfg.get("provider", ProviderType.OPENAI_COMPATIBLE.value)
+        provider = ProviderType(provider_raw)
 
         if not model or not base_url or not api_key:
             raise ValueError(
@@ -99,6 +108,7 @@ def load_llm_configs(
         top_k = cfg.get("top_k")
 
         profiles[name] = ModelEndpointConfig(
+            provider=provider,
             model=model,
             base_url=base_url,
             api_key=api_key,

--- a/src/agent_teams/env/runtime_config_service.py
+++ b/src/agent_teams/env/runtime_config_service.py
@@ -9,6 +9,8 @@ from agent_teams.env.config_manager import ConfigManager
 from agent_teams.env.runtime_config import RuntimeConfig, load_runtime_config
 from agent_teams.mcp.registry import McpRegistry
 from agent_teams.notifications import NotificationConfig
+from agent_teams.providers.model_config import ProviderModelInfo, ProviderType
+from agent_teams.providers.registry import list_provider_models
 from agent_teams.roles.registry import RoleRegistry
 from agent_teams.shared_types.json_types import JsonObject
 from agent_teams.skills.registry import SkillRegistry
@@ -67,6 +69,13 @@ class RuntimeConfigService:
 
     def get_model_profiles(self) -> dict[str, JsonObject]:
         return self._config_manager.get_model_profiles()
+
+    def get_provider_models(
+        self,
+        *,
+        provider: ProviderType | None = None,
+    ) -> tuple[ProviderModelInfo, ...]:
+        return list_provider_models(self._runtime.llm_profiles, provider)
 
     def save_model_profile(self, name: str, profile: JsonObject) -> None:
         self._config_manager.save_model_profile(name, profile)

--- a/src/agent_teams/interfaces/server/routers/system.py
+++ b/src/agent_teams/interfaces/server/routers/system.py
@@ -1,10 +1,11 @@
 ﻿from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 
 from agent_teams.env.runtime_config_service import RuntimeConfigService
 from agent_teams.interfaces.server.deps import get_system_config_service
+from agent_teams.providers.model_config import ProviderType
 from agent_teams.shared_types.json_types import JsonObject
 
 router = APIRouter(prefix="/system", tags=["System"])
@@ -39,6 +40,7 @@ def get_model_profiles(
 class ModelProfileRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    provider: ProviderType = ProviderType.OPENAI_COMPATIBLE
     model: str
     base_url: str
     api_key: str
@@ -58,6 +60,7 @@ def save_model_profile(
             name,
             {
                 "model": req.model,
+                "provider": req.provider.value,
                 "base_url": req.base_url,
                 "api_key": req.api_key,
                 "temperature": req.temperature,
@@ -68,6 +71,17 @@ def save_model_profile(
         return {"status": "ok"}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/configs/model/providers/models")
+def get_provider_models(
+    provider: ProviderType | None = Query(default=None),
+    service: RuntimeConfigService = Depends(get_system_config_service),
+) -> list[JsonObject]:
+    return [
+        model.model_dump(mode="json")
+        for model in service.get_provider_models(provider=provider)
+    ]
 
 
 @router.delete("/configs/model/profiles/{name}")
@@ -156,5 +170,4 @@ def reload_skills_config(
         return {"status": "ok"}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
-
 

--- a/src/agent_teams/providers/__init__.py
+++ b/src/agent_teams/providers/__init__.py
@@ -1,12 +1,28 @@
+# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 from agent_teams.providers.llm import EchoProvider, LLMProvider, OpenAICompatibleProvider
-from agent_teams.providers.model_config import ModelEndpointConfig, SamplingConfig
+from agent_teams.providers.model_config import (
+    ModelEndpointConfig,
+    ProviderModelInfo,
+    ProviderType,
+    SamplingConfig,
+)
+from agent_teams.providers.registry import (
+    ProviderRegistry,
+    create_default_provider_registry,
+    list_provider_models,
+)
 
 __all__ = [
     "EchoProvider",
     "LLMProvider",
     "ModelEndpointConfig",
     "OpenAICompatibleProvider",
+    "ProviderModelInfo",
+    "ProviderRegistry",
+    "ProviderType",
     "SamplingConfig",
+    "create_default_provider_registry",
+    "list_provider_models",
 ]

--- a/src/agent_teams/providers/model_config.py
+++ b/src/agent_teams/providers/model_config.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from enum import StrEnum
+
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProviderType(StrEnum):
+    OPENAI_COMPATIBLE = "openai_compatible"
+    ECHO = "echo"
 
 
 class SamplingConfig(BaseModel):
@@ -16,7 +23,17 @@ class SamplingConfig(BaseModel):
 class ModelEndpointConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    provider: ProviderType = ProviderType.OPENAI_COMPATIBLE
     model: str = Field(min_length=1)
     base_url: str = Field(min_length=1)
     api_key: str = Field(min_length=1)
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
+
+
+class ProviderModelInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    profile: str = Field(min_length=1)
+    provider: ProviderType
+    model: str = Field(min_length=1)
+    base_url: str = Field(min_length=1)

--- a/src/agent_teams/providers/registry.py
+++ b/src/agent_teams/providers/registry.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from agent_teams.providers.llm import EchoProvider, LLMProvider
+from agent_teams.providers.model_config import ModelEndpointConfig, ProviderModelInfo, ProviderType
+
+ProviderBuilder = Callable[[ModelEndpointConfig], LLMProvider]
+
+
+class ProviderRegistry:
+    def __init__(self) -> None:
+        self._builders: dict[ProviderType, ProviderBuilder] = {}
+
+    def register(self, provider_type: ProviderType, builder: ProviderBuilder) -> None:
+        self._builders[provider_type] = builder
+
+    def create(self, config: ModelEndpointConfig) -> LLMProvider:
+        builder = self._builders.get(config.provider)
+        if builder is None:
+            raise ValueError(f"Provider '{config.provider}' is not registered")
+        return builder(config)
+
+
+def list_provider_models(
+    profiles: dict[str, ModelEndpointConfig],
+    provider: ProviderType | None = None,
+) -> tuple[ProviderModelInfo, ...]:
+    entries: list[ProviderModelInfo] = []
+    for profile_name, config in profiles.items():
+        if provider is not None and config.provider != provider:
+            continue
+        entries.append(
+            ProviderModelInfo(
+                profile=profile_name,
+                provider=config.provider,
+                model=config.model,
+                base_url=config.base_url,
+            )
+        )
+    entries.sort(key=lambda item: (item.provider.value, item.profile, item.model))
+    return tuple(entries)
+
+
+def create_default_provider_registry(
+    *,
+    openai_compatible_builder: ProviderBuilder,
+) -> ProviderRegistry:
+    registry = ProviderRegistry()
+    registry.register(ProviderType.OPENAI_COMPATIBLE, openai_compatible_builder)
+    registry.register(ProviderType.ECHO, lambda _config: EchoProvider())
+    return registry

--- a/src/agent_teams/providers/runtime_factory.py
+++ b/src/agent_teams/providers/runtime_factory.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 from pathlib import Path
@@ -9,16 +10,13 @@ from agent_teams.env.runtime_config import RuntimeConfig
 from agent_teams.mcp.registry import McpRegistry
 from agent_teams.notifications import NotificationService
 from agent_teams.prompting.runtime_prompt_builder import RuntimePromptBuilder
-from agent_teams.providers.llm import (
-    EchoProvider,
-    LLMProvider,
-    OpenAICompatibleProvider,
-)
-from agent_teams.roles.registry import RoleRegistry
+from agent_teams.providers.llm import EchoProvider, LLMProvider, OpenAICompatibleProvider
+from agent_teams.providers.registry import create_default_provider_registry
 from agent_teams.roles.models import RoleDefinition
-from agent_teams.runs.injection_queue import RunInjectionManager
+from agent_teams.roles.registry import RoleRegistry
 from agent_teams.runs.control import RunControlManager
 from agent_teams.runs.event_stream import RunEventHub
+from agent_teams.runs.injection_queue import RunInjectionManager
 from agent_teams.skills.registry import SkillRegistry
 from agent_teams.state.agent_repo import AgentInstanceRepository
 from agent_teams.state.event_log import EventLog
@@ -58,31 +56,34 @@ def create_provider_factory(
         if config_to_use is None:
             return EchoProvider()
 
-        return OpenAICompatibleProvider(
-            config_to_use,
-            task_repo=task_repo,
-            instance_pool=instance_pool,
-            shared_store=shared_store,
-            event_bus=event_log,
-            injection_manager=injection_manager,
-            run_event_hub=run_event_hub,
-            agent_repo=agent_repo,
-            workspace_root=Path.cwd(),
-            tool_registry=tool_registry,
-            mcp_registry=mcp_registry,
-            skill_registry=skill_registry,
-            allowed_tools=role.tools,
-            allowed_mcp_servers=role.mcp_servers,
-            allowed_skills=role.skills,
-            message_repo=message_repo,
-            role_registry=role_registry,
-            task_execution_service=get_task_execution_service(),
-            run_control_manager=run_control_manager,
-            tool_approval_manager=tool_approval_manager,
-            tool_approval_policy=tool_approval_policy,
-            notification_service=notification_service,
-            token_usage_repo=token_usage_repo,
+        provider_registry = create_default_provider_registry(
+            openai_compatible_builder=lambda config: OpenAICompatibleProvider(
+                config,
+                task_repo=task_repo,
+                instance_pool=instance_pool,
+                shared_store=shared_store,
+                event_bus=event_log,
+                injection_manager=injection_manager,
+                run_event_hub=run_event_hub,
+                agent_repo=agent_repo,
+                workspace_root=Path.cwd(),
+                tool_registry=tool_registry,
+                mcp_registry=mcp_registry,
+                skill_registry=skill_registry,
+                allowed_tools=role.tools,
+                allowed_mcp_servers=role.mcp_servers,
+                allowed_skills=role.skills,
+                message_repo=message_repo,
+                role_registry=role_registry,
+                task_execution_service=get_task_execution_service(),
+                run_control_manager=run_control_manager,
+                tool_approval_manager=tool_approval_manager,
+                tool_approval_policy=tool_approval_policy,
+                notification_service=notification_service,
+                token_usage_repo=token_usage_repo,
+            ),
         )
+        return provider_registry.create(config_to_use)
 
     return provider_factory
 

--- a/tests/unit_tests/env/test_runtime_config.py
+++ b/tests/unit_tests/env/test_runtime_config.py
@@ -43,3 +43,24 @@ def test_load_llm_configs_error_mentions_model_file_only(tmp_path: Path) -> None
         runtime_config.load_llm_configs(tmp_path, {})
 
     assert "Please create model.json with a 'default' profile." in str(exc_info.value)
+
+
+def test_load_llm_configs_reads_provider_field(tmp_path: Path) -> None:
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "default": {
+                    "provider": "openai_compatible",
+                    "model": "gpt-4o-mini",
+                    "base_url": "https://example.test/v1",
+                    "api_key": "plain-text-key",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    profiles = runtime_config.load_llm_configs(tmp_path, {})
+
+    assert profiles["default"].provider.value == "openai_compatible"

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from agent_teams.interfaces.server.deps import get_system_config_service
 from agent_teams.interfaces.server.routers import system
+from agent_teams.providers.model_config import ProviderModelInfo, ProviderType
 
 
 class _FakeSystemService:
@@ -53,6 +54,29 @@ class _FakeSystemService:
     def save_notification_config(self, config: dict[str, object]) -> None:
         self.saved_notification_config = config
 
+    def get_provider_models(
+        self,
+        *,
+        provider: ProviderType | None = None,
+    ) -> tuple[ProviderModelInfo, ...]:
+        models = (
+            ProviderModelInfo(
+                profile="default",
+                provider=ProviderType.OPENAI_COMPATIBLE,
+                model="gpt-4o-mini",
+                base_url="https://example.com/v1",
+            ),
+            ProviderModelInfo(
+                profile="echo",
+                provider=ProviderType.ECHO,
+                model="echo",
+                base_url="http://localhost",
+            ),
+        )
+        if provider is None:
+            return models
+        return tuple(model for model in models if model.provider == provider)
+
 
 def _create_test_client(fake_service: object) -> TestClient:
     app = FastAPI()
@@ -91,3 +115,28 @@ def test_save_notification_config() -> None:
     run_completed = service.saved_notification_config["run_completed"]
     assert isinstance(run_completed, dict)
     assert run_completed["enabled"] is True
+
+
+def test_get_provider_models() -> None:
+    client = _create_test_client(_FakeSystemService())
+
+    response = client.get("/api/system/configs/model/providers/models")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 2
+    assert payload[0]["profile"] == "default"
+
+
+def test_get_provider_models_with_filter() -> None:
+    client = _create_test_client(_FakeSystemService())
+
+    response = client.get(
+        "/api/system/configs/model/providers/models",
+        params={"provider": ProviderType.ECHO.value},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["provider"] == ProviderType.ECHO.value

--- a/tests/unit_tests/providers/test_registry.py
+++ b/tests/unit_tests/providers/test_registry.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from agent_teams.providers.llm import EchoProvider
+from agent_teams.providers.model_config import ModelEndpointConfig, ProviderType
+from agent_teams.providers.registry import (
+    ProviderRegistry,
+    create_default_provider_registry,
+    list_provider_models,
+)
+
+
+def test_provider_registry_creates_registered_provider() -> None:
+    registry = ProviderRegistry()
+    registry.register(ProviderType.ECHO, lambda _config: EchoProvider())
+
+    provider = registry.create(
+        ModelEndpointConfig(
+            provider=ProviderType.ECHO,
+            model="echo",
+            base_url="http://localhost",
+            api_key="unused",
+        )
+    )
+
+    assert isinstance(provider, EchoProvider)
+
+
+def test_create_default_provider_registry_has_echo_support() -> None:
+    registry = create_default_provider_registry(
+        openai_compatible_builder=lambda _config: EchoProvider()
+    )
+
+    provider = registry.create(
+        ModelEndpointConfig(
+            provider=ProviderType.ECHO,
+            model="echo",
+            base_url="http://localhost",
+            api_key="unused",
+        )
+    )
+
+    assert isinstance(provider, EchoProvider)
+
+
+def test_list_provider_models_can_filter_by_provider() -> None:
+    profiles = {
+        "default": ModelEndpointConfig(
+            provider=ProviderType.OPENAI_COMPATIBLE,
+            model="gpt-4o-mini",
+            base_url="https://openai-compatible.local/v1",
+            api_key="key-openai",
+        ),
+        "local": ModelEndpointConfig(
+            provider=ProviderType.ECHO,
+            model="echo",
+            base_url="http://localhost",
+            api_key="unused",
+        ),
+    }
+
+    models = list_provider_models(
+        profiles=profiles,
+        provider=ProviderType.OPENAI_COMPATIBLE,
+    )
+
+    assert len(models) == 1
+    assert models[0].profile == "default"
+    assert models[0].provider == ProviderType.OPENAI_COMPATIBLE


### PR DESCRIPTION
### Motivation

- Introduce explicit provider typing and plumbing to support multiple LLM provider implementations and to expose available provider/model metadata.
- Allow model profiles to declare a `provider` and make that information available via runtime config and the system API.

### Description

- Add `ProviderType` enum and `ProviderModelInfo` model in `src/agent_teams/providers/model_config.py` and include `provider` in `ModelEndpointConfig` with a default of `openai_compatible`.
- Implement a provider registry in `src/agent_teams/providers/registry.py` with `ProviderRegistry`, `list_provider_models`, and `create_default_provider_registry` helpers, and wire it into the runtime provider factory in `src/agent_teams/providers/runtime_factory.py` to create providers by profile `provider` type.
- Surface provider information in runtime and configuration layers by adding `provider` to profile outputs in `src/agent_teams/env/config_manager.py` and loading `provider` from `model.json` in `src/agent_teams/env/runtime_config.py`.
- Expose a new API endpoint `GET /system/configs/model/providers/models` in `src/agent_teams/interfaces/server/routers/system.py` that returns provider-model metadata with an optional `provider` query filter, and add `provider` to the model profile request payload for `PUT /system/configs/model/profiles/{name}`.
- Export registry and provider types from `src/agent_teams/providers/__init__.py` and add `ProviderType`/registry usage across services and tests.
- Update documentation `docs/api-design.md` to include the `provider` sample in `PUT /system/configs/model/profiles/{name}` and document the new `GET /system/configs/model/providers/models` endpoint.

### Testing

- Ran unit tests that cover provider integration and API behavior: `tests/unit_tests/providers/test_registry.py` passed. 
- Ran updated runtime config tests in `tests/unit_tests/env/test_runtime_config.py` which verify `provider` is read from `model.json`, and they passed. 
- Ran API router tests in `tests/unit_tests/interfaces/server/test_system_router.py` which exercise the new `GET /system/configs/model/providers/models` endpoint and related behavior, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa75bb89708333a0465d47ccdbf137)