### PR TITLE
Add pytest asyncio runner and extend tests for root path and stage docs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "asyncio: mark a test function to run in an asyncio event loop",
+    )
+
+
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    marker = pyfuncitem.get_closest_marker("asyncio")
+    if marker is None:
+        return None
+
+    test_function = pyfuncitem.obj
+    if not inspect.iscoroutinefunction(test_function):
+        return None
+
+    funcargs = pyfuncitem.funcargs
+    test_args = {name: funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
+    asyncio.run(test_function(**test_args))
+    return True

--- a/tests/unit_tests/paths/test_root_paths.py
+++ b/tests/unit_tests/paths/test_root_paths.py
@@ -135,6 +135,74 @@ def test_get_project_root_or_none_returns_none_on_git_failure(
     assert root_paths.get_project_root_or_none(start_dir=tmp_path) is None
 
 
+def test_get_project_root_or_none_returns_none_on_os_error(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: str,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = (command, cwd, check, capture_output, text, timeout)
+        raise OSError("git unavailable")
+
+    monkeypatch.setattr(root_paths.subprocess, "run", fake_run)
+
+    assert root_paths.get_project_root_or_none(start_dir=tmp_path) is None
+
+
+def test_get_project_root_or_none_returns_none_on_timeout(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: str,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = (command, cwd, check, capture_output, text, timeout)
+        raise subprocess.TimeoutExpired(cmd="git", timeout=5.0)
+
+    monkeypatch.setattr(root_paths.subprocess, "run", fake_run)
+
+    assert root_paths.get_project_root_or_none(start_dir=tmp_path) is None
+
+
+def test_get_project_root_or_none_returns_none_on_blank_stdout(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: str,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = (cwd, check, capture_output, text, timeout)
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="\n\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(root_paths.subprocess, "run", fake_run)
+
+    assert root_paths.get_project_root_or_none(start_dir=tmp_path) is None
+
+
 def test_get_project_config_dir_uses_project_root_when_available(monkeypatch) -> None:
     project_root = Path("D:/repo-root").resolve()
     monkeypatch.setattr(root_paths, "get_project_root_or_none", lambda: project_root)
@@ -183,3 +251,41 @@ def test_get_user_config_dir_uses_user_home_override(tmp_path: Path) -> None:
     config_dir = root_paths.get_user_config_dir(user_home_dir=user_home_dir)
 
     assert config_dir == user_home_dir.resolve() / ".agent_teams"
+
+
+def test_get_project_config_dir_resolves_user_supplied_root(tmp_path: Path) -> None:
+    unresolved_project_root = tmp_path / "parent" / ".." / "project-root"
+    unresolved_project_root.mkdir(parents=True)
+
+    config_dir = root_paths.get_project_config_dir(project_root=unresolved_project_root)
+
+    assert config_dir == (tmp_path / "project-root").resolve() / ".agent_teams"
+
+
+
+
+def test_resolve_start_dir_defaults_to_cwd(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    resolved = root_paths._resolve_start_dir(start_dir=None)
+
+    assert resolved == tmp_path.resolve()
+
+
+def test_resolve_start_dir_keeps_directory_input(tmp_path: Path) -> None:
+    nested_dir = tmp_path / "nested-dir"
+    nested_dir.mkdir()
+
+    resolved = root_paths._resolve_start_dir(start_dir=nested_dir)
+
+    assert resolved == nested_dir.resolve()
+
+def test_resolve_start_dir_uses_parent_for_file_path(tmp_path: Path) -> None:
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    file_path = nested_dir / "source.txt"
+    file_path.write_text("data", encoding="utf-8")
+
+    resolved = root_paths._resolve_start_dir(start_dir=file_path)
+
+    assert resolved == nested_dir.resolve()

--- a/tests/unit_tests/tools/stage_tools/test_docs.py
+++ b/tests/unit_tests/tools/stage_tools/test_docs.py
@@ -1,15 +1,19 @@
-import pytest
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from pathlib import Path
+
+import pytest
 
 from agent_teams.tools.stage_tools.docs import (
     current_stage_doc_path,
     previous_stage_doc_path,
+    write_stage_doc_once,
 )
-from agent_teams.tools.stage_tools.docs import write_stage_doc_once
 
 
-def test_stage_doc_paths() -> None:
-    root = Path("D:/workspace/agent_teams")
+def test_stage_doc_paths(tmp_path: Path) -> None:
+    root = tmp_path / "workspace" / "agent_teams"
     run_id = "run123"
 
     assert current_stage_doc_path(
@@ -43,9 +47,10 @@ def test_write_stage_doc_once_rejects_duplicate(
         return written["exists"]
 
     def _mkdir(_: Path, parents: bool, exist_ok: bool) -> None:
-        return None
+        _ = (parents, exist_ok)
 
     def _write_text(_: Path, content: str, encoding: str) -> int:
+        _ = encoding
         written["exists"] = True
         return len(content)
 


### PR DESCRIPTION
### Motivation

- Provide support for running asyncio-based tests under `pytest` and increase coverage for path resolution and stage-doc utilities.

### Description

- Add a `tests/conftest.py` pytest hook that registers an `asyncio` marker and runs coroutine test functions via `asyncio.run` in `pytest_pyfunc_call`.
- Extend `tests/unit_tests/paths/test_root_paths.py` with tests covering `get_project_root_or_none` failure modes (`OSError`, `TimeoutExpired`, and blank stdout) and add tests for `get_project_config_dir` with an unresolved supplied root and for `_resolve_start_dir` behavior with directories and file paths.
- Update `tests/unit_tests/tools/stage_tools/test_docs.py` to use `tmp_path` for workspace paths, import and test `write_stage_doc_once`, and adjust test stubs to properly accept and ignore parameters for `Path.mkdir` and `Path.write_text`.

### Testing

- Ran the unit test suite with `pytest tests/unit_tests` and the updated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab1f200b08333af3191210bf4340a)