### PR TITLE
docs: clarify core nature of multi-agent collaboration

### DIFF
--- a/docs/role-state-space-recursive-communication.md
+++ b/docs/role-state-space-recursive-communication.md
@@ -4,6 +4,8 @@
 
 This document describes how the current `roles`, `agents`, and `coordination` modules implement role-scoped communication based on state-space boundaries and recursive feedback loops.
 
+多 Agent 协作的本质，不是消息传递，而是角色作用域状态空间之间，在约束下进行的递归状态变换与反馈控制。
+
 The design follows these principles:
 
 1. Role is prior to instance: role defines state-space boundaries, instance only executes transitions.


### PR DESCRIPTION
### Motivation
- Clarify the design intent by explicitly stating that multi-agent collaboration is fundamentally recursive state transformations and feedback control between role-scoped state spaces rather than mere message passing. 

### Description
- Inserted the Chinese sentence `多 Agent 协作的本质，不是消息传递，而是角色作用域状态空间之间，在约束下进行的递归状态变换与反馈控制。` immediately under the Purpose section in `docs/role-state-space-recursive-communication.md` to frame the document's core viewpoint. 

### Testing
- Ran `uv run ruff check --fix` which passed. 
- Ran `uv run basedpyright` which failed because the `basedpyright` executable is unavailable in the environment. 
- Ran `uv run pytest -q tests/unit_tests` which failed during test collection due to missing runtime/test dependencies such as `pydantic`, `pydantic_ai`, `typer`, and `fastapi`, and environment incompatibilities (e.g., `datetime.UTC` import issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf19f10a48333a517be482bc74d80)