### PR TITLE
Document Skills and add skill-override test for prompts preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Core code lives under `src/agent_teams/`:
 
 Frontend assets are built into `frontend/dist` (`css/` and `js/`) and served by the backend.
 
+## Skills
+
+Skills are composable capability modules. Agents load skills at runtime based on the current task context, so the same role can attach different capability sets for different runs.
+
 ## Web Interface
 
 ![Agent Teams Web Interface](docs/agent_teams.png)
@@ -209,4 +213,3 @@ Run browser automation tests (Playwright):
 uv run playwright install chromium
 uv run pytest -q tests/integration_tests/browser
 ```
-

--- a/tests/unit_tests/interfaces/server/test_prompts_router.py
+++ b/tests/unit_tests/interfaces/server/test_prompts_router.py
@@ -18,7 +18,7 @@ from agent_teams.tools.registry import ToolRegistry
 
 class _FakeSkillRegistry:
     def __init__(self) -> None:
-        self._known = {"time"}
+        self._known = {"time", "planner"}
 
     def validate_known(self, skill_names: tuple[str, ...]) -> None:
         unknown = [name for name in skill_names if name not in self._known]
@@ -32,7 +32,11 @@ class _FakeSkillRegistry:
         return tuple(
             SkillInstructionEntry(
                 name=name,
-                instructions="Normalize all times to UTC.",
+                instructions=(
+                    "Normalize all times to UTC."
+                    if name == "time"
+                    else "Break objectives into executable plans."
+                ),
             )
             for name in skill_names
         )
@@ -96,6 +100,25 @@ def test_prompts_preview_returns_runtime_provider_and_user_sections() -> None:
     assert payload["tool_prompt"].startswith("## Tool Rules")
     assert payload["skill_prompt"].startswith("## Skill Instructions")
 
+
+
+def test_prompts_preview_skill_override_replaces_role_default() -> None:
+    client = _create_client()
+
+    response = client.post(
+        "/api/prompts:preview",
+        json={
+            "role_id": "coordinator_agent",
+            "skills": ["planner"],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["skills"] == ["planner"]
+    assert "### Skill: planner" in payload["provider_system_prompt"]
+    assert "Break objectives into executable plans." in payload["provider_system_prompt"]
+    assert "### Skill: time" not in payload["provider_system_prompt"]
 
 def test_prompts_preview_returns_404_for_unknown_role() -> None:
     client = _create_client()


### PR DESCRIPTION
### Motivation

- Introduce a short documentation entry for the runtime `Skills` concept to explain composable capability modules and how agents load skills per run.
- Add coverage for a skill-override path in the prompts preview to ensure skill overrides replace role defaults when provided at request time.

### Description

- Add a new `Skills` section to `README.md` describing composable skills and how agents attach skill sets at runtime. 
- Extend the test double `_FakeSkillRegistry` in `tests/unit_tests/interfaces/server/test_prompts_router.py` to include a `planner` skill and to return different `instructions` text for `time` vs `planner` entries. 
- Add `test_prompts_preview_skill_override_replaces_role_default` which posts to `POST /api/prompts:preview` with `skills: ["planner"]` and asserts the provider system prompt contains the `planner` instructions and omits the `time` instructions. 

### Testing

- Ran the updated prompts router unit tests with `pytest -q tests/unit_tests/interfaces/server/test_prompts_router.py` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad05cf12f4833394d75c90f350440d)