### PR TITLE
feat: add minimax provider support for model profiles

### DIFF
--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -153,6 +153,7 @@ function createModal() {
                                                 <select id="profile-provider">
                                                     <option value="openai_compatible">openai_compatible</option>
                                                     <option value="bigmodel">bigmodel</option>
+                                                    <option value="minimax">minimax</option>
                                                 </select>
                                             </div>
                                             <div class="form-group form-group-span-2">

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -25,6 +25,7 @@ let isModelMenuOpen = false;
 
 const PROVIDER_DEFAULT_BASE_URLS = {
     bigmodel: 'https://open.bigmodel.cn/api/paas/v4',
+    minimax: 'https://api.minimaxi.com/v1',
 };
 
 export function bindModelProfileHandlers() {

--- a/src/agent_teams/providers/model_config.py
+++ b/src/agent_teams/providers/model_config.py
@@ -16,6 +16,7 @@ DEFAULT_LLM_RETRY_BACKOFF_MULTIPLIER = 2.0
 class ProviderType(StrEnum):
     OPENAI_COMPATIBLE = "openai_compatible"
     BIGMODEL = "bigmodel"
+    MINIMAX = "minimax"
     ECHO = "echo"
 
 

--- a/src/agent_teams/providers/model_connectivity.py
+++ b/src/agent_teams/providers/model_connectivity.py
@@ -27,6 +27,7 @@ def _uses_openai_compatible_transport(provider: ProviderType) -> bool:
     return provider in (
         ProviderType.OPENAI_COMPATIBLE,
         ProviderType.BIGMODEL,
+        ProviderType.MINIMAX,
     )
 
 

--- a/src/agent_teams/providers/provider_registry.py
+++ b/src/agent_teams/providers/provider_registry.py
@@ -54,5 +54,6 @@ def create_default_provider_registry(
     registry = ProviderRegistry()
     registry.register(ProviderType.OPENAI_COMPATIBLE, openai_compatible_builder)
     registry.register(ProviderType.BIGMODEL, openai_compatible_builder)
+    registry.register(ProviderType.MINIMAX, openai_compatible_builder)
     registry.register(ProviderType.ECHO, lambda _config: EchoProvider())
     return registry

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -309,6 +309,59 @@ console.log(JSON.stringify({
     assert payload["baseUrlValue"] == "https://custom.example/v1"
 
 
+def test_selecting_minimax_prefills_default_base_url(tmp_path: Path) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+document.getElementById("add-profile-btn").onclick();
+document.getElementById("profile-provider").value = "minimax";
+document.getElementById("profile-provider").onchange();
+
+console.log(JSON.stringify({
+    providerValue: document.getElementById("profile-provider").value,
+    baseUrlValue: document.getElementById("profile-base-url").value,
+}));
+""".strip(),
+    )
+
+    assert payload["providerValue"] == "minimax"
+    assert payload["baseUrlValue"] == "https://api.minimaxi.com/v1"
+
+
+def test_selecting_minimax_does_not_override_existing_base_url(tmp_path: Path) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+document.getElementById("add-profile-btn").onclick();
+document.getElementById("profile-base-url").value = "https://custom.example/v1";
+document.getElementById("profile-provider").value = "minimax";
+document.getElementById("profile-provider").onchange();
+
+console.log(JSON.stringify({
+    baseUrlValue: document.getElementById("profile-base-url").value,
+}));
+""".strip(),
+    )
+
+    assert payload["baseUrlValue"] == "https://custom.example/v1"
+
+
 def test_fetching_models_keeps_full_browser_list_when_model_input_is_partial(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -283,6 +283,7 @@ console.log(JSON.stringify({
     assert '<select id="profile-provider">' in modal_html
     assert 'value="openai_compatible"' in modal_html
     assert 'value="bigmodel"' in modal_html
+    assert 'value="minimax"' in modal_html
     assert 'value="echo"' not in modal_html
     assert (
         '<input type="text" id="profile-model" autocomplete="off" spellcheck="false">'

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -744,6 +744,29 @@ def test_save_model_profile_accepts_bigmodel_provider() -> None:
     assert saved_profile["provider"] == ProviderType.BIGMODEL.value
 
 
+def test_save_model_profile_accepts_minimax_provider() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model/profiles/minimax",
+        json={
+            "provider": ProviderType.MINIMAX.value,
+            "model": "MiniMax-M1-80k",
+            "base_url": "https://api.minimaxi.com/v1",
+            "api_key": "secret",
+            "temperature": 0.2,
+            "top_p": 0.9,
+            "max_tokens": 4096,
+        },
+    )
+
+    assert response.status_code == 200
+    assert service.saved_model_profile is not None
+    _, saved_profile, _ = service.saved_model_profile
+    assert saved_profile["provider"] == ProviderType.MINIMAX.value
+
+
 def test_save_model_profile_accepts_source_name_for_rename() -> None:
     service = _FakeSystemService()
     client = _create_test_client(service)

--- a/tests/unit_tests/providers/test_provider_registry.py
+++ b/tests/unit_tests/providers/test_provider_registry.py
@@ -43,6 +43,23 @@ def test_create_default_provider_registry_has_bigmodel_support() -> None:
     assert isinstance(provider, EchoProvider)
 
 
+def test_create_default_provider_registry_has_minimax_support() -> None:
+    registry = create_default_provider_registry(
+        openai_compatible_builder=lambda _config: EchoProvider()
+    )
+
+    provider = registry.create(
+        ModelEndpointConfig(
+            provider=ProviderType.MINIMAX,
+            model="MiniMax-M1-80k",
+            base_url="https://api.minimaxi.com/v1",
+            api_key="unused",
+        )
+    )
+
+    assert isinstance(provider, EchoProvider)
+
+
 def test_create_default_provider_registry_has_echo_support() -> None:
     registry = create_default_provider_registry(
         openai_compatible_builder=lambda _config: EchoProvider()


### PR DESCRIPTION
### Motivation
- Add support for the `minimax` LLM provider so model profiles, connectivity probing, discovery, and UI flows can be used with MiniMax endpoints.

### Description
- Add `MINIMAX` to `ProviderType` in `src/agent_teams/providers/model_config.py` and treat it as an OpenAI-compatible transport in `model_connectivity.py` by including `ProviderType.MINIMAX` in `_uses_openai_compatible_transport`.
- Register `ProviderType.MINIMAX` in the default provider registry in `src/agent_teams/providers/provider_registry.py` so the registry will build a provider for `minimax` profiles.
- Add `minimax` as a selectable provider in the frontend settings UI and prefill its default base URL `https://api.minimaxi.com/v1` in `frontend/dist/js/components/settings/index.js` and `frontend/dist/js/components/settings/modelProfiles.js`.
- Add unit tests covering registry support, system router profile save for `minimax`, and frontend behavior for prefilling and preserving `minimax` base URL in `tests/unit_tests/*`.

### Testing
- Ran static checks with `uv run ruff check ...` on the modified files and related tests, and the linter checks passed successfully.
- Attempted to run unit tests with `uv run pytest -q tests/unit_tests/providers/test_provider_registry.py tests/unit_tests/frontend/test_model_profiles_ui.py tests/unit_tests/frontend/test_settings_shell_ui.py tests/unit_tests/interfaces/server/test_system_router.py`, but test bootstrap failed in this environment due to missing `mcp` package metadata (`PackageNotFoundError`), preventing full pytest verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b93571ac8333aa55db1bc2ff7e83)