### PR TITLE
Fix IM file path env expansion for mixed-case %VAR% names

### DIFF
--- a/src/agent_teams/tools/im_tools/path_resolution.py
+++ b/src/agent_teams/tools/im_tools/path_resolution.py
@@ -49,6 +49,17 @@ def _expand_path_variables(raw_path: str) -> str:
     expanded = os.path.expandvars(raw_path)
     return re.sub(
         r"%([A-Za-z_][A-Za-z0-9_]*)%",
-        lambda match: os.environ.get(match.group(1), match.group(0)),
+        lambda match: _get_env_var(match.group(1), fallback=match.group(0)),
         expanded,
     )
+
+
+def _get_env_var(name: str, *, fallback: str) -> str:
+    value = os.environ.get(name)
+    if value is not None:
+        return value
+    lowered_name = name.lower()
+    for key, candidate in os.environ.items():
+        if key.lower() == lowered_name:
+            return candidate
+    return fallback

--- a/tests/unit_tests/tools/im_tools/test_path_resolution.py
+++ b/tests/unit_tests/tools/im_tools/test_path_resolution.py
@@ -81,6 +81,25 @@ def test_resolve_im_file_path_expands_environment_variables_and_quotes(
     assert resolved == external_file.resolve()
 
 
+def test_resolve_im_file_path_expands_percent_variables_case_insensitively(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = _build_workspace_handle(tmp_path / "workspace")
+    external_dir = tmp_path / "external"
+    external_dir.mkdir(parents=True)
+    external_file = external_dir / "case-insensitive.txt"
+    external_file.write_text("notes", encoding="utf-8")
+    monkeypatch.setenv("IM_TEST_FILE_MIXED", str(external_file))
+
+    resolved = resolve_im_file_path(
+        file_path='"%im_test_file_mixed%"',
+        workspace=workspace,
+    )
+
+    assert resolved == external_file.resolve()
+
+
 def _build_workspace_handle(root_path: Path) -> WorkspaceHandle:
     root_path.mkdir(parents=True, exist_ok=True)
     profile = default_workspace_profile()


### PR DESCRIPTION
### Motivation
- Percent-style Windows environment variable placeholders like `%VAR%` in IM file paths could fail to expand when the placeholder case did not match the actual environment variable name, causing file resolution to miss valid external files.

### Description
- Add `_get_env_var` helper that first tries `os.environ.get(name)` and then falls back to a case-insensitive search over `os.environ` keys to locate mixed-case environment variables. 
- Use the new helper from `_expand_path_variables` so `%VAR%` replacement becomes case-insensitive while preserving `os.path.expanduser`/`os.path.expandvars` behavior. 
- Add unit test `test_resolve_im_file_path_expands_percent_variables_case_insensitively` to cover a lowercase placeholder resolving to an uppercase environment variable name.

### Testing
- Ran `uv run ruff check --fix` on the modified files and the check completed successfully. 
- Ran `uv run ruff format --no-cache --force-exclude` on the modified files and formatting passed. 
- Performed a quick automated functional check with `uv run python - <<'PY' ...` that exercised `_expand_path_variables` and confirmed mixed-case `%...%` expansion worked as expected. 
- `basedpyright` could not be executed in this environment because the tool is not available, and a full `pytest` run was not completed here due to missing test dependencies/network restrictions in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c531bb11d08333989f8c4f432aab76)