### PR TITLE
Refine temporary role models and template inheritance

### DIFF
--- a/src/agent_teams/agents/execution/llm_session.py
+++ b/src/agent_teams/agents/execution/llm_session.py
@@ -321,6 +321,9 @@ class AgentLlmSession:
             instance_id=request.instance_id,
             role_id=request.role_id,
             role_registry=self._role_registry,
+            runtime_role_resolver=getattr(
+                self._task_execution_service, "runtime_role_resolver", None
+            ),
             mcp_registry=self._mcp_registry,
             task_service=self._task_service,
             task_execution_service=self._task_execution_service,

--- a/src/agent_teams/agents/orchestration/task_execution_service.py
+++ b/src/agent_teams/agents/orchestration/task_execution_service.py
@@ -42,6 +42,7 @@ from agent_teams.roles.memory_injection import build_role_with_memory
 from agent_teams.roles.memory_service import RoleMemoryService
 from agent_teams.roles.role_models import RoleDefinition
 from agent_teams.roles.role_registry import RoleRegistry
+from agent_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from agent_teams.sessions.runs.event_log import EventLog
 from agent_teams.sessions.runs.injection_queue import RunInjectionManager
 from agent_teams.sessions.runs.run_control_manager import RunControlManager
@@ -88,6 +89,7 @@ class TaskExecutionService(BaseModel):
     injection_manager: RunInjectionManager | None = None
     run_control_manager: RunControlManager | None = None
     role_memory_service: RoleMemoryService | None = None
+    runtime_role_resolver: RuntimeRoleResolver | None = None
     run_intent_repo: RunIntentRepository | None = None
     media_asset_service: MediaAssetService | None = None
 
@@ -183,7 +185,13 @@ class TaskExecutionService(BaseModel):
             )
         )
 
-        role: RoleDefinition = self.role_registry.get(role_id)
+        if self.runtime_role_resolver is not None:
+            role = self.runtime_role_resolver.get_effective_role(
+                run_id=task.trace_id,
+                role_id=role_id,
+            )
+        else:
+            role = self.role_registry.get(role_id)
         instance_record = self.agent_repo.get_instance(instance_id)
         workspace = self.workspace_manager.resolve(
             session_id=task.session_id,

--- a/src/agent_teams/agents/orchestration/task_execution_service_factory.py
+++ b/src/agent_teams/agents/orchestration/task_execution_service_factory.py
@@ -13,6 +13,7 @@ from agent_teams.providers.provider_contracts import LLMProvider
 from agent_teams.roles.memory_service import RoleMemoryService
 from agent_teams.roles.role_models import RoleDefinition
 from agent_teams.roles.role_registry import RoleRegistry
+from agent_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from agent_teams.sessions.runs.run_control_manager import RunControlManager
 from agent_teams.sessions.runs.injection_queue import RunInjectionManager
 from agent_teams.agents.instances.instance_repository import AgentInstanceRepository
@@ -50,6 +51,7 @@ def create_task_execution_service(
     injection_manager: RunInjectionManager,
     run_control_manager: RunControlManager,
     role_memory_service: RoleMemoryService | None = None,
+    runtime_role_resolver: RuntimeRoleResolver | None = None,
 ) -> TaskExecutionService:
     return TaskExecutionService(
         role_registry=role_registry,
@@ -76,6 +78,7 @@ def create_task_execution_service(
         injection_manager=injection_manager,
         run_control_manager=run_control_manager,
         role_memory_service=role_memory_service,
+        runtime_role_resolver=runtime_role_resolver,
         run_intent_repo=run_intent_repo,
         media_asset_service=media_asset_service,
     )

--- a/src/agent_teams/agents/orchestration/task_orchestration_service.py
+++ b/src/agent_teams/agents/orchestration/task_orchestration_service.py
@@ -9,6 +9,7 @@ from agent_teams.agents.orchestration.task_execution_service import (
     TaskExecutionService,
 )
 from agent_teams.roles.role_registry import RoleRegistry
+from agent_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from agent_teams.agents.instances.instance_repository import AgentInstanceRepository
 from agent_teams.agents.execution.message_repository import MessageRepository
 from agent_teams.sessions.session_repository import SessionRepository
@@ -52,6 +53,7 @@ class TaskOrchestrationService:
         task_execution_service: TaskExecutionService,
         message_repo: MessageRepository,
         session_repo: SessionRepository | None = None,
+        runtime_role_resolver: RuntimeRoleResolver | None = None,
     ) -> None:
         self._task_repo = task_repo
         self._role_registry = role_registry
@@ -59,6 +61,7 @@ class TaskOrchestrationService:
         self._task_execution_service = task_execution_service
         self._message_repo = message_repo
         self._session_repo = session_repo
+        self._runtime_role_resolver = runtime_role_resolver
 
     async def create_tasks(
         self,
@@ -174,7 +177,13 @@ class TaskOrchestrationService:
         normalized_role_id = str(role_id).strip()
         if not normalized_role_id:
             raise ValueError("role_id must not be empty")
-        self._role_registry.get(normalized_role_id)
+        if self._runtime_role_resolver is not None:
+            self._runtime_role_resolver.get_effective_role(
+                run_id=resolved_run_id,
+                role_id=normalized_role_id,
+            )
+        else:
+            self._role_registry.get(normalized_role_id)
 
         normalized_prompt = prompt.strip()
         bound_role_id = str(record.envelope.role_id or "").strip()

--- a/src/agent_teams/builtin/roles/coordinator.md
+++ b/src/agent_teams/builtin/roles/coordinator.md
@@ -6,6 +6,7 @@ model_profile: default
 version: 1.0.0
 tools:
   - create_tasks
+  - create_temporary_role
   - update_task
   - list_delegated_tasks
   - dispatch_task

--- a/src/agent_teams/interfaces/server/container.py
+++ b/src/agent_teams/interfaces/server/container.py
@@ -102,6 +102,8 @@ from agent_teams.roles import (
     RoleMemoryRepository,
     RoleMemoryService,
     RoleRegistry,
+    RuntimeRoleResolver,
+    TemporaryRoleRepository,
 )
 from agent_teams.roles.settings_service import RoleSettingsService
 from agent_teams.sessions.runs.active_run_registry import ActiveSessionRunRegistry
@@ -319,6 +321,13 @@ class ServerContainer:
         self.role_memory_service: RoleMemoryService = RoleMemoryService(
             repository=self.role_memory_repo
         )
+        self.temporary_role_repo: TemporaryRoleRepository = TemporaryRoleRepository(
+            runtime.paths.db_path
+        )
+        self.runtime_role_resolver: RuntimeRoleResolver = RuntimeRoleResolver(
+            role_registry=self.role_registry,
+            temporary_role_repository=self.temporary_role_repo,
+        )
         self.subagent_reflection_service = self._build_subagent_reflection_service()
         self._ensure_default_workspace()
 
@@ -469,6 +478,7 @@ class ServerContainer:
             notification_service=self.notification_service,
             orchestration_settings_service=self.orchestration_settings_service,
             media_asset_service=self.media_asset_service,
+            runtime_role_resolver=self.runtime_role_resolver,
         )
         self.session_service: SessionService = SessionService(
             session_repo=self.session_repo,
@@ -688,6 +698,7 @@ class ServerContainer:
             injection_manager=self.injection_manager,
             run_control_manager=self.run_control_manager,
             role_memory_service=self.role_memory_service,
+            runtime_role_resolver=self.runtime_role_resolver,
         )
         self.task_service = TaskOrchestrationService(
             task_repo=self.task_repo,
@@ -696,6 +707,7 @@ class ServerContainer:
             task_execution_service=self.task_execution_service,
             message_repo=self.message_repo,
             session_repo=self.session_repo,
+            runtime_role_resolver=self.runtime_role_resolver,
         )
 
     def _resolve_reflection_model_config(self) -> ModelEndpointConfig | None:

--- a/src/agent_teams/roles/__init__.py
+++ b/src/agent_teams/roles/__init__.py
@@ -19,6 +19,13 @@ from agent_teams.roles.memory_models import (
 from agent_teams.roles.memory_repository import RoleMemoryRepository
 from agent_teams.roles.memory_service import RoleMemoryService
 from agent_teams.roles.role_registry import RoleLoader, RoleRegistry
+from agent_teams.roles.runtime_role_resolver import RuntimeRoleResolver
+from agent_teams.roles.temporary_role_models import (
+    TemporaryRoleRecord,
+    TemporaryRoleSource,
+    TemporaryRoleSpec,
+)
+from agent_teams.roles.temporary_role_repository import TemporaryRoleRepository
 
 __all__ = [
     "default_memory_profile",
@@ -37,4 +44,9 @@ __all__ = [
     "RoleMemoryService",
     "RoleRegistry",
     "RoleValidationResult",
+    "RuntimeRoleResolver",
+    "TemporaryRoleRecord",
+    "TemporaryRoleRepository",
+    "TemporaryRoleSource",
+    "TemporaryRoleSpec",
 ]

--- a/src/agent_teams/roles/runtime_role_resolver.py
+++ b/src/agent_teams/roles/runtime_role_resolver.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from agent_teams.roles.role_models import RoleDefinition
+from agent_teams.roles.role_registry import RoleRegistry
+from agent_teams.roles.temporary_role_models import (
+    TemporaryRoleRecord,
+    TemporaryRoleSource,
+    TemporaryRoleSpec,
+)
+from agent_teams.roles.temporary_role_repository import TemporaryRoleRepository
+
+
+class RuntimeRoleResolver:
+    def __init__(
+        self,
+        *,
+        role_registry: RoleRegistry,
+        temporary_role_repository: TemporaryRoleRepository,
+    ) -> None:
+        self._role_registry = role_registry
+        self._temporary_role_repository = temporary_role_repository
+
+    def get_effective_role(self, *, run_id: str | None, role_id: str) -> RoleDefinition:
+        if run_id is not None:
+            try:
+                temp = self._temporary_role_repository.get(
+                    run_id=run_id, role_id=role_id
+                )
+            except KeyError:
+                pass
+            else:
+                return temp.role.to_role_definition()
+        return self._role_registry.get(role_id)
+
+    def list_effective_roles(self, *, run_id: str | None) -> tuple[RoleDefinition, ...]:
+        static_roles = list(self._role_registry.list_roles())
+        if run_id is None:
+            return tuple(static_roles)
+        temp_roles = [
+            record.role.to_role_definition()
+            for record in self._temporary_role_repository.list_by_run(run_id)
+        ]
+        return tuple(static_roles + temp_roles)
+
+    def create_temporary_role(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        role: TemporaryRoleSpec,
+        source: TemporaryRoleSource = TemporaryRoleSource.META_AGENT_GENERATED,
+    ) -> RoleDefinition:
+        if self._role_registry.is_coordinator_role(role.role_id):
+            raise ValueError(
+                f"Temporary role id conflicts with coordinator role: {role.role_id}"
+            )
+        if self._role_registry.is_main_agent_role(role.role_id):
+            raise ValueError(
+                f"Temporary role id conflicts with main agent role: {role.role_id}"
+            )
+        if role.template_role_id is not None:
+            role = self._merge_with_template(run_id=run_id, role=role)
+        record = self._temporary_role_repository.upsert(
+            TemporaryRoleRecord(
+                run_id=run_id,
+                session_id=session_id,
+                source=source,
+                role=role,
+            )
+        )
+        return record.role.to_role_definition()
+
+    def cleanup_run(self, *, run_id: str) -> None:
+        self._temporary_role_repository.delete_by_run(run_id)
+
+    def _merge_with_template(
+        self, *, run_id: str, role: TemporaryRoleSpec
+    ) -> TemporaryRoleSpec:
+        template_role_id = role.template_role_id
+        if template_role_id is None:
+            return role
+        template = self.get_effective_role(run_id=run_id, role_id=template_role_id)
+        return TemporaryRoleSpec(
+            role_id=role.role_id,
+            name=role.name,
+            description=role.description,
+            version=role.version,
+            tools=template.tools if len(role.tools) == 0 else role.tools,
+            mcp_servers=(
+                template.mcp_servers if len(role.mcp_servers) == 0 else role.mcp_servers
+            ),
+            skills=template.skills if len(role.skills) == 0 else role.skills,
+            model_profile=template.model_profile
+            if role.model_profile == "default"
+            else role.model_profile,
+            bound_agent_id=role.bound_agent_id or template.bound_agent_id,
+            memory_profile=role.memory_profile,
+            system_prompt=role.system_prompt,
+            template_role_id=role.template_role_id,
+        )

--- a/src/agent_teams/roles/temporary_role_models.py
+++ b/src/agent_teams/roles/temporary_role_models.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent_teams.roles.role_models import RoleDefinition
+from agent_teams.roles.memory_models import MemoryProfile, default_memory_profile
+
+
+class TemporaryRoleSource(str, Enum):
+    META_AGENT_GENERATED = "meta_agent_generated"
+
+
+class TemporaryRoleSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    version: str = Field(min_length=1, default="temporary")
+    tools: tuple[str, ...] = ()
+    mcp_servers: tuple[str, ...] = ()
+    skills: tuple[str, ...] = ()
+    model_profile: str = Field(default="default", min_length=1)
+    bound_agent_id: str | None = None
+    memory_profile: MemoryProfile = Field(default_factory=default_memory_profile)
+    system_prompt: str = Field(min_length=1)
+    template_role_id: str | None = None
+
+    def to_role_definition(self) -> RoleDefinition:
+        return RoleDefinition(
+            role_id=self.role_id,
+            name=self.name,
+            description=self.description,
+            version=self.version,
+            tools=self.tools,
+            mcp_servers=self.mcp_servers,
+            skills=self.skills,
+            model_profile=self.model_profile,
+            bound_agent_id=self.bound_agent_id,
+            memory_profile=self.memory_profile,
+            system_prompt=self.system_prompt,
+        )
+
+
+class TemporaryRoleRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(min_length=1)
+    session_id: str = Field(min_length=1)
+    source: TemporaryRoleSource = TemporaryRoleSource.META_AGENT_GENERATED
+    role: TemporaryRoleSpec
+    created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))

--- a/src/agent_teams/roles/temporary_role_repository.py
+++ b/src/agent_teams/roles/temporary_role_repository.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import RLock
+
+from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from agent_teams.roles.memory_models import MemoryProfile
+from agent_teams.roles.temporary_role_models import TemporaryRoleRecord
+from agent_teams.roles.temporary_role_models import TemporaryRoleSpec
+
+
+class TemporaryRoleRepository:
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = Path(db_path)
+        self._conn = open_sqlite(db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = RLock()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        def operation() -> None:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS temporary_roles (
+                    run_id TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    role_id TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    description TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    tools_json TEXT NOT NULL,
+                    mcp_servers_json TEXT NOT NULL,
+                    skills_json TEXT NOT NULL,
+                    model_profile TEXT NOT NULL,
+                    bound_agent_id TEXT,
+                    memory_profile_json TEXT NOT NULL,
+                    system_prompt TEXT NOT NULL,
+                    template_role_id TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (run_id, role_id)
+                )
+                """
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_temp_roles_run ON temporary_roles(run_id, created_at ASC)"
+            )
+
+        run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=operation,
+            lock=self._lock,
+            repository_name="TemporaryRoleRepository",
+            operation_name="init_tables",
+        )
+
+    def upsert(self, record: TemporaryRoleRecord) -> TemporaryRoleRecord:
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        def operation() -> None:
+            self._conn.execute(
+                """
+                INSERT INTO temporary_roles(
+                    run_id, session_id, role_id, source, name, description, version,
+                    tools_json, mcp_servers_json, skills_json, model_profile,
+                    bound_agent_id, memory_profile_json, system_prompt, template_role_id,
+                    created_at, updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id, role_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    source=excluded.source,
+                    name=excluded.name,
+                    description=excluded.description,
+                    version=excluded.version,
+                    tools_json=excluded.tools_json,
+                    mcp_servers_json=excluded.mcp_servers_json,
+                    skills_json=excluded.skills_json,
+                    model_profile=excluded.model_profile,
+                    bound_agent_id=excluded.bound_agent_id,
+                    memory_profile_json=excluded.memory_profile_json,
+                    system_prompt=excluded.system_prompt,
+                    template_role_id=excluded.template_role_id,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    record.run_id,
+                    record.session_id,
+                    record.role.role_id,
+                    record.source,
+                    record.role.name,
+                    record.role.description,
+                    record.role.version,
+                    _json_tuple(record.role.tools),
+                    _json_tuple(record.role.mcp_servers),
+                    _json_tuple(record.role.skills),
+                    record.role.model_profile,
+                    record.role.bound_agent_id,
+                    record.role.memory_profile.model_dump_json(),
+                    record.role.system_prompt,
+                    record.role.template_role_id,
+                    record.created_at.isoformat(),
+                    now,
+                ),
+            )
+
+        run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=operation,
+            lock=self._lock,
+            repository_name="TemporaryRoleRepository",
+            operation_name="upsert",
+        )
+        return self.get(run_id=record.run_id, role_id=record.role.role_id)
+
+    def get(self, *, run_id: str, role_id: str) -> TemporaryRoleRecord:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM temporary_roles WHERE run_id=? AND role_id=?",
+                (run_id, role_id),
+            ).fetchone()
+        if row is None:
+            raise KeyError(
+                f"Unknown temporary role: run_id={run_id}, role_id={role_id}"
+            )
+        return self._to_record(row)
+
+    def list_by_run(self, run_id: str) -> tuple[TemporaryRoleRecord, ...]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM temporary_roles WHERE run_id=? ORDER BY created_at ASC",
+                (run_id,),
+            ).fetchall()
+        return tuple(self._to_record(row) for row in rows)
+
+    def delete_by_run(self, run_id: str) -> None:
+        run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=lambda: self._conn.execute(
+                "DELETE FROM temporary_roles WHERE run_id=?", (run_id,)
+            ),
+            lock=self._lock,
+            repository_name="TemporaryRoleRepository",
+            operation_name="delete_by_run",
+        )
+
+    def _to_record(self, row: sqlite3.Row) -> TemporaryRoleRecord:
+        return TemporaryRoleRecord(
+            run_id=str(row["run_id"]),
+            session_id=str(row["session_id"]),
+            source=str(row["source"]),
+            role=TemporaryRoleSpec(
+                role_id=str(row["role_id"]),
+                name=str(row["name"]),
+                description=str(row["description"]),
+                version=str(row["version"]),
+                tools=tuple(_json_load_tuple(str(row["tools_json"]))),
+                mcp_servers=tuple(_json_load_tuple(str(row["mcp_servers_json"]))),
+                skills=tuple(_json_load_tuple(str(row["skills_json"]))),
+                model_profile=str(row["model_profile"]),
+                bound_agent_id=(
+                    str(row["bound_agent_id"])
+                    if row["bound_agent_id"] is not None
+                    else None
+                ),
+                memory_profile=_memory_profile_from_json(
+                    str(row["memory_profile_json"])
+                ),
+                system_prompt=str(row["system_prompt"]),
+                template_role_id=(
+                    str(row["template_role_id"])
+                    if row["template_role_id"] is not None
+                    else None
+                ),
+            ),
+            created_at=datetime.fromisoformat(str(row["created_at"])),
+            updated_at=datetime.fromisoformat(str(row["updated_at"])),
+        )
+
+
+def _json_tuple(values: tuple[str, ...]) -> str:
+    import json
+
+    return json.dumps(list(values), ensure_ascii=False)
+
+
+def _json_load_tuple(raw: str) -> tuple[str, ...]:
+    import json
+
+    loaded = json.loads(raw)
+    if not isinstance(loaded, list):
+        return ()
+    return tuple(str(item) for item in loaded)
+
+
+def _memory_profile_from_json(raw: str) -> "MemoryProfile":
+    import json
+
+    payload = json.loads(raw)
+    return MemoryProfile.model_validate(payload)

--- a/src/agent_teams/sessions/runs/run_manager.py
+++ b/src/agent_teams/sessions/runs/run_manager.py
@@ -38,6 +38,7 @@ from agent_teams.providers.provider_contracts import (
 )
 from agent_teams.roles.role_models import RoleDefinition
 from agent_teams.roles.role_registry import RoleRegistry
+from agent_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from agent_teams.sessions.runs.active_run_registry import ActiveSessionRunRegistry
 from agent_teams.sessions.runs.run_control_manager import RunControlManager
 from agent_teams.sessions.runs.enums import InjectionSource, RunEventType
@@ -104,6 +105,7 @@ class RunManager:
         notification_service: NotificationService | None = None,
         orchestration_settings_service: OrchestrationSettingsService | None = None,
         media_asset_service: MediaAssetService | None = None,
+        runtime_role_resolver: RuntimeRoleResolver | None = None,
     ) -> None:
         self._meta_agent: MetaAgent = meta_agent
         self._provider_factory = provider_factory or (
@@ -129,6 +131,7 @@ class RunManager:
         self._notification_service: NotificationService | None = notification_service
         self._orchestration_settings_service = orchestration_settings_service
         self._media_asset_service = media_asset_service
+        self._runtime_role_resolver = runtime_role_resolver
         self._pending_runs: dict[str, IntentInput] = {}
         self._running_run_ids: set[str] = set()
         self._resume_requested_runs: set[str] = set()
@@ -920,6 +923,8 @@ class RunManager:
         if runtime is not None and runtime.is_recoverable:
             self._remember_active_run(session_id, run_id)
             return
+        if self._runtime_role_resolver is not None:
+            self._runtime_role_resolver.cleanup_run(run_id=run_id)
         self._drop_active_run(session_id, run_id)
 
     def _safe_finalize_run(self, *, run_id: str, session_id: str) -> None:

--- a/src/agent_teams/tools/runtime/context.py
+++ b/src/agent_teams/tools/runtime/context.py
@@ -22,6 +22,7 @@ from agent_teams.notifications import NotificationService
 from agent_teams.persistence.shared_state_repo import SharedStateRepository
 from agent_teams.roles.memory_service import RoleMemoryService
 from agent_teams.roles.role_registry import RoleRegistry
+from agent_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from agent_teams.sessions.runs.event_log import EventLog
 from agent_teams.sessions.runs.event_stream import RunEventHub
 from agent_teams.sessions.runs.injection_queue import RunInjectionManager
@@ -117,6 +118,7 @@ class ToolDeps(BaseModel):
     instance_id: str
     role_id: str
     role_registry: SkipValidation[RoleRegistry]
+    runtime_role_resolver: SkipValidation[RuntimeRoleResolver | None] = None
     mcp_registry: SkipValidation[McpRegistry]
     task_service: SkipValidation[TaskOrchestrationServiceLike]
     task_execution_service: SkipValidation[TaskExecutionServiceLike]

--- a/src/agent_teams/tools/task_tools/__init__.py
+++ b/src/agent_teams/tools/task_tools/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from agent_teams.tools.task_tools.create_tasks import register as register_create_tasks
+from agent_teams.tools.task_tools.create_temporary_role import (
+    register as register_create_temporary_role,
+)
 from agent_teams.tools.task_tools.dispatch_task import (
     register as register_dispatch_task,
 )
@@ -11,6 +14,7 @@ from agent_teams.tools.task_tools.update_task import register as register_update
 
 TOOLS = {
     "create_tasks": register_create_tasks,
+    "create_temporary_role": register_create_temporary_role,
     "update_task": register_update_task,
     "list_delegated_tasks": register_list_delegated_tasks,
     "dispatch_task": register_dispatch_task,

--- a/src/agent_teams/tools/task_tools/create_temporary_role.py
+++ b/src/agent_teams/tools/task_tools/create_temporary_role.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic_ai import Agent
+
+from agent_teams.roles.temporary_role_models import (
+    TemporaryRoleSource,
+    TemporaryRoleSpec,
+)
+from agent_teams.tools._description_loader import load_tool_description
+from agent_teams.tools.runtime import ToolContext, ToolDeps, execute_tool
+
+DESCRIPTION = load_tool_description(__file__)
+
+
+class CreateTemporaryRoleInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    system_prompt: str = Field(min_length=1)
+    tools: tuple[str, ...] | None = None
+    mcp_servers: tuple[str, ...] | None = None
+    skills: tuple[str, ...] | None = None
+    model_profile: str | None = Field(default=None, min_length=1)
+    template_role_id: str | None = None
+
+
+def register(agent: Agent[ToolDeps, str]) -> None:
+    @agent.tool(description=DESCRIPTION)
+    async def create_temporary_role(
+        ctx: ToolContext,
+        role_id: str,
+        name: str,
+        description: str,
+        system_prompt: str,
+        tools: list[str] | None = None,
+        mcp_servers: list[str] | None = None,
+        skills: list[str] | None = None,
+        model_profile: str | None = None,
+        template_role_id: str | None = None,
+    ) -> dict[str, JsonValue]:
+        """Create a run-scoped temporary role for orchestration dispatch."""
+
+        if ctx.deps.runtime_role_resolver is None:
+            raise RuntimeError("Temporary role creation is unavailable")
+
+        payload = CreateTemporaryRoleInput(
+            role_id=role_id,
+            name=name,
+            description=description,
+            system_prompt=system_prompt,
+            tools=tuple(tools) if tools is not None else None,
+            mcp_servers=tuple(mcp_servers) if mcp_servers is not None else None,
+            skills=tuple(skills) if skills is not None else None,
+            model_profile=model_profile,
+            template_role_id=template_role_id,
+        )
+
+        def _action() -> dict[str, JsonValue]:
+            role = ctx.deps.runtime_role_resolver.create_temporary_role(
+                run_id=ctx.deps.run_id,
+                session_id=ctx.deps.session_id,
+                source=TemporaryRoleSource.META_AGENT_GENERATED,
+                role=TemporaryRoleSpec(
+                    role_id=payload.role_id,
+                    name=payload.name,
+                    description=payload.description,
+                    version="temporary",
+                    tools=payload.tools or (),
+                    mcp_servers=payload.mcp_servers or (),
+                    skills=payload.skills or (),
+                    model_profile=payload.model_profile or "default",
+                    system_prompt=payload.system_prompt,
+                    template_role_id=payload.template_role_id,
+                ),
+            )
+            return {
+                "role": {
+                    "role_id": role.role_id,
+                    "name": role.name,
+                    "description": role.description,
+                    "tools": list(role.tools),
+                    "mcp_servers": list(role.mcp_servers),
+                    "skills": list(role.skills),
+                    "model_profile": role.model_profile,
+                    "source": "temporary",
+                    "run_id": ctx.deps.run_id,
+                }
+            }
+
+        return await execute_tool(
+            ctx,
+            tool_name="create_temporary_role",
+            args_summary=payload.model_dump(mode="json"),
+            action=_action,
+        )

--- a/src/agent_teams/tools/task_tools/create_temporary_role.txt
+++ b/src/agent_teams/tools/task_tools/create_temporary_role.txt
@@ -1,0 +1,2 @@
+Create a run-scoped temporary role that can be selected in `dispatch_task` during orchestration.
+Use this when no existing role is a good fit for a delegated subtask.

--- a/src/agent_teams/tools/task_tools/list_available_roles.py
+++ b/src/agent_teams/tools/task_tools/list_available_roles.py
@@ -17,9 +17,16 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         """List worker roles that can be selected for delegated tasks."""
 
         def _action() -> dict[str, JsonValue]:
+            source_roles = (
+                ctx.deps.runtime_role_resolver.list_effective_roles(
+                    run_id=ctx.deps.run_id
+                )
+                if ctx.deps.runtime_role_resolver is not None
+                else ctx.deps.role_registry.list_roles()
+            )
             roles = [
                 role
-                for role in ctx.deps.role_registry.list_roles()
+                for role in source_roles
                 if not ctx.deps.role_registry.is_coordinator_role(role.role_id)
                 and not ctx.deps.role_registry.is_main_agent_role(role.role_id)
             ]
@@ -29,6 +36,14 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                         "role_id": role.role_id,
                         "name": role.name,
                         "tools": list(role.tools),
+                        "source": (
+                            "static"
+                            if any(
+                                r.role_id == role.role_id
+                                for r in ctx.deps.role_registry.list_roles()
+                            )
+                            else "temporary"
+                        ),
                     }
                     for role in roles
                 ],

--- a/tests/unit_tests/roles/test_coordinator_tools.py
+++ b/tests/unit_tests/roles/test_coordinator_tools.py
@@ -11,6 +11,7 @@ def test_coordinator_uses_task_tools_and_not_emit_event() -> None:
     tools = set(coordinator.tools)
 
     assert "create_tasks" in tools
+    assert "create_temporary_role" in tools
     assert "update_task" in tools
     assert "list_delegated_tasks" in tools
     assert "dispatch_task" in tools

--- a/tests/unit_tests/roles/test_runtime_role_resolver.py
+++ b/tests/unit_tests/roles/test_runtime_role_resolver.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_teams.roles.role_models import RoleDefinition
+from agent_teams.roles.role_registry import RoleRegistry
+from agent_teams.roles.runtime_role_resolver import RuntimeRoleResolver
+from agent_teams.roles.temporary_role_models import TemporaryRoleSpec
+from agent_teams.roles.temporary_role_repository import TemporaryRoleRepository
+
+
+def _base_registry() -> RoleRegistry:
+    registry = RoleRegistry()
+    registry.register(
+        RoleDefinition(
+            role_id="Coordinator",
+            name="Coordinator",
+            description="system",
+            version="1",
+            tools=("create_tasks", "update_task", "dispatch_task"),
+            system_prompt="coord",
+        )
+    )
+    registry.register(
+        RoleDefinition(
+            role_id="MainAgent",
+            name="MainAgent",
+            description="system",
+            version="1",
+            tools=("read",),
+            system_prompt="main",
+        )
+    )
+    registry.register(
+        RoleDefinition(
+            role_id="Analyst",
+            name="Analyst",
+            description="static",
+            version="1",
+            tools=("read",),
+            system_prompt="analyst",
+        )
+    )
+    return registry
+
+
+def test_runtime_role_resolver_prefers_run_temporary_roles(tmp_path: Path) -> None:
+    resolver = RuntimeRoleResolver(
+        role_registry=_base_registry(),
+        temporary_role_repository=TemporaryRoleRepository(tmp_path / "roles.db"),
+    )
+    resolver.create_temporary_role(
+        run_id="run-1",
+        session_id="session-1",
+        role=TemporaryRoleSpec(
+            role_id="tmp_writer",
+            name="Tmp Writer",
+            description="temporary",
+            system_prompt="tmp",
+            tools=("write_tmp",),
+        ),
+    )
+
+    role = resolver.get_effective_role(run_id="run-1", role_id="tmp_writer")
+    assert role.role_id == "tmp_writer"
+    assert role.tools == ("write_tmp",)
+
+
+def test_runtime_role_resolver_rejects_reserved_ids(tmp_path: Path) -> None:
+    resolver = RuntimeRoleResolver(
+        role_registry=_base_registry(),
+        temporary_role_repository=TemporaryRoleRepository(tmp_path / "roles.db"),
+    )
+
+    with pytest.raises(ValueError):
+        resolver.create_temporary_role(
+            run_id="run-1",
+            session_id="session-1",
+            role=TemporaryRoleSpec(
+                role_id="Coordinator",
+                name="Bad",
+                description="bad",
+                system_prompt="bad",
+            ),
+        )
+
+
+def test_runtime_role_resolver_applies_template_defaults(tmp_path: Path) -> None:
+    resolver = RuntimeRoleResolver(
+        role_registry=_base_registry(),
+        temporary_role_repository=TemporaryRoleRepository(tmp_path / "roles.db"),
+    )
+
+    resolver.create_temporary_role(
+        run_id="run-1",
+        session_id="session-1",
+        role=TemporaryRoleSpec(
+            role_id="tmp_researcher",
+            name="Tmp Researcher",
+            description="temporary",
+            system_prompt="tmp",
+            template_role_id="Analyst",
+        ),
+    )
+
+    role = resolver.get_effective_role(run_id="run-1", role_id="tmp_researcher")
+    assert role.tools == ("read",)
+    assert role.model_profile == "default"

--- a/tests/unit_tests/roles/test_temporary_role_repository.py
+++ b/tests/unit_tests/roles/test_temporary_role_repository.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_teams.roles.temporary_role_models import (
+    TemporaryRoleRecord,
+    TemporaryRoleSource,
+    TemporaryRoleSpec,
+)
+from agent_teams.roles.temporary_role_repository import TemporaryRoleRepository
+
+
+def test_temporary_role_repository_roundtrip_and_cleanup(tmp_path: Path) -> None:
+    repo = TemporaryRoleRepository(tmp_path / "roles.db")
+    spec = TemporaryRoleSpec(
+        role_id="tmp_researcher",
+        name="Temporary Researcher",
+        description="Run scoped role",
+        system_prompt="You are temporary.",
+        tools=("read",),
+    )
+    stored = repo.upsert(
+        TemporaryRoleRecord(
+            run_id="run-1",
+            session_id="session-1",
+            source=TemporaryRoleSource.META_AGENT_GENERATED,
+            role=spec,
+        )
+    )
+
+    assert stored.role.role_id == "tmp_researcher"
+    assert stored.source == TemporaryRoleSource.META_AGENT_GENERATED
+    assert repo.get(run_id="run-1", role_id="tmp_researcher").role.name == (
+        "Temporary Researcher"
+    )
+
+    repo.delete_by_run("run-1")
+    assert repo.list_by_run("run-1") == ()


### PR DESCRIPTION
### Motivation
- Make temporary (run-scoped) role semantics explicit and ensure temporary roles can be converted to runtime `RoleDefinition` instances without scattered conversion logic.
- Ensure `template_role_id` actually applies template defaults when creating temporary roles so generated roles inherit sensible defaults (tools, mcp servers, skills, model profile).
- Expose temporary roles at runtime and wire resolution through orchestration and execution paths so delegation can target run-scoped roles.

### Description
- Added typed temporary role domain: `TemporaryRoleSpec`, `TemporaryRoleRecord`, and `TemporaryRoleSource` enum in `src/agent_teams/roles/temporary_role_models.py` and exported via `roles.__init__`.
- Added `TemporaryRoleSpec.to_role_definition()` to centralize conversion from temporary model to `RoleDefinition` and removed ad-hoc converters.
- Implemented `TemporaryRoleRepository` (SQLite-backed) at `src/agent_teams/roles/temporary_role_repository.py` with `upsert`, `get`, `list_by_run`, and `delete_by_run`.
- Introduced `RuntimeRoleResolver` at `src/agent_teams/roles/runtime_role_resolver.py` to merge static registry roles and run-scoped temporary roles, enforce reserved-id checks, apply template inheritance, and provide `cleanup_run`.
- Added orchestration tooling and runtime wiring: new tool `create_temporary_role` and description files at `src/agent_teams/tools/task_tools/create_temporary_role.py` and `.txt`, registered in `tools.task_tools.__init__`, and updated `list_available_roles` to surface temporary roles and label their source.
- Wired resolver through runtime: `ToolContext` now carries `runtime_role_resolver`, `TaskExecutionService` accepts and uses `runtime_role_resolver`, factory and `ServerContainer` create and inject `TemporaryRoleRepository`/`RuntimeRoleResolver`, `TaskOrchestrationService` validates using resolver, and `RunManager` calls `cleanup_run` at run finalization.
- Updated coordinator builtin to include `create_temporary_role` in its tool list and adjusted tests and exports accordingly.

### Testing
- Ran lint/format/compile checks: `uv run ruff check --fix` and `uv run ruff format --no-cache --force-exclude` on changed files and `uv run python -m compileall -q src/agent_teams` and they passed.
- Ran targeted unit tests and added tests at `tests/unit_tests/roles/test_temporary_role_repository.py` and `tests/unit_tests/roles/test_runtime_role_resolver.py`, and updated `tests/unit_tests/roles/test_coordinator_tools.py` to assert the new tool; the tests were executed but `pytest` fails in this environment due to missing `mcp` package metadata raising `PackageNotFoundError` in `tests/conftest.py` so full `pytest` run could not complete.
- Local quick-run checks and scripted assertions covering temporary role repository roundtrip, resolver precedence, and template default inheritance succeeded in the development environment prior to encountering the `mcp` metadata issue during `pytest` runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c53885d5608333b34600de42d5966c)