### PR TITLE
Guard ACP prompts when a recoverable run is paused

### DIFF
--- a/src/agent_teams/gateway/acp_stdio.py
+++ b/src/agent_teams/gateway/acp_stdio.py
@@ -40,6 +40,9 @@ type AcpNotifier = Callable[[dict[str, JsonValue]], Awaitable[None]]
 
 
 LOGGER = get_logger(__name__)
+RECOVERABLE_PAUSED_RUN_MESSAGE = (
+    "Session has a recoverable paused run; use session/resume or session/cancel"
+)
 
 
 class AcpProtocolError(ValueError):
@@ -304,6 +307,9 @@ class AcpGatewayServer:
         prompt_blocks = _required_list(params, "prompt")
         record = self._gateway_session_service.get_session(gateway_session_id)
         session = self._session_service.get_session(record.internal_session_id)
+        paused_run_id = self._recoverable_paused_run_id(record.internal_session_id)
+        if paused_run_id is not None:
+            raise AcpProtocolError(-32000, RECOVERABLE_PAUSED_RUN_MESSAGE)
         prompt_input = self._prompt_blocks_to_content_parts(
             prompt_blocks=prompt_blocks,
             session_id=record.internal_session_id,
@@ -442,6 +448,25 @@ class AcpGatewayServer:
                 clear_active_run=clear_active_run,
             )
         raise RuntimeError(f"ACP run watcher ended before a stop event for {run_id}.")
+
+    def _recoverable_paused_run_id(self, internal_session_id: str) -> str | None:
+        recovery_snapshot = self._session_service.get_recovery_snapshot(
+            internal_session_id
+        )
+        active_run = recovery_snapshot.get("active_run")
+        if not isinstance(active_run, Mapping):
+            return None
+        run_id = str(active_run.get("run_id") or "").strip()
+        if not run_id:
+            return None
+        if active_run.get("is_recoverable") is not True:
+            return None
+        phase = str(active_run.get("phase") or "").strip()
+        status = str(active_run.get("status") or "").strip()
+        should_show_recover = active_run.get("should_show_recover") is True
+        if phase == "awaiting_recovery" or status == "paused" or should_show_recover:
+            return run_id
+        return None
 
     def _resume_after_event_id(self, *, internal_session_id: str, run_id: str) -> int:
         recovery_snapshot = self._session_service.get_recovery_snapshot(

--- a/tests/unit_tests/gateway/test_acp_stdio.py
+++ b/tests/unit_tests/gateway/test_acp_stdio.py
@@ -12,7 +12,11 @@ import pytest
 from pydantic import JsonValue
 
 import agent_teams.gateway.acp_stdio as acp_stdio_module
-from agent_teams.gateway.acp_stdio import AcpGatewayServer, AcpStdioRuntime
+from agent_teams.gateway.acp_stdio import (
+    RECOVERABLE_PAUSED_RUN_MESSAGE,
+    AcpGatewayServer,
+    AcpStdioRuntime,
+)
 from agent_teams.gateway.gateway_session_repository import GatewaySessionRepository
 from agent_teams.gateway.gateway_session_model_profile_store import (
     GatewaySessionModelProfileStore,
@@ -474,6 +478,57 @@ async def test_session_prompt_returns_paused_run_without_clearing_binding(
     repository = GatewaySessionRepository(tmp_path / "gateway.db")
     record = repository.get(session_id)
     assert record.active_run_id == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_session_prompt_rejects_recoverable_paused_run(
+    tmp_path: Path,
+) -> None:
+    server, session_service, run_manager, notifications = _build_server(tmp_path)
+    created = await server.handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": str(tmp_path), "mcpServers": []},
+        }
+    )
+    session_id = _require_str(_require_result_object(created), "sessionId")
+    session_service.recovery_snapshot_by_session["session-1"] = {
+        "active_run": {
+            "run_id": "run-paused",
+            "status": "paused",
+            "phase": "awaiting_recovery",
+            "is_recoverable": True,
+            "should_show_recover": True,
+        },
+        "pending_tool_approvals": [],
+        "paused_subagent": None,
+        "round_snapshot": None,
+    }
+
+    response = await server.handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "keep going"}],
+            },
+        }
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "error": {
+            "code": -32000,
+            "message": RECOVERABLE_PAUSED_RUN_MESSAGE,
+        },
+    }
+    assert run_manager.create_calls == []
+    assert notifications == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reject `session/prompt` when the target session already has a recoverable paused run
- return a fixed ACP `-32000` message that tells clients to use `session/resume` or `session/cancel`
- cover the gateway behavior with a regression test

## Testing
- uv run --project /opt/workspace/agent-teams --extra dev pytest -q /opt/workspace/agent-teams/tests/unit_tests/gateway/test_acp_stdio.py