### PR TITLE
docs: capture ppt layout feedback loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@
 - Changed behavior must come with tests.
 - `tests/unit_tests/` should mirror `src/agent_teams/`. Add matching `__init__.py` files for new test directories.
 - Prefer focused unit tests first. Add integration coverage when run/SSE/interface flows change.
+- When a user reports a PPT layout defect (for example遮挡、重叠、溢出、页脚挤压), do not stop at fixing the generated file. Capture the reusable rule in repository docs and proactively prepare a PR so the iteration becomes part of the system, not a one-off repair.
 
 ## Interface Boundaries
 - Public backend contract is `/api/*`.

--- a/docs/agent-memory-ppt-iteration.md
+++ b/docs/agent-memory-ppt-iteration.md
@@ -1,0 +1,10 @@
+# Memory: PPT iteration should become a PR
+
+When a user reports a PPT layout problem, remember this policy:
+
+- repair the specific slide immediately
+- extract the reusable layout rule
+- document the rule in the repository
+- proactively submit a PR so the improvement is preserved
+
+Do not treat layout feedback as a one-time artifact fix. Treat it as a system iteration.

--- a/docs/ppt-layout-feedback-loop.md
+++ b/docs/ppt-layout-feedback-loop.md
@@ -1,0 +1,66 @@
+# PPT Layout Feedback Loop
+
+## Why this exists
+
+Generated PPT pages can look correct in HTML while still failing after conversion because of real slide constraints such as fixed height, line wrapping, footer pressure, and card density. When a user reports a visual defect, the fix should not stop at the one page. We should turn the incident into a reusable rule and upstream it through a pull request.
+
+## Trigger conditions
+
+Use this playbook when a user reports any of the following on a generated PPT page:
+
+- text occlusion
+- block overlap
+- footer pressing into cards
+- fixed-height intro boxes clipping wrapped titles
+- three-column information pages becoming too dense after conversion
+
+## Iteration workflow
+
+1. Read the generated HTML page that failed.
+2. Identify the page pattern, not just the local symptom.
+   - Example: top intro banner + three cards + footer
+3. Apply a conservative fix to the generated page first.
+   - Prefer reducing density over squeezing more text in.
+4. Extract the reusable layout rule from the fix.
+5. Record the rule in docs and open a PR proactively.
+
+## Stable rules learned from the 2026-03-28 incident
+
+### Pattern
+A page with:
+- fixed header
+- fixed-height intro box
+- three-column card grid
+- footer note
+
+### What caused the defect
+The intro box and card grid together consumed too much vertical space. After text wrapped during rendering and conversion, the effective content height exceeded the safe slide area and the footer visually pressed into the bottom of the cards.
+
+### Reusable mitigation
+
+- Use `min-height` instead of fixed `height` for intro/summary boxes when title wrapping is possible.
+- For dense three-column information pages, use safer text sizes:
+  - intro title: `26-28px`
+  - intro body: `16px`
+  - card title: `20-22px`
+  - card list text: `16px`
+- Reduce spacing before reducing readability:
+  - card gap: around `20px` instead of `24px+`
+  - card padding: around `18px` instead of `22px+`
+- Keep the effective card area around `340-360px` height when the page also contains an intro box and a footer.
+- Add a top border and top padding to the footer area so it is visually and spatially separated from the main content.
+- Prefer shorter copy in three-column cards. If a card title exceeds two lines, shorten copy first, then reduce font size.
+
+## Default response for future incidents
+
+When the user says a PPT page is blocked/overlapped:
+
+- fix the current generated HTML
+- regenerate the PPTX
+- validate the corrected file
+- add or update a rule in this document
+- create a PR unless the user explicitly says not to
+
+## Rationale
+
+This keeps the PPT generation process self-improving. A user-reported defect becomes repository knowledge, not just a repaired artifact.


### PR DESCRIPTION
## Summary
- document the reusable fix pattern for PPT pages with intro banner + three-column cards + footer
- add a repository memory note that layout feedback should become a PR, not only a one-off artifact repair
- update AGENTS.md so future runs proactively upstream reusable PPT layout fixes

## Why
A user reported that page 2 of a generated PPT had content occlusion. We fixed the page and extracted the general mitigation pattern:
- prefer min-height for intro boxes
- reduce density on three-column info pages
- separate footer from content with border and padding
- upstream the rule after the fix

## Notes
This PR is intentionally documentation-focused so the iteration pattern is preserved and reused in future runs.