### PR TITLE
Fix blank session started_at parsing

### DIFF
--- a/src/agent_teams/sessions/session_repository.py
+++ b/src/agent_teams/sessions/session_repository.py
@@ -72,6 +72,13 @@ class SessionRepository:
             )
         if "started_at" not in columns:
             self._conn.execute("ALTER TABLE sessions ADD COLUMN started_at TEXT")
+        self._conn.execute(
+            """
+            UPDATE sessions
+            SET started_at=NULL
+            WHERE TRIM(COALESCE(started_at, ''))=''
+            """
+        )
         self._conn.commit()
 
     def create(
@@ -278,6 +285,8 @@ class SessionRepository:
         session_id = str(row["session_id"])
         workspace_id = str(row["workspace_id"])
         project_id = str(row["project_id"] or "").strip() or str(row["workspace_id"])
+        started_at_raw = str(row["started_at"] or "").strip()
+        started_at = datetime.fromisoformat(started_at_raw) if started_at_raw else None
         return SessionRecord(
             session_id=session_id,
             workspace_id=workspace_id,
@@ -288,12 +297,8 @@ class SessionRepository:
             normal_root_role_id=str(row["normal_root_role_id"] or "").strip() or None,
             orchestration_preset_id=str(row["orchestration_preset_id"] or "").strip()
             or None,
-            started_at=(
-                datetime.fromisoformat(str(row["started_at"]))
-                if row["started_at"] is not None
-                else None
-            ),
-            can_switch_mode=row["started_at"] is None,
+            started_at=started_at,
+            can_switch_mode=started_at is None,
             created_at=datetime.fromisoformat(str(row["created_at"])),
             updated_at=datetime.fromisoformat(str(row["updated_at"])),
         )

--- a/tests/unit_tests/sessions/test_session_repository.py
+++ b/tests/unit_tests/sessions/test_session_repository.py
@@ -60,11 +60,95 @@ def test_list_all_filters_non_string_metadata_values(tmp_path: Path) -> None:
     }
 
 
+def test_list_all_tolerates_blank_started_at(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_repository_blank_started_at.db"
+    repository = SessionRepository(db_path)
+    _insert_session_row(
+        db_path,
+        session_id="session-blank-started-at",
+        metadata_json="{}",
+        started_at="",
+    )
+
+    records = repository.list_all()
+
+    assert len(records) == 1
+    assert records[0].session_id == "session-blank-started-at"
+    assert records[0].started_at is None
+    assert records[0].can_switch_mode is True
+
+
+def test_repository_init_normalizes_blank_started_at_for_mark_started(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_repository_started_at_cleanup.db"
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        CREATE TABLE sessions (
+            session_id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL DEFAULT '',
+            project_kind TEXT NOT NULL DEFAULT 'workspace',
+            project_id TEXT NOT NULL DEFAULT '',
+            metadata   TEXT NOT NULL,
+            session_mode TEXT NOT NULL DEFAULT 'normal',
+            normal_root_role_id TEXT,
+            orchestration_preset_id TEXT,
+            started_at TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO sessions(
+            session_id,
+            workspace_id,
+            project_kind,
+            project_id,
+            metadata,
+            session_mode,
+            normal_root_role_id,
+            orchestration_preset_id,
+            started_at,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "session-preexisting-blank-started-at",
+            "default",
+            "workspace",
+            "default",
+            "{}",
+            "normal",
+            None,
+            None,
+            "",
+            now,
+            now,
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    repository = SessionRepository(db_path)
+
+    record = repository.mark_started("session-preexisting-blank-started-at")
+
+    assert record.started_at is not None
+    assert record.can_switch_mode is False
+
+
 def _insert_session_row(
     db_path: Path,
     *,
     session_id: str,
     metadata_json: str,
+    started_at: str | None = None,
 ) -> None:
     now = datetime.now(tz=timezone.utc).isoformat()
     connection = sqlite3.connect(db_path)
@@ -94,7 +178,7 @@ def _insert_session_row(
             "normal",
             None,
             None,
-            None,
+            started_at,
             now,
             now,
         ),


### PR DESCRIPTION
## Summary
- normalize blank persisted `started_at` values to `NULL` when initializing the session repository
- treat blank `started_at` values as `None` when hydrating `SessionRecord` so `/api/sessions` no longer crashes on legacy rows
- add regression tests for both listing sessions and `mark_started()` with preexisting blank timestamps

## Testing
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests