### PR TITLE
Fix automation recovery retries and Feishu cleanup

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -863,8 +863,13 @@ CREATE TABLE IF NOT EXISTS automation_deliveries (
     terminal_attempts INTEGER NOT NULL,
     started_message TEXT,
     terminal_message TEXT,
+    started_message_id TEXT,
+    terminal_message_id TEXT,
     started_sent_at TEXT,
     terminal_sent_at TEXT,
+    started_cleanup_status TEXT NOT NULL DEFAULT 'skipped',
+    started_cleanup_attempts INTEGER NOT NULL DEFAULT 0,
+    started_cleaned_at TEXT,
     last_error TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
@@ -879,6 +884,11 @@ CREATE INDEX IF NOT EXISTS idx_automation_deliveries_terminal
 ```
 
 Purpose: persists Feishu delivery state for automation runs so started/completed/failed messages can be retried and resumed after process restart.
+
+Notes:
+- `started_message_id` and `terminal_message_id` store the provider `message_id` returned by Feishu for sent automation messages.
+- `started_cleanup_status`, `started_cleanup_attempts`, and `started_cleaned_at` track best-effort cleanup for superseded non-terminal started messages after a terminal delivery succeeds.
+- terminal messages are persisted but are not automatically deleted by the current cleanup policy.
 
 ### 2.1.4 `automation_bound_session_queue`
 
@@ -899,6 +909,12 @@ CREATE TABLE IF NOT EXISTS automation_bound_session_queue (
     status TEXT NOT NULL,
     start_attempts INTEGER NOT NULL DEFAULT 0,
     next_attempt_at TEXT NOT NULL,
+    resume_attempts INTEGER NOT NULL DEFAULT 0,
+    resume_next_attempt_at TEXT NOT NULL,
+    queue_message_id TEXT,
+    queue_cleanup_status TEXT NOT NULL DEFAULT 'skipped',
+    queue_cleanup_attempts INTEGER NOT NULL DEFAULT 0,
+    queue_cleaned_at TEXT,
     last_error TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
@@ -925,6 +941,9 @@ Notes:
   run is queued
 - `run_id` is populated only after the queued item has successfully started
 - `status` flows through `queued`, `starting`, `waiting_result`, then a terminal state
+- `resume_attempts` and `resume_next_attempt_at` persist the auto-resume retry state for recoverable `awaiting_recovery` runs bound to that session
+- `queue_message_id` stores the Feishu provider `message_id` for the queue receipt
+- `queue_cleanup_status`, `queue_cleanup_attempts`, and `queue_cleaned_at` track best-effort deletion of queue receipts once the queued run starts or a final failure message replaces them
 
 ### 2.1.5 `sessions` additions
 

--- a/docs/feishu-integration.md
+++ b/docs/feishu-integration.md
@@ -167,6 +167,17 @@ rule from inbound chat messages:
   fails and does not fall back to a new `MainAgent` automation session
 - for these automation-bound runs, receipts, terminal result messages, and `im_send`
   tool output all use direct send to the chat, not reply-to-message, even in group chats
+- when a bound run enters recoverable `awaiting_recovery`, the bound-session queue
+  persists auto-resume retry state and retries `resume` with exponential backoff
+  (`10s`, `20s`, `40s`, `80s`, `160s`) before sending a final failure
+- Feishu provider `message_id` values are persisted for automation queue receipts and
+  started/terminal messages so superseded non-terminal messages can be deleted later
+- queue receipts are best-effort deleted after the queued run actually starts or after
+  a final queue-owned failure replaces them
+- started automation messages are best-effort deleted after a terminal completed/failed
+  message is successfully sent
+- cleanup failures are logged and retried, but they do not roll back the primary send
+  or change the run's terminal state
 
 This separates three concerns:
 

--- a/src/agent_teams/automation/__init__.py
+++ b/src/agent_teams/automation/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from agent_teams.automation.automation_models import (
     AutomationBoundSessionQueueRecord,
     AutomationBoundSessionQueueStatus,
+    AutomationCleanupStatus,
     AutomationDeliveryEvent,
     AutomationDeliveryStatus,
     AutomationExecutionHandle,
@@ -52,6 +53,7 @@ __all__ = [
     "AutomationBoundSessionQueueService",
     "AutomationBoundSessionQueueStatus",
     "AutomationBoundSessionQueueWorker",
+    "AutomationCleanupStatus",
     "AutomationDeliveryEvent",
     "AutomationDeliveryRepository",
     "AutomationEventRepository",

--- a/src/agent_teams/automation/automation_bound_session_queue_repository.py
+++ b/src/agent_teams/automation/automation_bound_session_queue_repository.py
@@ -10,6 +10,7 @@ from threading import RLock
 from agent_teams.automation.automation_models import (
     AutomationBoundSessionQueueRecord,
     AutomationBoundSessionQueueStatus,
+    AutomationCleanupStatus,
     AutomationDeliveryEvent,
     AutomationFeishuBinding,
     AutomationRunConfig,
@@ -51,6 +52,12 @@ class AutomationBoundSessionQueueRepository:
                     status                 TEXT NOT NULL,
                     start_attempts         INTEGER NOT NULL DEFAULT 0,
                     next_attempt_at        TEXT NOT NULL,
+                    resume_attempts        INTEGER NOT NULL DEFAULT 0,
+                    resume_next_attempt_at TEXT NOT NULL,
+                    queue_message_id       TEXT,
+                    queue_cleanup_status   TEXT NOT NULL DEFAULT 'skipped',
+                    queue_cleanup_attempts INTEGER NOT NULL DEFAULT 0,
+                    queue_cleaned_at       TEXT,
                     last_error             TEXT,
                     created_at             TEXT NOT NULL,
                     updated_at             TEXT NOT NULL,
@@ -76,6 +83,36 @@ class AutomationBoundSessionQueueRepository:
                 ON automation_bound_session_queue(automation_project_id, created_at DESC)
                 """
             )
+            self._ensure_column(
+                "automation_bound_session_queue",
+                "resume_attempts",
+                "INTEGER NOT NULL DEFAULT 0",
+            )
+            self._ensure_column(
+                "automation_bound_session_queue",
+                "resume_next_attempt_at",
+                "TEXT NOT NULL DEFAULT '1970-01-01T00:00:00+00:00'",
+            )
+            self._ensure_column(
+                "automation_bound_session_queue",
+                "queue_message_id",
+                "TEXT",
+            )
+            self._ensure_column(
+                "automation_bound_session_queue",
+                "queue_cleanup_status",
+                "TEXT NOT NULL DEFAULT 'skipped'",
+            )
+            self._ensure_column(
+                "automation_bound_session_queue",
+                "queue_cleanup_attempts",
+                "INTEGER NOT NULL DEFAULT 0",
+            )
+            self._ensure_column(
+                "automation_bound_session_queue",
+                "queue_cleaned_at",
+                "TEXT",
+            )
 
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -85,6 +122,12 @@ class AutomationBoundSessionQueueRepository:
             repository_name="AutomationBoundSessionQueueRepository",
             operation_name="init_tables",
         )
+
+    def _ensure_column(self, table: str, column: str, ddl: str) -> None:
+        columns = self._conn.execute(f"PRAGMA table_info({table})").fetchall()
+        if any(str(row["name"]) == column for row in columns):
+            return
+        self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl}")
 
     def create(
         self,
@@ -110,12 +153,18 @@ class AutomationBoundSessionQueueRepository:
                     status,
                     start_attempts,
                     next_attempt_at,
+                    resume_attempts,
+                    resume_next_attempt_at,
+                    queue_message_id,
+                    queue_cleanup_status,
+                    queue_cleanup_attempts,
+                    queue_cleaned_at,
                     last_error,
                     created_at,
                     updated_at,
                     completed_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._to_row(record),
             ),
@@ -153,6 +202,12 @@ class AutomationBoundSessionQueueRepository:
                     status=?,
                     start_attempts=?,
                     next_attempt_at=?,
+                    resume_attempts=?,
+                    resume_next_attempt_at=?,
+                    queue_message_id=?,
+                    queue_cleanup_status=?,
+                    queue_cleanup_attempts=?,
+                    queue_cleaned_at=?,
                     last_error=?,
                     updated_at=?,
                     completed_at=?
@@ -172,6 +227,12 @@ class AutomationBoundSessionQueueRepository:
                     record.status.value,
                     record.start_attempts,
                     record.next_attempt_at.isoformat(),
+                    record.resume_attempts,
+                    record.resume_next_attempt_at.isoformat(),
+                    record.queue_message_id,
+                    record.queue_cleanup_status.value,
+                    record.queue_cleanup_attempts,
+                    _to_iso(record.queue_cleaned_at),
                     record.last_error,
                     record.updated_at.isoformat(),
                     _to_iso(record.completed_at),
@@ -333,6 +394,85 @@ class AutomationBoundSessionQueueRepository:
             return None
         return self.get(automation_queue_id)
 
+    def list_pending_queue_cleanup(
+        self,
+        *,
+        limit: int = 20,
+        stale_before: datetime | None = None,
+    ) -> tuple[AutomationBoundSessionQueueRecord, ...]:
+        safe_limit = max(1, min(limit, 100))
+        if stale_before is None:
+            with self._lock:
+                rows = self._conn.execute(
+                    """
+                    SELECT *
+                    FROM automation_bound_session_queue
+                    WHERE queue_cleanup_status=?
+                    ORDER BY updated_at ASC
+                    LIMIT ?
+                    """,
+                    (AutomationCleanupStatus.PENDING.value, safe_limit),
+                ).fetchall()
+        else:
+            with self._lock:
+                rows = self._conn.execute(
+                    """
+                    SELECT *
+                    FROM automation_bound_session_queue
+                    WHERE queue_cleanup_status=?
+                       OR (queue_cleanup_status=? AND updated_at<=?)
+                    ORDER BY updated_at ASC
+                    LIMIT ?
+                    """,
+                    (
+                        AutomationCleanupStatus.PENDING.value,
+                        AutomationCleanupStatus.CLEANING.value,
+                        stale_before.isoformat(),
+                        safe_limit,
+                    ),
+                ).fetchall()
+        return tuple(self._to_record(row) for row in rows)
+
+    def claim_queue_cleanup(
+        self,
+        *,
+        automation_queue_id: str,
+        stale_before: datetime,
+    ) -> AutomationBoundSessionQueueRecord | None:
+        updated_at = datetime.now(tz=stale_before.tzinfo).isoformat()
+        updated = run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                    UPDATE automation_bound_session_queue
+                    SET queue_cleanup_status=?,
+                        updated_at=?
+                    WHERE automation_queue_id=?
+                      AND (
+                        queue_cleanup_status=?
+                        OR (queue_cleanup_status=? AND updated_at<=?)
+                      )
+                    """,
+                    (
+                        AutomationCleanupStatus.CLEANING.value,
+                        updated_at,
+                        automation_queue_id,
+                        AutomationCleanupStatus.PENDING.value,
+                        AutomationCleanupStatus.CLEANING.value,
+                        stale_before.isoformat(),
+                    ),
+                ).rowcount
+            ),
+            lock=self._lock,
+            repository_name="AutomationBoundSessionQueueRepository",
+            operation_name="claim_queue_cleanup",
+        )
+        if updated <= 0:
+            return None
+        return self.get(automation_queue_id)
+
     def delete_by_project(self, automation_project_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -365,6 +505,12 @@ class AutomationBoundSessionQueueRepository:
             record.status.value,
             record.start_attempts,
             record.next_attempt_at.isoformat(),
+            record.resume_attempts,
+            record.resume_next_attempt_at.isoformat(),
+            record.queue_message_id,
+            record.queue_cleanup_status.value,
+            record.queue_cleanup_attempts,
+            _to_iso(record.queue_cleaned_at),
             record.last_error,
             record.created_at.isoformat(),
             record.updated_at.isoformat(),
@@ -389,6 +535,20 @@ class AutomationBoundSessionQueueRepository:
             status=AutomationBoundSessionQueueStatus(str(row["status"])),
             start_attempts=int(row["start_attempts"] or 0),
             next_attempt_at=datetime.fromisoformat(str(row["next_attempt_at"])),
+            resume_attempts=int(row["resume_attempts"] or 0),
+            resume_next_attempt_at=datetime.fromisoformat(
+                str(row["resume_next_attempt_at"])
+            ),
+            queue_message_id=(
+                str(row["queue_message_id"])
+                if row["queue_message_id"] is not None
+                else None
+            ),
+            queue_cleanup_status=AutomationCleanupStatus(
+                str(row["queue_cleanup_status"])
+            ),
+            queue_cleanup_attempts=int(row["queue_cleanup_attempts"] or 0),
+            queue_cleaned_at=_from_iso(row["queue_cleaned_at"]),
             last_error=str(row["last_error"])
             if row["last_error"] is not None
             else None,

--- a/src/agent_teams/automation/automation_bound_session_queue_service.py
+++ b/src/agent_teams/automation/automation_bound_session_queue_service.py
@@ -14,6 +14,7 @@ from agent_teams.automation.automation_delivery_service import AutomationDeliver
 from agent_teams.automation.automation_models import (
     AutomationBoundSessionQueueRecord,
     AutomationBoundSessionQueueStatus,
+    AutomationCleanupStatus,
     AutomationDeliveryEvent,
     AutomationExecutionHandle,
     AutomationFeishuBinding,
@@ -29,6 +30,8 @@ from agent_teams.sessions.runs.run_models import (
     RuntimePromptConversationContext,
 )
 from agent_teams.sessions.runs.run_runtime_repo import (
+    RunRuntimeRecord,
+    RunRuntimePhase,
     RunRuntimeRepository,
     RunRuntimeStatus,
 )
@@ -37,6 +40,8 @@ from agent_teams.sessions.session_models import SessionRecord
 logger = get_logger(__name__)
 
 _START_MAX_ATTEMPTS = 5
+_RESUME_MAX_ATTEMPTS = 5
+_QUEUE_CLEANUP_MAX_ATTEMPTS = 5
 _CLAIM_STALE_AFTER_SECONDS = 60
 
 
@@ -48,6 +53,8 @@ class RunServiceLike(Protocol):
     def create_detached_run(self, intent: IntentInput) -> tuple[str, str]: ...
 
     def ensure_run_started(self, run_id: str) -> None: ...
+
+    def resume_run(self, run_id: str) -> str: ...
 
 
 class FeishuRuntimeConfigLookup(Protocol):
@@ -67,6 +74,13 @@ class FeishuClientLike(Protocol):
         *,
         chat_id: str,
         text: str,
+        environment: FeishuEnvironment | None = None,
+    ) -> str: ...
+
+    def delete_message(
+        self,
+        *,
+        message_id: str,
         environment: FeishuEnvironment | None = None,
     ) -> None: ...
 
@@ -150,10 +164,18 @@ class AutomationBoundSessionQueueService:
                     ),
                 )
             )
-            self._send_direct_text(
+            queue_message_id = self._send_direct_text(
                 record.binding.trigger_id,
                 record.binding.chat_id,
                 record.queue_message,
+            )
+            _ = self._repository.update(
+                record.model_copy(
+                    update={
+                        "queue_message_id": queue_message_id,
+                        "updated_at": _utc_now(),
+                    }
+                )
             )
             return AutomationExecutionHandle(session_id=session_id, queued=True)
 
@@ -181,6 +203,7 @@ class AutomationBoundSessionQueueService:
         progress = False
         progress = self._finalize_waiting_results(limit=limit) or progress
         progress = self._start_queued_runs(limit=limit) or progress
+        progress = self._cleanup_queue_receipts(limit=limit) or progress
         return progress
 
     def delete_project_queue(self, automation_project_id: str) -> None:
@@ -207,6 +230,7 @@ class AutomationBoundSessionQueueService:
             runtime = self._run_runtime_repo.get(run_id)
             if runtime is None:
                 continue
+            runtime = self._normalize_recovery_runtime(runtime)
             if runtime.status == RunRuntimeStatus.COMPLETED:
                 _ = self._repository.update(
                     record.model_copy(
@@ -220,8 +244,17 @@ class AutomationBoundSessionQueueService:
                 )
                 progress = True
                 continue
+            if self._should_auto_resume(runtime):
+                updated_record, changed = self._handle_recoverable_runtime(
+                    record=record,
+                    runtime=runtime,
+                )
+                record = updated_record
+                progress = changed or progress
+                if changed:
+                    continue
             if runtime.status == RunRuntimeStatus.FAILED:
-                _ = self._repository.update(
+                final_record = self._repository.update(
                     record.model_copy(
                         update={
                             "status": AutomationBoundSessionQueueStatus.FAILED,
@@ -230,6 +263,23 @@ class AutomationBoundSessionQueueService:
                             "updated_at": now,
                         }
                     )
+                )
+                failure_message = _build_start_failure_message(
+                    project_name=record.automation_project_name,
+                    error=str(runtime.last_error or "").strip(),
+                )
+                _ = self._send_direct_text(
+                    record.binding.trigger_id,
+                    record.binding.chat_id,
+                    failure_message,
+                )
+                _ = self._schedule_queue_cleanup(
+                    final_record,
+                    updated_at=_utc_now(),
+                )
+                self._delivery_service.mark_terminal_delivery_skipped(
+                    run_id=run_id,
+                    terminal_message=failure_message,
                 )
                 progress = True
         return progress
@@ -269,17 +319,22 @@ class AutomationBoundSessionQueueService:
                 self._handle_start_failure(claimed, error=str(exc))
                 continue
             started_at = _utc_now()
-            _ = self._repository.update(
+            started_record = self._repository.update(
                 claimed.model_copy(
                     update={
                         "run_id": run_id,
                         "status": AutomationBoundSessionQueueStatus.WAITING_RESULT,
                         "start_attempts": claimed.start_attempts + 1,
                         "next_attempt_at": started_at,
+                        "resume_next_attempt_at": started_at,
                         "last_error": None,
                         "updated_at": started_at,
                     }
                 )
+            )
+            _ = self._schedule_queue_cleanup(
+                started_record,
+                updated_at=started_at,
             )
             self._touch_project_started(
                 automation_project_id=claimed.automation_project_id,
@@ -339,7 +394,7 @@ class AutomationBoundSessionQueueService:
         attempts = record.start_attempts + 1
         now = _utc_now()
         if attempts >= _START_MAX_ATTEMPTS:
-            _ = self._repository.update(
+            failed_record = self._repository.update(
                 record.model_copy(
                     update={
                         "status": AutomationBoundSessionQueueStatus.FAILED,
@@ -350,7 +405,7 @@ class AutomationBoundSessionQueueService:
                     }
                 )
             )
-            self._send_direct_text(
+            _ = self._send_direct_text(
                 record.binding.trigger_id,
                 record.binding.chat_id,
                 _build_start_failure_message(
@@ -358,6 +413,7 @@ class AutomationBoundSessionQueueService:
                     error=error,
                 ),
             )
+            _ = self._schedule_queue_cleanup(failed_record, updated_at=_utc_now())
             return
         _ = self._repository.update(
             record.model_copy(
@@ -378,14 +434,259 @@ class AutomationBoundSessionQueueService:
             reverse=True,
         )
         for runtime in runtimes:
-            if runtime.status in {
+            normalized_runtime = self._normalize_recovery_runtime(runtime)
+            if normalized_runtime.status in {
                 RunRuntimeStatus.QUEUED,
                 RunRuntimeStatus.RUNNING,
                 RunRuntimeStatus.PAUSED,
                 RunRuntimeStatus.STOPPED,
-            }:
+            } or self._should_auto_resume(normalized_runtime):
                 return runtime.run_id
         return None
+
+    def _handle_recoverable_runtime(
+        self,
+        *,
+        record: AutomationBoundSessionQueueRecord,
+        runtime: RunRuntimeRecord,
+    ) -> tuple[AutomationBoundSessionQueueRecord, bool]:
+        now = _utc_now()
+        if (
+            record.resume_attempts == 0
+            and record.resume_next_attempt_at <= record.updated_at
+        ):
+            next_record = self._repository.update(
+                record.model_copy(
+                    update={
+                        "resume_next_attempt_at": now + _resume_backoff_for_attempt(1),
+                        "last_error": runtime.last_error,
+                        "updated_at": now,
+                    }
+                )
+            )
+            return next_record, True
+        if record.resume_next_attempt_at > now:
+            return record, False
+        if record.resume_attempts >= _RESUME_MAX_ATTEMPTS:
+            failed_record = self._repository.update(
+                record.model_copy(
+                    update={
+                        "status": AutomationBoundSessionQueueStatus.FAILED,
+                        "last_error": runtime.last_error or record.last_error,
+                        "completed_at": now,
+                        "updated_at": now,
+                    }
+                )
+            )
+            failure_message = _build_resume_failure_message(
+                project_name=record.automation_project_name,
+                error=str(runtime.last_error or record.last_error or "").strip(),
+            )
+            _ = self._send_direct_text(
+                record.binding.trigger_id,
+                record.binding.chat_id,
+                failure_message,
+            )
+            _ = self._schedule_queue_cleanup(
+                failed_record,
+                updated_at=_utc_now(),
+            )
+            self._delivery_service.mark_terminal_delivery_skipped(
+                run_id=runtime.run_id,
+                terminal_message=failure_message,
+            )
+            return failed_record, True
+        attempts = record.resume_attempts + 1
+        try:
+            _ = self._run_service.resume_run(runtime.run_id)
+        except RuntimeError as exc:
+            if attempts >= _RESUME_MAX_ATTEMPTS:
+                failed_record = self._repository.update(
+                    record.model_copy(
+                        update={
+                            "status": AutomationBoundSessionQueueStatus.FAILED,
+                            "resume_attempts": attempts,
+                            "last_error": str(exc),
+                            "completed_at": now,
+                            "updated_at": now,
+                        }
+                    )
+                )
+                failure_message = _build_resume_failure_message(
+                    project_name=record.automation_project_name,
+                    error=str(exc),
+                )
+                _ = self._send_direct_text(
+                    record.binding.trigger_id,
+                    record.binding.chat_id,
+                    failure_message,
+                )
+                _ = self._schedule_queue_cleanup(
+                    failed_record,
+                    updated_at=_utc_now(),
+                )
+                self._delivery_service.mark_terminal_delivery_skipped(
+                    run_id=runtime.run_id,
+                    terminal_message=failure_message,
+                )
+                return failed_record, True
+            next_record = self._repository.update(
+                record.model_copy(
+                    update={
+                        "resume_attempts": attempts,
+                        "resume_next_attempt_at": now
+                        + _resume_backoff_for_attempt(attempts + 1),
+                        "last_error": str(exc),
+                        "updated_at": now,
+                    }
+                )
+            )
+            return next_record, True
+        next_record = self._repository.update(
+            record.model_copy(
+                update={
+                    "resume_attempts": attempts,
+                    "resume_next_attempt_at": now
+                    + _resume_backoff_for_attempt(attempts + 1),
+                    "last_error": None,
+                    "updated_at": now,
+                }
+            )
+        )
+        return next_record, True
+
+    def _should_auto_resume(self, runtime: RunRuntimeRecord) -> bool:
+        if runtime.phase != RunRuntimePhase.AWAITING_RECOVERY:
+            return False
+        return runtime.status in {
+            RunRuntimeStatus.PAUSED,
+            RunRuntimeStatus.STOPPED,
+            RunRuntimeStatus.FAILED,
+        }
+
+    def _normalize_recovery_runtime(
+        self, runtime: RunRuntimeRecord
+    ) -> RunRuntimeRecord:
+        if not (
+            runtime.phase == RunRuntimePhase.AWAITING_RECOVERY
+            and runtime.status == RunRuntimeStatus.FAILED
+        ):
+            return runtime
+        repaired = self._run_runtime_repo.update(
+            runtime.run_id,
+            status=RunRuntimeStatus.PAUSED,
+        )
+        log_event(
+            logger,
+            logging.WARNING,
+            event="automation.bound_session_queue.runtime_repaired",
+            message="Repaired dirty recoverable runtime state",
+            payload={
+                "run_id": runtime.run_id,
+                "from_status": RunRuntimeStatus.FAILED.value,
+                "to_status": RunRuntimeStatus.PAUSED.value,
+            },
+        )
+        return repaired
+
+    def _schedule_queue_cleanup(
+        self,
+        record: AutomationBoundSessionQueueRecord,
+        *,
+        updated_at: datetime,
+    ) -> AutomationBoundSessionQueueRecord:
+        if not str(record.queue_message_id or "").strip():
+            return record
+        if record.queue_cleanup_status in {
+            AutomationCleanupStatus.CLEANING,
+            AutomationCleanupStatus.CLEANED,
+            AutomationCleanupStatus.PENDING,
+        }:
+            return record
+        return self._repository.update(
+            record.model_copy(
+                update={
+                    "queue_cleanup_status": AutomationCleanupStatus.PENDING,
+                    "updated_at": updated_at,
+                }
+            )
+        )
+
+    def _cleanup_queue_receipts(self, *, limit: int) -> bool:
+        progress = False
+        stale_before = _utc_now() - timedelta(seconds=_CLAIM_STALE_AFTER_SECONDS)
+        for record in self._repository.list_pending_queue_cleanup(
+            limit=limit,
+            stale_before=stale_before,
+        ):
+            message_id = str(record.queue_message_id or "").strip()
+            if not message_id:
+                now = _utc_now()
+                _ = self._repository.update(
+                    record.model_copy(
+                        update={
+                            "queue_cleanup_status": AutomationCleanupStatus.SKIPPED,
+                            "updated_at": now,
+                        }
+                    )
+                )
+                progress = True
+                continue
+            claimed = self._repository.claim_queue_cleanup(
+                automation_queue_id=record.automation_queue_id,
+                stale_before=stale_before,
+            )
+            if claimed is None:
+                continue
+            attempts = claimed.queue_cleanup_attempts + 1
+            try:
+                self._delete_message(
+                    claimed.binding.trigger_id,
+                    message_id,
+                )
+            except RuntimeError as exc:
+                next_status = (
+                    AutomationCleanupStatus.FAILED
+                    if attempts >= _QUEUE_CLEANUP_MAX_ATTEMPTS
+                    else AutomationCleanupStatus.PENDING
+                )
+                now = _utc_now()
+                _ = self._repository.update(
+                    claimed.model_copy(
+                        update={
+                            "queue_cleanup_status": next_status,
+                            "queue_cleanup_attempts": attempts,
+                            "updated_at": now,
+                        }
+                    )
+                )
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    event="automation.bound_session_queue.cleanup_failed",
+                    message="Automation queue receipt cleanup failed",
+                    payload={
+                        "automation_queue_id": claimed.automation_queue_id,
+                        "message_id": message_id,
+                        "attempt": attempts,
+                        "error": str(exc),
+                    },
+                )
+                progress = True
+                continue
+            now = _utc_now()
+            _ = self._repository.update(
+                claimed.model_copy(
+                    update={
+                        "queue_cleanup_status": AutomationCleanupStatus.CLEANED,
+                        "queue_cleanup_attempts": attempts,
+                        "queue_cleaned_at": now,
+                        "updated_at": now,
+                    }
+                )
+            )
+            progress = True
+        return progress
 
     def _touch_project_started(
         self,
@@ -409,15 +710,26 @@ class AutomationBoundSessionQueueService:
             )
         )
 
-    def _send_direct_text(self, trigger_id: str, chat_id: str, text: str) -> None:
+    def _send_direct_text(self, trigger_id: str, chat_id: str, text: str) -> str:
         runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
             trigger_id
         )
         if runtime_config is None:
             raise RuntimeError("missing_runtime_config")
-        self._feishu_client.send_text_message(
+        return self._feishu_client.send_text_message(
             chat_id=chat_id,
             text=text,
+            environment=runtime_config.environment,
+        )
+
+    def _delete_message(self, trigger_id: str, message_id: str) -> None:
+        runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
+            trigger_id
+        )
+        if runtime_config is None:
+            raise RuntimeError("missing_runtime_config")
+        self._feishu_client.delete_message(
+            message_id=message_id,
             environment=runtime_config.environment,
         )
 
@@ -487,6 +799,11 @@ def _build_start_failure_message(*, project_name: str, error: str) -> str:
     return f"定时任务 {project_name} 执行失败。\n\n{failure_detail}"
 
 
+def _build_resume_failure_message(*, project_name: str, error: str) -> str:
+    failure_detail = str(error).strip() or "未知错误。"
+    return f"定时任务 {project_name} 自动恢复失败。\n\n{failure_detail}"
+
+
 def _backoff_for_attempt(attempt: int) -> timedelta:
     if attempt <= 1:
         return timedelta(seconds=1)
@@ -495,6 +812,11 @@ def _backoff_for_attempt(attempt: int) -> timedelta:
     if attempt == 3:
         return timedelta(seconds=15)
     return timedelta(minutes=1)
+
+
+def _resume_backoff_for_attempt(attempt: int) -> timedelta:
+    safe_attempt = max(1, attempt)
+    return timedelta(seconds=10 * (2 ** (safe_attempt - 1)))
 
 
 def _utc_now() -> datetime:

--- a/src/agent_teams/automation/automation_delivery_repository.py
+++ b/src/agent_teams/automation/automation_delivery_repository.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from threading import RLock
 
 from agent_teams.automation.automation_models import (
+    AutomationCleanupStatus,
     AutomationDeliveryEvent,
     AutomationDeliveryStatus,
     AutomationFeishuBinding,
@@ -44,8 +45,13 @@ class AutomationDeliveryRepository:
                     terminal_attempts INTEGER NOT NULL,
                     started_message TEXT,
                     terminal_message TEXT,
+                    started_message_id TEXT,
+                    terminal_message_id TEXT,
                     started_sent_at TEXT,
                     terminal_sent_at TEXT,
+                    started_cleanup_status TEXT NOT NULL DEFAULT 'skipped',
+                    started_cleanup_attempts INTEGER NOT NULL DEFAULT 0,
+                    started_cleaned_at TEXT,
                     last_error TEXT,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
@@ -70,6 +76,31 @@ class AutomationDeliveryRepository:
                 ON automation_deliveries(terminal_status, updated_at ASC)
                 """
             )
+            self._ensure_column(
+                "automation_deliveries",
+                "started_message_id",
+                "TEXT",
+            )
+            self._ensure_column(
+                "automation_deliveries",
+                "terminal_message_id",
+                "TEXT",
+            )
+            self._ensure_column(
+                "automation_deliveries",
+                "started_cleanup_status",
+                "TEXT NOT NULL DEFAULT 'skipped'",
+            )
+            self._ensure_column(
+                "automation_deliveries",
+                "started_cleanup_attempts",
+                "INTEGER NOT NULL DEFAULT 0",
+            )
+            self._ensure_column(
+                "automation_deliveries",
+                "started_cleaned_at",
+                "TEXT",
+            )
 
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -79,6 +110,12 @@ class AutomationDeliveryRepository:
             repository_name="AutomationDeliveryRepository",
             operation_name="init_tables",
         )
+
+    def _ensure_column(self, table: str, column: str, ddl: str) -> None:
+        columns = self._conn.execute(f"PRAGMA table_info({table})").fetchall()
+        if any(str(row["name"]) == column for row in columns):
+            return
+        self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl}")
 
     def create(
         self, record: AutomationRunDeliveryRecord
@@ -104,13 +141,18 @@ class AutomationDeliveryRepository:
                     terminal_attempts,
                     started_message,
                     terminal_message,
+                    started_message_id,
+                    terminal_message_id,
                     started_sent_at,
                     terminal_sent_at,
+                    started_cleanup_status,
+                    started_cleanup_attempts,
+                    started_cleaned_at,
                     last_error,
                     created_at,
                     updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._to_row(record),
             ),
@@ -142,8 +184,13 @@ class AutomationDeliveryRepository:
                     terminal_attempts=?,
                     started_message=?,
                     terminal_message=?,
+                    started_message_id=?,
+                    terminal_message_id=?,
                     started_sent_at=?,
                     terminal_sent_at=?,
+                    started_cleanup_status=?,
+                    started_cleanup_attempts=?,
+                    started_cleaned_at=?,
                     last_error=?,
                     updated_at=?
                 WHERE automation_delivery_id=?
@@ -164,8 +211,13 @@ class AutomationDeliveryRepository:
                     record.terminal_attempts,
                     record.started_message,
                     record.terminal_message,
+                    record.started_message_id,
+                    record.terminal_message_id,
                     _to_iso(record.started_sent_at),
                     _to_iso(record.terminal_sent_at),
+                    record.started_cleanup_status.value,
+                    record.started_cleanup_attempts,
+                    _to_iso(record.started_cleaned_at),
                     record.last_error,
                     record.updated_at.isoformat(),
                     record.automation_delivery_id,
@@ -352,6 +404,89 @@ class AutomationDeliveryRepository:
             return None
         return self._to_record(row)
 
+    def list_pending_started_cleanup(
+        self,
+        *,
+        limit: int = 20,
+        stale_before: datetime | None = None,
+    ) -> tuple[AutomationRunDeliveryRecord, ...]:
+        if stale_before is None:
+            rows = self._conn.execute(
+                """
+                SELECT *
+                FROM automation_deliveries
+                WHERE started_cleanup_status=?
+                ORDER BY updated_at ASC
+                LIMIT ?
+                """,
+                (AutomationCleanupStatus.PENDING.value, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT *
+                FROM automation_deliveries
+                WHERE started_cleanup_status=?
+                   OR (started_cleanup_status=? AND updated_at<=?)
+                ORDER BY updated_at ASC
+                LIMIT ?
+                """,
+                (
+                    AutomationCleanupStatus.PENDING.value,
+                    AutomationCleanupStatus.CLEANING.value,
+                    stale_before.isoformat(),
+                    limit,
+                ),
+            ).fetchall()
+        return tuple(self._to_record(row) for row in rows)
+
+    def claim_started_cleanup(
+        self,
+        *,
+        automation_delivery_id: str,
+        stale_before: datetime,
+    ) -> AutomationRunDeliveryRecord | None:
+        claimed_at = stale_before.isoformat()
+        updated_at = datetime.now(tz=stale_before.tzinfo).isoformat()
+        updated = run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                UPDATE automation_deliveries
+                SET started_cleanup_status=?,
+                    updated_at=?
+                WHERE automation_delivery_id=?
+                  AND (
+                    started_cleanup_status=?
+                    OR (started_cleanup_status=? AND updated_at<=?)
+                  )
+                """,
+                    (
+                        AutomationCleanupStatus.CLEANING.value,
+                        updated_at,
+                        automation_delivery_id,
+                        AutomationCleanupStatus.PENDING.value,
+                        AutomationCleanupStatus.CLEANING.value,
+                        claimed_at,
+                    ),
+                ).rowcount
+            ),
+            lock=self._lock,
+            repository_name="AutomationDeliveryRepository",
+            operation_name="claim_started_cleanup",
+        )
+        if updated <= 0:
+            return None
+        row = self._conn.execute(
+            "SELECT * FROM automation_deliveries WHERE automation_delivery_id=?",
+            (automation_delivery_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._to_record(row)
+
     def delete_by_project(self, automation_project_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -382,8 +517,13 @@ class AutomationDeliveryRepository:
             record.terminal_attempts,
             record.started_message,
             record.terminal_message,
+            record.started_message_id,
+            record.terminal_message_id,
             _to_iso(record.started_sent_at),
             _to_iso(record.terminal_sent_at),
+            record.started_cleanup_status.value,
+            record.started_cleanup_attempts,
+            _to_iso(record.started_cleaned_at),
             record.last_error,
             record.created_at.isoformat(),
             record.updated_at.isoformat(),
@@ -419,8 +559,23 @@ class AutomationDeliveryRepository:
                 if row["terminal_message"] is not None
                 else None
             ),
+            started_message_id=(
+                str(row["started_message_id"])
+                if row["started_message_id"] is not None
+                else None
+            ),
+            terminal_message_id=(
+                str(row["terminal_message_id"])
+                if row["terminal_message_id"] is not None
+                else None
+            ),
             started_sent_at=_from_iso(row["started_sent_at"]),
             terminal_sent_at=_from_iso(row["terminal_sent_at"]),
+            started_cleanup_status=AutomationCleanupStatus(
+                str(row["started_cleanup_status"])
+            ),
+            started_cleanup_attempts=int(row["started_cleanup_attempts"] or 0),
+            started_cleaned_at=_from_iso(row["started_cleaned_at"]),
             last_error=str(row["last_error"])
             if row["last_error"] is not None
             else None,

--- a/src/agent_teams/automation/automation_delivery_service.py
+++ b/src/agent_teams/automation/automation_delivery_service.py
@@ -11,6 +11,7 @@ from agent_teams.automation.automation_delivery_repository import (
     AutomationDeliveryRepository,
 )
 from agent_teams.automation.automation_models import (
+    AutomationCleanupStatus,
     AutomationDeliveryEvent,
     AutomationDeliveryStatus,
     AutomationFeishuBinding,
@@ -21,6 +22,7 @@ from agent_teams.gateway.feishu.models import FeishuEnvironment
 from agent_teams.logger import get_logger, log_event
 from agent_teams.sessions.runs.event_log import EventLog
 from agent_teams.sessions.runs.run_runtime_repo import (
+    RunRuntimePhase,
     RunRuntimeRepository,
     RunRuntimeStatus,
 )
@@ -34,6 +36,7 @@ logger = get_logger(__name__)
 
 _STARTED_MAX_ATTEMPTS = 3
 _TERMINAL_MAX_ATTEMPTS = 5
+_CLEANUP_MAX_ATTEMPTS = 5
 _CLAIM_STALE_AFTER_SECONDS = 60
 
 
@@ -54,6 +57,13 @@ class FeishuClientLike(Protocol):
         *,
         chat_id: str,
         text: str,
+        environment: FeishuEnvironment | None = None,
+    ) -> str: ...
+
+    def delete_message(
+        self,
+        *,
+        message_id: str,
         environment: FeishuEnvironment | None = None,
     ) -> None: ...
 
@@ -155,10 +165,43 @@ class AutomationDeliveryService:
             stale_before=stale_before,
         ):
             progress = self._attempt_terminal_delivery(record) or progress
+        for record in self._repository.list_pending_started_cleanup(
+            limit=limit,
+            stale_before=stale_before,
+        ):
+            progress = self._attempt_started_cleanup(record) or progress
         return progress
 
     def delete_project_deliveries(self, automation_project_id: str) -> None:
         self._repository.delete_by_project(automation_project_id)
+
+    def mark_terminal_delivery_skipped(
+        self,
+        *,
+        run_id: str,
+        terminal_message: str | None = None,
+    ) -> None:
+        try:
+            record = self._repository.get_by_run_id(run_id)
+        except KeyError:
+            return
+        if record.terminal_status == AutomationDeliveryStatus.SENT:
+            return
+        now = _utc_now()
+        _ = self._repository.update(
+            record.model_copy(
+                update={
+                    "terminal_event": AutomationDeliveryEvent.FAILED,
+                    "terminal_status": AutomationDeliveryStatus.SKIPPED,
+                    "terminal_message": (
+                        terminal_message
+                        if terminal_message is not None
+                        else record.terminal_message
+                    ),
+                    "updated_at": now,
+                }
+            )
+        )
 
     def _attempt_started_delivery(self, record: AutomationRunDeliveryRecord) -> bool:
         claim_cutoff = _utc_now() - timedelta(seconds=_CLAIM_STALE_AFTER_SECONDS)
@@ -175,7 +218,7 @@ class AutomationDeliveryService:
             return False
         attempts = claimed.started_attempts + 1
         try:
-            self._send_text(
+            message_id = self._send_text(
                 trigger_id=claimed.binding.trigger_id,
                 chat_id=claimed.binding.chat_id,
                 text=str(claimed.started_message or "").strip(),
@@ -204,6 +247,7 @@ class AutomationDeliveryService:
                 update={
                     "started_attempts": attempts,
                     "started_status": AutomationDeliveryStatus.SENT,
+                    "started_message_id": message_id,
                     "started_sent_at": now,
                     "last_error": None,
                     "updated_at": now,
@@ -223,6 +267,8 @@ class AutomationDeliveryService:
             RunRuntimeStatus.COMPLETED,
             RunRuntimeStatus.FAILED,
         }:
+            return False
+        if runtime.phase == RunRuntimePhase.AWAITING_RECOVERY:
             return False
         claim_cutoff = _utc_now() - timedelta(seconds=_CLAIM_STALE_AFTER_SECONDS)
         claimed = self._repository.claim_terminal(
@@ -261,7 +307,7 @@ class AutomationDeliveryService:
             return True
         attempts = claimed.terminal_attempts + 1
         try:
-            self._send_text(
+            message_id = self._send_text(
                 trigger_id=claimed.binding.trigger_id,
                 chat_id=claimed.binding.chat_id,
                 text=terminal_message,
@@ -292,9 +338,15 @@ class AutomationDeliveryService:
                 update={
                     "terminal_event": terminal_event,
                     "terminal_message": terminal_message,
+                    "terminal_message_id": message_id,
                     "terminal_attempts": attempts,
                     "terminal_status": AutomationDeliveryStatus.SENT,
                     "terminal_sent_at": now,
+                    "started_cleanup_status": (
+                        AutomationCleanupStatus.PENDING
+                        if str(claimed.started_message_id or "").strip()
+                        else claimed.started_cleanup_status
+                    ),
                     "last_error": None,
                     "updated_at": now,
                 }
@@ -302,15 +354,99 @@ class AutomationDeliveryService:
         )
         return True
 
-    def _send_text(self, *, trigger_id: str, chat_id: str, text: str) -> None:
+    def _attempt_started_cleanup(self, record: AutomationRunDeliveryRecord) -> bool:
+        if record.started_cleanup_status not in {
+            AutomationCleanupStatus.PENDING,
+            AutomationCleanupStatus.CLEANING,
+        }:
+            return False
+        message_id = str(record.started_message_id or "").strip()
+        if not message_id:
+            now = _utc_now()
+            _ = self._repository.update(
+                record.model_copy(
+                    update={
+                        "started_cleanup_status": AutomationCleanupStatus.SKIPPED,
+                        "updated_at": now,
+                    }
+                )
+            )
+            return True
+        claim_cutoff = _utc_now() - timedelta(seconds=_CLAIM_STALE_AFTER_SECONDS)
+        claimed = self._repository.claim_started_cleanup(
+            automation_delivery_id=record.automation_delivery_id,
+            stale_before=claim_cutoff,
+        )
+        if claimed is None:
+            return False
+        attempts = claimed.started_cleanup_attempts + 1
+        try:
+            self._delete_message(
+                trigger_id=claimed.binding.trigger_id,
+                message_id=message_id,
+            )
+        except RuntimeError as exc:
+            next_status = (
+                AutomationCleanupStatus.FAILED
+                if attempts >= _CLEANUP_MAX_ATTEMPTS
+                else AutomationCleanupStatus.PENDING
+            )
+            now = _utc_now()
+            _ = self._repository.update(
+                claimed.model_copy(
+                    update={
+                        "started_cleanup_status": next_status,
+                        "started_cleanup_attempts": attempts,
+                        "updated_at": now,
+                    }
+                )
+            )
+            log_event(
+                logger,
+                logging.WARNING,
+                event="automation.delivery.cleanup_failed",
+                message="Automation started-message cleanup failed",
+                payload={
+                    "run_id": claimed.run_id,
+                    "message_id": message_id,
+                    "attempt": attempts,
+                    "error": str(exc),
+                },
+            )
+            return True
+        now = _utc_now()
+        _ = self._repository.update(
+            claimed.model_copy(
+                update={
+                    "started_cleanup_status": AutomationCleanupStatus.CLEANED,
+                    "started_cleanup_attempts": attempts,
+                    "started_cleaned_at": now,
+                    "updated_at": now,
+                }
+            )
+        )
+        return True
+
+    def _send_text(self, *, trigger_id: str, chat_id: str, text: str) -> str:
         runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
             trigger_id
         )
         if runtime_config is None:
             raise RuntimeError("missing_runtime_config")
-        self._feishu_client.send_text_message(
+        return self._feishu_client.send_text_message(
             chat_id=chat_id,
             text=text,
+            environment=runtime_config.environment,
+        )
+
+    def _delete_message(self, *, trigger_id: str, message_id: str) -> None:
+        runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
+            trigger_id
+        )
+        if runtime_config is None:
+            raise RuntimeError("missing_runtime_config")
+        self._feishu_client.delete_message(
+            message_id=message_id,
             environment=runtime_config.environment,
         )
 

--- a/src/agent_teams/automation/automation_models.py
+++ b/src/agent_teams/automation/automation_models.py
@@ -36,6 +36,14 @@ class AutomationDeliveryStatus(str, Enum):
     FAILED = "failed"
 
 
+class AutomationCleanupStatus(str, Enum):
+    PENDING = "pending"
+    CLEANING = "cleaning"
+    CLEANED = "cleaned"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
 class AutomationBoundSessionQueueStatus(str, Enum):
     QUEUED = "queued"
     STARTING = "starting"
@@ -174,8 +182,13 @@ class AutomationRunDeliveryRecord(BaseModel):
     terminal_attempts: int = Field(default=0, ge=0)
     started_message: str | None = None
     terminal_message: str | None = None
+    started_message_id: str | None = None
+    terminal_message_id: str | None = None
     started_sent_at: datetime | None = None
     terminal_sent_at: datetime | None = None
+    started_cleanup_status: AutomationCleanupStatus = AutomationCleanupStatus.SKIPPED
+    started_cleanup_attempts: int = Field(default=0, ge=0)
+    started_cleaned_at: datetime | None = None
     last_error: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
@@ -200,6 +213,14 @@ class AutomationBoundSessionQueueRecord(BaseModel):
     next_attempt_at: datetime = Field(
         default_factory=lambda: datetime.now(tz=timezone.utc)
     )
+    resume_attempts: int = Field(default=0, ge=0)
+    resume_next_attempt_at: datetime = Field(
+        default_factory=lambda: datetime.now(tz=timezone.utc)
+    )
+    queue_message_id: str | None = None
+    queue_cleanup_status: AutomationCleanupStatus = AutomationCleanupStatus.SKIPPED
+    queue_cleanup_attempts: int = Field(default=0, ge=0)
+    queue_cleaned_at: datetime | None = None
     last_error: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
@@ -218,6 +239,7 @@ class AutomationExecutionHandle(BaseModel):
 __all__ = [
     "AutomationBoundSessionQueueRecord",
     "AutomationBoundSessionQueueStatus",
+    "AutomationCleanupStatus",
     "AutomationDeliveryEvent",
     "AutomationDeliveryStatus",
     "AutomationExecutionHandle",

--- a/src/agent_teams/gateway/feishu/client.py
+++ b/src/agent_teams/gateway/feishu/client.py
@@ -101,8 +101,8 @@ class FeishuClient:
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
-        self._send_message(
+    ) -> str:
+        return self._send_message(
             chat_id=chat_id,
             msg_type="text",
             content={"text": text},
@@ -159,8 +159,8 @@ class FeishuClient:
         chat_id: str,
         card: dict[str, object],
         environment: FeishuEnvironment | None = None,
-    ) -> None:
-        self._send_message(
+    ) -> str:
+        return self._send_message(
             chat_id=chat_id,
             msg_type="interactive",
             content={"card": card},
@@ -363,8 +363,8 @@ class FeishuClient:
         chat_id: str,
         image_key: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
-        self._send_message(
+    ) -> str:
+        return self._send_message(
             chat_id=chat_id,
             msg_type="image",
             content={"image_key": image_key},
@@ -378,12 +378,28 @@ class FeishuClient:
         file_key: str,
         file_name: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
-        self._send_message(
+    ) -> str:
+        return self._send_message(
             chat_id=chat_id,
             msg_type="file",
             content={"file_key": file_key, "file_name": file_name},
             environment=environment,
+        )
+
+    def delete_message(
+        self,
+        *,
+        message_id: str,
+        environment: FeishuEnvironment | None = None,
+    ) -> None:
+        normalized_message_id = str(message_id).strip()
+        if not normalized_message_id:
+            raise RuntimeError("Feishu delete requires a message_id.")
+        _ = self._request_json(
+            method="DELETE",
+            path=f"/open-apis/im/v1/messages/{normalized_message_id}",
+            environment=self.require_environment(environment),
+            error_context="delete message",
         )
 
     def send_file(
@@ -426,8 +442,8 @@ class FeishuClient:
         msg_type: str,
         content: dict[str, object],
         environment: FeishuEnvironment | None,
-    ) -> None:
-        self._request_json(
+    ) -> str:
+        response_json = self._request_json(
             method="POST",
             path="/open-apis/im/v1/messages",
             params={"receive_id_type": "chat_id"},
@@ -439,6 +455,14 @@ class FeishuClient:
             environment=self.require_environment(environment),
             error_context="send message",
         )
+        response_data = _require_json_object(
+            response_json.get("data"),
+            error_context="send message",
+        )
+        message_id = str(response_data.get("message_id", "")).strip()
+        if not message_id:
+            raise RuntimeError("Feishu API failed to send message: missing message_id")
+        return message_id
 
     def _upload_asset(
         self,

--- a/src/agent_teams/gateway/feishu/message_pool_service.py
+++ b/src/agent_teams/gateway/feishu/message_pool_service.py
@@ -86,7 +86,7 @@ class FeishuClientLike(Protocol):
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> str: ...
 
     def resolve_user_name(
         self,

--- a/src/agent_teams/gateway/feishu/notification_delivery.py
+++ b/src/agent_teams/gateway/feishu/notification_delivery.py
@@ -41,7 +41,7 @@ class FeishuMessageSender(Protocol):
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> str: ...
 
     def send_card_message(
         self,
@@ -49,7 +49,7 @@ class FeishuMessageSender(Protocol):
         chat_id: str,
         card: dict[str, object],
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> str: ...
 
 
 class TerminalNotificationSuppressor(Protocol):

--- a/src/agent_teams/gateway/im/service.py
+++ b/src/agent_teams/gateway/im/service.py
@@ -33,7 +33,7 @@ class _FeishuSender(Protocol):
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> str: ...
 
     def send_file(
         self,

--- a/tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agent_teams.automation import (
+    AutomationBoundSessionQueueRepository,
+    AutomationBoundSessionQueueService,
+    AutomationCleanupStatus,
+    AutomationDeliveryEvent,
+    AutomationDeliveryRepository,
+    AutomationDeliveryService,
+    AutomationDeliveryStatus,
+    AutomationFeishuBinding,
+    AutomationProjectRecord,
+    AutomationProjectStatus,
+    AutomationRunConfig,
+    AutomationScheduleMode,
+)
+from agent_teams.gateway.feishu.models import FeishuEnvironment
+from agent_teams.sessions.runs.enums import RunEventType
+from agent_teams.sessions.runs.event_log import EventLog
+from agent_teams.sessions.runs.run_models import RunEvent
+from agent_teams.sessions.runs.run_runtime_repo import (
+    RunRuntimePhase,
+    RunRuntimeRecord,
+    RunRuntimeRepository,
+    RunRuntimeStatus,
+)
+from agent_teams.sessions.session_models import ProjectKind, SessionRecord
+
+
+class _FakeSessionLookup:
+    def __init__(self, sessions: dict[str, SessionRecord]) -> None:
+        self._sessions = sessions
+
+    def get_session(self, session_id: str) -> SessionRecord:
+        if session_id not in self._sessions:
+            raise KeyError(session_id)
+        return self._sessions[session_id]
+
+
+class _FakeRunService:
+    def __init__(self) -> None:
+        self.started_run_ids: list[str] = []
+        self.resume_run_ids: list[str] = []
+
+    def create_detached_run(self, intent: object) -> tuple[str, str]:
+        _ = intent
+        return ("run-1", "session-1")
+
+    def ensure_run_started(self, run_id: str) -> None:
+        self.started_run_ids.append(run_id)
+
+    def resume_run(self, run_id: str) -> str:
+        self.resume_run_ids.append(run_id)
+        return "session-1"
+
+
+class _FakeRuntimeConfigLookup:
+    class _RuntimeConfig:
+        def __init__(self) -> None:
+            self.environment = FeishuEnvironment(
+                app_id="cli_demo",
+                app_secret="secret",
+                app_name="Agent Teams Bot",
+            )
+
+    def get_runtime_config_by_trigger_id(self, trigger_id: str) -> _RuntimeConfig:
+        _ = trigger_id
+        return self._RuntimeConfig()
+
+
+class _FakeFeishuClient:
+    def __init__(self) -> None:
+        self.sent_messages: list[dict[str, str]] = []
+        self.deleted_messages: list[str] = []
+
+    def send_text_message(self, *, chat_id: str, text: str, environment=None) -> str:
+        _ = environment
+        self.sent_messages.append({"chat_id": chat_id, "text": text})
+        return f"om_{len(self.sent_messages)}"
+
+    def delete_message(self, *, message_id: str, environment=None) -> None:
+        _ = environment
+        self.deleted_messages.append(message_id)
+
+
+class _FakeProjectRepository:
+    def __init__(self, project: AutomationProjectRecord) -> None:
+        self.project = project
+
+    def get(self, automation_project_id: str) -> AutomationProjectRecord:
+        if automation_project_id != self.project.automation_project_id:
+            raise KeyError(automation_project_id)
+        return self.project
+
+    def update(self, record: AutomationProjectRecord) -> AutomationProjectRecord:
+        self.project = record
+        return record
+
+
+def _build_project() -> AutomationProjectRecord:
+    return AutomationProjectRecord(
+        automation_project_id="aut_1",
+        name="daily-briefing",
+        display_name="Daily Briefing",
+        status=AutomationProjectStatus.ENABLED,
+        workspace_id="default",
+        prompt="Summarize the day.",
+        schedule_mode=AutomationScheduleMode.CRON,
+        cron_expression="0 9 * * *",
+        timezone="UTC",
+        run_config=AutomationRunConfig(),
+        delivery_binding=AutomationFeishuBinding(
+            trigger_id="trigger-1",
+            tenant_key="tenant-1",
+            chat_id="oc_123",
+            session_id="session-1",
+            chat_type="p2p",
+            source_label="Daily Briefing",
+        ),
+        delivery_events=(
+            AutomationDeliveryEvent.STARTED,
+            AutomationDeliveryEvent.COMPLETED,
+            AutomationDeliveryEvent.FAILED,
+        ),
+        trigger_id="schedule-aut_1",
+    )
+
+
+def test_bound_queue_and_delivery_services_resume_without_premature_failed(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "automation-bound-session-delivery-e2e.db"
+    project = _build_project()
+    queue_repo = AutomationBoundSessionQueueRepository(db_path)
+    delivery_repo = AutomationDeliveryRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+    event_log = EventLog(db_path)
+    run_service = _FakeRunService()
+    feishu_client = _FakeFeishuClient()
+    runtime_config_lookup = _FakeRuntimeConfigLookup()
+    delivery_service = AutomationDeliveryService(
+        repository=delivery_repo,
+        runtime_config_lookup=runtime_config_lookup,
+        feishu_client=feishu_client,
+        run_runtime_repo=run_runtime_repo,
+        event_log=event_log,
+    )
+    queue_service = AutomationBoundSessionQueueService(
+        repository=queue_repo,
+        session_lookup=_FakeSessionLookup(
+            {
+                "session-1": SessionRecord(
+                    session_id="session-1",
+                    workspace_id="default",
+                    project_kind=ProjectKind.WORKSPACE,
+                    metadata={"title": "Bound Session"},
+                )
+            }
+        ),
+        run_service=run_service,
+        run_runtime_repo=run_runtime_repo,
+        delivery_service=delivery_service,
+        runtime_config_lookup=runtime_config_lookup,
+        feishu_client=feishu_client,
+        project_repository=_FakeProjectRepository(project),
+    )
+
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="active-run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.RUNNING,
+            phase=RunRuntimePhase.COORDINATOR_RUNNING,
+        )
+    )
+
+    handle = queue_service.materialize_execution(project=project, reason="schedule")
+
+    assert handle is not None
+    assert handle.queued is True
+    assert feishu_client.sent_messages == [
+        {
+            "chat_id": "oc_123",
+            "text": "定时任务 Daily Briefing 准备执行，当前任务前面有 1 个消息",
+        }
+    ]
+
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="active-run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.COMPLETED,
+            phase=RunRuntimePhase.TERMINAL,
+        )
+    )
+
+    assert queue_service.process_pending() is True
+    waiting_record = queue_repo.list_waiting_for_result(limit=10)[0]
+    delivery_record = delivery_repo.get_by_run_id("run-1")
+    assert waiting_record.run_id == "run-1"
+    assert waiting_record.queue_cleanup_status == AutomationCleanupStatus.CLEANED
+    assert delivery_record.started_status == AutomationDeliveryStatus.SKIPPED
+    assert feishu_client.deleted_messages == ["om_1"]
+
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.FAILED,
+            phase=RunRuntimePhase.AWAITING_RECOVERY,
+            last_error="stream interrupted",
+        )
+    )
+
+    assert delivery_service.process_pending() is False
+    assert [message["text"] for message in feishu_client.sent_messages] == [
+        "定时任务 Daily Briefing 准备执行，当前任务前面有 1 个消息"
+    ]
+
+    assert queue_service.process_pending() is True
+    waiting_record = queue_repo.list_waiting_for_result(limit=10)[0]
+    assert waiting_record.resume_attempts == 0
+    assert waiting_record.resume_next_attempt_at > waiting_record.updated_at
+
+    _ = queue_repo.update(
+        waiting_record.model_copy(
+            update={
+                "resume_next_attempt_at": datetime.now(tz=timezone.utc),
+            }
+        )
+    )
+
+    assert queue_service.process_pending() is True
+    assert run_service.resume_run_ids == ["run-1"]
+
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.COMPLETED,
+            phase=RunRuntimePhase.TERMINAL,
+        )
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed","output":"Recovered report is ready."}',
+            occurred_at=datetime.now(tz=timezone.utc),
+        )
+    )
+
+    assert delivery_service.process_pending() is True
+    delivery_record = delivery_repo.get_by_run_id("run-1")
+    assert delivery_record.terminal_status == AutomationDeliveryStatus.SENT
+    assert delivery_record.terminal_event == AutomationDeliveryEvent.COMPLETED
+    assert delivery_record.terminal_message == "Recovered report is ready."
+    assert delivery_record.terminal_message_id == "om_2"
+    assert all(
+        "执行失败" not in message["text"] for message in feishu_client.sent_messages
+    )
+    assert feishu_client.sent_messages[-1]["text"] == "Recovered report is ready."

--- a/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
@@ -7,6 +7,8 @@ from typing import cast
 from agent_teams.automation import (
     AutomationBoundSessionQueueRepository,
     AutomationBoundSessionQueueService,
+    AutomationBoundSessionQueueStatus,
+    AutomationCleanupStatus,
     AutomationDeliveryService,
     AutomationDeliveryEvent,
     AutomationFeishuBinding,
@@ -41,6 +43,8 @@ class _FakeRunService:
     def __init__(self) -> None:
         self.created_intents: list[IntentInput] = []
         self.started_run_ids: list[str] = []
+        self.resume_run_ids: list[str] = []
+        self.resume_errors: list[str] = []
 
     def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
         self.created_intents.append(intent)
@@ -49,14 +53,29 @@ class _FakeRunService:
     def ensure_run_started(self, run_id: str) -> None:
         self.started_run_ids.append(run_id)
 
+    def resume_run(self, run_id: str) -> str:
+        self.resume_run_ids.append(run_id)
+        if self.resume_errors:
+            raise RuntimeError(self.resume_errors.pop(0))
+        return "session-1"
+
 
 class _FakeDeliveryService:
     def __init__(self) -> None:
         self.register_calls: list[dict[str, object]] = []
+        self.skipped_terminal_runs: list[tuple[str, str | None]] = []
 
     def register_run(self, **kwargs: object) -> None:
         self.register_calls.append(kwargs)
         return None
+
+    def mark_terminal_delivery_skipped(
+        self,
+        *,
+        run_id: str,
+        terminal_message: str | None = None,
+    ) -> None:
+        self.skipped_terminal_runs.append((run_id, terminal_message))
 
 
 class _FakeRuntimeConfigLookup:
@@ -77,10 +96,16 @@ class _FakeRuntimeConfigLookup:
 class _FakeFeishuClient:
     def __init__(self) -> None:
         self.sent_messages: list[dict[str, str]] = []
+        self.deleted_messages: list[str] = []
 
-    def send_text_message(self, *, chat_id: str, text: str, environment=None) -> None:
+    def send_text_message(self, *, chat_id: str, text: str, environment=None) -> str:
         _ = environment
         self.sent_messages.append({"chat_id": chat_id, "text": text})
+        return f"om_{len(self.sent_messages)}"
+
+    def delete_message(self, *, message_id: str, environment=None) -> None:
+        _ = environment
+        self.deleted_messages.append(message_id)
 
 
 class _FakeProjectRepository:
@@ -177,6 +202,55 @@ def _build_service(
     )
 
 
+def _queue_and_start_bound_run(
+    tmp_path: Path,
+) -> tuple[
+    AutomationBoundSessionQueueService,
+    AutomationBoundSessionQueueRepository,
+    RunRuntimeRepository,
+    _FakeRunService,
+    _FakeDeliveryService,
+    _FakeFeishuClient,
+    _FakeProjectRepository,
+]:
+    (
+        service,
+        queue_repo,
+        run_runtime_repo,
+        run_service,
+        delivery_service,
+        feishu_client,
+        project_repo,
+    ) = _build_service(tmp_path)
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="active-run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.RUNNING,
+            phase=RunRuntimePhase.COORDINATOR_RUNNING,
+        )
+    )
+    _ = service.materialize_execution(project=_build_project(), reason="schedule")
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="active-run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.COMPLETED,
+            phase=RunRuntimePhase.TERMINAL,
+        )
+    )
+    _ = service.process_pending()
+    return (
+        service,
+        queue_repo,
+        run_runtime_repo,
+        run_service,
+        delivery_service,
+        feishu_client,
+        project_repo,
+    )
+
+
 def test_materialize_execution_starts_in_bound_session_when_idle(
     tmp_path: Path,
 ) -> None:
@@ -254,6 +328,8 @@ def test_materialize_execution_queues_when_bound_session_is_busy(
         queued_records[0].queue_message
         == "定时任务 Daily Briefing 准备执行，当前任务前面有 1 个消息"
     )
+    assert queued_records[0].queue_message_id == "om_1"
+    assert queued_records[0].queue_cleanup_status == AutomationCleanupStatus.SKIPPED
     assert feishu_client.sent_messages == [
         {
             "chat_id": "oc_123",
@@ -304,10 +380,12 @@ def test_process_pending_starts_queued_run_after_bound_session_becomes_idle(
     assert run_service.started_run_ids == ["run-1"]
     assert len(waiting_records) == 1
     assert waiting_records[0].run_id == "run-1"
+    assert waiting_records[0].queue_cleanup_status == AutomationCleanupStatus.CLEANED
     assert len(delivery_service.register_calls) == 1
     assert delivery_service.register_calls[0]["send_started"] is False
     assert project_repo.project.last_session_id == "session-1"
     assert project_repo.project.last_run_started_at is not None
+    assert _feishu_client.deleted_messages == ["om_1"]
 
 
 def test_materialize_execution_fails_when_bound_session_is_missing(
@@ -342,3 +420,162 @@ def test_materialize_execution_fails_when_bound_session_is_missing(
     else:
         raise AssertionError("Expected missing bound session to fail")
     assert run_service.created_intents == []
+
+
+def test_process_pending_schedules_recoverable_resume_with_backoff(
+    tmp_path: Path,
+) -> None:
+    (
+        service,
+        queue_repo,
+        run_runtime_repo,
+        run_service,
+        _delivery_service,
+        _feishu_client,
+        _project_repo,
+    ) = _queue_and_start_bound_run(tmp_path)
+    waiting = queue_repo.list_waiting_for_result(limit=10)[0]
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id=str(waiting.run_id),
+            session_id="session-1",
+            status=RunRuntimeStatus.PAUSED,
+            phase=RunRuntimePhase.AWAITING_RECOVERY,
+            last_error="stream interrupted",
+        )
+    )
+
+    progressed = service.process_pending()
+
+    updated = queue_repo.list_waiting_for_result(limit=10)[0]
+    assert progressed is True
+    assert run_service.resume_run_ids == []
+    assert updated.resume_attempts == 0
+    assert updated.last_error == "stream interrupted"
+    assert updated.resume_next_attempt_at > updated.updated_at
+
+
+def test_process_pending_requests_resume_after_backoff_elapsed(
+    tmp_path: Path,
+) -> None:
+    (
+        service,
+        queue_repo,
+        run_runtime_repo,
+        run_service,
+        _delivery_service,
+        _feishu_client,
+        _project_repo,
+    ) = _queue_and_start_bound_run(tmp_path)
+    waiting = queue_repo.list_waiting_for_result(limit=10)[0]
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id=str(waiting.run_id),
+            session_id="session-1",
+            status=RunRuntimeStatus.PAUSED,
+            phase=RunRuntimePhase.AWAITING_RECOVERY,
+            last_error="stream interrupted",
+        )
+    )
+    _ = queue_repo.update(
+        waiting.model_copy(
+            update={
+                "resume_next_attempt_at": datetime.now(tz=timezone.utc),
+            }
+        )
+    )
+
+    progressed = service.process_pending()
+
+    updated = queue_repo.list_waiting_for_result(limit=10)[0]
+    assert progressed is True
+    assert run_service.resume_run_ids == ["run-1"]
+    assert updated.resume_attempts == 1
+    assert updated.last_error is None
+
+
+def test_materialize_execution_treats_dirty_failed_recovery_run_as_busy(
+    tmp_path: Path,
+) -> None:
+    (
+        service,
+        queue_repo,
+        run_runtime_repo,
+        run_service,
+        _delivery_service,
+        feishu_client,
+        _project_repo,
+    ) = _build_service(tmp_path)
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="active-run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.FAILED,
+            phase=RunRuntimePhase.AWAITING_RECOVERY,
+            last_error="stream interrupted",
+        )
+    )
+
+    handle = service.materialize_execution(project=_build_project(), reason="schedule")
+
+    assert handle is not None
+    assert handle.queued is True
+    assert run_service.created_intents == []
+    queued_records = queue_repo.list_ready_to_start(
+        ready_at=datetime.now(tz=timezone.utc),
+        limit=10,
+    )
+    assert len(queued_records) == 1
+    assert feishu_client.sent_messages[0]["text"].startswith(
+        "定时任务 Daily Briefing 准备执行"
+    )
+    repaired = run_runtime_repo.get("active-run-1")
+    assert repaired is not None
+    assert repaired.status == RunRuntimeStatus.PAUSED
+
+
+def test_process_pending_exhausts_resume_attempts_and_skips_terminal_delivery(
+    tmp_path: Path,
+) -> None:
+    (
+        service,
+        queue_repo,
+        run_runtime_repo,
+        run_service,
+        delivery_service,
+        feishu_client,
+        _project_repo,
+    ) = _queue_and_start_bound_run(tmp_path)
+    waiting = queue_repo.list_waiting_for_result(limit=10)[0]
+    run_service.resume_errors = ["still paused"]
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id=str(waiting.run_id),
+            session_id="session-1",
+            status=RunRuntimeStatus.PAUSED,
+            phase=RunRuntimePhase.AWAITING_RECOVERY,
+            last_error="stream interrupted",
+        )
+    )
+    _ = queue_repo.update(
+        waiting.model_copy(
+            update={
+                "resume_attempts": 4,
+                "resume_next_attempt_at": datetime.now(tz=timezone.utc),
+            }
+        )
+    )
+
+    progressed = service.process_pending()
+
+    failed_record = queue_repo.get(waiting.automation_queue_id)
+    assert failed_record is not None
+    assert progressed is True
+    assert run_service.resume_run_ids == ["run-1"]
+    assert failed_record.status == AutomationBoundSessionQueueStatus.FAILED
+    assert failed_record.queue_cleanup_status == AutomationCleanupStatus.CLEANED
+    assert "自动恢复失败" in feishu_client.sent_messages[-1]["text"]
+    assert feishu_client.deleted_messages == ["om_1"]
+    assert delivery_service.skipped_terminal_runs == [
+        ("run-1", feishu_client.sent_messages[-1]["text"])
+    ]

--- a/tests/unit_tests/automation/test_automation_delivery_service.py
+++ b/tests/unit_tests/automation/test_automation_delivery_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from agent_teams.automation import (
+    AutomationCleanupStatus,
     AutomationDeliveryEvent,
     AutomationDeliveryRepository,
     AutomationDeliveryService,
@@ -43,10 +44,19 @@ class _FakeRuntimeConfigLookup:
 class _FakeFeishuClient:
     def __init__(self) -> None:
         self.sent_messages: list[dict[str, str]] = []
+        self.deleted_messages: list[str] = []
+        self.fail_delete = False
 
-    def send_text_message(self, *, chat_id: str, text: str, environment=None) -> None:
+    def send_text_message(self, *, chat_id: str, text: str, environment=None) -> str:
         _ = environment
         self.sent_messages.append({"chat_id": chat_id, "text": text})
+        return f"om_{len(self.sent_messages)}"
+
+    def delete_message(self, *, message_id: str, environment=None) -> None:
+        _ = environment
+        if self.fail_delete:
+            raise RuntimeError("delete_failed")
+        self.deleted_messages.append(message_id)
 
 
 def _build_project() -> AutomationProjectRecord:
@@ -118,6 +128,7 @@ def test_register_run_sends_started_message_immediately(tmp_path: Path) -> None:
     assert feishu_client.sent_messages[0]["text"] == "定时任务 Daily Briefing 开始执行"
     persisted = repository.get_by_run_id("run-1")
     assert persisted.started_status.value == "sent"
+    assert persisted.started_message_id == "om_1"
     assert persisted.terminal_status.value == "pending"
 
 
@@ -182,6 +193,9 @@ def test_process_pending_sends_completed_message_when_run_finishes(
     persisted = repository.get_by_run_id("run-1")
     assert persisted.terminal_status.value == "sent"
     assert persisted.terminal_event == AutomationDeliveryEvent.COMPLETED
+    assert persisted.terminal_message_id == "om_2"
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.CLEANED
+    assert feishu_client.deleted_messages == ["om_1"]
 
 
 def test_process_pending_skips_completed_message_when_run_has_no_output(
@@ -223,6 +237,8 @@ def test_process_pending_skips_completed_message_when_run_has_no_output(
     assert persisted.terminal_status.value == "skipped"
     assert persisted.terminal_event == AutomationDeliveryEvent.COMPLETED
     assert persisted.terminal_message == ""
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.SKIPPED
+    assert feishu_client.deleted_messages == []
 
 
 def test_process_pending_sends_structured_completed_message_when_run_finishes(
@@ -269,6 +285,7 @@ def test_process_pending_sends_structured_completed_message_when_run_finishes(
     persisted = repository.get_by_run_id("run-1")
     assert persisted.terminal_status.value == "sent"
     assert persisted.terminal_event == AutomationDeliveryEvent.COMPLETED
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.CLEANED
 
 
 def test_process_pending_uses_terminal_error_when_failed_output_is_empty(
@@ -310,3 +327,78 @@ def test_process_pending_uses_terminal_error_when_failed_output_is_empty(
     persisted = repository.get_by_run_id("run-1")
     assert persisted.terminal_status.value == "sent"
     assert persisted.terminal_event == AutomationDeliveryEvent.FAILED
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.CLEANED
+
+
+def test_process_pending_defers_failed_delivery_while_run_is_awaiting_recovery(
+    tmp_path: Path,
+) -> None:
+    service, feishu_client, run_runtime_repo, _event_log, repository = _build_service(
+        tmp_path
+    )
+    _ = service.register_run(
+        project=_build_project(),
+        session_id="session-1",
+        run_id="run-1",
+        reason="schedule",
+    )
+    run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.FAILED,
+            phase=RunRuntimePhase.AWAITING_RECOVERY,
+            last_error="stream interrupted",
+        )
+    )
+
+    progressed = service.process_pending()
+
+    persisted = repository.get_by_run_id("run-1")
+    assert progressed is False
+    assert len(feishu_client.sent_messages) == 1
+    assert persisted.terminal_status == AutomationDeliveryStatus.PENDING
+    assert persisted.terminal_message_id is None
+
+
+def test_process_pending_cleanup_failure_does_not_break_terminal_delivery(
+    tmp_path: Path,
+) -> None:
+    service, feishu_client, run_runtime_repo, event_log, repository = _build_service(
+        tmp_path
+    )
+    feishu_client.fail_delete = True
+    _ = service.register_run(
+        project=_build_project(),
+        session_id="session-1",
+        run_id="run-1",
+        reason="schedule",
+    )
+    run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.COMPLETED,
+            phase=RunRuntimePhase.TERMINAL,
+        )
+    )
+    event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed","output":"Daily report is ready."}',
+            occurred_at=datetime.now(tz=timezone.utc),
+        )
+    )
+
+    progressed = service.process_pending()
+
+    persisted = repository.get_by_run_id("run-1")
+    assert progressed is True
+    assert len(feishu_client.sent_messages) == 2
+    assert feishu_client.deleted_messages == []
+    assert persisted.terminal_status == AutomationDeliveryStatus.SENT
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.PENDING
+    assert persisted.started_cleanup_attempts == 1

--- a/tests/unit_tests/feishu/test_client.py
+++ b/tests/unit_tests/feishu/test_client.py
@@ -218,12 +218,13 @@ def test_send_text_message_uses_net_client_request_chain(monkeypatch) -> None:
     client = FeishuClient()
     environment = FeishuEnvironment(app_id="cli_1", app_secret="secret", app_name="bot")
 
-    client.send_text_message(
+    message_id = client.send_text_message(
         chat_id="oc_group_1",
         text="hello",
         environment=environment,
     )
 
+    assert message_id == "om_1"
     assert [request[:2] for request in fake_client.requests] == [
         ("POST", f"{base_url}/open-apis/auth/v3/tenant_access_token/internal"),
         ("POST", f"{base_url}/open-apis/im/v1/messages"),
@@ -234,6 +235,47 @@ def test_send_text_message_uses_net_client_request_chain(monkeypatch) -> None:
         "msg_type": "text",
         "content": '{"text": "hello"}',
     }
+
+
+def test_delete_message_uses_delete_endpoint(monkeypatch) -> None:
+    base_url = "https://open.feishu.cn"
+    fake_client = _FakeSyncHttpClient(
+        {
+            (
+                "POST",
+                f"{base_url}/open-apis/auth/v3/tenant_access_token/internal",
+            ): [
+                _response(
+                    200,
+                    {"code": 0, "tenant_access_token": "token-1", "expire": 7200},
+                    method="POST",
+                    url=f"{base_url}/open-apis/auth/v3/tenant_access_token/internal",
+                )
+            ],
+            ("DELETE", f"{base_url}/open-apis/im/v1/messages/om_1"): [
+                _response(
+                    200,
+                    {"code": 0, "data": {}},
+                    method="DELETE",
+                    url=f"{base_url}/open-apis/im/v1/messages/om_1",
+                )
+            ],
+        }
+    )
+
+    monkeypatch.setattr(
+        "agent_teams.gateway.feishu.client.create_sync_http_client",
+        lambda **_: fake_client,
+    )
+    client = FeishuClient()
+    environment = FeishuEnvironment(app_id="cli_1", app_secret="secret", app_name="bot")
+
+    client.delete_message(message_id="om_1", environment=environment)
+
+    assert [request[:2] for request in fake_client.requests] == [
+        ("POST", f"{base_url}/open-apis/auth/v3/tenant_access_token/internal"),
+        ("DELETE", f"{base_url}/open-apis/im/v1/messages/om_1"),
+    ]
 
 
 def test_reply_text_message_uses_reply_endpoint(monkeypatch) -> None:

--- a/tests/unit_tests/feishu/test_message_pool_service.py
+++ b/tests/unit_tests/feishu/test_message_pool_service.py
@@ -139,9 +139,10 @@ class _FakeFeishuClient:
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         _ = environment
         self.sent_messages.append((chat_id, text))
+        return f"om_{len(self.sent_messages)}"
 
     def reply_text_message(
         self,

--- a/tests/unit_tests/feishu/test_notification_delivery.py
+++ b/tests/unit_tests/feishu/test_notification_delivery.py
@@ -74,8 +74,9 @@ class _FakeFeishuClient:
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         self.sent.append(("text", chat_id, text, environment))
+        return "om_text"
 
     def send_card_message(
         self,
@@ -83,8 +84,9 @@ class _FakeFeishuClient:
         chat_id: str,
         card: dict[str, object],
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         self.sent.append(("card", chat_id, card, environment))
+        return "om_card"
 
 
 class _FakeTerminalNotificationSuppressor:

--- a/tests/unit_tests/feishu/test_trigger_handler.py
+++ b/tests/unit_tests/feishu/test_trigger_handler.py
@@ -146,9 +146,10 @@ class _FakeFeishuClient:
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         _ = environment
         self.sent_messages.append((chat_id, text))
+        return f"om_{len(self.sent_messages)}"
 
     def reply_text_message(
         self,

--- a/tests/unit_tests/tools/im_tools/test_service.py
+++ b/tests/unit_tests/tools/im_tools/test_service.py
@@ -155,9 +155,10 @@ class _FakeFeishuClient:
         chat_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         _ = environment
         self.sent_texts.append((chat_id, text))
+        return f"om_{len(self.sent_texts)}"
 
     def reply_text_message(
         self,


### PR DESCRIPTION
## Summary
- fix bound-session automation queue recovery so `awaiting_recovery` runs are auto-resumed with persisted exponential backoff instead of failing early
- persist Feishu provider message ids for queue/start/terminal delivery and best-effort delete superseded non-terminal messages
- add coverage for recovery retry behavior, delivery cleanup, and a cross-service automation queue/delivery flow

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`
- live Feishu smoke against bound P2P session for started/completed delivery and cleanup
- browser smoke on `2026-03-29` via local UI create/run/delete flow against real Feishu binding

Closes #118
Closes #120