### PR TITLE
Fix streaming tool event ordering and live tool rendering

### DIFF
--- a/frontend/dist/css/components.css
+++ b/frontend/dist/css/components.css
@@ -740,7 +740,8 @@
 }
 
 .msg-text > .msg-image,
-.tool-result > .msg-image {
+.tool-result > .msg-image,
+.tool-output > .msg-image {
     margin-top: 0.75rem;
 }
 
@@ -4858,7 +4859,7 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
 }
 
 .msg-header {
-    margin-bottom: 0.4rem;
+    display: none;
 }
 
 .msg-role {
@@ -4885,29 +4886,8 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
 .markdown-code-block,
 .msg-content pre,
 .msg-text pre,
-.tool-block,
-.tool-result,
 .tool-call {
     border-radius: 8px;
-}
-
-.tool-block {
-    background: var(--bg-tool-block);
-    border-color: var(--border-color);
-}
-
-.tool-header {
-    padding: 0.7rem 0.85rem;
-    background: var(--bg-surface);
-    border-bottom: 1px solid var(--border-color);
-}
-
-.tool-header:hover {
-    background: var(--bg-hover);
-}
-
-.tool-body {
-    background: var(--bg-surface);
 }
 
 #prompt-input {
@@ -5308,7 +5288,6 @@ body.light-theme .session-item:hover {
     background: color-mix(in srgb, var(--bg-surface-muted) 84%, #eceeed 16%);
 }
 
-body.light-theme .tool-header,
 body.light-theme .round-state-pill,
 body.light-theme .round-nav-state,
 body.light-theme .recovery-status-pill,
@@ -5912,8 +5891,6 @@ body.light-theme .subagent-toggle-btn.active {
     background: var(--bg-hover);
 }
 
-body.light-theme .tool-body,
-body.light-theme .tool-result,
 body.light-theme .tool-call,
 body.light-theme .markdown-code-block,
 body.light-theme .msg-content pre,
@@ -5921,27 +5898,9 @@ body.light-theme .msg-text pre {
     background: var(--bg-surface-muted);
 }
 
-body.light-theme .tool-block,
-body.light-theme .tool-header,
-body.light-theme .tool-body,
-body.light-theme .tool-call,
-body.light-theme .tool-result {
-    background: var(--bg-tool-block);
-}
-
-body.light-theme .tool-header {
-    background: var(--bg-tool-header);
-    border-bottom-color: var(--border-color);
-}
-
-body.light-theme .tool-header:hover {
-    background: var(--bg-tool-header-hover);
-}
-
-body.light-theme .tool-body,
-body.light-theme .tool-call,
-body.light-theme .tool-result {
-    background: var(--bg-tool-body);
+body.light-theme .tool-detail-card {
+    background: var(--bg-surface-muted);
+    border-color: var(--border-color);
 }
 
 body.light-theme .markdown-code-header {
@@ -5970,7 +5929,6 @@ body.light-theme .round-nav-float,
 body.light-theme .recovery-banner,
 body.light-theme .human-dispatch-panel,
 body.light-theme .gate-card,
-body.light-theme .tool-block,
 body.light-theme .system-intro {
     border-color: var(--border-color);
 }
@@ -5982,112 +5940,8 @@ body.light-theme .composer-select-field select,
 body.light-theme .composer-mode-inline-select {
     background: var(--bg-surface);
 }
-/* Tool Call Blocks */
-.tool-block {
-    margin: 0.5rem 0 1rem 0;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    background-color: var(--bg-tool-block);
-    overflow: hidden;
-}
-
-.tool-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.75rem 1rem;
-    background-color: var(--bg-tool-header);
-    cursor: pointer;
-    user-select: none;
-    transition: background-color 0.2s;
-}
-
-.tool-header:hover {
-    background-color: var(--bg-tool-header-hover);
-}
-
-.tool-title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.875rem;
-    font-family: var(--font-mono);
-    color: var(--text-secondary);
-}
-
-.tool-title .name {
-    color: var(--text-tool-name);
-    font-weight: 500;
-}
-
-.tool-status {
-    display: flex;
-    align-items: center;
-}
-
-.spinner {
-    width: 14px;
-    height: 14px;
-    border: 2px solid var(--bg-hover-strong);
-    border-top-color: var(--primary);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
-.status-icon {
-    width: 16px;
-    height: 16px;
-}
-
-.status-success {
-    color: var(--success);
-}
-
-.status-error {
-    color: var(--danger);
-}
-
-.status-warning {
-    color: var(--warning);
-}
-
-.tool-body {
-    padding: 1rem;
-    border-top: 1px solid var(--border-color);
-    background-color: var(--bg-tool-body);
-    font-size: 0.8125rem;
-    font-family: var(--font-mono);
-    display: none;
-    /* hidden by default, toggled via JS */
-}
-
-.tool-body.open {
-    display: block;
-    animation: fadeIn 0.3s;
-}
-
-.tool-args {
-    color: var(--text-tool-args);
-    margin-bottom: 0.5rem;
-}
-
-.tool-result {
-    color: var(--text-secondary);
-    white-space: pre-wrap;
-}
-
-.tool-result.error-text {
-    color: var(--danger);
-}
-
-.tool-result.warning-text {
-    color: var(--warning);
-}
-
-.tool-approval-inline {
-    margin-bottom: 0.65rem;
-}
-
+/* Tool Call Blocks - styles moved to components/tools.css */
+/* Only keep approval-state here for backward compat */
 .tool-approval-state {
     display: inline-flex;
     align-items: center;

--- a/frontend/dist/css/components/messages.css
+++ b/frontend/dist/css/components/messages.css
@@ -7,10 +7,7 @@
 }
 
 .msg-header {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.35rem;
+    display: none;
 }
 
 .msg-role {
@@ -175,7 +172,8 @@
 }
 
 .msg-text > .msg-image,
-.tool-result > .msg-image {
+.tool-result > .msg-image,
+.tool-output > .msg-image {
     margin-top: 0.75rem;
 }
 

--- a/frontend/dist/css/components/tools.css
+++ b/frontend/dist/css/components/tools.css
@@ -1,58 +1,206 @@
-/* Tool Call Blocks */
+/* Tool Call Blocks - Claude Code style collapsible design */
+
 .tool-block {
-    margin: 0.5rem 0 1rem 0;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    background-color: var(--bg-tool-block);
-    overflow: hidden;
+    margin: 0.35rem 0;
+    border: none;
+    background: transparent;
+    overflow: visible;
 }
 
-.tool-header {
+/* --- Summary / collapsed state --- */
+
+.tool-summary {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 0.75rem 1rem;
-    background-color: var(--bg-tool-header);
+    gap: 0.35rem;
+    padding: 0.25rem 0;
     cursor: pointer;
-    user-select: none;
-    transition: background-color 0.2s;
-}
-
-.tool-header:hover {
-    background-color: var(--bg-tool-header-hover);
-}
-
-.tool-title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.875rem;
-    font-family: var(--font-mono);
+    list-style: none;
     color: var(--text-secondary);
+    font-size: 0.8125rem;
+    font-family: var(--font-ui);
+    user-select: none;
+    transition: color 0.15s;
 }
 
-.tool-title .name {
-    color: var(--text-tool-name);
+.tool-summary:hover {
+    color: var(--text-primary);
+}
+
+.tool-summary::-webkit-details-marker {
+    display: none;
+}
+
+.tool-summary::before {
+    content: '>';
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    transform: rotate(0deg);
+    transition: transform 0.16s ease;
+    flex: 0 0 auto;
+}
+
+.tool-block[open] > .tool-summary::before {
+    transform: rotate(90deg);
+}
+
+.tool-summary-label {
     font-weight: 500;
+    white-space: nowrap;
+    flex: 0 0 auto;
+}
+
+.tool-summary-preview {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 55ch;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text-muted, var(--text-secondary));
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .tool-status {
     display: flex;
     align-items: center;
+    flex: 0 0 auto;
+    margin-left: auto;
 }
+
+/* --- Detail / expanded state --- */
+
+.tool-detail {
+    padding: 0.25rem 0 0.5rem 0;
+}
+
+.tool-detail-card {
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--bg-tool-body, var(--bg-surface-muted));
+    overflow: hidden;
+}
+
+.tool-detail-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.55rem 0.85rem 0;
+}
+
+.tool-lang-label {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    letter-spacing: 0.02em;
+}
+
+.tool-copy-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm, 4px);
+    cursor: pointer;
+    color: var(--text-secondary);
+    padding: 0.2rem 0.3rem;
+    transition: color 0.15s, border-color 0.15s, background-color 0.15s;
+}
+
+.tool-copy-btn:hover {
+    color: var(--text-primary);
+    border-color: var(--border-color);
+    background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+}
+
+/* Command display (for shell tools) */
+
+.tool-command {
+    padding: 0.55rem 0.85rem;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.55;
+    color: var(--text-primary);
+}
+
+.tool-input-value {
+    padding: 0.55rem 0.85rem;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.55;
+    color: var(--text-primary);
+}
+
+.tool-prompt {
+    color: var(--text-secondary);
+    user-select: none;
+    margin-right: 0.25rem;
+}
+
+/* Args display (for non-shell tools) */
+
+.tool-args {
+    padding: 0.55rem 0.85rem;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.55;
+    color: var(--text-tool-args, var(--text-secondary));
+    margin: 0;
+}
+
+/* Output display */
+
+.tool-output {
+    padding: 0.55rem 0.85rem;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.55;
+    color: var(--text-secondary);
+    max-height: 400px;
+    overflow-y: auto;
+    border-top: 1px solid var(--border-color);
+}
+
+.tool-output:empty {
+    display: none;
+}
+
+.tool-output.error-text {
+    color: var(--danger);
+}
+
+.tool-output.warning-text {
+    color: var(--warning);
+}
+
+/* Spinner */
 
 .spinner {
     width: 14px;
     height: 14px;
-    border: 2px solid var(--bg-hover-strong);
+    border: 2px solid var(--bg-hover-strong, rgba(255, 255, 255, 0.1));
     border-top-color: var(--primary);
     border-radius: 50%;
     animation: spin 1s linear infinite;
 }
 
+/* Status icons */
+
 .status-icon {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
+    flex: 0 0 auto;
 }
 
 .status-success {
@@ -67,41 +215,11 @@
     color: var(--warning);
 }
 
-.tool-body {
-    padding: 1rem;
-    border-top: 1px solid var(--border-color);
-    background-color: var(--bg-tool-body);
-    font-size: 0.8125rem;
-    font-family: var(--font-mono);
-    display: none;
-    /* hidden by default, toggled via JS */
-}
-
-.tool-body.open {
-    display: block;
-    animation: fadeIn 0.3s;
-}
-
-.tool-args {
-    color: var(--text-tool-args);
-    margin-bottom: 0.5rem;
-}
-
-.tool-result {
-    color: var(--text-secondary);
-    white-space: pre-wrap;
-}
-
-.tool-result.error-text {
-    color: var(--danger);
-}
-
-.tool-result.warning-text {
-    color: var(--warning);
-}
+/* Approval inline */
 
 .tool-approval-inline {
-    margin-bottom: 0.65rem;
+    padding: 0.4rem 0.85rem;
+    border-top: 1px solid var(--border-color);
 }
 
 .tool-approval-state {
@@ -116,6 +234,17 @@
     font-size: 0.72rem;
     font-weight: 600;
 }
+
+/* Computer use meta */
+
+.tool-computer-meta {
+    padding: 0.35rem 0.85rem;
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border-color);
+}
+
+/* ---- Non-tool-block styles kept for backward compat ---- */
 
 #prompt-input {
     width: 100%;
@@ -298,4 +427,3 @@
 .typing-dot:nth-child(2) {
     animation-delay: -0.16s;
 }
-

--- a/frontend/dist/js/components/messageRenderer/helpers.js
+++ b/frontend/dist/js/components/messageRenderer/helpers.js
@@ -22,9 +22,11 @@ export {
 
 export {
     buildToolBlock,
+    buildPendingToolBlock,
     findToolBlock,
     setToolValidationFailureState,
     applyToolReturn,
+    setToolStatus,
     indexPendingToolBlock,
     resolvePendingToolBlock,
     findToolBlockInContainer,

--- a/frontend/dist/js/components/messageRenderer/helpers/approval.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/approval.js
@@ -11,18 +11,17 @@ export function decoratePendingApprovalBlock(toolBlock, approval) {
     }
 
     const statusEl = toolBlock.querySelector('.tool-status');
-    const resultEl = toolBlock.querySelector('.tool-result');
+    const outputEl = toolBlock.querySelector('.tool-output');
     if (statusEl) {
-        statusEl.innerHTML = `<svg class="status-icon status-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.29 3.86l-8.2 14.2A2 2 0 0 0 3.8 21h16.4a2 2 0 0 0 1.73-2.94l-8.2-14.2a2 2 0 0 0-3.46 0z"/></svg>`;
+        statusEl.innerHTML = `<svg class="status-icon status-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.29 3.86l-8.2 14.2A2 2 0 0 0 3.8 21h16.4a2 2 0 0 0 1.73-2.94l-8.2-14.2a2 2 0 0 0-3.46 0z"/></svg>`;
     }
-    if (resultEl) {
-        resultEl.classList.remove('error-text');
-        resultEl.classList.add('warning-text');
-        resultEl.innerHTML = parseMarkdown(formatPendingApprovalResult(approval));
+    if (outputEl) {
+        outputEl.classList.remove('error-text');
+        outputEl.classList.add('warning-text');
+        outputEl.innerHTML = parseMarkdown(formatPendingApprovalResult(approval));
     }
     if (String(approval?.status || 'requested').toLowerCase() === 'requested') {
-        const body = toolBlock.querySelector('.tool-body');
-        if (body) body.classList.add('open');
+        toolBlock.open = true;
     }
 
     let approvalEl = toolBlock.querySelector('.tool-approval-inline');
@@ -30,11 +29,14 @@ export function decoratePendingApprovalBlock(toolBlock, approval) {
         approvalEl = document.createElement('div');
         approvalEl.className = 'tool-approval-inline';
         approvalEl.innerHTML = `<div class="tool-approval-state"></div>`;
-        const body = toolBlock.querySelector('.tool-body');
-        if (body && resultEl) {
-            body.insertBefore(approvalEl, resultEl);
-        } else if (body) {
-            body.appendChild(approvalEl);
+        const detail = toolBlock.querySelector('.tool-detail');
+        if (detail && outputEl) {
+            const card = toolBlock.querySelector('.tool-detail-card');
+            if (card) {
+                card.insertBefore(approvalEl, outputEl);
+            }
+        } else if (detail) {
+            detail.appendChild(approvalEl);
         }
     }
     const stateEl = approvalEl.querySelector('.tool-approval-state');
@@ -63,12 +65,12 @@ export function syncApprovalStateFromEnvelope(toolBlock, envelope) {
         approvalEl = document.createElement('div');
         approvalEl.className = 'tool-approval-inline';
         approvalEl.innerHTML = `<div class="tool-approval-state"></div>`;
-        const body = toolBlock.querySelector('.tool-body');
-        const resultEl = toolBlock.querySelector('.tool-result');
-        if (body && resultEl) {
-            body.insertBefore(approvalEl, resultEl);
-        } else if (body) {
-            body.appendChild(approvalEl);
+        const card = toolBlock.querySelector('.tool-detail-card');
+        const outputEl = toolBlock.querySelector('.tool-output');
+        if (card && outputEl) {
+            card.insertBefore(approvalEl, outputEl);
+        } else if (card) {
+            card.appendChild(approvalEl);
         }
     }
 

--- a/frontend/dist/js/components/messageRenderer/helpers/block.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/block.js
@@ -15,7 +15,7 @@ import { appendStructuredContentPart, renderRichContent } from './content.js';
 
 const STREAMING_CURSOR_CLASS = 'streaming-cursor';
 
-export function renderMessageBlock(container, role, label, parts = []) {
+export function renderMessageBlock(container, role, label, parts = [], options = {}) {
     const safeLabel = label || 'Agent';
     if (container) {
         const empty = container.querySelector('.panel-empty');
@@ -24,6 +24,7 @@ export function renderMessageBlock(container, role, label, parts = []) {
     const wrapper = document.createElement('div');
     wrapper.className = 'message';
     wrapper.dataset.role = role;
+    applyMessageMetadata(wrapper, options);
 
     const roleClass = roleClassName(role, safeLabel);
     wrapper.innerHTML = `
@@ -43,6 +44,17 @@ export function renderMessageBlock(container, role, label, parts = []) {
     }
 
     return { wrapper, contentEl, pendingToolBlocks };
+}
+
+function applyMessageMetadata(wrapper, options = {}) {
+    const runId = String(options.runId || '').trim();
+    const instanceId = String(options.instanceId || '').trim();
+    const roleId = String(options.roleId || '').trim();
+    const streamKey = String(options.streamKey || '').trim();
+    if (runId) wrapper.dataset.runId = runId;
+    if (instanceId) wrapper.dataset.instanceId = instanceId;
+    if (roleId) wrapper.dataset.roleId = roleId;
+    if (streamKey) wrapper.dataset.streamKey = streamKey;
 }
 
 export function renderParts(contentEl, parts, pendingToolBlocks) {

--- a/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
@@ -4,28 +4,202 @@
  */
 import { syncApprovalStateFromEnvelope } from './approval.js';
 import { appendStructuredContentPart, renderRichContent } from './content.js';
+import { t, formatMessage } from '../../../utils/i18n.js';
+
+const TOOL_SUMMARY_MAP = {
+    shell:     { key: 'tool.summary.shell',     fields: ['command', 'cmd'], lang: 'tool.lang.shell', detailKind: 'command' },
+    read:      { key: 'tool.summary.read',      fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'value' },
+    write:     { key: 'tool.summary.write',     fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'value' },
+    write_tmp: { key: 'tool.summary.write',     fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'value' },
+    edit:      { key: 'tool.summary.edit',      fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'value' },
+    grep:      { key: 'tool.summary.grep',      fields: ['pattern', 'query'], detailKind: 'value' },
+    glob:      { key: 'tool.summary.glob',      fields: ['pattern', 'glob'], detailKind: 'value' },
+    websearch: { key: 'tool.summary.websearch', fields: ['query', 'q', 'search_query'], detailKind: 'value' },
+    webfetch:  { key: 'tool.summary.webfetch',  fields: ['url', 'uri'], detailKind: 'value' },
+};
+
+const COPY_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+const CHECK_SVG = '<svg class="status-icon status-success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;"><path d="M20 6L9 17l-5-5"/></svg>';
+const ERROR_SVG = '<svg class="status-icon status-error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;"><path d="M18 6L6 18M6 6l12 12"/></svg>';
+const WARNING_SVG = '<svg class="status-icon status-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.29 3.86l-8.2 14.2A2 2 0 0 0 3.8 21h16.4a2 2 0 0 0 1.73-2.94l-8.2-14.2a2 2 0 0 0-3.46 0z"/></svg>';
+const SPINNER_HTML = '<div class="spinner"></div>';
+
+function classifyTool(toolName, args) {
+    const normalizedArgs = normalizeToolArgs(args);
+    const entry = TOOL_SUMMARY_MAP[toolName];
+    if (entry) {
+        const detailText = pickToolFieldValue(normalizedArgs, entry.fields);
+        return {
+            summaryLabel: t(entry.key),
+            langLabel: entry.lang ? t(entry.lang) : '',
+            preview: truncatePreview(detailText || argsPreviewText(normalizedArgs)),
+            detailText: detailText || '',
+            detailKind: entry.detailKind || 'json',
+            args: normalizedArgs,
+        };
+    }
+    return {
+        summaryLabel: formatMessage('tool.summary.generic', { tool: toolName }),
+        langLabel: '',
+        preview: truncatePreview(argsPreviewText(normalizedArgs)),
+        detailText: '',
+        detailKind: 'json',
+        args: normalizedArgs,
+    };
+}
+
+function normalizeToolArgs(args) {
+    if (!args) return {};
+    if (typeof args === 'object') return args;
+    const raw = String(args || '').trim();
+    if (!raw) return {};
+    try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') {
+            return parsed;
+        }
+        return { __raw: String(parsed ?? '') };
+    } catch (_) {
+        return { __raw: raw };
+    }
+}
+
+function pickToolFieldValue(args, fields = []) {
+    if (!args || typeof args !== 'object') return '';
+    for (const field of fields) {
+        const value = args[field];
+        if (value === undefined || value === null) continue;
+        const text = String(value).trim();
+        if (text) return text;
+    }
+    const raw = typeof args.__raw === 'string' ? args.__raw.trim() : '';
+    return raw;
+}
+
+function truncatePreview(text, maxLen = 80) {
+    if (!text) return '';
+    if (text.length <= maxLen) return text;
+    return text.slice(0, maxLen) + '...';
+}
+
+function argsPreviewText(args) {
+    if (!args || typeof args !== 'object') return '';
+    if (typeof args.__raw === 'string' && Object.keys(args).length === 1) {
+        return args.__raw;
+    }
+    try {
+        const str = JSON.stringify(args);
+        return str.length > 2 ? str : '';
+    } catch (_) {
+        return '';
+    }
+}
+
+function escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+}
 
 export function buildToolBlock(toolName, args, toolCallId = null) {
-    const tb = document.createElement('div');
+    const info = classifyTool(toolName, args);
+    const tb = document.createElement('details');
     tb.className = 'tool-block';
     tb.dataset.toolName = toolName;
     if (toolCallId) {
         tb.dataset.toolCallId = toolCallId;
     }
+
+    const langHeader = info.langLabel
+        ? `<span class="tool-lang-label">${escapeHtml(info.langLabel)}</span>`
+        : '<span></span>';
+
     tb.innerHTML = `
-        <div class="tool-header" onclick="this.nextElementSibling.classList.toggle('open')">
-            <div class="tool-title">
-                <svg viewBox="0 0 24 24" fill="none" class="icon" style="width:14px;height:14px;"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" stroke="currentColor" stroke-width="2"/></svg>
-                <span class="name">${toolName}</span>
+        <summary class="tool-summary">
+            <span class="tool-summary-label">${escapeHtml(info.summaryLabel)}</span>
+            <span class="tool-summary-preview">${escapeHtml(info.preview)}</span>
+            <span class="tool-status">${CHECK_SVG}</span>
+        </summary>
+        <div class="tool-detail">
+            <div class="tool-detail-card">
+                <div class="tool-detail-header">
+                    ${langHeader}
+                    <button class="tool-copy-btn" title="${escapeHtml(t('tool.action.copy'))}">${COPY_SVG}</button>
+                </div>
+                ${renderToolInput(info)}
+                <div class="tool-output"></div>
             </div>
-            <div class="tool-status"><svg class="status-icon status-success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg></div>
-        </div>
-        <div class="tool-body">
-            <div class="tool-args">${JSON.stringify(args || {}, null, 2)}</div>
-            <div class="tool-result"></div>
         </div>
     `;
+
+    const copyBtn = tb.querySelector('.tool-copy-btn');
+    if (copyBtn) {
+        copyBtn.addEventListener('click', handleCopyClick);
+    }
+
+    tb.dataset.status = 'completed';
     return tb;
+}
+
+export function buildPendingToolBlock(toolName, args, toolCallId = null) {
+    const info = classifyTool(toolName, args);
+    const tb = document.createElement('details');
+    tb.className = 'tool-block';
+    tb.dataset.toolName = toolName;
+    if (toolCallId) {
+        tb.dataset.toolCallId = toolCallId;
+    }
+
+    const langHeader = info.langLabel
+        ? `<span class="tool-lang-label">${escapeHtml(info.langLabel)}</span>`
+        : '<span></span>';
+
+    tb.innerHTML = `
+        <summary class="tool-summary">
+            <span class="tool-summary-label">${escapeHtml(info.summaryLabel)}</span>
+            <span class="tool-summary-preview">${escapeHtml(info.preview)}</span>
+            <span class="tool-status">${SPINNER_HTML}</span>
+        </summary>
+        <div class="tool-detail">
+            <div class="tool-detail-card">
+                <div class="tool-detail-header">
+                    ${langHeader}
+                    <button class="tool-copy-btn" title="${escapeHtml(t('tool.action.copy'))}">${COPY_SVG}</button>
+                </div>
+                ${renderToolInput(info)}
+                <div class="tool-output"></div>
+            </div>
+        </div>
+    `;
+
+    const copyBtn = tb.querySelector('.tool-copy-btn');
+    if (copyBtn) {
+        copyBtn.addEventListener('click', handleCopyClick);
+    }
+
+    tb.dataset.status = 'running';
+    return tb;
+}
+
+function formatArgs(args) {
+    if (args && typeof args === 'object' && typeof args.__raw === 'string' && Object.keys(args).length === 1) {
+        return args.__raw;
+    }
+    try {
+        return JSON.stringify(args || {}, null, 2);
+    } catch (_) {
+        return String(args || '');
+    }
+}
+
+function renderToolInput(info) {
+    if (info.detailKind === 'command' && info.detailText) {
+        return `<div class="tool-command"><span class="tool-prompt">$</span> <code>${escapeHtml(info.detailText)}</code></div>`;
+    }
+    if (info.detailKind === 'value' && info.detailText) {
+        return `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code></div>`;
+    }
+    return `<pre class="tool-args">${escapeHtml(formatArgs(info.args))}</pre>`;
 }
 
 export function findToolBlock(contentEl, toolName, toolCallId) {
@@ -37,34 +211,52 @@ export function findToolBlock(contentEl, toolName, toolCallId) {
 }
 
 export function setToolValidationFailureState(toolBlock, payload) {
-    const statusEl = toolBlock.querySelector('.tool-status');
-    const resultEl = toolBlock.querySelector('.tool-result');
-    if (!statusEl || !resultEl) return;
-
-    statusEl.innerHTML = `<svg class="status-icon status-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.29 3.86l-8.2 14.2A2 2 0 0 0 3.8 21h16.4a2 2 0 0 0 1.73-2.94l-8.2-14.2a2 2 0 0 0-3.46 0z"/></svg>`;
-    resultEl.classList.remove('error-text');
-    resultEl.classList.add('warning-text');
-    renderRichContent(resultEl, formatValidationDetails(payload));
+    const outputEl = toolBlock.querySelector('.tool-output');
+    setToolStatus(toolBlock, 'warning');
+    if (outputEl) {
+        outputEl.classList.remove('error-text');
+        outputEl.classList.add('warning-text');
+        renderRichContent(outputEl, formatValidationDetails(payload));
+    }
 }
 
 export function applyToolReturn(toolBlock, content) {
-    const statusEl = toolBlock.querySelector('.tool-status');
-    const resultEl = toolBlock.querySelector('.tool-result');
-    if (!statusEl || !resultEl) return;
+    const outputEl = toolBlock.querySelector('.tool-output');
 
     const isError = isToolEnvelopeError(content);
     if (isError) {
-        statusEl.innerHTML = `<svg class="status-icon status-error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>`;
-        resultEl.classList.add('error-text');
-        resultEl.classList.remove('warning-text');
+        setToolStatus(toolBlock, 'error');
+        if (outputEl) {
+            outputEl.classList.add('error-text');
+            outputEl.classList.remove('warning-text');
+        }
     } else {
-        statusEl.innerHTML = `<svg class="status-icon status-success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>`;
-        resultEl.classList.remove('error-text');
-        resultEl.classList.remove('warning-text');
+        setToolStatus(toolBlock, 'completed');
+        if (outputEl) {
+            outputEl.classList.remove('error-text');
+            outputEl.classList.remove('warning-text');
+        }
     }
 
-    renderToolResultContent(resultEl, content);
+    if (outputEl) {
+        renderToolResultContent(outputEl, content, toolBlock.dataset.toolName);
+    }
     syncApprovalStateFromEnvelope(toolBlock, content);
+}
+
+export function setToolStatus(toolBlock, status) {
+    const statusEl = toolBlock?.querySelector('.tool-status');
+    if (!toolBlock || !statusEl) return;
+    if (status === 'running') {
+        statusEl.innerHTML = SPINNER_HTML;
+    } else if (status === 'error') {
+        statusEl.innerHTML = ERROR_SVG;
+    } else if (status === 'warning') {
+        statusEl.innerHTML = WARNING_SVG;
+    } else {
+        statusEl.innerHTML = CHECK_SVG;
+    }
+    toolBlock.dataset.status = String(status || '');
 }
 
 export function indexPendingToolBlock(pendingToolBlocks, toolBlock, toolName, toolCallId) {
@@ -119,34 +311,43 @@ function isToolEnvelopeError(content) {
     return !!(content && typeof content === 'object' && content.ok === false);
 }
 
-function renderToolResultContent(targetEl, content) {
+function renderToolResultContent(targetEl, content, toolName) {
     targetEl.replaceChildren();
     if (content && typeof content === 'object' && typeof content.ok === 'boolean') {
-        renderEnvelopeResult(targetEl, content);
+        renderEnvelopeResult(targetEl, content, toolName);
         return;
     }
     if (renderStructuredPayload(targetEl, content)) {
         return;
     }
     const val = typeof content === 'object' ? JSON.stringify(content, null, 2) : String(content);
-    renderRichContent(targetEl, val);
+    targetEl.textContent = val;
 }
 
-function renderEnvelopeResult(targetEl, envelope) {
+function renderEnvelopeResult(targetEl, envelope, toolName) {
     if (envelope.ok !== true) {
         const error = envelope.error && typeof envelope.error === 'object'
             ? envelope.error.message || JSON.stringify(envelope.error, null, 2)
             : JSON.stringify(envelope, null, 2);
-        renderRichContent(targetEl, String(error || 'Tool execution failed.'));
+        targetEl.textContent = String(error || 'Tool execution failed.');
         return;
     }
-    if (renderStructuredPayload(targetEl, envelope.data, envelope.meta)) {
+
+    const data = envelope.data;
+
+    if (toolName === 'shell' && data && typeof data === 'object') {
+        const output = String(data.output || '');
+        targetEl.textContent = output;
         return;
     }
-    const val = typeof envelope.data === 'object'
-        ? JSON.stringify(envelope.data, null, 2)
-        : String(envelope.data ?? '');
-    renderRichContent(targetEl, val);
+
+    if (renderStructuredPayload(targetEl, data, envelope.meta)) {
+        return;
+    }
+    const val = typeof data === 'object'
+        ? JSON.stringify(data, null, 2)
+        : String(data ?? '');
+    targetEl.textContent = val;
 }
 
 function renderStructuredPayload(targetEl, payload, meta = null) {
@@ -199,6 +400,33 @@ function renderStructuredPayload(targetEl, payload, meta = null) {
         renderRichContent(targetEl, JSON.stringify(payload, null, 2));
     }
     return true;
+}
+
+function handleCopyClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const btn = event.currentTarget;
+    const toolBlock = btn.closest('.tool-block');
+    if (!toolBlock) return;
+
+    const outputEl = toolBlock.querySelector('.tool-output');
+    const commandEl = toolBlock.querySelector('.tool-command code')
+        || toolBlock.querySelector('.tool-input-value code')
+        || toolBlock.querySelector('.tool-args');
+    const parts = [];
+    if (commandEl) parts.push(commandEl.textContent || '');
+    if (outputEl) parts.push(outputEl.textContent || '');
+    const textToCopy = parts.filter(Boolean).join('\n\n');
+
+    navigator.clipboard.writeText(textToCopy).then(() => {
+        const original = btn.innerHTML;
+        btn.innerHTML = `${CHECK_SVG}`;
+        btn.title = t('tool.action.copied');
+        setTimeout(() => {
+            btn.innerHTML = original;
+            btn.title = t('tool.action.copy');
+        }, 1500);
+    }).catch(() => {});
 }
 
 function pendingToolKey(toolName, toolCallId) {

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -2,6 +2,7 @@
  * components/messageRenderer/history.js
  * Historical message rendering and approval state hydration.
  */
+import { isRunPrimaryRoleId } from '../../core/state.js';
 import {
     applyToolReturn,
     appendMessageText,
@@ -16,6 +17,7 @@ import {
     renderParts,
     resolvePendingToolBlock,
     forceScrollBottom,
+    setToolStatus,
     setToolValidationFailureState,
 } from './helpers.js';
 
@@ -67,17 +69,28 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
         const label = role === 'user' && String(options.userRoleLabel || '').trim()
             ? String(options.userRoleLabel || '').trim()
             : labelFromRole(role, msgItem.role_id, msgItem.instance_id);
-        const { contentEl } = renderMessageBlock(container, role, label, []);
+        const streamKey = resolveHistoryStreamKey(runId, msgItem.instance_id, msgItem.role_id);
+        const { wrapper, contentEl } = renderMessageBlock(container, role, label, [], {
+            runId,
+            instanceId: String(msgItem.instance_id || '').trim(),
+            roleId: String(msgItem.role_id || '').trim(),
+            streamKey,
+        });
         renderParts(contentEl, parts, pendingToolBlocks);
         lastRenderedMessage = {
             role,
             label,
+            wrapper,
             contentEl,
+            runId,
+            roleId: String(msgItem.role_id || '').trim(),
+            instanceId: String(msgItem.instance_id || '').trim(),
+            streamKey,
         };
     });
 
     if (streamOverlayEntry && Array.isArray(streamOverlayEntry.parts) && streamOverlayEntry.parts.length > 0) {
-        renderStreamOverlayEntry(container, streamOverlayEntry, pendingToolBlocks, lastRenderedMessage);
+        renderStreamOverlayEntry(container, streamOverlayEntry, pendingToolBlocks, lastRenderedMessage, runId);
     }
 
     applyPendingApprovalsToHistory(container, pendingToolApprovals, runId);
@@ -118,7 +131,10 @@ function applyPendingApprovalsToHistory(container, approvals, runId) {
     if (missing.length === 0) return;
     const primaryRoleLabel = String(container?.dataset?.primaryRoleLabel || '').trim()
         || 'Main Agent';
-    const { contentEl } = renderMessageBlock(container, 'model', primaryRoleLabel, []);
+    const { contentEl } = renderMessageBlock(container, 'model', primaryRoleLabel, [], {
+        runId,
+        streamKey: 'primary',
+    });
     missing.forEach(approval => {
         const toolBlock = buildToolBlock(
             approval?.tool_name || 'unknown_tool',
@@ -135,10 +151,17 @@ function renderStreamOverlayEntry(
     streamOverlayEntry,
     pendingToolBlocks,
     lastRenderedMessage = null,
+    runId = '',
 ) {
     const label = streamOverlayEntry.label
         || labelFromRole('assistant', streamOverlayEntry.roleId, streamOverlayEntry.instanceId);
-    const contentEl = resolveOverlayContentTarget(container, label, lastRenderedMessage);
+    const contentEl = resolveOverlayContentTarget(
+        container,
+        label,
+        streamOverlayEntry,
+        lastRenderedMessage,
+        runId,
+    );
     let combinedText = '';
     const overlayParts = Array.isArray(streamOverlayEntry.parts) ? streamOverlayEntry.parts : [];
     const trailingTextPart = [...overlayParts].reverse().find(part => part && typeof part === 'object');
@@ -183,43 +206,66 @@ function renderStreamOverlayEntry(
     flushText(trailingTextPart?.kind === 'text');
 }
 
-function resolveOverlayContentTarget(container, label, lastRenderedMessage) {
+function resolveOverlayContentTarget(container, label, streamOverlayEntry, lastRenderedMessage, runId = '') {
     const safeLabel = String(label || '').trim();
     const lastLabel = String(lastRenderedMessage?.label || '').trim();
+    const overlayStreamKey = resolveHistoryStreamKey(
+        runId || lastRenderedMessage?.runId || '',
+        streamOverlayEntry?.instanceId,
+        streamOverlayEntry?.roleId,
+    );
     if (
-        lastRenderedMessage?.contentEl
-        && lastRenderedMessage.role !== 'user'
+        wrapperMatchesOverlay(lastRenderedMessage?.wrapper, {
+            runId: runId || lastRenderedMessage?.runId || '',
+            roleId: streamOverlayEntry?.roleId,
+            instanceId: streamOverlayEntry?.instanceId,
+            streamKey: overlayStreamKey,
+        })
         && safeLabel
+        && lastRenderedMessage?.contentEl
+        && lastRenderedMessage.role !== 'user'
         && safeLabel.localeCompare(lastLabel, undefined, { sensitivity: 'accent' }) === 0
     ) {
         return lastRenderedMessage.contentEl;
     }
-    const lastMessageContentEl = findLastCompatibleMessageContent(container, safeLabel);
+    const lastMessageContentEl = findLastCompatibleMessageContent(container, safeLabel, {
+        runId: runId || lastRenderedMessage?.runId || '',
+        roleId: streamOverlayEntry?.roleId,
+        instanceId: streamOverlayEntry?.instanceId,
+        streamKey: overlayStreamKey,
+    });
     if (lastMessageContentEl) {
         return lastMessageContentEl;
     }
-    return renderMessageBlock(container, 'assistant', label, []).contentEl;
+    return renderMessageBlock(container, 'assistant', label, [], {
+        runId: runId || lastRenderedMessage?.runId || '',
+        roleId: String(streamOverlayEntry?.roleId || '').trim(),
+        instanceId: String(streamOverlayEntry?.instanceId || '').trim(),
+        streamKey: overlayStreamKey,
+    }).contentEl;
 }
 
-function findLastCompatibleMessageContent(container, label) {
+function findLastCompatibleMessageContent(container, label, options = {}) {
     if (!container || !label) return null;
     const messages = Array.from(container.querySelectorAll('.message'));
-    const lastMessage = messages[messages.length - 1];
-    if (!lastMessage) return null;
-
-    const roleEl = lastMessage.querySelector('.msg-role');
-    const contentEl = lastMessage.querySelector('.msg-content');
-    const renderedLabel = String(roleEl?.textContent || '').trim();
     const expectedLabel = String(label || '').trim().toUpperCase();
-    if (!contentEl || !renderedLabel || !expectedLabel) return null;
-    if (renderedLabel !== expectedLabel) return null;
-    return contentEl;
+    if (!expectedLabel) return null;
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+        const message = messages[index];
+        const roleEl = message.querySelector('.msg-role');
+        const contentEl = message.querySelector('.msg-content');
+        const renderedLabel = String(roleEl?.textContent || '').trim();
+        if (!contentEl || !renderedLabel) continue;
+        if (renderedLabel !== expectedLabel) continue;
+        if (!wrapperMatchesOverlay(message, options)) continue;
+        return contentEl;
+    }
+    return null;
 }
 
 function applyOverlayToolState(toolBlock, part) {
-    const statusEl = toolBlock.querySelector('.tool-status');
-    const resultEl = toolBlock.querySelector('.tool-result');
-    if (!statusEl || !resultEl) return;
+    const outputEl = toolBlock.querySelector('.tool-output');
+    if (!outputEl) return;
 
     if (part.validation) {
         setToolValidationFailureState(toolBlock, part.validation);
@@ -237,16 +283,18 @@ function applyOverlayToolState(toolBlock, part) {
     }
 
     if (part.approvalStatus === 'deny') {
-        resultEl.classList.remove('error-text');
-        resultEl.classList.add('warning-text');
-        resultEl.innerHTML = 'Approval denied. Tool will not execute.';
+        setToolStatus(toolBlock, 'warning');
+        outputEl.classList.remove('error-text');
+        outputEl.classList.add('warning-text');
+        outputEl.innerHTML = 'Approval denied. Tool will not execute.';
         return;
     }
 
     if (part.approvalStatus === 'approve' && part.result === undefined) {
-        resultEl.classList.remove('error-text');
-        resultEl.classList.add('warning-text');
-        resultEl.innerHTML = 'Approval submitted. Waiting for tool result...';
+        setToolStatus(toolBlock, 'running');
+        outputEl.classList.remove('error-text');
+        outputEl.classList.add('warning-text');
+        outputEl.innerHTML = 'Approval submitted. Waiting for tool result...';
         return;
     }
 
@@ -255,8 +303,37 @@ function applyOverlayToolState(toolBlock, part) {
         return;
     }
 
-    statusEl.innerHTML = '<div class="spinner"></div>';
-    resultEl.classList.remove('error-text');
-    resultEl.classList.add('warning-text');
-    resultEl.innerHTML = 'Processing...';
+    setToolStatus(toolBlock, 'running');
+    outputEl.classList.remove('error-text');
+    outputEl.classList.remove('warning-text');
+    outputEl.textContent = '';
+}
+
+function resolveHistoryStreamKey(runId, instanceId, roleId) {
+    const safeRoleId = String(roleId || '').trim();
+    const safeInstanceId = String(instanceId || '').trim();
+    if (!safeRoleId || safeInstanceId === 'primary' || safeInstanceId === 'coordinator') {
+        return 'primary';
+    }
+    if (runId && isRunPrimaryRoleId(safeRoleId, runId)) {
+        return 'primary';
+    }
+    return safeInstanceId || `role:${safeRoleId}`;
+}
+
+function wrapperMatchesOverlay(wrapper, options = {}) {
+    if (!wrapper) return false;
+    const expectedRunId = String(options.runId || '').trim();
+    const expectedRoleId = String(options.roleId || '').trim();
+    const expectedInstanceId = String(options.instanceId || '').trim();
+    const expectedStreamKey = String(options.streamKey || '').trim();
+    const wrapperRunId = String(wrapper.dataset.runId || '').trim();
+    const wrapperRoleId = String(wrapper.dataset.roleId || '').trim();
+    const wrapperInstanceId = String(wrapper.dataset.instanceId || '').trim();
+    const wrapperStreamKey = String(wrapper.dataset.streamKey || '').trim();
+    if (expectedRunId && wrapperRunId && wrapperRunId !== expectedRunId) return false;
+    if (expectedStreamKey && wrapperStreamKey && wrapperStreamKey !== expectedStreamKey) return false;
+    if (expectedRoleId && wrapperRoleId && wrapperRoleId !== expectedRoleId) return false;
+    if (expectedInstanceId && wrapperInstanceId && wrapperInstanceId !== expectedInstanceId) return false;
+    return true;
 }

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -7,10 +7,14 @@ import {
     applyToolReturn,
     appendStructuredContentPart,
     appendThinkingText,
+    buildPendingToolBlock,
     findToolBlock,
     findToolBlockInContainer,
+    indexPendingToolBlock,
     renderMessageBlock,
+    resolvePendingToolBlock,
     scrollBottom,
+    setToolStatus,
     setToolValidationFailureState,
     syncStreamingCursor,
     updateThinkingText,
@@ -44,6 +48,7 @@ export function getOrCreateStreamBlock(
     } else {
         if (!st.thinkingParts) st.thinkingParts = new Map();
         if (!st.thinkingActiveByPart) st.thinkingActiveByPart = new Map();
+        if (!st.pendingToolBlocks) st.pendingToolBlocks = {};
         if (typeof st.thinkingSequence !== 'number') st.thinkingSequence = 0;
         if (typeof st.activeRaw !== 'string') st.activeRaw = '';
     }
@@ -230,41 +235,16 @@ export function appendToolCallBlock(
     } else {
         if (!st.thinkingParts) st.thinkingParts = new Map();
         if (!st.thinkingActiveByPart) st.thinkingActiveByPart = new Map();
+        if (!st.pendingToolBlocks) st.pendingToolBlocks = {};
         if (typeof st.thinkingSequence !== 'number') st.thinkingSequence = 0;
         if (typeof st.activeRaw !== 'string') st.activeRaw = '';
     }
 
     endActiveText(st);
 
-    let argsStr = '';
-    try {
-        argsStr = typeof args === 'object' ? JSON.stringify(args, null, 2) : String(args || '');
-    } catch (e) {
-        argsStr = String(args);
-    }
-
-    const toolBlock = document.createElement('div');
-    toolBlock.className = 'tool-block';
-    toolBlock.dataset.toolName = toolName;
-    if (toolCallId) {
-        toolBlock.dataset.toolCallId = toolCallId;
-    }
-    toolBlock.style.display = 'block';
-    toolBlock.style.visibility = 'visible';
-    toolBlock.innerHTML = `
-        <div class="tool-header" onclick="this.nextElementSibling.classList.toggle('open')">
-            <div class="tool-title">
-                <svg viewBox="0 0 24 24" fill="none" class="icon" style="width:14px;height:14px;"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" stroke="currentColor" stroke-width="2"/></svg>
-                <span class="name">${toolName}</span>
-            </div>
-            <div class="tool-status"><div class="spinner"></div></div>
-        </div>
-        <div class="tool-body">
-            <pre class="tool-args" style="white-space:pre-wrap;">${argsStr}</pre>
-            <div class="tool-result">Processing...</div>
-        </div>
-    `;
+    const toolBlock = buildPendingToolBlock(toolName, args, toolCallId);
     st.contentEl.appendChild(toolBlock);
+    indexPendingToolBlock(st.pendingToolBlocks, toolBlock, toolName, toolCallId);
     updateOverlayToolCall(st.runId || runId, st.instanceId || instanceId, roleId || st.roleId, st.label, {
         tool_call_id: toolCallId || '',
         tool_name: toolName,
@@ -341,6 +321,7 @@ export function startThinkingBlock(instanceId, partIndex, options = {}) {
     } else if (st) {
         if (!st.thinkingParts) st.thinkingParts = new Map();
         if (!st.thinkingActiveByPart) st.thinkingActiveByPart = new Map();
+        if (!st.pendingToolBlocks) st.pendingToolBlocks = {};
         if (typeof st.thinkingSequence !== 'number') st.thinkingSequence = 0;
         if (typeof st.activeRaw !== 'string') st.activeRaw = '';
     }
@@ -412,8 +393,7 @@ export function attachToolApprovalControls(instanceId, toolName, payload, handle
 
     const approvalEl = ensureApprovalState(toolBlock);
 
-    const body = toolBlock.querySelector('.tool-body');
-    if (body) body.classList.add('open');
+    toolBlock.open = true;
 
     const stateEl = approvalEl.querySelector('.tool-approval-state');
     if (stateEl) stateEl.textContent = t('stream.approval_required');
@@ -450,14 +430,18 @@ export function markToolApprovalResolved(instanceId, payload, options = {}) {
     if (stateEl) {
         stateEl.textContent = formatMessage('stream.approval_action', { action });
     }
-    const resultEl = toolBlock.querySelector('.tool-result');
-    if (resultEl) {
-        resultEl.classList.remove('error-text');
-        resultEl.classList.add('warning-text');
+    setToolStatus(
+        toolBlock,
+        String(payload.action || '').toLowerCase() === 'deny' ? 'warning' : 'running',
+    );
+    const outputEl = toolBlock.querySelector('.tool-output');
+    if (outputEl) {
+        outputEl.classList.remove('error-text');
+        outputEl.classList.add('warning-text');
         if (String(payload.action || '').toLowerCase() === 'deny') {
-            resultEl.innerHTML = t('stream.approval_denied');
+            outputEl.innerHTML = t('stream.approval_denied');
         } else {
-            resultEl.innerHTML = t('stream.approval_waiting');
+            outputEl.innerHTML = t('stream.approval_waiting');
         }
     }
     scrollBottom((st && st.container) || container);
@@ -564,13 +548,17 @@ function ensureApprovalState(toolBlock) {
 
     approvalEl = document.createElement('div');
     approvalEl.className = 'tool-approval-inline';
-    approvalEl.innerHTML = `<div class="tool-approval-state">${escapeHtml(t('approval.state.required'))}</div>`;
-    const body = toolBlock.querySelector('.tool-body');
-    const resultEl = toolBlock.querySelector('.tool-result');
-    if (body && resultEl) {
-        body.insertBefore(approvalEl, resultEl);
-    } else if (body) {
-        body.appendChild(approvalEl);
+    const _label = t('approval.state.required');
+    const _labelEl = document.createElement('div');
+    _labelEl.className = 'tool-approval-state';
+    _labelEl.textContent = _label;
+    approvalEl.replaceChildren(_labelEl);
+    const card = toolBlock.querySelector('.tool-detail-card');
+    const outputEl = toolBlock.querySelector('.tool-output');
+    if (card && outputEl) {
+        card.insertBefore(approvalEl, outputEl);
+    } else if (card) {
+        card.appendChild(approvalEl);
     }
     return approvalEl;
 }
@@ -591,6 +579,7 @@ function createStreamState({
     label,
     runId,
 }) {
+    const streamKey = resolveStreamKey(instanceId, roleId);
     const reused = findReusableStreamState({
         container,
         instanceId,
@@ -601,11 +590,17 @@ function createStreamState({
     if (reused) {
         return reused;
     }
-    const { wrapper, contentEl } = renderMessageBlock(container, 'model', label, []);
+    const { wrapper, contentEl } = renderMessageBlock(container, 'model', label, [], {
+        runId,
+        instanceId: String(instanceId || '').trim(),
+        roleId: String(roleId || '').trim(),
+        streamKey,
+    });
     return {
         container,
         wrapper,
         contentEl,
+        pendingToolBlocks: {},
         activeTextEl: null,
         raw: '',
         activeRaw: '',
@@ -616,6 +611,7 @@ function createStreamState({
         label,
         runId: String(runId || ''),
         instanceId: String(instanceId || ''),
+        streamKey,
     };
 }
 
@@ -640,10 +636,12 @@ function findReusableStreamState({
     const activeTextEl = findLastReusableTextElement(contentEl);
     const activeRaw = resolveReusableRawText(overlayEntry);
     const thinkingBinding = bindReusableThinkingState(contentEl, overlayEntry);
+    const pendingToolBlocks = bindReusableToolBlocks(contentEl, overlayEntry);
     return {
         container,
         wrapper,
         contentEl,
+        pendingToolBlocks,
         activeTextEl,
         raw: activeRaw,
         activeRaw,
@@ -654,6 +652,7 @@ function findReusableStreamState({
         label,
         runId: String(runId || ''),
         instanceId: String(instanceId || ''),
+        streamKey: resolveStreamKey(instanceId, roleId),
     };
 }
 
@@ -700,8 +699,9 @@ function findReusableMessageWrapper({
 
 function wrapperMatchesStreamKey(wrapper, streamKey, roleId) {
     const safeStreamKey = String(streamKey || '').trim();
-    if (safeStreamKey === PRIMARY_KEY) {
-        return true;
+    const wrapperStreamKey = String(wrapper.dataset.streamKey || '').trim();
+    if (wrapperStreamKey) {
+        return wrapperStreamKey === safeStreamKey;
     }
     const wrapperInstanceId = String(wrapper.dataset.instanceId || '').trim();
     const wrapperRoleId = String(wrapper.dataset.roleId || '').trim();
@@ -713,6 +713,10 @@ function wrapperMatchesStreamKey(wrapper, streamKey, roleId) {
 }
 
 function wrapperBelongsToRun(wrapper, runId) {
+    const wrapperRunId = String(wrapper.dataset.runId || '').trim();
+    if (wrapperRunId) {
+        return wrapperRunId === runId;
+    }
     const section = wrapper.closest('.session-round-section');
     if (!section) return true;
     return String(section.dataset.runId || '').trim() === runId;
@@ -778,6 +782,29 @@ function bindReusableThinkingState(contentEl, overlayEntry) {
     return { parts, activeByPart, nextSequence };
 }
 
+function bindReusableToolBlocks(contentEl, overlayEntry) {
+    const pendingToolBlocks = {};
+    if (!contentEl || !overlayEntry || !Array.isArray(overlayEntry.parts)) {
+        return pendingToolBlocks;
+    }
+    overlayEntry.parts.forEach(part => {
+        if (!part || part.kind !== 'tool') {
+            return;
+        }
+        const toolBlock = findToolBlock(contentEl, part.tool_name, part.tool_call_id || null);
+        if (!toolBlock) {
+            return;
+        }
+        indexPendingToolBlock(
+            pendingToolBlocks,
+            toolBlock,
+            part.tool_name,
+            part.tool_call_id || null,
+        );
+    });
+    return pendingToolBlocks;
+}
+
 function findReusableThinkingTextElement(contentEl, key, partIndex) {
     if (!contentEl) {
         return null;
@@ -821,6 +848,12 @@ function endActiveText(st) {
 
 function resolveToolBlockTarget(st, container, toolName, toolCallId) {
     if (st) {
+        const indexed = resolvePendingToolBlock(
+            st.pendingToolBlocks || {},
+            toolName,
+            toolCallId,
+        );
+        if (indexed) return indexed;
         const byStreamState = findToolBlock(st.contentEl, toolName, toolCallId);
         if (byStreamState) return byStreamState;
     }

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -2036,6 +2036,21 @@ Object.assign(TRANSLATIONS['en-US'], {
     'workspace_view.feishu_chat': 'Feishu chat',
     'workspace_view.chat_type': 'Chat type',
     'workspace_view.delivery_help_feishu': 'Automation updates will be pushed to the selected Feishu chat.',
+    'tool.summary.shell': 'Ran command',
+    'tool.summary.read': 'Read file',
+    'tool.summary.write': 'Wrote file',
+    'tool.summary.edit': 'Edited file',
+    'tool.summary.grep': 'Searched content',
+    'tool.summary.glob': 'Searched files',
+    'tool.summary.websearch': 'Web search',
+    'tool.summary.webfetch': 'Fetched page',
+    'tool.summary.generic': 'Ran {tool}',
+    'tool.lang.shell': 'Shell',
+    'tool.status.success': 'Success',
+    'tool.status.error': 'Failed',
+    'tool.status.running': 'Running...',
+    'tool.action.copy': 'Copy',
+    'tool.action.copied': 'Copied',
 });
 
 Object.assign(TRANSLATIONS['zh-CN'], {
@@ -2085,6 +2100,21 @@ Object.assign(TRANSLATIONS['zh-CN'], {
     'workspace_view.feishu_chat': '飞书会话',
     'workspace_view.chat_type': '会话类型',
     'workspace_view.delivery_help_feishu': '自动化更新会推送到所选的飞书会话。',
+    'tool.summary.shell': '已运行命令',
+    'tool.summary.read': '已读取文件',
+    'tool.summary.write': '已写入文件',
+    'tool.summary.edit': '已编辑文件',
+    'tool.summary.grep': '已搜索内容',
+    'tool.summary.glob': '已搜索文件',
+    'tool.summary.websearch': '已搜索网络',
+    'tool.summary.webfetch': '已获取网页',
+    'tool.summary.generic': '已运行 {tool}',
+    'tool.lang.shell': 'Shell',
+    'tool.status.success': '成功',
+    'tool.status.error': '失败',
+    'tool.status.running': '运行中...',
+    'tool.action.copy': '复制',
+    'tool.action.copied': '已复制',
 });
 
 export function getCurrentLanguage() {

--- a/src/agent_teams/agents/execution/llm_session.py
+++ b/src/agent_teams/agents/execution/llm_session.py
@@ -377,6 +377,7 @@ class AgentLlmSession:
         attempt_text_emitted = False
         attempt_tool_event_emitted = False
         attempt_messages_committed = False
+        published_tool_call_ids: set[str] = set()
         history: list[ModelRequest | ModelResponse] = (
             self._truncate_history_to_safe_boundary(
                 self._filter_model_messages(
@@ -526,6 +527,15 @@ class AgentLlmSession:
                             new_messages=new_batch,
                         )
                         if new_to_process:
+                            tool_call_events_emitted = (
+                                self._publish_tool_call_events_from_messages(
+                                    request=request,
+                                    messages=new_to_process,
+                                    published_tool_call_ids=published_tool_call_ids,
+                                )
+                            )
+                            if tool_call_events_emitted:
+                                attempt_tool_event_emitted = True
                             buffered_messages.extend(new_to_process)
                             previous_history_size = len(history)
                             (
@@ -602,6 +612,15 @@ class AgentLlmSession:
                         new_messages=list(all_new)[seen_count:],
                     )
                     if to_save:
+                        tool_call_events_emitted = (
+                            self._publish_tool_call_events_from_messages(
+                                request=request,
+                                messages=to_save,
+                                published_tool_call_ids=published_tool_call_ids,
+                            )
+                        )
+                        if tool_call_events_emitted:
+                            attempt_tool_event_emitted = True
                         buffered_messages.extend(to_save)
                     previous_history_size = len(history)
                     (
@@ -1656,10 +1675,6 @@ class AgentLlmSession:
             trace_id=request.trace_id,
             messages=ready,
         )
-        self._publish_tool_call_events_from_messages(
-            request=request,
-            messages=ready,
-        )
         self._publish_committed_tool_outcome_events_from_messages(
             request=request,
             messages=ready,
@@ -1810,12 +1825,19 @@ class AgentLlmSession:
         *,
         request: LLMRequest,
         messages: Sequence[ModelResponse | ModelRequest],
-    ) -> None:
+        published_tool_call_ids: set[str] | None = None,
+    ) -> bool:
+        emitted = False
         for msg in messages:
             if isinstance(msg, ModelResponse):
                 for part in msg.parts:
                     if not isinstance(part, ToolCallPart):
                         continue
+                    tool_call_id = str(part.tool_call_id or "").strip()
+                    if tool_call_id and published_tool_call_ids is not None:
+                        if tool_call_id in published_tool_call_ids:
+                            continue
+                        published_tool_call_ids.add(tool_call_id)
                     self._run_event_hub.publish(
                         RunEvent(
                             session_id=request.session_id,
@@ -1828,7 +1850,7 @@ class AgentLlmSession:
                             payload_json=self._to_json(
                                 {
                                     "tool_name": part.tool_name,
-                                    "tool_call_id": part.tool_call_id,
+                                    "tool_call_id": tool_call_id,
                                     "args": part.args,
                                     "role_id": request.role_id,
                                     "instance_id": request.instance_id,
@@ -1836,6 +1858,8 @@ class AgentLlmSession:
                             ),
                         )
                     )
+                    emitted = True
+        return emitted
 
     def _publish_committed_tool_outcome_events_from_messages(
         self,

--- a/src/agent_teams/providers/openai_compatible.py
+++ b/src/agent_teams/providers/openai_compatible.py
@@ -265,10 +265,12 @@ class OpenAICompatibleProvider(LLMProvider):
         *,
         request: LLMRequest,
         messages: Sequence[ModelResponse | ModelRequest],
-    ) -> None:
-        self._session._publish_tool_call_events_from_messages(
+        published_tool_call_ids: set[str] | None = None,
+    ) -> bool:
+        return self._session._publish_tool_call_events_from_messages(
             request=request,
             messages=messages,
+            published_tool_call_ids=published_tool_call_ids,
         )
 
     def _publish_committed_tool_outcome_events_from_messages(

--- a/tests/unit_tests/frontend/test_message_history_labels_ui.py
+++ b/tests/unit_tests/frontend/test_message_history_labels_ui.py
@@ -129,6 +129,10 @@ export function resolvePendingToolBlock() {
     return null;
 }
 
+export function setToolStatus() {
+    return undefined;
+}
+
 export function setToolValidationFailureState() {
     return undefined;
 }
@@ -137,8 +141,8 @@ export function setToolValidationFailureState() {
     )
     (tmp_path / "mockState.mjs").write_text(
         """
-export function getPrimaryRoleLabel() {
-    return 'Coordinator';
+export function isRunPrimaryRoleId() {
+    return false;
 }
 """.strip(),
         encoding="utf-8",

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -148,15 +148,28 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert "function resolveReusableRawText(overlayEntry) {" in renderer_stream_script
     assert "let lastRenderedMessage = null;" in history_script
     assert (
-        "renderStreamOverlayEntry(container, streamOverlayEntry, pendingToolBlocks, lastRenderedMessage);"
-        in history_script
-    )
-    assert "return lastRenderedMessage.contentEl;" in history_script
-    assert (
-        "const lastMessageContentEl = findLastCompatibleMessageContent(container, safeLabel);"
+        "renderStreamOverlayEntry(container, streamOverlayEntry, pendingToolBlocks, lastRenderedMessage, runId);"
         in history_script
     )
     assert (
-        "function findLastCompatibleMessageContent(container, label) {"
+        "const streamKey = resolveStreamKey(instanceId, roleId);"
+        in renderer_stream_script
+    )
+    assert "wrapper.dataset.streamKey = streamKey;" in (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "block.js"
+    ).read_text(encoding="utf-8")
+    assert (
+        "const lastMessageContentEl = findLastCompatibleMessageContent(container, safeLabel, {"
+        in history_script
+    )
+    assert (
+        "function findLastCompatibleMessageContent(container, label, options = {}) {"
         in history_script
     )

--- a/tests/unit_tests/frontend/test_streaming_tool_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_tool_ui.py
@@ -39,3 +39,74 @@ def test_tool_result_updates_can_patch_dom_after_stream_finalize() -> None:
         in tool_events_script
     )
     assert "container," in tool_events_script
+
+
+def test_streaming_tool_calls_keep_indexed_dom_targets_and_message_metadata() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    stream_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "stream.js"
+    ).read_text(encoding="utf-8")
+    block_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "block.js"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "indexPendingToolBlock(st.pendingToolBlocks, toolBlock, toolName, toolCallId);"
+        in stream_script
+    )
+    assert "const indexed = resolvePendingToolBlock(" in stream_script
+    assert (
+        "const pendingToolBlocks = bindReusableToolBlocks(contentEl, overlayEntry);"
+        in stream_script
+    )
+    assert "function bindReusableToolBlocks(contentEl, overlayEntry) {" in stream_script
+    assert "wrapper.dataset.runId = runId;" in block_script
+    assert "wrapper.dataset.instanceId = instanceId;" in block_script
+    assert "wrapper.dataset.roleId = roleId;" in block_script
+    assert "wrapper.dataset.streamKey = streamKey;" in block_script
+
+
+def test_tool_blocks_extract_effective_inputs_instead_of_footer_status() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    tool_blocks_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "toolBlocks.js"
+    ).read_text(encoding="utf-8")
+    tools_css = (
+        repo_root / "frontend" / "dist" / "css" / "components" / "tools.css"
+    ).read_text(encoding="utf-8")
+
+    assert "fields: ['command', 'cmd']" in tool_blocks_script
+    assert (
+        "fields: ['path', 'file_path', 'filepath', 'target_path']" in tool_blocks_script
+    )
+    assert "fields: ['query', 'q', 'search_query']" in tool_blocks_script
+    assert "fields: ['url', 'uri']" in tool_blocks_script
+    assert "function normalizeToolArgs(args) {" in tool_blocks_script
+    assert "return { __raw: raw };" in tool_blocks_script
+    assert (
+        'return `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code></div>`;'
+        in tool_blocks_script
+    )
+    assert ".tool-input-value {" in tools_css
+    assert ".tool-detail-footer {" not in tools_css
+    assert ".tool-result-status {" not in tools_css

--- a/tests/unit_tests/frontend/test_workspace_prompt_ui.py
+++ b/tests/unit_tests/frontend/test_workspace_prompt_ui.py
@@ -259,8 +259,8 @@ def test_light_theme_workspace_uses_shared_surface_hierarchy() -> None:
     )
     assert "body.light-theme .round-state-pill," in components_css
     assert "background: transparent;" in components_css
-    assert "body.light-theme .tool-block," in components_css
-    assert "background: var(--bg-tool-block);" in components_css
+    assert "body.light-theme .tool-detail-card" in components_css
+    assert "background: var(--bg-surface-muted);" in components_css
     assert "background: var(--bg-surface-glass);" in layout_css
     assert "--bg-surface-glass: #f3f4f4;" in (
         repo_root / "frontend" / "dist" / "css" / "base.css"

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -1459,9 +1459,14 @@ async def test_subagent_resume_after_tool_call_cancellation_replays_from_safe_bo
 
     history_after_cancel = message_repo.get_history("inst-sub")
     assert len(history_after_cancel) == 1
-    assert not any(
-        event.event_type == RunEventType.TOOL_CALL for event in cancel_hub.events
-    )
+    cancel_tool_call_payloads = [
+        json.loads(event.payload_json)
+        for event in cancel_hub.events
+        if event.event_type == RunEventType.TOOL_CALL
+    ]
+    assert [payload["tool_call_id"] for payload in cancel_tool_call_payloads] == [
+        "call-pre"
+    ]
     assert not any(
         event.event_type == RunEventType.TOOL_RESULT for event in cancel_hub.events
     )

--- a/tests/unit_tests/providers/test_llm_tool_events.py
+++ b/tests/unit_tests/providers/test_llm_tool_events.py
@@ -284,7 +284,7 @@ def test_commit_ready_messages_defers_tool_call_event_until_safe_commit() -> Non
     assert hub.events == []
 
 
-def test_commit_ready_messages_publishes_tool_events_after_safe_commit() -> None:
+def test_commit_ready_messages_publishes_only_tool_outcomes_after_safe_commit() -> None:
     hub = _FakeRunEventHub()
     provider = _provider_with_hub(hub)
     fake_repo = _FakeMessageRepository()
@@ -321,10 +321,48 @@ def test_commit_ready_messages_publishes_tool_events_after_safe_commit() -> None
     assert len(history) == 2
     assert pending == []
     assert tool_events_published is True
-    assert [event.event_type for event in hub.events] == [
-        RunEventType.TOOL_CALL,
-        RunEventType.TOOL_RESULT,
-    ]
+    assert [event.event_type for event in hub.events] == [RunEventType.TOOL_RESULT]
+
+
+def test_publish_tool_call_events_deduplicates_published_tool_call_ids() -> None:
+    hub = _FakeRunEventHub()
+    provider = _provider_with_hub(hub)
+    published_tool_call_ids: set[str] = set()
+
+    emitted_first = provider._publish_tool_call_events_from_messages(
+        request=_request(),
+        messages=[
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="create_tasks",
+                        args={"objective": "x"},
+                        tool_call_id="call-live",
+                    )
+                ]
+            )
+        ],
+        published_tool_call_ids=published_tool_call_ids,
+    )
+    emitted_second = provider._publish_tool_call_events_from_messages(
+        request=_request(),
+        messages=[
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="create_tasks",
+                        args={"objective": "x"},
+                        tool_call_id="call-live",
+                    )
+                ]
+            )
+        ],
+        published_tool_call_ids=published_tool_call_ids,
+    )
+
+    assert emitted_first is True
+    assert emitted_second is False
+    assert [event.event_type for event in hub.events] == [RunEventType.TOOL_CALL]
 
 
 def test_publish_tool_events_skips_retry_without_tool_name() -> None:


### PR DESCRIPTION
## Summary
- fix tool block rendering so live runs use a single summary status, show effective tool inputs, and keep tool results bound to the correct block
- add message metadata and stream overlay matching so live round rendering no longer inserts tool calls into the wrong message position
- publish `TOOL_CALL` events as soon as new tool calls appear in the LLM stream instead of waiting for safe message commit, while deduplicating repeated emissions

## Testing
- `uv run --extra dev pytest -q tests/unit_tests/frontend tests/unit_tests/providers/test_llm_tool_events.py tests/unit_tests/agents/execution/test_llm_session.py`