### PR TITLE
Fix automation recovery, web tool errors, and config validation

### DIFF
--- a/src/agent_teams/agents/execution/system_prompts.py
+++ b/src/agent_teams/agents/execution/system_prompts.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from agent_teams.agents.instances.models import RuntimeToolsSnapshot
 from agent_teams.agents.execution.prompt_instructions import (
     LoadedPromptInstructions,
     PromptInstructionResolver,
@@ -72,6 +73,7 @@ ROLE_BLOCK_SKILLS_PREFIX = "- Skills: "
 AVAILABLE_SKILLS_HEADING = "## Available Skills"
 AVAILABLE_SKILL_ITEM_PREFIX = "- "
 NONE_LABEL = "none"
+AUTHORIZED_RUNTIME_TOOLS_HEADING = "## Authorized Runtime Tools"
 
 
 class RuntimePromptBuildInput(BaseModel):
@@ -84,6 +86,7 @@ class RuntimePromptBuildInput(BaseModel):
     working_directory: Path | None = None
     worktree_root: Path | None = None
     conversation_context: RuntimePromptConversationContext | None = None
+    runtime_tools: RuntimeToolsSnapshot | None = None
 
 
 class PromptSkillInstruction(BaseModel):
@@ -244,6 +247,9 @@ async def build_runtime_system_prompt_result(
     workspace_context_sections.extend(loaded_instructions.sections)
     if _is_feishu_group_conversation(data.conversation_context):
         workspace_context_sections.append(FEISHU_GROUP_CONTEXT_PROMPT)
+    runtime_tools_prompt = build_runtime_tools_prompt(data.runtime_tools)
+    if runtime_tools_prompt:
+        workspace_context_sections.append(runtime_tools_prompt)
 
     if is_main_agent_role_definition(data.role):
         return _build_runtime_prompt_sections(
@@ -353,6 +359,21 @@ def build_skill_instructions_prompt(
     )
 
 
+def build_runtime_tools_prompt(runtime_tools: RuntimeToolsSnapshot | None) -> str:
+    if runtime_tools is None:
+        return ""
+    lines = [AUTHORIZED_RUNTIME_TOOLS_HEADING]
+    lines.append("- Only call tools that appear in this runtime-authorized list.")
+    lines.append(
+        "- Local Tools: " + _format_names(_tool_names(runtime_tools.local_tools))
+    )
+    lines.append(
+        "- Skill Tools: " + _format_names(_tool_names(runtime_tools.skill_tools))
+    )
+    lines.extend(_format_mcp_tool_lines(runtime_tools))
+    return "\n".join(lines)
+
+
 def compose_system_prompt(data: SystemPromptSectionsInput) -> str:
     sections: list[str] = [data.base_instructions]
     skill_prompt = build_skill_instructions_prompt(data.skill_instructions)
@@ -453,6 +474,31 @@ def _format_names(names: tuple[str, ...]) -> str:
     if not names:
         return NONE_LABEL
     return ", ".join(names)
+
+
+def _tool_names(entries: Sequence[object]) -> tuple[str, ...]:
+    names: list[str] = []
+    for entry in entries:
+        name = getattr(entry, "name", None)
+        if isinstance(name, str) and name.strip():
+            names.append(name)
+    return tuple(names)
+
+
+def _format_mcp_tool_lines(runtime_tools: RuntimeToolsSnapshot) -> list[str]:
+    if not runtime_tools.mcp_tools:
+        return ["- MCP Tools: none"]
+    grouped: dict[str, list[str]] = {}
+    for entry in runtime_tools.mcp_tools:
+        server_name = entry.server_name or "unknown"
+        grouped.setdefault(server_name, []).append(entry.name)
+    lines: list[str] = []
+    for index, server_name in enumerate(sorted(grouped.keys())):
+        prefix = "- MCP Tools: " if index == 0 else "- MCP Tools "
+        lines.append(
+            f"{prefix}{server_name}: {', '.join(sorted(grouped[server_name]))}"
+        )
+    return lines
 
 
 def _validate_base_instruction_prefix(

--- a/src/agent_teams/agents/orchestration/coordinator.py
+++ b/src/agent_teams/agents/orchestration/coordinator.py
@@ -123,6 +123,8 @@ class CoordinatorGraph(BaseModel):
                 session_id=session_id,
                 trace_id=trace_id,
                 root_task=root_task,
+                assigned_instance_id=None,
+                reuse_existing_instance=intent.reuse_root_instance,
             )
             if intent.session_mode == SessionMode.NORMAL:
                 result = await self._task_executor(
@@ -172,6 +174,7 @@ class CoordinatorGraph(BaseModel):
             session_id=root_task.session_id,
             trace_id=trace_id,
             root_task=root_task,
+            assigned_instance_id=root_task_record.assigned_instance_id,
         )
         self._prepare_recovery(
             trace_id=trace_id,
@@ -493,10 +496,21 @@ class CoordinatorGraph(BaseModel):
         session_id: str,
         trace_id: str,
         root_task: TaskEnvelope,
+        assigned_instance_id: str | None = None,
+        reuse_existing_instance: bool = True,
     ) -> str:
         root_role_id = _require_task_role_id(root_task)
         _ = self.role_registry.get(root_role_id)
-        existing = self.agent_repo.get_session_role_instance(session_id, root_role_id)
+        existing = None
+        if assigned_instance_id is not None:
+            try:
+                existing = self.agent_repo.get_instance(assigned_instance_id)
+            except KeyError:
+                existing = None
+        if existing is None and reuse_existing_instance:
+            existing = self.agent_repo.get_session_role_instance(
+                session_id, root_role_id
+            )
         if existing is not None:
             coordinator_instance_id = existing.instance_id
             _ = self.agent_repo.mark_status(
@@ -535,11 +549,15 @@ class CoordinatorGraph(BaseModel):
                 "CoordinatorGraph requires session_repo to resolve workspace"
             )
         workspace_id = session.workspace_id
-        conversation_id = build_conversation_id(session_id, root_role_id)
         instance = create_subagent_instance(
             root_role_id,
             workspace_id=workspace_id,
-            conversation_id=conversation_id,
+            session_id=(None if reuse_existing_instance else session_id),
+            conversation_id=(
+                build_conversation_id(session_id, root_role_id)
+                if reuse_existing_instance
+                else None
+            ),
         )
         _ = self.task_repo.update_status(
             task_id=root_task.task_id,

--- a/src/agent_teams/agents/orchestration/task_execution_service.py
+++ b/src/agent_teams/agents/orchestration/task_execution_service.py
@@ -560,6 +560,7 @@ class TaskExecutionService(BaseModel):
     ) -> PreparedRuntimeSnapshot:
         topology = self._topology_for_run(task.trace_id)
         conversation_context = self._conversation_context_for_run(task.trace_id)
+        runtime_tools = await self._build_runtime_tools_snapshot(role=role, task=task)
         prompt_sections = await self.prompt_builder.build_sections(
             PromptBuildInput(
                 role=role,
@@ -569,6 +570,7 @@ class TaskExecutionService(BaseModel):
                 working_directory=working_directory,
                 worktree_root=worktree_root,
                 conversation_context=conversation_context,
+                runtime_tools=runtime_tools,
             )
         )
         record_prompt_instruction_paths_loaded(
@@ -576,7 +578,6 @@ class TaskExecutionService(BaseModel):
             task_id=task.task_id,
             paths=prompt_sections.local_instruction_paths,
         )
-        runtime_tools = await self._build_runtime_tools_snapshot(role=role, task=task)
         user_prompt, skill_instructions = self._build_user_prompt(
             role=role,
             objective=objective,

--- a/src/agent_teams/automation/automation_bound_session_queue_service.py
+++ b/src/agent_teams/automation/automation_bound_session_queue_service.py
@@ -48,6 +48,13 @@ _CLAIM_STALE_AFTER_SECONDS = 60
 class SessionLookup(Protocol):
     def get_session(self, session_id: str) -> SessionRecord: ...
 
+    def rebind_session_workspace(
+        self,
+        session_id: str,
+        *,
+        workspace_id: str,
+    ) -> SessionRecord: ...
+
 
 class RunServiceLike(Protocol):
     def create_detached_run(self, intent: IntentInput) -> tuple[str, str]: ...
@@ -183,6 +190,7 @@ class AutomationBoundSessionQueueService:
             project_name=project.display_name,
             project_id=project.automation_project_id,
             session_id=session_id,
+            workspace_id=project.workspace_id,
             reason=reason,
             prompt=build_automation_prompt(
                 project_name=project.display_name,
@@ -192,6 +200,30 @@ class AutomationBoundSessionQueueService:
             binding=binding,
             delivery_events=project.delivery_events,
             send_started=True,
+        )
+        started_at = _utc_now()
+        _ = self._repository.create(
+            AutomationBoundSessionQueueRecord(
+                automation_queue_id=f"autq_{uuid4().hex[:12]}",
+                automation_project_id=project.automation_project_id,
+                automation_project_name=project.display_name,
+                session_id=session_id,
+                reason=reason,
+                binding=binding,
+                delivery_events=project.delivery_events,
+                run_config=project.run_config,
+                prompt=build_automation_prompt(
+                    project_name=project.display_name,
+                    prompt=project.prompt,
+                ),
+                queue_message=_build_direct_start_message(
+                    project_name=project.display_name
+                ),
+                run_id=run_id,
+                status=AutomationBoundSessionQueueStatus.WAITING_RESULT,
+                next_attempt_at=started_at,
+                resume_next_attempt_at=started_at,
+            )
         )
         return AutomationExecutionHandle(
             session_id=session_id,
@@ -308,6 +340,9 @@ class AutomationBoundSessionQueueService:
                     project_name=claimed.automation_project_name,
                     project_id=claimed.automation_project_id,
                     session_id=claimed.session_id,
+                    workspace_id=self._project_workspace_id(
+                        claimed.automation_project_id
+                    ),
                     reason=claimed.reason,
                     prompt=claimed.prompt,
                     run_config=claimed.run_config,
@@ -349,6 +384,7 @@ class AutomationBoundSessionQueueService:
         project_name: str,
         project_id: str,
         session_id: str,
+        workspace_id: str,
         reason: str,
         prompt: str,
         run_config: AutomationRunConfig,
@@ -356,12 +392,17 @@ class AutomationBoundSessionQueueService:
         delivery_events: tuple[AutomationDeliveryEvent, ...],
         send_started: bool,
     ) -> str:
+        _ = self._ensure_session_workspace(
+            session_id=session_id,
+            workspace_id=workspace_id,
+        )
         run_id, _ = self._run_service.create_detached_run(
             IntentInput(
                 session_id=session_id,
                 input=content_parts_from_text(prompt),
                 execution_mode=run_config.execution_mode,
                 yolo=run_config.yolo,
+                reuse_root_instance=False,
                 thinking=run_config.thinking,
                 conversation_context=RuntimePromptConversationContext(
                     source_provider=FEISHU_PLATFORM,
@@ -722,6 +763,34 @@ class AutomationBoundSessionQueueService:
             environment=runtime_config.environment,
         )
 
+    def _ensure_session_workspace(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+    ) -> SessionRecord:
+        try:
+            session = self._session_lookup.get_session(session_id)
+        except KeyError:
+            raise RuntimeError(f"missing_bound_session:{session_id}") from None
+        if session.workspace_id == workspace_id:
+            return session
+        try:
+            return self._session_lookup.rebind_session_workspace(
+                session_id,
+                workspace_id=workspace_id,
+            )
+        except KeyError:
+            raise RuntimeError(f"missing_bound_session:{session_id}") from None
+
+    def _project_workspace_id(self, automation_project_id: str) -> str:
+        try:
+            return self._project_repository.get(automation_project_id).workspace_id
+        except KeyError:
+            raise RuntimeError(
+                f"missing_automation_project:{automation_project_id}"
+            ) from None
+
     def _delete_message(self, trigger_id: str, message_id: str) -> None:
         runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
             trigger_id
@@ -792,6 +861,10 @@ class AutomationBoundSessionQueueWorker:
 
 def _build_queue_message(*, project_name: str, ahead_count: int) -> str:
     return f"定时任务 {project_name} 准备执行，当前任务前面有 {ahead_count} 个消息"
+
+
+def _build_direct_start_message(*, project_name: str) -> str:
+    return f"定时任务 {project_name} 已直接启动"
 
 
 def _build_start_failure_message(*, project_name: str, error: str) -> str:

--- a/src/agent_teams/automation/automation_service.py
+++ b/src/agent_teams/automation/automation_service.py
@@ -39,6 +39,7 @@ from agent_teams.sessions import ProjectKind
 from agent_teams.sessions.runs.run_manager import RunManager
 from agent_teams.sessions.runs.run_models import IntentInput
 from agent_teams.sessions.session_service import SessionService
+from agent_teams.workspace import WorkspaceService
 
 
 class AutomationService:
@@ -52,6 +53,7 @@ class AutomationService:
         feishu_binding_service: AutomationFeishuBindingService | None = None,
         delivery_service: AutomationDeliveryService | None = None,
         bound_session_queue_service: AutomationBoundSessionQueueService | None = None,
+        workspace_service: WorkspaceService | None = None,
     ) -> None:
         self._repository = repository
         self._event_repository = event_repository
@@ -60,12 +62,14 @@ class AutomationService:
         self._feishu_binding_service = feishu_binding_service
         self._delivery_service = delivery_service
         self._bound_session_queue_service = bound_session_queue_service
+        self._workspace_service = workspace_service
 
     def create_project(
         self,
         payload: AutomationProjectCreateInput,
     ) -> AutomationProjectRecord:
         timezone_name = _validate_timezone(payload.timezone)
+        self._validate_workspace(payload.workspace_id)
         delivery_binding = self._resolve_delivery_binding(
             payload.delivery_binding,
             existing_binding=None,
@@ -169,6 +173,7 @@ class AutomationService:
                 else existing.status == AutomationProjectStatus.ENABLED
             ),
         )
+        self._validate_workspace(probe.workspace_id)
         now = datetime.now(tz=UTC)
         updated = existing.model_copy(
             update={
@@ -210,6 +215,8 @@ class AutomationService:
         status: AutomationProjectStatus,
     ) -> AutomationProjectRecord:
         existing = self._repository.get(automation_project_id)
+        if status == AutomationProjectStatus.ENABLED:
+            self._validate_workspace(existing.workspace_id)
         now = datetime.now(tz=UTC)
         updated = existing.model_copy(
             update={
@@ -457,6 +464,14 @@ class AutomationService:
             project=project,
             reason=reason,
         )
+
+    def _validate_workspace(self, workspace_id: str) -> None:
+        if self._workspace_service is None:
+            return
+        try:
+            _ = self._workspace_service.require_workspace(workspace_id)
+        except KeyError as exc:
+            raise ValueError(f"Unknown workspace: {workspace_id}") from exc
 
     def _record_execution_event(
         self,

--- a/src/agent_teams/gateway/feishu/gateway_service.py
+++ b/src/agent_teams/gateway/feishu/gateway_service.py
@@ -29,12 +29,15 @@ from agent_teams.gateway.feishu.secret_store import (
     FeishuTriggerSecretStore,
     get_feishu_trigger_secret_store,
 )
+from agent_teams.logger import get_logger, log_event
 from agent_teams.roles import RoleRegistry
 from agent_teams.sessions.external_session_binding_repository import (
     ExternalSessionBindingRepository,
 )
 from agent_teams.sessions.session_models import SessionMode, SessionRecord
 from agent_teams.workspace import WorkspaceService
+
+LOGGER = get_logger(__name__)
 
 
 class FeishuGatewayService:
@@ -143,6 +146,8 @@ class FeishuGatewayService:
         enabled: bool,
     ) -> FeishuGatewayAccountRecord:
         existing = self._repository.get_account(account_id)
+        if enabled:
+            self._validate_runtime_account(existing, require_app_secret=True)
         updated = existing.model_copy(
             update={
                 "status": (
@@ -170,6 +175,7 @@ class FeishuGatewayService:
             self._config_dir,
             account.account_id,
         )
+        last_error = self._account_runtime_error(account, secret_config=secret_config)
         return account.model_copy(
             update={
                 "secret_config": secret_config.model_dump(
@@ -180,6 +186,7 @@ class FeishuGatewayService:
                 "secret_status": self.get_secret_status(account.account_id).model_dump(
                     mode="json"
                 ),
+                "last_error": last_error,
             }
         )
 
@@ -262,13 +269,20 @@ class FeishuGatewayService:
         self,
         account: FeishuGatewayAccountRecord,
     ) -> FeishuTriggerRuntimeConfig | None:
-        source = FeishuTriggerSourceConfig.model_validate(account.source_config)
-        target = FeishuTriggerTargetConfig.model_validate(account.target_config or {})
         secret_config = self._secret_store.get_secret_config(
             self._config_dir,
             account.account_id,
         )
-        if secret_config.app_secret is None:
+        validation_error = self._account_runtime_error(
+            account,
+            secret_config=secret_config,
+        )
+        if validation_error is not None:
+            return None
+        source = FeishuTriggerSourceConfig.model_validate(account.source_config)
+        target = FeishuTriggerTargetConfig.model_validate(account.target_config or {})
+        app_secret = secret_config.app_secret
+        if app_secret is None:
             return None
         return FeishuTriggerRuntimeConfig(
             trigger_id=account.account_id,
@@ -277,7 +291,7 @@ class FeishuGatewayService:
             target=target,
             environment=FeishuEnvironment(
                 app_id=source.app_id,
-                app_secret=secret_config.app_secret,
+                app_secret=app_secret,
                 app_name=source.app_name,
                 verification_token=secret_config.verification_token,
                 encrypt_key=secret_config.encrypt_key,
@@ -304,6 +318,20 @@ class FeishuGatewayService:
         resolved: list[FeishuTriggerRuntimeConfig] = []
         for account in self._repository.list_accounts():
             if account.status != FeishuGatewayAccountStatus.ENABLED:
+                continue
+            attached = self.attach_secret_status(account)
+            if attached.last_error is not None:
+                log_event(
+                    LOGGER,
+                    30,
+                    event="gateway.feishu.runtime_config_skipped",
+                    message="Skipped invalid persisted Feishu gateway account",
+                    payload={
+                        "account_id": attached.account_id,
+                        "account_name": attached.name,
+                        "last_error": attached.last_error,
+                    },
+                )
                 continue
             runtime = self.resolve_runtime_config(account)
             if runtime is None:
@@ -360,7 +388,7 @@ class FeishuGatewayService:
         target = FeishuTriggerTargetConfig.model_validate(
             {} if target_config is None else dict(target_config.items())
         )
-        self._workspace_service.require_workspace(target.workspace_id)
+        self._require_workspace(target.workspace_id)
         normalized_root_role_id = self._resolve_normal_root_role_id(
             target.normal_root_role_id
         )
@@ -377,6 +405,48 @@ class FeishuGatewayService:
             )
             _ = self._orchestration_settings_service.resolve_run_topology(probe)
         _ = source
+
+    def _validate_runtime_account(
+        self,
+        account: FeishuGatewayAccountRecord,
+        *,
+        require_app_secret: bool,
+    ) -> None:
+        secret_config = self._secret_store.get_secret_config(
+            self._config_dir,
+            account.account_id,
+        )
+        error = self._account_runtime_error(
+            account,
+            secret_config=secret_config,
+            require_app_secret=require_app_secret,
+        )
+        if error is not None:
+            raise ValueError(error)
+
+    def _account_runtime_error(
+        self,
+        account: FeishuGatewayAccountRecord,
+        *,
+        secret_config: FeishuTriggerSecretConfig,
+        require_app_secret: bool = True,
+    ) -> str | None:
+        try:
+            self._validate_source_and_target(
+                source_config=account.source_config,
+                target_config=account.target_config,
+            )
+        except (KeyError, ValueError) as exc:
+            return str(exc)
+        if require_app_secret and secret_config.app_secret is None:
+            return "Feishu app_secret is required"
+        return None
+
+    def _require_workspace(self, workspace_id: str) -> None:
+        try:
+            _ = self._workspace_service.require_workspace(workspace_id)
+        except KeyError as exc:
+            raise ValueError(f"Unknown workspace: {workspace_id}") from exc
 
     def _normalized_target(
         self,

--- a/src/agent_teams/gateway/feishu/models.py
+++ b/src/agent_teams/gateway/feishu/models.py
@@ -158,6 +158,7 @@ class FeishuGatewayAccountRecord(BaseModel):
     target_config: dict[str, JsonValue] | None = None
     secret_config: dict[str, str] | None = None
     secret_status: dict[str, bool] | None = None
+    last_error: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/src/agent_teams/interfaces/server/container.py
+++ b/src/agent_teams/interfaces/server/container.py
@@ -635,6 +635,7 @@ class ServerContainer:
             feishu_binding_service=self.automation_feishu_binding_service,
             delivery_service=self.automation_delivery_service,
             bound_session_queue_service=self.automation_bound_session_queue_service,
+            workspace_service=self.workspace_service,
         )
         self.automation_scheduler_service: AutomationSchedulerService = (
             AutomationSchedulerService(automation_service=self.automation_service)

--- a/src/agent_teams/interfaces/server/routers/automation.py
+++ b/src/agent_teams/interfaces/server/routers/automation.py
@@ -114,6 +114,8 @@ def enable_project(
         )
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.post(

--- a/src/agent_teams/interfaces/server/routers/feishu_gateway.py
+++ b/src/agent_teams/interfaces/server/routers/feishu_gateway.py
@@ -91,6 +91,8 @@ def enable_feishu_account(
         return updated
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.post(

--- a/src/agent_teams/sessions/runs/run_intent_repo.py
+++ b/src/agent_teams/sessions/runs/run_intent_repo.py
@@ -47,6 +47,7 @@ class RunIntentRepository:
                 generation_config_json TEXT,
                 execution_mode TEXT NOT NULL,
                 yolo           TEXT NOT NULL DEFAULT 'false',
+                reuse_root_instance TEXT NOT NULL DEFAULT 'true',
                 thinking_enabled TEXT NOT NULL DEFAULT 'false',
                 thinking_effort TEXT,
                 target_role_id TEXT,
@@ -79,6 +80,10 @@ class RunIntentRepository:
         if "thinking_enabled" not in columns:
             self._conn.execute(
                 "ALTER TABLE run_intents ADD COLUMN thinking_enabled TEXT NOT NULL DEFAULT 'false'"
+            )
+        if "reuse_root_instance" not in columns:
+            self._conn.execute(
+                "ALTER TABLE run_intents ADD COLUMN reuse_root_instance TEXT NOT NULL DEFAULT 'true'"
             )
         if "input_json" not in columns:
             self._conn.execute("ALTER TABLE run_intents ADD COLUMN input_json TEXT")
@@ -124,6 +129,7 @@ class RunIntentRepository:
                 generation_config_json,
                 execution_mode,
                 yolo,
+                reuse_root_instance,
                 thinking_enabled,
                 thinking_effort,
                 target_role_id,
@@ -133,7 +139,7 @@ class RunIntentRepository:
                 created_at,
                 updated_at
             )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(run_id)
             DO UPDATE SET
                 session_id=excluded.session_id,
@@ -143,6 +149,7 @@ class RunIntentRepository:
                 generation_config_json=excluded.generation_config_json,
                 execution_mode=excluded.execution_mode,
                 yolo=excluded.yolo,
+                reuse_root_instance=excluded.reuse_root_instance,
                 thinking_enabled=excluded.thinking_enabled,
                 thinking_effort=excluded.thinking_effort,
                 target_role_id=excluded.target_role_id,
@@ -164,6 +171,7 @@ class RunIntentRepository:
                 ),
                 intent.execution_mode.value,
                 "true" if intent.yolo else "false",
+                "true" if intent.reuse_root_instance else "false",
                 "true" if intent.thinking.enabled else "false",
                 intent.thinking.effort,
                 intent.target_role_id,
@@ -223,6 +231,7 @@ class RunIntentRepository:
                 generation_config_json,
                 execution_mode,
                 yolo,
+                reuse_root_instance,
                 thinking_enabled,
                 thinking_effort,
                 target_role_id,
@@ -243,6 +252,9 @@ class RunIntentRepository:
             generation_config=_coerce_generation_config(row["generation_config_json"]),
             execution_mode=ExecutionMode(str(row["execution_mode"])),
             yolo=str(row["yolo"]).strip().lower() == "true",
+            reuse_root_instance=(
+                str(row["reuse_root_instance"]).strip().lower() != "false"
+            ),
             thinking=RunThinkingConfig(
                 enabled=str(row["thinking_enabled"]).strip().lower() == "true",
                 effort=_coerce_thinking_effort(row["thinking_effort"]),

--- a/src/agent_teams/sessions/runs/run_manager.py
+++ b/src/agent_teams/sessions/runs/run_manager.py
@@ -302,6 +302,7 @@ class RunManager:
         return self._create_run_local(intent, allow_active_run_attach=True)
 
     def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
+        intent.reuse_root_instance = False
         if self._should_delegate_to_bound_loop():
             delegated_intent = intent.model_copy(deep=True)
             return self._call_in_bound_loop(

--- a/src/agent_teams/sessions/runs/run_models.py
+++ b/src/agent_teams/sessions/runs/run_models.py
@@ -97,6 +97,7 @@ class IntentInput(BaseModel):
     generation_config: MediaGenerationConfig | None = None
     execution_mode: ExecutionMode = ExecutionMode.AI
     yolo: bool = False
+    reuse_root_instance: bool = True
     thinking: RunThinkingConfig = Field(default_factory=RunThinkingConfig)
     target_role_id: str | None = None
     session_mode: SessionMode = SessionMode.NORMAL

--- a/src/agent_teams/tools/runtime/__init__.py
+++ b/src/agent_teams/tools/runtime/__init__.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         ToolApprovalDecision,
         ToolApprovalRequest,
         ToolError,
+        ToolExecutionError,
         ToolInternalRecord,
         ToolResultEnvelope,
         ToolResultProjection,
@@ -39,6 +40,7 @@ __all__ = [
     "ToolContext",
     "ToolDeps",
     "ToolError",
+    "ToolExecutionError",
     "ToolInternalRecord",
     "ToolResultEnvelope",
     "ToolResultProjection",
@@ -82,6 +84,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ToolContext": ("agent_teams.tools.runtime.context", "ToolContext"),
     "ToolDeps": ("agent_teams.tools.runtime.context", "ToolDeps"),
     "ToolError": ("agent_teams.tools.runtime.models", "ToolError"),
+    "ToolExecutionError": (
+        "agent_teams.tools.runtime.models",
+        "ToolExecutionError",
+    ),
     "ToolInternalRecord": (
         "agent_teams.tools.runtime.models",
         "ToolInternalRecord",

--- a/src/agent_teams/tools/runtime/execution.py
+++ b/src/agent_teams/tools/runtime/execution.py
@@ -29,6 +29,7 @@ from agent_teams.tools.runtime.models import (
     ToolApprovalDecision,
     ToolApprovalRequest,
     ToolError,
+    ToolExecutionError,
     ToolInternalRecord,
     ToolResultEnvelope,
     ToolResultProjection,
@@ -186,12 +187,15 @@ async def execute_tool(
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             meta["duration_ms"] = elapsed_ms
             error = _error_payload(exc)
+            if error.details:
+                meta["error_details"] = dict(error.details)
 
             compact = json.dumps(
                 {
                     "tool": tool_name,
                     "type": error.type,
                     "message": error.message,
+                    "details": error.details,
                 },
                 ensure_ascii=False,
             )
@@ -206,6 +210,7 @@ async def execute_tool(
                     "tool_name": tool_name,
                     "error_type": error.type,
                     "retryable": error.retryable,
+                    "details": error.details,
                 },
             )
             envelope = _visible_envelope(
@@ -260,6 +265,14 @@ def _record_tool_metrics(
 
 
 def _error_payload(exc: Exception) -> ToolError:
+    if isinstance(exc, ToolExecutionError):
+        return ToolError(
+            type=exc.error_type,
+            message=str(exc) or exc.__class__.__name__,
+            retryable=exc.retryable,
+            details=exc.details,
+        )
+
     err_type = "internal_error"
     retryable = False
     message = str(exc) or exc.__class__.__name__

--- a/src/agent_teams/tools/runtime/models.py
+++ b/src/agent_teams/tools/runtime/models.py
@@ -6,7 +6,7 @@ from agent_teams.computer import (
     ComputerPermissionScope,
     ExecutionSurface,
 )
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_serializer
 
 
 class ToolError(BaseModel):
@@ -15,6 +15,29 @@ class ToolError(BaseModel):
     type: str = Field(min_length=1)
     message: str = Field(min_length=1)
     retryable: bool = False
+    details: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        payload = handler(self)
+        if not self.details:
+            payload.pop("details", None)
+        return payload
+
+
+class ToolExecutionError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        error_type: str,
+        message: str,
+        retryable: bool = False,
+        details: dict[str, JsonValue] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_type = error_type
+        self.retryable = retryable
+        self.details = {} if details is None else dict(details)
 
 
 class ToolResultEnvelope(BaseModel):

--- a/src/agent_teams/tools/web_tools/webfetch.py
+++ b/src/agent_teams/tools/web_tools/webfetch.py
@@ -17,6 +17,7 @@ from agent_teams.tools._description_loader import load_tool_description
 from agent_teams.tools.runtime import (
     ToolContext,
     ToolDeps,
+    ToolExecutionError,
     ToolResultProjection,
     execute_tool,
 )
@@ -208,6 +209,7 @@ async def fetch_url(
     url: str,
     response_format: str,
 ) -> httpx.Response:
+    url_host = urlparse(url).netloc
     headers = {
         "User-Agent": BROWSER_USER_AGENT,
         "Accept": build_accept_header(response_format),
@@ -221,8 +223,32 @@ async def fetch_url(
         retry_headers = dict(headers)
         retry_headers["User-Agent"] = FALLBACK_USER_AGENT
         response = await _perform_request(client=client, url=url, headers=retry_headers)
+    if (
+        response.status_code == 403
+        and response.headers.get("cf-mitigated") == "challenge"
+    ):
+        raise ToolExecutionError(
+            error_type="anti_bot_challenge",
+            message=f"Website blocked automated fetch with an anti-bot challenge: {url_host or url}",
+            retryable=False,
+            details={
+                "url_host": url_host,
+                "status_code": response.status_code,
+                "mitigation": "cloudflare_challenge",
+            },
+        )
     if response.status_code >= 400:
-        raise RuntimeError(f"Request failed with status code: {response.status_code}")
+        raise ToolExecutionError(
+            error_type=_webfetch_status_error_type(response.status_code),
+            message=_webfetch_status_error_message(
+                url_host=url_host, response=response
+            ),
+            retryable=response.status_code in {429} or response.status_code >= 500,
+            details={
+                "url_host": url_host,
+                "status_code": response.status_code,
+            },
+        )
     enforce_content_length_limit(response)
     return response
 
@@ -233,12 +259,23 @@ async def _perform_request(
     url: str,
     headers: dict[str, str],
 ) -> httpx.Response:
+    url_host = urlparse(url).netloc
     try:
         return await client.get(url, headers=headers)
     except httpx.TimeoutException as exc:
-        raise RuntimeError("Request timed out") from exc
+        raise ToolExecutionError(
+            error_type="network_timeout",
+            message=f"Web fetch timed out for {url_host or url}",
+            retryable=True,
+            details={"url_host": url_host},
+        ) from exc
     except httpx.RequestError as exc:
-        raise RuntimeError(f"Request failed: {exc}") from exc
+        raise ToolExecutionError(
+            error_type="network_error",
+            message=f"Web fetch request failed for {url_host or url}: {exc}",
+            retryable=True,
+            details={"url_host": url_host},
+        ) from exc
 
 
 def enforce_content_length_limit(response: httpx.Response) -> None:
@@ -250,14 +287,45 @@ def enforce_content_length_limit(response: httpx.Response) -> None:
     except ValueError:
         return
     if parsed_length > MAX_RESPONSE_SIZE_BYTES:
-        raise RuntimeError("Response too large (exceeds 5MB limit)")
+        raise ToolExecutionError(
+            error_type="response_too_large",
+            message="Response too large (exceeds 5MB limit)",
+            retryable=False,
+        )
 
 
 async def read_response_body(response: httpx.Response) -> bytes:
     body = await response.aread()
     if len(body) > MAX_RESPONSE_SIZE_BYTES:
-        raise RuntimeError("Response too large (exceeds 5MB limit)")
+        raise ToolExecutionError(
+            error_type="response_too_large",
+            message="Response too large (exceeds 5MB limit)",
+            retryable=False,
+        )
     return body
+
+
+def _webfetch_status_error_type(status_code: int) -> str:
+    if status_code == 401:
+        return "auth_error"
+    if status_code == 403:
+        return "source_access_denied"
+    if status_code == 404:
+        return "not_found"
+    if status_code == 429:
+        return "rate_limited"
+    if status_code >= 500:
+        return "upstream_unavailable"
+    return "upstream_error"
+
+
+def _webfetch_status_error_message(
+    *,
+    url_host: str,
+    response: httpx.Response,
+) -> str:
+    target = url_host or str(response.request.url)
+    return f"Web fetch failed for {target} with HTTP {response.status_code}"
 
 
 def normalize_content_type(content_type_header: str) -> str:

--- a/src/agent_teams/tools/web_tools/websearch.py
+++ b/src/agent_teams/tools/web_tools/websearch.py
@@ -13,6 +13,7 @@ from agent_teams.tools._description_loader import load_tool_description
 from agent_teams.tools.runtime import (
     ToolContext,
     ToolDeps,
+    ToolExecutionError,
     ToolResultProjection,
     execute_tool,
 )
@@ -148,6 +149,7 @@ async def fetch_exa_search_response(
     endpoint: str,
     payload: dict[str, JsonValue],
 ) -> str:
+    endpoint_host = httpx.URL(endpoint).host or ""
     try:
         response = await client.post(
             endpoint,
@@ -158,15 +160,58 @@ async def fetch_exa_search_response(
             json=payload,
         )
     except httpx.TimeoutException as exc:
-        raise RuntimeError("Search request timed out") from exc
+        raise ToolExecutionError(
+            error_type="network_timeout",
+            message="Exa web search timed out",
+            retryable=True,
+            details={
+                "provider": WebProvider.EXA.value,
+                "endpoint_host": endpoint_host,
+            },
+        ) from exc
     except httpx.RequestError as exc:
-        raise RuntimeError(f"Search request failed: {exc}") from exc
+        raise ToolExecutionError(
+            error_type="network_error",
+            message=f"Exa web search request failed: {exc}",
+            retryable=True,
+            details={
+                "provider": WebProvider.EXA.value,
+                "endpoint_host": endpoint_host,
+            },
+        ) from exc
 
     if response.status_code >= 400:
-        raise RuntimeError(
-            f"Search error ({response.status_code}): {response.text.strip()}"
+        raise ToolExecutionError(
+            error_type=_search_status_error_type(response.status_code),
+            message=_search_status_error_message(response),
+            retryable=response.status_code in {429} or response.status_code >= 500,
+            details={
+                "provider": WebProvider.EXA.value,
+                "endpoint_host": endpoint_host,
+                "status_code": response.status_code,
+            },
         )
     return response.text
+
+
+def _search_status_error_type(status_code: int) -> str:
+    if status_code == 401:
+        return "auth_error"
+    if status_code == 403:
+        return "source_access_denied"
+    if status_code == 429:
+        return "rate_limited"
+    if status_code >= 500:
+        return "upstream_unavailable"
+    return "upstream_error"
+
+
+def _search_status_error_message(response: httpx.Response) -> str:
+    detail = response.text.strip()
+    base = f"Exa web search returned HTTP {response.status_code}"
+    if detail:
+        return f"{base}: {detail}"
+    return base
 
 
 def extract_search_output(response_text: str) -> str | None:

--- a/tests/unit_tests/agents/orchestration/test_coordinator_terminal_status.py
+++ b/tests/unit_tests/agents/orchestration/test_coordinator_terminal_status.py
@@ -35,6 +35,10 @@ from agent_teams.agents.tasks.models import (
     VerificationPlan,
     VerificationResult,
 )
+from agent_teams.workspace import (
+    build_conversation_id,
+    build_instance_conversation_id,
+)
 
 
 class _RecordingTaskExecutionService:
@@ -412,3 +416,51 @@ async def test_run_resolves_dynamic_coordinator_role_id(tmp_path: Path) -> None:
     assert root_task.envelope.role_id == "Coordinator"
     assert coordinator_instance is not None
     assert coordinator_instance.role_id == "Coordinator"
+
+
+@pytest.mark.asyncio
+async def test_run_with_fresh_root_instance_skips_stale_session_role_instance(
+    tmp_path: Path,
+) -> None:
+    coordinator, task_repo, agent_repo, _run_runtime_repo, _ = _build_coordinator(
+        tmp_path,
+        coordinator_role_id="Coordinator",
+    )
+    stale_instance = create_subagent_instance(
+        "Coordinator",
+        workspace_id="default",
+        conversation_id=build_conversation_id("session-1", "Coordinator"),
+    )
+    agent_repo.upsert_instance(
+        run_id="run-stale",
+        trace_id="run-stale",
+        session_id="session-1",
+        instance_id=stale_instance.instance_id,
+        role_id="Coordinator",
+        workspace_id=stale_instance.workspace_id,
+        conversation_id=stale_instance.conversation_id,
+        status=InstanceStatus.IDLE,
+    )
+
+    trace_id, root_task_id, status, _result = await coordinator.run(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("hello"),
+            reuse_root_instance=False,
+        ),
+        trace_id="run-fresh",
+    )
+
+    root_task = task_repo.get(root_task_id)
+    assigned_instance_id = root_task.assigned_instance_id
+    assert trace_id == "run-fresh"
+    assert status == "completed"
+    assert assigned_instance_id is not None
+    assert assigned_instance_id != stale_instance.instance_id
+    runtime_record = agent_repo.get_instance(assigned_instance_id)
+    assert runtime_record.conversation_id != stale_instance.conversation_id
+    assert runtime_record.conversation_id == build_instance_conversation_id(
+        "session-1",
+        "Coordinator",
+        assigned_instance_id,
+    )

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -461,6 +461,85 @@ async def test_execute_runtime_snapshot_includes_skill_list_for_ui(
 
 
 @pytest.mark.asyncio
+async def test_execute_runtime_prompt_lists_authorized_runtime_tools(
+    tmp_path: Path,
+) -> None:
+    provider = _CapturingProvider()
+    role = RoleDefinition(
+        role_id="reader",
+        name="reader",
+        description="Reads workspace files.",
+        version="1",
+        tools=("read",),
+        system_prompt="You are the reader role.",
+    )
+    role_registry = RoleRegistry()
+    role_registry.register(role)
+
+    db_path = tmp_path / "task_execution_service_runtime_tools_prompt.db"
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    message_repo = MessageRepository(db_path)
+    shared_store = SharedStateRepository(db_path)
+    service = TaskExecutionService(
+        role_registry=role_registry,
+        task_repo=task_repo,
+        shared_store=shared_store,
+        event_bus=EventLog(db_path),
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+        approval_ticket_repo=ApprovalTicketRepository(db_path),
+        run_runtime_repo=RunRuntimeRepository(db_path),
+        workspace_manager=WorkspaceManager(
+            project_root=Path("."), shared_store=shared_store
+        ),
+        prompt_builder=RuntimePromptBuilder(
+            role_registry=role_registry,
+            mcp_registry=McpRegistry(),
+        ),
+        provider_factory=lambda _, __=None: provider,
+        tool_registry=build_default_registry(),
+        skill_registry=SkillRegistry.from_config_dirs(app_config_dir=db_path.parent),
+        mcp_registry=McpRegistry(),
+        run_intent_repo=RunIntentRepository(db_path),
+    )
+    instance = create_subagent_instance(
+        "reader",
+        workspace_id="default",
+        conversation_id=build_conversation_id("session-1", "reader"),
+    )
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        parent_task_id="task-root",
+        trace_id="run-1",
+        objective="read a file",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(task)
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=instance.instance_id,
+        role_id="reader",
+        workspace_id=instance.workspace_id,
+        conversation_id=instance.conversation_id,
+        status=InstanceStatus.IDLE,
+    )
+
+    _ = await service.execute(
+        instance_id=instance.instance_id,
+        role_id="reader",
+        task=task,
+    )
+
+    runtime_record = agent_repo.get_instance(instance.instance_id)
+    assert "## Authorized Runtime Tools" in runtime_record.runtime_system_prompt
+    assert "Local Tools: read" in runtime_record.runtime_system_prompt
+
+
+@pytest.mark.asyncio
 async def test_execute_persists_followup_prompt_before_turn(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
@@ -39,6 +39,17 @@ class _FakeSessionLookup:
             raise KeyError(session_id)
         return self._sessions[session_id]
 
+    def rebind_session_workspace(
+        self,
+        session_id: str,
+        *,
+        workspace_id: str,
+    ) -> SessionRecord:
+        session = self.get_session(session_id)
+        rebound = session.model_copy(update={"workspace_id": workspace_id})
+        self._sessions[session_id] = rebound
+        return rebound
+
 
 class _FakeRunService:
     def __init__(self) -> None:

--- a/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
@@ -32,11 +32,24 @@ from agent_teams.sessions.session_models import ProjectKind, SessionRecord
 class _FakeSessionLookup:
     def __init__(self, sessions: dict[str, SessionRecord]) -> None:
         self._sessions = sessions
+        self.rebind_calls: list[tuple[str, str]] = []
 
     def get_session(self, session_id: str) -> SessionRecord:
         if session_id not in self._sessions:
             raise KeyError(session_id)
         return self._sessions[session_id]
+
+    def rebind_session_workspace(
+        self,
+        session_id: str,
+        *,
+        workspace_id: str,
+    ) -> SessionRecord:
+        session = self.get_session(session_id)
+        rebound = session.model_copy(update={"workspace_id": workspace_id})
+        self._sessions[session_id] = rebound
+        self.rebind_calls.append((session_id, workspace_id))
+        return rebound
 
 
 class _FakeRunService:
@@ -157,6 +170,7 @@ def _build_service(
     tmp_path: Path,
 ) -> tuple[
     AutomationBoundSessionQueueService,
+    _FakeSessionLookup,
     AutomationBoundSessionQueueRepository,
     RunRuntimeRepository,
     _FakeRunService,
@@ -172,18 +186,19 @@ def _build_service(
     delivery_service = _FakeDeliveryService()
     feishu_client = _FakeFeishuClient()
     project_repo = _FakeProjectRepository(project)
+    session_lookup = _FakeSessionLookup(
+        {
+            "session-1": SessionRecord(
+                session_id="session-1",
+                workspace_id="default",
+                project_kind=ProjectKind.WORKSPACE,
+                metadata={"title": "Bound Session"},
+            )
+        }
+    )
     service = AutomationBoundSessionQueueService(
         repository=queue_repo,
-        session_lookup=_FakeSessionLookup(
-            {
-                "session-1": SessionRecord(
-                    session_id="session-1",
-                    workspace_id="default",
-                    project_kind=ProjectKind.WORKSPACE,
-                    metadata={"title": "Bound Session"},
-                )
-            }
-        ),
+        session_lookup=session_lookup,
         run_service=run_service,
         run_runtime_repo=run_runtime_repo,
         delivery_service=cast(AutomationDeliveryService, delivery_service),
@@ -193,6 +208,7 @@ def _build_service(
     )
     return (
         service,
+        session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -206,6 +222,7 @@ def _queue_and_start_bound_run(
     tmp_path: Path,
 ) -> tuple[
     AutomationBoundSessionQueueService,
+    _FakeSessionLookup,
     AutomationBoundSessionQueueRepository,
     RunRuntimeRepository,
     _FakeRunService,
@@ -215,6 +232,7 @@ def _queue_and_start_bound_run(
 ]:
     (
         service,
+        session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -242,6 +260,7 @@ def _queue_and_start_bound_run(
     _ = service.process_pending()
     return (
         service,
+        session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -256,6 +275,7 @@ def test_materialize_execution_starts_in_bound_session_when_idle(
 ) -> None:
     (
         service,
+        _session_lookup,
         queue_repo,
         _run_runtime_repo,
         run_service,
@@ -270,7 +290,9 @@ def test_materialize_execution_starts_in_bound_session_when_idle(
     assert handle.session_id == "session-1"
     assert handle.run_id == "run-1"
     assert handle.queued is False
-    assert queue_repo.count_non_terminal_by_session("session-1") == 0
+    waiting_records = queue_repo.list_waiting_for_result(limit=10)
+    assert len(waiting_records) == 1
+    assert waiting_records[0].run_id == "run-1"
     assert len(run_service.created_intents) == 1
     assert (
         content_parts_to_text(run_service.created_intents[0].input)
@@ -292,6 +314,7 @@ def test_materialize_execution_queues_when_bound_session_is_busy(
 ) -> None:
     (
         service,
+        _session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -343,6 +366,7 @@ def test_process_pending_starts_queued_run_after_bound_session_becomes_idle(
 ) -> None:
     (
         service,
+        _session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -393,6 +417,7 @@ def test_materialize_execution_fails_when_bound_session_is_missing(
 ) -> None:
     (
         service,
+        _session_lookup,
         _queue_repo,
         _run_runtime_repo,
         run_service,
@@ -427,6 +452,7 @@ def test_process_pending_schedules_recoverable_resume_with_backoff(
 ) -> None:
     (
         service,
+        _session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -460,6 +486,7 @@ def test_process_pending_requests_resume_after_backoff_elapsed(
 ) -> None:
     (
         service,
+        _session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -499,6 +526,7 @@ def test_materialize_execution_treats_dirty_failed_recovery_run_as_busy(
 ) -> None:
     (
         service,
+        _session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -539,6 +567,7 @@ def test_process_pending_exhausts_resume_attempts_and_skips_terminal_delivery(
 ) -> None:
     (
         service,
+        _session_lookup,
         queue_repo,
         run_runtime_repo,
         run_service,
@@ -579,3 +608,67 @@ def test_process_pending_exhausts_resume_attempts_and_skips_terminal_delivery(
     assert delivery_service.skipped_terminal_runs == [
         ("run-1", feishu_client.sent_messages[-1]["text"])
     ]
+
+
+def test_materialize_execution_rebinds_bound_session_workspace_before_start(
+    tmp_path: Path,
+) -> None:
+    (
+        service,
+        session_lookup,
+        _queue_repo,
+        _run_runtime_repo,
+        run_service,
+        _delivery_service,
+        _feishu_client,
+        _project_repo,
+    ) = _build_service(tmp_path)
+    session_lookup._sessions["session-1"] = session_lookup._sessions[
+        "session-1"
+    ].model_copy(update={"workspace_id": "stale-worktree"})
+    project = _build_project().model_copy(update={"workspace_id": "fresh-worktree"})
+
+    handle = service.materialize_execution(project=project, reason="manual")
+
+    assert handle is not None
+    assert session_lookup.rebind_calls == [("session-1", "fresh-worktree")]
+    assert run_service.created_intents[0].reuse_root_instance is False
+
+
+def test_direct_start_waiting_record_auto_resumes_recoverable_runtime(
+    tmp_path: Path,
+) -> None:
+    (
+        service,
+        _session_lookup,
+        queue_repo,
+        run_runtime_repo,
+        run_service,
+        _delivery_service,
+        _feishu_client,
+        _project_repo,
+    ) = _build_service(tmp_path)
+    _ = service.materialize_execution(project=_build_project(), reason="schedule")
+    waiting = queue_repo.list_waiting_for_result(limit=10)[0]
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id=str(waiting.run_id),
+            session_id="session-1",
+            status=RunRuntimeStatus.PAUSED,
+            phase=RunRuntimePhase.AWAITING_RECOVERY,
+            last_error="stream interrupted",
+        )
+    )
+    _ = queue_repo.update(
+        waiting.model_copy(
+            update={"resume_next_attempt_at": datetime.now(tz=timezone.utc)}
+        )
+    )
+
+    progressed = service.process_pending()
+
+    updated = queue_repo.list_waiting_for_result(limit=10)[0]
+    assert progressed is True
+    assert run_service.resume_run_ids == ["run-1"]
+    assert updated.resume_attempts == 1
+    assert updated.last_error is None

--- a/tests/unit_tests/automation/test_automation_service.py
+++ b/tests/unit_tests/automation/test_automation_service.py
@@ -4,6 +4,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
 
+import pytest
+
 from agent_teams.agents.execution.message_repository import MessageRepository
 from agent_teams.agents.instances.instance_repository import AgentInstanceRepository
 from agent_teams.agents.tasks.task_repository import TaskRepository
@@ -16,6 +18,7 @@ from agent_teams.automation import (
     AutomationProjectCreateInput,
     AutomationProjectRepository,
     AutomationProjectStatus,
+    AutomationProjectUpdateInput,
     AutomationScheduleMode,
     AutomationService,
 )
@@ -25,6 +28,7 @@ from agent_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from agent_teams.sessions.session_repository import SessionRepository
 from agent_teams.sessions.session_service import SessionService
 from agent_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from agent_teams.workspace import WorkspaceRepository, WorkspaceService
 
 
 class _FakeRunManager:
@@ -87,6 +91,11 @@ def _build_service(
     db_path = tmp_path / "automation.db"
     run_manager = _FakeRunManager()
     session_service = _build_session_service(db_path)
+    workspace_service = WorkspaceService(repository=WorkspaceRepository(db_path))
+    _ = workspace_service.create_workspace(
+        workspace_id="default",
+        root_path=tmp_path,
+    )
     service = AutomationService(
         repository=AutomationProjectRepository(db_path),
         event_repository=AutomationEventRepository(db_path),
@@ -100,6 +109,7 @@ def _build_service(
             AutomationBoundSessionQueueService | None,
             bound_session_queue_service,
         ),
+        workspace_service=workspace_service,
     )
     return service, run_manager, session_service
 
@@ -324,3 +334,66 @@ def test_run_now_fails_when_bound_session_execution_errors(tmp_path: Path) -> No
     updated = service.get_project(created.automation_project_id)
     assert updated.last_error == "missing_bound_session:session-im-1"
     assert run_manager.create_calls == []
+
+
+def test_create_project_rejects_unknown_workspace(tmp_path: Path) -> None:
+    service, _, _ = _build_service(tmp_path)
+
+    with pytest.raises(ValueError, match="Unknown workspace: missing"):
+        service.create_project(
+            AutomationProjectCreateInput(
+                name="daily-briefing",
+                workspace_id="missing",
+                prompt="Summarize the day.",
+                schedule_mode=AutomationScheduleMode.CRON,
+                cron_expression="0 9 * * 1-5",
+                timezone="UTC",
+            )
+        )
+
+
+def test_update_project_rejects_unknown_workspace(tmp_path: Path) -> None:
+    service, _, _ = _build_service(tmp_path)
+    created = service.create_project(
+        AutomationProjectCreateInput(
+            name="daily-briefing",
+            workspace_id="default",
+            prompt="Summarize the day.",
+            schedule_mode=AutomationScheduleMode.CRON,
+            cron_expression="0 9 * * 1-5",
+            timezone="UTC",
+        )
+    )
+
+    with pytest.raises(ValueError, match="Unknown workspace: missing"):
+        service.update_project(
+            created.automation_project_id,
+            AutomationProjectUpdateInput(workspace_id="missing"),
+        )
+
+
+def test_enable_project_rejects_unknown_workspace_on_persisted_record(
+    tmp_path: Path,
+) -> None:
+    service, _, _ = _build_service(tmp_path)
+    created = service.create_project(
+        AutomationProjectCreateInput(
+            name="daily-briefing",
+            workspace_id="default",
+            prompt="Summarize the day.",
+            schedule_mode=AutomationScheduleMode.CRON,
+            cron_expression="0 9 * * 1-5",
+            timezone="UTC",
+            enabled=False,
+        )
+    )
+    persisted = service.get_project(created.automation_project_id)
+    _ = service._repository.update(
+        persisted.model_copy(update={"workspace_id": "missing"})
+    )
+
+    with pytest.raises(ValueError, match="Unknown workspace: missing"):
+        service.set_project_status(
+            created.automation_project_id,
+            status=AutomationProjectStatus.ENABLED,
+        )

--- a/tests/unit_tests/gateway/test_feishu_gateway_service.py
+++ b/tests/unit_tests/gateway/test_feishu_gateway_service.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_teams.agents.orchestration.settings_service import (
+    OrchestrationSettingsService,
+)
+from agent_teams.gateway.feishu.account_repository import FeishuAccountRepository
+from agent_teams.gateway.feishu.gateway_service import FeishuGatewayService
+from agent_teams.gateway.feishu.models import (
+    FeishuGatewayAccountCreateInput,
+    FeishuGatewayAccountStatus,
+    FeishuTriggerSecretConfig,
+)
+from agent_teams.gateway.feishu.secret_store import FeishuTriggerSecretStore
+from agent_teams.roles.role_models import RoleDefinition
+from agent_teams.roles.role_registry import RoleRegistry
+from agent_teams.sessions.external_session_binding_repository import (
+    ExternalSessionBindingRepository,
+)
+from agent_teams.sessions.runs.run_models import RunTopologySnapshot
+from agent_teams.sessions.session_models import SessionMode
+from agent_teams.workspace import WorkspaceRepository, WorkspaceService
+
+
+class _FakeSecretStore(FeishuTriggerSecretStore):
+    def __init__(self) -> None:
+        self._values: dict[str, FeishuTriggerSecretConfig] = {}
+
+    def get_secret_config(
+        self,
+        config_dir: Path,
+        trigger_id: str,
+    ) -> FeishuTriggerSecretConfig:
+        _ = config_dir
+        return self._values.get(trigger_id, FeishuTriggerSecretConfig())
+
+    def set_secret_config(
+        self,
+        config_dir: Path,
+        trigger_id: str,
+        secret_config: FeishuTriggerSecretConfig,
+    ) -> None:
+        _ = config_dir
+        self._values[trigger_id] = secret_config
+
+    def delete_secret_config(self, config_dir: Path, trigger_id: str) -> None:
+        _ = config_dir
+        self._values.pop(trigger_id, None)
+
+
+class _FakeOrchestrationSettingsService(OrchestrationSettingsService):
+    def __init__(self) -> None:
+        pass
+
+    def resolve_run_topology(self, session) -> RunTopologySnapshot:
+        preset_id = str(getattr(session, "orchestration_preset_id", "") or "").strip()
+        if preset_id != "preset-1":
+            raise ValueError(f"Unknown orchestration preset: {preset_id or 'none'}")
+        return RunTopologySnapshot(
+            session_mode=SessionMode.ORCHESTRATION,
+            main_agent_role_id="MainAgent",
+            normal_root_role_id="MainAgent",
+            coordinator_role_id="Coordinator",
+            orchestration_preset_id="preset-1",
+        )
+
+
+def _build_role_registry() -> RoleRegistry:
+    role_registry = RoleRegistry()
+    role_registry.register(
+        RoleDefinition(
+            role_id="MainAgent",
+            name="Main Agent",
+            description="Default role.",
+            version="1",
+            tools=(),
+            system_prompt="You are Main Agent.",
+        )
+    )
+    role_registry.register(
+        RoleDefinition(
+            role_id="Coordinator",
+            name="Coordinator",
+            description="Coordinates tasks.",
+            version="1",
+            tools=("create_tasks", "update_task", "dispatch_task"),
+            system_prompt="Coordinate work.",
+        )
+    )
+    return role_registry
+
+
+def _build_service(tmp_path: Path) -> FeishuGatewayService:
+    db_path = tmp_path / "feishu_gateway.db"
+    workspace_service = WorkspaceService(repository=WorkspaceRepository(db_path))
+    _ = workspace_service.create_workspace(
+        workspace_id="default",
+        root_path=tmp_path,
+    )
+    return FeishuGatewayService(
+        config_dir=tmp_path / "config",
+        repository=FeishuAccountRepository(db_path),
+        secret_store=_FakeSecretStore(),
+        role_registry=_build_role_registry(),
+        orchestration_settings_service=_FakeOrchestrationSettingsService(),
+        workspace_service=workspace_service,
+        external_session_binding_repo=ExternalSessionBindingRepository(db_path),
+    )
+
+
+def test_set_account_enabled_rejects_invalid_persisted_workspace(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    created = service.create_account(
+        FeishuGatewayAccountCreateInput(
+            name="feishu-main",
+            enabled=False,
+            source_config={
+                "provider": "feishu",
+                "trigger_rule": "mention_only",
+                "app_id": "cli_123",
+                "app_name": "Feishu Bot",
+            },
+            target_config={"workspace_id": "default"},
+            secret_config={"app_secret": "secret-1"},
+        )
+    )
+    _ = service._repository.update_account(
+        created.model_copy(
+            update={
+                "target_config": {"workspace_id": "missing-workspace"},
+                "status": FeishuGatewayAccountStatus.DISABLED,
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="Unknown workspace: missing-workspace"):
+        service.set_account_enabled(created.account_id, True)
+
+
+def test_get_account_exposes_last_error_for_invalid_persisted_preset(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    created = service.create_account(
+        FeishuGatewayAccountCreateInput(
+            name="feishu-main",
+            enabled=False,
+            source_config={
+                "provider": "feishu",
+                "trigger_rule": "mention_only",
+                "app_id": "cli_123",
+                "app_name": "Feishu Bot",
+            },
+            target_config={"workspace_id": "default"},
+            secret_config={"app_secret": "secret-1"},
+        )
+    )
+    _ = service._repository.update_account(
+        created.model_copy(
+            update={
+                "target_config": {
+                    "workspace_id": "default",
+                    "session_mode": "orchestration",
+                    "orchestration_preset_id": "preset-missing",
+                },
+                "status": FeishuGatewayAccountStatus.ENABLED,
+            }
+        )
+    )
+
+    account = service.get_account(created.account_id)
+
+    assert account.last_error == "Unknown orchestration preset: preset-missing"
+
+
+def test_list_enabled_runtime_configs_skips_invalid_persisted_accounts(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    valid = service.create_account(
+        FeishuGatewayAccountCreateInput(
+            name="feishu-valid",
+            enabled=True,
+            source_config={
+                "provider": "feishu",
+                "trigger_rule": "mention_only",
+                "app_id": "cli_valid",
+                "app_name": "Valid Bot",
+            },
+            target_config={"workspace_id": "default"},
+            secret_config={"app_secret": "secret-valid"},
+        )
+    )
+    invalid = service.create_account(
+        FeishuGatewayAccountCreateInput(
+            name="feishu-invalid",
+            enabled=False,
+            source_config={
+                "provider": "feishu",
+                "trigger_rule": "mention_only",
+                "app_id": "cli_invalid",
+                "app_name": "Invalid Bot",
+            },
+            target_config={"workspace_id": "default"},
+            secret_config={"app_secret": "secret-invalid"},
+        )
+    )
+    _ = service._repository.update_account(
+        invalid.model_copy(
+            update={
+                "status": FeishuGatewayAccountStatus.ENABLED,
+                "target_config": {"workspace_id": "missing-workspace"},
+            }
+        )
+    )
+
+    runtime_configs = service.list_enabled_runtime_configs()
+
+    assert len(runtime_configs) == 1
+    assert runtime_configs[0].trigger_id == valid.account_id

--- a/tests/unit_tests/interfaces/server/test_automation_router.py
+++ b/tests/unit_tests/interfaces/server/test_automation_router.py
@@ -136,6 +136,8 @@ class _FakeAutomationService:
         automation_project_id: str,
         status: AutomationProjectStatus,
     ) -> AutomationProjectRecord:
+        if automation_project_id == "invalid":
+            raise ValueError("Unknown workspace: missing-workspace")
         if automation_project_id != "aut_1":
             raise KeyError(f"Unknown automation_project_id: {automation_project_id}")
         self.status_calls.append((automation_project_id, status))
@@ -292,6 +294,15 @@ def test_enable_project_route_returns_enabled_record() -> None:
     assert response.status_code == 200
     assert response.json()["status"] == "enabled"
     assert fake_service.status_calls == [("aut_1", AutomationProjectStatus.ENABLED)]
+
+
+def test_enable_project_route_maps_validation_error_to_422() -> None:
+    client = _client(_FakeAutomationService())
+
+    response = client.post("/api/automation/projects/invalid:enable")
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Unknown workspace: missing-workspace"
 
 
 def test_disable_project_route_returns_disabled_record() -> None:

--- a/tests/unit_tests/interfaces/server/test_feishu_gateway_router.py
+++ b/tests/unit_tests/interfaces/server/test_feishu_gateway_router.py
@@ -72,6 +72,8 @@ class _FakeFeishuGatewayService:
         account_id: str,
         enabled: bool,
     ) -> FeishuGatewayAccountRecord:
+        if account_id == "invalid":
+            raise ValueError("Unknown workspace: missing-workspace")
         return self._record().model_copy(
             update={
                 "account_id": account_id,
@@ -200,3 +202,12 @@ def test_delete_feishu_account_route_maps_missing_account_to_404() -> None:
 
     assert response.status_code == 404
     assert "Unknown Feishu account" in response.json()["detail"]
+
+
+def test_enable_feishu_account_route_maps_validation_error_to_422() -> None:
+    client = _client(_FakeFeishuGatewayService(), _FakeSubscriptionService())
+
+    response = client.post("/api/gateway/feishu/accounts/invalid:enable")
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Unknown workspace: missing-workspace"

--- a/tests/unit_tests/sessions/runs/test_run_manager_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_manager_recovery.py
@@ -329,6 +329,23 @@ def test_create_run_blocks_when_tool_approval_pending(tmp_path: Path) -> None:
         )
 
 
+def test_create_detached_run_disables_root_instance_reuse(tmp_path: Path) -> None:
+    db_path = tmp_path / "run_detached.db"
+    manager = _build_manager(db_path)
+
+    run_id, session_id = manager.create_detached_run(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("fresh automation run"),
+        )
+    )
+
+    persisted = RunIntentRepository(db_path).get(run_id)
+    assert session_id == "session-1"
+    assert manager._pending_runs[run_id].reuse_root_instance is False
+    assert persisted.reuse_root_instance is False
+
+
 def test_manager_hydrates_recoverable_run_from_runtime_repo(tmp_path: Path) -> None:
     db_path = tmp_path / "run_hydration.db"
     runtime_repo = RunRuntimeRepository(db_path)

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -29,6 +29,7 @@ from agent_teams.sessions.runs.run_runtime_repo import (
 from agent_teams.tools.runtime import (
     ToolApprovalPolicy,
     ToolContext,
+    ToolExecutionError,
     ToolResultProjection,
     execute_tool,
 )
@@ -317,6 +318,47 @@ def test_execute_tool_returns_timeout_error_when_approval_times_out() -> None:
     assert runtime_meta["approval_status"] == "timeout"
     assert ticket is not None
     assert ticket.status == ApprovalTicketStatus.TIMED_OUT
+
+
+def test_execute_tool_preserves_custom_tool_error_details() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-webfetch-error"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="webfetch",
+            args_summary={"url": "https://example.com"},
+            action=lambda: _raise_tool_execution_error(),
+        )
+    )
+
+    error = cast(dict[str, JsonValue], result["error"])
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert result["ok"] is False
+    assert error["type"] == "source_access_denied"
+    assert error["retryable"] is False
+    assert cast(dict[str, JsonValue], error["details"]) == {
+        "url_host": "example.com",
+        "status_code": 403,
+    }
+    assert cast(dict[str, JsonValue], meta["error_details"]) == {
+        "url_host": "example.com",
+        "status_code": 403,
+    }
+
+
+def _raise_tool_execution_error() -> object:
+    raise ToolExecutionError(
+        error_type="source_access_denied",
+        message="Web fetch failed for example.com with HTTP 403",
+        retryable=False,
+        details={"url_host": "example.com", "status_code": 403},
+    )
 
 
 def test_execute_tool_approval_uses_model_tool_call_id_when_present() -> None:

--- a/tests/unit_tests/tools/web_tools/test_webfetch.py
+++ b/tests/unit_tests/tools/web_tools/test_webfetch.py
@@ -7,6 +7,7 @@ from typing import cast
 import httpx
 import pytest
 
+from agent_teams.tools.runtime import ToolExecutionError
 from agent_teams.tools.web_tools import common, webfetch
 
 
@@ -143,6 +144,59 @@ async def test_fetch_url_retries_cloudflare_challenge() -> None:
 
     assert response.status_code == 200
     assert calls == [webfetch.BROWSER_USER_AGENT, webfetch.FALLBACK_USER_AGENT]
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_raises_anti_bot_challenge_after_retry() -> None:
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            request=request,
+            headers={"cf-mitigated": "challenge"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await webfetch.fetch_url(
+                client=client,
+                url="https://example.com",
+                response_format="markdown",
+            )
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.error_type == "anti_bot_challenge"
+    assert exc_info.value.retryable is False
+    assert exc_info.value.details == {
+        "url_host": "example.com",
+        "status_code": 403,
+        "mitigation": "cloudflare_challenge",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_classifies_upstream_status_errors() -> None:
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, request=request, text="unavailable")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await webfetch.fetch_url(
+                client=client,
+                url="https://example.com",
+                response_format="markdown",
+            )
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.error_type == "upstream_unavailable"
+    assert exc_info.value.retryable is True
+    assert exc_info.value.details == {
+        "url_host": "example.com",
+        "status_code": 503,
+    }
 
 
 def test_build_webfetch_projection_saves_binary_file(tmp_path: Path) -> None:

--- a/tests/unit_tests/tools/web_tools/test_websearch.py
+++ b/tests/unit_tests/tools/web_tools/test_websearch.py
@@ -5,6 +5,7 @@ import httpx
 from typing import cast
 import pytest
 
+from agent_teams.tools.runtime import ToolExecutionError
 from agent_teams.tools.web_tools import websearch
 
 
@@ -44,13 +45,13 @@ def test_extract_search_output_reads_first_sse_text_block() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fetch_exa_search_response_wraps_http_errors() -> None:
+async def test_fetch_exa_search_response_classifies_http_errors() -> None:
     async def _handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, request=request, text="boom")
 
     client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
     try:
-        with pytest.raises(RuntimeError, match="Search error \\(500\\): boom"):
+        with pytest.raises(ToolExecutionError) as exc_info:
             await websearch.fetch_exa_search_response(
                 client=client,
                 endpoint="https://mcp.exa.ai/mcp",
@@ -63,3 +64,11 @@ async def test_fetch_exa_search_response_wraps_http_errors() -> None:
             )
     finally:
         await client.aclose()
+
+    assert exc_info.value.error_type == "upstream_unavailable"
+    assert exc_info.value.retryable is True
+    assert exc_info.value.details == {
+        "provider": "exa",
+        "endpoint_host": "mcp.exa.ai",
+        "status_code": 500,
+    }


### PR DESCRIPTION
## Summary
- fix bound-session automation recovery by persisting waiting records for direct starts, rebinding the target workspace before reuse, and forcing detached automation runs onto a fresh root instance
- include authorized runtime tools in the runtime prompt and preserve structured runtime tool errors so websearch/webfetch surface actionable retryable diagnostics instead of opaque internal failures
- validate automation and Feishu gateway workspace/runtime config on create, update, and enable flows, and expose `last_error` for persisted dirty gateway configs

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`
- browser E2E against a local server:
  - automation project create/enable rejects unknown workspaces with HTTP 422
  - Feishu account list surfaces `last_error` for invalid persisted configs and enable rejects them with HTTP 422
  - bound-session automation run rebinds the reused session to the project workspace before execution

Fixes #127
Fixes #128
Fixes #129
