### PR TITLE
Harden identifier validation and persisted row parsing

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -15,6 +15,10 @@ Common status codes:
 - `409`: runtime conflict
 - `422`: request validation error
 
+Common validation rules:
+- Identifier and reference fields reject blank strings, whitespace-only strings, and the explicit string values `"None"` and `"null"` with `422`.
+- Optional identifier fields still accept real JSON `null`.
+
 ## Core Concepts
 
 - A run starts from one root task.
@@ -377,6 +381,7 @@ Notes:
 - New sessions default to `session_mode = "normal"`.
 - New sessions default to `normal_root_role_id = "MainAgent"`.
 - New sessions also store the current default orchestration preset id so they can be switched to orchestration before the first run.
+- Omitting `session_id` or sending `session_id = null` auto-generates a session id. Sending `"None"` or `"null"` as a string is rejected with `422`.
 
 ### `GET /sessions`
 
@@ -678,6 +683,7 @@ Notes:
 - `target_role_id` is optional. When set, that run starts from the specified role instead of the session-default root role, without mutating the saved session topology.
 - `target_role_id` may point to `Coordinator`, `MainAgent`, or any normal role known to the role registry.
 - The backend resolves the session mode at run creation time and snapshots the chosen root topology into the run intent for queued and recoverable resume flows.
+- `session_id`, `target_role_id`, `run_id`, and other identifier-style request fields follow the common identifier validation rules above.
 
 Response:
 
@@ -1001,6 +1007,7 @@ Rules:
 - `root_path` must already exist.
 - `root_path` must be a directory.
 - `workspace_id` must be unique.
+- `workspace_id` follows the common identifier validation rules above.
 
 ### `GET /workspaces/{workspace_id}`
 
@@ -1250,6 +1257,7 @@ Each record includes:
 ### `POST /gateway/feishu/accounts`
 
 Creates a Feishu gateway account and persists its secret config.
+The request `name` and all `account_id` path parameters follow the common identifier validation rules above.
 
 ### `PATCH /gateway/feishu/accounts/{account_id}`
 
@@ -1413,6 +1421,7 @@ Response fields:
 
 Notes:
 - On success, the backend stores the returned bot token in the unified secret store and upserts the account into `wechat_accounts`.
+- `session_key` and `account_id` follow the common identifier validation rules above.
 - Newly connected accounts default to `workspace_id = "default"` and `session_mode = "normal"` unless a previous record already exists for that account id.
 
 ### `PATCH /gateway/wechat/accounts/{account_id}`
@@ -1558,6 +1567,7 @@ Notes:
 - `delivery_binding.session_id` is required for explicit create/update requests and binds the automation project to that exact saved session.
 - When `delivery_binding` is present and `delivery_events` is omitted, the backend defaults to `started`, `completed`, and `failed`.
 - When a bound session cannot be resolved at run time, the run fails instead of falling back to a fresh automation session.
+- `workspace_id`, `automation_project_id`, and delivery-binding identifiers follow the common identifier validation rules above.
 
 ### `GET /automation/projects/{automation_project_id}`
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -7,6 +7,13 @@
 - Foreign keys: enabled on each connection (`PRAGMA foreign_keys = ON`)
 - Runtime logs are file-based and stored under `~/.agent-teams/log/backend.log`, `~/.agent-teams/log/debug.log`, and `~/.agent-teams/log/frontend.log`
 
+## 1.1 Application-Layer Constraints
+
+- SQLite tables do not currently enforce identifier-text `CHECK` constraints. The application layer rejects identifier and reference inputs that are blank, whitespace-only, or the explicit strings `"None"` and `"null"`.
+- Optional identifier fields still allow real `NULL` at the API and model layer.
+- Repository read paths tolerate previously persisted dirty rows for identifier-heavy tables such as `sessions`, `workspaces`, `external_session_bindings`, `session_history_markers`, `run_runtime`, `approval_tickets`, `gateway_sessions`, `feishu_gateway_accounts`, and `wechat_accounts`.
+- When those readers encounter invalid persisted identifiers or timestamps, they log a warning and skip the bad row or treat the row as missing instead of failing the whole `/api/*` request.
+
 ---
 
 ## 2. Tables

--- a/src/agent_teams/agents/tasks/models.py
+++ b/src/agent_teams/agents/tasks/models.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_teams.agents.tasks.enums import TaskStatus
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 
 class VerificationPlan(BaseModel):
@@ -16,11 +17,11 @@ class VerificationPlan(BaseModel):
 class TaskEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    task_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
-    parent_task_id: str | None = None
-    trace_id: str = Field(min_length=1)
-    role_id: str | None = "coordinator_agent"
+    task_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
+    parent_task_id: OptionalIdentifierStr = None
+    trace_id: RequiredIdentifierStr
+    role_id: OptionalIdentifierStr = "coordinator_agent"
     title: str | None = None
     objective: str = Field(min_length=1)
     verification: VerificationPlan
@@ -31,7 +32,7 @@ class TaskRecord(BaseModel):
 
     envelope: TaskEnvelope
     status: TaskStatus = TaskStatus.CREATED
-    assigned_instance_id: str | None = None
+    assigned_instance_id: OptionalIdentifierStr = None
     result: str | None = None
     error_message: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
@@ -41,6 +42,6 @@ class TaskRecord(BaseModel):
 class VerificationResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    task_id: str
+    task_id: RequiredIdentifierStr
     passed: bool
     details: tuple[str, ...]

--- a/src/agent_teams/automation/automation_models.py
+++ b/src/agent_teams/automation/automation_models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from agent_teams.sessions.runs.enums import ExecutionMode
 from agent_teams.sessions.runs.run_models import RunThinkingConfig
 from agent_teams.sessions.session_models import SessionMode
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 
 class AutomationProjectStatus(str, Enum):
@@ -56,7 +57,7 @@ class AutomationRunConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     session_mode: SessionMode = SessionMode.NORMAL
-    orchestration_preset_id: str | None = None
+    orchestration_preset_id: OptionalIdentifierStr = None
     execution_mode: ExecutionMode = ExecutionMode.AI
     yolo: bool = True
     thinking: RunThinkingConfig = Field(default_factory=RunThinkingConfig)
@@ -66,10 +67,10 @@ class AutomationFeishuBinding(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     provider: Literal["feishu"] = "feishu"
-    trigger_id: str = Field(min_length=1)
-    tenant_key: str = Field(min_length=1)
-    chat_id: str = Field(min_length=1)
-    session_id: str | None = None
+    trigger_id: RequiredIdentifierStr
+    tenant_key: RequiredIdentifierStr
+    chat_id: RequiredIdentifierStr
+    session_id: OptionalIdentifierStr = None
     chat_type: str = Field(min_length=1)
     source_label: str = Field(min_length=1)
 
@@ -78,13 +79,13 @@ class AutomationFeishuBindingCandidate(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     provider: Literal["feishu"] = "feishu"
-    trigger_id: str = Field(min_length=1)
+    trigger_id: RequiredIdentifierStr
     trigger_name: str = Field(min_length=1)
-    tenant_key: str = Field(min_length=1)
-    chat_id: str = Field(min_length=1)
+    tenant_key: RequiredIdentifierStr
+    chat_id: RequiredIdentifierStr
     chat_type: str = Field(min_length=1)
     source_label: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
+    session_id: RequiredIdentifierStr
     session_title: str = Field(min_length=1)
     updated_at: datetime
 
@@ -94,7 +95,7 @@ class AutomationProjectCreateInput(BaseModel):
 
     name: str = Field(min_length=1)
     display_name: str | None = None
-    workspace_id: str = Field(min_length=1)
+    workspace_id: RequiredIdentifierStr
     prompt: str = Field(min_length=1)
     schedule_mode: AutomationScheduleMode
     cron_expression: str | None = None
@@ -127,7 +128,7 @@ class AutomationProjectUpdateInput(BaseModel):
 
     name: str | None = Field(default=None, min_length=1)
     display_name: str | None = None
-    workspace_id: str | None = Field(default=None, min_length=1)
+    workspace_id: OptionalIdentifierStr = None
     prompt: str | None = Field(default=None, min_length=1)
     schedule_mode: AutomationScheduleMode | None = None
     cron_expression: str | None = None
@@ -142,11 +143,11 @@ class AutomationProjectUpdateInput(BaseModel):
 class AutomationProjectRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    automation_project_id: str = Field(min_length=1)
+    automation_project_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     display_name: str = Field(min_length=1)
     status: AutomationProjectStatus
-    workspace_id: str = Field(min_length=1)
+    workspace_id: RequiredIdentifierStr
     prompt: str = Field(min_length=1)
     schedule_mode: AutomationScheduleMode
     cron_expression: str | None = None
@@ -155,8 +156,8 @@ class AutomationProjectRecord(BaseModel):
     run_config: AutomationRunConfig = Field(default_factory=AutomationRunConfig)
     delivery_binding: AutomationFeishuBinding | None = None
     delivery_events: tuple[AutomationDeliveryEvent, ...] = ()
-    trigger_id: str = Field(min_length=1)
-    last_session_id: str | None = None
+    trigger_id: RequiredIdentifierStr
+    last_session_id: OptionalIdentifierStr = None
     last_run_started_at: datetime | None = None
     last_error: str | None = None
     next_run_at: datetime | None = None
@@ -167,11 +168,11 @@ class AutomationProjectRecord(BaseModel):
 class AutomationRunDeliveryRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    automation_delivery_id: str = Field(min_length=1)
-    automation_project_id: str = Field(min_length=1)
+    automation_delivery_id: RequiredIdentifierStr
+    automation_project_id: RequiredIdentifierStr
     automation_project_name: str = Field(min_length=1)
-    run_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
+    run_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
     reason: str = Field(min_length=1)
     binding: AutomationFeishuBinding
     delivery_events: tuple[AutomationDeliveryEvent, ...] = ()
@@ -182,8 +183,8 @@ class AutomationRunDeliveryRecord(BaseModel):
     terminal_attempts: int = Field(default=0, ge=0)
     started_message: str | None = None
     terminal_message: str | None = None
-    started_message_id: str | None = None
-    terminal_message_id: str | None = None
+    started_message_id: OptionalIdentifierStr = None
+    terminal_message_id: OptionalIdentifierStr = None
     started_sent_at: datetime | None = None
     terminal_sent_at: datetime | None = None
     started_cleanup_status: AutomationCleanupStatus = AutomationCleanupStatus.SKIPPED
@@ -197,17 +198,17 @@ class AutomationRunDeliveryRecord(BaseModel):
 class AutomationBoundSessionQueueRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    automation_queue_id: str = Field(min_length=1)
-    automation_project_id: str = Field(min_length=1)
+    automation_queue_id: RequiredIdentifierStr
+    automation_project_id: RequiredIdentifierStr
     automation_project_name: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
+    session_id: RequiredIdentifierStr
     reason: str = Field(min_length=1)
     binding: AutomationFeishuBinding
     delivery_events: tuple[AutomationDeliveryEvent, ...] = ()
     run_config: AutomationRunConfig = Field(default_factory=AutomationRunConfig)
     prompt: str = Field(min_length=1)
     queue_message: str = Field(min_length=1)
-    run_id: str | None = None
+    run_id: OptionalIdentifierStr = None
     status: AutomationBoundSessionQueueStatus = AutomationBoundSessionQueueStatus.QUEUED
     start_attempts: int = Field(default=0, ge=0)
     next_attempt_at: datetime = Field(
@@ -217,7 +218,7 @@ class AutomationBoundSessionQueueRecord(BaseModel):
     resume_next_attempt_at: datetime = Field(
         default_factory=lambda: datetime.now(tz=timezone.utc)
     )
-    queue_message_id: str | None = None
+    queue_message_id: OptionalIdentifierStr = None
     queue_cleanup_status: AutomationCleanupStatus = AutomationCleanupStatus.SKIPPED
     queue_cleanup_attempts: int = Field(default=0, ge=0)
     queue_cleaned_at: datetime | None = None
@@ -230,8 +231,8 @@ class AutomationBoundSessionQueueRecord(BaseModel):
 class AutomationExecutionHandle(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    session_id: str = Field(min_length=1)
-    run_id: str | None = None
+    session_id: RequiredIdentifierStr
+    run_id: OptionalIdentifierStr = None
     queued: bool = False
     reused_bound_session: bool = False
 

--- a/src/agent_teams/external_agents/models.py
+++ b/src/agent_teams/external_agents/models.py
@@ -7,6 +7,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
+from agent_teams.validation import RequiredIdentifierStr
+
 
 class ExternalAgentTransportType(str, Enum):
     STDIO = "stdio"
@@ -51,7 +53,7 @@ class CustomTransportConfig(BaseModel):
     transport: Literal[ExternalAgentTransportType.CUSTOM] = (
         ExternalAgentTransportType.CUSTOM
     )
-    adapter_id: str = Field(min_length=1)
+    adapter_id: RequiredIdentifierStr
     config: dict[str, JsonValue] = Field(default_factory=dict)
 
 
@@ -63,7 +65,7 @@ ExternalAgentTransportConfig = (
 class ExternalAgentConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    agent_id: str = Field(min_length=1)
+    agent_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     description: str = ""
     transport: ExternalAgentTransportConfig = Field(discriminator="transport")
@@ -78,7 +80,7 @@ class ExternalAgentCollection(BaseModel):
 class ExternalAgentSummary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    agent_id: str = Field(min_length=1)
+    agent_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     description: str = ""
     transport: ExternalAgentTransportType
@@ -87,7 +89,7 @@ class ExternalAgentSummary(BaseModel):
 class ExternalAgentOption(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    agent_id: str = Field(min_length=1)
+    agent_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     transport: ExternalAgentTransportType
 
@@ -110,11 +112,11 @@ class ExternalAgentSessionStatus(str, Enum):
 class ExternalAgentSessionRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    session_id: str = Field(min_length=1)
-    role_id: str = Field(min_length=1)
-    agent_id: str = Field(min_length=1)
+    session_id: RequiredIdentifierStr
+    role_id: RequiredIdentifierStr
+    agent_id: RequiredIdentifierStr
     transport: ExternalAgentTransportType
-    external_session_id: str = Field(min_length=1)
+    external_session_id: RequiredIdentifierStr
     status: ExternalAgentSessionStatus = ExternalAgentSessionStatus.READY
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))

--- a/src/agent_teams/gateway/feishu/account_repository.py
+++ b/src/agent_teams/gateway/feishu/account_repository.py
@@ -2,19 +2,28 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import RLock
 
-from pydantic import JsonValue
+from pydantic import JsonValue, ValidationError
 
 from agent_teams.gateway.feishu.models import (
     FEISHU_PLATFORM,
     FeishuGatewayAccountRecord,
     FeishuGatewayAccountStatus,
 )
+from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from agent_teams.validation import (
+    normalize_persisted_text,
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+LOGGER = get_logger(__name__)
 
 
 class FeishuAccountNameConflictError(ValueError):
@@ -215,7 +224,11 @@ class FeishuAccountRepository:
         ).fetchone()
         if row is None:
             raise KeyError(f"Unknown Feishu account: {account_id}")
-        return self._row_to_record(row)
+        try:
+            return self._row_to_record(row)
+        except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+            _log_invalid_feishu_account_row(row=row, error=exc)
+            raise KeyError(f"Unknown Feishu account: {account_id}") from exc
 
     def list_accounts(self) -> tuple[FeishuGatewayAccountRecord, ...]:
         rows = self._conn.execute(
@@ -225,7 +238,13 @@ class FeishuAccountRepository:
             ORDER BY created_at DESC
             """
         ).fetchall()
-        return tuple(self._row_to_record(row) for row in rows)
+        records: list[FeishuGatewayAccountRecord] = []
+        for row in rows:
+            try:
+                records.append(self._row_to_record(row))
+            except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+                _log_invalid_feishu_account_row(row=row, error=exc)
+        return tuple(records)
 
     def delete_account(self, account_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -243,28 +262,101 @@ class FeishuAccountRepository:
     @staticmethod
     def _row_to_record(row: sqlite3.Row) -> FeishuGatewayAccountRecord:
         return FeishuGatewayAccountRecord(
-            account_id=str(row["account_id"]),
-            name=str(row["name"]),
+            account_id=require_persisted_identifier(
+                row["account_id"],
+                field_name="account_id",
+            ),
+            name=require_persisted_identifier(row["name"], field_name="name"),
             display_name=str(row["display_name"]),
             status=FeishuGatewayAccountStatus(str(row["status"])),
             source_config=_load_json_object(row["source_config_json"]),
             target_config=(
                 _load_json_object(row["target_config_json"])
-                if row["target_config_json"] is not None
+                if normalize_persisted_text(row["target_config_json"]) is not None
                 else None
             ),
-            created_at=datetime.fromisoformat(str(row["created_at"])).astimezone(UTC),
-            updated_at=datetime.fromisoformat(str(row["updated_at"])).astimezone(UTC),
+            created_at=_require_feishu_account_timestamp(
+                row=row,
+                account_id=str(row["account_id"]),
+                field_name="created_at",
+            ).astimezone(UTC),
+            updated_at=_require_feishu_account_timestamp(
+                row=row,
+                account_id=str(row["account_id"]),
+                field_name="updated_at",
+            ).astimezone(UTC),
         )
 
 
 def _load_json_object(raw_value: object) -> dict[str, JsonValue]:
-    if raw_value is None:
+    normalized = normalize_persisted_text(raw_value)
+    if normalized is None:
         return {}
-    parsed = json.loads(str(raw_value))
+    parsed = json.loads(normalized)
     if not isinstance(parsed, dict):
         return {}
     return {str(key): value for key, value in parsed.items()}
+
+
+def _require_feishu_account_timestamp(
+    *,
+    row: sqlite3.Row,
+    account_id: str,
+    field_name: str,
+) -> datetime:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_feishu_account_timestamp(
+        account_id=account_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _persisted_value_preview(value: object) -> str:
+    if value is None:
+        return "<null>"
+    return str(value)[:200]
+
+
+def _log_invalid_feishu_account_timestamp(
+    *,
+    account_id: str,
+    field_name: str,
+    raw_preview: str,
+) -> None:
+    payload: dict[str, JsonValue] = {
+        "account_id": account_id,
+        "field_name": field_name,
+        "raw_preview": raw_preview,
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="gateway.feishu.account_repository.timestamp_invalid",
+        message="Invalid persisted Feishu account timestamp",
+        payload=payload,
+    )
+
+
+def _log_invalid_feishu_account_row(*, row: sqlite3.Row, error: Exception) -> None:
+    payload: dict[str, JsonValue] = {
+        "account_id": _persisted_value_preview(row["account_id"]),
+        "name": _persisted_value_preview(row["name"]),
+        "created_at": _persisted_value_preview(row["created_at"]),
+        "updated_at": _persisted_value_preview(row["updated_at"]),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="gateway.feishu.account_repository.row_invalid",
+        message="Skipping invalid persisted Feishu account row",
+        payload=payload,
+    )
 
 
 __all__ = ["FeishuAccountNameConflictError", "FeishuAccountRepository"]

--- a/src/agent_teams/gateway/feishu/models.py
+++ b/src/agent_teams/gateway/feishu/models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
 
 from agent_teams.sessions.runs.run_models import RunThinkingConfig
 from agent_teams.sessions.session_models import SessionMode
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 FEISHU_PLATFORM = "feishu"
 FEISHU_METADATA_PLATFORM_KEY = "feishu_platform"
@@ -40,7 +41,7 @@ class FeishuMessageFormat(str, Enum):
 class FeishuEnvironment(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    app_id: str = Field(min_length=1)
+    app_id: RequiredIdentifierStr
     app_secret: str = Field(min_length=1)
     app_name: str | None = None
     verification_token: str | None = None
@@ -50,8 +51,8 @@ class FeishuEnvironment(BaseModel):
 class FeishuNotificationTarget(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    tenant_key: str = Field(min_length=1)
-    chat_id: str = Field(min_length=1)
+    tenant_key: RequiredIdentifierStr
+    chat_id: RequiredIdentifierStr
     chat_type: str = Field(min_length=1)
 
 
@@ -76,17 +77,17 @@ class FeishuTriggerSourceConfig(BaseModel):
 
     provider: Literal["feishu"] = FEISHU_PLATFORM
     trigger_rule: Literal["mention_only", "all_messages"] = "mention_only"
-    app_id: str = Field(min_length=1)
+    app_id: RequiredIdentifierStr
     app_name: str = Field(min_length=1)
 
 
 class FeishuTriggerTargetConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    workspace_id: str = Field(default="default", min_length=1)
+    workspace_id: RequiredIdentifierStr = "default"
     session_mode: SessionMode = SessionMode.NORMAL
-    normal_root_role_id: str | None = None
-    orchestration_preset_id: str | None = None
+    normal_root_role_id: OptionalIdentifierStr = None
+    orchestration_preset_id: OptionalIdentifierStr = None
     yolo: bool = True
     thinking: RunThinkingConfig = Field(default_factory=RunThinkingConfig)
 
@@ -105,7 +106,7 @@ class FeishuTriggerTargetConfig(BaseModel):
 class FeishuTriggerRuntimeConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    trigger_id: str = Field(min_length=1)
+    trigger_id: RequiredIdentifierStr
     trigger_name: str = Field(min_length=1)
     source: FeishuTriggerSourceConfig
     target: FeishuTriggerTargetConfig
@@ -129,7 +130,7 @@ class FeishuGatewayAccountStatus(str, Enum):
 class FeishuGatewayAccountCreateInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    name: str = Field(min_length=1)
+    name: RequiredIdentifierStr
     display_name: str | None = None
     source_config: dict[str, JsonValue] = Field(default_factory=dict)
     target_config: dict[str, JsonValue] | None = None
@@ -140,7 +141,7 @@ class FeishuGatewayAccountCreateInput(BaseModel):
 class FeishuGatewayAccountUpdateInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    name: str | None = Field(default=None, min_length=1)
+    name: OptionalIdentifierStr = None
     display_name: str | None = None
     source_config: dict[str, JsonValue] | None = None
     target_config: dict[str, JsonValue] | None = None
@@ -150,8 +151,8 @@ class FeishuGatewayAccountUpdateInput(BaseModel):
 class FeishuGatewayAccountRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    account_id: str = Field(min_length=1)
-    name: str = Field(min_length=1)
+    account_id: RequiredIdentifierStr
+    name: RequiredIdentifierStr
     display_name: str = Field(min_length=1)
     status: FeishuGatewayAccountStatus
     source_config: dict[str, JsonValue] = Field(default_factory=dict)
@@ -187,12 +188,12 @@ class TriggerProcessingResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     status: str = Field(min_length=1)
-    trigger_id: str | None = None
+    trigger_id: OptionalIdentifierStr = None
     trigger_name: str | None = None
-    event_id: str | None = None
+    event_id: OptionalIdentifierStr = None
     duplicate: bool = False
-    session_id: str | None = None
-    run_id: str | None = None
+    session_id: OptionalIdentifierStr = None
+    run_id: OptionalIdentifierStr = None
     ignored: bool = False
     reason: str | None = None
 
@@ -220,15 +221,15 @@ class FeishuMessagePoolRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     sequence_id: int = Field(default=0, ge=0)
-    message_pool_id: str = Field(min_length=1)
-    trigger_id: str = Field(min_length=1)
+    message_pool_id: RequiredIdentifierStr
+    trigger_id: RequiredIdentifierStr
     trigger_name: str = Field(min_length=1)
-    tenant_key: str = Field(min_length=1)
-    chat_id: str = Field(min_length=1)
+    tenant_key: RequiredIdentifierStr
+    chat_id: RequiredIdentifierStr
     chat_type: str = Field(min_length=1)
-    event_id: str = Field(min_length=1)
-    message_key: str = Field(min_length=1)
-    message_id: str | None = None
+    event_id: RequiredIdentifierStr
+    message_key: RequiredIdentifierStr
+    message_id: OptionalIdentifierStr = None
     command_name: str | None = None
     sender_name: str | None = None
     intent_text: str = ""
@@ -250,8 +251,8 @@ class FeishuMessagePoolRecord(BaseModel):
     process_attempts: int = Field(default=0, ge=0)
     ack_attempts: int = Field(default=0, ge=0)
     final_reply_attempts: int = Field(default=0, ge=0)
-    session_id: str | None = None
-    run_id: str | None = None
+    session_id: OptionalIdentifierStr = None
+    run_id: OptionalIdentifierStr = None
     next_attempt_at: datetime
     last_claimed_at: datetime | None = None
     last_error: str | None = None
@@ -263,10 +264,10 @@ class FeishuMessagePoolRecord(BaseModel):
 class FeishuChatQueueItemPreview(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    message_pool_id: str = Field(min_length=1)
+    message_pool_id: RequiredIdentifierStr
     processing_status: FeishuMessageProcessingStatus
     intent_preview: str = ""
-    run_id: str | None = None
+    run_id: OptionalIdentifierStr = None
     run_status: str | None = None
     run_phase: str | None = None
     blocking_reason: str | None = None
@@ -276,9 +277,9 @@ class FeishuChatQueueItemPreview(BaseModel):
 class FeishuChatQueueSummary(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    trigger_id: str = Field(min_length=1)
-    tenant_key: str = Field(min_length=1)
-    chat_id: str = Field(min_length=1)
+    trigger_id: RequiredIdentifierStr
+    tenant_key: RequiredIdentifierStr
+    chat_id: RequiredIdentifierStr
     active_total: int = Field(default=0, ge=0)
     queued_count: int = Field(default=0, ge=0)
     claimed_count: int = Field(default=0, ge=0)
@@ -293,8 +294,8 @@ class FeishuChatQueueSummary(BaseModel):
 class FeishuChatQueueClearResult(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    trigger_id: str = Field(min_length=1)
-    tenant_key: str = Field(min_length=1)
-    chat_id: str = Field(min_length=1)
+    trigger_id: RequiredIdentifierStr
+    tenant_key: RequiredIdentifierStr
+    chat_id: RequiredIdentifierStr
     cleared_queue_count: int = Field(default=0, ge=0)
     stopped_run_count: int = Field(default=0, ge=0)

--- a/src/agent_teams/gateway/gateway_models.py
+++ b/src/agent_teams/gateway/gateway_models.py
@@ -6,6 +6,8 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
+
 
 class GatewayChannelType(str, Enum):
     ACP_STDIO = "acp_stdio"
@@ -20,7 +22,7 @@ class GatewayMcpConnectionStatus(str, Enum):
 class GatewayMcpServerSpec(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    server_id: str = Field(min_length=1)
+    server_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     transport: str = Field(min_length=1)
     config: dict[str, JsonValue] = Field(default_factory=dict)
@@ -29,8 +31,8 @@ class GatewayMcpServerSpec(BaseModel):
 class GatewayMcpConnectionRecord(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    connection_id: str = Field(min_length=1)
-    server_id: str = Field(min_length=1)
+    connection_id: RequiredIdentifierStr
+    server_id: RequiredIdentifierStr
     status: GatewayMcpConnectionStatus
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
@@ -39,13 +41,13 @@ class GatewayMcpConnectionRecord(BaseModel):
 class GatewaySessionRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    gateway_session_id: str = Field(min_length=1)
+    gateway_session_id: RequiredIdentifierStr
     channel_type: GatewayChannelType
-    external_session_id: str = Field(min_length=1)
-    internal_session_id: str = Field(min_length=1)
-    active_run_id: str | None = None
-    peer_user_id: str | None = None
-    peer_chat_id: str | None = None
+    external_session_id: RequiredIdentifierStr
+    internal_session_id: RequiredIdentifierStr
+    active_run_id: OptionalIdentifierStr = None
+    peer_user_id: OptionalIdentifierStr = None
+    peer_chat_id: OptionalIdentifierStr = None
     cwd: str | None = None
     capabilities: dict[str, JsonValue] = Field(default_factory=dict)
     channel_state: dict[str, JsonValue] = Field(default_factory=dict)

--- a/src/agent_teams/gateway/gateway_session_repository.py
+++ b/src/agent_teams/gateway/gateway_session_repository.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
+
+from pydantic import JsonValue, ValidationError
 
 from agent_teams.gateway.gateway_models import (
     GatewayChannelType,
@@ -12,7 +15,15 @@ from agent_teams.gateway.gateway_models import (
     GatewayMcpServerSpec,
     GatewaySessionRecord,
 )
+from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite
+from agent_teams.validation import (
+    normalize_persisted_text,
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+LOGGER = get_logger(__name__)
 
 
 class GatewaySessionRepository:
@@ -113,7 +124,11 @@ class GatewaySessionRepository:
         ).fetchone()
         if row is None:
             raise KeyError(f"Unknown gateway_session_id: {gateway_session_id}")
-        return self._to_record(row)
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+            _log_invalid_gateway_session_row(row=row, error=exc)
+            raise KeyError(f"Unknown gateway_session_id: {gateway_session_id}") from exc
 
     def get_by_external(
         self,
@@ -130,7 +145,7 @@ class GatewaySessionRepository:
         ).fetchone()
         if row is None:
             return None
-        return self._to_record(row)
+        return self._record_or_none(row)
 
     def get_by_internal_session_id(
         self,
@@ -147,7 +162,7 @@ class GatewaySessionRepository:
         ).fetchone()
         if row is None:
             return None
-        return self._to_record(row)
+        return self._record_or_none(row)
 
     def update(self, record: GatewaySessionRecord) -> GatewaySessionRecord:
         cursor = self._conn.execute(
@@ -199,11 +214,23 @@ class GatewaySessionRepository:
         rows = self._conn.execute(
             "SELECT * FROM gateway_sessions ORDER BY created_at DESC"
         ).fetchall()
-        return tuple(self._to_record(row) for row in rows)
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
 
     def _to_record(self, row: sqlite3.Row) -> GatewaySessionRecord:
-        mcp_servers_raw = json.loads(str(row["session_mcp_servers_json"]))
-        connections_raw = json.loads(str(row["mcp_connections_json"]))
+        capabilities_raw = json.loads(
+            normalize_persisted_text(row["capabilities_json"]) or "{}"
+        )
+        channel_state_raw = json.loads(
+            normalize_persisted_text(row["channel_state_json"]) or "{}"
+        )
+        mcp_servers_raw = json.loads(
+            normalize_persisted_text(row["session_mcp_servers_json"]) or "[]"
+        )
+        connections_raw = json.loads(
+            normalize_persisted_text(row["mcp_connections_json"]) or "[]"
+        )
         mcp_servers = tuple(
             GatewayMcpServerSpec.model_validate(item)
             for item in mcp_servers_raw
@@ -215,28 +242,110 @@ class GatewaySessionRepository:
             if isinstance(item, dict)
         )
         return GatewaySessionRecord(
-            gateway_session_id=str(row["gateway_session_id"]),
+            gateway_session_id=require_persisted_identifier(
+                row["gateway_session_id"],
+                field_name="gateway_session_id",
+            ),
             channel_type=GatewayChannelType(str(row["channel_type"])),
-            external_session_id=str(row["external_session_id"]),
-            internal_session_id=str(row["internal_session_id"]),
-            active_run_id=(
-                str(row["active_run_id"]) if row["active_run_id"] is not None else None
+            external_session_id=require_persisted_identifier(
+                row["external_session_id"],
+                field_name="external_session_id",
             ),
-            peer_user_id=(
-                str(row["peer_user_id"]) if row["peer_user_id"] is not None else None
+            internal_session_id=require_persisted_identifier(
+                row["internal_session_id"],
+                field_name="internal_session_id",
             ),
-            peer_chat_id=(
-                str(row["peer_chat_id"]) if row["peer_chat_id"] is not None else None
+            active_run_id=normalize_persisted_text(row["active_run_id"]),
+            peer_user_id=normalize_persisted_text(row["peer_user_id"]),
+            peer_chat_id=normalize_persisted_text(row["peer_chat_id"]),
+            cwd=normalize_persisted_text(row["cwd"]),
+            capabilities=capabilities_raw if isinstance(capabilities_raw, dict) else {},
+            channel_state=(
+                channel_state_raw if isinstance(channel_state_raw, dict) else {}
             ),
-            cwd=str(row["cwd"]) if row["cwd"] is not None else None,
-            capabilities=json.loads(str(row["capabilities_json"])),
-            channel_state=json.loads(str(row["channel_state_json"])),
             session_mcp_servers=mcp_servers,
             mcp_connections=mcp_connections,
-            created_at=datetime.fromisoformat(str(row["created_at"])),
-            updated_at=datetime.fromisoformat(str(row["updated_at"])),
+            created_at=_require_gateway_session_timestamp(
+                row=row,
+                gateway_session_id=str(row["gateway_session_id"]),
+                field_name="created_at",
+            ),
+            updated_at=_require_gateway_session_timestamp(
+                row=row,
+                gateway_session_id=str(row["gateway_session_id"]),
+                field_name="updated_at",
+            ),
         )
 
     @staticmethod
     def utcnow() -> datetime:
         return datetime.now(tz=timezone.utc)
+
+    def _record_or_none(self, row: sqlite3.Row) -> GatewaySessionRecord | None:
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+            _log_invalid_gateway_session_row(row=row, error=exc)
+            return None
+
+
+def _require_gateway_session_timestamp(
+    *,
+    row: sqlite3.Row,
+    gateway_session_id: str,
+    field_name: str,
+) -> datetime:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_gateway_session_timestamp(
+        gateway_session_id=gateway_session_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _persisted_value_preview(value: object) -> str:
+    if value is None:
+        return "<null>"
+    return str(value)[:200]
+
+
+def _log_invalid_gateway_session_timestamp(
+    *,
+    gateway_session_id: str,
+    field_name: str,
+    raw_preview: str,
+) -> None:
+    payload: dict[str, JsonValue] = {
+        "gateway_session_id": gateway_session_id,
+        "field_name": field_name,
+        "raw_preview": raw_preview,
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="gateway.session_repository.timestamp_invalid",
+        message="Invalid persisted gateway session timestamp",
+        payload=payload,
+    )
+
+
+def _log_invalid_gateway_session_row(*, row: sqlite3.Row, error: Exception) -> None:
+    payload: dict[str, JsonValue] = {
+        "gateway_session_id": _persisted_value_preview(row["gateway_session_id"]),
+        "external_session_id": _persisted_value_preview(row["external_session_id"]),
+        "internal_session_id": _persisted_value_preview(row["internal_session_id"]),
+        "created_at": _persisted_value_preview(row["created_at"]),
+        "updated_at": _persisted_value_preview(row["updated_at"]),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="gateway.session_repository.row_invalid",
+        message="Skipping invalid persisted gateway session row",
+        payload=payload,
+    )

--- a/src/agent_teams/gateway/wechat/account_repository.py
+++ b/src/agent_teams/gateway/wechat/account_repository.py
@@ -2,16 +2,27 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import RLock
 
+from pydantic import JsonValue, ValidationError
+
+from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
 from agent_teams.gateway.wechat.models import (
     WeChatAccountRecord,
     WeChatAccountStatus,
 )
+from agent_teams.validation import (
+    normalize_persisted_text,
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+LOGGER = get_logger(__name__)
 
 
 class WeChatAccountRepository:
@@ -61,7 +72,13 @@ class WeChatAccountRepository:
         rows = self._conn.execute(
             "SELECT * FROM wechat_accounts ORDER BY created_at DESC"
         ).fetchall()
-        return tuple(self._to_record(row) for row in rows)
+        records: list[WeChatAccountRecord] = []
+        for row in rows:
+            try:
+                records.append(self._to_record(row))
+            except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+                _log_invalid_wechat_account_row(row=row, error=exc)
+        return tuple(records)
 
     def get_account(self, account_id: str) -> WeChatAccountRecord:
         row = self._conn.execute(
@@ -70,7 +87,11 @@ class WeChatAccountRepository:
         ).fetchone()
         if row is None:
             raise KeyError(f"Unknown account_id: {account_id}")
-        return self._to_record(row)
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+            _log_invalid_wechat_account_row(row=row, error=exc)
+            raise KeyError(f"Unknown account_id: {account_id}") from exc
 
     def upsert_account(self, record: WeChatAccountRecord) -> WeChatAccountRecord:
         run_sqlite_write_with_retry(
@@ -161,44 +182,130 @@ class WeChatAccountRepository:
     def _to_record(self, row: sqlite3.Row) -> WeChatAccountRecord:
         return WeChatAccountRecord.model_validate(
             {
-                "account_id": str(row["account_id"]),
+                "account_id": require_persisted_identifier(
+                    row["account_id"],
+                    field_name="account_id",
+                ),
                 "display_name": str(row["display_name"]),
                 "base_url": str(row["base_url"]),
                 "cdn_base_url": str(row["cdn_base_url"]),
-                "route_tag": str(row["route_tag"])
-                if row["route_tag"] is not None
-                else None,
+                "route_tag": normalize_persisted_text(row["route_tag"]),
                 "status": WeChatAccountStatus(str(row["status"])),
-                "remote_user_id": (
-                    str(row["remote_user_id"])
-                    if row["remote_user_id"] is not None
-                    else None
-                ),
+                "remote_user_id": normalize_persisted_text(row["remote_user_id"]),
                 "sync_cursor": str(row["sync_cursor"]),
-                "workspace_id": str(row["workspace_id"]),
-                "session_mode": str(row["session_mode"]),
-                "normal_root_role_id": (
-                    str(row["normal_root_role_id"])
-                    if row["normal_root_role_id"] is not None
-                    else None
+                "workspace_id": require_persisted_identifier(
+                    row["workspace_id"],
+                    field_name="workspace_id",
                 ),
-                "orchestration_preset_id": (
-                    str(row["orchestration_preset_id"])
-                    if row["orchestration_preset_id"] is not None
-                    else None
+                "session_mode": str(row["session_mode"]),
+                "normal_root_role_id": normalize_persisted_text(
+                    row["normal_root_role_id"]
+                ),
+                "orchestration_preset_id": normalize_persisted_text(
+                    row["orchestration_preset_id"]
                 ),
                 "yolo": bool(int(row["yolo"])),
                 "thinking": json.loads(str(row["thinking_json"])),
                 "last_login_at": (
-                    datetime.fromisoformat(str(row["last_login_at"]))
-                    if row["last_login_at"] is not None
+                    _optional_wechat_account_timestamp(
+                        row=row,
+                        account_id=str(row["account_id"]),
+                        field_name="last_login_at",
+                    )
+                    if normalize_persisted_text(row["last_login_at"]) is not None
                     else None
                 ),
-                "created_at": datetime.fromisoformat(str(row["created_at"])),
-                "updated_at": datetime.fromisoformat(str(row["updated_at"])),
+                "created_at": _require_wechat_account_timestamp(
+                    row=row,
+                    account_id=str(row["account_id"]),
+                    field_name="created_at",
+                ),
+                "updated_at": _require_wechat_account_timestamp(
+                    row=row,
+                    account_id=str(row["account_id"]),
+                    field_name="updated_at",
+                ),
             }
         )
 
     @staticmethod
     def utcnow() -> datetime:
         return datetime.now(tz=timezone.utc)
+
+
+def _require_wechat_account_timestamp(
+    *,
+    row: sqlite3.Row,
+    account_id: str,
+    field_name: str,
+) -> datetime:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_wechat_account_timestamp(
+        account_id=account_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _optional_wechat_account_timestamp(
+    *,
+    row: sqlite3.Row,
+    account_id: str,
+    field_name: str,
+) -> datetime | None:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_wechat_account_timestamp(
+        account_id=account_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _persisted_value_preview(value: object) -> str:
+    if value is None:
+        return "<null>"
+    return str(value)[:200]
+
+
+def _log_invalid_wechat_account_timestamp(
+    *,
+    account_id: str,
+    field_name: str,
+    raw_preview: str,
+) -> None:
+    payload: dict[str, JsonValue] = {
+        "account_id": account_id,
+        "field_name": field_name,
+        "raw_preview": raw_preview,
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="gateway.wechat.account_repository.timestamp_invalid",
+        message="Invalid persisted WeChat account timestamp",
+        payload=payload,
+    )
+
+
+def _log_invalid_wechat_account_row(*, row: sqlite3.Row, error: Exception) -> None:
+    payload: dict[str, JsonValue] = {
+        "account_id": _persisted_value_preview(row["account_id"]),
+        "workspace_id": _persisted_value_preview(row["workspace_id"]),
+        "created_at": _persisted_value_preview(row["created_at"]),
+        "updated_at": _persisted_value_preview(row["updated_at"]),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="gateway.wechat.account_repository.row_invalid",
+        message="Skipping invalid persisted WeChat account row",
+        payload=payload,
+    )

--- a/src/agent_teams/gateway/wechat/models.py
+++ b/src/agent_teams/gateway/wechat/models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from agent_teams.sessions.runs.run_models import RunThinkingConfig
 from agent_teams.sessions.session_models import SessionMode
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 WECHAT_PLATFORM = "wechat"
 DEFAULT_WECHAT_BASE_URL = "https://ilinkai.weixin.qq.com"
@@ -36,7 +37,7 @@ class WeChatUploadMediaType(int, Enum):
 class WeChatAccountRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    account_id: str = Field(min_length=1)
+    account_id: RequiredIdentifierStr
     display_name: str = Field(min_length=1)
     base_url: str = Field(min_length=1, default=DEFAULT_WECHAT_BASE_URL)
     cdn_base_url: str = Field(min_length=1, default=DEFAULT_WECHAT_CDN_BASE_URL)
@@ -44,10 +45,10 @@ class WeChatAccountRecord(BaseModel):
     status: WeChatAccountStatus = WeChatAccountStatus.ENABLED
     remote_user_id: str | None = None
     sync_cursor: str = ""
-    workspace_id: str = Field(min_length=1, default="default")
+    workspace_id: RequiredIdentifierStr = "default"
     session_mode: SessionMode = SessionMode.NORMAL
-    normal_root_role_id: str | None = None
-    orchestration_preset_id: str | None = None
+    normal_root_role_id: OptionalIdentifierStr = None
+    orchestration_preset_id: OptionalIdentifierStr = None
     yolo: bool = True
     thinking: RunThinkingConfig = Field(default_factory=RunThinkingConfig)
     last_login_at: datetime | None = None
@@ -68,10 +69,10 @@ class WeChatAccountUpdateInput(BaseModel):
     cdn_base_url: str | None = None
     route_tag: str | None = None
     enabled: bool | None = None
-    workspace_id: str | None = None
+    workspace_id: OptionalIdentifierStr = None
     session_mode: SessionMode | None = None
-    normal_root_role_id: str | None = None
-    orchestration_preset_id: str | None = None
+    normal_root_role_id: OptionalIdentifierStr = None
+    orchestration_preset_id: OptionalIdentifierStr = None
     yolo: bool | None = None
     thinking: RunThinkingConfig | None = None
 
@@ -87,7 +88,7 @@ class WeChatLoginStartRequest(BaseModel):
 class WeChatLoginStartResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    session_key: str = Field(min_length=1)
+    session_key: RequiredIdentifierStr
     qr_code_url: str | None = None
     message: str = Field(min_length=1)
 
@@ -95,7 +96,7 @@ class WeChatLoginStartResponse(BaseModel):
 class WeChatLoginWaitRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    session_key: str = Field(min_length=1)
+    session_key: RequiredIdentifierStr
     timeout_ms: int = Field(default=480000, ge=1000, le=900000)
 
 
@@ -103,7 +104,7 @@ class WeChatLoginWaitResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     connected: bool
-    account_id: str | None = None
+    account_id: OptionalIdentifierStr = None
     message: str = Field(min_length=1)
 
 
@@ -264,7 +265,7 @@ class WeChatUploadedMedia(BaseModel):
 class WeChatGatewaySnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    account_id: str = Field(min_length=1)
+    account_id: RequiredIdentifierStr
     running: bool = False
     last_error: str | None = None
     last_event_at: datetime | None = None
@@ -275,7 +276,7 @@ class WeChatGatewaySnapshot(BaseModel):
 class WeChatLoginSession(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    session_key: str = Field(min_length=1)
+    session_key: RequiredIdentifierStr
     qrcode: str = Field(min_length=1)
     qr_code_url: str = Field(min_length=1)
     base_url: str = Field(min_length=1)

--- a/src/agent_teams/interfaces/server/routers/automation.py
+++ b/src/agent_teams/interfaces/server/routers/automation.py
@@ -15,6 +15,7 @@ from agent_teams.automation import (
     AutomationService,
 )
 from agent_teams.interfaces.server.deps import get_automation_service
+from agent_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/automation", tags=["Automation"])
 
@@ -48,7 +49,7 @@ def list_projects(
 
 @router.get("/projects/{automation_project_id}", response_model=AutomationProjectRecord)
 def get_project(
-    automation_project_id: str,
+    automation_project_id: RequiredIdentifierStr,
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
     try:
@@ -61,7 +62,7 @@ def get_project(
     "/projects/{automation_project_id}", response_model=AutomationProjectRecord
 )
 def update_project(
-    automation_project_id: str,
+    automation_project_id: RequiredIdentifierStr,
     req: AutomationProjectUpdateInput,
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
@@ -77,7 +78,7 @@ def update_project(
 
 @router.delete("/projects/{automation_project_id}")
 def delete_project(
-    automation_project_id: str,
+    automation_project_id: RequiredIdentifierStr,
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> dict[str, JsonValue]:
     try:
@@ -89,7 +90,7 @@ def delete_project(
 
 @router.post("/projects/{automation_project_id}:run")
 async def run_project(
-    automation_project_id: str,
+    automation_project_id: RequiredIdentifierStr,
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> dict[str, JsonValue]:
     try:
@@ -104,7 +105,7 @@ async def run_project(
     "/projects/{automation_project_id}:enable", response_model=AutomationProjectRecord
 )
 def enable_project(
-    automation_project_id: str,
+    automation_project_id: RequiredIdentifierStr,
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
     try:
@@ -123,7 +124,7 @@ def enable_project(
     response_model=AutomationProjectRecord,
 )
 def disable_project(
-    automation_project_id: str,
+    automation_project_id: RequiredIdentifierStr,
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
     try:
@@ -137,7 +138,7 @@ def disable_project(
 
 @router.get("/projects/{automation_project_id}/sessions")
 def list_project_sessions(
-    automation_project_id: str,
+    automation_project_id: RequiredIdentifierStr,
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> list[dict[str, object]]:
     try:

--- a/src/agent_teams/interfaces/server/routers/feishu_gateway.py
+++ b/src/agent_teams/interfaces/server/routers/feishu_gateway.py
@@ -17,6 +17,7 @@ from agent_teams.interfaces.server.deps import (
     get_feishu_gateway_service,
     get_feishu_subscription_service,
 )
+from agent_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/gateway/feishu", tags=["Gateway"])
 
@@ -49,7 +50,7 @@ def create_feishu_account(
 
 @router.patch("/accounts/{account_id}", response_model=FeishuGatewayAccountRecord)
 def update_feishu_account(
-    account_id: str,
+    account_id: RequiredIdentifierStr,
     req: FeishuGatewayAccountUpdateInput,
     service: Annotated[FeishuGatewayService, Depends(get_feishu_gateway_service)],
     subscription_service: Annotated[
@@ -78,7 +79,7 @@ def update_feishu_account(
 
 @router.post("/accounts/{account_id}:enable", response_model=FeishuGatewayAccountRecord)
 def enable_feishu_account(
-    account_id: str,
+    account_id: RequiredIdentifierStr,
     service: Annotated[FeishuGatewayService, Depends(get_feishu_gateway_service)],
     subscription_service: Annotated[
         FeishuSubscriptionService,
@@ -99,7 +100,7 @@ def enable_feishu_account(
     "/accounts/{account_id}:disable", response_model=FeishuGatewayAccountRecord
 )
 def disable_feishu_account(
-    account_id: str,
+    account_id: RequiredIdentifierStr,
     service: Annotated[FeishuGatewayService, Depends(get_feishu_gateway_service)],
     subscription_service: Annotated[
         FeishuSubscriptionService,
@@ -116,7 +117,7 @@ def disable_feishu_account(
 
 @router.delete("/accounts/{account_id}")
 def delete_feishu_account(
-    account_id: str,
+    account_id: RequiredIdentifierStr,
     service: Annotated[FeishuGatewayService, Depends(get_feishu_gateway_service)],
     subscription_service: Annotated[
         FeishuSubscriptionService,

--- a/src/agent_teams/interfaces/server/routers/gateway.py
+++ b/src/agent_teams/interfaces/server/routers/gateway.py
@@ -14,6 +14,7 @@ from agent_teams.gateway.wechat import (
     WeChatLoginWaitRequest,
     WeChatLoginWaitResponse,
 )
+from agent_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/gateway", tags=["Gateway"])
 
@@ -51,7 +52,7 @@ def wait_wechat_login(
 
 @router.patch("/wechat/accounts/{account_id}", response_model=WeChatAccountRecord)
 def update_wechat_account(
-    account_id: str,
+    account_id: RequiredIdentifierStr,
     req: WeChatAccountUpdateInput,
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> WeChatAccountRecord:
@@ -65,7 +66,7 @@ def update_wechat_account(
 
 @router.post("/wechat/accounts/{account_id}:enable", response_model=WeChatAccountRecord)
 def enable_wechat_account(
-    account_id: str,
+    account_id: RequiredIdentifierStr,
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> WeChatAccountRecord:
     try:
@@ -80,7 +81,7 @@ def enable_wechat_account(
     "/wechat/accounts/{account_id}:disable", response_model=WeChatAccountRecord
 )
 def disable_wechat_account(
-    account_id: str,
+    account_id: RequiredIdentifierStr,
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> WeChatAccountRecord:
     try:
@@ -93,7 +94,7 @@ def disable_wechat_account(
 
 @router.delete("/wechat/accounts/{account_id}")
 def delete_wechat_account(
-    account_id: str,
+    account_id: RequiredIdentifierStr,
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> dict[str, str]:
     try:

--- a/src/agent_teams/interfaces/server/routers/logs.py
+++ b/src/agent_teams/interfaces/server/routers/logs.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 from agent_teams.logger import get_logger, log_event
 from agent_teams.trace import bind_trace_context, generate_trace_id
+from agent_teams.validation import OptionalIdentifierStr
 
 router = APIRouter(prefix="/logs", tags=["Logs"])
 logger = get_logger(__name__, source="frontend")
@@ -20,16 +21,16 @@ class FrontendLogEvent(BaseModel):
     level: str = Field(pattern="^(debug|info|warn|error)$")
     event: str = Field(min_length=1, max_length=128)
     message: str = Field(min_length=1, max_length=2000)
-    trace_id: str | None = None
-    request_id: str | None = None
-    run_id: str | None = None
-    session_id: str | None = None
-    task_id: str | None = None
-    instance_id: str | None = None
-    role_id: str | None = None
+    trace_id: OptionalIdentifierStr = None
+    request_id: OptionalIdentifierStr = None
+    run_id: OptionalIdentifierStr = None
+    session_id: OptionalIdentifierStr = None
+    task_id: OptionalIdentifierStr = None
+    instance_id: OptionalIdentifierStr = None
+    role_id: OptionalIdentifierStr = None
     page: str | None = None
     route: str | None = None
-    browser_session_id: str | None = None
+    browser_session_id: OptionalIdentifierStr = None
     user_agent: str | None = None
     payload: dict[str, JsonValue] = Field(default_factory=dict)
     ts: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/src/agent_teams/interfaces/server/routers/prompts.py
+++ b/src/agent_teams/interfaces/server/routers/prompts.py
@@ -37,6 +37,7 @@ from agent_teams.sessions.runs.run_models import RuntimePromptConversationContex
 from agent_teams.sessions.runs.run_models import RunTopologySnapshot
 from agent_teams.sessions.session_models import SessionMode
 from agent_teams.tools.registry import ToolRegistry, ToolResolutionContext
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 from agent_teams.workspace import WorkspaceManager, WorkspaceService
 
 router = APIRouter(prefix="/prompts", tags=["Prompts"])
@@ -45,8 +46,8 @@ router = APIRouter(prefix="/prompts", tags=["Prompts"])
 class PromptPreviewRequest(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    role_id: str = Field(min_length=1)
-    workspace_id: str | None = Field(default=None, min_length=1)
+    role_id: RequiredIdentifierStr
+    workspace_id: OptionalIdentifierStr = None
     objective: str | None = None
     shared_state: dict[str, JsonValue] = Field(default_factory=dict)
     tools: tuple[str, ...] | None = None
@@ -58,7 +59,7 @@ class PromptPreviewRequest(BaseModel):
 class PromptPreviewResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    role_id: str
+    role_id: RequiredIdentifierStr
     objective: str
     tools: tuple[str, ...]
     skills: tuple[str, ...]

--- a/src/agent_teams/interfaces/server/routers/roles.py
+++ b/src/agent_teams/interfaces/server/routers/roles.py
@@ -30,6 +30,7 @@ from agent_teams.external_agents import ExternalAgentConfigService
 from agent_teams.roles.settings_service import RoleSettingsService
 from agent_teams.skills.skill_registry import SkillRegistry
 from agent_teams.tools.registry import ToolRegistry
+from agent_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/roles", tags=["Roles"])
 
@@ -106,7 +107,7 @@ def list_role_configs(
     response_model_exclude_none=True,
 )
 def get_role_config(
-    role_id: str,
+    role_id: RequiredIdentifierStr,
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> RoleDocumentRecord:
     try:
@@ -121,7 +122,7 @@ def get_role_config(
     response_model_exclude_none=True,
 )
 def save_role_config(
-    role_id: str,
+    role_id: RequiredIdentifierStr,
     draft: RoleDocumentDraft,
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> RoleDocumentRecord:
@@ -133,7 +134,7 @@ def save_role_config(
 
 @router.delete("/configs/{role_id}")
 def delete_role_config(
-    role_id: str,
+    role_id: RequiredIdentifierStr,
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> dict[str, str]:
     try:

--- a/src/agent_teams/interfaces/server/routers/runs.py
+++ b/src/agent_teams/interfaces/server/routers/runs.py
@@ -25,6 +25,7 @@ from agent_teams.sessions.runs.run_models import (
     RunThinkingConfig,
 )
 from agent_teams.trace import bind_trace_context
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/runs", tags=["Runs"])
@@ -33,14 +34,14 @@ router = APIRouter(prefix="/runs", tags=["Runs"])
 class CreateRunRequest(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    session_id: str = Field(min_length=1)
+    session_id: RequiredIdentifierStr
     input: tuple[ContentPart, ...] = Field(default_factory=tuple)
     run_kind: RunKind = RunKind.CONVERSATION
     generation_config: MediaGenerationConfig | None = None
     execution_mode: ExecutionMode = ExecutionMode.AI
     yolo: bool = False
     thinking: RunThinkingConfig = Field(default_factory=RunThinkingConfig)
-    target_role_id: str | None = None
+    target_role_id: OptionalIdentifierStr = None
 
     @model_validator(mode="before")
     @classmethod
@@ -59,9 +60,9 @@ class CreateRunRequest(BaseModel):
 class CreateRunResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    run_id: str
-    session_id: str
-    target_role_id: str | None = None
+    run_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
+    target_role_id: OptionalIdentifierStr = None
 
 
 class InjectMessageRequest(BaseModel):
@@ -82,7 +83,7 @@ class StopRunRequest(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     scope: Literal["main", "subagent"] = "main"
-    instance_id: str | None = None
+    instance_id: OptionalIdentifierStr = None
 
 
 class InjectSubagentRequest(BaseModel):
@@ -168,7 +169,7 @@ async def create_run(
 
 @router.get("/{run_id}/events")
 async def stream_run_events(
-    run_id: str,
+    run_id: RequiredIdentifierStr,
     service: Annotated[RunManager, Depends(get_run_service)],
     after_event_id: int = 0,
 ) -> StreamingResponse:
@@ -223,7 +224,7 @@ async def stream_run_events(
 
 @router.post("/{run_id}/inject")
 def inject_message(
-    run_id: str,
+    run_id: RequiredIdentifierStr,
     req: InjectMessageRequest,
     service: Annotated[RunManager, Depends(get_run_service)],
 ) -> dict[str, object]:
@@ -246,7 +247,7 @@ def inject_message(
 
 @router.get("/{run_id}/tool-approvals")
 def list_tool_approvals(
-    run_id: str,
+    run_id: RequiredIdentifierStr,
     service: Annotated[RunManager, Depends(get_run_service)],
 ) -> list[dict[str, str]]:
     with bind_trace_context(trace_id=run_id, run_id=run_id):
@@ -263,8 +264,8 @@ def list_tool_approvals(
 
 @router.post("/{run_id}/tool-approvals/{tool_call_id}/resolve")
 def resolve_tool_approval(
-    run_id: str,
-    tool_call_id: str,
+    run_id: RequiredIdentifierStr,
+    tool_call_id: RequiredIdentifierStr,
     req: ResolveToolApprovalRequest,
     service: Annotated[RunManager, Depends(get_run_service)],
 ) -> dict[str, str]:
@@ -294,7 +295,7 @@ def resolve_tool_approval(
 
 @router.post("/{run_id}/stop")
 def stop_run(
-    run_id: str,
+    run_id: RequiredIdentifierStr,
     req: StopRunRequest,
     service: Annotated[RunManager, Depends(get_run_service)],
 ) -> dict[str, str]:
@@ -337,7 +338,7 @@ def stop_run(
 
 @router.post("/{run_id}:resume")
 async def resume_run(
-    run_id: str,
+    run_id: RequiredIdentifierStr,
     service: Annotated[RunManager, Depends(get_run_service)],
 ) -> dict[str, str]:
     try:
@@ -359,8 +360,8 @@ async def resume_run(
 
 @router.post("/{run_id}/subagents/{instance_id}/inject")
 def inject_subagent(
-    run_id: str,
-    instance_id: str,
+    run_id: RequiredIdentifierStr,
+    instance_id: RequiredIdentifierStr,
     req: InjectSubagentRequest,
     service: Annotated[RunManager, Depends(get_run_service)],
 ) -> dict[str, str]:

--- a/src/agent_teams/interfaces/server/routers/session_media.py
+++ b/src/agent_teams/interfaces/server/routers/session_media.py
@@ -17,13 +17,14 @@ from agent_teams.media import (
     infer_media_modality,
 )
 from agent_teams.sessions import SessionService
+from agent_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/sessions", tags=["Sessions"])
 
 
 @router.get("/{session_id}/media", response_model=list[MediaRefContentPart])
 def list_session_media(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     session_service: Annotated[SessionService, Depends(get_session_service)],
     media_asset_service: Annotated[MediaAssetService, Depends(get_media_asset_service)],
 ) -> list[MediaRefContentPart]:
@@ -39,7 +40,7 @@ def list_session_media(
 
 @router.post("/{session_id}/media", response_model=MediaRefContentPart)
 async def upload_session_media(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     file: Annotated[UploadFile, File(...)],
     session_service: Annotated[SessionService, Depends(get_session_service)],
     media_asset_service: Annotated[MediaAssetService, Depends(get_media_asset_service)],
@@ -85,8 +86,8 @@ async def upload_session_media(
 
 @router.get("/{session_id}/media/{asset_id}", response_model=MediaRefContentPart)
 def get_session_media(
-    session_id: str,
-    asset_id: str,
+    session_id: RequiredIdentifierStr,
+    asset_id: RequiredIdentifierStr,
     session_service: Annotated[SessionService, Depends(get_session_service)],
     media_asset_service: Annotated[MediaAssetService, Depends(get_media_asset_service)],
 ) -> MediaRefContentPart:
@@ -102,8 +103,8 @@ def get_session_media(
 
 @router.get("/{session_id}/media/{asset_id}/file", response_model=None)
 def get_session_media_file(
-    session_id: str,
-    asset_id: str,
+    session_id: RequiredIdentifierStr,
+    asset_id: RequiredIdentifierStr,
     session_service: Annotated[SessionService, Depends(get_session_service)],
     media_asset_service: Annotated[MediaAssetService, Depends(get_media_asset_service)],
 ) -> FileResponse | RedirectResponse:

--- a/src/agent_teams/interfaces/server/routers/sessions.py
+++ b/src/agent_teams/interfaces/server/routers/sessions.py
@@ -7,6 +7,7 @@ from agent_teams.interfaces.server.deps import get_session_service
 from agent_teams.roles import SystemRolesUnavailableError
 from agent_teams.sessions import SessionService
 from agent_teams.sessions.session_models import SessionMode, SessionRecord
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 router = APIRouter(prefix="/sessions", tags=["Sessions"])
 
@@ -14,8 +15,8 @@ router = APIRouter(prefix="/sessions", tags=["Sessions"])
 class CreateSessionRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    session_id: str | None = None
-    workspace_id: str
+    session_id: OptionalIdentifierStr = None
+    workspace_id: RequiredIdentifierStr
     metadata: dict[str, str] | None = None
 
 
@@ -29,8 +30,8 @@ class UpdateSessionTopologyRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     session_mode: SessionMode
-    normal_root_role_id: str | None = None
-    orchestration_preset_id: str | None = None
+    normal_root_role_id: OptionalIdentifierStr = None
+    orchestration_preset_id: OptionalIdentifierStr = None
 
 
 class UpdateAgentReflectionRequest(BaseModel):
@@ -63,7 +64,7 @@ def list_sessions(
 
 @router.get("/{session_id}", response_model=SessionRecord)
 def get_session(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> SessionRecord:
     try:
@@ -74,7 +75,7 @@ def get_session(
 
 @router.patch("/{session_id}")
 def update_session(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     req: UpdateSessionRequest,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, str]:
@@ -87,7 +88,7 @@ def update_session(
 
 @router.patch("/{session_id}/topology", response_model=SessionRecord)
 def update_session_topology(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     req: UpdateSessionTopologyRequest,
     service: SessionService = Depends(get_session_service),
 ) -> SessionRecord:
@@ -110,7 +111,7 @@ def update_session_topology(
 
 @router.delete("/{session_id}")
 def delete_session(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, str]:
     try:
@@ -122,9 +123,9 @@ def delete_session(
 
 @router.get("/{session_id}/rounds")
 def get_session_rounds(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     limit: int = 8,
-    cursor_run_id: str | None = None,
+    cursor_run_id: OptionalIdentifierStr = None,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     return service.get_session_rounds(
@@ -136,7 +137,7 @@ def get_session_rounds(
 
 @router.get("/{session_id}/recovery")
 def get_session_recovery(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
@@ -147,8 +148,8 @@ def get_session_recovery(
 
 @router.get("/{session_id}/rounds/{run_id}")
 def get_round(
-    session_id: str,
-    run_id: str,
+    session_id: RequiredIdentifierStr,
+    run_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
@@ -159,7 +160,7 @@ def get_round(
 
 @router.get("/{session_id}/agents")
 def list_session_agents(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
     return list(service.list_agents_in_session(session_id))
@@ -167,8 +168,8 @@ def list_session_agents(
 
 @router.get("/{session_id}/agents/{instance_id}/reflection")
 def get_agent_reflection(
-    session_id: str,
-    instance_id: str,
+    session_id: RequiredIdentifierStr,
+    instance_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
@@ -179,8 +180,8 @@ def get_agent_reflection(
 
 @router.post("/{session_id}/agents/{instance_id}/reflection:refresh")
 async def refresh_agent_reflection(
-    session_id: str,
-    instance_id: str,
+    session_id: RequiredIdentifierStr,
+    instance_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
@@ -193,8 +194,8 @@ async def refresh_agent_reflection(
 
 @router.patch("/{session_id}/agents/{instance_id}/reflection")
 def update_agent_reflection(
-    session_id: str,
-    instance_id: str,
+    session_id: RequiredIdentifierStr,
+    instance_id: RequiredIdentifierStr,
     req: UpdateAgentReflectionRequest,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
@@ -212,8 +213,8 @@ def update_agent_reflection(
 
 @router.delete("/{session_id}/agents/{instance_id}/reflection")
 def delete_agent_reflection(
-    session_id: str,
-    instance_id: str,
+    session_id: RequiredIdentifierStr,
+    instance_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
@@ -226,7 +227,7 @@ def delete_agent_reflection(
 
 @router.get("/{session_id}/events")
 def get_session_events(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
     return service.get_global_events(session_id)
@@ -234,7 +235,7 @@ def get_session_events(
 
 @router.get("/{session_id}/messages")
 def get_session_messages(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
     return service.get_session_messages(session_id)
@@ -242,8 +243,8 @@ def get_session_messages(
 
 @router.get("/{session_id}/agents/{instance_id}/messages")
 def get_agent_messages(
-    session_id: str,
-    instance_id: str,
+    session_id: RequiredIdentifierStr,
+    instance_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
     return service.get_agent_messages(session_id, instance_id)
@@ -251,7 +252,7 @@ def get_agent_messages(
 
 @router.get("/{session_id}/tasks")
 def get_session_tasks(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
     return service.get_session_tasks(session_id)
@@ -259,7 +260,7 @@ def get_session_tasks(
 
 @router.get("/{session_id}/token-usage")
 def get_session_token_usage(
-    session_id: str,
+    session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     summary = service.get_token_usage_by_session(session_id)
@@ -290,8 +291,8 @@ def get_session_token_usage(
 
 @router.get("/{session_id}/runs/{run_id}/token-usage")
 def get_run_token_usage(
-    session_id: str,
-    run_id: str,
+    session_id: RequiredIdentifierStr,
+    run_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     usage = service.get_token_usage_by_run(run_id)

--- a/src/agent_teams/interfaces/server/routers/system.py
+++ b/src/agent_teams/interfaces/server/routers/system.py
@@ -72,6 +72,7 @@ from agent_teams.providers.model_connectivity import (
     ModelConnectivityProbeResult,
 )
 from agent_teams.skills.config_reload_service import SkillsConfigReloadService
+from agent_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/system", tags=["System"])
 
@@ -340,7 +341,7 @@ def list_external_agents(
 
 @router.get("/configs/agents/{agent_id}", response_model=ExternalAgentConfig)
 def get_external_agent(
-    agent_id: str,
+    agent_id: RequiredIdentifierStr,
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> ExternalAgentConfig:
     try:
@@ -351,7 +352,7 @@ def get_external_agent(
 
 @router.put("/configs/agents/{agent_id}", response_model=ExternalAgentConfig)
 def save_external_agent(
-    agent_id: str,
+    agent_id: RequiredIdentifierStr,
     req: ExternalAgentConfig,
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> ExternalAgentConfig:
@@ -363,7 +364,7 @@ def save_external_agent(
 
 @router.delete("/configs/agents/{agent_id}")
 def delete_external_agent(
-    agent_id: str,
+    agent_id: RequiredIdentifierStr,
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> dict[str, str]:
     try:
@@ -375,7 +376,7 @@ def delete_external_agent(
 
 @router.post("/configs/agents/{agent_id}:test", response_model=ExternalAgentTestResult)
 async def test_external_agent(
-    agent_id: str,
+    agent_id: RequiredIdentifierStr,
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> ExternalAgentTestResult:
     try:

--- a/src/agent_teams/interfaces/server/routers/tasks.py
+++ b/src/agent_teams/interfaces/server/routers/tasks.py
@@ -10,6 +10,7 @@ from agent_teams.agents.orchestration.task_orchestration_service import (
     TaskUpdate,
 )
 from agent_teams.interfaces.server.deps import get_task_repo, get_task_service
+from agent_teams.validation import RequiredIdentifierStr
 
 from agent_teams.agents.tasks.task_repository import TaskRepository
 from agent_teams.agents.tasks.models import TaskRecord
@@ -33,7 +34,7 @@ class UpdateTaskRequest(BaseModel):
 class DispatchTaskRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    role_id: str = Field(min_length=1)
+    role_id: RequiredIdentifierStr
     prompt: str = ""
 
 
@@ -44,7 +45,7 @@ def list_tasks(task_repo: TaskRepository = Depends(get_task_repo)) -> list[TaskR
 
 @router.post("/runs/{run_id}")
 async def create_tasks_for_run(
-    run_id: str,
+    run_id: RequiredIdentifierStr,
     req: CreateTasksRequest,
     service: TaskOrchestrationService = Depends(get_task_service),
 ) -> dict[str, JsonValue]:
@@ -61,7 +62,7 @@ async def create_tasks_for_run(
 
 @router.get("/runs/{run_id}")
 def list_tasks_for_run(
-    run_id: str,
+    run_id: RequiredIdentifierStr,
     include_root: bool = False,
     service: TaskOrchestrationService = Depends(get_task_service),
 ) -> dict[str, JsonValue]:
@@ -73,7 +74,7 @@ def list_tasks_for_run(
 
 @router.get("/{task_id}", response_model=TaskRecord)
 def get_task(
-    task_id: str,
+    task_id: RequiredIdentifierStr,
     task_repo: TaskRepository = Depends(get_task_repo),
 ) -> TaskRecord:
     try:
@@ -84,7 +85,7 @@ def get_task(
 
 @router.patch("/{task_id}")
 def update_task_by_id(
-    task_id: str,
+    task_id: RequiredIdentifierStr,
     req: UpdateTaskRequest,
     service: TaskOrchestrationService = Depends(get_task_service),
 ) -> dict[str, JsonValue]:
@@ -105,7 +106,7 @@ def update_task_by_id(
 
 @router.post("/{task_id}/dispatch")
 async def dispatch_task_by_id(
-    task_id: str,
+    task_id: RequiredIdentifierStr,
     req: DispatchTaskRequest,
     service: TaskOrchestrationService = Depends(get_task_service),
 ) -> dict[str, JsonValue]:

--- a/src/agent_teams/interfaces/server/routers/workspaces.py
+++ b/src/agent_teams/interfaces/server/routers/workspaces.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_teams.interfaces.server.deps import get_workspace_service
+from agent_teams.validation import RequiredIdentifierStr
 from agent_teams.workspace import (
     WorkspaceDiffFile,
     WorkspaceDiffListing,
@@ -26,7 +27,7 @@ router = APIRouter(prefix="/workspaces", tags=["Workspaces"])
 class CreateWorkspaceRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    workspace_id: str = Field(min_length=1)
+    workspace_id: RequiredIdentifierStr
     root_path: str = Field(min_length=1)
 
 
@@ -95,7 +96,7 @@ def list_workspaces(
 
 @router.get("/{workspace_id}", response_model=WorkspaceRecord)
 def get_workspace(
-    workspace_id: str,
+    workspace_id: RequiredIdentifierStr,
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceRecord:
     try:
@@ -106,7 +107,7 @@ def get_workspace(
 
 @router.get("/{workspace_id}/snapshot", response_model=WorkspaceSnapshot)
 def get_workspace_snapshot(
-    workspace_id: str,
+    workspace_id: RequiredIdentifierStr,
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceSnapshot:
     try:
@@ -119,7 +120,7 @@ def get_workspace_snapshot(
 
 @router.get("/{workspace_id}/tree", response_model=WorkspaceTreeListing)
 def get_workspace_tree_listing(
-    workspace_id: str,
+    workspace_id: RequiredIdentifierStr,
     path: Annotated[str, Query()] = ".",
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceTreeListing:
@@ -136,7 +137,7 @@ def get_workspace_tree_listing(
 
 @router.get("/{workspace_id}/diffs", response_model=WorkspaceDiffListing)
 def get_workspace_diffs(
-    workspace_id: str,
+    workspace_id: RequiredIdentifierStr,
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceDiffListing:
     try:
@@ -149,7 +150,7 @@ def get_workspace_diffs(
 
 @router.get("/{workspace_id}/diff", response_model=WorkspaceDiffFile)
 def get_workspace_diff_file(
-    workspace_id: str,
+    workspace_id: RequiredIdentifierStr,
     path: Annotated[str, Query(min_length=1)],
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceDiffFile:
@@ -166,7 +167,7 @@ def get_workspace_diff_file(
 
 @router.get("/{workspace_id}/preview-file")
 def get_workspace_preview_file(
-    workspace_id: str,
+    workspace_id: RequiredIdentifierStr,
     path: Annotated[str, Query(min_length=1)],
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> FileResponse:
@@ -191,7 +192,7 @@ def get_workspace_preview_file(
 
 @router.delete("/{workspace_id}")
 def delete_workspace(
-    workspace_id: str,
+    workspace_id: RequiredIdentifierStr,
     remove_worktree: Annotated[bool, Query()] = False,
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> dict[str, str]:
@@ -209,7 +210,7 @@ def delete_workspace(
 
 @router.post("/{workspace_id}:fork", response_model=WorkspaceRecord)
 def fork_workspace(
-    workspace_id: str,
+    workspace_id: RequiredIdentifierStr,
     req: ForkWorkspaceRequest,
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceRecord:

--- a/src/agent_teams/roles/memory_models.py
+++ b/src/agent_teams/roles/memory_models.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
+
+from agent_teams.validation import RequiredIdentifierStr
 
 
 class MemoryProfile(BaseModel):
@@ -19,7 +21,7 @@ def default_memory_profile() -> MemoryProfile:
 class RoleMemoryRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    role_id: str = Field(min_length=1)
-    workspace_id: str = Field(min_length=1)
+    role_id: RequiredIdentifierStr
+    workspace_id: RequiredIdentifierStr
     content_markdown: str = ""
     updated_at: datetime | None = None

--- a/src/agent_teams/roles/role_models.py
+++ b/src/agent_teams/roles/role_models.py
@@ -7,6 +7,7 @@ from agent_teams.computer import ExecutionSurface
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_teams.roles.memory_models import MemoryProfile, default_memory_profile
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 
 class RoleConfigSource(str, Enum):
@@ -17,7 +18,7 @@ class RoleConfigSource(str, Enum):
 class RoleDefinition(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    role_id: str = Field(min_length=1)
+    role_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     description: str = Field(min_length=1)
     version: str = Field(min_length=1)
@@ -25,7 +26,7 @@ class RoleDefinition(BaseModel):
     mcp_servers: tuple[str, ...] = ()
     skills: tuple[str, ...] = ()
     model_profile: str = Field(default="default")
-    bound_agent_id: str | None = None
+    bound_agent_id: OptionalIdentifierStr = None
     execution_surface: ExecutionSurface = ExecutionSurface.API
     memory_profile: MemoryProfile = Field(default_factory=default_memory_profile)
     system_prompt: str = Field(min_length=1)
@@ -34,12 +35,12 @@ class RoleDefinition(BaseModel):
 class RoleDocumentSummary(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    role_id: str = Field(min_length=1)
+    role_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     description: str = Field(min_length=1)
     version: str = Field(min_length=1)
     model_profile: str = Field(min_length=1)
-    bound_agent_id: str | None = None
+    bound_agent_id: OptionalIdentifierStr = None
     execution_surface: ExecutionSurface = ExecutionSurface.API
     source: RoleConfigSource = RoleConfigSource.APP
     deletable: bool = False
@@ -48,8 +49,8 @@ class RoleDocumentSummary(BaseModel):
 class RoleDocumentDraft(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    source_role_id: str | None = None
-    role_id: str = Field(min_length=1)
+    source_role_id: OptionalIdentifierStr = None
+    role_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     description: str = Field(min_length=1)
     version: str = Field(min_length=1)
@@ -57,7 +58,7 @@ class RoleDocumentDraft(BaseModel):
     mcp_servers: tuple[str, ...] = ()
     skills: tuple[str, ...] = ()
     model_profile: str = Field(default="default", min_length=1)
-    bound_agent_id: str | None = None
+    bound_agent_id: OptionalIdentifierStr = None
     execution_surface: ExecutionSurface = ExecutionSurface.API
     memory_profile: MemoryProfile = Field(default_factory=default_memory_profile)
     system_prompt: str = Field(min_length=1)
@@ -79,7 +80,7 @@ class RoleValidationResult(BaseModel):
 class NormalModeRoleOption(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    role_id: str = Field(min_length=1)
+    role_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     description: str = Field(min_length=1)
 
@@ -87,7 +88,7 @@ class NormalModeRoleOption(BaseModel):
 class RoleAgentOption(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    agent_id: str = Field(min_length=1)
+    agent_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     transport: str = Field(min_length=1)
 
@@ -104,8 +105,8 @@ class RoleSkillOption(BaseModel):
 class RoleConfigOptions(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    coordinator_role_id: str = Field(min_length=1)
-    main_agent_role_id: str = Field(min_length=1)
+    coordinator_role_id: RequiredIdentifierStr
+    main_agent_role_id: RequiredIdentifierStr
     normal_mode_roles: tuple[NormalModeRoleOption, ...] = ()
     tools: tuple[str, ...] = ()
     mcp_servers: tuple[str, ...] = ()

--- a/src/agent_teams/roles/temporary_role_models.py
+++ b/src/agent_teams/roles/temporary_role_models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from agent_teams.roles.role_models import RoleDefinition
 from agent_teams.roles.memory_models import MemoryProfile, default_memory_profile
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 
 class TemporaryRoleSource(str, Enum):
@@ -18,7 +19,7 @@ class TemporaryRoleSource(str, Enum):
 class TemporaryRoleSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    role_id: str = Field(min_length=1)
+    role_id: RequiredIdentifierStr
     name: str = Field(min_length=1)
     description: str = Field(min_length=1)
     version: str = Field(min_length=1, default="temporary")
@@ -26,11 +27,11 @@ class TemporaryRoleSpec(BaseModel):
     mcp_servers: tuple[str, ...] = ()
     skills: tuple[str, ...] = ()
     model_profile: str = Field(default="default", min_length=1)
-    bound_agent_id: str | None = None
+    bound_agent_id: OptionalIdentifierStr = None
     execution_surface: ExecutionSurface = ExecutionSurface.API
     memory_profile: MemoryProfile = Field(default_factory=default_memory_profile)
     system_prompt: str = Field(min_length=1)
-    template_role_id: str | None = None
+    template_role_id: OptionalIdentifierStr = None
 
     def to_role_definition(self) -> RoleDefinition:
         return RoleDefinition(
@@ -52,8 +53,8 @@ class TemporaryRoleSpec(BaseModel):
 class TemporaryRoleRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    run_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
+    run_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
     source: TemporaryRoleSource = TemporaryRoleSource.META_AGENT_GENERATED
     role: TemporaryRoleSpec
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))

--- a/src/agent_teams/sessions/external_session_binding_models.py
+++ b/src/agent_teams/sessions/external_session_binding_models.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
+
+from agent_teams.validation import RequiredIdentifierStr
 
 
 class ExternalSessionBinding(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    platform: str = Field(min_length=1)
-    trigger_id: str = Field(min_length=1)
-    tenant_key: str = Field(min_length=1)
-    external_chat_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
+    platform: RequiredIdentifierStr
+    trigger_id: RequiredIdentifierStr
+    tenant_key: RequiredIdentifierStr
+    external_chat_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
     created_at: datetime
     updated_at: datetime

--- a/src/agent_teams/sessions/external_session_binding_repository.py
+++ b/src/agent_teams/sessions/external_session_binding_repository.py
@@ -2,14 +2,24 @@
 from __future__ import annotations
 
 import sqlite3
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import RLock
 
+from pydantic import JsonValue, ValidationError
+
+from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
 from agent_teams.sessions.external_session_binding_models import (
     ExternalSessionBinding,
 )
+from agent_teams.validation import (
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+LOGGER = get_logger(__name__)
 
 
 class ExternalSessionBindingRepository:
@@ -98,7 +108,7 @@ class ExternalSessionBindingRepository:
         ).fetchone()
         if row is None:
             return None
-        return self._to_record(row)
+        return self._record_or_none(row)
 
     def upsert_binding(
         self,
@@ -164,7 +174,9 @@ class ExternalSessionBindingRepository:
             """,
             (platform,),
         ).fetchall()
-        return tuple(self._to_record(row) for row in rows)
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
 
     def exists(
         self,
@@ -213,11 +225,102 @@ class ExternalSessionBindingRepository:
     @staticmethod
     def _to_record(row: sqlite3.Row) -> ExternalSessionBinding:
         return ExternalSessionBinding(
-            platform=str(row["platform"]),
-            trigger_id=str(row["trigger_id"]),
-            tenant_key=str(row["tenant_key"]),
-            external_chat_id=str(row["external_chat_id"]),
-            session_id=str(row["session_id"]),
-            created_at=datetime.fromisoformat(str(row["created_at"])),
-            updated_at=datetime.fromisoformat(str(row["updated_at"])),
+            platform=require_persisted_identifier(
+                row["platform"], field_name="platform"
+            ),
+            trigger_id=require_persisted_identifier(
+                row["trigger_id"],
+                field_name="trigger_id",
+            ),
+            tenant_key=require_persisted_identifier(
+                row["tenant_key"],
+                field_name="tenant_key",
+            ),
+            external_chat_id=require_persisted_identifier(
+                row["external_chat_id"],
+                field_name="external_chat_id",
+            ),
+            session_id=require_persisted_identifier(
+                row["session_id"],
+                field_name="session_id",
+            ),
+            created_at=_require_binding_timestamp(
+                row=row,
+                trigger_id=str(row["trigger_id"]),
+                field_name="created_at",
+            ),
+            updated_at=_require_binding_timestamp(
+                row=row,
+                trigger_id=str(row["trigger_id"]),
+                field_name="updated_at",
+            ),
         )
+
+    def _record_or_none(self, row: sqlite3.Row) -> ExternalSessionBinding | None:
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError) as exc:
+            _log_invalid_binding_row(row=row, error=exc)
+            return None
+
+
+def _require_binding_timestamp(
+    *,
+    row: sqlite3.Row,
+    trigger_id: str,
+    field_name: str,
+) -> datetime:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_binding_timestamp(
+        trigger_id=trigger_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _persisted_value_preview(value: object) -> str:
+    if value is None:
+        return "<null>"
+    return str(value)[:200]
+
+
+def _log_invalid_binding_timestamp(
+    *,
+    trigger_id: str,
+    field_name: str,
+    raw_preview: str,
+) -> None:
+    payload: dict[str, JsonValue] = {
+        "trigger_id": trigger_id,
+        "field_name": field_name,
+        "raw_preview": raw_preview,
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="sessions.external_session_binding_repository.timestamp_invalid",
+        message="Invalid persisted external session binding timestamp",
+        payload=payload,
+    )
+
+
+def _log_invalid_binding_row(*, row: sqlite3.Row, error: Exception) -> None:
+    payload: dict[str, JsonValue] = {
+        "platform": _persisted_value_preview(row["platform"]),
+        "trigger_id": _persisted_value_preview(row["trigger_id"]),
+        "session_id": _persisted_value_preview(row["session_id"]),
+        "created_at": _persisted_value_preview(row["created_at"]),
+        "updated_at": _persisted_value_preview(row["updated_at"]),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="sessions.external_session_binding_repository.row_invalid",
+        message="Skipping invalid persisted external session binding row",
+        payload=payload,
+    )

--- a/src/agent_teams/sessions/runs/run_models.py
+++ b/src/agent_teams/sessions/runs/run_models.py
@@ -16,6 +16,7 @@ from agent_teams.sessions.runs.enums import (
     RunEventType,
 )
 from agent_teams.sessions.session_models import SessionMode
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 
 class RunKind(str, Enum):
@@ -36,10 +37,10 @@ class RunTopologySnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     session_mode: SessionMode
-    main_agent_role_id: str = Field(min_length=1)
-    normal_root_role_id: str = Field(min_length=1)
-    coordinator_role_id: str = Field(min_length=1)
-    orchestration_preset_id: str | None = None
+    main_agent_role_id: RequiredIdentifierStr
+    normal_root_role_id: RequiredIdentifierStr
+    coordinator_role_id: RequiredIdentifierStr
+    orchestration_preset_id: OptionalIdentifierStr = None
     orchestration_prompt: str = ""
     allowed_role_ids: tuple[str, ...] = ()
 
@@ -91,7 +92,7 @@ MediaGenerationConfig = (
 class IntentInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    session_id: str = Field(min_length=1)
+    session_id: RequiredIdentifierStr
     input: tuple[ContentPart, ...] = Field(default_factory=tuple)
     run_kind: RunKind = RunKind.CONVERSATION
     generation_config: MediaGenerationConfig | None = None
@@ -99,7 +100,7 @@ class IntentInput(BaseModel):
     yolo: bool = False
     reuse_root_instance: bool = True
     thinking: RunThinkingConfig = Field(default_factory=RunThinkingConfig)
-    target_role_id: str | None = None
+    target_role_id: OptionalIdentifierStr = None
     session_mode: SessionMode = SessionMode.NORMAL
     topology: RunTopologySnapshot | None = None
     conversation_context: RuntimePromptConversationContext | None = None
@@ -129,8 +130,8 @@ class IntentInput(BaseModel):
 class RunResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    trace_id: str
-    root_task_id: str
+    trace_id: RequiredIdentifierStr
+    root_task_id: RequiredIdentifierStr
     status: Literal["completed", "failed"]
     output: tuple[ContentPart, ...] = Field(default_factory=tuple)
 
@@ -158,12 +159,12 @@ class RunResult(BaseModel):
 class InjectionMessage(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    run_id: str = Field(min_length=1)
-    recipient_instance_id: str = Field(min_length=1)
+    run_id: RequiredIdentifierStr
+    recipient_instance_id: RequiredIdentifierStr
     source: InjectionSource
     content: str = Field(min_length=1)
-    sender_instance_id: str | None = None
-    sender_role_id: str | None = None
+    sender_instance_id: OptionalIdentifierStr = None
+    sender_role_id: OptionalIdentifierStr = None
     priority: int = Field(ge=0)
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
 
@@ -171,12 +172,12 @@ class InjectionMessage(BaseModel):
 class RunEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    session_id: str = Field(min_length=1)
-    run_id: str = Field(min_length=1)
-    trace_id: str = Field(min_length=1)
-    task_id: str | None = None
-    instance_id: str | None = None
-    role_id: str | None = None
+    session_id: RequiredIdentifierStr
+    run_id: RequiredIdentifierStr
+    trace_id: RequiredIdentifierStr
+    task_id: OptionalIdentifierStr = None
+    instance_id: OptionalIdentifierStr = None
+    role_id: OptionalIdentifierStr = None
     event_type: RunEventType
     payload_json: str = Field(default="{}")
     occurred_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))

--- a/src/agent_teams/sessions/runs/run_runtime_repo.py
+++ b/src/agent_teams/sessions/runs/run_runtime_repo.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
 import sqlite3
+import logging
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from threading import RLock
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
 
+from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from agent_teams.validation import (
+    OptionalIdentifierStr,
+    RequiredIdentifierStr,
+    normalize_persisted_text,
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+LOGGER = get_logger(__name__)
 
 
 class RunRuntimeStatus(str, Enum):
@@ -35,15 +46,15 @@ class RunRuntimePhase(str, Enum):
 class RunRuntimeRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    run_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
-    root_task_id: str | None = None
+    run_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
+    root_task_id: OptionalIdentifierStr = None
     status: RunRuntimeStatus = RunRuntimeStatus.QUEUED
     phase: RunRuntimePhase = RunRuntimePhase.IDLE
-    active_instance_id: str | None = None
-    active_task_id: str | None = None
-    active_role_id: str | None = None
-    active_subagent_instance_id: str | None = None
+    active_instance_id: OptionalIdentifierStr = None
+    active_task_id: OptionalIdentifierStr = None
+    active_role_id: OptionalIdentifierStr = None
+    active_subagent_instance_id: OptionalIdentifierStr = None
     last_error: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
@@ -203,7 +214,7 @@ class RunRuntimeRepository:
             ).fetchone()
             if row is None:
                 return None
-            return self._to_record(row)
+            return self._record_or_none(row)
 
     def list_by_session(self, session_id: str) -> tuple[RunRuntimeRecord, ...]:
         with self._lock:
@@ -211,7 +222,11 @@ class RunRuntimeRepository:
                 "SELECT * FROM run_runtime WHERE session_id=? ORDER BY updated_at DESC",
                 (session_id,),
             ).fetchall()
-            return tuple(self._to_record(row) for row in rows)
+            return tuple(
+                record
+                for row in rows
+                if (record := self._record_or_none(row)) is not None
+            )
 
     def list_recoverable(self) -> tuple[RunRuntimeRecord, ...]:
         with self._lock:
@@ -228,7 +243,11 @@ class RunRuntimeRepository:
                     RunRuntimeStatus.STOPPED.value,
                 ),
             ).fetchall()
-            return tuple(self._to_record(row) for row in rows)
+            return tuple(
+                record
+                for row in rows
+                if (record := self._record_or_none(row)) is not None
+            )
 
     def mark_transient_runs_interrupted(self) -> int:
         affected = 0
@@ -285,26 +304,97 @@ class RunRuntimeRepository:
 
     def _to_record(self, row: sqlite3.Row) -> RunRuntimeRecord:
         return RunRuntimeRecord(
-            run_id=str(row["run_id"]),
-            session_id=str(row["session_id"]),
-            root_task_id=str(row["root_task_id"]) if row["root_task_id"] else None,
+            run_id=require_persisted_identifier(row["run_id"], field_name="run_id"),
+            session_id=require_persisted_identifier(
+                row["session_id"],
+                field_name="session_id",
+            ),
+            root_task_id=normalize_persisted_text(row["root_task_id"]),
             status=RunRuntimeStatus(str(row["status"])),
             phase=RunRuntimePhase(str(row["phase"])),
-            active_instance_id=(
-                str(row["active_instance_id"]) if row["active_instance_id"] else None
-            ),
-            active_task_id=str(row["active_task_id"])
-            if row["active_task_id"]
-            else None,
-            active_role_id=str(row["active_role_id"])
-            if row["active_role_id"]
-            else None,
-            active_subagent_instance_id=(
-                str(row["active_subagent_instance_id"])
-                if row["active_subagent_instance_id"]
-                else None
+            active_instance_id=normalize_persisted_text(row["active_instance_id"]),
+            active_task_id=normalize_persisted_text(row["active_task_id"]),
+            active_role_id=normalize_persisted_text(row["active_role_id"]),
+            active_subagent_instance_id=normalize_persisted_text(
+                row["active_subagent_instance_id"]
             ),
             last_error=str(row["last_error"]) if row["last_error"] else None,
-            created_at=datetime.fromisoformat(str(row["created_at"])),
-            updated_at=datetime.fromisoformat(str(row["updated_at"])),
+            created_at=_require_runtime_timestamp(
+                row=row,
+                run_id=normalize_persisted_text(row["run_id"]) or "<invalid>",
+                field_name="created_at",
+            ),
+            updated_at=_require_runtime_timestamp(
+                row=row,
+                run_id=normalize_persisted_text(row["run_id"]) or "<invalid>",
+                field_name="updated_at",
+            ),
         )
+
+    def _record_or_none(self, row: sqlite3.Row) -> RunRuntimeRecord | None:
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError) as exc:
+            _log_invalid_runtime_row(row=row, error=exc)
+            return None
+
+
+def _require_runtime_timestamp(
+    *,
+    row: sqlite3.Row,
+    run_id: str,
+    field_name: str,
+) -> datetime:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_runtime_timestamp(
+        run_id=run_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _persisted_value_preview(value: object) -> str:
+    if value is None:
+        return "<null>"
+    return str(value)[:200]
+
+
+def _log_invalid_runtime_timestamp(
+    *,
+    run_id: str,
+    field_name: str,
+    raw_preview: str,
+) -> None:
+    payload: dict[str, JsonValue] = {
+        "run_id": run_id,
+        "field_name": field_name,
+        "raw_preview": raw_preview,
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="sessions.run_runtime_repo.timestamp_invalid",
+        message="Invalid persisted run runtime timestamp",
+        payload=payload,
+    )
+
+
+def _log_invalid_runtime_row(*, row: sqlite3.Row, error: Exception) -> None:
+    payload: dict[str, JsonValue] = {
+        "run_id": _persisted_value_preview(row["run_id"]),
+        "session_id": _persisted_value_preview(row["session_id"]),
+        "created_at": _persisted_value_preview(row["created_at"]),
+        "updated_at": _persisted_value_preview(row["updated_at"]),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="sessions.run_runtime_repo.row_invalid",
+        message="Skipping invalid persisted run runtime row",
+        payload=payload,
+    )

--- a/src/agent_teams/sessions/runs/run_state_models.py
+++ b/src/agent_teams/sessions/runs/run_state_models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from agent_teams.sessions.runs.enums import RunEventType
 from agent_teams.sessions.runs.run_models import RunEvent
+from agent_teams.validation import RequiredIdentifierStr
 
 
 class RunStateStatus(str, Enum):
@@ -32,7 +33,7 @@ class RunStatePhase(str, Enum):
 class PendingToolApprovalState(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    tool_call_id: str = Field(min_length=1)
+    tool_call_id: RequiredIdentifierStr
     tool_name: str = ""
     args_preview: str = ""
     role_id: str = ""
@@ -59,8 +60,8 @@ class PausedSubagentState(BaseModel):
 class RunStateRecord(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    run_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
+    run_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
     status: RunStateStatus = RunStateStatus.QUEUED
     phase: RunStatePhase = RunStatePhase.IDLE
     recoverable: bool = True
@@ -74,8 +75,8 @@ class RunStateRecord(BaseModel):
 class RunSnapshotRecord(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    run_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
+    run_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
     checkpoint_event_id: int = Field(ge=1)
     state: RunStateRecord
     created_at: datetime

--- a/src/agent_teams/sessions/session_history_marker_models.py
+++ b/src/agent_teams/sessions/session_history_marker_models.py
@@ -6,6 +6,8 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from agent_teams.validation import RequiredIdentifierStr
+
 
 class SessionHistoryMarkerType(str, Enum):
     CLEAR = "clear"
@@ -15,8 +17,8 @@ class SessionHistoryMarkerType(str, Enum):
 class SessionHistoryMarkerRecord(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    marker_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
+    marker_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
     marker_type: SessionHistoryMarkerType
     metadata: dict[str, str] = Field(default_factory=dict)
     created_at: datetime

--- a/src/agent_teams/sessions/session_history_marker_repository.py
+++ b/src/agent_teams/sessions/session_history_marker_repository.py
@@ -2,17 +2,27 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import RLock
 
+from pydantic import JsonValue, ValidationError
+
+from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
 from agent_teams.sessions.session_history_marker_models import (
     SessionHistoryMarkerRecord,
     SessionHistoryMarkerType,
 )
+from agent_teams.validation import (
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+LOGGER = get_logger(__name__)
 
 
 class SessionHistoryMarkerRepository:
@@ -116,7 +126,9 @@ class SessionHistoryMarkerRepository:
                 """,
                 (session_id,),
             ).fetchall()
-        return tuple(self._to_record(row) for row in rows)
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
 
     def get_latest(
         self,
@@ -135,12 +147,14 @@ class SessionHistoryMarkerRepository:
         else:
             query += " AND marker_type=?"
             params = (session_id, marker_type.value)
-        query += " ORDER BY created_at DESC, marker_id DESC LIMIT 1"
+        query += " ORDER BY created_at DESC, marker_id DESC"
         with self._lock:
-            row = self._conn.execute(query, params).fetchone()
-        if row is None:
-            return None
-        return self._to_record(row)
+            rows = self._conn.execute(query, params).fetchall()
+        for row in rows:
+            record = self._record_or_none(row)
+            if record is not None:
+                return record
+        return None
 
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -159,12 +173,29 @@ class SessionHistoryMarkerRepository:
     def _to_record(row: sqlite3.Row) -> SessionHistoryMarkerRecord:
         metadata = _load_metadata(str(row["metadata_json"]))
         return SessionHistoryMarkerRecord(
-            marker_id=str(row["marker_id"]),
-            session_id=str(row["session_id"]),
+            marker_id=require_persisted_identifier(
+                row["marker_id"],
+                field_name="marker_id",
+            ),
+            session_id=require_persisted_identifier(
+                row["session_id"],
+                field_name="session_id",
+            ),
             marker_type=SessionHistoryMarkerType(str(row["marker_type"])),
             metadata=metadata,
-            created_at=datetime.fromisoformat(str(row["created_at"])),
+            created_at=_require_history_marker_timestamp(
+                row=row,
+                marker_id=str(row["marker_id"]),
+                field_name="created_at",
+            ),
         )
+
+    def _record_or_none(self, row: sqlite3.Row) -> SessionHistoryMarkerRecord | None:
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError) as exc:
+            _log_invalid_history_marker_row(row=row, error=exc)
+            return None
 
 
 def _load_metadata(raw_value: str) -> dict[str, str]:
@@ -179,3 +210,63 @@ def _load_metadata(raw_value: str) -> dict[str, str]:
         for key, value in parsed.items()
         if isinstance(key, str) and isinstance(value, str)
     }
+
+
+def _require_history_marker_timestamp(
+    *,
+    row: sqlite3.Row,
+    marker_id: str,
+    field_name: str,
+) -> datetime:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_history_marker_timestamp(
+        marker_id=marker_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _persisted_value_preview(value: object) -> str:
+    if value is None:
+        return "<null>"
+    return str(value)[:200]
+
+
+def _log_invalid_history_marker_timestamp(
+    *,
+    marker_id: str,
+    field_name: str,
+    raw_preview: str,
+) -> None:
+    payload: dict[str, JsonValue] = {
+        "marker_id": marker_id,
+        "field_name": field_name,
+        "raw_preview": raw_preview,
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="sessions.history_marker_repository.timestamp_invalid",
+        message="Invalid persisted session history marker timestamp",
+        payload=payload,
+    )
+
+
+def _log_invalid_history_marker_row(*, row: sqlite3.Row, error: Exception) -> None:
+    payload: dict[str, JsonValue] = {
+        "marker_id": _persisted_value_preview(row["marker_id"]),
+        "session_id": _persisted_value_preview(row["session_id"]),
+        "created_at": _persisted_value_preview(row["created_at"]),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="sessions.history_marker_repository.row_invalid",
+        message="Skipping invalid persisted session history marker row",
+        payload=payload,
+    )

--- a/src/agent_teams/sessions/session_models.py
+++ b/src/agent_teams/sessions/session_models.py
@@ -6,6 +6,8 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
+
 
 class SessionMode(str, Enum):
     NORMAL = "normal"
@@ -20,18 +22,18 @@ class ProjectKind(str, Enum):
 class SessionRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    session_id: str = Field(min_length=1)
-    workspace_id: str = Field(min_length=1)
+    session_id: RequiredIdentifierStr
+    workspace_id: RequiredIdentifierStr
     project_kind: ProjectKind = ProjectKind.WORKSPACE
-    project_id: str | None = None
+    project_id: OptionalIdentifierStr = None
     metadata: dict[str, str] = Field(default_factory=dict)
     session_mode: SessionMode = SessionMode.NORMAL
-    normal_root_role_id: str | None = None
-    orchestration_preset_id: str | None = None
+    normal_root_role_id: OptionalIdentifierStr = None
+    orchestration_preset_id: OptionalIdentifierStr = None
     started_at: datetime | None = None
     can_switch_mode: bool = True
     has_active_run: bool = False
-    active_run_id: str | None = None
+    active_run_id: OptionalIdentifierStr = None
     active_run_status: str | None = None
     active_run_phase: str | None = None
     pending_tool_approval_count: int = 0

--- a/src/agent_teams/sessions/session_repository.py
+++ b/src/agent_teams/sessions/session_repository.py
@@ -11,6 +11,11 @@ from pydantic import JsonValue, ValidationError
 from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite
 from agent_teams.sessions.session_models import ProjectKind, SessionMode, SessionRecord
+from agent_teams.validation import (
+    normalize_persisted_text,
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
 
 LOGGER = get_logger(__name__)
 
@@ -237,13 +242,22 @@ class SessionRepository:
             """
         ).fetchall()
         for row in rows:
-            started_at = str(row["started_at"] or "").strip()
-            if started_at:
+            try:
+                started_at = normalize_persisted_text(row["started_at"])
+                if started_at is not None:
+                    continue
+                session_id = require_persisted_identifier(
+                    row["session_id"],
+                    field_name="session_id",
+                )
+                session_mode = SessionMode(str(row["session_mode"] or "normal"))
+                normal_root_role_id = normalize_persisted_text(
+                    row["normal_root_role_id"]
+                )
+                preset_id = normalize_persisted_text(row["orchestration_preset_id"])
+            except (ValidationError, ValueError) as exc:
+                _log_invalid_session_row(row=row, error=exc)
                 continue
-            session_id = str(row["session_id"])
-            session_mode = SessionMode(str(row["session_mode"] or "normal"))
-            normal_root_role_id = str(row["normal_root_role_id"] or "").strip() or None
-            preset_id = str(row["orchestration_preset_id"] or "").strip() or None
             next_mode = session_mode
             next_normal_root_role_id = normal_root_role_id
             next_preset_id = preset_id
@@ -269,7 +283,11 @@ class SessionRepository:
         ).fetchone()
         if row is None:
             raise KeyError(f"Unknown session_id: {session_id}")
-        return self._to_record(row)
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError) as exc:
+            _log_invalid_session_row(row=row, error=exc)
+            raise KeyError(f"Unknown session_id: {session_id}") from exc
 
     def list_all(self) -> tuple[SessionRecord, ...]:
         rows = self._conn.execute(
@@ -288,25 +306,26 @@ class SessionRepository:
         self._conn.commit()
 
     def _to_record(self, row: sqlite3.Row) -> SessionRecord:
-        session_id = _require_session_text(row["session_id"], field_name="session_id")
-        workspace_id = _require_session_text(
+        session_id = require_persisted_identifier(
+            row["session_id"],
+            field_name="session_id",
+        )
+        workspace_id = require_persisted_identifier(
             row["workspace_id"],
             field_name="workspace_id",
         )
-        project_id = str(row["project_id"] or "").strip() or workspace_id
-        started_at_raw = _normalize_persisted_text(row["started_at"])
-        started_at = _parse_isoformat_or_none(started_at_raw)
+        project_id = normalize_persisted_text(row["project_id"]) or workspace_id
+        started_at_raw = normalize_persisted_text(row["started_at"])
+        started_at = parse_persisted_datetime_or_none(started_at_raw)
         if started_at_raw is not None and started_at is None:
             _log_invalid_session_timestamp(
                 session_id=session_id,
                 field_name="started_at",
-                raw_preview=started_at_raw,
+                raw_preview=_persisted_value_preview(row["started_at"]),
                 fallback_iso=None,
             )
-        created_at_raw = _normalize_persisted_text(row["created_at"])
-        updated_at_raw = _normalize_persisted_text(row["updated_at"])
-        created_at = _parse_isoformat_or_none(created_at_raw)
-        updated_at = _parse_isoformat_or_none(updated_at_raw)
+        created_at = parse_persisted_datetime_or_none(row["created_at"])
+        updated_at = parse_persisted_datetime_or_none(row["updated_at"])
         fallback_now = datetime.now(tz=timezone.utc)
         if created_at is None:
             created_at = updated_at or fallback_now
@@ -331,9 +350,10 @@ class SessionRepository:
             project_id=project_id,
             metadata=_metadata_from_json(row["metadata"], session_id=session_id),
             session_mode=SessionMode(str(row["session_mode"] or "normal")),
-            normal_root_role_id=str(row["normal_root_role_id"] or "").strip() or None,
-            orchestration_preset_id=str(row["orchestration_preset_id"] or "").strip()
-            or None,
+            normal_root_role_id=normalize_persisted_text(row["normal_root_role_id"]),
+            orchestration_preset_id=normalize_persisted_text(
+                row["orchestration_preset_id"]
+            ),
             started_at=started_at,
             can_switch_mode=started_at is None,
             created_at=created_at,
@@ -393,35 +413,6 @@ def _metadata_from_json(value: object, *, session_id: str) -> dict[str, str]:
             message="Ignored non-string session metadata values from persisted row",
             payload=payload,
         )
-    return normalized
-
-
-def _normalize_persisted_text(value: object) -> str | None:
-    if value is None:
-        return None
-    normalized = str(value).strip()
-    if not normalized:
-        return None
-    if normalized.lower() in {"none", "null"}:
-        return None
-    return normalized
-
-
-def _parse_isoformat_or_none(value: str | None) -> datetime | None:
-    if value is None:
-        return None
-    try:
-        return datetime.fromisoformat(value)
-    except ValueError:
-        return None
-
-
-def _require_session_text(value: object, *, field_name: str) -> str:
-    if value is None:
-        raise ValueError(f"Missing session {field_name} in persisted row")
-    normalized = str(value).strip()
-    if not normalized:
-        raise ValueError(f"Blank session {field_name} in persisted row")
     return normalized
 
 

--- a/src/agent_teams/tools/runtime/approval_ticket_repo.py
+++ b/src/agent_teams/tools/runtime/approval_ticket_repo.py
@@ -2,14 +2,24 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
+import logging
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from threading import RLock
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
 
+from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from agent_teams.validation import (
+    RequiredIdentifierStr,
+    normalize_persisted_text,
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+LOGGER = get_logger(__name__)
 
 
 class ApprovalTicketStatus(str, Enum):
@@ -23,14 +33,14 @@ class ApprovalTicketStatus(str, Enum):
 class ApprovalTicketRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    tool_call_id: str = Field(min_length=1)
-    signature_key: str = Field(min_length=1)
-    run_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
-    task_id: str = Field(min_length=1)
-    instance_id: str = Field(min_length=1)
-    role_id: str = Field(min_length=1)
-    tool_name: str = Field(min_length=1)
+    tool_call_id: RequiredIdentifierStr
+    signature_key: RequiredIdentifierStr
+    run_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
+    task_id: RequiredIdentifierStr
+    instance_id: RequiredIdentifierStr
+    role_id: RequiredIdentifierStr
+    tool_name: RequiredIdentifierStr
     args_preview: str = ""
     status: ApprovalTicketStatus = ApprovalTicketStatus.REQUESTED
     feedback: str = ""
@@ -238,7 +248,7 @@ class ApprovalTicketRepository:
             ).fetchone()
         if row is None:
             return None
-        return self._to_record(row)
+        return self._record_or_none(row)
 
     def list_open_by_run(self, run_id: str) -> tuple[ApprovalTicketRecord, ...]:
         with self._lock:
@@ -246,7 +256,9 @@ class ApprovalTicketRepository:
                 "SELECT * FROM approval_tickets WHERE run_id=? AND status=? ORDER BY created_at ASC",
                 (run_id, ApprovalTicketStatus.REQUESTED.value),
             ).fetchall()
-        return tuple(self._to_record(row) for row in rows)
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
 
     def list_open_by_session(self, session_id: str) -> tuple[ApprovalTicketRecord, ...]:
         with self._lock:
@@ -254,7 +266,9 @@ class ApprovalTicketRepository:
                 "SELECT * FROM approval_tickets WHERE session_id=? AND status=? ORDER BY created_at ASC",
                 (session_id, ApprovalTicketStatus.REQUESTED.value),
             ).fetchall()
-        return tuple(self._to_record(row) for row in rows)
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
 
     def find_reusable(
         self,
@@ -291,7 +305,7 @@ class ApprovalTicketRepository:
             ).fetchone()
         if row is None:
             return None
-        return self._to_record(row)
+        return self._record_or_none(row)
 
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -306,24 +320,142 @@ class ApprovalTicketRepository:
         )
 
     def _to_record(self, row: sqlite3.Row) -> ApprovalTicketRecord:
-        resolved_at_raw = row["resolved_at"]
         return ApprovalTicketRecord(
-            tool_call_id=str(row["tool_call_id"]),
-            signature_key=str(row["signature_key"]),
-            run_id=str(row["run_id"]),
-            session_id=str(row["session_id"]),
-            task_id=str(row["task_id"]),
-            instance_id=str(row["instance_id"]),
-            role_id=str(row["role_id"]),
-            tool_name=str(row["tool_name"]),
+            tool_call_id=require_persisted_identifier(
+                row["tool_call_id"],
+                field_name="tool_call_id",
+            ),
+            signature_key=require_persisted_identifier(
+                row["signature_key"],
+                field_name="signature_key",
+            ),
+            run_id=require_persisted_identifier(row["run_id"], field_name="run_id"),
+            session_id=require_persisted_identifier(
+                row["session_id"],
+                field_name="session_id",
+            ),
+            task_id=require_persisted_identifier(row["task_id"], field_name="task_id"),
+            instance_id=require_persisted_identifier(
+                row["instance_id"],
+                field_name="instance_id",
+            ),
+            role_id=require_persisted_identifier(row["role_id"], field_name="role_id"),
+            tool_name=require_persisted_identifier(
+                row["tool_name"],
+                field_name="tool_name",
+            ),
             args_preview=str(row["args_preview"]),
             status=ApprovalTicketStatus(str(row["status"])),
             feedback=str(row["feedback"]),
-            created_at=datetime.fromisoformat(str(row["created_at"])),
-            updated_at=datetime.fromisoformat(str(row["updated_at"])),
+            created_at=_require_ticket_timestamp(
+                row=row,
+                tool_call_id=normalize_persisted_text(row["tool_call_id"])
+                or "<invalid>",
+                field_name="created_at",
+            ),
+            updated_at=_require_ticket_timestamp(
+                row=row,
+                tool_call_id=normalize_persisted_text(row["tool_call_id"])
+                or "<invalid>",
+                field_name="updated_at",
+            ),
             resolved_at=(
-                datetime.fromisoformat(str(resolved_at_raw))
-                if resolved_at_raw
-                else None
+                _optional_ticket_timestamp(
+                    row=row,
+                    tool_call_id=normalize_persisted_text(row["tool_call_id"])
+                    or "<invalid>",
+                    field_name="resolved_at",
+                )
             ),
         )
+
+    def _record_or_none(self, row: sqlite3.Row) -> ApprovalTicketRecord | None:
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError) as exc:
+            _log_invalid_ticket_row(row=row, error=exc)
+            return None
+
+
+def _require_ticket_timestamp(
+    *,
+    row: sqlite3.Row,
+    tool_call_id: str,
+    field_name: str,
+) -> datetime:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_ticket_timestamp(
+        tool_call_id=tool_call_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _optional_ticket_timestamp(
+    *,
+    row: sqlite3.Row,
+    tool_call_id: str,
+    field_name: str,
+) -> datetime | None:
+    raw_value = row[field_name]
+    normalized = normalize_persisted_text(raw_value)
+    if normalized is None:
+        return None
+    parsed = parse_persisted_datetime_or_none(raw_value)
+    if parsed is not None:
+        return parsed
+    _log_invalid_ticket_timestamp(
+        tool_call_id=tool_call_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(raw_value),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _persisted_value_preview(value: object) -> str:
+    if value is None:
+        return "<null>"
+    return str(value)[:200]
+
+
+def _log_invalid_ticket_timestamp(
+    *,
+    tool_call_id: str,
+    field_name: str,
+    raw_preview: str,
+) -> None:
+    payload: dict[str, JsonValue] = {
+        "tool_call_id": tool_call_id,
+        "field_name": field_name,
+        "raw_preview": raw_preview,
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="tools.approval_ticket_repo.timestamp_invalid",
+        message="Invalid persisted approval ticket timestamp",
+        payload=payload,
+    )
+
+
+def _log_invalid_ticket_row(*, row: sqlite3.Row, error: Exception) -> None:
+    payload: dict[str, JsonValue] = {
+        "tool_call_id": _persisted_value_preview(row["tool_call_id"]),
+        "run_id": _persisted_value_preview(row["run_id"]),
+        "session_id": _persisted_value_preview(row["session_id"]),
+        "created_at": _persisted_value_preview(row["created_at"]),
+        "updated_at": _persisted_value_preview(row["updated_at"]),
+        "resolved_at": _persisted_value_preview(row["resolved_at"]),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="tools.approval_ticket_repo.row_invalid",
+        message="Skipping invalid persisted approval ticket row",
+        payload=payload,
+    )

--- a/src/agent_teams/validation/__init__.py
+++ b/src/agent_teams/validation/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from agent_teams.validation.identifiers import (
+    NONE_LIKE_IDENTIFIER_TEXT,
+    OptionalIdentifierStr,
+    RequiredIdentifierStr,
+    is_none_like_identifier_text,
+    normalize_persisted_text,
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+__all__ = [
+    "NONE_LIKE_IDENTIFIER_TEXT",
+    "OptionalIdentifierStr",
+    "RequiredIdentifierStr",
+    "is_none_like_identifier_text",
+    "normalize_persisted_text",
+    "parse_persisted_datetime_or_none",
+    "require_persisted_identifier",
+]

--- a/src/agent_teams/validation/identifiers.py
+++ b/src/agent_teams/validation/identifiers.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BeforeValidator
+
+NONE_LIKE_IDENTIFIER_TEXT = frozenset({"none", "null"})
+
+
+def is_none_like_identifier_text(value: str) -> bool:
+    return value.casefold() in NONE_LIKE_IDENTIFIER_TEXT
+
+
+def _normalize_required_identifier(value: object) -> object:
+    if value is None:
+        raise ValueError("Identifier is required")
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized or is_none_like_identifier_text(normalized):
+            raise ValueError("Identifier cannot be blank, 'None', or 'null'")
+        return normalized
+    return value
+
+
+def _normalize_optional_identifier(value: object) -> object:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized or is_none_like_identifier_text(normalized):
+            raise ValueError("Identifier cannot be blank, 'None', or 'null'")
+        return normalized
+    return value
+
+
+RequiredIdentifierStr = Annotated[str, BeforeValidator(_normalize_required_identifier)]
+OptionalIdentifierStr = Annotated[
+    str | None, BeforeValidator(_normalize_optional_identifier)
+]
+
+
+def normalize_persisted_text(value: object) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    if not normalized or is_none_like_identifier_text(normalized):
+        return None
+    return normalized
+
+
+def parse_persisted_datetime_or_none(value: object) -> datetime | None:
+    normalized = normalize_persisted_text(value)
+    if normalized is None:
+        return None
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def require_persisted_identifier(value: object, *, field_name: str) -> str:
+    normalized = normalize_persisted_text(value)
+    if normalized is None:
+        raise ValueError(f"Invalid persisted {field_name}")
+    return normalized

--- a/src/agent_teams/workspace/workspace_models.py
+++ b/src/agent_teams/workspace/workspace_models.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from agent_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
+
 
 class WorkspaceBackend(str, Enum):
     FILESYSTEM = "filesystem"
@@ -34,7 +36,7 @@ class WorkspaceFileScope(BaseModel):
     branch_binding: BranchBinding = BranchBinding.SHARED
     branch_name: str | None = None
     source_root_path: str | None = None
-    forked_from_workspace_id: str | None = None
+    forked_from_workspace_id: OptionalIdentifierStr = None
 
 
 def default_workspace_profile() -> WorkspaceProfile:
@@ -54,11 +56,11 @@ class WorkspaceProfile(BaseModel):
 class WorkspaceRef(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    workspace_id: str = Field(min_length=1)
-    session_id: str = Field(min_length=1)
-    role_id: str = Field(min_length=1)
-    conversation_id: str = Field(min_length=1)
-    instance_id: str | None = None
+    workspace_id: RequiredIdentifierStr
+    session_id: RequiredIdentifierStr
+    role_id: RequiredIdentifierStr
+    conversation_id: RequiredIdentifierStr
+    instance_id: OptionalIdentifierStr = None
     profile: WorkspaceProfile = Field(default_factory=default_workspace_profile)
 
 
@@ -76,7 +78,7 @@ class WorkspaceLocations(BaseModel):
 class WorkspaceRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    workspace_id: str = Field(min_length=1)
+    workspace_id: RequiredIdentifierStr
     root_path: Path
     profile: WorkspaceProfile = Field(default_factory=default_workspace_profile)
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
@@ -112,7 +114,7 @@ class WorkspaceTreeNode(BaseModel):
 class WorkspaceTreeListing(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    workspace_id: str = Field(min_length=1)
+    workspace_id: RequiredIdentifierStr
     directory_path: str
     children: tuple[WorkspaceTreeNode, ...] = ()
 
@@ -138,7 +140,7 @@ class WorkspaceDiffFile(BaseModel):
 class WorkspaceDiffListing(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    workspace_id: str = Field(min_length=1)
+    workspace_id: RequiredIdentifierStr
     root_path: Path
     diff_files: tuple[WorkspaceDiffFileSummary, ...] = ()
     is_git_repository: bool = False
@@ -149,6 +151,6 @@ class WorkspaceDiffListing(BaseModel):
 class WorkspaceSnapshot(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    workspace_id: str = Field(min_length=1)
+    workspace_id: RequiredIdentifierStr
     root_path: Path
     tree: WorkspaceTreeNode

--- a/src/agent_teams/workspace/workspace_repository.py
+++ b/src/agent_teams/workspace/workspace_repository.py
@@ -2,17 +2,27 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import RLock
 
+from pydantic import JsonValue, ValidationError
+
+from agent_teams.logger import get_logger, log_event
 from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from agent_teams.validation import (
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
 from agent_teams.workspace.workspace_models import (
     WorkspaceProfile,
     WorkspaceRecord,
     default_workspace_profile,
 )
+
+LOGGER = get_logger(__name__)
 
 
 class WorkspaceRepository:
@@ -105,14 +115,24 @@ class WorkspaceRepository:
             ).fetchone()
         if row is None:
             raise KeyError(f"Unknown workspace_id: {workspace_id}")
-        return self._to_record(row)
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+            _log_invalid_workspace_row(row=row, error=exc)
+            raise KeyError(f"Unknown workspace_id: {workspace_id}") from exc
 
     def list_all(self) -> tuple[WorkspaceRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
                 "SELECT * FROM workspaces ORDER BY created_at DESC"
             ).fetchall()
-        return tuple(self._to_record(row) for row in rows)
+        records: list[WorkspaceRecord] = []
+        for row in rows:
+            try:
+                records.append(self._to_record(row))
+            except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+                _log_invalid_workspace_row(row=row, error=exc)
+        return tuple(records)
 
     def delete(self, workspace_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -144,9 +164,80 @@ class WorkspaceRepository:
             else default_workspace_profile()
         )
         return WorkspaceRecord(
-            workspace_id=str(row["workspace_id"]),
+            workspace_id=require_persisted_identifier(
+                row["workspace_id"],
+                field_name="workspace_id",
+            ),
             root_path=Path(str(row["root_path"])).resolve(),
             profile=profile,
-            created_at=datetime.fromisoformat(str(row["created_at"])),
-            updated_at=datetime.fromisoformat(str(row["updated_at"])),
+            created_at=_require_workspace_timestamp(
+                row=row,
+                workspace_id=str(row["workspace_id"]),
+                field_name="created_at",
+            ),
+            updated_at=_require_workspace_timestamp(
+                row=row,
+                workspace_id=str(row["workspace_id"]),
+                field_name="updated_at",
+            ),
         )
+
+
+def _require_workspace_timestamp(
+    *,
+    row: sqlite3.Row,
+    workspace_id: str,
+    field_name: str,
+) -> datetime:
+    parsed = parse_persisted_datetime_or_none(row[field_name])
+    if parsed is not None:
+        return parsed
+    _log_invalid_workspace_timestamp(
+        workspace_id=workspace_id,
+        field_name=field_name,
+        raw_preview=_persisted_value_preview(row[field_name]),
+    )
+    raise ValueError(f"Invalid persisted {field_name}")
+
+
+def _persisted_value_preview(value: object) -> str:
+    if value is None:
+        return "<null>"
+    return str(value)[:200]
+
+
+def _log_invalid_workspace_timestamp(
+    *,
+    workspace_id: str,
+    field_name: str,
+    raw_preview: str,
+) -> None:
+    payload: dict[str, JsonValue] = {
+        "workspace_id": workspace_id,
+        "field_name": field_name,
+        "raw_preview": raw_preview,
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="workspace.repository.timestamp_invalid",
+        message="Invalid persisted workspace timestamp",
+        payload=payload,
+    )
+
+
+def _log_invalid_workspace_row(*, row: sqlite3.Row, error: Exception) -> None:
+    payload: dict[str, JsonValue] = {
+        "workspace_id": _persisted_value_preview(row["workspace_id"]),
+        "created_at": _persisted_value_preview(row["created_at"]),
+        "updated_at": _persisted_value_preview(row["updated_at"]),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="workspace.repository.row_invalid",
+        message="Skipping invalid persisted workspace row",
+        payload=payload,
+    )

--- a/tests/unit_tests/gateway/test_feishu_account_repository.py
+++ b/tests/unit_tests/gateway/test_feishu_account_repository.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from agent_teams.gateway.feishu.account_repository import FeishuAccountRepository
+from agent_teams.gateway.feishu.models import (
+    FeishuGatewayAccountRecord,
+    FeishuGatewayAccountStatus,
+)
+
+
+def test_feishu_account_repository_skips_invalid_persisted_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "feishu_accounts.db"
+    repository = FeishuAccountRepository(db_path)
+    now = datetime.now(tz=timezone.utc)
+    _ = repository.create_account(
+        FeishuGatewayAccountRecord(
+            account_id="fsg_valid",
+            name="feishu-valid",
+            display_name="Feishu Valid",
+            status=FeishuGatewayAccountStatus.ENABLED,
+            source_config={
+                "provider": "feishu",
+                "trigger_rule": "mention_only",
+                "app_id": "cli_demo",
+                "app_name": "Agent Teams Bot",
+            },
+            target_config={"workspace_id": "default"},
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    _insert_feishu_account_row(
+        db_path,
+        account_id="None",
+    )
+
+    records = repository.list_accounts()
+
+    assert [record.account_id for record in records] == ["fsg_valid"]
+    with pytest.raises(KeyError):
+        repository.get_account("None")
+
+
+def _insert_feishu_account_row(
+    db_path: Path,
+    *,
+    account_id: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO feishu_gateway_accounts(
+            account_id,
+            name,
+            display_name,
+            status,
+            source_config_json,
+            target_config_json,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            account_id,
+            "feishu-bad",
+            "Broken Account",
+            "enabled",
+            '{"provider":"feishu","trigger_rule":"mention_only","app_id":"cli_demo","app_name":"Agent Teams Bot"}',
+            '{"workspace_id":"default"}',
+            now,
+            now,
+        ),
+    )
+    connection.commit()
+    connection.close()

--- a/tests/unit_tests/gateway/test_gateway_session_repository.py
+++ b/tests/unit_tests/gateway/test_gateway_session_repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+import sqlite3
 
 from agent_teams.gateway.gateway_models import (
     GatewayChannelType,
@@ -128,3 +129,77 @@ def test_gateway_session_repository_gets_latest_by_internal_session_id(
     assert loaded.gateway_session_id == "gws_new"
     assert repository.get_by_internal_session_id("missing") is None
     assert first.gateway_session_id == "gws_old"
+
+
+def test_gateway_session_repository_skips_invalid_persisted_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "gateway.db"
+    repository = GatewaySessionRepository(db_path)
+    _ = repository.create(
+        GatewaySessionRecord(
+            gateway_session_id="gws_valid",
+            channel_type=GatewayChannelType.WECHAT,
+            external_session_id="wechat:wx_1:user_valid",
+            internal_session_id="session_valid",
+        )
+    )
+    _insert_gateway_session_row(
+        db_path,
+        gateway_session_id="None",
+        internal_session_id="session_bad",
+    )
+
+    records = repository.list_all()
+
+    assert [record.gateway_session_id for record in records] == ["gws_valid"]
+    assert repository.get_by_internal_session_id("session_bad") is None
+
+
+def _insert_gateway_session_row(
+    db_path: Path,
+    *,
+    gateway_session_id: str,
+    internal_session_id: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO gateway_sessions(
+            gateway_session_id,
+            channel_type,
+            external_session_id,
+            internal_session_id,
+            active_run_id,
+            peer_user_id,
+            peer_chat_id,
+            cwd,
+            capabilities_json,
+            channel_state_json,
+            session_mcp_servers_json,
+            mcp_connections_json,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            gateway_session_id,
+            GatewayChannelType.WECHAT.value,
+            "wechat:wx_1:user_bad",
+            internal_session_id,
+            None,
+            None,
+            None,
+            None,
+            "{}",
+            "{}",
+            "[]",
+            "[]",
+            now,
+            now,
+        ),
+    )
+    connection.commit()
+    connection.close()

--- a/tests/unit_tests/interfaces/server/test_automation_router.py
+++ b/tests/unit_tests/interfaces/server/test_automation_router.py
@@ -221,6 +221,26 @@ def test_create_project_route_maps_name_conflict_to_409() -> None:
     assert "already exists" in response.json()["detail"]
 
 
+def test_create_project_route_rejects_none_like_workspace_id() -> None:
+    fake_service = _FakeAutomationService()
+    client = _client(fake_service)
+
+    response = client.post(
+        "/api/automation/projects",
+        json={
+            "name": "daily-briefing",
+            "workspace_id": "None",
+            "prompt": "Summarize the day.",
+            "schedule_mode": "cron",
+            "cron_expression": "0 9 * * *",
+            "timezone": "UTC",
+        },
+    )
+
+    assert response.status_code == 422
+    assert fake_service.created_payloads == []
+
+
 def test_list_projects_route_returns_records() -> None:
     client = _client(_FakeAutomationService())
 
@@ -255,6 +275,14 @@ def test_get_project_route_returns_record() -> None:
 
     assert response.status_code == 200
     assert response.json()["automation_project_id"] == "aut_1"
+
+
+def test_get_project_route_rejects_none_like_path_identifier() -> None:
+    client = _client(_FakeAutomationService())
+
+    response = client.get("/api/automation/projects/None")
+
+    assert response.status_code == 422
 
 
 def test_run_project_route_returns_session_id() -> None:

--- a/tests/unit_tests/interfaces/server/test_feishu_gateway_router.py
+++ b/tests/unit_tests/interfaces/server/test_feishu_gateway_router.py
@@ -171,6 +171,30 @@ def test_create_feishu_account_route_reloads_subscription_service() -> None:
     assert gateway_service.created_payloads[0].name == "feishu_ops"
 
 
+def test_create_feishu_account_route_rejects_none_like_name() -> None:
+    gateway_service = _FakeFeishuGatewayService()
+    subscription_service = _FakeSubscriptionService()
+    client = _client(gateway_service, subscription_service)
+
+    response = client.post(
+        "/api/gateway/feishu/accounts",
+        json={
+            "name": "None",
+            "source_config": {
+                "provider": "feishu",
+                "trigger_rule": "mention_only",
+                "app_id": "cli_demo",
+                "app_name": "Agent Teams Bot",
+            },
+            "target_config": {"workspace_id": "default"},
+            "secret_config": {"app_secret": "secret-demo"},
+        },
+    )
+
+    assert response.status_code == 422
+    assert gateway_service.created_payloads == []
+
+
 def test_update_feishu_account_route_reloads_when_runtime_changes() -> None:
     gateway_service = _FakeFeishuGatewayService()
     subscription_service = _FakeSubscriptionService()
@@ -211,3 +235,17 @@ def test_enable_feishu_account_route_maps_validation_error_to_422() -> None:
 
     assert response.status_code == 422
     assert response.json()["detail"] == "Unknown workspace: missing-workspace"
+
+
+def test_update_feishu_account_route_rejects_none_like_path_identifier() -> None:
+    gateway_service = _FakeFeishuGatewayService()
+    subscription_service = _FakeSubscriptionService()
+    client = _client(gateway_service, subscription_service)
+
+    response = client.patch(
+        "/api/gateway/feishu/accounts/None",
+        json={"display_name": "Feishu Ops"},
+    )
+
+    assert response.status_code == 422
+    assert gateway_service.updated_payloads == []

--- a/tests/unit_tests/interfaces/server/test_gateway_router.py
+++ b/tests/unit_tests/interfaces/server/test_gateway_router.py
@@ -138,6 +138,17 @@ def test_wait_wechat_login_route_maps_missing_session_to_404() -> None:
     assert "Unknown WeChat login session" in response.json()["detail"]
 
 
+def test_wait_wechat_login_route_rejects_none_like_session_key() -> None:
+    client = _client(_FakeWeChatGatewayService())
+
+    response = client.post(
+        "/api/gateway/wechat/login/wait",
+        json={"session_key": "None", "timeout_ms": 1000},
+    )
+
+    assert response.status_code == 422
+
+
 def test_update_wechat_account_route_maps_validation_error_to_422() -> None:
     fake_service = _FakeWeChatGatewayService()
     client = _client(fake_service)
@@ -164,3 +175,16 @@ def test_reload_wechat_gateway_route_calls_service() -> None:
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
     assert fake_service.reload_calls == 1
+
+
+def test_update_wechat_account_route_rejects_none_like_path_identifier() -> None:
+    fake_service = _FakeWeChatGatewayService()
+    client = _client(fake_service)
+
+    response = client.patch(
+        "/api/gateway/wechat/accounts/None",
+        json={"display_name": "Ops WeChat"},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.updated_payloads == []

--- a/tests/unit_tests/interfaces/server/test_runs_router.py
+++ b/tests/unit_tests/interfaces/server/test_runs_router.py
@@ -84,6 +84,23 @@ def test_create_run_route_accepts_yolo() -> None:
     assert fake_service.started_run_ids == ["run-1"]
 
 
+def test_create_run_route_rejects_none_like_session_id() -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "session_id": "None",
+            "intent": "hello",
+            "execution_mode": "ai",
+        },
+    )
+
+    assert response.status_code == 422
+    assert fake_service.created_run_inputs == []
+
+
 def test_create_run_route_accepts_thinking_config() -> None:
     fake_service = _FakeRunService()
     client = _create_client(fake_service)
@@ -145,3 +162,13 @@ def test_resolve_tool_approval_route_returns_conflict_for_stopped_run() -> None:
     assert response.json()["detail"] == (
         "Run run-1 is stopped. Resume the run before resolving tool approval."
     )
+
+
+def test_resume_route_rejects_none_like_run_id() -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+
+    response = client.post("/api/runs/None:resume")
+
+    assert response.status_code == 422
+    assert fake_service.resumed_run_ids == []

--- a/tests/unit_tests/interfaces/server/test_sessions_router.py
+++ b/tests/unit_tests/interfaces/server/test_sessions_router.py
@@ -216,6 +216,19 @@ def test_create_session_route_returns_created_session() -> None:
     assert fake_service.created_calls == [("session-1", "default", None)]
 
 
+def test_create_session_route_rejects_none_like_session_id() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/sessions",
+        json={"session_id": "None", "workspace_id": "default"},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.created_calls == []
+
+
 def test_create_session_route_returns_503_when_system_roles_are_missing() -> None:
     fake_service = _FakeSessionService()
     fake_service.create_session_error = SystemRolesUnavailableError(
@@ -241,6 +254,19 @@ def test_update_session_route_returns_not_found_for_missing_session() -> None:
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Session not found"}
+
+
+def test_update_session_route_rejects_none_like_path_identifier() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.patch(
+        "/api/sessions/None",
+        json={"metadata": {"title": "Renamed Session"}},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.updated_calls == []
 
 
 def test_update_session_topology_route_returns_updated_session() -> None:

--- a/tests/unit_tests/interfaces/server/test_workspaces_router.py
+++ b/tests/unit_tests/interfaces/server/test_workspaces_router.py
@@ -121,6 +121,22 @@ def test_create_workspace(tmp_path: Path) -> None:
     assert payload["root_path"] == str(root_path.resolve())
 
 
+def test_create_workspace_rejects_none_like_workspace_id(tmp_path: Path) -> None:
+    client, _ = _create_test_client(tmp_path)
+    root_path = tmp_path / "workspace-root"
+    root_path.mkdir()
+
+    response = client.post(
+        "/api/workspaces",
+        json={
+            "workspace_id": "None",
+            "root_path": str(root_path),
+        },
+    )
+
+    assert response.status_code == 422
+
+
 def test_list_and_get_workspaces(tmp_path: Path) -> None:
     client, service = _create_test_client(tmp_path)
     root_path = tmp_path / "workspace-root"
@@ -137,6 +153,14 @@ def test_list_and_get_workspaces(tmp_path: Path) -> None:
     assert [item["workspace_id"] for item in list_response.json()] == ["project-alpha"]
     assert get_response.status_code == 200
     assert get_response.json()["root_path"] == str(root_path.resolve())
+
+
+def test_get_workspace_rejects_none_like_path_identifier(tmp_path: Path) -> None:
+    client, _ = _create_test_client(tmp_path)
+
+    response = client.get("/api/workspaces/None")
+
+    assert response.status_code == 422
 
 
 def test_create_workspace_rejects_missing_root(tmp_path: Path) -> None:

--- a/tests/unit_tests/sessions/runs/test_run_runtime_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_runtime_repo.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 from pathlib import Path
+import sqlite3
 from threading import Barrier
 
 from agent_teams.sessions.runs.run_runtime_repo import (
@@ -113,3 +115,70 @@ def test_run_runtime_repo_marks_transient_runs_interrupted(tmp_path: Path) -> No
     assert queued.last_error == "interrupted_by_process_restart"
     assert paused.status == RunRuntimeStatus.PAUSED
     assert paused.phase == RunRuntimePhase.AWAITING_TOOL_APPROVAL
+
+
+def test_run_runtime_repo_skips_invalid_persisted_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "run_runtime_invalid_rows.db"
+    repo = RunRuntimeRepository(db_path)
+    _ = repo.ensure(
+        run_id="run-valid",
+        session_id="session-1",
+        root_task_id="task-1",
+    )
+    _insert_run_runtime_row(
+        db_path,
+        run_id="run-invalid",
+        session_id="session-1",
+        updated_at="None",
+    )
+
+    records = repo.list_by_session("session-1")
+
+    assert [record.run_id for record in records] == ["run-valid"]
+    assert repo.get("run-invalid") is None
+
+
+def _insert_run_runtime_row(
+    db_path: Path,
+    *,
+    run_id: str,
+    session_id: str,
+    updated_at: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO run_runtime(
+            run_id,
+            session_id,
+            root_task_id,
+            status,
+            phase,
+            active_instance_id,
+            active_task_id,
+            active_role_id,
+            active_subagent_instance_id,
+            last_error,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            run_id,
+            session_id,
+            "task-x",
+            RunRuntimeStatus.RUNNING.value,
+            RunRuntimePhase.COORDINATOR_RUNNING.value,
+            None,
+            None,
+            None,
+            None,
+            None,
+            now,
+            updated_at,
+        ),
+    )
+    connection.commit()
+    connection.close()

--- a/tests/unit_tests/sessions/test_external_session_binding_repository.py
+++ b/tests/unit_tests/sessions/test_external_session_binding_repository.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
+import sqlite3
 
 from agent_teams.sessions import ExternalSessionBindingRepository
 
@@ -47,3 +49,66 @@ def test_upsert_updates_existing_binding(tmp_path: Path) -> None:
     )
 
     assert updated.session_id == "session-2"
+
+
+def test_external_session_binding_repository_skips_invalid_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "bindings.db"
+    repo = ExternalSessionBindingRepository(db_path)
+    _ = repo.upsert_binding(
+        platform="feishu",
+        trigger_id="trigger-valid",
+        tenant_key="tenant-1",
+        external_chat_id="chat-1",
+        session_id="session-1",
+    )
+    _insert_binding_row(
+        db_path,
+        trigger_id="None",
+    )
+
+    bindings = repo.list_by_platform("feishu")
+
+    assert [binding.trigger_id for binding in bindings] == ["trigger-valid"]
+    assert (
+        repo.get_binding(
+            platform="feishu",
+            trigger_id="None",
+            tenant_key="tenant-1",
+            external_chat_id="chat-2",
+        )
+        is None
+    )
+
+
+def _insert_binding_row(
+    db_path: Path,
+    *,
+    trigger_id: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO external_session_bindings(
+            platform,
+            trigger_id,
+            tenant_key,
+            external_chat_id,
+            session_id,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "feishu",
+            trigger_id,
+            "tenant-1",
+            "chat-2",
+            "session-2",
+            now,
+            now,
+        ),
+    )
+    connection.commit()
+    connection.close()

--- a/tests/unit_tests/sessions/test_session_history_markers.py
+++ b/tests/unit_tests/sessions/test_session_history_markers.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
+import sqlite3
 
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
 
@@ -144,3 +146,53 @@ def test_session_clear_uses_logical_history_divider(tmp_path: Path) -> None:
     coordinator_messages = round_new["coordinator_messages"]
     assert isinstance(coordinator_messages, list)
     assert len(coordinator_messages) == 1
+
+
+def test_session_history_marker_repository_skips_invalid_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_history_markers_invalid.db"
+    repository = SessionHistoryMarkerRepository(db_path)
+    _ = repository.create_clear_marker("session-1")
+    _insert_history_marker_row(
+        db_path,
+        marker_id="None",
+        session_id="session-1",
+    )
+
+    markers = repository.list_by_session("session-1")
+
+    assert len(markers) == 1
+    assert markers[0].session_id == "session-1"
+    assert repository.get_latest("session-1") is not None
+
+
+def _insert_history_marker_row(
+    db_path: Path,
+    *,
+    marker_id: str,
+    session_id: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO session_history_markers(
+            marker_id,
+            session_id,
+            marker_type,
+            metadata_json,
+            created_at
+        )
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            marker_id,
+            session_id,
+            "clear",
+            "{}",
+            now,
+        ),
+    )
+    connection.commit()
+    connection.close()

--- a/tests/unit_tests/sessions/test_session_list_status.py
+++ b/tests/unit_tests/sessions/test_session_list_status.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
+import sqlite3
 
 from agent_teams.sessions.session_service import SessionService
 from agent_teams.agents.instances.instance_repository import AgentInstanceRepository
@@ -124,3 +126,175 @@ def test_list_sessions_uses_runtime_overlay_for_running_subagent(
     assert active.active_run_status == "paused"
     assert active.active_run_phase == "awaiting_subagent_followup"
     assert active.pending_tool_approval_count == 0
+
+
+def test_list_sessions_skips_invalid_persisted_run_runtime_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_list_status_invalid_runtime.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-active", workspace_id="default")
+
+    _seed_root_task(db_path, run_id="run-active", session_id="session-active")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-active",
+        session_id="session-active",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-active",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    _insert_invalid_run_runtime_row(
+        db_path,
+        run_id="run-invalid",
+        session_id="session-active",
+    )
+
+    sessions = service.list_sessions()
+    active = {record.session_id: record for record in sessions}["session-active"]
+
+    assert active.has_active_run is True
+    assert active.active_run_id == "run-active"
+    assert active.active_run_phase == "running"
+
+
+def test_list_sessions_skips_invalid_persisted_approval_ticket_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_list_status_invalid_approval.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-active", workspace_id="default")
+
+    _seed_root_task(db_path, run_id="run-active", session_id="session-active")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-active",
+        session_id="session-active",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-active",
+        status=RunRuntimeStatus.PAUSED,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    approval_repo = ApprovalTicketRepository(db_path)
+    approval_repo.upsert_requested(
+        tool_call_id="dispatch_task:1",
+        run_id="run-active",
+        session_id="session-active",
+        task_id="task-root-1",
+        instance_id="inst-1",
+        role_id="coordinator_agent",
+        tool_name="dispatch_task",
+        args_preview='{"task_id":"task-1"}',
+    )
+    _insert_invalid_approval_ticket_row(
+        db_path,
+        tool_call_id="dispatch_task:invalid",
+        run_id="run-active",
+        session_id="session-active",
+    )
+
+    sessions = service.list_sessions()
+    active = {record.session_id: record for record in sessions}["session-active"]
+
+    assert active.has_active_run is True
+    assert active.pending_tool_approval_count == 1
+
+
+def _insert_invalid_run_runtime_row(
+    db_path: Path,
+    *,
+    run_id: str,
+    session_id: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO run_runtime(
+            run_id,
+            session_id,
+            root_task_id,
+            status,
+            phase,
+            active_instance_id,
+            active_task_id,
+            active_role_id,
+            active_subagent_instance_id,
+            last_error,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            run_id,
+            session_id,
+            "task-bad",
+            RunRuntimeStatus.RUNNING.value,
+            RunRuntimePhase.COORDINATOR_RUNNING.value,
+            None,
+            None,
+            None,
+            None,
+            None,
+            now,
+            "None",
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+
+def _insert_invalid_approval_ticket_row(
+    db_path: Path,
+    *,
+    tool_call_id: str,
+    run_id: str,
+    session_id: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO approval_tickets(
+            tool_call_id,
+            signature_key,
+            run_id,
+            session_id,
+            task_id,
+            instance_id,
+            role_id,
+            tool_name,
+            args_preview,
+            status,
+            feedback,
+            created_at,
+            updated_at,
+            resolved_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            tool_call_id,
+            "sig-invalid",
+            run_id,
+            session_id,
+            "task-root-1",
+            "inst-1",
+            "coordinator_agent",
+            "dispatch_task",
+            "{}",
+            "requested",
+            "",
+            now,
+            "None",
+            None,
+        ),
+    )
+    connection.commit()
+    connection.close()

--- a/tests/unit_tests/sessions/test_session_repository.py
+++ b/tests/unit_tests/sessions/test_session_repository.py
@@ -125,6 +125,42 @@ def test_list_all_skips_rows_with_blank_session_id(tmp_path: Path) -> None:
     assert [record.session_id for record in records] == ["session-valid"]
 
 
+@pytest.mark.parametrize("session_id", ["None", "null"])
+def test_list_all_skips_rows_with_none_like_session_id(
+    tmp_path: Path,
+    session_id: str,
+) -> None:
+    db_path = tmp_path / "session_repository_none_like_session_id.db"
+    repository = SessionRepository(db_path)
+    _insert_session_row(
+        db_path,
+        session_id="session-valid",
+        metadata_json="{}",
+    )
+    _insert_session_row(
+        db_path,
+        session_id=session_id,
+        metadata_json="{}",
+    )
+
+    records = repository.list_all()
+
+    assert [record.session_id for record in records] == ["session-valid"]
+
+
+def test_get_raises_key_error_for_invalid_persisted_row(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_repository_invalid_get.db"
+    repository = SessionRepository(db_path)
+    _insert_session_row(
+        db_path,
+        session_id="None",
+        metadata_json="{}",
+    )
+
+    with pytest.raises(KeyError):
+        repository.get("None")
+
+
 @pytest.mark.parametrize("started_at", ["", "None", "null"])
 def test_repository_init_normalizes_missing_or_none_like_started_at_for_mark_started(
     tmp_path: Path,

--- a/tests/unit_tests/tools/runtime/test_approval_ticket_repo.py
+++ b/tests/unit_tests/tools/runtime/test_approval_ticket_repo.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sqlite3
+
+from agent_teams.tools.runtime.approval_ticket_repo import (
+    ApprovalTicketRepository,
+    ApprovalTicketStatus,
+)
+
+
+def test_approval_ticket_repo_skips_invalid_persisted_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "approval_ticket_invalid_rows.db"
+    repository = ApprovalTicketRepository(db_path)
+    _ = repository.upsert_requested(
+        tool_call_id="call-valid",
+        run_id="run-1",
+        session_id="session-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="writer",
+        tool_name="dispatch_task",
+        args_preview="{}",
+    )
+    _insert_approval_ticket_row(
+        db_path,
+        tool_call_id="call-invalid",
+        run_id="run-1",
+        session_id="session-1",
+        updated_at="None",
+    )
+
+    records = repository.list_open_by_session("session-1")
+
+    assert [record.tool_call_id for record in records] == ["call-valid"]
+    assert repository.get("call-invalid") is None
+
+
+def _insert_approval_ticket_row(
+    db_path: Path,
+    *,
+    tool_call_id: str,
+    run_id: str,
+    session_id: str,
+    updated_at: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO approval_tickets(
+            tool_call_id,
+            signature_key,
+            run_id,
+            session_id,
+            task_id,
+            instance_id,
+            role_id,
+            tool_name,
+            args_preview,
+            status,
+            feedback,
+            created_at,
+            updated_at,
+            resolved_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            tool_call_id,
+            "sig-invalid",
+            run_id,
+            session_id,
+            "task-2",
+            "inst-2",
+            "writer",
+            "dispatch_task",
+            "{}",
+            ApprovalTicketStatus.REQUESTED.value,
+            "",
+            now,
+            updated_at,
+            None,
+        ),
+    )
+    connection.commit()
+    connection.close()

--- a/tests/unit_tests/validation/__init__.py
+++ b/tests/unit_tests/validation/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/unit_tests/validation/test_identifiers.py
+++ b/tests/unit_tests/validation/test_identifiers.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ValidationError
+import pytest
+
+from agent_teams.validation import (
+    OptionalIdentifierStr,
+    RequiredIdentifierStr,
+    normalize_persisted_text,
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+
+class _RequiredIdentifierModel(BaseModel):
+    value: RequiredIdentifierStr
+
+
+class _OptionalIdentifierModel(BaseModel):
+    value: OptionalIdentifierStr = None
+
+
+@pytest.mark.parametrize("raw_value", ["", "   ", "None", "none", "Null", " null "])
+def test_required_identifier_rejects_blank_and_none_like_strings(
+    raw_value: str,
+) -> None:
+    with pytest.raises(ValidationError):
+        _RequiredIdentifierModel(value=raw_value)
+
+
+def test_required_identifier_strips_whitespace() -> None:
+    model = _RequiredIdentifierModel(value="  session-1  ")
+
+    assert model.value == "session-1"
+
+
+@pytest.mark.parametrize("raw_value", ["", "   ", "None", "NULL"])
+def test_optional_identifier_rejects_explicit_blank_and_none_like_strings(
+    raw_value: str,
+) -> None:
+    with pytest.raises(ValidationError):
+        _OptionalIdentifierModel(value=raw_value)
+
+
+def test_optional_identifier_allows_real_none() -> None:
+    model = _OptionalIdentifierModel(value=None)
+
+    assert model.value is None
+
+
+def test_persisted_helpers_normalize_none_like_values() -> None:
+    assert normalize_persisted_text(" None ") is None
+    assert normalize_persisted_text(" value ") == "value"
+    assert require_persisted_identifier(" run-1 ", field_name="run_id") == "run-1"
+    with pytest.raises(ValueError, match="Invalid persisted run_id"):
+        require_persisted_identifier("null", field_name="run_id")
+
+
+def test_parse_persisted_datetime_or_none_rejects_invalid_isoformat() -> None:
+    assert parse_persisted_datetime_or_none("None") is None
+    assert parse_persisted_datetime_or_none("not-a-datetime") is None
+    assert parse_persisted_datetime_or_none("2026-03-30T06:52:47+00:00") is not None

--- a/tests/unit_tests/wechat/test_account_repository.py
+++ b/tests/unit_tests/wechat/test_account_repository.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
+import sqlite3
 
+import pytest
 from agent_teams.sessions.runs.run_models import RunThinkingConfig
 from agent_teams.sessions.session_models import SessionMode
 from agent_teams.gateway.wechat import WeChatAccountRecord, WeChatAccountRepository
@@ -53,3 +56,80 @@ def test_wechat_account_repository_deletes_account(tmp_path: Path) -> None:
     repository.delete_account("wx_delete")
 
     assert repository.list_accounts() == ()
+
+
+def test_wechat_account_repository_skips_invalid_persisted_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "wechat_invalid_rows.db"
+    repository = WeChatAccountRepository(db_path)
+    _ = repository.upsert_account(
+        WeChatAccountRecord(
+            account_id="wx_valid",
+            display_name="Valid Account",
+        )
+    )
+    _insert_wechat_account_row(
+        db_path,
+        account_id="None",
+    )
+
+    records = repository.list_accounts()
+
+    assert [record.account_id for record in records] == ["wx_valid"]
+    with pytest.raises(KeyError):
+        repository.get_account("None")
+
+
+def _insert_wechat_account_row(
+    db_path: Path,
+    *,
+    account_id: str,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO wechat_accounts(
+            account_id,
+            display_name,
+            base_url,
+            cdn_base_url,
+            route_tag,
+            status,
+            remote_user_id,
+            sync_cursor,
+            workspace_id,
+            session_mode,
+            normal_root_role_id,
+            orchestration_preset_id,
+            yolo,
+            thinking_json,
+            last_login_at,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            account_id,
+            "Broken Account",
+            "https://wechat.example.test",
+            "https://cdn.example.test",
+            None,
+            "enabled",
+            None,
+            "",
+            "default",
+            "normal",
+            None,
+            None,
+            1,
+            "{}",
+            None,
+            now,
+            now,
+        ),
+    )
+    connection.commit()
+    connection.close()

--- a/tests/unit_tests/workspace/test_repository.py
+++ b/tests/unit_tests/workspace/test_repository.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from pathlib import Path
+import sqlite3
 
+import pytest
 from agent_teams.workspace import WorkspaceRepository
 
 
@@ -31,3 +34,51 @@ def test_workspace_repository_supports_concurrent_reads(tmp_path: Path) -> None:
 
     assert len(results) == 128
     assert all(result == (True, True, "project-alpha") for result in results)
+
+
+def test_workspace_repository_skips_invalid_persisted_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "workspace_invalid_rows.db"
+    root_path = tmp_path / "workspace-root"
+    root_path.mkdir()
+    repository = WorkspaceRepository(db_path)
+    _ = repository.create(
+        workspace_id="project-alpha",
+        root_path=root_path,
+    )
+    _insert_workspace_row(
+        db_path,
+        workspace_id="None",
+        root_path=root_path,
+    )
+
+    records = repository.list_all()
+
+    assert [record.workspace_id for record in records] == ["project-alpha"]
+    with pytest.raises(KeyError):
+        repository.get("None")
+
+
+def _insert_workspace_row(
+    db_path: Path,
+    *,
+    workspace_id: str,
+    root_path: Path,
+) -> None:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        INSERT INTO workspaces(workspace_id, root_path, backend, profile_json, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            workspace_id,
+            str(root_path),
+            "filesystem",
+            "{}",
+            now,
+            now,
+        ),
+    )
+    connection.commit()
+    connection.close()


### PR DESCRIPTION
## Summary
- add shared identifier validators that reject blank, `"None"`, and `"null"` string values while still allowing real `null` for optional identifier fields
- apply the shared identifier types across session, run, workspace, gateway, automation, and related core models and `/api/*` request paths
- harden persisted-row readers so invalid identifiers or timestamps in historical sqlite rows are logged and skipped instead of crashing APIs such as `/api/sessions`
- add regression coverage for router `422` behavior, repository dirty-row tolerance, and session list aggregation when `run_runtime` or `approval_tickets` contain bad rows
- update API and database docs to document the new identifier contract and dirty-data tolerance behavior

## Verification
- `uv run --extra dev python -m compileall src/agent_teams tests/unit_tests`
- `uv run --extra dev ruff check --fix src tests`
- `uv run --extra dev ruff format --no-cache --force-exclude src tests`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`

## Issue linkage
- searched for existing issues in `coolplayagent/agent-teams` around `session_id=None`, identifier validation, and persisted dirty-row crashes
- no matching open issue was found, so this PR is not linked to an existing issue