### PR TITLE
Unify gateway session ingress across IM, automation, and ACP

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -1295,6 +1295,9 @@ Behavior:
   `收到来自 {sender_name} 的飞书消息：{message}` with `sender_open_id` fallback.
 - Deduplicates delivery using Feishu `message_id`, falling back to `event_id`.
 - Same-chat inbound messages are processed in queue order.
+- Inbound Feishu messages enter the shared gateway session ingress path and start
+  detached runs only when the bound internal session is idle.
+- A Feishu message never implicitly attaches to an already running session run.
 - Accepted group messages use a Feishu reaction acknowledgement with emoji `eyes`.
 - Only queued messages send a separate text reply: `已进入队列，前面还有 N 条消息。`
 - Group command responses and group final run replies use Feishu reply-to-message on the triggering message.
@@ -1393,6 +1396,9 @@ Each record includes:
 Notes:
 - WeChat is managed as a long-lived conversational gateway, not as a trigger.
 - Current implementation handles direct chat only. Group chat routing is reserved for later expansion.
+- Accepted WeChat direct messages are persisted into a local inbound queue before run start.
+- WeChat inbound messages also use the shared gateway session ingress path, so busy
+  sessions queue later messages instead of auto-attaching them to the active run.
 
 ### `POST /gateway/wechat/login/start`
 
@@ -1590,6 +1596,12 @@ session; projects with a Feishu delivery binding reuse the exact saved bound ses
 Response fields:
 - `automation_project_id`
 - `session_id`
+
+Behavior notes:
+- Bound-session automation execution also goes through the shared gateway session
+  ingress path and always starts detached runs.
+- If the bound session is busy, the automation job queues behind the current
+  session backlog instead of inserting prompt text into the active run.
 
 ### `POST /automation/projects/{automation_project_id}:enable`
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -558,6 +558,51 @@ Notes:
 - `workspace_id`, `session_mode`, `normal_root_role_id`, and `orchestration_preset_id` define the runtime preset applied to new or resolved gateway sessions for that account
 - runtime status fields such as `running` and `last_error` are computed in memory and returned by the API, not persisted in this table
 
+### 2.10.3 `wechat_inbound_queue`
+
+```sql
+CREATE TABLE IF NOT EXISTS wechat_inbound_queue (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    inbound_queue_id   TEXT NOT NULL UNIQUE,
+    account_id         TEXT NOT NULL,
+    message_key        TEXT NOT NULL,
+    gateway_session_id TEXT NOT NULL,
+    session_id         TEXT NOT NULL,
+    peer_user_id       TEXT NOT NULL,
+    context_token      TEXT,
+    text               TEXT NOT NULL,
+    status             TEXT NOT NULL,
+    run_id             TEXT,
+    last_error         TEXT,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL,
+    completed_at       TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_wechat_inbound_queue_message
+    ON wechat_inbound_queue(account_id, peer_user_id, message_key);
+
+CREATE INDEX IF NOT EXISTS idx_wechat_inbound_queue_session
+    ON wechat_inbound_queue(session_id, id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_wechat_inbound_queue_status
+    ON wechat_inbound_queue(status, id ASC);
+```
+
+Purpose: persists inbound WeChat direct messages before they enter the shared gateway
+session ingress path so same-session traffic queues deterministically and survives
+process restarts.
+
+Notes:
+- `message_key` is the durable deduplication key derived from upstream message ids,
+  sequence numbers, or fallback metadata
+- `gateway_session_id` points back to the transport-facing WeChat gateway session row
+- `status` flows through `queued`, `waiting_result`, then a terminal state
+- `run_id` is populated only after the shared gateway ingress path successfully starts
+  the detached run for that message
+- queued WeChat messages never auto-attach to an already active session run
+- `last_error` captures terminal start/reply failures for that inbound item
+
 ---
 
 ## 3. Relationship Keys
@@ -573,7 +618,8 @@ Primary query keys used by repositories:
 - `gateway_session_id`: external channel session retrieval across `gateway_sessions`.
 - `external_session_id`: channel-scoped lookup key for reconnect and session resume flows.
 - `account_id`: Feishu gateway account retrieval across `feishu_gateway_accounts`.
-- `account_id`: WeChat gateway account retrieval across `wechat_accounts`.
+- `account_id`: WeChat gateway account retrieval across `wechat_accounts`,
+  `wechat_inbound_queue`.
 
 ---
 
@@ -592,7 +638,7 @@ Primary query keys used by repositories:
 - `agent_teams.gateway.feishu`: `feishu_gateway_accounts`, `feishu_message_pool`.
 - `agent_teams.automation`: `automation_execution_events`.
 - `agent_teams.gateway`: `gateway_sessions`.
-- `agent_teams.wechat`: `wechat_accounts`.
+- `agent_teams.gateway.wechat`: `wechat_accounts`, `wechat_inbound_queue`.
 - `agent_teams.roles`: `role_memories`.
 
 ---
@@ -870,6 +916,7 @@ CREATE TABLE IF NOT EXISTS automation_deliveries (
     terminal_attempts INTEGER NOT NULL,
     started_message TEXT,
     terminal_message TEXT,
+    reply_to_message_id TEXT,
     started_message_id TEXT,
     terminal_message_id TEXT,
     started_sent_at TEXT,
@@ -893,8 +940,9 @@ CREATE INDEX IF NOT EXISTS idx_automation_deliveries_terminal
 Purpose: persists Feishu delivery state for automation runs so started/completed/failed messages can be retried and resumed after process restart.
 
 Notes:
+- `reply_to_message_id` stores the persisted receipt that later automation output should reply to when the run did not create its own started receipt.
 - `started_message_id` and `terminal_message_id` store the provider `message_id` returned by Feishu for sent automation messages.
-- `started_cleanup_status`, `started_cleanup_attempts`, and `started_cleaned_at` track best-effort cleanup for superseded non-terminal started messages after a terminal delivery succeeds.
+- `started_cleanup_status`, `started_cleanup_attempts`, and `started_cleaned_at` remain for compatibility with older rows, but new receipts are not automatically deleted by the current cleanup policy.
 - terminal messages are persisted but are not automatically deleted by the current cleanup policy.
 
 ### 2.1.4 `automation_bound_session_queue`
@@ -950,7 +998,7 @@ Notes:
 - `status` flows through `queued`, `starting`, `waiting_result`, then a terminal state
 - `resume_attempts` and `resume_next_attempt_at` persist the auto-resume retry state for recoverable `awaiting_recovery` runs bound to that session
 - `queue_message_id` stores the Feishu provider `message_id` for the queue receipt
-- `queue_cleanup_status`, `queue_cleanup_attempts`, and `queue_cleaned_at` track best-effort deletion of queue receipts once the queued run starts or a final failure message replaces them
+- `queue_cleanup_status`, `queue_cleanup_attempts`, and `queue_cleaned_at` remain for compatibility with older rows, but current queue receipts are retained in chat instead of being auto-deleted
 
 ### 2.1.5 `sessions` additions
 

--- a/docs/feishu-integration.md
+++ b/docs/feishu-integration.md
@@ -145,6 +145,11 @@ Behavior:
 - deduplication still uses the Feishu `message_id`, falling back to `event_id`
 - duplicate deliveries do not send a second acknowledgement
 - same-chat messages are processed in order
+- inbound Feishu messages enter the shared gateway session ingress path before run start
+- inbound Feishu messages never auto-attach to an already running session run
+- if the bound session is already occupied by a queued/running automation-bound task, the
+  Feishu message stays queued behind that same session backlog instead of being inserted
+  into the active run
 - accepted group and p2p messages use a Feishu message reaction acknowledgement
   - default reaction emoji: `OK`
 - only queued messages emit a separate text reply
@@ -165,19 +170,15 @@ rule from inbound chat messages:
   work and the bound chat receives `定时任务 {display_name} 准备执行，当前任务前面有 n 个消息`
 - if that saved session later disappears or becomes unusable, the automation run
   fails and does not fall back to a new `MainAgent` automation session
-- for these automation-bound runs, receipts, terminal result messages, and `im_send`
-  tool output all use direct send to the chat, not reply-to-message, even in group chats
+- for these automation-bound runs, queue/start receipts remain visible in the chat
+- terminal result messages and `im_send` tool output reply to the persisted receipt
+  message when one exists; otherwise they fall back to a direct send
 - when a bound run enters recoverable `awaiting_recovery`, the bound-session queue
   persists auto-resume retry state and retries `resume` with exponential backoff
   (`10s`, `20s`, `40s`, `80s`, `160s`) before sending a final failure
 - Feishu provider `message_id` values are persisted for automation queue receipts and
-  started/terminal messages so superseded non-terminal messages can be deleted later
-- queue receipts are best-effort deleted after the queued run actually starts or after
-  a final queue-owned failure replaces them
-- started automation messages are best-effort deleted after a terminal completed/failed
-  message is successfully sent
-- cleanup failures are logged and retried, but they do not roll back the primary send
-  or change the run's terminal state
+  started/terminal messages so later automation output can target the same receipt
+- queue and started receipts are not automatically deleted by the current policy
 
 This separates three concerns:
 

--- a/docs/wechat-integration.md
+++ b/docs/wechat-integration.md
@@ -4,11 +4,8 @@
 
 Agent Teams supports WeChat as a conversational `gateway` channel.
 
-This differs from Feishu:
-
-- WeChat inbound chat goes through `gateway -> session/run`
-- Feishu inbound chat currently still uses the `triggers` backend path
-- the settings UI groups both under the Gateway section, but the backend ownership is different
+This now shares the same internal session-ingress orchestration used by Feishu,
+automation-bound session delivery, and gateway ACP.
 
 The current WeChat scope is:
 
@@ -43,8 +40,10 @@ Enabled accounts run a background long-poll worker. For each accepted message:
 1. the worker polls `getupdates`
 2. the service extracts direct-message text content
 3. `GatewaySessionService.resolve_or_create_session(...)` maps `wechat:{account_id}:{peer_user_id}` to one internal session
-4. the backend creates or reuses a run for that session
-5. terminal run output is sent back through WeChat `sendmessage`
+4. the message is persisted into `wechat_inbound_queue`
+5. the shared gateway session ingress path starts a detached run only when that internal session is idle
+6. if the session is already busy, the message stays queued and the user receives a queue receipt instead of being auto-attached to the active run
+7. terminal run output is sent back through WeChat `sendmessage`
 
 ## Login Flow
 

--- a/src/agent_teams/automation/automation_bound_session_queue_service.py
+++ b/src/agent_teams/automation/automation_bound_session_queue_service.py
@@ -21,6 +21,11 @@ from agent_teams.automation.automation_models import (
     AutomationProjectRecord,
     AutomationRunConfig,
 )
+from agent_teams.gateway.session_ingress_service import (
+    GatewaySessionIngressBusyPolicy,
+    GatewaySessionIngressRequest,
+    GatewaySessionIngressService,
+)
 from agent_teams.gateway.feishu.models import FEISHU_PLATFORM, FeishuEnvironment
 from agent_teams.logger import get_logger, log_event
 from agent_teams.automation.prompt_building import build_automation_prompt
@@ -41,7 +46,6 @@ logger = get_logger(__name__)
 
 _START_MAX_ATTEMPTS = 5
 _RESUME_MAX_ATTEMPTS = 5
-_QUEUE_CLEANUP_MAX_ATTEMPTS = 5
 _CLAIM_STALE_AFTER_SECONDS = 60
 
 
@@ -84,12 +88,13 @@ class FeishuClientLike(Protocol):
         environment: FeishuEnvironment | None = None,
     ) -> str: ...
 
-    def delete_message(
+    def reply_text_message(
         self,
         *,
         message_id: str,
+        text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> str: ...
 
 
 class AutomationProjectLookup(Protocol):
@@ -110,6 +115,7 @@ class AutomationBoundSessionQueueService:
         runtime_config_lookup: FeishuRuntimeConfigLookup,
         feishu_client: FeishuClientLike,
         project_repository: AutomationProjectLookup,
+        session_ingress_service: GatewaySessionIngressService | None = None,
     ) -> None:
         self._repository = repository
         self._session_lookup = session_lookup
@@ -119,6 +125,7 @@ class AutomationBoundSessionQueueService:
         self._runtime_config_lookup = runtime_config_lookup
         self._feishu_client = feishu_client
         self._project_repository = project_repository
+        self._session_ingress_service = session_ingress_service
 
     def materialize_execution(
         self,
@@ -300,10 +307,9 @@ class AutomationBoundSessionQueueService:
                     project_name=record.automation_project_name,
                     error=str(runtime.last_error or "").strip(),
                 )
-                _ = self._send_direct_text(
-                    record.binding.trigger_id,
-                    record.binding.chat_id,
-                    failure_message,
+                _ = self._send_record_text(
+                    record=record,
+                    text=failure_message,
                 )
                 _ = self._schedule_queue_cleanup(
                     final_record,
@@ -349,6 +355,7 @@ class AutomationBoundSessionQueueService:
                     binding=claimed.binding,
                     delivery_events=claimed.delivery_events,
                     send_started=False,
+                    reply_to_message_id=claimed.queue_message_id,
                 )
             except RuntimeError as exc:
                 self._handle_start_failure(claimed, error=str(exc))
@@ -391,28 +398,39 @@ class AutomationBoundSessionQueueService:
         binding: AutomationFeishuBinding,
         delivery_events: tuple[AutomationDeliveryEvent, ...],
         send_started: bool,
+        reply_to_message_id: str | None = None,
     ) -> str:
         _ = self._ensure_session_workspace(
             session_id=session_id,
             workspace_id=workspace_id,
         )
-        run_id, _ = self._run_service.create_detached_run(
-            IntentInput(
-                session_id=session_id,
-                input=content_parts_from_text(prompt),
-                execution_mode=run_config.execution_mode,
-                yolo=run_config.yolo,
-                reuse_root_instance=False,
-                thinking=run_config.thinking,
-                conversation_context=RuntimePromptConversationContext(
-                    source_provider=FEISHU_PLATFORM,
-                    source_kind="im",
-                    feishu_chat_type=binding.chat_type,
-                    im_force_direct_send=True,
-                ),
-            )
+        intent = IntentInput(
+            session_id=session_id,
+            input=content_parts_from_text(prompt),
+            execution_mode=run_config.execution_mode,
+            yolo=run_config.yolo,
+            reuse_root_instance=False,
+            thinking=run_config.thinking,
+            conversation_context=RuntimePromptConversationContext(
+                source_provider=FEISHU_PLATFORM,
+                source_kind="im",
+                feishu_chat_type=binding.chat_type,
+                im_reply_to_message_id=reply_to_message_id,
+            ),
         )
-        self._run_service.ensure_run_started(run_id)
+        if self._session_ingress_service is not None:
+            result = self._session_ingress_service.require_started(
+                GatewaySessionIngressRequest(
+                    intent=intent,
+                    busy_policy=GatewaySessionIngressBusyPolicy.START_IF_IDLE,
+                )
+            )
+            if result.run_id is None:
+                raise RuntimeError("automation_bound_run_not_started")
+            run_id = result.run_id
+        else:
+            run_id, _ = self._run_service.create_detached_run(intent)
+            self._run_service.ensure_run_started(run_id)
         _ = self._delivery_service.register_run(
             project=None,
             session_id=session_id,
@@ -423,6 +441,7 @@ class AutomationBoundSessionQueueService:
             binding=binding,
             delivery_events=delivery_events,
             send_started=send_started,
+            reply_to_message_id=reply_to_message_id,
         )
         return run_id
 
@@ -446,10 +465,9 @@ class AutomationBoundSessionQueueService:
                     }
                 )
             )
-            _ = self._send_direct_text(
-                record.binding.trigger_id,
-                record.binding.chat_id,
-                _build_start_failure_message(
+            _ = self._send_record_text(
+                record=record,
+                text=_build_start_failure_message(
                     project_name=record.automation_project_name,
                     error=error,
                 ),
@@ -523,10 +541,9 @@ class AutomationBoundSessionQueueService:
                 project_name=record.automation_project_name,
                 error=str(runtime.last_error or record.last_error or "").strip(),
             )
-            _ = self._send_direct_text(
-                record.binding.trigger_id,
-                record.binding.chat_id,
-                failure_message,
+            _ = self._send_record_text(
+                record=record,
+                text=failure_message,
             )
             _ = self._schedule_queue_cleanup(
                 failed_record,
@@ -557,10 +574,9 @@ class AutomationBoundSessionQueueService:
                     project_name=record.automation_project_name,
                     error=str(exc),
                 )
-                _ = self._send_direct_text(
-                    record.binding.trigger_id,
-                    record.binding.chat_id,
-                    failure_message,
+                _ = self._send_record_text(
+                    record=record,
+                    text=failure_message,
                 )
                 _ = self._schedule_queue_cleanup(
                     failed_record,
@@ -638,16 +654,12 @@ class AutomationBoundSessionQueueService:
     ) -> AutomationBoundSessionQueueRecord:
         if not str(record.queue_message_id or "").strip():
             return record
-        if record.queue_cleanup_status in {
-            AutomationCleanupStatus.CLEANING,
-            AutomationCleanupStatus.CLEANED,
-            AutomationCleanupStatus.PENDING,
-        }:
+        if record.queue_cleanup_status == AutomationCleanupStatus.SKIPPED:
             return record
         return self._repository.update(
             record.model_copy(
                 update={
-                    "queue_cleanup_status": AutomationCleanupStatus.PENDING,
+                    "queue_cleanup_status": AutomationCleanupStatus.SKIPPED,
                     "updated_at": updated_at,
                 }
             )
@@ -660,68 +672,11 @@ class AutomationBoundSessionQueueService:
             limit=limit,
             stale_before=stale_before,
         ):
-            message_id = str(record.queue_message_id or "").strip()
-            if not message_id:
-                now = _utc_now()
-                _ = self._repository.update(
-                    record.model_copy(
-                        update={
-                            "queue_cleanup_status": AutomationCleanupStatus.SKIPPED,
-                            "updated_at": now,
-                        }
-                    )
-                )
-                progress = True
-                continue
-            claimed = self._repository.claim_queue_cleanup(
-                automation_queue_id=record.automation_queue_id,
-                stale_before=stale_before,
-            )
-            if claimed is None:
-                continue
-            attempts = claimed.queue_cleanup_attempts + 1
-            try:
-                self._delete_message(
-                    claimed.binding.trigger_id,
-                    message_id,
-                )
-            except RuntimeError as exc:
-                next_status = (
-                    AutomationCleanupStatus.FAILED
-                    if attempts >= _QUEUE_CLEANUP_MAX_ATTEMPTS
-                    else AutomationCleanupStatus.PENDING
-                )
-                now = _utc_now()
-                _ = self._repository.update(
-                    claimed.model_copy(
-                        update={
-                            "queue_cleanup_status": next_status,
-                            "queue_cleanup_attempts": attempts,
-                            "updated_at": now,
-                        }
-                    )
-                )
-                log_event(
-                    logger,
-                    logging.WARNING,
-                    event="automation.bound_session_queue.cleanup_failed",
-                    message="Automation queue receipt cleanup failed",
-                    payload={
-                        "automation_queue_id": claimed.automation_queue_id,
-                        "message_id": message_id,
-                        "attempt": attempts,
-                        "error": str(exc),
-                    },
-                )
-                progress = True
-                continue
             now = _utc_now()
             _ = self._repository.update(
-                claimed.model_copy(
+                record.model_copy(
                     update={
-                        "queue_cleanup_status": AutomationCleanupStatus.CLEANED,
-                        "queue_cleanup_attempts": attempts,
-                        "queue_cleaned_at": now,
+                        "queue_cleanup_status": AutomationCleanupStatus.SKIPPED,
                         "updated_at": now,
                     }
                 )
@@ -763,6 +718,30 @@ class AutomationBoundSessionQueueService:
             environment=runtime_config.environment,
         )
 
+    def _send_record_text(
+        self,
+        *,
+        record: AutomationBoundSessionQueueRecord,
+        text: str,
+    ) -> str:
+        runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
+            record.binding.trigger_id
+        )
+        if runtime_config is None:
+            raise RuntimeError("missing_runtime_config")
+        reply_to_message_id = str(record.queue_message_id or "").strip()
+        if reply_to_message_id:
+            return self._feishu_client.reply_text_message(
+                message_id=reply_to_message_id,
+                text=text,
+                environment=runtime_config.environment,
+            )
+        return self._feishu_client.send_text_message(
+            chat_id=record.binding.chat_id,
+            text=text,
+            environment=runtime_config.environment,
+        )
+
     def _ensure_session_workspace(
         self,
         *,
@@ -790,17 +769,6 @@ class AutomationBoundSessionQueueService:
             raise RuntimeError(
                 f"missing_automation_project:{automation_project_id}"
             ) from None
-
-    def _delete_message(self, trigger_id: str, message_id: str) -> None:
-        runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
-            trigger_id
-        )
-        if runtime_config is None:
-            raise RuntimeError("missing_runtime_config")
-        self._feishu_client.delete_message(
-            message_id=message_id,
-            environment=runtime_config.environment,
-        )
 
 
 class AutomationBoundSessionQueueWorker:

--- a/src/agent_teams/automation/automation_delivery_repository.py
+++ b/src/agent_teams/automation/automation_delivery_repository.py
@@ -45,6 +45,7 @@ class AutomationDeliveryRepository:
                     terminal_attempts INTEGER NOT NULL,
                     started_message TEXT,
                     terminal_message TEXT,
+                    reply_to_message_id TEXT,
                     started_message_id TEXT,
                     terminal_message_id TEXT,
                     started_sent_at TEXT,
@@ -75,6 +76,11 @@ class AutomationDeliveryRepository:
                 CREATE INDEX IF NOT EXISTS idx_automation_deliveries_terminal
                 ON automation_deliveries(terminal_status, updated_at ASC)
                 """
+            )
+            self._ensure_column(
+                "automation_deliveries",
+                "reply_to_message_id",
+                "TEXT",
             )
             self._ensure_column(
                 "automation_deliveries",
@@ -141,6 +147,7 @@ class AutomationDeliveryRepository:
                     terminal_attempts,
                     started_message,
                     terminal_message,
+                    reply_to_message_id,
                     started_message_id,
                     terminal_message_id,
                     started_sent_at,
@@ -152,7 +159,7 @@ class AutomationDeliveryRepository:
                     created_at,
                     updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._to_row(record),
             ),
@@ -184,6 +191,7 @@ class AutomationDeliveryRepository:
                     terminal_attempts=?,
                     started_message=?,
                     terminal_message=?,
+                    reply_to_message_id=?,
                     started_message_id=?,
                     terminal_message_id=?,
                     started_sent_at=?,
@@ -211,6 +219,7 @@ class AutomationDeliveryRepository:
                     record.terminal_attempts,
                     record.started_message,
                     record.terminal_message,
+                    record.reply_to_message_id,
                     record.started_message_id,
                     record.terminal_message_id,
                     _to_iso(record.started_sent_at),
@@ -517,6 +526,7 @@ class AutomationDeliveryRepository:
             record.terminal_attempts,
             record.started_message,
             record.terminal_message,
+            record.reply_to_message_id,
             record.started_message_id,
             record.terminal_message_id,
             _to_iso(record.started_sent_at),
@@ -557,6 +567,11 @@ class AutomationDeliveryRepository:
             terminal_message=(
                 str(row["terminal_message"])
                 if row["terminal_message"] is not None
+                else None
+            ),
+            reply_to_message_id=(
+                str(row["reply_to_message_id"])
+                if row["reply_to_message_id"] is not None
                 else None
             ),
             started_message_id=(

--- a/src/agent_teams/automation/automation_delivery_service.py
+++ b/src/agent_teams/automation/automation_delivery_service.py
@@ -20,6 +20,7 @@ from agent_teams.automation.automation_models import (
 )
 from agent_teams.gateway.feishu.models import FeishuEnvironment
 from agent_teams.logger import get_logger, log_event
+from agent_teams.notifications import NotificationContext, NotificationType
 from agent_teams.sessions.runs.event_log import EventLog
 from agent_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
@@ -36,7 +37,6 @@ logger = get_logger(__name__)
 
 _STARTED_MAX_ATTEMPTS = 3
 _TERMINAL_MAX_ATTEMPTS = 5
-_CLEANUP_MAX_ATTEMPTS = 5
 _CLAIM_STALE_AFTER_SECONDS = 60
 
 
@@ -60,12 +60,25 @@ class FeishuClientLike(Protocol):
         environment: FeishuEnvironment | None = None,
     ) -> str: ...
 
-    def delete_message(
+    def reply_text_message(
         self,
         *,
         message_id: str,
+        text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> str: ...
+
+
+class NotificationServiceLike(Protocol):
+    def emit(
+        self,
+        *,
+        notification_type: NotificationType,
+        title: str,
+        body: str,
+        context: NotificationContext,
+        dedupe_key: str | None = None,
+    ) -> bool: ...
 
 
 class AutomationDeliveryService:
@@ -77,12 +90,14 @@ class AutomationDeliveryService:
         feishu_client: FeishuClientLike,
         run_runtime_repo: RunRuntimeRepository,
         event_log: EventLog,
+        notification_service: NotificationServiceLike | None = None,
     ) -> None:
         self._repository = repository
         self._runtime_config_lookup = runtime_config_lookup
         self._feishu_client = feishu_client
         self._run_runtime_repo = run_runtime_repo
         self._event_log = event_log
+        self._notification_service = notification_service
 
     def register_run(
         self,
@@ -96,6 +111,7 @@ class AutomationDeliveryService:
         binding: AutomationFeishuBinding | None = None,
         delivery_events: tuple[AutomationDeliveryEvent, ...] | None = None,
         send_started: bool = True,
+        reply_to_message_id: str | None = None,
     ) -> AutomationRunDeliveryRecord | None:
         resolved_binding = (
             binding
@@ -125,6 +141,7 @@ class AutomationDeliveryService:
                 reason=reason,
                 binding=resolved_binding,
                 delivery_events=resolved_events,
+                reply_to_message_id=reply_to_message_id,
                 started_status=(
                     AutomationDeliveryStatus.PENDING
                     if send_started
@@ -174,6 +191,24 @@ class AutomationDeliveryService:
 
     def delete_project_deliveries(self, automation_project_id: str) -> None:
         self._repository.delete_by_project(automation_project_id)
+
+    def should_suppress_terminal_notification(self, run_id: str | None) -> bool:
+        normalized_run_id = str(run_id or "").strip()
+        if not normalized_run_id:
+            return False
+        try:
+            record = self._repository.get_by_run_id(normalized_run_id)
+        except KeyError:
+            return False
+        if record.terminal_status in {
+            AutomationDeliveryStatus.PENDING,
+            AutomationDeliveryStatus.SENDING,
+            AutomationDeliveryStatus.SENT,
+        }:
+            return True
+        if record.terminal_status == AutomationDeliveryStatus.FAILED:
+            return False
+        return bool(str(record.terminal_message or "").strip())
 
     def mark_terminal_delivery_skipped(
         self,
@@ -306,11 +341,16 @@ class AutomationDeliveryService:
             )
             return True
         attempts = claimed.terminal_attempts + 1
+        reply_to_message_id = (
+            str(claimed.started_message_id or "").strip()
+            or str(claimed.reply_to_message_id or "").strip()
+        )
         try:
             message_id = self._send_text(
                 trigger_id=claimed.binding.trigger_id,
                 chat_id=claimed.binding.chat_id,
                 text=terminal_message,
+                reply_to_message_id=reply_to_message_id or None,
             )
         except RuntimeError as exc:
             now = _utc_now()
@@ -319,7 +359,7 @@ class AutomationDeliveryService:
                 if attempts >= _TERMINAL_MAX_ATTEMPTS
                 else AutomationDeliveryStatus.PENDING
             )
-            _ = self._repository.update(
+            persisted = self._repository.update(
                 claimed.model_copy(
                     update={
                         "terminal_event": terminal_event,
@@ -331,6 +371,11 @@ class AutomationDeliveryService:
                     }
                 )
             )
+            if next_status == AutomationDeliveryStatus.FAILED:
+                self._emit_fallback_terminal_notification(
+                    record=persisted,
+                    runtime_status=runtime.status,
+                )
             return True
         now = _utc_now()
         _ = self._repository.update(
@@ -342,11 +387,7 @@ class AutomationDeliveryService:
                     "terminal_attempts": attempts,
                     "terminal_status": AutomationDeliveryStatus.SENT,
                     "terminal_sent_at": now,
-                    "started_cleanup_status": (
-                        AutomationCleanupStatus.PENDING
-                        if str(claimed.started_message_id or "").strip()
-                        else claimed.started_cleanup_status
-                    ),
+                    "started_cleanup_status": AutomationCleanupStatus.SKIPPED,
                     "last_error": None,
                     "updated_at": now,
                 }
@@ -360,94 +401,74 @@ class AutomationDeliveryService:
             AutomationCleanupStatus.CLEANING,
         }:
             return False
-        message_id = str(record.started_message_id or "").strip()
-        if not message_id:
-            now = _utc_now()
-            _ = self._repository.update(
-                record.model_copy(
-                    update={
-                        "started_cleanup_status": AutomationCleanupStatus.SKIPPED,
-                        "updated_at": now,
-                    }
-                )
-            )
-            return True
-        claim_cutoff = _utc_now() - timedelta(seconds=_CLAIM_STALE_AFTER_SECONDS)
-        claimed = self._repository.claim_started_cleanup(
-            automation_delivery_id=record.automation_delivery_id,
-            stale_before=claim_cutoff,
-        )
-        if claimed is None:
-            return False
-        attempts = claimed.started_cleanup_attempts + 1
-        try:
-            self._delete_message(
-                trigger_id=claimed.binding.trigger_id,
-                message_id=message_id,
-            )
-        except RuntimeError as exc:
-            next_status = (
-                AutomationCleanupStatus.FAILED
-                if attempts >= _CLEANUP_MAX_ATTEMPTS
-                else AutomationCleanupStatus.PENDING
-            )
-            now = _utc_now()
-            _ = self._repository.update(
-                claimed.model_copy(
-                    update={
-                        "started_cleanup_status": next_status,
-                        "started_cleanup_attempts": attempts,
-                        "updated_at": now,
-                    }
-                )
-            )
-            log_event(
-                logger,
-                logging.WARNING,
-                event="automation.delivery.cleanup_failed",
-                message="Automation started-message cleanup failed",
-                payload={
-                    "run_id": claimed.run_id,
-                    "message_id": message_id,
-                    "attempt": attempts,
-                    "error": str(exc),
-                },
-            )
-            return True
         now = _utc_now()
         _ = self._repository.update(
-            claimed.model_copy(
+            record.model_copy(
                 update={
-                    "started_cleanup_status": AutomationCleanupStatus.CLEANED,
-                    "started_cleanup_attempts": attempts,
-                    "started_cleaned_at": now,
+                    "started_cleanup_status": AutomationCleanupStatus.SKIPPED,
                     "updated_at": now,
                 }
             )
         )
         return True
 
-    def _send_text(self, *, trigger_id: str, chat_id: str, text: str) -> str:
+    def _send_text(
+        self,
+        *,
+        trigger_id: str,
+        chat_id: str,
+        text: str,
+        reply_to_message_id: str | None = None,
+    ) -> str:
         runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
             trigger_id
         )
         if runtime_config is None:
             raise RuntimeError("missing_runtime_config")
+        normalized_reply_to_message_id = str(reply_to_message_id or "").strip()
+        if normalized_reply_to_message_id:
+            return self._feishu_client.reply_text_message(
+                message_id=normalized_reply_to_message_id,
+                text=text,
+                environment=runtime_config.environment,
+            )
         return self._feishu_client.send_text_message(
             chat_id=chat_id,
             text=text,
             environment=runtime_config.environment,
         )
 
-    def _delete_message(self, *, trigger_id: str, message_id: str) -> None:
-        runtime_config = self._runtime_config_lookup.get_runtime_config_by_trigger_id(
-            trigger_id
+    def _emit_fallback_terminal_notification(
+        self,
+        *,
+        record: AutomationRunDeliveryRecord,
+        runtime_status: RunRuntimeStatus,
+    ) -> None:
+        if self._notification_service is None:
+            return
+        notification_type = (
+            NotificationType.RUN_COMPLETED
+            if runtime_status == RunRuntimeStatus.COMPLETED
+            else NotificationType.RUN_FAILED
         )
-        if runtime_config is None:
-            raise RuntimeError("missing_runtime_config")
-        self._feishu_client.delete_message(
-            message_id=message_id,
-            environment=runtime_config.environment,
+        title = (
+            "Run Completed"
+            if notification_type == NotificationType.RUN_COMPLETED
+            else "Run Failed"
+        )
+        body = str(record.terminal_message or "").strip()
+        if not body:
+            return
+        _ = self._notification_service.emit(
+            notification_type=notification_type,
+            title=title,
+            body=body,
+            context=NotificationContext(
+                session_id=record.session_id,
+                run_id=record.run_id,
+                trace_id=record.run_id,
+            ),
+            dedupe_key=f"automation-terminal-fallback:{record.run_id}",
         )
 
 

--- a/src/agent_teams/automation/automation_models.py
+++ b/src/agent_teams/automation/automation_models.py
@@ -183,6 +183,7 @@ class AutomationRunDeliveryRecord(BaseModel):
     terminal_attempts: int = Field(default=0, ge=0)
     started_message: str | None = None
     terminal_message: str | None = None
+    reply_to_message_id: OptionalIdentifierStr = None
     started_message_id: OptionalIdentifierStr = None
     terminal_message_id: OptionalIdentifierStr = None
     started_sent_at: datetime | None = None

--- a/src/agent_teams/automation/automation_service.py
+++ b/src/agent_teams/automation/automation_service.py
@@ -34,6 +34,11 @@ from agent_teams.automation.automation_repository import (
 from agent_teams.automation.feishu_binding_service import (
     AutomationFeishuBindingService,
 )
+from agent_teams.gateway.session_ingress_service import (
+    GatewaySessionIngressBusyPolicy,
+    GatewaySessionIngressRequest,
+    GatewaySessionIngressService,
+)
 from agent_teams.media import content_parts_from_text
 from agent_teams.sessions import ProjectKind
 from agent_teams.sessions.runs.run_manager import RunManager
@@ -54,6 +59,7 @@ class AutomationService:
         delivery_service: AutomationDeliveryService | None = None,
         bound_session_queue_service: AutomationBoundSessionQueueService | None = None,
         workspace_service: WorkspaceService | None = None,
+        session_ingress_service: GatewaySessionIngressService | None = None,
     ) -> None:
         self._repository = repository
         self._event_repository = event_repository
@@ -63,6 +69,7 @@ class AutomationService:
         self._delivery_service = delivery_service
         self._bound_session_queue_service = bound_session_queue_service
         self._workspace_service = workspace_service
+        self._session_ingress_service = session_ingress_service
 
     def create_project(
         self,
@@ -352,22 +359,20 @@ class AutomationService:
                 session_mode=project.run_config.session_mode,
                 orchestration_preset_id=project.run_config.orchestration_preset_id,
             )
-            run_id, _ = self._run_service.create_run(
-                IntentInput(
-                    session_id=session.session_id,
-                    input=content_parts_from_text(
-                        build_automation_prompt(
-                            project_name=project.display_name,
-                            prompt=project.prompt,
-                        )
-                    ),
-                    execution_mode=project.run_config.execution_mode,
-                    yolo=project.run_config.yolo,
-                    thinking=project.run_config.thinking,
-                    session_mode=project.run_config.session_mode,
-                )
+            intent = IntentInput(
+                session_id=session.session_id,
+                input=content_parts_from_text(
+                    build_automation_prompt(
+                        project_name=project.display_name,
+                        prompt=project.prompt,
+                    )
+                ),
+                execution_mode=project.run_config.execution_mode,
+                yolo=project.run_config.yolo,
+                thinking=project.run_config.thinking,
+                session_mode=project.run_config.session_mode,
             )
-            self._run_service.ensure_run_started(run_id)
+            run_id = self._start_unbound_run(intent)
             if self._delivery_service is not None:
                 _ = self._delivery_service.register_run(
                     project=project,
@@ -415,6 +420,21 @@ class AutomationService:
                 )
             )
             raise
+
+    def _start_unbound_run(self, intent: IntentInput) -> str:
+        if self._session_ingress_service is not None:
+            result = self._session_ingress_service.require_started(
+                GatewaySessionIngressRequest(
+                    intent=intent,
+                    busy_policy=GatewaySessionIngressBusyPolicy.START_IF_IDLE,
+                )
+            )
+            if result.run_id is None:
+                raise RuntimeError("automation_run_not_started")
+            return result.run_id
+        run_id, _ = self._run_service.create_run(intent)
+        self._run_service.ensure_run_started(run_id)
+        return run_id
 
     def _resolve_delivery_binding(
         self,

--- a/src/agent_teams/gateway/__init__.py
+++ b/src/agent_teams/gateway/__init__.py
@@ -15,6 +15,14 @@ if TYPE_CHECKING:
     )
     from agent_teams.gateway.gateway_session_repository import GatewaySessionRepository
     from agent_teams.gateway.gateway_session_service import GatewaySessionService
+    from agent_teams.gateway.session_ingress_service import (
+        GatewaySessionBusyError,
+        GatewaySessionIngressBusyPolicy,
+        GatewaySessionIngressRequest,
+        GatewaySessionIngressResult,
+        GatewaySessionIngressService,
+        GatewaySessionIngressStatus,
+    )
 
 __all__ = [
     "AcpGatewayServer",
@@ -26,6 +34,12 @@ __all__ = [
     "GatewaySessionRecord",
     "GatewaySessionRepository",
     "GatewaySessionService",
+    "GatewaySessionBusyError",
+    "GatewaySessionIngressBusyPolicy",
+    "GatewaySessionIngressRequest",
+    "GatewaySessionIngressResult",
+    "GatewaySessionIngressService",
+    "GatewaySessionIngressStatus",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
@@ -58,6 +72,30 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "GatewaySessionService": (
         "agent_teams.gateway.gateway_session_service",
         "GatewaySessionService",
+    ),
+    "GatewaySessionBusyError": (
+        "agent_teams.gateway.session_ingress_service",
+        "GatewaySessionBusyError",
+    ),
+    "GatewaySessionIngressBusyPolicy": (
+        "agent_teams.gateway.session_ingress_service",
+        "GatewaySessionIngressBusyPolicy",
+    ),
+    "GatewaySessionIngressRequest": (
+        "agent_teams.gateway.session_ingress_service",
+        "GatewaySessionIngressRequest",
+    ),
+    "GatewaySessionIngressResult": (
+        "agent_teams.gateway.session_ingress_service",
+        "GatewaySessionIngressResult",
+    ),
+    "GatewaySessionIngressService": (
+        "agent_teams.gateway.session_ingress_service",
+        "GatewaySessionIngressService",
+    ),
+    "GatewaySessionIngressStatus": (
+        "agent_teams.gateway.session_ingress_service",
+        "GatewaySessionIngressStatus",
     ),
 }
 

--- a/src/agent_teams/gateway/acp_stdio.py
+++ b/src/agent_teams/gateway/acp_stdio.py
@@ -18,6 +18,12 @@ from agent_teams.gateway.gateway_model_profile_override import (
 )
 from agent_teams.gateway.gateway_models import GatewayChannelType, GatewayMcpServerSpec
 from agent_teams.gateway.gateway_session_service import GatewaySessionService
+from agent_teams.gateway.session_ingress_service import (
+    GatewaySessionBusyError,
+    GatewaySessionIngressBusyPolicy,
+    GatewaySessionIngressRequest,
+    GatewaySessionIngressService,
+)
 from agent_teams.logger import get_logger, log_event
 from agent_teams.media import (
     ContentPart,
@@ -94,6 +100,7 @@ class AcpGatewayServer:
         media_asset_service: MediaAssetService,
         notify: AcpNotifier,
         mcp_relay: AcpMcpRelay | None = None,
+        session_ingress_service: GatewaySessionIngressService | None = None,
     ) -> None:
         self._gateway_session_service = gateway_session_service
         self._session_service = session_service
@@ -103,6 +110,7 @@ class AcpGatewayServer:
         self._active_runs: dict[str, str] = {}
         self._zed_compat_mode = False
         self._mcp_relay = mcp_relay or AcpMcpRelay()
+        self._session_ingress_service = session_ingress_service
 
     def set_notify(self, notify: AcpNotifier) -> None:
         self._notify = notify
@@ -319,15 +327,21 @@ class AcpGatewayServer:
             raise AcpProtocolError(
                 -32602, "prompt must contain at least one supported content block"
             )
+        intent = IntentInput(
+            session_id=record.internal_session_id,
+            input=prompt_input,
+            yolo=True,
+        )
         with self._mcp_relay.session_scope(gateway_session_id):
-            run_id, _ = self._run_service.create_run(
-                IntentInput(
-                    session_id=record.internal_session_id,
-                    input=prompt_input,
-                    yolo=True,
+            try:
+                run_id = self._start_prompt_run(intent)
+            except GatewaySessionBusyError as exc:
+                raise AcpProtocolError(
+                    -32000,
+                    f"Session already has an active run: {exc.blocking_run_id}",
                 )
-            )
-            self._run_service.ensure_run_started(run_id)
+            except RuntimeError as exc:
+                raise AcpProtocolError(-32000, str(exc)) from exc
             self._active_runs[gateway_session_id] = run_id
             _ = self._gateway_session_service.bind_active_run(
                 gateway_session_id, run_id
@@ -362,6 +376,21 @@ class AcpGatewayServer:
             "runStatus": result.run_status,
             "recoverable": result.recoverable,
         }
+
+    def _start_prompt_run(self, intent: IntentInput) -> str:
+        if self._session_ingress_service is not None:
+            result = self._session_ingress_service.require_started(
+                GatewaySessionIngressRequest(
+                    intent=intent,
+                    busy_policy=GatewaySessionIngressBusyPolicy.REJECT_IF_BUSY,
+                )
+            )
+            if result.run_id is None:
+                raise RuntimeError("acp_run_not_started")
+            return result.run_id
+        run_id, _ = self._run_service.create_run(intent)
+        self._run_service.ensure_run_started(run_id)
+        return run_id
 
     async def _resume_session(
         self,

--- a/src/agent_teams/gateway/feishu/client.py
+++ b/src/agent_teams/gateway/feishu/client.py
@@ -115,11 +115,11 @@ class FeishuClient:
         message_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         normalized_message_id = str(message_id).strip()
         if not normalized_message_id:
             raise RuntimeError("Feishu reply requires a message_id.")
-        self._request_json(
+        response_json = self._request_json(
             method="POST",
             path=f"/open-apis/im/v1/messages/{normalized_message_id}/reply",
             json_body={
@@ -129,6 +129,14 @@ class FeishuClient:
             environment=self.require_environment(environment),
             error_context="reply message",
         )
+        response_data = _require_json_object(
+            response_json.get("data"),
+            error_context="reply message",
+        )
+        reply_message_id = str(response_data.get("message_id", "")).strip()
+        if not reply_message_id:
+            raise RuntimeError("Feishu API failed to reply message: missing message_id")
+        return reply_message_id
 
     def create_message_reaction(
         self,

--- a/src/agent_teams/gateway/feishu/inbound_runtime.py
+++ b/src/agent_teams/gateway/feishu/inbound_runtime.py
@@ -27,6 +27,10 @@ from agent_teams.gateway.feishu.models import (
     SESSION_TITLE_SOURCE_AUTO,
     SESSION_TITLE_SOURCE_MANUAL,
 )
+from agent_teams.gateway.session_ingress_service import (
+    GatewaySessionIngressRequest,
+    GatewaySessionIngressService,
+)
 from agent_teams.logger import get_logger, log_event
 from agent_teams.media import content_parts_from_text
 from agent_teams.providers.token_usage_repo import SessionTokenUsage
@@ -65,6 +69,8 @@ class SessionServiceLike(Protocol):
 class RunServiceLike(Protocol):
     def create_run(self, intent: IntentInput) -> tuple[str, str]: ...
 
+    def create_detached_run(self, intent: IntentInput) -> tuple[str, str]: ...
+
     def ensure_run_started(self, run_id: str) -> None: ...
 
     def stop_run(self, run_id: str) -> None: ...
@@ -95,11 +101,13 @@ class FeishuInboundRuntime:
         run_service: RunServiceLike,
         external_session_binding_repo: ExternalSessionBindingRepository,
         feishu_client: FeishuClientLike | None = None,
+        session_ingress_service: GatewaySessionIngressService | None = None,
     ) -> None:
         self._session_service = session_service
         self._run_service = run_service
         self._external_session_binding_repo = external_session_binding_repo
         self._feishu_client = feishu_client
+        self._session_ingress_service = session_ingress_service
 
     def start_run(
         self,
@@ -111,18 +119,22 @@ class FeishuInboundRuntime:
             runtime_config=runtime_config,
             message=message,
         )
-        run_id, _session_id = self._run_service.create_run(
-            IntentInput(
-                session_id=session_id,
-                input=content_parts_from_text(
-                    self._build_run_intent_text(message=message)
-                ),
-                execution_mode=ExecutionMode.AI,
-                yolo=runtime_config.target.yolo,
-                thinking=runtime_config.target.thinking,
-                conversation_context=self._build_conversation_context(message=message),
-            )
+        intent = IntentInput(
+            session_id=session_id,
+            input=content_parts_from_text(self._build_run_intent_text(message=message)),
+            execution_mode=ExecutionMode.AI,
+            yolo=runtime_config.target.yolo,
+            thinking=runtime_config.target.thinking,
+            conversation_context=self._build_conversation_context(message=message),
         )
+        if self._session_ingress_service is not None:
+            result = self._session_ingress_service.require_started(
+                GatewaySessionIngressRequest(intent=intent)
+            )
+            if result.run_id is None:
+                raise RuntimeError("session_busy")
+            return session_id, result.run_id
+        run_id, _session_id = self._run_service.create_detached_run(intent)
         self._run_service.ensure_run_started(run_id)
         return session_id, run_id
 

--- a/src/agent_teams/gateway/feishu/message_pool_service.py
+++ b/src/agent_teams/gateway/feishu/message_pool_service.py
@@ -24,7 +24,9 @@ from agent_teams.gateway.feishu.models import (
     FeishuTriggerRuntimeConfig,
     TriggerProcessingResult,
 )
+from agent_teams.gateway.session_ingress_service import GatewaySessionBusyError
 from agent_teams.logger import get_logger, log_event
+from agent_teams.sessions import ExternalSessionBindingRepository
 from agent_teams.sessions.runs.enums import RunEventType
 from agent_teams.sessions.runs.event_log import EventLog
 from agent_teams.sessions.runs.run_runtime_repo import (
@@ -36,6 +38,9 @@ from agent_teams.sessions.runs.run_runtime_repo import (
 from agent_teams.sessions.runs.terminal_payload import (
     extract_terminal_error,
     extract_terminal_output,
+)
+from agent_teams.automation.automation_bound_session_queue_repository import (
+    AutomationBoundSessionQueueRepository,
 )
 
 logger = get_logger(__name__)
@@ -70,7 +75,7 @@ class FeishuClientLike(Protocol):
         message_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> str: ...
 
     def create_message_reaction(
         self,
@@ -107,6 +112,8 @@ class FeishuMessagePoolService:
         message_pool_repo: FeishuMessagePoolRepository,
         run_runtime_repo: RunRuntimeRepository,
         event_log: EventLog,
+        external_session_binding_repo: ExternalSessionBindingRepository,
+        automation_queue_repo: AutomationBoundSessionQueueRepository,
     ) -> None:
         self._runtime_config_lookup = runtime_config_lookup
         self._inbound_runtime = inbound_runtime
@@ -114,6 +121,8 @@ class FeishuMessagePoolService:
         self._message_pool_repo = message_pool_repo
         self._run_runtime_repo = run_runtime_repo
         self._event_log = event_log
+        self._external_session_binding_repo = external_session_binding_repo
+        self._automation_queue_repo = automation_queue_repo
         self._stop_event = Event()
         self._wake_event = Event()
         self._thread: Thread | None = None
@@ -210,7 +219,7 @@ class FeishuMessagePoolService:
             )
         queue_depth = self._message_pool_repo.count_active_chat_messages_ahead(
             record.message_pool_id
-        )
+        ) + self._count_external_session_queue_ahead(record)
         queue_reply_text = _build_queue_reply_text(queue_depth)
         updated = self._message_pool_repo.update(
             record.message_pool_id,
@@ -429,6 +438,9 @@ class FeishuMessagePoolService:
                     runtime_config=runtime_config,
                     message=_record_to_normalized_message(claimed),
                 )
+            except GatewaySessionBusyError:
+                self._requeue_busy_record(claimed)
+                continue
             except Exception as exc:
                 self._mark_retryable_failure(claimed, error=str(exc))
                 continue
@@ -773,6 +785,31 @@ class FeishuMessagePoolService:
             completed_at=datetime.now(tz=timezone.utc)
             if processing_status == FeishuMessageProcessingStatus.DEAD_LETTER
             else None,
+        )
+
+    def _requeue_busy_record(self, record: FeishuMessagePoolRecord) -> None:
+        now = datetime.now(tz=timezone.utc)
+        _ = self._message_pool_repo.update(
+            record.message_pool_id,
+            processing_status=FeishuMessageProcessingStatus.QUEUED,
+            next_attempt_at=now + timedelta(seconds=1),
+            last_error=None,
+        )
+
+    def _count_external_session_queue_ahead(
+        self,
+        record: FeishuMessagePoolRecord,
+    ) -> int:
+        binding = self._external_session_binding_repo.get_binding(
+            platform="feishu",
+            trigger_id=record.trigger_id,
+            tenant_key=record.tenant_key,
+            external_chat_id=record.chat_id,
+        )
+        if binding is None:
+            return 0
+        return self._automation_queue_repo.count_non_terminal_by_session(
+            binding.session_id
         )
 
     def _enrich_sender_name(

--- a/src/agent_teams/gateway/feishu/notification_delivery.py
+++ b/src/agent_teams/gateway/feishu/notification_delivery.py
@@ -56,6 +56,22 @@ class TerminalNotificationSuppressor(Protocol):
     def should_suppress_terminal_notification(self, run_id: str | None) -> bool: ...
 
 
+class CompositeTerminalNotificationSuppressor:
+    def __init__(
+        self,
+        *suppressors: TerminalNotificationSuppressor | None,
+    ) -> None:
+        self._suppressors = tuple(
+            suppressor for suppressor in suppressors if suppressor is not None
+        )
+
+    def should_suppress_terminal_notification(self, run_id: str | None) -> bool:
+        return any(
+            suppressor.should_suppress_terminal_notification(run_id)
+            for suppressor in self._suppressors
+        )
+
+
 class FeishuNotificationDispatcher:
     def __init__(
         self,

--- a/src/agent_teams/gateway/gateway_cli.py
+++ b/src/agent_teams/gateway/gateway_cli.py
@@ -334,6 +334,7 @@ def _build_acp_stdio_runtime(*, role_id: str | None = None) -> AcpStdioRuntime:
         media_asset_service=container.media_asset_service,
         notify=_noop_notify,
         mcp_relay=mcp_relay,
+        session_ingress_service=container.session_ingress_service,
     )
     runtime = AcpStdioRuntime(
         server=server,

--- a/src/agent_teams/gateway/im/service.py
+++ b/src/agent_teams/gateway/im/service.py
@@ -16,6 +16,7 @@ from agent_teams.gateway.im.context import (
 )
 from agent_teams.sessions.runs.run_models import IntentInput
 from agent_teams.gateway.wechat.models import WeChatAccountRecord
+from agent_teams.automation import AutomationRunDeliveryRecord
 
 
 class _FeishuSender(Protocol):
@@ -25,7 +26,7 @@ class _FeishuSender(Protocol):
         message_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None: ...
+    ) -> str: ...
 
     def send_text_message(
         self,
@@ -78,6 +79,10 @@ class _RunIntentLookup(Protocol):
     def get(self, run_id: str) -> IntentInput: ...
 
 
+class _AutomationDeliveryLookup(Protocol):
+    def get_by_run_id(self, run_id: str) -> AutomationRunDeliveryRecord: ...
+
+
 class ImToolService:
     def __init__(
         self,
@@ -87,6 +92,7 @@ class ImToolService:
         runtime_config_lookup: _RuntimeConfigLookup,
         run_intent_lookup: _RunIntentLookup | None = None,
         automation_project_repo: _AutomationProjectLookup | None = None,
+        automation_delivery_lookup: _AutomationDeliveryLookup | None = None,
         gateway_session_lookup: _GatewaySessionLookup | None = None,
         feishu_client: _FeishuSender,
         wechat_account_repo: _WeChatAccountLookup,
@@ -98,6 +104,7 @@ class ImToolService:
         self._runtime_config_lookup = runtime_config_lookup
         self._run_intent_lookup = run_intent_lookup
         self._automation_project_repo = automation_project_repo
+        self._automation_delivery_lookup = automation_delivery_lookup
         self._gateway_session_lookup = gateway_session_lookup
         self._feishu_client = feishu_client
         self._wechat_account_repo = wechat_account_repo
@@ -206,13 +213,32 @@ class ImToolService:
         run_id: str | None = None,
     ) -> FeishuChatContext | WeChatChatContext | None:
         prefer_direct_send = self._should_force_direct_send(run_id)
-        return resolve_im_chat_context(
+        ctx = resolve_im_chat_context(
             session_repo=self._session_repo,
             runtime_config_lookup=self._runtime_config_lookup,
             automation_project_repo=self._automation_project_repo,
             gateway_session_lookup=self._gateway_session_lookup,
             session_id=session_id,
             prefer_direct_send=prefer_direct_send,
+        )
+        if not isinstance(ctx, FeishuChatContext):
+            return ctx
+        reply_to_message_id = self._resolve_reply_to_message_id(run_id)
+        if reply_to_message_id is None:
+            if self._has_delivery_without_receipt(run_id):
+                return FeishuChatContext(
+                    chat_id=ctx.chat_id,
+                    environment=ctx.environment,
+                    chat_type=ctx.chat_type,
+                    prefer_reply=False,
+                )
+            return ctx
+        return FeishuChatContext(
+            chat_id=ctx.chat_id,
+            environment=ctx.environment,
+            chat_type=ctx.chat_type,
+            reply_to_message_id=reply_to_message_id,
+            prefer_reply=True,
         )
 
     def _should_force_direct_send(self, run_id: str | None) -> bool:
@@ -227,6 +253,48 @@ class ImToolService:
         if context is None:
             return False
         return context.im_force_direct_send
+
+    def _resolve_reply_to_message_id(self, run_id: str | None) -> str | None:
+        normalized_run_id = str(run_id or "").strip()
+        if not normalized_run_id:
+            return None
+        intent_reply_to_message_id = self._intent_reply_to_message_id(normalized_run_id)
+        if intent_reply_to_message_id is not None:
+            return intent_reply_to_message_id
+        if self._automation_delivery_lookup is None:
+            return None
+        try:
+            delivery = self._automation_delivery_lookup.get_by_run_id(normalized_run_id)
+        except KeyError:
+            return None
+        reply_to_message_id = (
+            str(delivery.started_message_id or "").strip()
+            or str(delivery.reply_to_message_id or "").strip()
+        )
+        return reply_to_message_id or None
+
+    def _has_delivery_without_receipt(self, run_id: str | None) -> bool:
+        normalized_run_id = str(run_id or "").strip()
+        if not normalized_run_id or self._automation_delivery_lookup is None:
+            return False
+        try:
+            _ = self._automation_delivery_lookup.get_by_run_id(normalized_run_id)
+        except KeyError:
+            return False
+        return True
+
+    def _intent_reply_to_message_id(self, run_id: str) -> str | None:
+        if self._run_intent_lookup is None:
+            return None
+        try:
+            intent = self._run_intent_lookup.get(run_id)
+        except KeyError:
+            return None
+        context = intent.conversation_context
+        if context is None:
+            return None
+        reply_to_message_id = str(context.im_reply_to_message_id or "").strip()
+        return reply_to_message_id or None
 
     def _send_wechat_text(
         self,

--- a/src/agent_teams/gateway/session_ingress_service.py
+++ b/src/agent_teams/gateway/session_ingress_service.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent_teams.sessions.runs.run_models import IntentInput
+from agent_teams.sessions.runs.run_runtime_repo import (
+    RunRuntimeRecord,
+    RunRuntimeRepository,
+    RunRuntimeStatus,
+)
+
+
+class GatewaySessionBusyError(RuntimeError):
+    def __init__(self, *, session_id: str, blocking_run_id: str) -> None:
+        self.session_id = session_id
+        self.blocking_run_id = blocking_run_id
+        super().__init__(
+            f"Session {session_id} is busy with active run {blocking_run_id}"
+        )
+
+
+class GatewaySessionIngressBusyPolicy(str, Enum):
+    START_IF_IDLE = "start_if_idle"
+    QUEUE_IF_BUSY = "queue_if_busy"
+    REJECT_IF_BUSY = "reject_if_busy"
+
+
+class GatewaySessionIngressStatus(str, Enum):
+    STARTED = "started"
+    QUEUED = "queued"
+    REJECTED = "rejected"
+
+
+class GatewaySessionIngressRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    intent: IntentInput
+    busy_policy: GatewaySessionIngressBusyPolicy = (
+        GatewaySessionIngressBusyPolicy.REJECT_IF_BUSY
+    )
+
+
+class GatewaySessionIngressResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: GatewaySessionIngressStatus
+    session_id: str = Field(min_length=1)
+    run_id: str | None = None
+    blocking_run_id: str | None = None
+
+
+class _CreateDetachedRun(Protocol):
+    def __call__(self, intent: IntentInput) -> tuple[str, str]: ...
+
+
+class _EnsureRunStarted(Protocol):
+    def __call__(self, run_id: str) -> None: ...
+
+
+class GatewaySessionIngressService:
+    def __init__(
+        self,
+        *,
+        run_service: object,
+        run_runtime_repo: RunRuntimeRepository,
+    ) -> None:
+        self._run_service = run_service
+        self._run_runtime_repo = run_runtime_repo
+
+    def submit(
+        self,
+        request: GatewaySessionIngressRequest,
+    ) -> GatewaySessionIngressResult:
+        blocking_run_id = self.active_run_id(request.intent.session_id)
+        if blocking_run_id is not None:
+            return self._busy_result(
+                session_id=request.intent.session_id,
+                blocking_run_id=blocking_run_id,
+                busy_policy=request.busy_policy,
+            )
+        safe_intent = request.intent.model_copy(
+            deep=True,
+            update={"reuse_root_instance": False},
+        )
+        try:
+            run_id, _ = self._create_detached_run(safe_intent)
+            self._ensure_run_started(run_id)
+        except RuntimeError as exc:
+            blocking_run_id = self.active_run_id(request.intent.session_id)
+            if blocking_run_id is None or not _looks_like_session_busy_error(exc):
+                raise
+            return self._busy_result(
+                session_id=request.intent.session_id,
+                blocking_run_id=blocking_run_id,
+                busy_policy=request.busy_policy,
+            )
+        return GatewaySessionIngressResult(
+            status=GatewaySessionIngressStatus.STARTED,
+            session_id=request.intent.session_id,
+            run_id=run_id,
+        )
+
+    def require_started(
+        self,
+        request: GatewaySessionIngressRequest,
+    ) -> GatewaySessionIngressResult:
+        result = self.submit(request)
+        if result.status is GatewaySessionIngressStatus.STARTED:
+            return result
+        blocking_run_id = str(result.blocking_run_id or "").strip() or "unknown"
+        raise GatewaySessionBusyError(
+            session_id=request.intent.session_id,
+            blocking_run_id=blocking_run_id,
+        )
+
+    def active_run_id(self, session_id: str) -> str | None:
+        for runtime in self._list_session_runtimes(session_id):
+            if self._is_busy_runtime(runtime):
+                return runtime.run_id
+        return None
+
+    def is_session_busy(self, session_id: str) -> bool:
+        return self.active_run_id(session_id) is not None
+
+    def _busy_result(
+        self,
+        *,
+        session_id: str,
+        blocking_run_id: str,
+        busy_policy: GatewaySessionIngressBusyPolicy,
+    ) -> GatewaySessionIngressResult:
+        if busy_policy is GatewaySessionIngressBusyPolicy.QUEUE_IF_BUSY:
+            return GatewaySessionIngressResult(
+                status=GatewaySessionIngressStatus.QUEUED,
+                session_id=session_id,
+                blocking_run_id=blocking_run_id,
+            )
+        return GatewaySessionIngressResult(
+            status=GatewaySessionIngressStatus.REJECTED,
+            session_id=session_id,
+            blocking_run_id=blocking_run_id,
+        )
+
+    def _list_session_runtimes(self, session_id: str) -> tuple[RunRuntimeRecord, ...]:
+        return tuple(
+            sorted(
+                self._run_runtime_repo.list_by_session(session_id),
+                key=lambda item: item.updated_at,
+                reverse=True,
+            )
+        )
+
+    @staticmethod
+    def _is_busy_runtime(runtime: RunRuntimeRecord) -> bool:
+        return runtime.status in {
+            RunRuntimeStatus.QUEUED,
+            RunRuntimeStatus.RUNNING,
+            RunRuntimeStatus.STOPPING,
+            RunRuntimeStatus.PAUSED,
+            RunRuntimeStatus.STOPPED,
+        }
+
+    def _create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
+        run_service = self._run_service
+        create_detached_run = getattr(run_service, "create_detached_run", None)
+        if callable(create_detached_run):
+            return cast(_CreateDetachedRun, create_detached_run)(intent)
+        create_run = getattr(run_service, "create_run", None)
+        if not callable(create_run):
+            raise RuntimeError("Gateway session ingress run service is unavailable")
+        return cast(_CreateDetachedRun, create_run)(intent)
+
+    def _ensure_run_started(self, run_id: str) -> None:
+        ensure_run_started = getattr(self._run_service, "ensure_run_started", None)
+        if not callable(ensure_run_started):
+            raise RuntimeError("Gateway session ingress run service is unavailable")
+        cast(_EnsureRunStarted, ensure_run_started)(run_id)
+
+
+def _looks_like_session_busy_error(error: RuntimeError) -> bool:
+    message = str(error).strip().lower()
+    return (
+        "already has active run" in message
+        or "does not accept follow-up input" in message
+        or "waiting for tool approval" in message
+        or "stopping. wait for it to stop" in message
+    )
+
+
+__all__ = [
+    "GatewaySessionBusyError",
+    "GatewaySessionIngressBusyPolicy",
+    "GatewaySessionIngressRequest",
+    "GatewaySessionIngressResult",
+    "GatewaySessionIngressService",
+    "GatewaySessionIngressStatus",
+]

--- a/src/agent_teams/gateway/wechat/__init__.py
+++ b/src/agent_teams/gateway/wechat/__init__.py
@@ -18,8 +18,13 @@ if TYPE_CHECKING:
         WeChatGatewaySnapshot,
         WeChatLoginStartRequest,
         WeChatLoginStartResponse,
+        WeChatInboundQueueRecord,
+        WeChatInboundQueueStatus,
         WeChatLoginWaitRequest,
         WeChatLoginWaitResponse,
+    )
+    from agent_teams.gateway.wechat.inbound_queue_repository import (
+        WeChatInboundQueueRepository,
     )
     from agent_teams.gateway.wechat.secret_store import (
         WeChatSecretStore,
@@ -39,6 +44,9 @@ __all__ = [
     "WeChatClient",
     "WeChatGatewayService",
     "WeChatGatewaySnapshot",
+    "WeChatInboundQueueRecord",
+    "WeChatInboundQueueRepository",
+    "WeChatInboundQueueStatus",
     "WeChatLoginStartRequest",
     "WeChatLoginStartResponse",
     "WeChatLoginWaitRequest",
@@ -85,6 +93,18 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "WeChatGatewaySnapshot": (
         "agent_teams.gateway.wechat.models",
         "WeChatGatewaySnapshot",
+    ),
+    "WeChatInboundQueueRecord": (
+        "agent_teams.gateway.wechat.models",
+        "WeChatInboundQueueRecord",
+    ),
+    "WeChatInboundQueueRepository": (
+        "agent_teams.gateway.wechat.inbound_queue_repository",
+        "WeChatInboundQueueRepository",
+    ),
+    "WeChatInboundQueueStatus": (
+        "agent_teams.gateway.wechat.models",
+        "WeChatInboundQueueStatus",
     ),
     "WeChatLoginStartRequest": (
         "agent_teams.gateway.wechat.models",

--- a/src/agent_teams/gateway/wechat/inbound_queue_repository.py
+++ b/src/agent_teams/gateway/wechat/inbound_queue_repository.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import RLock
+
+from agent_teams.gateway.wechat.models import (
+    WeChatInboundQueueRecord,
+    WeChatInboundQueueStatus,
+)
+from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+
+_NON_TERMINAL_QUEUE_STATUSES = (
+    WeChatInboundQueueStatus.QUEUED.value,
+    WeChatInboundQueueStatus.STARTING.value,
+    WeChatInboundQueueStatus.WAITING_RESULT.value,
+)
+
+
+class WeChatInboundQueueDuplicateError(ValueError):
+    def __init__(self, *, account_id: str, peer_user_id: str, message_key: str) -> None:
+        self.account_id = account_id
+        self.peer_user_id = peer_user_id
+        self.message_key = message_key
+        super().__init__(
+            "Duplicate WeChat inbound queue record for "
+            f"account_id={account_id}, peer_user_id={peer_user_id}, "
+            f"message_key={message_key}"
+        )
+
+
+class WeChatInboundQueueRepository:
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = Path(db_path)
+        self._conn = open_sqlite(db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = RLock()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        def operation() -> None:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS wechat_inbound_queue (
+                    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                    inbound_queue_id  TEXT NOT NULL UNIQUE,
+                    account_id        TEXT NOT NULL,
+                    message_key       TEXT NOT NULL,
+                    gateway_session_id TEXT NOT NULL,
+                    session_id        TEXT NOT NULL,
+                    peer_user_id      TEXT NOT NULL,
+                    context_token     TEXT,
+                    text              TEXT NOT NULL,
+                    status            TEXT NOT NULL,
+                    run_id            TEXT,
+                    last_error        TEXT,
+                    created_at        TEXT NOT NULL,
+                    updated_at        TEXT NOT NULL,
+                    completed_at      TEXT
+                )
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_wechat_inbound_queue_message
+                ON wechat_inbound_queue(account_id, peer_user_id, message_key)
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_wechat_inbound_queue_session
+                ON wechat_inbound_queue(session_id, id ASC)
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_wechat_inbound_queue_status
+                ON wechat_inbound_queue(status, id ASC)
+                """
+            )
+
+        run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=operation,
+            lock=self._lock,
+            repository_name="WeChatInboundQueueRepository",
+            operation_name="init_tables",
+        )
+
+    def create_or_get(
+        self,
+        record: WeChatInboundQueueRecord,
+    ) -> tuple[WeChatInboundQueueRecord, bool]:
+        try:
+            return self._create(record), True
+        except WeChatInboundQueueDuplicateError:
+            return (
+                self.get_by_message_key(
+                    account_id=record.account_id,
+                    peer_user_id=record.peer_user_id,
+                    message_key=record.message_key,
+                ),
+                False,
+            )
+
+    def _create(
+        self,
+        record: WeChatInboundQueueRecord,
+    ) -> WeChatInboundQueueRecord:
+        def operation() -> None:
+            self._conn.execute(
+                """
+                INSERT INTO wechat_inbound_queue(
+                    inbound_queue_id,
+                    account_id,
+                    message_key,
+                    gateway_session_id,
+                    session_id,
+                    peer_user_id,
+                    context_token,
+                    text,
+                    status,
+                    run_id,
+                    last_error,
+                    created_at,
+                    updated_at,
+                    completed_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.inbound_queue_id,
+                    record.account_id,
+                    record.message_key,
+                    record.gateway_session_id,
+                    record.session_id,
+                    record.peer_user_id,
+                    record.context_token,
+                    record.text,
+                    record.status.value,
+                    record.run_id,
+                    record.last_error,
+                    record.created_at.isoformat(),
+                    record.updated_at.isoformat(),
+                    _to_iso(record.completed_at),
+                ),
+            )
+
+        try:
+            run_sqlite_write_with_retry(
+                conn=self._conn,
+                db_path=self._db_path,
+                operation=operation,
+                lock=self._lock,
+                repository_name="WeChatInboundQueueRepository",
+                operation_name="create",
+            )
+        except sqlite3.IntegrityError as exc:
+            message = str(exc).lower()
+            if (
+                "uq_wechat_inbound_queue_message" in message
+                or "wechat_inbound_queue.account_id, wechat_inbound_queue.peer_user_id, wechat_inbound_queue.message_key"
+                in message
+            ):
+                raise WeChatInboundQueueDuplicateError(
+                    account_id=record.account_id,
+                    peer_user_id=record.peer_user_id,
+                    message_key=record.message_key,
+                ) from exc
+            raise
+        stored = self.get(record.inbound_queue_id)
+        if stored is None:
+            raise RuntimeError(
+                f"Failed to persist WeChat inbound queue {record.inbound_queue_id}"
+            )
+        return stored
+
+    def update(self, record: WeChatInboundQueueRecord) -> WeChatInboundQueueRecord:
+        run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=lambda: self._conn.execute(
+                """
+                UPDATE wechat_inbound_queue
+                SET account_id=?,
+                    message_key=?,
+                    gateway_session_id=?,
+                    session_id=?,
+                    peer_user_id=?,
+                    context_token=?,
+                    text=?,
+                    status=?,
+                    run_id=?,
+                    last_error=?,
+                    updated_at=?,
+                    completed_at=?
+                WHERE inbound_queue_id=?
+                """,
+                (
+                    record.account_id,
+                    record.message_key,
+                    record.gateway_session_id,
+                    record.session_id,
+                    record.peer_user_id,
+                    record.context_token,
+                    record.text,
+                    record.status.value,
+                    record.run_id,
+                    record.last_error,
+                    record.updated_at.isoformat(),
+                    _to_iso(record.completed_at),
+                    record.inbound_queue_id,
+                ),
+            ),
+            lock=self._lock,
+            repository_name="WeChatInboundQueueRepository",
+            operation_name="update",
+        )
+        stored = self.get(record.inbound_queue_id)
+        if stored is None:
+            raise RuntimeError(
+                f"Failed to reload WeChat inbound queue {record.inbound_queue_id}"
+            )
+        return stored
+
+    def get(self, inbound_queue_id: str) -> WeChatInboundQueueRecord | None:
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT *
+                FROM wechat_inbound_queue
+                WHERE inbound_queue_id=?
+                """,
+                (inbound_queue_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._to_record(row)
+
+    def get_by_message_key(
+        self,
+        *,
+        account_id: str,
+        peer_user_id: str,
+        message_key: str,
+    ) -> WeChatInboundQueueRecord:
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT *
+                FROM wechat_inbound_queue
+                WHERE account_id=? AND peer_user_id=? AND message_key=?
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (account_id, peer_user_id, message_key),
+            ).fetchone()
+        if row is None:
+            raise KeyError(
+                "Unknown WeChat inbound queue record for "
+                f"account_id={account_id}, peer_user_id={peer_user_id}, "
+                f"message_key={message_key}"
+            )
+        return self._to_record(row)
+
+    def get_latest_by_run_id(self, run_id: str) -> WeChatInboundQueueRecord | None:
+        if not str(run_id).strip():
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT *
+                FROM wechat_inbound_queue
+                WHERE run_id=?
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (run_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._to_record(row)
+
+    def has_non_terminal_item_for_run(self, run_id: str) -> bool:
+        if not str(run_id).strip():
+            return False
+        with self._lock:
+            row = self._conn.execute(
+                f"""
+                SELECT 1
+                FROM wechat_inbound_queue
+                WHERE run_id=?
+                  AND status IN ({",".join("?" for _ in _NON_TERMINAL_QUEUE_STATUSES)})
+                LIMIT 1
+                """,
+                (run_id, *_NON_TERMINAL_QUEUE_STATUSES),
+            ).fetchone()
+        return row is not None
+
+    def count_non_terminal_by_session(self, session_id: str) -> int:
+        with self._lock:
+            row = self._conn.execute(
+                f"""
+                SELECT COUNT(*) AS total
+                FROM wechat_inbound_queue
+                WHERE session_id=?
+                  AND status IN ({",".join("?" for _ in _NON_TERMINAL_QUEUE_STATUSES)})
+                """,
+                (session_id, *_NON_TERMINAL_QUEUE_STATUSES),
+            ).fetchone()
+        return int(row["total"]) if row is not None else 0
+
+    def count_non_terminal_ahead(self, inbound_queue_id: str) -> int:
+        with self._lock:
+            row = self._conn.execute(
+                f"""
+                SELECT COUNT(*) AS total
+                FROM wechat_inbound_queue AS queued
+                JOIN wechat_inbound_queue AS current
+                    ON current.inbound_queue_id=?
+                WHERE queued.session_id=current.session_id
+                  AND queued.id < current.id
+                  AND queued.status IN ({",".join("?" for _ in _NON_TERMINAL_QUEUE_STATUSES)})
+                """,
+                (inbound_queue_id, *_NON_TERMINAL_QUEUE_STATUSES),
+            ).fetchone()
+        return int(row["total"]) if row is not None else 0
+
+    def list_ready_to_start(
+        self,
+        *,
+        limit: int = 20,
+        stale_before: datetime | None = None,
+    ) -> tuple[WeChatInboundQueueRecord, ...]:
+        safe_limit = max(1, min(limit, 100))
+        with self._lock:
+            if stale_before is None:
+                rows = self._conn.execute(
+                    """
+                    SELECT *
+                    FROM wechat_inbound_queue
+                    WHERE status=?
+                    ORDER BY id ASC
+                    LIMIT ?
+                    """,
+                    (
+                        WeChatInboundQueueStatus.QUEUED.value,
+                        safe_limit,
+                    ),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """
+                    SELECT *
+                    FROM wechat_inbound_queue
+                    WHERE status=?
+                       OR (status=? AND updated_at<=?)
+                    ORDER BY id ASC
+                    LIMIT ?
+                    """,
+                    (
+                        WeChatInboundQueueStatus.QUEUED.value,
+                        WeChatInboundQueueStatus.STARTING.value,
+                        stale_before.isoformat(),
+                        safe_limit,
+                    ),
+                ).fetchall()
+        return tuple(self._to_record(row) for row in rows)
+
+    def claim_starting(
+        self,
+        *,
+        inbound_queue_id: str,
+        stale_before: datetime,
+    ) -> WeChatInboundQueueRecord | None:
+        claimed_at = stale_before.isoformat()
+        updated_at = datetime.now(tz=timezone.utc).isoformat()
+        updated = run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                    UPDATE wechat_inbound_queue
+                    SET status=?,
+                        last_error=?,
+                        updated_at=?
+                    WHERE inbound_queue_id=?
+                      AND (
+                        status=?
+                        OR (status=? AND updated_at<=?)
+                      )
+                    """,
+                    (
+                        WeChatInboundQueueStatus.STARTING.value,
+                        None,
+                        updated_at,
+                        inbound_queue_id,
+                        WeChatInboundQueueStatus.QUEUED.value,
+                        WeChatInboundQueueStatus.STARTING.value,
+                        claimed_at,
+                    ),
+                ).rowcount
+            ),
+            lock=self._lock,
+            repository_name="WeChatInboundQueueRepository",
+            operation_name="claim_starting",
+        )
+        if updated <= 0:
+            return None
+        return self.get(inbound_queue_id)
+
+    def requeue_if_starting(
+        self,
+        *,
+        inbound_queue_id: str,
+        last_error: str | None = None,
+    ) -> WeChatInboundQueueRecord | None:
+        updated_at = datetime.now(tz=timezone.utc).isoformat()
+        updated = run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                    UPDATE wechat_inbound_queue
+                    SET status=?,
+                        run_id=?,
+                        last_error=?,
+                        updated_at=?,
+                        completed_at=?
+                    WHERE inbound_queue_id=?
+                      AND status=?
+                    """,
+                    (
+                        WeChatInboundQueueStatus.QUEUED.value,
+                        None,
+                        last_error,
+                        updated_at,
+                        None,
+                        inbound_queue_id,
+                        WeChatInboundQueueStatus.STARTING.value,
+                    ),
+                ).rowcount
+            ),
+            lock=self._lock,
+            repository_name="WeChatInboundQueueRepository",
+            operation_name="requeue_if_starting",
+        )
+        if updated <= 0:
+            return None
+        return self.get(inbound_queue_id)
+
+    def _to_record(self, row: sqlite3.Row) -> WeChatInboundQueueRecord:
+        return WeChatInboundQueueRecord(
+            inbound_queue_id=str(row["inbound_queue_id"]),
+            account_id=str(row["account_id"]),
+            message_key=str(row["message_key"]),
+            gateway_session_id=str(row["gateway_session_id"]),
+            session_id=str(row["session_id"]),
+            peer_user_id=str(row["peer_user_id"]),
+            context_token=(
+                str(row["context_token"]) if row["context_token"] is not None else None
+            ),
+            text=str(row["text"]),
+            status=WeChatInboundQueueStatus(str(row["status"])),
+            run_id=str(row["run_id"]) if row["run_id"] is not None else None,
+            last_error=(
+                str(row["last_error"]) if row["last_error"] is not None else None
+            ),
+            created_at=datetime.fromisoformat(str(row["created_at"])),
+            updated_at=datetime.fromisoformat(str(row["updated_at"])),
+            completed_at=(
+                datetime.fromisoformat(str(row["completed_at"]))
+                if row["completed_at"] is not None
+                else None
+            ),
+        )
+
+
+def _to_iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).isoformat()
+
+
+__all__ = [
+    "WeChatInboundQueueDuplicateError",
+    "WeChatInboundQueueRepository",
+]

--- a/src/agent_teams/gateway/wechat/models.py
+++ b/src/agent_teams/gateway/wechat/models.py
@@ -34,6 +34,14 @@ class WeChatUploadMediaType(int, Enum):
     VOICE = 4
 
 
+class WeChatInboundQueueStatus(str, Enum):
+    QUEUED = "queued"
+    STARTING = "starting"
+    WAITING_RESULT = "waiting_result"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
 class WeChatAccountRecord(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -188,6 +196,25 @@ class WeChatInboundMessage(BaseModel):
     message_state: int | None = None
     item_list: tuple[WeChatMessageItem, ...] = ()
     context_token: str | None = None
+
+
+class WeChatInboundQueueRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    inbound_queue_id: str = Field(min_length=1)
+    account_id: str = Field(min_length=1)
+    message_key: str = Field(min_length=1)
+    gateway_session_id: str = Field(min_length=1)
+    session_id: str = Field(min_length=1)
+    peer_user_id: str = Field(min_length=1)
+    context_token: str | None = None
+    text: str = Field(min_length=1)
+    status: WeChatInboundQueueStatus = WeChatInboundQueueStatus.QUEUED
+    run_id: str | None = None
+    last_error: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    completed_at: datetime | None = None
 
 
 class WeChatGetUpdatesResponse(BaseModel):

--- a/src/agent_teams/gateway/wechat/service.py
+++ b/src/agent_teams/gateway/wechat/service.py
@@ -8,7 +8,7 @@ from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import Future as ConcurrentFuture
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
 from threading import Event, Lock, Thread
@@ -21,13 +21,25 @@ import qrcode.image.svg
 
 from agent_teams.gateway.gateway_models import GatewayChannelType
 from agent_teams.gateway.gateway_session_service import GatewaySessionService
+from agent_teams.gateway.session_ingress_service import (
+    GatewaySessionIngressBusyPolicy,
+    GatewaySessionIngressRequest,
+    GatewaySessionIngressService,
+)
+from agent_teams.gateway.wechat.inbound_queue_repository import (
+    WeChatInboundQueueRepository,
+)
 from agent_teams.logger import get_logger, log_event
 from agent_teams.media import content_parts_from_text
 from agent_teams.roles import RoleRegistry
 from agent_teams.sessions.runs import RunEventHub
 from agent_teams.sessions.runs.enums import RunEventType
 from agent_teams.sessions.runs.run_manager import RunManager
-from agent_teams.sessions.runs.run_models import IntentInput, RunThinkingConfig
+from agent_teams.sessions.runs.run_models import (
+    IntentInput,
+    RunThinkingConfig,
+    RuntimePromptConversationContext,
+)
 from agent_teams.sessions.runs.terminal_payload import (
     extract_terminal_error,
     extract_terminal_output,
@@ -47,11 +59,14 @@ from agent_teams.gateway.wechat.models import (
     WeChatAccountUpdateInput,
     WeChatGatewaySnapshot,
     WeChatInboundMessage,
+    WeChatInboundQueueRecord,
+    WeChatInboundQueueStatus,
     WeChatLoginSession,
     WeChatLoginStartRequest,
     WeChatLoginStartResponse,
     WeChatLoginWaitRequest,
     WeChatLoginWaitResponse,
+    WECHAT_PLATFORM,
 )
 from agent_teams.gateway.wechat.secret_store import (
     WeChatSecretStore,
@@ -67,6 +82,7 @@ _TERMINAL_EVENT_TYPES = {
     RunEventType.RUN_STOPPED,
 }
 _DEFAULT_POLL_TIMEOUT_MS = 35000
+_INBOUND_QUEUE_CLAIM_STALE_AFTER_SECONDS = 60
 
 LOGGER = get_logger(__name__)
 
@@ -88,6 +104,8 @@ class WeChatGatewayService:
         session_service: SessionService,
         im_tool_service: ImToolService,
         im_session_command_service: ImSessionCommandService,
+        inbound_queue_repo: WeChatInboundQueueRepository,
+        session_ingress_service: GatewaySessionIngressService | None = None,
     ) -> None:
         self._config_dir = config_dir
         self._repository = repository
@@ -104,12 +122,15 @@ class WeChatGatewayService:
         self._session_service = session_service
         self._im_tool_service = im_tool_service
         self._im_session_command_service = im_session_command_service
+        self._inbound_queue_repo = inbound_queue_repo
+        self._session_ingress_service = session_ingress_service
         self._status_lock = Lock()
         self._status_by_account: dict[str, WeChatGatewaySnapshot] = {}
         self._monitor_stop_events: dict[str, Event] = {}
         self._monitor_threads: dict[str, Thread] = {}
         self._login_sessions: dict[str, WeChatLoginSession] = {}
         self._watched_runs: set[str] = set()
+        self._drain_watched_runs: set[str] = set()
 
     def replace_role_registry(self, role_registry: RoleRegistry) -> None:
         self._role_registry = role_registry
@@ -534,14 +555,25 @@ class WeChatGatewayService:
                     context_token=message.context_token,
                 )
             return
-        recovery_snapshot = self._session_service.get_recovery_snapshot(
-            gateway_session.internal_session_id
+        queue_record, created = self._inbound_queue_repo.create_or_get(
+            WeChatInboundQueueRecord(
+                inbound_queue_id=f"wq_{uuid4().hex[:16]}",
+                account_id=account.account_id,
+                message_key=self._message_key(message),
+                gateway_session_id=gateway_session.gateway_session_id,
+                session_id=gateway_session.internal_session_id,
+                peer_user_id=peer_user_id,
+                context_token=message.context_token,
+                text=text,
+            )
         )
-        has_active_run = isinstance(recovery_snapshot.get("active_run"), Mapping)
-        if has_active_run:
-            receipt_text = "\u6536\u5230\uff0c\u5df2\u52a0\u5165\u5f53\u524d\u4f1a\u8bdd\u5904\u7406\u3002"
-        else:
-            receipt_text = "\u6536\u5230\uff0c\u6b63\u5728\u5904\u7406\u3002"
+        if not created:
+            return
+        self._drain_inbound_queue()
+        latest = self._inbound_queue_repo.get(queue_record.inbound_queue_id)
+        if latest is None:
+            return
+        receipt_text = self._build_receipt_text(latest)
         self._send_intermediate_text(
             account_id=account.account_id,
             gateway_session_id=gateway_session.gateway_session_id,
@@ -550,26 +582,6 @@ class WeChatGatewayService:
             text=receipt_text,
             event_name="wechat.receipt",
             failure_message="Failed to send WeChat receipt",
-        )
-        run_id, _ = self._run_service.create_run(
-            IntentInput(
-                session_id=gateway_session.internal_session_id,
-                input=content_parts_from_text(text),
-                yolo=account.yolo,
-                thinking=account.thinking,
-            )
-        )
-        self._gateway_session_service.bind_active_run(
-            gateway_session.gateway_session_id, run_id
-        )
-        self._run_service.ensure_run_started(run_id)
-        self._send_typing(account, token, peer_user_id, message.context_token, 1)
-        self._start_run_watcher(
-            account_id=account.account_id,
-            gateway_session_id=gateway_session.gateway_session_id,
-            run_id=run_id,
-            peer_user_id=peer_user_id,
-            context_token=message.context_token,
         )
 
     def _start_run_watcher(
@@ -605,6 +617,31 @@ class WeChatGatewayService:
             )
 
         future.add_done_callback(on_reply_done)
+
+    def _start_queue_drain_watcher(self, *, session_id: str, run_id: str) -> None:
+        if run_id in self._watched_runs or run_id in self._drain_watched_runs:
+            return
+        try:
+            loop = self._require_loop()
+        except RuntimeError:
+            return
+        self._drain_watched_runs.add(run_id)
+        future = asyncio.run_coroutine_threadsafe(
+            self._await_run_completion_for_queue_drain(
+                session_id=session_id,
+                run_id=run_id,
+            ),
+            loop,
+        )
+
+        def on_drain_done(done: ConcurrentFuture[None]) -> None:
+            self._handle_queue_drain_future(
+                session_id=session_id,
+                run_id=run_id,
+                future=done,
+            )
+
+        future.add_done_callback(on_drain_done)
 
     async def _await_terminal_and_reply(
         self,
@@ -692,6 +729,25 @@ class WeChatGatewayService:
         finally:
             self._watched_runs.discard(run_id)
 
+    async def _await_run_completion_for_queue_drain(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+    ) -> None:
+        async for event in self._run_service.stream_run_events(run_id):
+            if event.event_type in _TERMINAL_EVENT_TYPES:
+                return
+            if (
+                event.event_type == RunEventType.RUN_PAUSED
+                and self._active_run_id(session_id) != run_id
+            ):
+                return
+        if self._active_run_id(session_id) == run_id:
+            raise RuntimeError(
+                f"WeChat queue drain watcher ended before a terminal event for {run_id}."
+            )
+
     def _handle_reply_future(
         self,
         *,
@@ -741,6 +797,42 @@ class WeChatGatewayService:
                 exc_info=exc,
             )
 
+    def _handle_queue_drain_future(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        future: ConcurrentFuture[None],
+    ) -> None:
+        try:
+            future.result()
+        except FutureCancelledError as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="wechat.queue_drain.cancelled",
+                message="WeChat queue drain watcher was cancelled",
+                payload={"session_id": session_id, "run_id": run_id},
+                exc_info=exc,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="wechat.queue_drain.failed",
+                message="WeChat queue drain watcher failed",
+                payload={
+                    "session_id": session_id,
+                    "run_id": run_id,
+                    "error": str(exc),
+                },
+                exc_info=exc,
+            )
+        finally:
+            self._drain_watched_runs.discard(run_id)
+            if self._active_run_id(session_id) != run_id:
+                self._drain_inbound_queue()
+
     def _record_reply_success(
         self,
         *,
@@ -777,12 +869,14 @@ class WeChatGatewayService:
                 exc_info=exc,
             )
         self._clear_active_run(gateway_session_id)
+        self._mark_queue_record_completed(run_id=run_id, failed=False)
         self._set_status(
             account_id,
             last_error=None,
             last_outbound_at=occurred_at,
             last_event_at=occurred_at,
         )
+        self._drain_inbound_queue()
         log_event(
             LOGGER,
             logging.INFO,
@@ -806,11 +900,17 @@ class WeChatGatewayService:
         error_message: str,
     ) -> None:
         self._clear_active_run(gateway_session_id)
+        self._mark_queue_record_completed(
+            run_id=run_id,
+            failed=True,
+            error_message=error_message,
+        )
         self._set_status(
             account_id,
             last_error=error_message,
             last_event_at=datetime.now(tz=timezone.utc),
         )
+        self._drain_inbound_queue()
 
     def _record_pause_notice(
         self,
@@ -955,9 +1055,222 @@ class WeChatGatewayService:
             raise RuntimeError("RunManager event loop is not bound")
         return loop
 
+    def _drain_inbound_queue(self) -> None:
+        stale_before = datetime.now(tz=timezone.utc) - timedelta(
+            seconds=_INBOUND_QUEUE_CLAIM_STALE_AFTER_SECONDS
+        )
+        for record in self._inbound_queue_repo.list_ready_to_start(
+            stale_before=stale_before
+        ):
+            claimed = self._inbound_queue_repo.claim_starting(
+                inbound_queue_id=record.inbound_queue_id,
+                stale_before=stale_before,
+            )
+            if claimed is None:
+                continue
+            blocking_run_id = self._active_run_id(claimed.session_id)
+            if blocking_run_id is not None:
+                self._start_queue_drain_watcher(
+                    session_id=claimed.session_id,
+                    run_id=blocking_run_id,
+                )
+            if self._inbound_queue_repo.count_non_terminal_ahead(
+                claimed.inbound_queue_id
+            ):
+                _ = self._inbound_queue_repo.requeue_if_starting(
+                    inbound_queue_id=claimed.inbound_queue_id
+                )
+                continue
+            if blocking_run_id is not None:
+                _ = self._inbound_queue_repo.requeue_if_starting(
+                    inbound_queue_id=claimed.inbound_queue_id
+                )
+                continue
+            if not self._start_queued_record(claimed):
+                continue
+
+    def _start_queued_record(self, record: WeChatInboundQueueRecord) -> bool:
+        try:
+            account = self._repository.get_account(record.account_id)
+        except KeyError:
+            self._fail_starting_record(
+                inbound_queue_id=record.inbound_queue_id,
+                error_message=f"WeChat account not found: {record.account_id}",
+            )
+            return False
+        intent = IntentInput(
+            session_id=record.session_id,
+            input=content_parts_from_text(record.text),
+            yolo=account.yolo,
+            thinking=account.thinking,
+            conversation_context=RuntimePromptConversationContext(
+                source_provider=WECHAT_PLATFORM,
+                source_kind="im",
+            ),
+        )
+        try:
+            run_id = self._start_session_ingress_run(intent)
+        except RuntimeError as exc:
+            if str(exc).strip() != "session_busy":
+                _ = self._inbound_queue_repo.requeue_if_starting(
+                    inbound_queue_id=record.inbound_queue_id,
+                    last_error=str(exc),
+                )
+                return False
+            _ = self._inbound_queue_repo.requeue_if_starting(
+                inbound_queue_id=record.inbound_queue_id
+            )
+            return False
+        now = datetime.now(tz=timezone.utc)
+        current = self._inbound_queue_repo.get(record.inbound_queue_id)
+        if current is None or current.status != WeChatInboundQueueStatus.STARTING:
+            return False
+        updated = self._inbound_queue_repo.update(
+            current.model_copy(
+                update={
+                    "status": WeChatInboundQueueStatus.WAITING_RESULT,
+                    "run_id": run_id,
+                    "last_error": None,
+                    "updated_at": now,
+                }
+            )
+        )
+        self._gateway_session_service.bind_active_run(
+            updated.gateway_session_id,
+            run_id,
+        )
+        token = self._secret_store.get_bot_token(self._config_dir, record.account_id)
+        if token is not None:
+            self._send_typing(
+                account,
+                token,
+                record.peer_user_id,
+                record.context_token,
+                1,
+            )
+        self._start_run_watcher(
+            account_id=updated.account_id,
+            gateway_session_id=updated.gateway_session_id,
+            run_id=run_id,
+            peer_user_id=updated.peer_user_id,
+            context_token=updated.context_token,
+        )
+        return True
+
+    def _fail_starting_record(
+        self,
+        *,
+        inbound_queue_id: str,
+        error_message: str,
+    ) -> None:
+        current = self._inbound_queue_repo.get(inbound_queue_id)
+        if current is None or current.status != WeChatInboundQueueStatus.STARTING:
+            return
+        now = datetime.now(tz=timezone.utc)
+        _ = self._inbound_queue_repo.update(
+            current.model_copy(
+                update={
+                    "status": WeChatInboundQueueStatus.FAILED,
+                    "run_id": None,
+                    "last_error": error_message,
+                    "updated_at": now,
+                    "completed_at": now,
+                }
+            )
+        )
+
+    def _start_session_ingress_run(self, intent: IntentInput) -> str:
+        if self._session_ingress_service is not None:
+            result = self._session_ingress_service.submit(
+                GatewaySessionIngressRequest(
+                    intent=intent,
+                    busy_policy=GatewaySessionIngressBusyPolicy.QUEUE_IF_BUSY,
+                )
+            )
+            if result.run_id is None:
+                raise RuntimeError("session_busy")
+            return result.run_id
+        run_id, _ = self._run_service.create_run(intent)
+        self._run_service.ensure_run_started(run_id)
+        return run_id
+
+    def _active_run_id(self, session_id: str) -> str | None:
+        if self._session_ingress_service is not None:
+            return self._session_ingress_service.active_run_id(session_id)
+        recovery_snapshot = self._session_service.get_recovery_snapshot(session_id)
+        active_run = recovery_snapshot.get("active_run")
+        if not isinstance(active_run, Mapping):
+            return None
+        run_id = active_run.get("run_id")
+        if isinstance(run_id, str) and run_id.strip():
+            return run_id.strip()
+        return None
+
+    def _build_receipt_text(self, record: WeChatInboundQueueRecord) -> str:
+        if record.status == WeChatInboundQueueStatus.FAILED:
+            error_message = str(record.last_error or "").strip()
+            if error_message:
+                return f"\u6536\u5230\uff0c\u4f46\u5904\u7406\u5931\u8d25\uff1a{error_message}"
+            return "\u6536\u5230\uff0c\u4f46\u5904\u7406\u5931\u8d25\u3002"
+        if record.status == WeChatInboundQueueStatus.WAITING_RESULT:
+            return "\u6536\u5230\uff0c\u6b63\u5728\u5904\u7406\u3002"
+        queue_depth = self._queue_depth(record)
+        if queue_depth <= 0:
+            return "\u6536\u5230\uff0c\u6b63\u5728\u5904\u7406\u3002"
+        return f"\u6536\u5230\uff0c\u5df2\u8fdb\u5165\u6392\u961f\u3002\u5f53\u524d\u4f1a\u8bdd\u524d\u9762\u8fd8\u6709 {queue_depth} \u6761\u6d88\u606f\u3002"
+
+    def _queue_depth(self, record: WeChatInboundQueueRecord) -> int:
+        ahead_count = self._inbound_queue_repo.count_non_terminal_ahead(
+            record.inbound_queue_id
+        )
+        blocking_run_id = self._active_run_id(record.session_id)
+        if blocking_run_id is None:
+            return ahead_count
+        if self._inbound_queue_repo.has_non_terminal_item_for_run(blocking_run_id):
+            return ahead_count
+        return ahead_count + 1
+
+    def _mark_queue_record_completed(
+        self,
+        *,
+        run_id: str,
+        failed: bool,
+        error_message: str | None = None,
+    ) -> None:
+        record = self._inbound_queue_repo.get_latest_by_run_id(run_id)
+        if record is None:
+            return
+        now = datetime.now(tz=timezone.utc)
+        _ = self._inbound_queue_repo.update(
+            record.model_copy(
+                update={
+                    "status": (
+                        WeChatInboundQueueStatus.FAILED
+                        if failed
+                        else WeChatInboundQueueStatus.COMPLETED
+                    ),
+                    "last_error": error_message if failed else None,
+                    "updated_at": now,
+                    "completed_at": now,
+                }
+            )
+        )
+
     @staticmethod
     def _external_session_id(account_id: str, peer_user_id: str) -> str:
         return f"wechat:{account_id}:{peer_user_id}"
+
+    @staticmethod
+    def _message_key(message: WeChatInboundMessage) -> str:
+        if message.message_id is not None:
+            return f"mid:{message.message_id}"
+        if message.seq is not None:
+            return f"seq:{message.seq}"
+        if message.context_token is not None and message.context_token.strip():
+            return f"ctx:{message.context_token.strip()}"
+        if message.create_time_ms is not None:
+            return f"ts:{message.create_time_ms}"
+        return f"anon:{uuid4().hex[:12]}"
 
     @staticmethod
     def _extract_text(message: WeChatInboundMessage) -> str:

--- a/src/agent_teams/interfaces/server/container.py
+++ b/src/agent_teams/interfaces/server/container.py
@@ -57,6 +57,9 @@ from agent_teams.gateway.feishu import (
     FeishuSubscriptionService,
     FeishuTriggerHandler,
 )
+from agent_teams.gateway.feishu.notification_delivery import (
+    CompositeTerminalNotificationSuppressor,
+)
 from agent_teams.gateway.im import (
     ImSessionCommandService,
     ImToolContextResolver,
@@ -64,6 +67,7 @@ from agent_teams.gateway.im import (
 )
 from agent_teams.gateway.gateway_session_repository import GatewaySessionRepository
 from agent_teams.gateway.gateway_session_service import GatewaySessionService
+from agent_teams.gateway.session_ingress_service import GatewaySessionIngressService
 from agent_teams.interfaces.server.config_status_service import ConfigStatusService
 from agent_teams.interfaces.server.ui_language_service import UiLanguageSettingsService
 from agent_teams.mcp.mcp_config_manager import McpConfigManager
@@ -150,6 +154,7 @@ from agent_teams.gateway.wechat import (
     WeChatAccountRepository,
     WeChatClient,
     WeChatGatewayService,
+    WeChatInboundQueueRepository,
     get_wechat_secret_store,
 )
 from agent_teams.workspace import (
@@ -368,6 +373,9 @@ class ServerContainer:
         )
         self.feishu_client = FeishuClient()
         self.wechat_account_repository = WeChatAccountRepository(runtime.paths.db_path)
+        self.wechat_inbound_queue_repo = WeChatInboundQueueRepository(
+            runtime.paths.db_path
+        )
         self.wechat_client = WeChatClient()
         self.feishu_gateway_service = FeishuGatewayService(
             config_dir=config_dir,
@@ -383,6 +391,7 @@ class ServerContainer:
             session_repo=self.session_repo,
             runtime_config_lookup=self.feishu_gateway_service,
             automation_project_repo=self.automation_repo,
+            automation_delivery_lookup=self.automation_delivery_repo,
             gateway_session_lookup=self.gateway_session_repository,
             feishu_client=self.feishu_client,
             wechat_account_repo=self.wechat_account_repository,
@@ -532,6 +541,10 @@ class ServerContainer:
             media_asset_service=self.media_asset_service,
             get_runtime=lambda: self.runtime,
         )
+        self.session_ingress_service = GatewaySessionIngressService(
+            run_service=self.run_service,
+            run_runtime_repo=self.run_runtime_repo,
+        )
         self.gateway_session_service = GatewaySessionService(
             repository=self.gateway_session_repository,
             session_service=self.session_service,
@@ -542,6 +555,7 @@ class ServerContainer:
             run_service=self.run_service,
             external_session_binding_repo=self.external_session_binding_repo,
             feishu_client=self.feishu_client,
+            session_ingress_service=self.session_ingress_service,
         )
         self.feishu_message_pool_service = FeishuMessagePoolService(
             runtime_config_lookup=self.feishu_gateway_service,
@@ -550,6 +564,8 @@ class ServerContainer:
             message_pool_repo=self.feishu_message_pool_repo,
             run_runtime_repo=self.run_runtime_repo,
             event_log=self.event_log,
+            external_session_binding_repo=self.external_session_binding_repo,
+            automation_queue_repo=self.automation_bound_session_queue_repo,
         )
         self.im_session_command_service = ImSessionCommandService(
             session_service=self.session_service,
@@ -572,20 +588,9 @@ class ServerContainer:
             session_service=self.session_service,
             im_tool_service=self.im_tool_service,
             im_session_command_service=self.im_session_command_service,
+            inbound_queue_repo=self.wechat_inbound_queue_repo,
+            session_ingress_service=self.session_ingress_service,
         )
-        self.notification_service = NotificationService(
-            run_event_hub=self.run_event_hub,
-            get_config=self.notification_config_manager.get_notification_config,
-            dispatchers=(
-                FeishuNotificationDispatcher(
-                    session_repo=self.session_repo,
-                    runtime_config_lookup=self.feishu_gateway_service,
-                    feishu_client=self.feishu_client,
-                    terminal_notification_suppressor=self.feishu_message_pool_service,
-                ),
-            ),
-        )
-        self.run_service._notification_service = self.notification_service
         self.automation_feishu_binding_service = AutomationFeishuBindingService(
             external_session_binding_repo=self.external_session_binding_repo,
             session_repo=self.session_repo,
@@ -598,10 +603,27 @@ class ServerContainer:
             feishu_client=self.feishu_client,
             run_runtime_repo=self.run_runtime_repo,
             event_log=self.event_log,
+            notification_service=self.notification_service,
         )
         self.automation_delivery_worker = AutomationDeliveryWorker(
             delivery_service=self.automation_delivery_service
         )
+        self.notification_service = NotificationService(
+            run_event_hub=self.run_event_hub,
+            get_config=self.notification_config_manager.get_notification_config,
+            dispatchers=(
+                FeishuNotificationDispatcher(
+                    session_repo=self.session_repo,
+                    runtime_config_lookup=self.feishu_gateway_service,
+                    feishu_client=self.feishu_client,
+                    terminal_notification_suppressor=CompositeTerminalNotificationSuppressor(
+                        self.feishu_message_pool_service,
+                        self.automation_delivery_service,
+                    ),
+                ),
+            ),
+        )
+        self.run_service._notification_service = self.notification_service
         self.automation_bound_session_queue_service = (
             AutomationBoundSessionQueueService(
                 repository=self.automation_bound_session_queue_repo,
@@ -612,6 +634,7 @@ class ServerContainer:
                 runtime_config_lookup=self.feishu_gateway_service,
                 feishu_client=self.feishu_client,
                 project_repository=self.automation_repo,
+                session_ingress_service=self.session_ingress_service,
             )
         )
         self.automation_bound_session_queue_worker = AutomationBoundSessionQueueWorker(
@@ -636,6 +659,7 @@ class ServerContainer:
             delivery_service=self.automation_delivery_service,
             bound_session_queue_service=self.automation_bound_session_queue_service,
             workspace_service=self.workspace_service,
+            session_ingress_service=self.session_ingress_service,
         )
         self.automation_scheduler_service: AutomationSchedulerService = (
             AutomationSchedulerService(automation_service=self.automation_service)

--- a/src/agent_teams/sessions/runs/run_models.py
+++ b/src/agent_teams/sessions/runs/run_models.py
@@ -52,6 +52,7 @@ class RuntimePromptConversationContext(BaseModel):
     source_kind: str | None = None
     feishu_chat_type: str | None = None
     im_force_direct_send: bool = False
+    im_reply_to_message_id: str | None = None
 
 
 class ImageGenerationConfig(BaseModel):

--- a/tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
@@ -85,12 +85,24 @@ class _FakeRuntimeConfigLookup:
 class _FakeFeishuClient:
     def __init__(self) -> None:
         self.sent_messages: list[dict[str, str]] = []
+        self.reply_messages: list[dict[str, str]] = []
         self.deleted_messages: list[str] = []
 
     def send_text_message(self, *, chat_id: str, text: str, environment=None) -> str:
         _ = environment
         self.sent_messages.append({"chat_id": chat_id, "text": text})
         return f"om_{len(self.sent_messages)}"
+
+    def reply_text_message(
+        self,
+        *,
+        message_id: str,
+        text: str,
+        environment=None,
+    ) -> str:
+        _ = environment
+        self.reply_messages.append({"message_id": message_id, "text": text})
+        return f"om_reply_{len(self.reply_messages)}"
 
     def delete_message(self, *, message_id: str, environment=None) -> None:
         _ = environment
@@ -212,9 +224,9 @@ def test_bound_queue_and_delivery_services_resume_without_premature_failed(
     waiting_record = queue_repo.list_waiting_for_result(limit=10)[0]
     delivery_record = delivery_repo.get_by_run_id("run-1")
     assert waiting_record.run_id == "run-1"
-    assert waiting_record.queue_cleanup_status == AutomationCleanupStatus.CLEANED
+    assert waiting_record.queue_cleanup_status == AutomationCleanupStatus.SKIPPED
     assert delivery_record.started_status == AutomationDeliveryStatus.SKIPPED
-    assert feishu_client.deleted_messages == ["om_1"]
+    assert feishu_client.deleted_messages == []
 
     _ = run_runtime_repo.upsert(
         RunRuntimeRecord(
@@ -271,8 +283,10 @@ def test_bound_queue_and_delivery_services_resume_without_premature_failed(
     assert delivery_record.terminal_status == AutomationDeliveryStatus.SENT
     assert delivery_record.terminal_event == AutomationDeliveryEvent.COMPLETED
     assert delivery_record.terminal_message == "Recovered report is ready."
-    assert delivery_record.terminal_message_id == "om_2"
+    assert delivery_record.terminal_message_id == "om_reply_1"
     assert all(
         "执行失败" not in message["text"] for message in feishu_client.sent_messages
     )
-    assert feishu_client.sent_messages[-1]["text"] == "Recovered report is ready."
+    assert feishu_client.reply_messages == [
+        {"message_id": "om_1", "text": "Recovered report is ready."}
+    ]

--- a/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
@@ -109,12 +109,24 @@ class _FakeRuntimeConfigLookup:
 class _FakeFeishuClient:
     def __init__(self) -> None:
         self.sent_messages: list[dict[str, str]] = []
+        self.reply_messages: list[dict[str, str]] = []
         self.deleted_messages: list[str] = []
 
     def send_text_message(self, *, chat_id: str, text: str, environment=None) -> str:
         _ = environment
         self.sent_messages.append({"chat_id": chat_id, "text": text})
         return f"om_{len(self.sent_messages)}"
+
+    def reply_text_message(
+        self,
+        *,
+        message_id: str,
+        text: str,
+        environment=None,
+    ) -> str:
+        _ = environment
+        self.reply_messages.append({"message_id": message_id, "text": text})
+        return f"om_reply_{len(self.reply_messages)}"
 
     def delete_message(self, *, message_id: str, environment=None) -> None:
         _ = environment
@@ -300,8 +312,8 @@ def test_materialize_execution_starts_in_bound_session_when_idle(
     )
     assert (
         run_service.created_intents[0].conversation_context is not None
-        and run_service.created_intents[0].conversation_context.im_force_direct_send
-        is True
+        and run_service.created_intents[0].conversation_context.im_reply_to_message_id
+        is None
     )
     assert run_service.started_run_ids == ["run-1"]
     assert len(delivery_service.register_calls) == 1
@@ -404,12 +416,18 @@ def test_process_pending_starts_queued_run_after_bound_session_becomes_idle(
     assert run_service.started_run_ids == ["run-1"]
     assert len(waiting_records) == 1
     assert waiting_records[0].run_id == "run-1"
-    assert waiting_records[0].queue_cleanup_status == AutomationCleanupStatus.CLEANED
+    assert waiting_records[0].queue_cleanup_status == AutomationCleanupStatus.SKIPPED
     assert len(delivery_service.register_calls) == 1
     assert delivery_service.register_calls[0]["send_started"] is False
     assert project_repo.project.last_session_id == "session-1"
     assert project_repo.project.last_run_started_at is not None
-    assert _feishu_client.deleted_messages == ["om_1"]
+    assert delivery_service.register_calls[0]["reply_to_message_id"] == "om_1"
+    assert run_service.created_intents[0].conversation_context is not None
+    assert (
+        run_service.created_intents[0].conversation_context.im_reply_to_message_id
+        == "om_1"
+    )
+    assert _feishu_client.deleted_messages == []
 
 
 def test_materialize_execution_fails_when_bound_session_is_missing(
@@ -602,11 +620,12 @@ def test_process_pending_exhausts_resume_attempts_and_skips_terminal_delivery(
     assert progressed is True
     assert run_service.resume_run_ids == ["run-1"]
     assert failed_record.status == AutomationBoundSessionQueueStatus.FAILED
-    assert failed_record.queue_cleanup_status == AutomationCleanupStatus.CLEANED
-    assert "自动恢复失败" in feishu_client.sent_messages[-1]["text"]
-    assert feishu_client.deleted_messages == ["om_1"]
+    assert failed_record.queue_cleanup_status == AutomationCleanupStatus.SKIPPED
+    assert feishu_client.reply_messages
+    assert "自动恢复失败" in feishu_client.reply_messages[-1]["text"]
+    assert feishu_client.deleted_messages == []
     assert delivery_service.skipped_terminal_runs == [
-        ("run-1", feishu_client.sent_messages[-1]["text"])
+        ("run-1", feishu_client.reply_messages[-1]["text"])
     ]
 
 

--- a/tests/unit_tests/automation/test_automation_delivery_service.py
+++ b/tests/unit_tests/automation/test_automation_delivery_service.py
@@ -17,6 +17,7 @@ from agent_teams.automation import (
 )
 from agent_teams.gateway.feishu.models import FeishuEnvironment
 from agent_teams.media import content_parts_from_text
+from agent_teams.notifications import NotificationContext, NotificationType
 from agent_teams.sessions.runs.enums import RunEventType
 from agent_teams.sessions.runs.event_log import EventLog
 from agent_teams.sessions.runs.run_models import RunEvent, RunResult
@@ -44,19 +45,62 @@ class _FakeRuntimeConfigLookup:
 class _FakeFeishuClient:
     def __init__(self) -> None:
         self.sent_messages: list[dict[str, str]] = []
+        self.reply_messages: list[dict[str, str]] = []
         self.deleted_messages: list[str] = []
         self.fail_delete = False
+        self.fail_send_error: RuntimeError | None = None
+        self.fail_reply_error: RuntimeError | None = None
 
     def send_text_message(self, *, chat_id: str, text: str, environment=None) -> str:
         _ = environment
+        if self.fail_send_error is not None:
+            raise self.fail_send_error
         self.sent_messages.append({"chat_id": chat_id, "text": text})
         return f"om_{len(self.sent_messages)}"
+
+    def reply_text_message(
+        self,
+        *,
+        message_id: str,
+        text: str,
+        environment=None,
+    ) -> str:
+        _ = environment
+        if self.fail_reply_error is not None:
+            raise self.fail_reply_error
+        self.reply_messages.append({"message_id": message_id, "text": text})
+        return f"om_reply_{len(self.reply_messages)}"
 
     def delete_message(self, *, message_id: str, environment=None) -> None:
         _ = environment
         if self.fail_delete:
             raise RuntimeError("delete_failed")
         self.deleted_messages.append(message_id)
+
+
+class _FakeNotificationService:
+    def __init__(self) -> None:
+        self.emit_calls: list[dict[str, object]] = []
+
+    def emit(
+        self,
+        *,
+        notification_type: NotificationType,
+        title: str,
+        body: str,
+        context: NotificationContext,
+        dedupe_key: str | None = None,
+    ) -> bool:
+        self.emit_calls.append(
+            {
+                "notification_type": notification_type,
+                "title": title,
+                "body": body,
+                "context": context,
+                "dedupe_key": dedupe_key,
+            }
+        )
+        return True
 
 
 def _build_project() -> AutomationProjectRecord:
@@ -95,10 +139,12 @@ def _build_service(
     RunRuntimeRepository,
     EventLog,
     AutomationDeliveryRepository,
+    _FakeNotificationService,
 ]:
     db_path = tmp_path / "automation-delivery.db"
     repository = AutomationDeliveryRepository(db_path)
     feishu_client = _FakeFeishuClient()
+    notification_service = _FakeNotificationService()
     run_runtime_repo = RunRuntimeRepository(db_path)
     event_log = EventLog(db_path)
     service = AutomationDeliveryService(
@@ -107,13 +153,21 @@ def _build_service(
         feishu_client=feishu_client,
         run_runtime_repo=run_runtime_repo,
         event_log=event_log,
+        notification_service=notification_service,
     )
-    return service, feishu_client, run_runtime_repo, event_log, repository
+    return (
+        service,
+        feishu_client,
+        run_runtime_repo,
+        event_log,
+        repository,
+        notification_service,
+    )
 
 
 def test_register_run_sends_started_message_immediately(tmp_path: Path) -> None:
-    service, feishu_client, _run_runtime_repo, _event_log, repository = _build_service(
-        tmp_path
+    service, feishu_client, _run_runtime_repo, _event_log, repository, _ = (
+        _build_service(tmp_path)
     )
 
     record = service.register_run(
@@ -133,8 +187,8 @@ def test_register_run_sends_started_message_immediately(tmp_path: Path) -> None:
 
 
 def test_attempt_started_delivery_claim_prevents_duplicate_send(tmp_path: Path) -> None:
-    service, feishu_client, _run_runtime_repo, _event_log, repository = _build_service(
-        tmp_path
+    service, feishu_client, _run_runtime_repo, _event_log, repository, _ = (
+        _build_service(tmp_path)
     )
     persisted = service.register_run(
         project=_build_project(),
@@ -157,7 +211,7 @@ def test_attempt_started_delivery_claim_prevents_duplicate_send(tmp_path: Path) 
 def test_process_pending_sends_completed_message_when_run_finishes(
     tmp_path: Path,
 ) -> None:
-    service, feishu_client, run_runtime_repo, event_log, repository = _build_service(
+    service, feishu_client, run_runtime_repo, event_log, repository, _ = _build_service(
         tmp_path
     )
     _ = service.register_run(
@@ -188,20 +242,22 @@ def test_process_pending_sends_completed_message_when_run_finishes(
     progressed = service.process_pending()
 
     assert progressed is True
-    assert len(feishu_client.sent_messages) == 2
-    assert feishu_client.sent_messages[1]["text"] == "Daily report is ready."
+    assert len(feishu_client.sent_messages) == 1
+    assert feishu_client.reply_messages == [
+        {"message_id": "om_1", "text": "Daily report is ready."}
+    ]
     persisted = repository.get_by_run_id("run-1")
     assert persisted.terminal_status.value == "sent"
     assert persisted.terminal_event == AutomationDeliveryEvent.COMPLETED
-    assert persisted.terminal_message_id == "om_2"
-    assert persisted.started_cleanup_status == AutomationCleanupStatus.CLEANED
-    assert feishu_client.deleted_messages == ["om_1"]
+    assert persisted.terminal_message_id == "om_reply_1"
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.SKIPPED
+    assert feishu_client.deleted_messages == []
 
 
 def test_process_pending_skips_completed_message_when_run_has_no_output(
     tmp_path: Path,
 ) -> None:
-    service, feishu_client, run_runtime_repo, event_log, repository = _build_service(
+    service, feishu_client, run_runtime_repo, event_log, repository, _ = _build_service(
         tmp_path
     )
     _ = service.register_run(
@@ -233,6 +289,7 @@ def test_process_pending_skips_completed_message_when_run_has_no_output(
 
     assert progressed is True
     assert len(feishu_client.sent_messages) == 1
+    assert feishu_client.reply_messages == []
     persisted = repository.get_by_run_id("run-1")
     assert persisted.terminal_status.value == "skipped"
     assert persisted.terminal_event == AutomationDeliveryEvent.COMPLETED
@@ -244,7 +301,7 @@ def test_process_pending_skips_completed_message_when_run_has_no_output(
 def test_process_pending_sends_structured_completed_message_when_run_finishes(
     tmp_path: Path,
 ) -> None:
-    service, feishu_client, run_runtime_repo, event_log, repository = _build_service(
+    service, feishu_client, run_runtime_repo, event_log, repository, _ = _build_service(
         tmp_path
     )
     _ = service.register_run(
@@ -280,18 +337,20 @@ def test_process_pending_sends_structured_completed_message_when_run_finishes(
     progressed = service.process_pending()
 
     assert progressed is True
-    assert len(feishu_client.sent_messages) == 2
-    assert feishu_client.sent_messages[1]["text"] == "Daily report is ready."
+    assert len(feishu_client.sent_messages) == 1
+    assert feishu_client.reply_messages == [
+        {"message_id": "om_1", "text": "Daily report is ready."}
+    ]
     persisted = repository.get_by_run_id("run-1")
     assert persisted.terminal_status.value == "sent"
     assert persisted.terminal_event == AutomationDeliveryEvent.COMPLETED
-    assert persisted.started_cleanup_status == AutomationCleanupStatus.CLEANED
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.SKIPPED
 
 
 def test_process_pending_uses_terminal_error_when_failed_output_is_empty(
     tmp_path: Path,
 ) -> None:
-    service, feishu_client, run_runtime_repo, event_log, repository = _build_service(
+    service, feishu_client, run_runtime_repo, event_log, repository, _ = _build_service(
         tmp_path
     )
     _ = service.register_run(
@@ -322,19 +381,20 @@ def test_process_pending_uses_terminal_error_when_failed_output_is_empty(
     progressed = service.process_pending()
 
     assert progressed is True
-    assert len(feishu_client.sent_messages) == 2
-    assert "provider timeout" in feishu_client.sent_messages[1]["text"]
+    assert len(feishu_client.sent_messages) == 1
+    assert len(feishu_client.reply_messages) == 1
+    assert "provider timeout" in feishu_client.reply_messages[0]["text"]
     persisted = repository.get_by_run_id("run-1")
     assert persisted.terminal_status.value == "sent"
     assert persisted.terminal_event == AutomationDeliveryEvent.FAILED
-    assert persisted.started_cleanup_status == AutomationCleanupStatus.CLEANED
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.SKIPPED
 
 
 def test_process_pending_defers_failed_delivery_while_run_is_awaiting_recovery(
     tmp_path: Path,
 ) -> None:
-    service, feishu_client, run_runtime_repo, _event_log, repository = _build_service(
-        tmp_path
+    service, feishu_client, run_runtime_repo, _event_log, repository, _ = (
+        _build_service(tmp_path)
     )
     _ = service.register_run(
         project=_build_project(),
@@ -364,7 +424,7 @@ def test_process_pending_defers_failed_delivery_while_run_is_awaiting_recovery(
 def test_process_pending_cleanup_failure_does_not_break_terminal_delivery(
     tmp_path: Path,
 ) -> None:
-    service, feishu_client, run_runtime_repo, event_log, repository = _build_service(
+    service, feishu_client, run_runtime_repo, event_log, repository, _ = _build_service(
         tmp_path
     )
     feishu_client.fail_delete = True
@@ -397,8 +457,99 @@ def test_process_pending_cleanup_failure_does_not_break_terminal_delivery(
 
     persisted = repository.get_by_run_id("run-1")
     assert progressed is True
-    assert len(feishu_client.sent_messages) == 2
+    assert len(feishu_client.sent_messages) == 1
+    assert feishu_client.reply_messages == [
+        {"message_id": "om_1", "text": "Daily report is ready."}
+    ]
     assert feishu_client.deleted_messages == []
     assert persisted.terminal_status == AutomationDeliveryStatus.SENT
-    assert persisted.started_cleanup_status == AutomationCleanupStatus.PENDING
-    assert persisted.started_cleanup_attempts == 1
+    assert persisted.started_cleanup_status == AutomationCleanupStatus.SKIPPED
+    assert persisted.started_cleanup_attempts == 0
+
+
+def test_delivery_service_suppresses_generic_terminal_notification_for_owned_run(
+    tmp_path: Path,
+) -> None:
+    service, _feishu_client, _run_runtime_repo, _event_log, _repository, _ = (
+        _build_service(tmp_path)
+    )
+    _ = service.register_run(
+        project=_build_project(),
+        session_id="session-1",
+        run_id="run-1",
+        reason="schedule",
+    )
+
+    assert service.should_suppress_terminal_notification("run-1") is True
+    assert service.should_suppress_terminal_notification("missing-run") is False
+
+
+def test_delivery_service_does_not_suppress_when_terminal_delivery_is_disabled(
+    tmp_path: Path,
+) -> None:
+    service, _feishu_client, _run_runtime_repo, _event_log, _repository, _ = (
+        _build_service(tmp_path)
+    )
+    project = _build_project().model_copy(update={"delivery_events": ()})
+    _ = service.register_run(
+        project=project,
+        session_id="session-1",
+        run_id="run-1",
+        reason="schedule",
+    )
+
+    assert service.should_suppress_terminal_notification("run-1") is False
+
+
+def test_delivery_service_emits_fallback_notification_after_terminal_delivery_failure(
+    tmp_path: Path,
+) -> None:
+    service, feishu_client, run_runtime_repo, event_log, repository, notifications = (
+        _build_service(tmp_path)
+    )
+    _ = service.register_run(
+        project=_build_project(),
+        session_id="session-1",
+        run_id="run-1",
+        reason="schedule",
+    )
+    feishu_client.fail_reply_error = RuntimeError("reply_failed")
+    run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="run-1",
+            session_id="session-1",
+            status=RunRuntimeStatus.FAILED,
+            phase=RunRuntimePhase.TERMINAL,
+            last_error="provider timeout",
+        )
+    )
+    event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_FAILED,
+            payload_json='{"status":"failed","output":"","error":"provider timeout"}',
+            occurred_at=datetime.now(tz=timezone.utc),
+        )
+    )
+
+    for _ in range(5):
+        assert service.process_pending() is True
+
+    persisted = repository.get_by_run_id("run-1")
+    assert persisted.terminal_status == AutomationDeliveryStatus.FAILED
+    assert notifications.emit_calls == [
+        {
+            "notification_type": NotificationType.RUN_FAILED,
+            "title": "Run Failed",
+            "body": "定时任务 Daily Briefing 执行失败。\n\nprovider timeout",
+            "context": NotificationContext(
+                session_id="session-1",
+                run_id="run-1",
+                trace_id="run-1",
+            ),
+            "dedupe_key": "automation-terminal-fallback:run-1",
+        }
+    ]
+    assert service.should_suppress_terminal_notification("run-1") is False

--- a/tests/unit_tests/feishu/test_client.py
+++ b/tests/unit_tests/feishu/test_client.py
@@ -311,12 +311,13 @@ def test_reply_text_message_uses_reply_endpoint(monkeypatch) -> None:
     client = FeishuClient()
     environment = FeishuEnvironment(app_id="cli_1", app_secret="secret", app_name="bot")
 
-    client.reply_text_message(
+    message_id = client.reply_text_message(
         message_id="om_1",
         text="queued",
         environment=environment,
     )
 
+    assert message_id == "om_reply_1"
     assert [request[:2] for request in fake_client.requests] == [
         ("POST", f"{base_url}/open-apis/auth/v3/tenant_access_token/internal"),
         ("POST", f"{base_url}/open-apis/im/v1/messages/om_1/reply"),

--- a/tests/unit_tests/feishu/test_inbound_runtime.py
+++ b/tests/unit_tests/feishu/test_inbound_runtime.py
@@ -90,6 +90,9 @@ class _FakeRunService:
         self.started: list[str] = []
 
     def create_run(self, intent: IntentInput) -> tuple[str, str]:
+        return self.create_detached_run(intent)
+
+    def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
         self.created.append(intent)
         return f"run-{len(self.created)}", intent.session_id
 

--- a/tests/unit_tests/feishu/test_message_pool_service.py
+++ b/tests/unit_tests/feishu/test_message_pool_service.py
@@ -30,6 +30,9 @@ from agent_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeStatus,
 )
 from agent_teams.sessions.session_models import SessionMode, SessionRecord
+from agent_teams.automation.automation_bound_session_queue_repository import (
+    AutomationBoundSessionQueueRepository,
+)
 
 
 class _FakeSessionService:
@@ -101,6 +104,9 @@ class _FakeRunService:
         self.fail_start_error: RuntimeError | None = None
 
     def create_run(self, intent: IntentInput) -> tuple[str, str]:
+        return self.create_detached_run(intent)
+
+    def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
         self.created.append(intent)
         return f"run-{len(self.created)}", intent.session_id
 
@@ -150,9 +156,10 @@ class _FakeFeishuClient:
         message_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         _ = environment
         self.reply_messages.append((message_id, text))
+        return f"om_reply_{len(self.reply_messages)}"
 
     def create_message_reaction(
         self,
@@ -230,12 +237,13 @@ def _build_service(
     repo = FeishuMessagePoolRepository(db_path)
     run_runtime_repo = RunRuntimeRepository(db_path)
     event_log = EventLog(db_path)
+    bindings = ExternalSessionBindingRepository(db_path)
     feishu_client = _FakeFeishuClient()
     run_service = _FakeRunService()
     inbound_runtime = FeishuInboundRuntime(
         session_service=_FakeSessionService(),
         run_service=run_service,
-        external_session_binding_repo=ExternalSessionBindingRepository(db_path),
+        external_session_binding_repo=bindings,
         feishu_client=None,
     )
     service = FeishuMessagePoolService(
@@ -245,6 +253,8 @@ def _build_service(
         message_pool_repo=repo,
         run_runtime_repo=run_runtime_repo,
         event_log=event_log,
+        external_session_binding_repo=bindings,
+        automation_queue_repo=AutomationBoundSessionQueueRepository(db_path),
     )
     return service, repo, feishu_client, run_runtime_repo, event_log, run_service
 

--- a/tests/unit_tests/feishu/test_trigger_handler.py
+++ b/tests/unit_tests/feishu/test_trigger_handler.py
@@ -157,9 +157,10 @@ class _FakeFeishuClient:
         message_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         _ = environment
         self.reply_messages.append((message_id, text))
+        return f"om_reply_{len(self.reply_messages)}"
 
 
 class _FakeImToolService:

--- a/tests/unit_tests/gateway/test_acp_stdio.py
+++ b/tests/unit_tests/gateway/test_acp_stdio.py
@@ -17,6 +17,7 @@ from agent_teams.gateway.acp_stdio import (
     AcpGatewayServer,
     AcpStdioRuntime,
 )
+from agent_teams.gateway.session_ingress_service import GatewaySessionIngressService
 from agent_teams.gateway.gateway_session_repository import GatewaySessionRepository
 from agent_teams.gateway.gateway_session_model_profile_store import (
     GatewaySessionModelProfileStore,
@@ -29,6 +30,12 @@ from agent_teams.sessions.session_models import SessionRecord
 from agent_teams.sessions.runs.enums import RunEventType
 from agent_teams.sessions.runs.run_manager import RunManager
 from agent_teams.sessions.runs.run_models import IntentInput, RunEvent
+from agent_teams.sessions.runs.run_runtime_repo import (
+    RunRuntimePhase,
+    RunRuntimeRecord,
+    RunRuntimeRepository,
+    RunRuntimeStatus,
+)
 from agent_teams.workspace import WorkspaceService
 from agent_teams.workspace.workspace_models import WorkspaceRecord
 
@@ -143,6 +150,9 @@ class FakeRunManager:
         run_id = f"run-{self._counter}"
         self.create_calls.append(intent.model_copy(deep=True))
         return run_id, run_id
+
+    def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
+        return self.create_run(intent)
 
     async def stream_run_events(
         self,
@@ -525,6 +535,79 @@ async def test_session_prompt_rejects_recoverable_paused_run(
         "error": {
             "code": -32000,
             "message": RECOVERABLE_PAUSED_RUN_MESSAGE,
+        },
+    }
+    assert run_manager.create_calls == []
+    assert notifications == []
+
+
+@pytest.mark.asyncio
+async def test_session_prompt_rejects_busy_active_run(
+    tmp_path: Path,
+) -> None:
+    session_service = FakeSessionService()
+    repository = GatewaySessionRepository(tmp_path / "gateway.db")
+    gateway_session_service = GatewaySessionService(
+        repository=repository,
+        session_service=cast(SessionService, session_service),
+    )
+    run_manager = FakeRunManager()
+    run_runtime_repo = RunRuntimeRepository(tmp_path / "gateway.db")
+    ingress_service = GatewaySessionIngressService(
+        run_service=cast(RunManager, run_manager),
+        run_runtime_repo=run_runtime_repo,
+    )
+    notifications: list[dict[str, JsonValue]] = []
+
+    async def notify(message: dict[str, JsonValue]) -> None:
+        notifications.append(message)
+
+    server = AcpGatewayServer(
+        gateway_session_service=gateway_session_service,
+        session_service=cast(SessionService, session_service),
+        run_service=cast(RunManager, run_manager),
+        media_asset_service=cast(MediaAssetService, object()),
+        notify=notify,
+        session_ingress_service=ingress_service,
+    )
+
+    created = await server.handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": str(tmp_path), "mcpServers": []},
+        }
+    )
+    session_id = _require_str(_require_result_object(created), "sessionId")
+    record = repository.get(session_id)
+    _ = run_runtime_repo.upsert(
+        RunRuntimeRecord(
+            run_id="run-busy",
+            session_id=record.internal_session_id,
+            status=RunRuntimeStatus.RUNNING,
+            phase=RunRuntimePhase.COORDINATOR_RUNNING,
+        )
+    )
+
+    response = await server.handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "keep going"}],
+            },
+        }
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "error": {
+            "code": -32000,
+            "message": "Session already has an active run: run-busy",
         },
     }
     assert run_manager.create_calls == []

--- a/tests/unit_tests/gateway/test_gateway_cli.py
+++ b/tests/unit_tests/gateway/test_gateway_cli.py
@@ -35,6 +35,7 @@ class _FakeContainer:
         self.session_service = object()
         self.workspace_service = object()
         self.run_service = object()
+        self.session_ingress_service = object()
         self.media_asset_service = object()
         self.role_registry = _FakeRoleRegistry()
         self.refreshed = False

--- a/tests/unit_tests/tools/im_tools/test_service.py
+++ b/tests/unit_tests/tools/im_tools/test_service.py
@@ -9,8 +9,10 @@ from agent_teams.automation import (
     AutomationFeishuBinding,
     AutomationProjectRecord,
     AutomationProjectStatus,
+    AutomationRunDeliveryRecord,
     AutomationRunConfig,
     AutomationScheduleMode,
+    AutomationDeliveryStatus,
 )
 from agent_teams.gateway.feishu.models import (
     FEISHU_METADATA_CHAT_ID_KEY,
@@ -143,6 +145,18 @@ class _FakeRunIntentLookup:
         return self._intents[run_id]
 
 
+class _FakeAutomationDeliveryLookup:
+    def __init__(
+        self, deliveries: dict[str, AutomationRunDeliveryRecord] | None = None
+    ):
+        self._deliveries = deliveries or {}
+
+    def get_by_run_id(self, run_id: str) -> AutomationRunDeliveryRecord:
+        if run_id not in self._deliveries:
+            raise KeyError(run_id)
+        return self._deliveries[run_id]
+
+
 class _FakeFeishuClient:
     def __init__(self) -> None:
         self.sent_texts: list[tuple[str, str]] = []
@@ -166,9 +180,10 @@ class _FakeFeishuClient:
         message_id: str,
         text: str,
         environment: FeishuEnvironment | None = None,
-    ) -> None:
+    ) -> str:
         _ = environment
         self.reply_texts.append((message_id, text))
+        return f"om_reply_{len(self.reply_texts)}"
 
     def send_file(
         self,
@@ -246,6 +261,7 @@ def _build_service(
     sessions: dict[str, SessionRecord] | None = None,
     configs: dict[str, FeishuTriggerRuntimeConfig] | None = None,
     projects: dict[str, AutomationProjectRecord] | None = None,
+    deliveries: dict[str, AutomationRunDeliveryRecord] | None = None,
     gateway_sessions: dict[str, GatewaySessionRecord] | None = None,
     run_intents: dict[str, IntentInput] | None = None,
     wechat_token: str | None = "wechat-token",
@@ -260,6 +276,7 @@ def _build_service(
         runtime_config_lookup=_FakeRuntimeConfigLookup(configs),
         run_intent_lookup=_FakeRunIntentLookup(run_intents),
         automation_project_repo=_FakeAutomationProjectRepo(projects),
+        automation_delivery_lookup=_FakeAutomationDeliveryLookup(deliveries),
         gateway_session_lookup=_FakeGatewaySessionLookup(gateway_sessions),
         feishu_client=resolved_feishu_client,
         wechat_account_repo=_FakeWeChatAccountRepo(),
@@ -339,6 +356,33 @@ def _automation_project(
             source_label="Release Updates",
         ),
         trigger_id="schedule-trigger",
+    )
+
+
+def _automation_delivery(
+    *,
+    run_id: str = "run-1",
+    reply_to_message_id: str | None = None,
+    started_message_id: str | None = None,
+) -> AutomationRunDeliveryRecord:
+    return AutomationRunDeliveryRecord(
+        automation_delivery_id=f"autd-{run_id}",
+        automation_project_id=_AUTOMATION_PROJECT_ID,
+        automation_project_name="Daily Briefing",
+        run_id=run_id,
+        session_id=_SESSION_ID,
+        reason="schedule",
+        binding=AutomationFeishuBinding(
+            trigger_id=_TRIGGER_ID,
+            tenant_key="tenant-1",
+            chat_id=_CHAT_ID,
+            chat_type="group",
+            source_label="Release Updates",
+        ),
+        reply_to_message_id=reply_to_message_id,
+        started_message_id=started_message_id,
+        started_status=AutomationDeliveryStatus.SENT,
+        terminal_status=AutomationDeliveryStatus.PENDING,
     )
 
 
@@ -550,6 +594,55 @@ def test_send_text_success_for_automation_session_binding() -> None:
     )
 
     result = service.send_text(session_id=_SESSION_ID, text="hello")
+
+    assert result == "Message sent."
+    assert feishu_client.sent_texts == [(_CHAT_ID, "hello")]
+    assert feishu_client.reply_texts == []
+    assert wechat_client.sent_texts == []
+
+
+def test_send_text_replies_to_automation_queue_receipt_for_run() -> None:
+    service, feishu_client, wechat_client = _build_service(
+        sessions={_SESSION_ID: _automation_session()},
+        configs=_default_configs(),
+        projects={_AUTOMATION_PROJECT_ID: _automation_project()},
+        deliveries={"run-1": _automation_delivery(reply_to_message_id="om_queue_1")},
+    )
+
+    result = service.send_text(session_id=_SESSION_ID, text="hello", run_id="run-1")
+
+    assert result == "Message sent."
+    assert feishu_client.sent_texts == []
+    assert feishu_client.reply_texts == [("om_queue_1", "hello")]
+    assert wechat_client.sent_texts == []
+
+
+def test_send_text_replies_to_automation_started_receipt_for_run() -> None:
+    service, feishu_client, wechat_client = _build_service(
+        sessions={_SESSION_ID: _automation_session()},
+        configs=_default_configs(),
+        projects={_AUTOMATION_PROJECT_ID: _automation_project()},
+        deliveries={"run-1": _automation_delivery(started_message_id="om_started_1")},
+    )
+
+    result = service.send_text(session_id=_SESSION_ID, text="hello", run_id="run-1")
+
+    assert result == "Message sent."
+    assert feishu_client.sent_texts == []
+    assert feishu_client.reply_texts == [("om_started_1", "hello")]
+    assert wechat_client.sent_texts == []
+
+
+def test_send_text_for_automation_run_without_receipt_falls_back_to_direct_send() -> (
+    None
+):
+    service, feishu_client, wechat_client = _build_service(
+        sessions=_default_sessions(),
+        configs=_default_configs(),
+        deliveries={"run-1": _automation_delivery()},
+    )
+
+    result = service.send_text(session_id=_SESSION_ID, text="hello", run_id="run-1")
 
     assert result == "Message sent."
     assert feishu_client.sent_texts == [(_CHAT_ID, "hello")]

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -497,16 +497,14 @@ def test_execute_tool_supports_projection_with_separate_visible_and_internal_dat
         tool_call_id="call-projection-1",
     )
 
-    assert result == {
-        "ok": True,
-        "data": {"output": "/tmp", "exit_code": 0},
-        "error": None,
-        "meta": {
-            "approval_required": False,
-            "approval_status": "not_required",
-            "duration_ms": 0,
-        },
-    }
+    assert result["ok"] is True
+    assert result["data"] == {"output": "/tmp", "exit_code": 0}
+    assert result["error"] is None
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert meta["approval_required"] is False
+    assert meta["approval_status"] == "not_required"
+    duration_ms = cast(int, meta["duration_ms"])
+    assert duration_ms >= 0
     assert state is not None
     assert state.result_envelope is not None
     internal_data = cast(

--- a/tests/unit_tests/wechat/test_service.py
+++ b/tests/unit_tests/wechat/test_service.py
@@ -19,9 +19,14 @@ from agent_teams.gateway.gateway_session_service import GatewaySessionService
 from agent_teams.gateway.im import ImSessionCommandService, ImToolService
 from agent_teams.gateway.wechat.account_repository import WeChatAccountRepository
 from agent_teams.gateway.wechat.client import WeChatClient
+from agent_teams.gateway.wechat.inbound_queue_repository import (
+    WeChatInboundQueueRepository,
+)
 from agent_teams.gateway.wechat.models import (
     WeChatAccountRecord,
     WeChatInboundMessage,
+    WeChatInboundQueueRecord,
+    WeChatInboundQueueStatus,
     WeChatMessageItem,
 )
 from agent_teams.gateway.wechat.secret_store import WeChatSecretStore
@@ -34,9 +39,7 @@ from agent_teams.sessions.runs.run_models import RunEvent, RunResult
 from agent_teams.sessions.session_models import SessionMode
 
 _RECEIPT_CREATED = "\u6536\u5230\uff0c\u6b63\u5728\u5904\u7406\u3002"
-_RECEIPT_JOINED = (
-    "\u6536\u5230\uff0c\u5df2\u52a0\u5165\u5f53\u524d\u4f1a\u8bdd\u5904\u7406\u3002"
-)
+_RECEIPT_QUEUED = "\u6536\u5230\uff0c\u5df2\u8fdb\u5165\u6392\u961f\u3002\u5f53\u524d\u4f1a\u8bdd\u524d\u9762\u8fd8\u6709 1 \u6761\u6d88\u606f\u3002"
 
 
 def test_normalize_qr_code_url_keeps_image_url() -> None:
@@ -234,6 +237,27 @@ async def test_await_terminal_and_reply_sends_pause_notice_without_clearing_bind
     assert "run-1" not in service._watched_runs
 
 
+@pytest.mark.asyncio
+async def test_await_run_completion_for_queue_drain_stops_on_terminal_event() -> None:
+    service, _gateway_session_service, _run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(
+                _event(
+                    run_id="external-run-1",
+                    event_type=RunEventType.RUN_COMPLETED,
+                    payload={"output": "done"},
+                ),
+            ),
+            has_active_run=False,
+        )
+    )
+
+    await service._await_run_completion_for_queue_drain(
+        session_id="session-1",
+        run_id="external-run-1",
+    )
+
+
 def test_handle_reply_future_records_cancelled_future() -> None:
     service, gateway_session_service, _, _, _ = _build_service(events=())
     future: Future[None] = Future()
@@ -319,12 +343,11 @@ def test_handle_message_sends_receipt_before_starting_run() -> None:
     assert gateway_session_service.bind_calls == [("gws-1", "run-created")]
 
 
-def test_handle_message_uses_joined_receipt_when_run_already_active() -> None:
+def test_handle_message_queues_when_run_is_already_active() -> None:
     service, _, run_service, im_tool_service, _ = _build_service(
         events=(),
         has_active_run=True,
     )
-    service._watched_runs.add("run-created")
 
     service._handle_message(
         _account(),
@@ -335,8 +358,293 @@ def test_handle_message_uses_joined_receipt_when_run_already_active() -> None:
         ),
     )
 
-    assert im_tool_service.send_text_calls[0]["text"] == _RECEIPT_JOINED
+    assert im_tool_service.send_text_calls[0]["text"] == _RECEIPT_QUEUED
+    assert len(run_service.created_intents) == 0
+
+
+def test_drain_inbound_queue_starts_queue_drain_watcher_for_external_blocker() -> None:
+    service, _gateway_session_service, run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(),
+            has_active_run=True,
+        )
+    )
+    repo = cast(_FakeInboundQueueRepo, service._inbound_queue_repo)
+    watcher_calls: list[tuple[str, str]] = []
+    repo.records["inq-external"] = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-external",
+        account_id="wx-account-1",
+        message_key="mid:external",
+        gateway_session_id="gws-1",
+        session_id="session-1",
+        peer_user_id="wx-peer-1",
+        text="hello",
+    )
+    setattr(
+        service,
+        "_start_queue_drain_watcher",
+        lambda *, session_id, run_id: watcher_calls.append((session_id, run_id)),
+    )
+
+    service._drain_inbound_queue()
+
+    assert watcher_calls == [("session-1", "run-1")]
+    assert run_service.created_intents == []
+    queued = repo.get("inq-external")
+    assert queued is not None
+    assert queued.status == WeChatInboundQueueStatus.QUEUED
+
+
+def test_drain_inbound_queue_starts_queue_drain_watcher_for_waiting_result_blocker() -> (
+    None
+):
+    service, _gateway_session_service, run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(),
+            has_active_run=True,
+        )
+    )
+    repo = cast(_FakeInboundQueueRepo, service._inbound_queue_repo)
+    repo.records["inq-active"] = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-active",
+        account_id="wx-account-1",
+        message_key="mid:active",
+        gateway_session_id="gws-1",
+        session_id="session-1",
+        peer_user_id="wx-peer-1",
+        text="first",
+        status=WeChatInboundQueueStatus.WAITING_RESULT,
+        run_id="run-1",
+    )
+    repo.records["inq-queued"] = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-queued",
+        account_id="wx-account-1",
+        message_key="mid:queued",
+        gateway_session_id="gws-1",
+        session_id="session-1",
+        peer_user_id="wx-peer-1",
+        text="second",
+    )
+    watcher_calls: list[tuple[str, str]] = []
+    setattr(
+        service,
+        "_start_queue_drain_watcher",
+        lambda *, session_id, run_id: watcher_calls.append((session_id, run_id)),
+    )
+
+    service._drain_inbound_queue()
+
+    assert watcher_calls == [("session-1", "run-1")]
+    assert run_service.created_intents == []
+    queued = repo.get("inq-queued")
+    assert queued is not None
+    assert queued.status == WeChatInboundQueueStatus.QUEUED
+
+
+def test_start_queued_record_busy_retry_does_not_clobber_waiting_result() -> None:
+    service, _gateway_session_service, _run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(),
+            has_active_run=False,
+        )
+    )
+    repo = cast(_FakeInboundQueueRepo, service._inbound_queue_repo)
+    record = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-1",
+        account_id="wx-account-1",
+        message_key="mid:1",
+        gateway_session_id="gws-1",
+        session_id="session-1",
+        peer_user_id="wx-peer-1",
+        context_token="ctx-1",
+        text="hello",
+        status=WeChatInboundQueueStatus.STARTING,
+    )
+    repo.records[record.inbound_queue_id] = record
+
+    def _simulate_concurrent_start(intent: object) -> str:
+        _ = intent
+        current = repo.get("inq-1")
+        assert current is not None
+        repo.update(
+            current.model_copy(
+                update={
+                    "status": WeChatInboundQueueStatus.WAITING_RESULT,
+                    "run_id": "run-existing",
+                    "updated_at": datetime.now(tz=timezone.utc),
+                }
+            )
+        )
+        raise RuntimeError("session_busy")
+
+    setattr(service, "_start_session_ingress_run", _simulate_concurrent_start)
+
+    started = service._start_queued_record(record)
+    updated = repo.get("inq-1")
+
+    assert started is False
+    assert updated is not None
+    assert updated.status == WeChatInboundQueueStatus.WAITING_RESULT
+    assert updated.run_id == "run-existing"
+
+
+def test_handle_queue_drain_future_redrains_when_blocker_clears() -> None:
+    service, _gateway_session_service, _run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(),
+            has_active_run=False,
+        )
+    )
+    future: Future[None] = Future()
+    future.set_result(None)
+    drain_calls: list[str] = []
+    service._drain_watched_runs.add("external-run-1")
+    setattr(service, "_drain_inbound_queue", lambda: drain_calls.append("drain"))
+
+    service._handle_queue_drain_future(
+        session_id="session-1",
+        run_id="external-run-1",
+        future=future,
+    )
+
+    assert drain_calls == ["drain"]
+    assert "external-run-1" not in service._drain_watched_runs
+
+
+def test_start_queued_record_requeues_non_busy_start_failure() -> None:
+    service, _gateway_session_service, _run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(),
+            has_active_run=False,
+        )
+    )
+    repo = cast(_FakeInboundQueueRepo, service._inbound_queue_repo)
+    record = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-2",
+        account_id="wx-account-1",
+        message_key="mid:2",
+        gateway_session_id="gws-1",
+        session_id="session-1",
+        peer_user_id="wx-peer-1",
+        context_token="ctx-2",
+        text="hello",
+        status=WeChatInboundQueueStatus.STARTING,
+    )
+    repo.records[record.inbound_queue_id] = record
+
+    def _fail_start(intent: object) -> str:
+        _ = intent
+        raise RuntimeError("temporary_start_failure")
+
+    setattr(service, "_start_session_ingress_run", _fail_start)
+
+    started = service._start_queued_record(record)
+    updated = repo.get("inq-2")
+
+    assert started is False
+    assert updated is not None
+    assert updated.status == WeChatInboundQueueStatus.QUEUED
+    assert updated.last_error == "temporary_start_failure"
+    assert updated.completed_at is None
+
+
+def test_start_queued_record_marks_missing_account_failed() -> None:
+    service, _gateway_session_service, _run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(),
+            has_active_run=False,
+        )
+    )
+    repo = cast(_FakeInboundQueueRepo, service._inbound_queue_repo)
+    record = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-missing-account",
+        account_id="missing-account",
+        message_key="mid:missing-account",
+        gateway_session_id="gws-1",
+        session_id="session-1",
+        peer_user_id="wx-peer-1",
+        context_token="ctx-1",
+        text="hello",
+        status=WeChatInboundQueueStatus.STARTING,
+    )
+    repo.records[record.inbound_queue_id] = record
+
+    started = service._start_queued_record(record)
+    updated = repo.get("inq-missing-account")
+
+    assert started is False
+    assert updated is not None
+    assert updated.status == WeChatInboundQueueStatus.FAILED
+    assert updated.run_id is None
+    assert updated.last_error == "WeChat account not found: missing-account"
+    assert updated.completed_at is not None
+
+
+def test_drain_inbound_queue_skips_missing_account_and_starts_later_record() -> None:
+    service, _gateway_session_service, run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(),
+            has_active_run=False,
+        )
+    )
+    repo = cast(_FakeInboundQueueRepo, service._inbound_queue_repo)
+    setattr(service, "_start_run_watcher", lambda **_: None)
+    repo.records["inq-bad"] = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-bad",
+        account_id="missing-account",
+        message_key="mid:bad",
+        gateway_session_id="gws-bad",
+        session_id="session-bad",
+        peer_user_id="wx-peer-1",
+        context_token="ctx-bad",
+        text="bad",
+    )
+    repo.records["inq-good"] = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-good",
+        account_id="wx-account-1",
+        message_key="mid:good",
+        gateway_session_id="gws-1",
+        session_id="session-1",
+        peer_user_id="wx-peer-1",
+        context_token="ctx-1",
+        text="good",
+    )
+
+    service._drain_inbound_queue()
+
+    bad = repo.get("inq-bad")
+    good = repo.get("inq-good")
+    assert bad is not None
+    assert bad.status == WeChatInboundQueueStatus.FAILED
+    assert bad.last_error == "WeChat account not found: missing-account"
+    assert good is not None
+    assert good.status == WeChatInboundQueueStatus.WAITING_RESULT
     assert len(run_service.created_intents) == 1
+    assert run_service.created_intents[0]["session_id"] == "session-1"
+
+
+def test_build_receipt_text_returns_failure_receipt_for_failed_record() -> None:
+    service, _gateway_session_service, _run_service, _im_tool_service, _ = (
+        _build_service(
+            events=(),
+            has_active_run=False,
+        )
+    )
+    record = WeChatInboundQueueRecord(
+        inbound_queue_id="inq-failed",
+        account_id="wx-account-1",
+        message_key="mid:failed",
+        gateway_session_id="gws-1",
+        session_id="session-1",
+        peer_user_id="wx-peer-1",
+        text="hello",
+        status=WeChatInboundQueueStatus.FAILED,
+        last_error="temporary_start_failure",
+    )
+
+    receipt_text = service._build_receipt_text(record)
+
+    assert receipt_text == "收到，但处理失败：temporary_start_failure"
 
 
 class _FakeRepository:
@@ -508,6 +816,139 @@ class _FakeGatewaySessionService:
         )
 
 
+class _FakeInboundQueueRepo:
+    def __init__(self) -> None:
+        self.records: dict[str, WeChatInboundQueueRecord] = {}
+
+    def create_or_get(
+        self,
+        record: WeChatInboundQueueRecord,
+    ) -> tuple[WeChatInboundQueueRecord, bool]:
+        for existing in self.records.values():
+            if (
+                existing.account_id == record.account_id
+                and existing.peer_user_id == record.peer_user_id
+                and existing.message_key == record.message_key
+            ):
+                return existing, False
+        self.records[record.inbound_queue_id] = record
+        return record, True
+
+    def get(self, inbound_queue_id: str) -> WeChatInboundQueueRecord | None:
+        return self.records.get(inbound_queue_id)
+
+    def get_latest_by_run_id(self, run_id: str) -> WeChatInboundQueueRecord | None:
+        matches = [
+            record
+            for record in self.records.values()
+            if str(record.run_id or "") == run_id
+        ]
+        if not matches:
+            return None
+        matches.sort(key=lambda item: item.updated_at, reverse=True)
+        return matches[0]
+
+    def update(self, record: WeChatInboundQueueRecord) -> WeChatInboundQueueRecord:
+        self.records[record.inbound_queue_id] = record
+        return record
+
+    def list_ready_to_start(
+        self,
+        *,
+        stale_before: datetime | None = None,
+    ) -> tuple[WeChatInboundQueueRecord, ...]:
+        ready = [
+            record
+            for record in self.records.values()
+            if record.status == WeChatInboundQueueStatus.QUEUED
+            or (
+                stale_before is not None
+                and record.status == WeChatInboundQueueStatus.STARTING
+                and record.updated_at <= stale_before
+            )
+        ]
+        ready.sort(key=lambda item: item.created_at)
+        return tuple(ready)
+
+    def claim_starting(
+        self,
+        *,
+        inbound_queue_id: str,
+        stale_before: datetime,
+    ) -> WeChatInboundQueueRecord | None:
+        record = self.records.get(inbound_queue_id)
+        if record is None:
+            return None
+        if record.status not in {
+            WeChatInboundQueueStatus.QUEUED,
+            WeChatInboundQueueStatus.STARTING,
+        }:
+            return None
+        if (
+            record.status == WeChatInboundQueueStatus.STARTING
+            and record.updated_at > stale_before
+        ):
+            return None
+        claimed = record.model_copy(
+            update={
+                "status": WeChatInboundQueueStatus.STARTING,
+                "last_error": None,
+                "updated_at": datetime.now(tz=timezone.utc),
+            }
+        )
+        self.records[inbound_queue_id] = claimed
+        return claimed
+
+    def requeue_if_starting(
+        self,
+        *,
+        inbound_queue_id: str,
+        last_error: str | None = None,
+    ) -> WeChatInboundQueueRecord | None:
+        record = self.records.get(inbound_queue_id)
+        if record is None or record.status != WeChatInboundQueueStatus.STARTING:
+            return None
+        updated = record.model_copy(
+            update={
+                "status": WeChatInboundQueueStatus.QUEUED,
+                "run_id": None,
+                "last_error": last_error,
+                "updated_at": datetime.now(tz=timezone.utc),
+                "completed_at": None,
+            }
+        )
+        self.records[inbound_queue_id] = updated
+        return updated
+
+    def count_non_terminal_ahead(self, inbound_queue_id: str) -> int:
+        current = self.records[inbound_queue_id]
+        ordered = list(self.records.values())
+        current_index = ordered.index(current)
+        return sum(
+            1
+            for record in ordered[:current_index]
+            if record.session_id == current.session_id
+            and record.status
+            in {
+                WeChatInboundQueueStatus.QUEUED,
+                WeChatInboundQueueStatus.STARTING,
+                WeChatInboundQueueStatus.WAITING_RESULT,
+            }
+        )
+
+    def has_non_terminal_item_for_run(self, run_id: str) -> bool:
+        return any(
+            str(record.run_id or "") == run_id
+            and record.status
+            in {
+                WeChatInboundQueueStatus.QUEUED,
+                WeChatInboundQueueStatus.STARTING,
+                WeChatInboundQueueStatus.WAITING_RESULT,
+            }
+            for record in self.records.values()
+        )
+
+
 class _FakeRunService:
     def __init__(self, events: tuple[RunEvent, ...]) -> None:
         self._events = events
@@ -592,12 +1033,18 @@ def _build_service(
         ImSessionCommandService,
         command_service,
     )
+    service._inbound_queue_repo = cast(
+        WeChatInboundQueueRepository,
+        _FakeInboundQueueRepo(),
+    )
+    service._session_ingress_service = None
     service._status_lock = Lock()
     service._status_by_account = {}
     service._monitor_stop_events = {}
     service._monitor_threads = {}
     service._login_sessions = {}
     service._watched_runs = set()
+    service._drain_watched_runs = set()
     return (
         service,
         gateway_session_service,


### PR DESCRIPTION
## Summary
- route Feishu, WeChat, automation, and ACP into sessions through one shared gateway ingress service
- queue WeChat inbound messages persistently and prevent implicit attach to active runs
- suppress duplicate Feishu terminal replies when automation delivery already owns the terminal message

## Testing
- uv run --extra dev pytest -q tests/unit_tests/automation/test_automation_delivery_service.py tests/unit_tests/feishu/test_notification_delivery.py tests/unit_tests/gateway/test_gateway_cli.py tests/unit_tests/feishu/test_message_pool_service.py tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
- uv run --extra dev pytest -q tests/unit_tests/feishu/test_inbound_runtime.py tests/unit_tests/feishu/test_message_pool_service.py tests/unit_tests/gateway/test_gateway_cli.py tests/unit_tests/gateway/test_acp_stdio.py tests/unit_tests/wechat/test_service.py tests/unit_tests/automation/test_automation_service.py tests/unit_tests/automation/test_automation_bound_session_queue_service.py
- uv run --extra dev pytest -q tests/integration_tests
- uv run --extra dev pytest -q tests/unit_tests currently has one unrelated flaky assertion in 	ests/unit_tests/tools/runtime/test_execution.py that intermittently expects duration_ms == 0

Closes #144
Closes #134