### PR TITLE
Improve tool block previews and layout

### DIFF
--- a/frontend/dist/css/components.css
+++ b/frontend/dist/css/components.css
@@ -757,10 +757,10 @@
 }
 
 .thinking-block {
-    margin: 0 0 0.95rem;
+    margin: 0 0 0.45rem;
     border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
     border-radius: var(--radius-md);
-    background: color-mix(in srgb, var(--bg-surface-muted) 86%, transparent);
+    background: color-mix(in srgb, var(--bg-surface-muted) 72%, transparent);
     overflow: hidden;
 }
 
@@ -769,10 +769,10 @@
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
-    padding: 0.65rem 0.85rem;
+    padding: 0.34rem 0.65rem;
     cursor: pointer;
-    color: var(--text-secondary);
-    font-size: 0.76rem;
+    color: color-mix(in srgb, var(--text-secondary) 85%, var(--primary) 15%);
+    font-size: 0.7rem;
     font-weight: 600;
     letter-spacing: 0.03em;
     text-transform: uppercase;
@@ -804,21 +804,85 @@
     flex: 0 0 auto;
     align-items: center;
     justify-content: center;
-    min-width: 2.5rem;
-    padding: 0.14rem 0.46rem;
+    min-width: 2.2rem;
+    padding: 0.1rem 0.38rem;
     border-radius: 999px;
-    background: color-mix(in srgb, var(--primary) 18%, transparent);
-    color: var(--primary);
-    font-size: 0.66rem;
+    background: color-mix(in srgb, var(--primary) 14%, transparent);
+    color: color-mix(in srgb, var(--primary) 86%, var(--text-secondary) 14%);
+    font-size: 0.62rem;
     letter-spacing: 0.04em;
 }
 
 .thinking-body {
-    padding: 0 0.85rem 0.85rem;
+    padding: 0 0.65rem 0.45rem;
 }
 
 .thinking-text {
     color: color-mix(in srgb, var(--text-msg-content) 88%, var(--text-secondary) 12%);
+}
+
+.user-prompt-block {
+    margin: 0 0 0.65rem;
+    border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--bg-surface-muted) 44%, transparent);
+    overflow: hidden;
+}
+
+.user-prompt-summary {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: 0.6rem;
+    row-gap: 0.15rem;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    list-style: none;
+}
+
+.user-prompt-summary::-webkit-details-marker {
+    display: none;
+}
+
+.user-prompt-summary::before {
+    content: '>';
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    transform: rotate(0deg);
+    transition: transform 0.16s ease;
+    grid-row: 1 / span 2;
+    margin-top: 0.1rem;
+}
+
+.user-prompt-block[open] > .user-prompt-summary::before {
+    transform: rotate(90deg);
+}
+
+.user-prompt-title {
+    color: var(--text-primary);
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.user-prompt-preview {
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.user-prompt-body {
+    padding: 0 0.75rem 0.75rem 2rem;
+}
+
+.user-prompt-text {
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--text-msg-content);
 }
 
 .streaming-cursor {
@@ -1672,6 +1736,66 @@
 .round-detail-intent {
     font-size: 0.875rem;
     color: var(--text-primary);
+}
+
+.round-detail-intent-summary {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: 0.65rem;
+    row-gap: 0.18rem;
+    padding-top: 0.15rem;
+    cursor: pointer;
+    list-style: none;
+}
+
+.round-detail-intent-summary::-webkit-details-marker {
+    display: none;
+}
+
+.round-detail-intent-summary::before {
+    content: '>';
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    transform: rotate(0deg);
+    transition: transform 0.16s ease;
+    grid-row: 1 / span 2;
+    margin-top: 0.08rem;
+}
+
+.round-detail-intent[open] > .round-detail-intent-summary::before {
+    transform: rotate(90deg);
+}
+
+.round-detail-intent-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.round-detail-intent-preview {
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.round-detail-intent-body {
+    padding: 0.5rem 0 0 1.55rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.6;
+}
+
+.round-detail-intent[open] > .round-detail-intent-summary .round-detail-intent-preview {
+    display: none;
 }
 
 .session-round-section {

--- a/frontend/dist/css/components/messages.css
+++ b/frontend/dist/css/components/messages.css
@@ -189,10 +189,10 @@
 }
 
 .thinking-block {
-    margin: 0 0 0.65rem;
+    margin: 0 0 0.45rem;
     border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
     border-radius: var(--radius-sm);
-    background: color-mix(in srgb, var(--bg-surface-muted) 50%, transparent);
+    background: color-mix(in srgb, var(--bg-surface-muted) 42%, transparent);
     overflow: hidden;
 }
 
@@ -201,10 +201,10 @@
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
-    padding: 0.4rem 0.7rem;
+    padding: 0.34rem 0.65rem;
     cursor: pointer;
-    color: var(--text-secondary);
-    font-size: 0.72rem;
+    color: color-mix(in srgb, var(--text-secondary) 85%, var(--primary) 15%);
+    font-size: 0.7rem;
     font-weight: 600;
     letter-spacing: 0.03em;
     text-transform: uppercase;
@@ -236,21 +236,85 @@
     flex: 0 0 auto;
     align-items: center;
     justify-content: center;
-    min-width: 2.5rem;
-    padding: 0.14rem 0.46rem;
+    min-width: 2.2rem;
+    padding: 0.1rem 0.38rem;
     border-radius: 999px;
-    background: color-mix(in srgb, var(--primary) 18%, transparent);
-    color: var(--primary);
-    font-size: 0.66rem;
+    background: color-mix(in srgb, var(--primary) 14%, transparent);
+    color: color-mix(in srgb, var(--primary) 86%, var(--text-secondary) 14%);
+    font-size: 0.62rem;
     letter-spacing: 0.04em;
 }
 
 .thinking-body {
-    padding: 0 0.7rem 0.55rem;
+    padding: 0 0.65rem 0.45rem;
 }
 
 .thinking-text {
     color: color-mix(in srgb, var(--text-msg-content) 88%, var(--text-secondary) 12%);
+}
+
+.user-prompt-block {
+    margin: 0 0 0.65rem;
+    border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--bg-surface-muted) 44%, transparent);
+    overflow: hidden;
+}
+
+.user-prompt-summary {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: 0.6rem;
+    row-gap: 0.15rem;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    list-style: none;
+}
+
+.user-prompt-summary::-webkit-details-marker {
+    display: none;
+}
+
+.user-prompt-summary::before {
+    content: '>';
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    transform: rotate(0deg);
+    transition: transform 0.16s ease;
+    grid-row: 1 / span 2;
+    margin-top: 0.1rem;
+}
+
+.user-prompt-block[open] > .user-prompt-summary::before {
+    transform: rotate(90deg);
+}
+
+.user-prompt-title {
+    color: var(--text-primary);
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.user-prompt-preview {
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.user-prompt-body {
+    padding: 0 0.75rem 0.75rem 2rem;
+}
+
+.user-prompt-text {
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--text-msg-content);
 }
 
 .streaming-cursor {

--- a/frontend/dist/css/components/tools.css
+++ b/frontend/dist/css/components/tools.css
@@ -13,7 +13,7 @@
     display: flex;
     align-items: center;
     gap: 0.35rem;
-    padding: 0.25rem 0;
+    padding: 0.25rem 0.5rem;
     cursor: pointer;
     list-style: none;
     color: var(--text-secondary);
@@ -61,6 +61,14 @@
     color: var(--text-muted, var(--text-secondary));
     flex: 1 1 auto;
     min-width: 0;
+    transition: opacity 0.2s ease, max-width 0.25s ease;
+    opacity: 1;
+}
+
+.tool-block[open] .tool-summary-preview {
+    opacity: 0;
+    max-width: 0;
+    overflow: hidden;
 }
 
 .tool-status {
@@ -74,12 +82,14 @@
 
 .tool-detail {
     padding: 0.25rem 0 0.5rem 0;
+    animation: tool-detail-in 0.2s ease;
 }
 
 .tool-detail-card {
-    border: 1px solid var(--border-color);
+    position: relative;
+    border: none;
     border-radius: var(--radius-md);
-    background: var(--bg-tool-body, var(--bg-surface-muted));
+    background: var(--bg-tool-card, rgba(255, 255, 255, 0.03));
     overflow: hidden;
 }
 
@@ -88,6 +98,14 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.55rem 0.85rem 0;
+}
+
+.tool-detail-header--minimal {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0.35rem 0.5rem;
+    z-index: 1;
 }
 
 .tool-lang-label {
@@ -126,6 +144,7 @@
     word-break: break-all;
     line-height: 1.55;
     color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.02);
 }
 
 .tool-input-value {
@@ -136,12 +155,105 @@
     word-break: break-all;
     line-height: 1.55;
     color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.02);
 }
 
 .tool-prompt {
     color: var(--text-secondary);
     user-select: none;
     margin-right: 0.25rem;
+}
+
+/* Line range badge (for read tool) */
+
+.tool-line-range {
+    margin-left: 0.5rem;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+}
+
+/* Lined code content (with line numbers) */
+
+.tool-lined-code {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.55;
+    padding: 0.35rem 0;
+}
+
+.tool-lined-code--scroll {
+    max-height: 400px;
+    overflow: auto;
+}
+
+.tool-line {
+    display: flex;
+    padding-right: 0.85rem;
+    min-height: 1.55em;
+}
+
+.tool-line:hover {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.tool-line-no {
+    flex: 0 0 auto;
+    min-width: 2.5rem;
+    padding: 0 0.65rem 0 0.55rem;
+    text-align: right;
+    color: var(--text-secondary);
+    opacity: 0.45;
+    user-select: none;
+    font-variant-numeric: tabular-nums;
+}
+
+.tool-line-text {
+    flex: 1 1 0;
+    min-width: 0;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+/* Side-by-side diff (for edit tool) */
+
+.tool-diff-side {
+    max-height: 400px;
+    overflow: auto;
+    padding: 0.35rem 0;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    line-height: 1.55;
+}
+
+.tool-diff-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    min-height: 1.55em;
+}
+
+.tool-diff-row:hover {
+    filter: brightness(1.15);
+}
+
+.tool-diff-cell {
+    padding: 0 0.5rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    min-width: 0;
+}
+
+.tool-diff-cell--old {
+    border-right: none;
+}
+
+.tool-diff-row--changed .tool-diff-cell--old {
+    background: rgba(239, 68, 68, 0.1);
+    color: var(--danger, #ef6b6b);
+}
+
+.tool-diff-row--changed .tool-diff-cell--new {
+    background: rgba(34, 197, 94, 0.1);
+    color: var(--success, #22c55e);
 }
 
 /* Args display (for non-shell tools) */
@@ -169,7 +281,11 @@
     color: var(--text-secondary);
     max-height: 400px;
     overflow-y: auto;
-    border-top: 1px solid var(--border-color);
+}
+
+.tool-output:has(.tool-lined-code) {
+    padding: 0;
+    white-space: normal;
 }
 
 .tool-output:empty {
@@ -219,7 +335,7 @@
 
 .tool-approval-inline {
     padding: 0.4rem 0.85rem;
-    border-top: 1px solid var(--border-color);
+    background: rgba(255, 255, 255, 0.015);
 }
 
 .tool-approval-state {
@@ -241,7 +357,14 @@
     padding: 0.35rem 0.85rem;
     font-size: 0.72rem;
     color: var(--text-secondary);
-    border-bottom: 1px solid var(--border-color);
+    background: rgba(255, 255, 255, 0.015);
+}
+
+/* --- Animations --- */
+
+@keyframes tool-detail-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
 }
 
 /* ---- Non-tool-block styles kept for backward compat ---- */

--- a/frontend/dist/js/components/messageRenderer/helpers/block.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/block.js
@@ -57,12 +57,16 @@ function applyMessageMetadata(wrapper, options = {}) {
     if (streamKey) wrapper.dataset.streamKey = streamKey;
 }
 
-export function renderParts(contentEl, parts, pendingToolBlocks) {
+export function renderParts(contentEl, parts, pendingToolBlocks, options = {}) {
     let combinedText = '';
 
     const flushText = () => {
         if (combinedText.trim()) {
-            appendMessageText(contentEl, combinedText.trim());
+            if (options.collapseUserPrompt === true) {
+                appendUserPromptText(contentEl, combinedText.trim());
+            } else {
+                appendMessageText(contentEl, combinedText.trim());
+            }
             combinedText = '';
         }
     };
@@ -234,6 +238,23 @@ export function appendMessageText(contentEl, text, options = {}) {
     return textEl;
 }
 
+export function appendUserPromptText(contentEl, text) {
+    const promptEl = document.createElement('details');
+    promptEl.className = 'user-prompt-block';
+    promptEl.innerHTML = `
+        <summary class="user-prompt-summary">
+            <span class="user-prompt-title"></span>
+            <span class="user-prompt-preview"></span>
+        </summary>
+        <div class="user-prompt-body">
+            <div class="user-prompt-text"></div>
+        </div>
+    `;
+    updateUserPromptText(promptEl, text);
+    contentEl.appendChild(promptEl);
+    return promptEl;
+}
+
 export function appendThinkingText(contentEl, text, options = {}) {
     const { textEl } = ensureThinkingBlock(contentEl, options);
     updateThinkingText(textEl, text, options);
@@ -244,6 +265,26 @@ export function updateMessageText(textEl, text, options = {}) {
     renderRichContent(textEl, String(text || ''));
     syncStreamingCursor(textEl, options.streaming === true);
     return textEl;
+}
+
+export function updateUserPromptText(promptEl, text) {
+    const normalized = String(text || '').replace(/\r\n?/g, '\n').trim();
+    const lines = normalized ? normalized.split('\n') : [];
+    const title = lines[0] || t('subagent.task_prompt');
+    const preview = lines.length > 1 ? lines.slice(1).join('\n') : title;
+    const titleEl = promptEl?.querySelector('.user-prompt-title');
+    const previewEl = promptEl?.querySelector('.user-prompt-preview');
+    const bodyEl = promptEl?.querySelector('.user-prompt-text');
+    if (titleEl) {
+        titleEl.textContent = title;
+    }
+    if (previewEl) {
+        previewEl.textContent = preview;
+    }
+    if (bodyEl) {
+        bodyEl.textContent = normalized;
+    }
+    return promptEl;
 }
 
 export function updateThinkingText(textEl, text, options = {}) {

--- a/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
@@ -7,11 +7,11 @@ import { appendStructuredContentPart, renderRichContent } from './content.js';
 import { t, formatMessage } from '../../../utils/i18n.js';
 
 const TOOL_SUMMARY_MAP = {
-    shell:     { key: 'tool.summary.shell',     fields: ['command', 'cmd'], lang: 'tool.lang.shell', detailKind: 'command' },
-    read:      { key: 'tool.summary.read',      fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'value' },
-    write:     { key: 'tool.summary.write',     fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'value' },
-    write_tmp: { key: 'tool.summary.write',     fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'value' },
-    edit:      { key: 'tool.summary.edit',      fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'value' },
+    shell:     { key: 'tool.summary.shell',     fields: ['command', 'cmd'], detailKind: 'command' },
+    read:      { key: 'tool.summary.read',      fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'read' },
+    write:     { key: 'tool.summary.write',     fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'write' },
+    write_tmp: { key: 'tool.summary.write',     fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'write' },
+    edit:      { key: 'tool.summary.edit',      fields: ['path', 'file_path', 'filepath', 'target_path'], detailKind: 'edit' },
     grep:      { key: 'tool.summary.grep',      fields: ['pattern', 'query'], detailKind: 'value' },
     glob:      { key: 'tool.summary.glob',      fields: ['pattern', 'glob'], detailKind: 'value' },
     websearch: { key: 'tool.summary.websearch', fields: ['query', 'q', 'search_query'], detailKind: 'value' },
@@ -23,25 +23,36 @@ const CHECK_SVG = '<svg class="status-icon status-success" viewBox="0 0 24 24" f
 const ERROR_SVG = '<svg class="status-icon status-error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;"><path d="M18 6L6 18M6 6l12 12"/></svg>';
 const WARNING_SVG = '<svg class="status-icon status-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px;"><path d="M12 9v4"/><path d="M12 17h.01"/><path d="M10.29 3.86l-8.2 14.2A2 2 0 0 0 3.8 21h16.4a2 2 0 0 0 1.73-2.94l-8.2-14.2a2 2 0 0 0-3.46 0z"/></svg>';
 const SPINNER_HTML = '<div class="spinner"></div>';
+const MAX_DIFF_DP_CELLS = 50000;
+const MAX_DIFF_TOTAL_LINES = 600;
+const MAX_WRITE_PREVIEW_LINES = 200;
+const MAX_WRITE_PREVIEW_CHARS = 12000;
+const INLINE_READ_TAGS = new Set(['path', 'type']);
 
 function classifyTool(toolName, args) {
     const normalizedArgs = normalizeToolArgs(args);
     const entry = TOOL_SUMMARY_MAP[toolName];
     if (entry) {
         const detailText = pickToolFieldValue(normalizedArgs, entry.fields);
+        let preview = detailText || argsPreviewText(normalizedArgs);
+        if (entry.detailKind === 'read' && detailText) {
+            const lineInfo = buildLineRangeText(normalizedArgs);
+            if (lineInfo) preview = `${detailText} ${lineInfo}`;
+        }
         return {
             summaryLabel: t(entry.key),
             langLabel: entry.lang ? t(entry.lang) : '',
-            preview: truncatePreview(detailText || argsPreviewText(normalizedArgs)),
+            preview: truncatePreview(preview),
             detailText: detailText || '',
             detailKind: entry.detailKind || 'json',
             args: normalizedArgs,
         };
     }
+    const genericPreview = pickGenericPreview(normalizedArgs);
     return {
         summaryLabel: formatMessage('tool.summary.generic', { tool: toolName }),
         langLabel: '',
-        preview: truncatePreview(argsPreviewText(normalizedArgs)),
+        preview: truncatePreview(genericPreview || argsPreviewText(normalizedArgs)),
         detailText: '',
         detailKind: 'json',
         args: normalizedArgs,
@@ -60,6 +71,21 @@ function normalizeToolArgs(args) {
         }
         return { __raw: String(parsed ?? '') };
     } catch (_) {
+        // Fallback: try to extract a JSON object or array from the string
+        const objMatch = raw.match(/(\{[\s\S]*\})/);
+        if (objMatch) {
+            try {
+                const extracted = JSON.parse(objMatch[1]);
+                if (extracted && typeof extracted === 'object') return extracted;
+            } catch (_e) { /* ignore */ }
+        }
+        const arrMatch = raw.match(/(\[[\s\S]*\])/);
+        if (arrMatch) {
+            try {
+                const extracted = JSON.parse(arrMatch[1]);
+                if (Array.isArray(extracted)) return { __items: extracted };
+            } catch (_e) { /* ignore */ }
+        }
         return { __raw: raw };
     }
 }
@@ -95,10 +121,82 @@ function argsPreviewText(args) {
     }
 }
 
+const GENERIC_PREVIEW_FIELDS = [
+    'title', 'name', 'description', 'query', 'path', 'url',
+    'command', 'prompt', 'message', 'content', 'text', 'objective',
+];
+
+function pickGenericPreview(args) {
+    if (!args || typeof args !== 'object') return '';
+    const direct = pickToolFieldValue(args, GENERIC_PREVIEW_FIELDS);
+    if (direct) return direct;
+    // Try first item of the first array-valued field
+    for (const key of Object.keys(args)) {
+        const val = args[key];
+        if (Array.isArray(val) && val.length > 0 && val[0] && typeof val[0] === 'object') {
+            const nested = pickToolFieldValue(val[0], GENERIC_PREVIEW_FIELDS);
+            if (nested) return nested;
+        }
+    }
+    return '';
+}
+
+function buildLineRangeText(args) {
+    const offset = Number(args.offset || args.line || args.start || 0);
+    const limit = Number(args.limit || args.count || 0);
+    if (!offset && !limit) return '';
+    const startLine = offset || 1;
+    if (limit) return `L${startLine}-${startLine + limit - 1}`;
+    return `L${startLine}`;
+}
+
 function escapeHtml(str) {
     const div = document.createElement('div');
     div.textContent = str;
     return div.innerHTML;
+}
+
+function escapeHtmlInline(str) {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function renderLinedContent(text, startLine = 1) {
+    const lines = String(text).split('\n');
+    const endLine = startLine + lines.length - 1;
+    const padWidth = String(endLine).length;
+    return lines.map((line, i) => {
+        const no = String(startLine + i).padStart(padWidth, '\u00a0');
+        return `<div class="tool-line"><span class="tool-line-no">${no}</span><span class="tool-line-text">${escapeHtmlInline(line) || '\u00a0'}</span></div>`;
+    }).join('');
+}
+
+function renderTaggedLineContent(text, fallbackStartLine = 1) {
+    const parsedLines = String(text).split('\n').map(parseTaggedLine);
+    const numberedLines = parsedLines.filter(line => line.lineNo != null);
+    if (numberedLines.length === 0) {
+        return renderLinedContent(text, fallbackStartLine);
+    }
+    const padWidth = Math.max(
+        String(fallbackStartLine).length,
+        ...numberedLines.map(line => String(line.lineNo).length),
+    );
+    return parsedLines.map(line => {
+        const lineNo = line.lineNo != null
+            ? String(line.lineNo).padStart(padWidth, '\u00a0')
+            : ''.padStart(padWidth, '\u00a0');
+        return `<div class="tool-line"><span class="tool-line-no">${lineNo}</span><span class="tool-line-text">${escapeHtmlInline(line.text) || '\u00a0'}</span></div>`;
+    }).join('');
+}
+
+function parseTaggedLine(line) {
+    const match = String(line).match(/^(\d+):\s?(.*)$/);
+    if (!match) {
+        return { lineNo: null, text: String(line) };
+    }
+    return {
+        lineNo: Number(match[1]),
+        text: match[2] || '',
+    };
 }
 
 export function buildToolBlock(toolName, args, toolCallId = null) {
@@ -109,10 +207,14 @@ export function buildToolBlock(toolName, args, toolCallId = null) {
     if (toolCallId) {
         tb.dataset.toolCallId = toolCallId;
     }
+    if (toolName === 'read') {
+        const off = Number(info.args.offset || info.args.line || info.args.start || 0);
+        if (off > 0) tb.dataset.readOffset = String(off);
+    }
 
-    const langHeader = info.langLabel
-        ? `<span class="tool-lang-label">${escapeHtml(info.langLabel)}</span>`
-        : '<span></span>';
+    const hasLangLabel = !!info.langLabel;
+    const headerClass = hasLangLabel ? 'tool-detail-header' : 'tool-detail-header tool-detail-header--minimal';
+    const langSpan = hasLangLabel ? `<span class="tool-lang-label">${escapeHtml(info.langLabel)}</span>` : '';
 
     tb.innerHTML = `
         <summary class="tool-summary">
@@ -122,8 +224,8 @@ export function buildToolBlock(toolName, args, toolCallId = null) {
         </summary>
         <div class="tool-detail">
             <div class="tool-detail-card">
-                <div class="tool-detail-header">
-                    ${langHeader}
+                <div class="${headerClass}">
+                    ${langSpan}
                     <button class="tool-copy-btn" title="${escapeHtml(t('tool.action.copy'))}">${COPY_SVG}</button>
                 </div>
                 ${renderToolInput(info)}
@@ -149,10 +251,14 @@ export function buildPendingToolBlock(toolName, args, toolCallId = null) {
     if (toolCallId) {
         tb.dataset.toolCallId = toolCallId;
     }
+    if (toolName === 'read') {
+        const off = Number(info.args.offset || info.args.line || info.args.start || 0);
+        if (off > 0) tb.dataset.readOffset = String(off);
+    }
 
-    const langHeader = info.langLabel
-        ? `<span class="tool-lang-label">${escapeHtml(info.langLabel)}</span>`
-        : '<span></span>';
+    const hasLangLabel = !!info.langLabel;
+    const headerClass = hasLangLabel ? 'tool-detail-header' : 'tool-detail-header tool-detail-header--minimal';
+    const langSpan = hasLangLabel ? `<span class="tool-lang-label">${escapeHtml(info.langLabel)}</span>` : '';
 
     tb.innerHTML = `
         <summary class="tool-summary">
@@ -162,8 +268,8 @@ export function buildPendingToolBlock(toolName, args, toolCallId = null) {
         </summary>
         <div class="tool-detail">
             <div class="tool-detail-card">
-                <div class="tool-detail-header">
-                    ${langHeader}
+                <div class="${headerClass}">
+                    ${langSpan}
                     <button class="tool-copy-btn" title="${escapeHtml(t('tool.action.copy'))}">${COPY_SVG}</button>
                 </div>
                 ${renderToolInput(info)}
@@ -194,12 +300,145 @@ function formatArgs(args) {
 
 function renderToolInput(info) {
     if (info.detailKind === 'command' && info.detailText) {
-        return `<div class="tool-command"><span class="tool-prompt">$</span> <code>${escapeHtml(info.detailText)}</code></div>`;
+        return `<div class="tool-command"><code>${escapeHtml(info.detailText)}</code></div>`;
+    }
+    if (info.detailKind === 'read' && info.detailText) {
+        return renderReadInput(info);
+    }
+    if (info.detailKind === 'write' && info.detailText) {
+        return renderWriteInput(info);
+    }
+    if (info.detailKind === 'edit' && info.detailText) {
+        return renderEditInput(info);
     }
     if (info.detailKind === 'value' && info.detailText) {
         return `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code></div>`;
     }
     return `<pre class="tool-args">${escapeHtml(formatArgs(info.args))}</pre>`;
+}
+
+function renderReadInput(info) {
+    const lineRange = buildLineRangeText(info.args);
+    const lineRangeHtml = lineRange
+        ? `<span class="tool-line-range">${escapeHtml(lineRange)}</span>`
+        : '';
+    return `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code>${lineRangeHtml}</div>`;
+}
+
+function renderWriteInput(info) {
+    const content = info.args.content || '';
+    let html = `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code></div>`;
+    if (content) {
+        const preview = buildBoundedPreview(String(content), {
+            maxLines: MAX_WRITE_PREVIEW_LINES,
+            maxChars: MAX_WRITE_PREVIEW_CHARS,
+        });
+        html += `<div class="tool-lined-code tool-lined-code--scroll">${renderLinedContent(preview.text)}</div>`;
+    }
+    return html;
+}
+
+function renderEditInput(info) {
+    const oldStr = String(info.args.old_string ?? '');
+    const newStr = String(info.args.new_string ?? '');
+    let html = `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code></div>`;
+    if (oldStr || newStr) {
+        html += renderSideBySideDiff(oldStr, newStr);
+    }
+    return html;
+}
+
+function renderSideBySideDiff(oldText, newText) {
+    const oldLines = oldText.split('\n');
+    const newLines = newText.split('\n');
+    const pairs = diffLinePairs(oldLines, newLines);
+    let html = '<div class="tool-diff-side">';
+    for (const p of pairs) {
+        const cls = p.type === 'same' ? 'tool-diff-row' : 'tool-diff-row tool-diff-row--changed';
+        const oTxt = p.old != null ? (escapeHtmlInline(p.old) || '\u00a0') : '\u00a0';
+        const nTxt = p.new != null ? (escapeHtmlInline(p.new) || '\u00a0') : '\u00a0';
+        html += `<div class="${cls}"><span class="tool-diff-cell tool-diff-cell--old">${oTxt}</span><span class="tool-diff-cell tool-diff-cell--new">${nTxt}</span></div>`;
+    }
+    html += '</div>';
+    return html;
+}
+
+function diffLinePairs(oldLines, newLines) {
+    const m = oldLines.length, n = newLines.length;
+    if (m === 0 || n === 0) {
+        return pairLinesByIndex(oldLines, newLines);
+    }
+    if ((m * n) > MAX_DIFF_DP_CELLS || (m + n) > MAX_DIFF_TOTAL_LINES) {
+        return pairLinesByIndex(oldLines, newLines);
+    }
+    // LCS DP
+    const dp = Array.from({ length: m + 1 }, () => new Uint16Array(n + 1));
+    for (let i = 1; i <= m; i++) {
+        for (let j = 1; j <= n; j++) {
+            dp[i][j] = oldLines[i - 1] === newLines[j - 1]
+                ? dp[i - 1][j - 1] + 1
+                : Math.max(dp[i - 1][j], dp[i][j - 1]);
+        }
+    }
+    // Backtrack LCS matches
+    const matches = [];
+    let i = m, j = n;
+    while (i > 0 && j > 0) {
+        if (oldLines[i - 1] === newLines[j - 1]) {
+            matches.unshift({ oi: i - 1, ni: j - 1 });
+            i--; j--;
+        } else if (dp[i - 1][j] >= dp[i][j - 1]) {
+            i--;
+        } else {
+            j--;
+        }
+    }
+    // Build raw entries from LCS
+    const raw = [];
+    let oi = 0, ni = 0;
+    for (const mt of matches) {
+        while (oi < mt.oi) { raw.push({ type: 'removed', old: oldLines[oi], oldNo: oi + 1 }); oi++; }
+        while (ni < mt.ni) { raw.push({ type: 'added', new: newLines[ni], newNo: ni + 1 }); ni++; }
+        raw.push({ type: 'same', old: oldLines[oi], new: newLines[ni], oldNo: oi + 1, newNo: ni + 1 });
+        oi++; ni++;
+    }
+    while (oi < m) { raw.push({ type: 'removed', old: oldLines[oi], oldNo: oi + 1 }); oi++; }
+    while (ni < n) { raw.push({ type: 'added', new: newLines[ni], newNo: ni + 1 }); ni++; }
+    // Merge adjacent removed+added into side-by-side changed pairs
+    const pairs = [];
+    let ri = 0;
+    while (ri < raw.length) {
+        if (raw[ri].type === 'same') { pairs.push(raw[ri]); ri++; continue; }
+        const rem = [], add = [];
+        while (ri < raw.length && raw[ri].type === 'removed') { rem.push(raw[ri]); ri++; }
+        while (ri < raw.length && raw[ri].type === 'added') { add.push(raw[ri]); ri++; }
+        const len = Math.max(rem.length, add.length);
+        for (let k = 0; k < len; k++) {
+            pairs.push({
+                type: 'changed',
+                old: rem[k]?.old ?? null, oldNo: rem[k]?.oldNo ?? null,
+                new: add[k]?.new ?? null, newNo: add[k]?.newNo ?? null,
+            });
+        }
+    }
+    return pairs;
+}
+
+function pairLinesByIndex(oldLines, newLines) {
+    const len = Math.max(oldLines.length, newLines.length);
+    const pairs = [];
+    for (let i = 0; i < len; i++) {
+        const hasOld = i < oldLines.length;
+        const hasNew = i < newLines.length;
+        pairs.push({
+            type: hasOld && hasNew && oldLines[i] === newLines[i] ? 'same' : 'changed',
+            old: hasOld ? oldLines[i] : null,
+            oldNo: hasOld ? i + 1 : null,
+            new: hasNew ? newLines[i] : null,
+            newNo: hasNew ? i + 1 : null,
+        });
+    }
+    return pairs;
 }
 
 export function findToolBlock(contentEl, toolName, toolCallId) {
@@ -341,6 +580,11 @@ function renderEnvelopeResult(targetEl, envelope, toolName) {
         return;
     }
 
+    if (toolName === 'read' && data != null) {
+        renderReadOutput(targetEl, data);
+        return;
+    }
+
     if (renderStructuredPayload(targetEl, data, envelope.meta)) {
         return;
     }
@@ -348,6 +592,125 @@ function renderEnvelopeResult(targetEl, envelope, toolName) {
         ? JSON.stringify(data, null, 2)
         : String(data ?? '');
     targetEl.textContent = val;
+}
+
+function renderReadOutput(targetEl, data) {
+    const text = getReadOutputText(data);
+    const toolBlock = targetEl.closest('.tool-block');
+    const startLine = Math.max(1, Number(toolBlock?.dataset?.readOffset || 1));
+    const container = document.createElement('div');
+    container.className = 'tool-lined-code';
+    const parsed = parseReadPayload(text);
+    if (parsed?.instructions) {
+        const instructionsEl = document.createElement('pre');
+        instructionsEl.className = 'tool-args';
+        instructionsEl.textContent = parsed.instructions;
+        targetEl.appendChild(instructionsEl);
+    }
+    if (parsed?.content) {
+        container.innerHTML = renderTaggedLineContent(parsed.content, startLine);
+    } else if (parsed?.entries) {
+        container.innerHTML = renderLinedContent(parsed.entries, startLine);
+    } else {
+        container.innerHTML = renderLinedContent(String(text), startLine);
+    }
+    targetEl.appendChild(container);
+}
+
+function getReadOutputText(data) {
+    return typeof data === 'string' ? data
+        : (data && typeof data === 'object')
+            ? (data.content || data.text || data.output || JSON.stringify(data, null, 2))
+            : String(data);
+}
+
+function parseReadPayload(text) {
+    if (typeof text !== 'string' || !text.includes('<type>')) {
+        return null;
+    }
+    const lines = text.split('\n');
+    const path = extractTaggedSection(text, lines, 'path');
+    const type = extractTaggedSection(text, lines, 'type');
+    const instructions = extractTaggedSection(text, lines, 'instructions');
+    const content = extractTaggedSection(text, lines, 'content');
+    const entries = extractTaggedSection(text, lines, 'entries');
+    if (!path && !type && !instructions && !content && !entries) {
+        return null;
+    }
+    return { path, type, instructions, content, entries };
+}
+
+function extractTaggedSection(text, lines, tagName) {
+    const inline = extractInlineTaggedSection(lines, tagName);
+    if (inline) {
+        return inline;
+    }
+    return extractBlockTaggedSection(lines, tagName);
+}
+
+function extractInlineTaggedSection(lines, tagName) {
+    if (!INLINE_READ_TAGS.has(tagName)) {
+        return '';
+    }
+    const tagPattern = new RegExp(`^<${tagName}>(.*)</${tagName}>$`);
+    for (const line of lines) {
+        const match = line.match(tagPattern);
+        if (match) {
+            return match[1].trim();
+        }
+    }
+    return '';
+}
+
+function extractBlockTaggedSection(lines, tagName) {
+    const startMarker = `<${tagName}>`;
+    const endMarker = `</${tagName}>`;
+    const startIndex = lines.indexOf(startMarker);
+    if (startIndex === -1) {
+        return '';
+    }
+    const endIndex = lines.lastIndexOf(endMarker);
+    if (endIndex <= startIndex) {
+        return '';
+    }
+    return lines.slice(startIndex + 1, endIndex).join('\n').replace(/^\n+|\n+$/g, '');
+}
+
+function buildBoundedPreview(text, { maxLines, maxChars }) {
+    const source = String(text);
+    const lines = source.split('\n');
+    const previewLines = [];
+    let charsUsed = 0;
+    let truncated = false;
+
+    for (let i = 0; i < lines.length; i++) {
+        if (previewLines.length >= maxLines) {
+            truncated = true;
+            break;
+        }
+        const line = lines[i];
+        const remainingChars = maxChars - charsUsed;
+        if (remainingChars <= 0) {
+            truncated = true;
+            break;
+        }
+        if (line.length > remainingChars) {
+            previewLines.push(line.slice(0, remainingChars));
+            charsUsed += remainingChars;
+            truncated = true;
+            break;
+        }
+        previewLines.push(line);
+        charsUsed += line.length;
+    }
+
+    if (!truncated) {
+        return { text: source };
+    }
+
+    const previewText = previewLines.join('\n');
+    const notice = `\n(Preview truncated. Showing first ${previewLines.length} of ${lines.length} lines.)`;
+    return { text: `${previewText}${notice}` };
 }
 
 function renderStructuredPayload(targetEl, payload, meta = null) {

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -76,7 +76,9 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
             roleId: String(msgItem.role_id || '').trim(),
             streamKey,
         });
-        renderParts(contentEl, parts, pendingToolBlocks);
+        renderParts(contentEl, parts, pendingToolBlocks, {
+            collapseUserPrompt: role === 'user' && options.collapsibleUserPrompts === true,
+        });
         lastRenderedMessage = {
             role,
             label,

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -398,13 +398,13 @@ function renderRoundSection(round, index) {
             <div class="round-detail-mainline">
                 <div class="round-detail-label">Round ${index + 1}${round.run_status === 'running' ? ' <span class="live-badge">LIVE</span>' : ''}</div>
                 <div class="round-detail-meta">
-                    <div class="round-detail-time">${time}</div>
+                <div class="round-detail-time">${time}</div>
                     <div class="round-detail-token-host"></div>
                 </div>
             </div>
             <div class="round-detail-badges">${renderRoundBadges(round, stateLabel, stateTone, approvalCount)}</div>
-        </div>
-        <div class="round-detail-intent">${esc(round.intent || t('rounds.no_intent'))}</div>`;
+        </div>`;
+    header.appendChild(buildRoundIntentBlock(round.intent || t('rounds.no_intent')));
     section.appendChild(header);
     renderRoundRetryEvents(section, round.retry_events || []);
     if (round.compaction_marker_before) {
@@ -420,6 +420,7 @@ function renderRoundSection(round, index) {
 
     if (round.coordinator_messages?.length > 0) {
         renderHistoricalMessageList(section, round.coordinator_messages, {
+            collapsibleUserPrompts: true,
             pendingToolApprovals: pendingCoordinatorApprovals,
             primaryRoleLabel,
             runId: round.run_id,
@@ -427,6 +428,7 @@ function renderRoundSection(round, index) {
         });
     } else if (pendingCoordinatorApprovals.length > 0 || coordinatorOverlay) {
         renderHistoricalMessageList(section, [], {
+            collapsibleUserPrompts: true,
             pendingToolApprovals: pendingCoordinatorApprovals,
             primaryRoleLabel,
             runId: round.run_id,
@@ -466,6 +468,42 @@ function renderRoundSection(round, index) {
     }
 
     return section;
+}
+
+function buildRoundIntentBlock(intentText) {
+    const normalized = normalizeRoundIntentText(intentText);
+    const lines = normalized.split('\n');
+    const title = lines[0] || t('rounds.no_intent');
+    const preview = lines.length > 1 ? lines.slice(1).join('\n') : normalized;
+
+    const block = document.createElement('details');
+    block.className = 'round-detail-intent';
+    block.innerHTML = `
+        <summary class="round-detail-intent-summary">
+            <span class="round-detail-intent-title"></span>
+            <span class="round-detail-intent-preview"></span>
+        </summary>
+        <div class="round-detail-intent-body"></div>
+    `;
+
+    const titleEl = block.querySelector('.round-detail-intent-title');
+    const previewEl = block.querySelector('.round-detail-intent-preview');
+    const bodyEl = block.querySelector('.round-detail-intent-body');
+    if (titleEl) {
+        titleEl.textContent = title;
+    }
+    if (previewEl) {
+        previewEl.textContent = preview;
+    }
+    if (bodyEl) {
+        bodyEl.textContent = normalized;
+    }
+    return block;
+}
+
+function normalizeRoundIntentText(intentText) {
+    const normalized = String(intentText || '').replace(/\r\n?/g, '\n').trim();
+    return normalized || t('rounds.no_intent');
 }
 
 function splitRoundsByHistoryMarkers(rounds) {

--- a/tests/unit_tests/frontend/test_round_user_prompt_ui.py
+++ b/tests/unit_tests/frontend/test_round_user_prompt_ui.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_round_user_prompts_are_collapsible_plaintext_blocks() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    timeline_script = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "rounds" / "timeline.js"
+    ).read_text(encoding="utf-8")
+    history_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "history.js"
+    ).read_text(encoding="utf-8")
+    block_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "block.js"
+    ).read_text(encoding="utf-8")
+    components_css = (
+        repo_root / "frontend" / "dist" / "css" / "components.css"
+    ).read_text(encoding="utf-8")
+
+    assert "collapsibleUserPrompts: true," in timeline_script
+    assert (
+        "collapseUserPrompt: role === 'user' && options.collapsibleUserPrompts === true,"
+        in history_script
+    )
+    assert "function appendUserPromptText(contentEl, text) {" in block_script
+    assert "function updateUserPromptText(promptEl, text) {" in block_script
+    assert "bodyEl.textContent = normalized;" in block_script
+    assert ".user-prompt-block {" in components_css
+    assert ".user-prompt-summary {" in components_css
+    assert ".user-prompt-preview {" in components_css
+    assert "-webkit-line-clamp: 2;" in components_css
+    assert ".user-prompt-text {" in components_css
+    assert "function buildRoundIntentBlock(intentText) {" in timeline_script
+    assert "function normalizeRoundIntentText(intentText) {" in timeline_script
+    assert (
+        "header.appendChild(buildRoundIntentBlock(round.intent || t('rounds.no_intent')));"
+        in timeline_script
+    )
+    assert ".round-detail-intent-summary {" in components_css
+    assert ".round-detail-intent-preview {" in components_css
+    assert ".round-detail-intent-body {" in components_css
+
+
+def test_thinking_blocks_use_compact_summary_spacing() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    components_css = (
+        repo_root / "frontend" / "dist" / "css" / "components.css"
+    ).read_text(encoding="utf-8")
+
+    assert ".thinking-block {" in components_css
+    assert "margin: 0 0 0.45rem;" in components_css
+    assert "padding: 0.34rem 0.65rem;" in components_css
+    assert "padding: 0 0.65rem 0.45rem;" in components_css

--- a/tests/unit_tests/frontend/test_streaming_tool_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_tool_ui.py
@@ -107,6 +107,50 @@ def test_tool_blocks_extract_effective_inputs_instead_of_footer_status() -> None
         'return `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code></div>`;'
         in tool_blocks_script
     )
+    assert (
+        'return `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code>${lineRangeHtml}</div>`;'
+        in tool_blocks_script
+    )
     assert ".tool-input-value {" in tools_css
     assert ".tool-detail-footer {" not in tools_css
     assert ".tool-result-status {" not in tools_css
+
+
+def test_tool_blocks_parse_tagged_read_payloads_and_cap_large_diffs() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    tool_blocks_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "toolBlocks.js"
+    ).read_text(encoding="utf-8")
+    tools_css = (
+        repo_root / "frontend" / "dist" / "css" / "components" / "tools.css"
+    ).read_text(encoding="utf-8")
+
+    assert "function parseReadPayload(text) {" in tool_blocks_script
+    assert "function extractTaggedSection(text, lines, tagName) {" in tool_blocks_script
+    assert "const INLINE_READ_TAGS = new Set(['path', 'type']);" in tool_blocks_script
+    assert "function extractInlineTaggedSection(lines, tagName) {" in tool_blocks_script
+    assert "if (!INLINE_READ_TAGS.has(tagName)) {" in tool_blocks_script
+    assert "function extractBlockTaggedSection(lines, tagName) {" in tool_blocks_script
+    assert (
+        "function renderTaggedLineContent(text, fallbackStartLine = 1) {"
+        in tool_blocks_script
+    )
+    assert "const MAX_DIFF_DP_CELLS = 50000;" in tool_blocks_script
+    assert "const MAX_DIFF_TOTAL_LINES = 600;" in tool_blocks_script
+    assert "const MAX_WRITE_PREVIEW_LINES = 200;" in tool_blocks_script
+    assert "const MAX_WRITE_PREVIEW_CHARS = 12000;" in tool_blocks_script
+    assert (
+        "function buildBoundedPreview(text, { maxLines, maxChars }) {"
+        in tool_blocks_script
+    )
+    assert "Preview truncated. Showing first" in tool_blocks_script
+    assert "return pairLinesByIndex(oldLines, newLines);" in tool_blocks_script
+    assert 'class="tool-diff-no"' not in tool_blocks_script
+    assert ".tool-diff-no {" not in tools_css


### PR DESCRIPTION
## Summary
- improve tool block previews for ead, write, and edit calls
- render read results with line numbers and preserve starting offsets
- add inline write previews, side-by-side edit diffs, and layout refinements for compact headers/output blocks

## Testing
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests

Closes #152