### PR TITLE
Add a shared SQLite write funnel for server repos

### DIFF
--- a/frontend/dist/js/utils/logger.js
+++ b/frontend/dist/js/utils/logger.js
@@ -34,13 +34,14 @@ function getPagePath() {
 }
 
 function buildBaseEvent(level, event, message, payload = {}) {
+    const traceId = state.activeRunId ? String(state.activeRunId) : null;
     return {
         level,
         event,
         message: truncateMessage(message),
-        trace_id: String(state.activeRunId || ''),
+        trace_id: traceId,
         request_id: null,
-        run_id: String(state.activeRunId || '') || null,
+        run_id: traceId,
         session_id: String(state.currentSessionId || '') || null,
         task_id: null,
         instance_id: null,

--- a/src/agent_teams/automation/automation_event_repository.py
+++ b/src/agent_teams/automation/automation_event_repository.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import json
-import sqlite3
 from datetime import datetime
 from pathlib import Path
 
 from pydantic import JsonValue
 
-from agent_teams.persistence.db import open_sqlite
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 
 class AutomationExecutionEventRecord:
@@ -32,62 +31,68 @@ class AutomationExecutionEventRecord:
         self.created_at = created_at
 
 
-class AutomationEventRepository:
+class AutomationEventRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS automation_execution_events (
-                event_id TEXT PRIMARY KEY,
-                automation_project_id TEXT NOT NULL,
-                reason TEXT NOT NULL,
-                payload_json TEXT NOT NULL,
-                metadata_json TEXT NOT NULL,
-                occurred_at TEXT NOT NULL,
-                created_at TEXT NOT NULL
+        def operation() -> None:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS automation_execution_events (
+                    event_id TEXT PRIMARY KEY,
+                    automation_project_id TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL,
+                    occurred_at TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                )
+                """
             )
-            """
+            self._conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_automation_execution_events_project
+                ON automation_execution_events(automation_project_id, created_at DESC)
+                """
+            )
+
+        self._run_write(
+            operation_name="init_tables",
+            operation=operation,
         )
-        self._conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_automation_execution_events_project
-            ON automation_execution_events(automation_project_id, created_at DESC)
-            """
-        )
-        self._conn.commit()
 
     def create_event(
         self,
         record: AutomationExecutionEventRecord,
     ) -> AutomationExecutionEventRecord:
-        self._conn.execute(
-            """
-            INSERT INTO automation_execution_events(
-                event_id,
-                automation_project_id,
-                reason,
-                payload_json,
-                metadata_json,
-                occurred_at,
-                created_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                record.event_id,
-                record.automation_project_id,
-                record.reason,
-                json.dumps(record.payload),
-                json.dumps(record.metadata),
-                record.occurred_at.isoformat(),
-                record.created_at.isoformat(),
+        self._run_write(
+            operation_name="create_event",
+            operation=lambda: self._conn.execute(
+                """
+                INSERT INTO automation_execution_events(
+                    event_id,
+                    automation_project_id,
+                    reason,
+                    payload_json,
+                    metadata_json,
+                    occurred_at,
+                    created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.event_id,
+                    record.automation_project_id,
+                    record.reason,
+                    json.dumps(record.payload),
+                    json.dumps(record.metadata),
+                    record.occurred_at.isoformat(),
+                    record.created_at.isoformat(),
+                ),
             ),
         )
-        self._conn.commit()
         return record
 
 

--- a/src/agent_teams/automation/automation_repository.py
+++ b/src/agent_teams/automation/automation_repository.py
@@ -18,7 +18,7 @@ from agent_teams.automation.automation_models import (
     AutomationScheduleMode,
 )
 from agent_teams.logger import get_logger, log_event
-from agent_teams.persistence.db import open_sqlite
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 from agent_teams.validation import (
     normalize_persisted_text,
     parse_persisted_datetime_or_none,
@@ -32,61 +32,62 @@ class AutomationProjectNameConflictError(ValueError):
     pass
 
 
-class AutomationProjectRepository:
+class AutomationProjectRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS automation_projects (
-                automation_project_id TEXT PRIMARY KEY,
-                name TEXT NOT NULL UNIQUE,
-                display_name TEXT NOT NULL,
-                status TEXT NOT NULL,
-                workspace_id TEXT NOT NULL DEFAULT 'automation-system',
-                prompt TEXT NOT NULL,
-                schedule_mode TEXT NOT NULL,
-                cron_expression TEXT,
-                run_at TEXT,
-                timezone TEXT NOT NULL,
-                run_config_json TEXT NOT NULL,
-                delivery_binding_json TEXT,
-                delivery_events_json TEXT NOT NULL DEFAULT '[]',
-                trigger_id TEXT NOT NULL UNIQUE,
-                last_session_id TEXT,
-                last_run_started_at TEXT,
-                last_error TEXT,
-                next_run_at TEXT,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
+        def operation() -> None:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS automation_projects (
+                    automation_project_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    display_name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    workspace_id TEXT NOT NULL DEFAULT 'automation-system',
+                    prompt TEXT NOT NULL,
+                    schedule_mode TEXT NOT NULL,
+                    cron_expression TEXT,
+                    run_at TEXT,
+                    timezone TEXT NOT NULL,
+                    run_config_json TEXT NOT NULL,
+                    delivery_binding_json TEXT,
+                    delivery_events_json TEXT NOT NULL DEFAULT '[]',
+                    trigger_id TEXT NOT NULL UNIQUE,
+                    last_session_id TEXT,
+                    last_run_started_at TEXT,
+                    last_error TEXT,
+                    next_run_at TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
             )
-            """
-        )
-        self._conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_automation_projects_schedule
-            ON automation_projects(status, next_run_at)
-            """
-        )
-        self._ensure_column(
-            "automation_projects",
-            "workspace_id",
-            "TEXT NOT NULL DEFAULT 'automation-system'",
-        )
-        self._ensure_column(
-            "automation_projects",
-            "delivery_binding_json",
-            "TEXT",
-        )
-        self._ensure_column(
-            "automation_projects",
-            "delivery_events_json",
-            "TEXT NOT NULL DEFAULT '[]'",
-        )
-        self._conn.commit()
+            self._conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_automation_projects_schedule
+                ON automation_projects(status, next_run_at)
+                """
+            )
+            self._ensure_column(
+                "automation_projects",
+                "workspace_id",
+                "TEXT NOT NULL DEFAULT 'automation-system'",
+            )
+            self._ensure_column(
+                "automation_projects",
+                "delivery_binding_json",
+                "TEXT",
+            )
+            self._ensure_column(
+                "automation_projects",
+                "delivery_events_json",
+                "TEXT NOT NULL DEFAULT '[]'",
+            )
+
+        self._run_write(operation_name="init_tables", operation=operation)
 
     def _ensure_column(self, table: str, column: str, ddl: str) -> None:
         columns = self._conn.execute(f"PRAGMA table_info({table})").fetchall()
@@ -96,20 +97,22 @@ class AutomationProjectRepository:
 
     def create(self, record: AutomationProjectRecord) -> AutomationProjectRecord:
         try:
-            self._conn.execute(
-                """
-                INSERT INTO automation_projects(
-                    automation_project_id, name, display_name, status, workspace_id, prompt,
-                    schedule_mode, cron_expression, run_at, timezone,
-                    run_config_json, delivery_binding_json, delivery_events_json,
-                    trigger_id, last_session_id, last_run_started_at,
-                    last_error, next_run_at, created_at, updated_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                self._to_row(record),
+            self._run_write(
+                operation_name="create",
+                operation=lambda: self._conn.execute(
+                    """
+                    INSERT INTO automation_projects(
+                        automation_project_id, name, display_name, status, workspace_id, prompt,
+                        schedule_mode, cron_expression, run_at, timezone,
+                        run_config_json, delivery_binding_json, delivery_events_json,
+                        trigger_id, last_session_id, last_run_started_at,
+                        last_error, next_run_at, created_at, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    self._to_row(record),
+                ),
             )
-            self._conn.commit()
         except sqlite3.IntegrityError as exc:
             if "automation_projects.name" in str(exc).lower():
                 raise AutomationProjectNameConflictError(
@@ -120,52 +123,54 @@ class AutomationProjectRepository:
 
     def update(self, record: AutomationProjectRecord) -> AutomationProjectRecord:
         try:
-            self._conn.execute(
-                """
-                UPDATE automation_projects
-                SET name=?,
-                    display_name=?,
-                    status=?,
-                    workspace_id=?,
-                    prompt=?,
-                    schedule_mode=?,
-                    cron_expression=?,
-                    run_at=?,
-                    timezone=?,
-                    run_config_json=?,
-                    delivery_binding_json=?,
-                    delivery_events_json=?,
-                    trigger_id=?,
-                    last_session_id=?,
-                    last_run_started_at=?,
-                    last_error=?,
-                    next_run_at=?,
-                    updated_at=?
-                WHERE automation_project_id=?
-                """,
-                (
-                    record.name,
-                    record.display_name,
-                    record.status.value,
-                    record.workspace_id,
-                    record.prompt,
-                    record.schedule_mode.value,
-                    record.cron_expression,
-                    _to_iso(record.run_at),
-                    record.timezone,
-                    json.dumps(record.run_config.model_dump(mode="json")),
-                    _binding_to_json(record.delivery_binding),
-                    _events_to_json(record.delivery_events),
-                    record.trigger_id,
-                    record.last_session_id,
-                    _to_iso(record.last_run_started_at),
-                    record.last_error,
-                    _to_iso(record.next_run_at),
-                    record.updated_at.isoformat(),
-                    record.automation_project_id,
+            self._run_write(
+                operation_name="update",
+                operation=lambda: self._conn.execute(
+                    """
+                    UPDATE automation_projects
+                    SET name=?,
+                        display_name=?,
+                        status=?,
+                        workspace_id=?,
+                        prompt=?,
+                        schedule_mode=?,
+                        cron_expression=?,
+                        run_at=?,
+                        timezone=?,
+                        run_config_json=?,
+                        delivery_binding_json=?,
+                        delivery_events_json=?,
+                        trigger_id=?,
+                        last_session_id=?,
+                        last_run_started_at=?,
+                        last_error=?,
+                        next_run_at=?,
+                        updated_at=?
+                    WHERE automation_project_id=?
+                    """,
+                    (
+                        record.name,
+                        record.display_name,
+                        record.status.value,
+                        record.workspace_id,
+                        record.prompt,
+                        record.schedule_mode.value,
+                        record.cron_expression,
+                        _to_iso(record.run_at),
+                        record.timezone,
+                        json.dumps(record.run_config.model_dump(mode="json")),
+                        _binding_to_json(record.delivery_binding),
+                        _events_to_json(record.delivery_events),
+                        record.trigger_id,
+                        record.last_session_id,
+                        _to_iso(record.last_run_started_at),
+                        record.last_error,
+                        _to_iso(record.next_run_at),
+                        record.updated_at.isoformat(),
+                        record.automation_project_id,
+                    ),
                 ),
             )
-            self._conn.commit()
         except sqlite3.IntegrityError as exc:
             if "automation_projects.name" in str(exc).lower():
                 raise AutomationProjectNameConflictError(
@@ -175,13 +180,15 @@ class AutomationProjectRepository:
         return record
 
     def get(self, automation_project_id: str) -> AutomationProjectRecord:
-        row = self._conn.execute(
-            """
-            SELECT * FROM automation_projects
-            WHERE automation_project_id=?
-            """,
-            (automation_project_id,),
-        ).fetchone()
+        row = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT * FROM automation_projects
+                WHERE automation_project_id=?
+                """,
+                (automation_project_id,),
+            ).fetchone()
+        )
         if row is None:
             raise KeyError(f"Unknown automation_project_id: {automation_project_id}")
         try:
@@ -193,41 +200,47 @@ class AutomationProjectRepository:
             ) from exc
 
     def list_all(self) -> tuple[AutomationProjectRecord, ...]:
-        rows = self._conn.execute(
-            """
-            SELECT * FROM automation_projects
-            ORDER BY created_at DESC
-            """
-        ).fetchall()
+        rows = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT * FROM automation_projects
+                ORDER BY created_at DESC
+                """
+            ).fetchall()
+        )
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
     def list_due(self, now: datetime) -> tuple[AutomationProjectRecord, ...]:
-        rows = self._conn.execute(
-            """
-            SELECT * FROM automation_projects
-            WHERE status=? AND next_run_at IS NOT NULL AND next_run_at <= ?
-            ORDER BY next_run_at ASC
-            """,
-            (
-                AutomationProjectStatus.ENABLED.value,
-                now.isoformat(),
-            ),
-        ).fetchall()
+        rows = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT * FROM automation_projects
+                WHERE status=? AND next_run_at IS NOT NULL AND next_run_at <= ?
+                ORDER BY next_run_at ASC
+                """,
+                (
+                    AutomationProjectStatus.ENABLED.value,
+                    now.isoformat(),
+                ),
+            ).fetchall()
+        )
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
     def delete(self, automation_project_id: str) -> None:
-        self._conn.execute(
-            """
-            DELETE FROM automation_projects
-            WHERE automation_project_id=?
-            """,
-            (automation_project_id,),
+        self._run_write(
+            operation_name="delete",
+            operation=lambda: self._conn.execute(
+                """
+                DELETE FROM automation_projects
+                WHERE automation_project_id=?
+                """,
+                (automation_project_id,),
+            ),
         )
-        self._conn.commit()
 
     def _to_row(self, record: AutomationProjectRecord) -> tuple[object, ...]:
         return (

--- a/src/agent_teams/gateway/gateway_session_repository.py
+++ b/src/agent_teams/gateway/gateway_session_repository.py
@@ -16,7 +16,7 @@ from agent_teams.gateway.gateway_models import (
     GatewaySessionRecord,
 )
 from agent_teams.logger import get_logger, log_event
-from agent_teams.persistence.db import open_sqlite
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 from agent_teams.validation import (
     normalize_persisted_text,
     parse_persisted_datetime_or_none,
@@ -26,102 +26,110 @@ from agent_teams.validation import (
 LOGGER = get_logger(__name__)
 
 
-class GatewaySessionRepository:
+class GatewaySessionRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS gateway_sessions (
-                gateway_session_id   TEXT PRIMARY KEY,
-                channel_type         TEXT NOT NULL,
-                external_session_id  TEXT NOT NULL,
-                internal_session_id  TEXT NOT NULL,
-                active_run_id        TEXT,
-                peer_user_id         TEXT,
-                peer_chat_id         TEXT,
-                cwd                  TEXT,
-                capabilities_json    TEXT NOT NULL,
-                channel_state_json   TEXT NOT NULL,
-                session_mcp_servers_json TEXT NOT NULL,
-                mcp_connections_json TEXT NOT NULL,
-                created_at           TEXT NOT NULL,
-                updated_at           TEXT NOT NULL
+        def operation() -> None:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS gateway_sessions (
+                    gateway_session_id   TEXT PRIMARY KEY,
+                    channel_type         TEXT NOT NULL,
+                    external_session_id  TEXT NOT NULL,
+                    internal_session_id  TEXT NOT NULL,
+                    active_run_id        TEXT,
+                    peer_user_id         TEXT,
+                    peer_chat_id         TEXT,
+                    cwd                  TEXT,
+                    capabilities_json    TEXT NOT NULL,
+                    channel_state_json   TEXT NOT NULL,
+                    session_mcp_servers_json TEXT NOT NULL,
+                    mcp_connections_json TEXT NOT NULL,
+                    created_at           TEXT NOT NULL,
+                    updated_at           TEXT NOT NULL
+                )
+                """
             )
-            """
-        )
-        self._conn.execute(
-            """
-            CREATE UNIQUE INDEX IF NOT EXISTS uq_gateway_sessions_channel_external
-            ON gateway_sessions(channel_type, external_session_id)
-            """
-        )
-        self._conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_gateway_sessions_internal_session
-            ON gateway_sessions(internal_session_id)
-            """
-        )
-        self._conn.commit()
+            self._conn.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_gateway_sessions_channel_external
+                ON gateway_sessions(channel_type, external_session_id)
+                """
+            )
+            self._conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_gateway_sessions_internal_session
+                ON gateway_sessions(internal_session_id)
+                """
+            )
+
+        self._run_write(operation_name="init_tables", operation=operation)
 
     def create(self, record: GatewaySessionRecord) -> GatewaySessionRecord:
-        self._conn.execute(
-            """
-            INSERT INTO gateway_sessions(
-                gateway_session_id,
-                channel_type,
-                external_session_id,
-                internal_session_id,
-                active_run_id,
-                peer_user_id,
-                peer_chat_id,
-                cwd,
-                capabilities_json,
-                channel_state_json,
-                session_mcp_servers_json,
-                mcp_connections_json,
-                created_at,
-                updated_at
-            )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                record.gateway_session_id,
-                record.channel_type.value,
-                record.external_session_id,
-                record.internal_session_id,
-                record.active_run_id,
-                record.peer_user_id,
-                record.peer_chat_id,
-                record.cwd,
-                json.dumps(record.capabilities, ensure_ascii=False),
-                json.dumps(record.channel_state, ensure_ascii=False),
-                json.dumps(
-                    [
-                        item.model_dump(mode="json")
-                        for item in record.session_mcp_servers
-                    ],
-                    ensure_ascii=False,
+        self._run_write(
+            operation_name="create",
+            operation=lambda: self._conn.execute(
+                """
+                INSERT INTO gateway_sessions(
+                    gateway_session_id,
+                    channel_type,
+                    external_session_id,
+                    internal_session_id,
+                    active_run_id,
+                    peer_user_id,
+                    peer_chat_id,
+                    cwd,
+                    capabilities_json,
+                    channel_state_json,
+                    session_mcp_servers_json,
+                    mcp_connections_json,
+                    created_at,
+                    updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.gateway_session_id,
+                    record.channel_type.value,
+                    record.external_session_id,
+                    record.internal_session_id,
+                    record.active_run_id,
+                    record.peer_user_id,
+                    record.peer_chat_id,
+                    record.cwd,
+                    json.dumps(record.capabilities, ensure_ascii=False),
+                    json.dumps(record.channel_state, ensure_ascii=False),
+                    json.dumps(
+                        [
+                            item.model_dump(mode="json")
+                            for item in record.session_mcp_servers
+                        ],
+                        ensure_ascii=False,
+                    ),
+                    json.dumps(
+                        [
+                            item.model_dump(mode="json")
+                            for item in record.mcp_connections
+                        ],
+                        ensure_ascii=False,
+                    ),
+                    record.created_at.isoformat(),
+                    record.updated_at.isoformat(),
                 ),
-                json.dumps(
-                    [item.model_dump(mode="json") for item in record.mcp_connections],
-                    ensure_ascii=False,
-                ),
-                record.created_at.isoformat(),
-                record.updated_at.isoformat(),
             ),
         )
-        self._conn.commit()
         return record
 
     def get(self, gateway_session_id: str) -> GatewaySessionRecord:
-        row = self._conn.execute(
-            "SELECT * FROM gateway_sessions WHERE gateway_session_id=?",
-            (gateway_session_id,),
-        ).fetchone()
+        row = self._run_read(
+            lambda: self._conn.execute(
+                "SELECT * FROM gateway_sessions WHERE gateway_session_id=?",
+                (gateway_session_id,),
+            ).fetchone()
+        )
         if row is None:
             raise KeyError(f"Unknown gateway_session_id: {gateway_session_id}")
         try:
@@ -136,13 +144,15 @@ class GatewaySessionRepository:
         channel_type: GatewayChannelType,
         external_session_id: str,
     ) -> GatewaySessionRecord | None:
-        row = self._conn.execute(
-            """
-            SELECT * FROM gateway_sessions
-            WHERE channel_type=? AND external_session_id=?
-            """,
-            (channel_type.value, external_session_id),
-        ).fetchone()
+        row = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT * FROM gateway_sessions
+                WHERE channel_type=? AND external_session_id=?
+                """,
+                (channel_type.value, external_session_id),
+            ).fetchone()
+        )
         if row is None:
             return None
         return self._record_or_none(row, fallback_invalid_timestamps=True)
@@ -151,14 +161,16 @@ class GatewaySessionRepository:
         self,
         internal_session_id: str,
     ) -> GatewaySessionRecord | None:
-        rows = self._conn.execute(
-            """
-            SELECT * FROM gateway_sessions
-            WHERE internal_session_id=?
-            ORDER BY updated_at DESC
-            """,
-            (internal_session_id,),
-        ).fetchall()
+        rows = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT * FROM gateway_sessions
+                WHERE internal_session_id=?
+                ORDER BY updated_at DESC
+                """,
+                (internal_session_id,),
+            ).fetchall()
+        )
         for row in rows:
             record = self._record_or_none(row, fallback_invalid_timestamps=True)
             if record is not None:
@@ -166,55 +178,64 @@ class GatewaySessionRepository:
         return None
 
     def update(self, record: GatewaySessionRecord) -> GatewaySessionRecord:
-        cursor = self._conn.execute(
-            """
-            UPDATE gateway_sessions
-            SET external_session_id=?,
-                internal_session_id=?,
-                active_run_id=?,
-                peer_user_id=?,
-                peer_chat_id=?,
-                cwd=?,
-                capabilities_json=?,
-                channel_state_json=?,
-                session_mcp_servers_json=?,
-                mcp_connections_json=?,
-                updated_at=?
-            WHERE gateway_session_id=?
-            """,
-            (
-                record.external_session_id,
-                record.internal_session_id,
-                record.active_run_id,
-                record.peer_user_id,
-                record.peer_chat_id,
-                record.cwd,
-                json.dumps(record.capabilities, ensure_ascii=False),
-                json.dumps(record.channel_state, ensure_ascii=False),
-                json.dumps(
-                    [
-                        item.model_dump(mode="json")
-                        for item in record.session_mcp_servers
-                    ],
-                    ensure_ascii=False,
-                ),
-                json.dumps(
-                    [item.model_dump(mode="json") for item in record.mcp_connections],
-                    ensure_ascii=False,
-                ),
-                record.updated_at.isoformat(),
-                record.gateway_session_id,
+        rowcount = self._run_write(
+            operation_name="update",
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                UPDATE gateway_sessions
+                SET external_session_id=?,
+                    internal_session_id=?,
+                    active_run_id=?,
+                    peer_user_id=?,
+                    peer_chat_id=?,
+                    cwd=?,
+                    capabilities_json=?,
+                    channel_state_json=?,
+                    session_mcp_servers_json=?,
+                    mcp_connections_json=?,
+                    updated_at=?
+                WHERE gateway_session_id=?
+                """,
+                    (
+                        record.external_session_id,
+                        record.internal_session_id,
+                        record.active_run_id,
+                        record.peer_user_id,
+                        record.peer_chat_id,
+                        record.cwd,
+                        json.dumps(record.capabilities, ensure_ascii=False),
+                        json.dumps(record.channel_state, ensure_ascii=False),
+                        json.dumps(
+                            [
+                                item.model_dump(mode="json")
+                                for item in record.session_mcp_servers
+                            ],
+                            ensure_ascii=False,
+                        ),
+                        json.dumps(
+                            [
+                                item.model_dump(mode="json")
+                                for item in record.mcp_connections
+                            ],
+                            ensure_ascii=False,
+                        ),
+                        record.updated_at.isoformat(),
+                        record.gateway_session_id,
+                    ),
+                ).rowcount
             ),
         )
-        self._conn.commit()
-        if cursor.rowcount == 0:
+        if rowcount == 0:
             raise KeyError(f"Unknown gateway_session_id: {record.gateway_session_id}")
         return record
 
     def list_all(self) -> tuple[GatewaySessionRecord, ...]:
-        rows = self._conn.execute(
-            "SELECT * FROM gateway_sessions ORDER BY created_at DESC"
-        ).fetchall()
+        rows = self._run_read(
+            lambda: self._conn.execute(
+                "SELECT * FROM gateway_sessions ORDER BY created_at DESC"
+            ).fetchall()
+        )
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
         )

--- a/src/agent_teams/metrics/stores/sqlite.py
+++ b/src/agent_teams/metrics/stores/sqlite.py
@@ -5,12 +5,11 @@ import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_teams.metrics.models import MetricEvent, MetricScope
-from agent_teams.persistence.db import open_sqlite
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 
 class MetricPointRecord(BaseModel):
@@ -25,15 +24,13 @@ class MetricPointRecord(BaseModel):
     recorded_at: datetime
 
 
-class SqliteMetricAggregateStore:
+class SqliteMetricAggregateStore(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
-        with self._lock:
+        def operation() -> None:
             self._conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS metric_points (
@@ -60,7 +57,8 @@ class SqliteMetricAggregateStore:
                 ON metric_points(metric_name, bucket_start)
                 """
             )
-            self._conn.commit()
+
+        self._run_write(operation_name="init_tables", operation=operation)
 
     def record(self, event: MetricEvent) -> None:
         bucket_start = event.occurred_at.astimezone(timezone.utc).replace(
@@ -74,7 +72,8 @@ class SqliteMetricAggregateStore:
             (MetricScope.SESSION, event.tags.session_id),
             (MetricScope.RUN, event.tags.run_id),
         )
-        with self._lock:
+
+        def operation() -> None:
             for scope, scope_id in scopes:
                 if not scope_id:
                     continue
@@ -96,7 +95,8 @@ class SqliteMetricAggregateStore:
                         recorded_at,
                     ),
                 )
-            self._conn.commit()
+
+        self._run_write(operation_name="record", operation=operation)
 
     def query_points(
         self,
@@ -108,8 +108,8 @@ class SqliteMetricAggregateStore:
         threshold = datetime.now(tz=timezone.utc) - timedelta(
             minutes=time_window_minutes
         )
-        with self._lock:
-            rows = self._conn.execute(
+        rows = self._run_read(
+            lambda: self._conn.execute(
                 """
                 SELECT scope, scope_id, metric_name, bucket_start,
                        tags_json, value, recorded_at
@@ -123,6 +123,7 @@ class SqliteMetricAggregateStore:
                     threshold.replace(second=0, microsecond=0).isoformat(),
                 ),
             ).fetchall()
+        )
         return tuple(self._row_to_record(row) for row in rows)
 
     def latest_recorded_at(
@@ -131,8 +132,8 @@ class SqliteMetricAggregateStore:
         scope: MetricScope,
         scope_id: str,
     ) -> str | None:
-        with self._lock:
-            row = self._conn.execute(
+        row = self._run_read(
+            lambda: self._conn.execute(
                 """
                 SELECT MAX(recorded_at) AS recorded_at
                 FROM metric_points
@@ -140,6 +141,7 @@ class SqliteMetricAggregateStore:
                 """,
                 (scope.value, scope_id),
             ).fetchone()
+        )
         if row is None:
             return None
         value = row["recorded_at"]
@@ -148,7 +150,7 @@ class SqliteMetricAggregateStore:
         return str(value)
 
     def delete_by_session(self, session_id: str) -> None:
-        with self._lock:
+        def operation() -> None:
             self._conn.execute(
                 "DELETE FROM metric_points WHERE scope=? AND scope_id=?",
                 (MetricScope.SESSION.value, session_id),
@@ -167,7 +169,8 @@ class SqliteMetricAggregateStore:
                 """,
                 (MetricScope.RUN.value, f'%"session_id": "{session_id}"%'),
             )
-            self._conn.commit()
+
+        self._run_write(operation_name="delete_by_session", operation=operation)
 
     def _row_to_record(self, row: sqlite3.Row) -> MetricPointRecord:
         return MetricPointRecord(

--- a/src/agent_teams/persistence/__init__.py
+++ b/src/agent_teams/persistence/__init__.py
@@ -13,6 +13,7 @@ from agent_teams.persistence.db import (
     sqlite_supports_fts5,
 )
 from agent_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 from agent_teams.persistence.shared_state_repo import (
     SharedStateRepository,
     build_global_scope_ref,
@@ -25,6 +26,7 @@ __all__ = [
     "SQLITE_WRITE_RETRY_ATTEMPTS",
     "ScopeRef",
     "ScopeType",
+    "SharedSqliteRepository",
     "SharedStateRepository",
     "StateMutation",
     "build_global_scope_ref",

--- a/src/agent_teams/persistence/shared_state_repo.py
+++ b/src/agent_teams/persistence/shared_state_repo.py
@@ -1,35 +1,35 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from agent_teams.persistence.db import open_sqlite
 from agent_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 
-class SharedStateRepository:
+class SharedStateRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS shared_state (
-                scope_type  TEXT NOT NULL,
-                scope_id    TEXT NOT NULL,
-                state_key   TEXT NOT NULL,
-                value_json  TEXT NOT NULL,
-                updated_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                expires_at  TEXT,
-                PRIMARY KEY (scope_type, scope_id, state_key)
-            )
-            """
+        self._run_write(
+            operation_name="init_tables",
+            operation=lambda: self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS shared_state (
+                    scope_type  TEXT NOT NULL,
+                    scope_id    TEXT NOT NULL,
+                    state_key   TEXT NOT NULL,
+                    value_json  TEXT NOT NULL,
+                    updated_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    expires_at  TEXT,
+                    PRIMARY KEY (scope_type, scope_id, state_key)
+                )
+                """
+            ),
         )
-        self._conn.commit()
 
     def manage_state(
         self,
@@ -41,46 +41,52 @@ class SharedStateRepository:
             expires_at = (
                 datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
             ).isoformat()
-        self._conn.execute(
-            """
-            INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
-            VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
-            ON CONFLICT(scope_type, scope_id, state_key)
-            DO UPDATE SET value_json=excluded.value_json, updated_at=CURRENT_TIMESTAMP,
-                          expires_at=COALESCE(excluded.expires_at, expires_at)
-            """,
-            (
-                mutation.scope.scope_type.value,
-                mutation.scope.scope_id,
-                mutation.key,
-                mutation.value_json,
-                expires_at,
+        self._run_write(
+            operation_name="manage_state",
+            operation=lambda: self._conn.execute(
+                """
+                INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
+                VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
+                ON CONFLICT(scope_type, scope_id, state_key)
+                DO UPDATE SET value_json=excluded.value_json, updated_at=CURRENT_TIMESTAMP,
+                              expires_at=COALESCE(excluded.expires_at, expires_at)
+                """,
+                (
+                    mutation.scope.scope_type.value,
+                    mutation.scope.scope_id,
+                    mutation.key,
+                    mutation.value_json,
+                    expires_at,
+                ),
             ),
         )
-        self._conn.commit()
 
     def get_state(self, scope: ScopeRef, key: str) -> str | None:
-        row = self._conn.execute(
-            """
-            SELECT value_json FROM shared_state
-            WHERE scope_type=? AND scope_id=? AND state_key=?
-              AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
-            """,
-            (scope.scope_type.value, scope.scope_id, key),
-        ).fetchone()
+        row = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT value_json FROM shared_state
+                WHERE scope_type=? AND scope_id=? AND state_key=?
+                  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                """,
+                (scope.scope_type.value, scope.scope_id, key),
+            ).fetchone()
+        )
         if row is None:
             return None
         return str(row["value_json"])
 
     def snapshot(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
-        rows = self._conn.execute(
-            """
-            SELECT state_key, value_json FROM shared_state
-            WHERE scope_type=? AND scope_id=?
-              AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
-            """,
-            (scope.scope_type.value, scope.scope_id),
-        ).fetchall()
+        rows = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT state_key, value_json FROM shared_state
+                WHERE scope_type=? AND scope_id=?
+                  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                """,
+                (scope.scope_type.value, scope.scope_id),
+            ).fetchall()
+        )
         return tuple((str(row["state_key"]), str(row["value_json"])) for row in rows)
 
     def snapshot_many(
@@ -95,11 +101,14 @@ class SharedStateRepository:
         return tuple((key, value) for key, value in ordered_items)
 
     def cleanup_expired(self) -> int:
-        cursor = self._conn.execute(
-            "DELETE FROM shared_state WHERE expires_at IS NOT NULL AND expires_at <= CURRENT_TIMESTAMP"
+        return self._run_write(
+            operation_name="cleanup_expired",
+            operation=lambda: (
+                self._conn.execute(
+                    "DELETE FROM shared_state WHERE expires_at IS NOT NULL AND expires_at <= CURRENT_TIMESTAMP"
+                ).rowcount
+            ),
         )
-        self._conn.commit()
-        return cursor.rowcount
 
     def delete_by_session(
         self,
@@ -129,32 +138,34 @@ class SharedStateRepository:
         conversation_placeholders = ",".join("?" * len(conversation_values))
         workspace_placeholders = ",".join("?" * len(workspace_values))
 
-        self._conn.execute(
-            f"""
-            DELETE FROM shared_state WHERE
-            (scope_type=? AND scope_id IN ({session_placeholders})) OR
-            (scope_type=? AND scope_id IN ({task_placeholders})) OR
-            (scope_type=? AND scope_id IN ({instance_placeholders})) OR
-            (scope_type=? AND scope_id IN ({role_placeholders})) OR
-            (scope_type=? AND scope_id IN ({conversation_placeholders})) OR
-            (scope_type=? AND scope_id IN ({workspace_placeholders}))
-            """,
-            (
-                ScopeType.SESSION.value,
-                *session_scope_values,
-                ScopeType.TASK.value,
-                *task_ids,
-                ScopeType.INSTANCE.value,
-                *instance_ids,
-                ScopeType.ROLE.value,
-                *role_scope_values,
-                ScopeType.CONVERSATION.value,
-                *conversation_values,
-                ScopeType.WORKSPACE.value,
-                *workspace_values,
+        self._run_write(
+            operation_name="delete_by_session",
+            operation=lambda: self._conn.execute(
+                f"""
+                DELETE FROM shared_state WHERE
+                (scope_type=? AND scope_id IN ({session_placeholders})) OR
+                (scope_type=? AND scope_id IN ({task_placeholders})) OR
+                (scope_type=? AND scope_id IN ({instance_placeholders})) OR
+                (scope_type=? AND scope_id IN ({role_placeholders})) OR
+                (scope_type=? AND scope_id IN ({conversation_placeholders})) OR
+                (scope_type=? AND scope_id IN ({workspace_placeholders}))
+                """,
+                (
+                    ScopeType.SESSION.value,
+                    *session_scope_values,
+                    ScopeType.TASK.value,
+                    *task_ids,
+                    ScopeType.INSTANCE.value,
+                    *instance_ids,
+                    ScopeType.ROLE.value,
+                    *role_scope_values,
+                    ScopeType.CONVERSATION.value,
+                    *conversation_values,
+                    ScopeType.WORKSPACE.value,
+                    *workspace_values,
+                ),
             ),
         )
-        self._conn.commit()
 
 
 def build_global_scope_ref() -> ScopeRef:

--- a/src/agent_teams/persistence/sqlite_repository.py
+++ b/src/agent_teams/persistence/sqlite_repository.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+from threading import RLock
+from typing import TypeVar
+
+from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+
+_ResultT = TypeVar("_ResultT")
+
+
+class SharedSqliteRepository:
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        repository_name: str | None = None,
+    ) -> None:
+        self._db_path = Path(db_path)
+        self._conn = open_sqlite(self._db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = RLock()
+        self._repository_name = repository_name or type(self).__name__
+
+    def _run_read(self, operation: Callable[[], _ResultT]) -> _ResultT:
+        with self._lock:
+            return operation()
+
+    def _run_write(
+        self,
+        *,
+        operation_name: str,
+        operation: Callable[[], _ResultT],
+    ) -> _ResultT:
+        return run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=operation,
+            lock=self._lock,
+            repository_name=self._repository_name,
+            operation_name=operation_name,
+        )

--- a/src/agent_teams/providers/token_usage_repo.py
+++ b/src/agent_teams/providers/token_usage_repo.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic import BaseModel, ConfigDict
 
-from agent_teams.persistence.db import open_sqlite
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 from agent_teams.sessions.session_history_marker_models import SessionHistoryMarkerType
 from agent_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
@@ -73,7 +72,7 @@ class SessionTokenUsage(BaseModel):
     by_role: dict[str, AgentTokenSummary]
 
 
-class TokenUsageRepository:
+class TokenUsageRepository(SharedSqliteRepository):
     _NUMERIC_COLUMNS: tuple[str, ...] = (
         "input_tokens",
         "cached_input_tokens",
@@ -89,14 +88,12 @@ class TokenUsageRepository:
         *,
         session_history_marker_repo: SessionHistoryMarkerRepository | None = None,
     ) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._session_history_marker_repo = session_history_marker_repo
         self._init_tables()
 
     def _init_tables(self) -> None:
-        with self._lock:
+        def operation() -> None:
             self._conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS token_usage (
@@ -150,7 +147,8 @@ class TokenUsageRepository:
                 "CREATE INDEX IF NOT EXISTS idx_token_usage_session ON token_usage(session_id)"
             )
             self._sanitize_numeric_columns()
-            self._conn.commit()
+
+        self._run_write(operation_name="init_tables", operation=operation)
 
     def record(
         self,
@@ -166,7 +164,7 @@ class TokenUsageRepository:
         requests: int = 0,
         tool_calls: int = 0,
     ) -> None:
-        with self._lock:
+        def operation() -> None:
             now = self._next_recorded_at(session_id=session_id)
             self._conn.execute(
                 """
@@ -190,14 +188,16 @@ class TokenUsageRepository:
                     now.isoformat(),
                 ),
             )
-            self._conn.commit()
+
+        self._run_write(operation_name="record", operation=operation)
 
     def get_by_run(self, run_id: str) -> RunTokenUsage:
-        with self._lock:
-            rows = self._conn.execute(
+        rows = self._run_read(
+            lambda: self._conn.execute(
                 "SELECT * FROM token_usage WHERE run_id=? ORDER BY id ASC",
                 (run_id,),
             ).fetchall()
+        )
 
         by_instance: dict[str, AgentTokenSummary] = {}
         for row in rows:
@@ -269,11 +269,12 @@ class TokenUsageRepository:
                 query += " AND recorded_at>?"
                 params = (session_id, cutoff)
         query += " ORDER BY id ASC"
-        with self._lock:
-            rows = self._conn.execute(
+        rows = self._run_read(
+            lambda: self._conn.execute(
                 query,
                 params,
             ).fetchall()
+        )
 
         by_role: dict[str, AgentTokenSummary] = {}
         for row in rows:
@@ -332,11 +333,12 @@ class TokenUsageRepository:
         )
 
     def delete_by_session(self, session_id: str) -> None:
-        with self._lock:
-            self._conn.execute(
+        self._run_write(
+            operation_name="delete_by_session",
+            operation=lambda: self._conn.execute(
                 "DELETE FROM token_usage WHERE session_id=?", (session_id,)
-            )
-            self._conn.commit()
+            ),
+        )
 
     def _latest_clear_cutoff(self, session_id: str) -> str | None:
         if self._session_history_marker_repo is None:

--- a/src/agent_teams/retrieval/sqlite_store.py
+++ b/src/agent_teams/retrieval/sqlite_store.py
@@ -5,12 +5,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 import re
 import sqlite3
-from threading import RLock
 
 from agent_teams.logger import get_logger
 from agent_teams.persistence import (
-    open_sqlite,
-    run_sqlite_write_with_retry,
+    SharedSqliteRepository,
     sqlite_supports_fts5,
 )
 from agent_teams.retrieval.retrieval_models import (
@@ -30,12 +28,9 @@ _UNICODE61_SPLIT_PATTERN = re.compile(r"[^\w]+", re.UNICODE)
 _MATCH_SANITIZE_PATTERN = re.compile(r'["\'`(){}\[\]:^*]+')
 
 
-class SqliteFts5RetrievalStore:
+class SqliteFts5RetrievalStore(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = db_path
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path, repository_name="retrieval.sqlite")
         self._require_fts5()
         self._init_tables()
 
@@ -61,11 +56,7 @@ class SqliteFts5RetrievalStore:
                 "tokenizer": config.tokenizer.value,
             },
         ):
-            run_sqlite_write_with_retry(
-                conn=self._conn,
-                db_path=self._db_path,
-                lock=self._lock,
-                repository_name="retrieval.sqlite",
+            self._run_write(
                 operation_name="replace_scope",
                 operation=lambda: self._replace_scope_locked(
                     config=config,
@@ -92,11 +83,7 @@ class SqliteFts5RetrievalStore:
                 "tokenizer": config.tokenizer.value,
             },
         ):
-            run_sqlite_write_with_retry(
-                conn=self._conn,
-                db_path=self._db_path,
-                lock=self._lock,
-                repository_name="retrieval.sqlite",
+            self._run_write(
                 operation_name="upsert_documents",
                 operation=lambda: self._upsert_documents_locked(
                     config=config,
@@ -123,11 +110,7 @@ class SqliteFts5RetrievalStore:
                 "document_count": len(normalized_ids),
             },
         ):
-            run_sqlite_write_with_retry(
-                conn=self._conn,
-                db_path=self._db_path,
-                lock=self._lock,
-                repository_name="retrieval.sqlite",
+            self._run_write(
                 operation_name="delete_documents",
                 operation=lambda: self._delete_documents_locked(
                     scope_kind=scope_kind,
@@ -152,9 +135,11 @@ class SqliteFts5RetrievalStore:
                 "limit": query.limit,
             },
         ):
-            config = self._get_scope_config(
-                scope_kind=query.scope_kind,
-                scope_id=query.scope_id,
+            config = self._run_read(
+                lambda: self._get_scope_config(
+                    scope_kind=query.scope_kind,
+                    scope_id=query.scope_id,
+                )
             )
             if config is None:
                 return ()
@@ -165,34 +150,36 @@ class SqliteFts5RetrievalStore:
             if not match_expression:
                 return ()
             table_name = _fts_table_name(config.tokenizer)
-            rows = self._conn.execute(
-                f"""
-                SELECT
-                    document_id,
-                    title,
-                    COALESCE(
-                        NULLIF(snippet({table_name}, 4, '[', ']', '...', 12), ''),
-                        NULLIF(snippet({table_name}, 3, '[', ']', '...', 12), ''),
-                        body,
+            rows = self._run_read(
+                lambda: self._conn.execute(
+                    f"""
+                    SELECT
+                        document_id,
                         title,
-                        ''
-                    ) AS snippet,
-                    bm25({table_name}, 0.0, 0.0, 0.0, ?, ?, ?) AS rank_score
-                FROM {table_name}
-                WHERE scope_kind = ? AND scope_id = ? AND {table_name} MATCH ?
-                ORDER BY rank_score ASC, document_id ASC
-                LIMIT ?
-                """,
-                (
-                    config.title_weight,
-                    config.body_weight,
-                    config.keyword_weight,
-                    query.scope_kind.value,
-                    query.scope_id,
-                    match_expression,
-                    query.limit,
-                ),
-            ).fetchall()
+                        COALESCE(
+                            NULLIF(snippet({table_name}, 4, '[', ']', '...', 12), ''),
+                            NULLIF(snippet({table_name}, 3, '[', ']', '...', 12), ''),
+                            body,
+                            title,
+                            ''
+                        ) AS snippet,
+                        bm25({table_name}, 0.0, 0.0, 0.0, ?, ?, ?) AS rank_score
+                    FROM {table_name}
+                    WHERE scope_kind = ? AND scope_id = ? AND {table_name} MATCH ?
+                    ORDER BY rank_score ASC, document_id ASC
+                    LIMIT ?
+                    """,
+                    (
+                        config.title_weight,
+                        config.body_weight,
+                        config.keyword_weight,
+                        query.scope_kind.value,
+                        query.scope_id,
+                        match_expression,
+                        query.limit,
+                    ),
+                ).fetchall()
+            )
             return tuple(
                 RetrievalHit(
                     document_id=str(row["document_id"]),
@@ -219,11 +206,7 @@ class SqliteFts5RetrievalStore:
                 "scope_id": scope_id,
             },
         ):
-            run_sqlite_write_with_retry(
-                conn=self._conn,
-                db_path=self._db_path,
-                lock=self._lock,
-                repository_name="retrieval.sqlite",
+            self._run_write(
                 operation_name="rebuild_scope",
                 operation=lambda: self._rebuild_scope_locked(
                     scope_kind=scope_kind,
@@ -247,22 +230,26 @@ class SqliteFts5RetrievalStore:
                 "scope_id": scope_id,
             },
         ):
-            row = self._conn.execute(
-                """
-                SELECT backend, tokenizer, updated_at
-                FROM retrieval_scopes
-                WHERE scope_kind = ? AND scope_id = ?
-                """,
-                (scope_kind.value, scope_id),
-            ).fetchone()
-            count_row = self._conn.execute(
-                """
-                SELECT COUNT(*) AS document_count
-                FROM retrieval_documents
-                WHERE scope_kind = ? AND scope_id = ?
-                """,
-                (scope_kind.value, scope_id),
-            ).fetchone()
+            row = self._run_read(
+                lambda: self._conn.execute(
+                    """
+                    SELECT backend, tokenizer, updated_at
+                    FROM retrieval_scopes
+                    WHERE scope_kind = ? AND scope_id = ?
+                    """,
+                    (scope_kind.value, scope_id),
+                ).fetchone()
+            )
+            count_row = self._run_read(
+                lambda: self._conn.execute(
+                    """
+                    SELECT COUNT(*) AS document_count
+                    FROM retrieval_documents
+                    WHERE scope_kind = ? AND scope_id = ?
+                    """,
+                    (scope_kind.value, scope_id),
+                ).fetchone()
+            )
             tokenizer = None
             updated_at = None
             if row is not None:
@@ -281,7 +268,7 @@ class SqliteFts5RetrievalStore:
             )
 
     def _require_fts5(self) -> None:
-        if sqlite_supports_fts5(self._conn):
+        if self._run_read(lambda: sqlite_supports_fts5(self._conn)):
             return
         raise RuntimeError("SQLite FTS5 is required for retrieval indexing")
 
@@ -292,81 +279,82 @@ class SqliteFts5RetrievalStore:
             operation="init_schema",
             attributes={"backend": self.backend_kind.value},
         ):
-            with self._lock:
-                self._conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS retrieval_scopes (
-                        scope_kind    TEXT NOT NULL,
-                        scope_id      TEXT NOT NULL,
-                        backend       TEXT NOT NULL,
-                        tokenizer     TEXT NOT NULL,
-                        title_weight  REAL NOT NULL,
-                        body_weight   REAL NOT NULL,
-                        keyword_weight REAL NOT NULL,
-                        updated_at    TEXT NOT NULL,
-                        PRIMARY KEY (scope_kind, scope_id)
-                    )
-                    """
-                )
-                self._conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS retrieval_documents (
-                        rowid         INTEGER PRIMARY KEY AUTOINCREMENT,
-                        scope_kind    TEXT NOT NULL,
-                        scope_id      TEXT NOT NULL,
-                        document_id   TEXT NOT NULL,
-                        title         TEXT NOT NULL,
-                        body          TEXT NOT NULL,
-                        keywords      TEXT NOT NULL,
-                        updated_at    TEXT NOT NULL,
-                        UNIQUE (scope_kind, scope_id, document_id),
-                        FOREIGN KEY (scope_kind, scope_id)
-                            REFERENCES retrieval_scopes(scope_kind, scope_id)
-                            ON DELETE CASCADE
-                    )
-                    """
-                )
-                self._conn.execute(
-                    """
-                    CREATE INDEX IF NOT EXISTS idx_retrieval_documents_scope
-                    ON retrieval_documents(scope_kind, scope_id, updated_at)
-                    """
-                )
-                self._conn.execute(
-                    """
-                    CREATE VIRTUAL TABLE IF NOT EXISTS retrieval_fts_unicode61
-                    USING fts5(
-                        scope_kind UNINDEXED,
-                        scope_id UNINDEXED,
-                        document_id UNINDEXED,
-                        title,
-                        body,
-                        keywords,
-                        content='retrieval_documents',
-                        content_rowid='rowid',
-                        tokenize='unicode61',
-                        detail='column'
-                    )
-                    """
-                )
-                self._conn.execute(
-                    """
-                    CREATE VIRTUAL TABLE IF NOT EXISTS retrieval_fts_trigram
-                    USING fts5(
-                        scope_kind UNINDEXED,
-                        scope_id UNINDEXED,
-                        document_id UNINDEXED,
-                        title,
-                        body,
-                        keywords,
-                        content='retrieval_documents',
-                        content_rowid='rowid',
-                        tokenize='trigram',
-                        detail='column'
-                    )
-                    """
-                )
-                self._conn.commit()
+            self._run_write(operation_name="init_schema", operation=self._create_tables)
+
+    def _create_tables(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS retrieval_scopes (
+                scope_kind    TEXT NOT NULL,
+                scope_id      TEXT NOT NULL,
+                backend       TEXT NOT NULL,
+                tokenizer     TEXT NOT NULL,
+                title_weight  REAL NOT NULL,
+                body_weight   REAL NOT NULL,
+                keyword_weight REAL NOT NULL,
+                updated_at    TEXT NOT NULL,
+                PRIMARY KEY (scope_kind, scope_id)
+            )
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS retrieval_documents (
+                rowid         INTEGER PRIMARY KEY AUTOINCREMENT,
+                scope_kind    TEXT NOT NULL,
+                scope_id      TEXT NOT NULL,
+                document_id   TEXT NOT NULL,
+                title         TEXT NOT NULL,
+                body          TEXT NOT NULL,
+                keywords      TEXT NOT NULL,
+                updated_at    TEXT NOT NULL,
+                UNIQUE (scope_kind, scope_id, document_id),
+                FOREIGN KEY (scope_kind, scope_id)
+                    REFERENCES retrieval_scopes(scope_kind, scope_id)
+                    ON DELETE CASCADE
+            )
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_retrieval_documents_scope
+            ON retrieval_documents(scope_kind, scope_id, updated_at)
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE VIRTUAL TABLE IF NOT EXISTS retrieval_fts_unicode61
+            USING fts5(
+                scope_kind UNINDEXED,
+                scope_id UNINDEXED,
+                document_id UNINDEXED,
+                title,
+                body,
+                keywords,
+                content='retrieval_documents',
+                content_rowid='rowid',
+                tokenize='unicode61',
+                detail='column'
+            )
+            """
+        )
+        self._conn.execute(
+            """
+            CREATE VIRTUAL TABLE IF NOT EXISTS retrieval_fts_trigram
+            USING fts5(
+                scope_kind UNINDEXED,
+                scope_id UNINDEXED,
+                document_id UNINDEXED,
+                title,
+                body,
+                keywords,
+                content='retrieval_documents',
+                content_rowid='rowid',
+                tokenize='trigram',
+                detail='column'
+            )
+            """
+        )
 
     def _replace_scope_locked(
         self,

--- a/src/agent_teams/roles/memory_repository.py
+++ b/src/agent_teams/roles/memory_repository.py
@@ -5,26 +5,29 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
-from agent_teams.persistence.db import open_sqlite
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 from agent_teams.roles.memory_models import RoleMemoryRecord
 
 
-class RoleMemoryRepository:
+class RoleMemoryRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
-        self._ensure_role_memories_schema()
-        self._drop_legacy_daily_table()
-        self._conn.commit()
+        def operation() -> None:
+            self._ensure_role_memories_schema()
+            self._drop_legacy_daily_table()
+
+        self._run_write(operation_name="init_tables", operation=operation)
 
     def read_role_memory(self, *, role_id: str, workspace_id: str) -> RoleMemoryRecord:
-        row = self._conn.execute(
-            "SELECT * FROM role_memories WHERE role_id=? AND workspace_id=?",
-            (role_id, workspace_id),
-        ).fetchone()
+        row = self._run_read(
+            lambda: self._conn.execute(
+                "SELECT * FROM role_memories WHERE role_id=? AND workspace_id=?",
+                (role_id, workspace_id),
+            ).fetchone()
+        )
         if row is None:
             return RoleMemoryRecord(
                 role_id=role_id,
@@ -47,24 +50,28 @@ class RoleMemoryRepository:
         content_markdown: str,
     ) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
-        self._conn.execute(
-            """
-            INSERT INTO role_memories(role_id, workspace_id, content_markdown, updated_at)
-            VALUES(?, ?, ?, ?)
-            ON CONFLICT(role_id, workspace_id)
-            DO UPDATE SET content_markdown=excluded.content_markdown,
-                          updated_at=excluded.updated_at
-            """,
-            (role_id, workspace_id, content_markdown, now),
+        self._run_write(
+            operation_name="write_role_memory",
+            operation=lambda: self._conn.execute(
+                """
+                INSERT INTO role_memories(role_id, workspace_id, content_markdown, updated_at)
+                VALUES(?, ?, ?, ?)
+                ON CONFLICT(role_id, workspace_id)
+                DO UPDATE SET content_markdown=excluded.content_markdown,
+                              updated_at=excluded.updated_at
+                """,
+                (role_id, workspace_id, content_markdown, now),
+            ),
         )
-        self._conn.commit()
 
     def delete_role_memory(self, *, role_id: str, workspace_id: str) -> None:
-        self._conn.execute(
-            "DELETE FROM role_memories WHERE role_id=? AND workspace_id=?",
-            (role_id, workspace_id),
+        self._run_write(
+            operation_name="delete_role_memory",
+            operation=lambda: self._conn.execute(
+                "DELETE FROM role_memories WHERE role_id=? AND workspace_id=?",
+                (role_id, workspace_id),
+            ),
         )
-        self._conn.commit()
 
     def _ensure_role_memories_schema(self) -> None:
         columns = self._table_info("role_memories")

--- a/src/agent_teams/sessions/runs/run_intent_repo.py
+++ b/src/agent_teams/sessions/runs/run_intent_repo.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
@@ -13,6 +12,7 @@ from agent_teams.media import (
     content_parts_to_text,
     text_part,
 )
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 from agent_teams.sessions.runs.enums import ExecutionMode
 from agent_teams.sessions.runs.run_models import (
     IntentInput,
@@ -22,7 +22,6 @@ from agent_teams.sessions.runs.run_models import (
     RunKind,
     RunTopologySnapshot,
 )
-from agent_teams.persistence.db import open_sqlite
 from agent_teams.sessions.session_models import SessionMode
 from agent_teams.validation import normalize_persisted_text
 
@@ -30,196 +29,209 @@ type _ThinkingEffort = Literal["minimal", "low", "medium", "high"] | None
 _MediaGenerationConfigAdapter = TypeAdapter(MediaGenerationConfig)
 
 
-class RunIntentRepository:
+class RunIntentRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS run_intents (
-                run_id         TEXT PRIMARY KEY,
-                session_id     TEXT NOT NULL,
-                intent         TEXT NOT NULL,
-                input_json     TEXT,
-                run_kind       TEXT NOT NULL DEFAULT 'conversation',
-                generation_config_json TEXT,
-                execution_mode TEXT NOT NULL,
-                yolo           TEXT NOT NULL DEFAULT 'false',
-                reuse_root_instance TEXT NOT NULL DEFAULT 'true',
-                thinking_enabled TEXT NOT NULL DEFAULT 'false',
-                thinking_effort TEXT,
-                target_role_id TEXT,
-                session_mode TEXT NOT NULL DEFAULT 'normal',
-                topology_json TEXT,
-                conversation_context_json TEXT,
-                created_at     TEXT NOT NULL,
-                updated_at     TEXT NOT NULL
-            )
-            """
-        )
-        columns = [
-            str(row["name"])
-            for row in self._conn.execute("PRAGMA table_info(run_intents)").fetchall()
-        ]
-        if "yolo" not in columns:
+        def operation() -> None:
             self._conn.execute(
-                "ALTER TABLE run_intents ADD COLUMN yolo TEXT NOT NULL DEFAULT 'false'"
+                """
+                CREATE TABLE IF NOT EXISTS run_intents (
+                    run_id         TEXT PRIMARY KEY,
+                    session_id     TEXT NOT NULL,
+                    intent         TEXT NOT NULL,
+                    input_json     TEXT,
+                    run_kind       TEXT NOT NULL DEFAULT 'conversation',
+                    generation_config_json TEXT,
+                    execution_mode TEXT NOT NULL,
+                    yolo           TEXT NOT NULL DEFAULT 'false',
+                    reuse_root_instance TEXT NOT NULL DEFAULT 'true',
+                    thinking_enabled TEXT NOT NULL DEFAULT 'false',
+                    thinking_effort TEXT,
+                    target_role_id TEXT,
+                    session_mode TEXT NOT NULL DEFAULT 'normal',
+                    topology_json TEXT,
+                    conversation_context_json TEXT,
+                    created_at     TEXT NOT NULL,
+                    updated_at     TEXT NOT NULL
+                )
+                """
             )
-            if "approval_mode" in columns:
+            columns = [
+                str(row["name"])
+                for row in self._conn.execute(
+                    "PRAGMA table_info(run_intents)"
+                ).fetchall()
+            ]
+            if "yolo" not in columns:
                 self._conn.execute(
                     """
-                    UPDATE run_intents
-                    SET yolo = CASE
-                        WHEN approval_mode = 'yolo' THEN 'true'
-                        ELSE 'false'
-                    END
+                    ALTER TABLE run_intents ADD COLUMN yolo TEXT NOT NULL DEFAULT 'false'
                     """
                 )
-        if "thinking_enabled" not in columns:
+                if "approval_mode" in columns:
+                    self._conn.execute(
+                        """
+                        UPDATE run_intents
+                        SET yolo = CASE
+                            WHEN approval_mode = 'yolo' THEN 'true'
+                            ELSE 'false'
+                        END
+                        """
+                    )
+            if "thinking_enabled" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN thinking_enabled TEXT NOT NULL DEFAULT 'false'"
+                )
+            if "reuse_root_instance" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN reuse_root_instance TEXT NOT NULL DEFAULT 'true'"
+                )
+            if "input_json" not in columns:
+                self._conn.execute("ALTER TABLE run_intents ADD COLUMN input_json TEXT")
+            if "run_kind" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN run_kind TEXT NOT NULL DEFAULT 'conversation'"
+                )
+            if "generation_config_json" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN generation_config_json TEXT"
+                )
+            if "thinking_effort" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN thinking_effort TEXT"
+                )
+            if "session_mode" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN session_mode TEXT NOT NULL DEFAULT 'normal'"
+                )
+            if "target_role_id" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN target_role_id TEXT"
+                )
+            if "topology_json" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN topology_json TEXT"
+                )
+            if "conversation_context_json" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE run_intents ADD COLUMN conversation_context_json TEXT"
+                )
             self._conn.execute(
-                "ALTER TABLE run_intents ADD COLUMN thinking_enabled TEXT NOT NULL DEFAULT 'false'"
+                "CREATE INDEX IF NOT EXISTS idx_run_intents_session ON run_intents(session_id)"
             )
-        if "reuse_root_instance" not in columns:
-            self._conn.execute(
-                "ALTER TABLE run_intents ADD COLUMN reuse_root_instance TEXT NOT NULL DEFAULT 'true'"
-            )
-        if "input_json" not in columns:
-            self._conn.execute("ALTER TABLE run_intents ADD COLUMN input_json TEXT")
-        if "run_kind" not in columns:
-            self._conn.execute(
-                "ALTER TABLE run_intents ADD COLUMN run_kind TEXT NOT NULL DEFAULT 'conversation'"
-            )
-        if "generation_config_json" not in columns:
-            self._conn.execute(
-                "ALTER TABLE run_intents ADD COLUMN generation_config_json TEXT"
-            )
-        if "thinking_effort" not in columns:
-            self._conn.execute(
-                "ALTER TABLE run_intents ADD COLUMN thinking_effort TEXT"
-            )
-        if "session_mode" not in columns:
-            self._conn.execute(
-                "ALTER TABLE run_intents ADD COLUMN session_mode TEXT NOT NULL DEFAULT 'normal'"
-            )
-        if "target_role_id" not in columns:
-            self._conn.execute("ALTER TABLE run_intents ADD COLUMN target_role_id TEXT")
-        if "topology_json" not in columns:
-            self._conn.execute("ALTER TABLE run_intents ADD COLUMN topology_json TEXT")
-        if "conversation_context_json" not in columns:
-            self._conn.execute(
-                "ALTER TABLE run_intents ADD COLUMN conversation_context_json TEXT"
-            )
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_run_intents_session ON run_intents(session_id)"
-        )
-        self._conn.commit()
+
+        self._run_write(operation_name="init_tables", operation=operation)
 
     def upsert(self, *, run_id: str, session_id: str, intent: IntentInput) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
-        self._conn.execute(
-            """
-            INSERT INTO run_intents(
-                run_id,
-                session_id,
-                intent,
-                input_json,
-                run_kind,
-                generation_config_json,
-                execution_mode,
-                yolo,
-                reuse_root_instance,
-                thinking_enabled,
-                thinking_effort,
-                target_role_id,
-                session_mode,
-                topology_json,
-                conversation_context_json,
-                created_at,
-                updated_at
-            )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(run_id)
-            DO UPDATE SET
-                session_id=excluded.session_id,
-                intent=excluded.intent,
-                input_json=excluded.input_json,
-                run_kind=excluded.run_kind,
-                generation_config_json=excluded.generation_config_json,
-                execution_mode=excluded.execution_mode,
-                yolo=excluded.yolo,
-                reuse_root_instance=excluded.reuse_root_instance,
-                thinking_enabled=excluded.thinking_enabled,
-                thinking_effort=excluded.thinking_effort,
-                target_role_id=excluded.target_role_id,
-                session_mode=excluded.session_mode,
-                topology_json=excluded.topology_json,
-                conversation_context_json=excluded.conversation_context_json,
-                updated_at=excluded.updated_at
-            """,
-            (
-                run_id,
-                session_id,
-                intent.intent,
-                ContentPartsAdapter.dump_json(intent.input).decode("utf-8"),
-                intent.run_kind.value,
+        self._run_write(
+            operation_name="upsert",
+            operation=lambda: self._conn.execute(
+                """
+                INSERT INTO run_intents(
+                    run_id,
+                    session_id,
+                    intent,
+                    input_json,
+                    run_kind,
+                    generation_config_json,
+                    execution_mode,
+                    yolo,
+                    reuse_root_instance,
+                    thinking_enabled,
+                    thinking_effort,
+                    target_role_id,
+                    session_mode,
+                    topology_json,
+                    conversation_context_json,
+                    created_at,
+                    updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    intent=excluded.intent,
+                    input_json=excluded.input_json,
+                    run_kind=excluded.run_kind,
+                    generation_config_json=excluded.generation_config_json,
+                    execution_mode=excluded.execution_mode,
+                    yolo=excluded.yolo,
+                    reuse_root_instance=excluded.reuse_root_instance,
+                    thinking_enabled=excluded.thinking_enabled,
+                    thinking_effort=excluded.thinking_effort,
+                    target_role_id=excluded.target_role_id,
+                    session_mode=excluded.session_mode,
+                    topology_json=excluded.topology_json,
+                    conversation_context_json=excluded.conversation_context_json,
+                    updated_at=excluded.updated_at
+                """,
                 (
-                    intent.generation_config.model_dump_json()
-                    if intent.generation_config is not None
-                    else None
+                    run_id,
+                    session_id,
+                    intent.intent,
+                    ContentPartsAdapter.dump_json(intent.input).decode("utf-8"),
+                    intent.run_kind.value,
+                    (
+                        intent.generation_config.model_dump_json()
+                        if intent.generation_config is not None
+                        else None
+                    ),
+                    intent.execution_mode.value,
+                    "true" if intent.yolo else "false",
+                    "true" if intent.reuse_root_instance else "false",
+                    "true" if intent.thinking.enabled else "false",
+                    intent.thinking.effort,
+                    intent.target_role_id,
+                    intent.session_mode.value,
+                    (
+                        intent.topology.model_dump_json()
+                        if intent.topology is not None
+                        else None
+                    ),
+                    (
+                        intent.conversation_context.model_dump_json()
+                        if intent.conversation_context is not None
+                        else None
+                    ),
+                    now,
+                    now,
                 ),
-                intent.execution_mode.value,
-                "true" if intent.yolo else "false",
-                "true" if intent.reuse_root_instance else "false",
-                "true" if intent.thinking.enabled else "false",
-                intent.thinking.effort,
-                intent.target_role_id,
-                intent.session_mode.value,
-                (
-                    intent.topology.model_dump_json()
-                    if intent.topology is not None
-                    else None
-                ),
-                (
-                    intent.conversation_context.model_dump_json()
-                    if intent.conversation_context is not None
-                    else None
-                ),
-                now,
-                now,
             ),
         )
-        self._conn.commit()
 
     def append_followup(self, *, run_id: str, content: str) -> None:
-        row = self._conn.execute(
-            "SELECT intent, input_json FROM run_intents WHERE run_id=?",
-            (run_id,),
-        ).fetchone()
-        if row is None:
-            raise KeyError(f"Unknown run_id: {run_id}")
-        current_parts = _coerce_input_parts(row["input_json"], row["intent"])
-        next_part = text_part(content)
-        next_parts = (
-            current_parts if next_part is None else current_parts + (next_part,)
-        )
-        next_intent = content_parts_to_text(next_parts)
-        self._conn.execute(
-            """
-            UPDATE run_intents
-            SET intent=?, input_json=?, updated_at=?
-            WHERE run_id=?
-            """,
-            (
-                next_intent,
-                ContentPartsAdapter.dump_json(next_parts).decode("utf-8"),
-                datetime.now(tz=timezone.utc).isoformat(),
-                run_id,
-            ),
-        )
-        self._conn.commit()
+        def operation() -> None:
+            row = self._conn.execute(
+                "SELECT intent, input_json FROM run_intents WHERE run_id=?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"Unknown run_id: {run_id}")
+            current_parts = _coerce_input_parts(row["input_json"], row["intent"])
+            next_part = text_part(content)
+            next_parts = (
+                current_parts if next_part is None else current_parts + (next_part,)
+            )
+            next_intent = content_parts_to_text(next_parts)
+            self._conn.execute(
+                """
+                UPDATE run_intents
+                SET intent=?, input_json=?, updated_at=?
+                WHERE run_id=?
+                """,
+                (
+                    next_intent,
+                    ContentPartsAdapter.dump_json(next_parts).decode("utf-8"),
+                    datetime.now(tz=timezone.utc).isoformat(),
+                    run_id,
+                ),
+            )
+
+        self._run_write(operation_name="append_followup", operation=operation)
 
     def get(
         self,
@@ -227,28 +239,30 @@ class RunIntentRepository:
         *,
         fallback_session_id: str | None = None,
     ) -> IntentInput:
-        row = self._conn.execute(
-            """
-            SELECT
-                session_id,
-                intent,
-                input_json,
-                run_kind,
-                generation_config_json,
-                execution_mode,
-                yolo,
-                reuse_root_instance,
-                thinking_enabled,
-                thinking_effort,
-                target_role_id,
-                session_mode,
-                topology_json,
-                conversation_context_json
-            FROM run_intents
-            WHERE run_id=?
-            """,
-            (run_id,),
-        ).fetchone()
+        row = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT
+                    session_id,
+                    intent,
+                    input_json,
+                    run_kind,
+                    generation_config_json,
+                    execution_mode,
+                    yolo,
+                    reuse_root_instance,
+                    thinking_enabled,
+                    thinking_effort,
+                    target_role_id,
+                    session_mode,
+                    topology_json,
+                    conversation_context_json
+                FROM run_intents
+                WHERE run_id=?
+                """,
+                (run_id,),
+            ).fetchone()
+        )
         if row is None:
             raise KeyError(f"Unknown run_id: {run_id}")
         session_id = _coerce_session_id(

--- a/src/agent_teams/sessions/session_repository.py
+++ b/src/agent_teams/sessions/session_repository.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from pydantic import JsonValue, ValidationError
 
 from agent_teams.logger import get_logger, log_event
-from agent_teams.persistence.db import open_sqlite
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
 from agent_teams.sessions.session_models import ProjectKind, SessionMode, SessionRecord
 from agent_teams.validation import (
     normalize_persisted_text,
@@ -20,71 +20,72 @@ from agent_teams.validation import (
 LOGGER = get_logger(__name__)
 
 
-class SessionRepository:
+class SessionRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS sessions (
-                session_id TEXT PRIMARY KEY,
-                workspace_id TEXT NOT NULL DEFAULT '',
-                project_kind TEXT NOT NULL DEFAULT 'workspace',
-                project_id TEXT NOT NULL DEFAULT '',
-                metadata   TEXT NOT NULL,
-                session_mode TEXT NOT NULL DEFAULT 'normal',
-                normal_root_role_id TEXT,
-                orchestration_preset_id TEXT,
-                started_at TEXT,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-            )
-            """
-        )
-        columns = [
-            str(row["name"])
-            for row in self._conn.execute("PRAGMA table_info(sessions)").fetchall()
-        ]
-        if "workspace_id" not in columns:
+        def operation() -> None:
             self._conn.execute(
-                "ALTER TABLE sessions ADD COLUMN workspace_id TEXT NOT NULL DEFAULT ''"
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    session_id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL DEFAULT '',
+                    project_kind TEXT NOT NULL DEFAULT 'workspace',
+                    project_id TEXT NOT NULL DEFAULT '',
+                    metadata   TEXT NOT NULL,
+                    session_mode TEXT NOT NULL DEFAULT 'normal',
+                    normal_root_role_id TEXT,
+                    orchestration_preset_id TEXT,
+                    started_at TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
             )
-        if "project_kind" not in columns:
+            columns = [
+                str(row["name"])
+                for row in self._conn.execute("PRAGMA table_info(sessions)").fetchall()
+            ]
+            if "workspace_id" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN workspace_id TEXT NOT NULL DEFAULT ''"
+                )
+            if "project_kind" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN project_kind TEXT NOT NULL DEFAULT 'workspace'"
+                )
+            if "project_id" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN project_id TEXT NOT NULL DEFAULT ''"
+                )
+                self._conn.execute(
+                    "UPDATE sessions SET project_id=workspace_id WHERE project_id=''"
+                )
+            if "session_mode" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN session_mode TEXT NOT NULL DEFAULT 'normal'"
+                )
+            if "normal_root_role_id" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN normal_root_role_id TEXT"
+                )
+            if "orchestration_preset_id" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN orchestration_preset_id TEXT"
+                )
+            if "started_at" not in columns:
+                self._conn.execute("ALTER TABLE sessions ADD COLUMN started_at TEXT")
             self._conn.execute(
-                "ALTER TABLE sessions ADD COLUMN project_kind TEXT NOT NULL DEFAULT 'workspace'"
+                """
+                UPDATE sessions
+                SET started_at=NULL
+                WHERE LOWER(TRIM(COALESCE(started_at, ''))) IN ('', 'none', 'null')
+                """
             )
-        if "project_id" not in columns:
-            self._conn.execute(
-                "ALTER TABLE sessions ADD COLUMN project_id TEXT NOT NULL DEFAULT ''"
-            )
-            self._conn.execute(
-                "UPDATE sessions SET project_id=workspace_id WHERE project_id=''"
-            )
-        if "session_mode" not in columns:
-            self._conn.execute(
-                "ALTER TABLE sessions ADD COLUMN session_mode TEXT NOT NULL DEFAULT 'normal'"
-            )
-        if "normal_root_role_id" not in columns:
-            self._conn.execute(
-                "ALTER TABLE sessions ADD COLUMN normal_root_role_id TEXT"
-            )
-        if "orchestration_preset_id" not in columns:
-            self._conn.execute(
-                "ALTER TABLE sessions ADD COLUMN orchestration_preset_id TEXT"
-            )
-        if "started_at" not in columns:
-            self._conn.execute("ALTER TABLE sessions ADD COLUMN started_at TEXT")
-        self._conn.execute(
-            """
-            UPDATE sessions
-            SET started_at=NULL
-            WHERE LOWER(TRIM(COALESCE(started_at, ''))) IN ('', 'none', 'null')
-            """
-        )
-        self._conn.commit()
+
+        self._run_write(operation_name="init_tables", operation=operation)
 
     def create(
         self,
@@ -114,38 +115,40 @@ class SessionRepository:
             updated_at=datetime.fromisoformat(now),
         )
 
-        self._conn.execute(
-            """
-            INSERT INTO sessions(
-                session_id,
-                workspace_id,
-                project_kind,
-                project_id,
-                metadata,
-                session_mode,
-                normal_root_role_id,
-                orchestration_preset_id,
-                started_at,
-                created_at,
-                updated_at
-            )
-            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                record.session_id,
-                record.workspace_id,
-                record.project_kind.value,
-                record.project_id,
-                json.dumps(record.metadata),
-                record.session_mode.value,
-                record.normal_root_role_id,
-                record.orchestration_preset_id,
-                None,
-                now,
-                now,
+        self._run_write(
+            operation_name="create",
+            operation=lambda: self._conn.execute(
+                """
+                INSERT INTO sessions(
+                    session_id,
+                    workspace_id,
+                    project_kind,
+                    project_id,
+                    metadata,
+                    session_mode,
+                    normal_root_role_id,
+                    orchestration_preset_id,
+                    started_at,
+                    created_at,
+                    updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.session_id,
+                    record.workspace_id,
+                    record.project_kind.value,
+                    record.project_id,
+                    json.dumps(record.metadata),
+                    record.session_mode.value,
+                    record.normal_root_role_id,
+                    record.orchestration_preset_id,
+                    None,
+                    now,
+                    now,
+                ),
             ),
         )
-        self._conn.commit()
         return record
 
     def update_topology(
@@ -157,22 +160,26 @@ class SessionRepository:
         orchestration_preset_id: str | None,
     ) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
-        cursor = self._conn.execute(
-            """
-            UPDATE sessions
-            SET session_mode=?, normal_root_role_id=?, orchestration_preset_id=?, updated_at=?
-            WHERE session_id=? AND started_at IS NULL
-            """,
-            (
-                session_mode.value,
-                normal_root_role_id,
-                orchestration_preset_id,
-                now,
-                session_id,
+        rowcount = self._run_write(
+            operation_name="update_topology",
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                UPDATE sessions
+                SET session_mode=?, normal_root_role_id=?, orchestration_preset_id=?, updated_at=?
+                WHERE session_id=? AND started_at IS NULL
+                """,
+                    (
+                        session_mode.value,
+                        normal_root_role_id,
+                        orchestration_preset_id,
+                        now,
+                        session_id,
+                    ),
+                ).rowcount
             ),
         )
-        self._conn.commit()
-        if cursor.rowcount == 0:
+        if rowcount == 0:
             existing = self.get(session_id)
             if existing.started_at is not None:
                 raise RuntimeError("Session mode can no longer be changed")
@@ -180,16 +187,20 @@ class SessionRepository:
 
     def update_metadata(self, session_id: str, metadata: dict[str, str]) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
-        cursor = self._conn.execute(
-            """
-            UPDATE sessions
-            SET metadata=?, updated_at=?
-            WHERE session_id=?
-            """,
-            (json.dumps(metadata), now, session_id),
+        rowcount = self._run_write(
+            operation_name="update_metadata",
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                UPDATE sessions
+                SET metadata=?, updated_at=?
+                WHERE session_id=?
+                """,
+                    (json.dumps(metadata), now, session_id),
+                ).rowcount
+            ),
         )
-        self._conn.commit()
-        if cursor.rowcount == 0:
+        if rowcount == 0:
             raise KeyError(f"Unknown session_id: {session_id}")
 
     def update_workspace(
@@ -200,30 +211,38 @@ class SessionRepository:
         project_id: str,
     ) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
-        cursor = self._conn.execute(
-            """
-            UPDATE sessions
-            SET workspace_id=?, project_id=?, updated_at=?
-            WHERE session_id=?
-            """,
-            (workspace_id, project_id, now, session_id),
+        rowcount = self._run_write(
+            operation_name="update_workspace",
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                UPDATE sessions
+                SET workspace_id=?, project_id=?, updated_at=?
+                WHERE session_id=?
+                """,
+                    (workspace_id, project_id, now, session_id),
+                ).rowcount
+            ),
         )
-        self._conn.commit()
-        if cursor.rowcount == 0:
+        if rowcount == 0:
             raise KeyError(f"Unknown session_id: {session_id}")
 
     def mark_started(self, session_id: str) -> SessionRecord:
         now = datetime.now(tz=timezone.utc).isoformat()
-        cursor = self._conn.execute(
-            """
-            UPDATE sessions
-            SET started_at=COALESCE(started_at, ?), updated_at=?
-            WHERE session_id=?
-            """,
-            (now, now, session_id),
+        rowcount = self._run_write(
+            operation_name="mark_started",
+            operation=lambda: (
+                self._conn.execute(
+                    """
+                UPDATE sessions
+                SET started_at=COALESCE(started_at, ?), updated_at=?
+                WHERE session_id=?
+                """,
+                    (now, now, session_id),
+                ).rowcount
+            ),
         )
-        self._conn.commit()
-        if cursor.rowcount == 0:
+        if rowcount == 0:
             raise KeyError(f"Unknown session_id: {session_id}")
         return self.get(session_id)
 
@@ -234,13 +253,15 @@ class SessionRepository:
         default_preset_id: str | None,
     ) -> None:
         valid_ids = set(valid_preset_ids)
-        rows = self._conn.execute(
-            """
-            SELECT session_id, session_mode, orchestration_preset_id, started_at
-                 , normal_root_role_id
-            FROM sessions
-            """
-        ).fetchall()
+        rows = self._run_read(
+            lambda: self._conn.execute(
+                """
+                SELECT session_id, session_mode, orchestration_preset_id, started_at
+                     , normal_root_role_id
+                FROM sessions
+                """
+            ).fetchall()
+        )
         for row in rows:
             try:
                 started_at = normalize_persisted_text(row["started_at"])
@@ -278,9 +299,11 @@ class SessionRepository:
                 )
 
     def get(self, session_id: str) -> SessionRecord:
-        row = self._conn.execute(
-            "SELECT * FROM sessions WHERE session_id=?", (session_id,)
-        ).fetchone()
+        row = self._run_read(
+            lambda: self._conn.execute(
+                "SELECT * FROM sessions WHERE session_id=?", (session_id,)
+            ).fetchone()
+        )
         if row is None:
             raise KeyError(f"Unknown session_id: {session_id}")
         try:
@@ -290,9 +313,11 @@ class SessionRepository:
             raise KeyError(f"Unknown session_id: {session_id}") from exc
 
     def list_all(self) -> tuple[SessionRecord, ...]:
-        rows = self._conn.execute(
-            "SELECT * FROM sessions ORDER BY created_at DESC"
-        ).fetchall()
+        rows = self._run_read(
+            lambda: self._conn.execute(
+                "SELECT * FROM sessions ORDER BY created_at DESC"
+            ).fetchall()
+        )
         records: list[SessionRecord] = []
         for row in rows:
             try:
@@ -302,8 +327,12 @@ class SessionRepository:
         return tuple(records)
 
     def delete(self, session_id: str) -> None:
-        self._conn.execute("DELETE FROM sessions WHERE session_id=?", (session_id,))
-        self._conn.commit()
+        self._run_write(
+            operation_name="delete",
+            operation=lambda: self._conn.execute(
+                "DELETE FROM sessions WHERE session_id=?", (session_id,)
+            ),
+        )
 
     def _to_record(self, row: sqlite3.Row) -> SessionRecord:
         session_id = require_persisted_identifier(

--- a/tests/unit_tests/frontend/test_logger_sdk.py
+++ b/tests/unit_tests/frontend/test_logger_sdk.py
@@ -37,8 +37,43 @@ console.log(JSON.stringify(globalThis.__capturedBatches));
     assert browser_session_id.startswith("browser_")
 
 
+def test_frontend_logger_uses_null_trace_id_without_active_run(tmp_path: Path) -> None:
+    payload = _run_frontend_logger_script(
+        tmp_path=tmp_path,
+        state_source="""
+export const state = {
+    currentSessionId: "session-ui",
+    activeRunId: null,
+};
+""".strip(),
+        runner_source="""
+import { flushFrontendLogs, logInfo } from "./logger.mjs";
+
+logInfo("frontend.test.info", "frontend ok");
+await flushFrontendLogs();
+
+console.log(JSON.stringify(globalThis.__capturedBatches));
+""".strip(),
+    )
+
+    events = cast(list[dict[str, JsonValue]], payload[0]["events"])
+    event = cast(dict[str, JsonValue], events[0])
+
+    assert event["trace_id"] is None
+    assert event["run_id"] is None
+    assert event["session_id"] == "session-ui"
+
+
 def _run_frontend_logger_script(
-    tmp_path: Path, runner_source: str
+    tmp_path: Path,
+    runner_source: str,
+    *,
+    state_source: str = """
+export const state = {
+    currentSessionId: "session-ui",
+    activeRunId: "run-ui",
+};
+""".strip(),
 ) -> list[dict[str, JsonValue]]:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = repo_root / "frontend" / "dist" / "js" / "utils" / "logger.js"
@@ -56,15 +91,7 @@ export const els = {
 """.strip(),
         encoding="utf-8",
     )
-    mock_state_path.write_text(
-        """
-export const state = {
-    currentSessionId: "session-ui",
-    activeRunId: "run-ui",
-};
-""".strip(),
-        encoding="utf-8",
-    )
+    mock_state_path.write_text(state_source, encoding="utf-8")
 
     source_text = (
         source_path.read_text(encoding="utf-8")

--- a/tests/unit_tests/persistence/test_sqlite_repository.py
+++ b/tests/unit_tests/persistence/test_sqlite_repository.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+import sqlite3
+import threading
+
+from pytest import MonkeyPatch
+
+import agent_teams.persistence.sqlite_repository as sqlite_repository_module
+from agent_teams.persistence.sqlite_repository import SharedSqliteRepository
+from agent_teams.retrieval.sqlite_store import SqliteFts5RetrievalStore
+
+
+class _DummyRepository(SharedSqliteRepository):
+    def __init__(self, db_path: Path, *, repository_name: str | None = None) -> None:
+        super().__init__(db_path, repository_name=repository_name)
+
+
+def test_shared_sqlite_repository_run_write_uses_retry_helper(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    repo = _DummyRepository(tmp_path / "shared_repo.db")
+    calls: list[tuple[Path, object, str, str]] = []
+
+    def fake_run_sqlite_write_with_retry(
+        *,
+        conn: sqlite3.Connection,
+        db_path: Path,
+        operation: Callable[[], str],
+        lock: object,
+        repository_name: str,
+        operation_name: str,
+        max_retries: int = 8,
+    ) -> str:
+        calls.append((db_path, lock, repository_name, operation_name))
+        return operation()
+
+    monkeypatch.setattr(
+        sqlite_repository_module,
+        "run_sqlite_write_with_retry",
+        fake_run_sqlite_write_with_retry,
+    )
+
+    result = repo._run_write(
+        operation_name="insert_item",
+        operation=lambda: "ok",
+    )
+
+    assert result == "ok"
+    assert calls == [
+        (tmp_path / "shared_repo.db", repo._lock, "_DummyRepository", "insert_item")
+    ]
+
+
+def test_shared_sqlite_repository_run_read_uses_repository_lock(
+    tmp_path: Path,
+) -> None:
+    repo = _DummyRepository(tmp_path / "shared_repo_read.db")
+    started = threading.Event()
+    finished = threading.Event()
+
+    def worker() -> None:
+        started.set()
+        repo._run_read(lambda: finished.set())
+
+    with repo._lock:
+        thread = threading.Thread(target=worker)
+        thread.start()
+        assert started.wait(timeout=1)
+        assert finished.wait(timeout=0.1) is False
+
+    thread.join(timeout=1)
+
+    assert finished.wait(timeout=1)
+    assert thread.is_alive() is False
+
+
+def test_shared_sqlite_repository_defaults_repository_name_to_class_name(
+    tmp_path: Path,
+) -> None:
+    repo = _DummyRepository(tmp_path / "shared_repo_name.db")
+
+    assert repo._repository_name == "_DummyRepository"
+
+
+def test_sqlite_retrieval_store_uses_stable_repository_name(tmp_path: Path) -> None:
+    store = SqliteFts5RetrievalStore(tmp_path / "retrieval.db")
+
+    assert store._repository_name == "retrieval.sqlite"

--- a/tests/unit_tests/persistence/test_sqlite_write_inventory.py
+++ b/tests/unit_tests/persistence/test_sqlite_write_inventory.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SRC_ROOT = _REPO_ROOT / "src" / "agent_teams"
+_ALLOWED_COMMIT_FILES = {
+    Path("src/agent_teams/persistence/db.py"),
+}
+_SHARED_SQLITE_WRITERS = {
+    Path(
+        "src/agent_teams/automation/automation_event_repository.py"
+    ): "AutomationEventRepository",
+    Path(
+        "src/agent_teams/automation/automation_repository.py"
+    ): "AutomationProjectRepository",
+    Path(
+        "src/agent_teams/gateway/gateway_session_repository.py"
+    ): "GatewaySessionRepository",
+    Path("src/agent_teams/metrics/stores/sqlite.py"): "SqliteMetricAggregateStore",
+    Path("src/agent_teams/persistence/shared_state_repo.py"): "SharedStateRepository",
+    Path("src/agent_teams/providers/token_usage_repo.py"): "TokenUsageRepository",
+    Path("src/agent_teams/retrieval/sqlite_store.py"): "SqliteFts5RetrievalStore",
+    Path("src/agent_teams/roles/memory_repository.py"): "RoleMemoryRepository",
+    Path("src/agent_teams/sessions/runs/run_intent_repo.py"): "RunIntentRepository",
+    Path("src/agent_teams/sessions/session_repository.py"): "SessionRepository",
+}
+
+
+def test_only_db_helper_commits_transactions() -> None:
+    offenders: list[str] = []
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        relative_path = path.relative_to(_REPO_ROOT)
+        if relative_path in _ALLOWED_COMMIT_FILES:
+            continue
+        if ".commit(" in path.read_text(encoding="utf-8"):
+            offenders.append(relative_path.as_posix())
+
+    assert offenders == []
+
+
+def test_shared_sqlite_writers_inherit_shared_repository_base() -> None:
+    missing: list[str] = []
+    for relative_path, class_name in _SHARED_SQLITE_WRITERS.items():
+        module_path = _REPO_ROOT / relative_path
+        class_bases = _class_bases_from_file(module_path, class_name=class_name)
+        if "SharedSqliteRepository" not in class_bases:
+            missing.append(f"{relative_path.as_posix()}::{class_name}")
+
+    assert missing == []
+
+
+def _class_bases_from_file(path: Path, *, class_name: str) -> tuple[str, ...]:
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return tuple(_base_name(base) for base in node.bases)
+    raise AssertionError(f"Class not found: {class_name} in {path}")
+
+
+def _base_name(base: ast.expr) -> str:
+    if isinstance(base, ast.Name):
+        return base.id
+    if isinstance(base, ast.Attribute):
+        return base.attr
+    return ast.unparse(base)

--- a/tests/unit_tests/sessions/runs/test_run_intent_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_intent_repo.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+import threading
+import time
 
 import pytest
 
@@ -239,3 +241,86 @@ def test_run_intent_repo_round_trips_session_topology(tmp_path: Path) -> None:
     assert record.topology is not None
     assert record.topology.orchestration_preset_id == "default"
     assert record.topology.allowed_role_ids == ("writer", "reviewer")
+
+
+def test_run_intent_repo_upsert_retries_transient_write_lock(tmp_path: Path) -> None:
+    db_path = tmp_path / "run_intent_retry_upsert.db"
+    repo = RunIntentRepository(db_path)
+    repo._conn.execute("PRAGMA busy_timeout = 0")
+
+    blocker = sqlite3.connect(db_path, check_same_thread=False)
+    blocker.execute("PRAGMA busy_timeout = 0")
+    blocker.execute("BEGIN IMMEDIATE")
+    blocker.execute("SELECT 1")
+
+    released = threading.Event()
+
+    def release_lock() -> None:
+        time.sleep(0.05)
+        blocker.commit()
+        blocker.close()
+        released.set()
+
+    thread = threading.Thread(target=release_lock)
+    thread.start()
+
+    repo.upsert(
+        run_id="run-retry",
+        session_id="session-1",
+        intent=IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("ship it"),
+            execution_mode=ExecutionMode.AI,
+            yolo=False,
+        ),
+    )
+
+    thread.join(timeout=1)
+
+    assert released.is_set()
+    assert repo.get("run-retry").intent == "ship it"
+
+
+def test_run_intent_repo_append_followup_retries_transient_write_lock(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_intent_retry_followup.db"
+    repo = RunIntentRepository(db_path)
+    repo.upsert(
+        run_id="run-followup",
+        session_id="session-1",
+        intent=IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("ship it"),
+            execution_mode=ExecutionMode.AI,
+            yolo=False,
+        ),
+    )
+    repo._conn.execute("PRAGMA busy_timeout = 0")
+
+    blocker = sqlite3.connect(db_path, check_same_thread=False)
+    blocker.execute("PRAGMA busy_timeout = 0")
+    blocker.execute("BEGIN IMMEDIATE")
+    blocker.execute(
+        "UPDATE run_intents SET updated_at=updated_at WHERE run_id=?",
+        ("run-followup",),
+    )
+
+    released = threading.Event()
+
+    def release_lock() -> None:
+        time.sleep(0.05)
+        blocker.commit()
+        blocker.close()
+        released.set()
+
+    thread = threading.Thread(target=release_lock)
+    thread.start()
+
+    repo.append_followup(run_id="run-followup", content="and validate it")
+
+    thread.join(timeout=1)
+
+    record = repo.get("run-followup")
+    assert released.is_set()
+    assert record.intent == "ship it\n\nand validate it"

--- a/tests/unit_tests/sessions/test_session_repository.py
+++ b/tests/unit_tests/sessions/test_session_repository.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 import sqlite3
+import threading
+import time
 
 import pytest
 
@@ -224,6 +226,40 @@ def test_repository_init_normalizes_missing_or_none_like_started_at_for_mark_sta
 
     record = repository.mark_started("session-preexisting-blank-started-at")
 
+    assert record.started_at is not None
+    assert record.can_switch_mode is False
+
+
+def test_mark_started_retries_transient_write_lock(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_repository_retry.db"
+    repository = SessionRepository(db_path)
+    repository.create(session_id="session-retry", workspace_id="default")
+    repository._conn.execute("PRAGMA busy_timeout = 0")
+
+    blocker = sqlite3.connect(db_path, check_same_thread=False)
+    blocker.execute("PRAGMA busy_timeout = 0")
+    blocker.execute("BEGIN IMMEDIATE")
+    blocker.execute(
+        "UPDATE sessions SET updated_at=updated_at WHERE session_id=?",
+        ("session-retry",),
+    )
+
+    released = threading.Event()
+
+    def release_lock() -> None:
+        time.sleep(0.05)
+        blocker.commit()
+        blocker.close()
+        released.set()
+
+    thread = threading.Thread(target=release_lock)
+    thread.start()
+
+    record = repository.mark_started("session-retry")
+
+    thread.join(timeout=1)
+
+    assert released.is_set()
     assert record.started_at is not None
     assert record.can_switch_mode is False
 


### PR DESCRIPTION
Fixes #160

## Summary
- add a shared SQLite repository base that funnels shared-db writes through the existing retry and serialization helper
- migrate the remaining server/runtime SQLite writer repos away from direct `commit()` calls and add CI guardrails to prevent regressions
- normalize frontend log shipping to send `trace_id: null` instead of `""` when there is no active run

## Testing
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`
