### PR TITLE
Add collapsible tool group for round messages

### DIFF
--- a/frontend/dist/css/components.css
+++ b/frontend/dist/css/components.css
@@ -5445,7 +5445,8 @@ body.light-theme .round-clear-divider-line {
 }
 
 body.light-theme .round-history-divider-line,
-body.light-theme .message-history-divider-line {
+body.light-theme .message-history-divider-line,
+body.light-theme .tool-group-line {
     background: color-mix(in srgb, var(--border-color) 78%, transparent);
 }
 

--- a/frontend/dist/css/components/tools.css
+++ b/frontend/dist/css/components/tools.css
@@ -360,6 +360,63 @@
     background: rgba(255, 255, 255, 0.015);
 }
 
+/* --- Tool Group - collapsible divider for grouped tool blocks --- */
+
+.tool-group {
+    margin: 0.35rem 0;
+}
+
+.tool-group-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    cursor: pointer;
+    list-style: none;
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+    font-family: var(--font-ui);
+    user-select: none;
+    padding: 0.2rem 0;
+    transition: color 0.15s;
+}
+
+.tool-group-summary::-webkit-details-marker {
+    display: none;
+}
+
+.tool-group-summary:hover {
+    color: var(--text-primary);
+}
+
+.tool-group-line {
+    flex: 1 1 auto;
+    height: 1px;
+    background: color-mix(in srgb, var(--border-color) 82%, transparent);
+}
+
+.tool-group-label {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+.tool-group-toggle {
+    flex: 0 0 auto;
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    line-height: 1;
+    transform: rotate(0deg);
+    transition: transform 0.16s ease;
+}
+
+.tool-group[open] > .tool-group-summary .tool-group-toggle {
+    transform: rotate(90deg);
+}
+
+.tool-group-body {
+    overflow: hidden;
+}
+
 /* --- Animations --- */
 
 @keyframes tool-detail-in {

--- a/frontend/dist/css/layout.css
+++ b/frontend/dist/css/layout.css
@@ -98,7 +98,6 @@
   flex: 1;
   overflow-y: auto;
   padding: 2rem 10%;
-  scroll-behavior: smooth;
 }
 
 /* Input Area */

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -3,6 +3,7 @@
  * Historical message rendering and approval state hydration.
  */
 import { isRunPrimaryRoleId } from '../../core/state.js';
+import { formatMessage } from '../../utils/i18n.js';
 import {
     applyToolReturn,
     appendMessageText,
@@ -76,6 +77,8 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
             roleId: String(msgItem.role_id || '').trim(),
             streamKey,
         });
+        const msgCreatedAt = String(msgItem.created_at || '').trim();
+        if (msgCreatedAt) wrapper.dataset.createdAt = msgCreatedAt;
         renderParts(contentEl, parts, pendingToolBlocks, {
             collapseUserPrompt: role === 'user' && options.collapsibleUserPrompts === true,
         });
@@ -90,6 +93,21 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
             streamKey,
         };
     });
+
+    // Store the last message timestamp from raw data (including tool-return
+    // messages not rendered as .message elements) so the collapse group can
+    // compute duration from round start to the final message.
+    if (historyMessages.length > 0) {
+        for (let i = historyMessages.length - 1; i >= 0; i -= 1) {
+            const ts = String(historyMessages[i]?.created_at || '').trim();
+            if (ts) {
+                container.dataset.roundLastMessageAt = ts;
+                break;
+            }
+        }
+    }
+
+    collapseIntermediateMessages(container);
 
     if (streamOverlayEntry && Array.isArray(streamOverlayEntry.parts) && streamOverlayEntry.parts.length > 0) {
         renderStreamOverlayEntry(container, streamOverlayEntry, pendingToolBlocks, lastRenderedMessage, runId);
@@ -321,6 +339,110 @@ function resolveHistoryStreamKey(runId, instanceId, roleId) {
         return 'primary';
     }
     return safeInstanceId || `role:${safeRoleId}`;
+}
+
+function collapseIntermediateMessages(container) {
+    if (!container) return;
+    const messages = Array.from(container.querySelectorAll(':scope > .message'));
+    if (messages.length === 0) return;
+
+    const last = messages[messages.length - 1];
+
+    // Everything before the last message is intermediate (coordinator_messages
+    // do not contain the user prompt; that lives in the round header intent).
+    const beforeLast = messages.slice(0, -1);
+
+    // Also lift thinking and tool blocks out of the final message so only
+    // the plain text reply remains visible.
+    const lastContent = last.querySelector('.msg-content');
+    const liftedFromLast = [];
+    if (lastContent) {
+        Array.from(lastContent.children).forEach(child => {
+            if (child.classList.contains('thinking-block') || child.classList.contains('tool-block')) {
+                liftedFromLast.push(child);
+            }
+        });
+    }
+
+    if (beforeLast.length === 0 && liftedFromLast.length === 0) return;
+
+    // Compute elapsed duration from round start (user sent message) to last
+    // coordinator message. Round start comes from the section's dataset
+    // (set by renderRoundSection); last message time from raw data stored
+    // by renderHistoricalMessageList (covers non-rendered tool-return messages).
+    const firstTime = Date.parse(container.dataset.roundCreatedAt || messages[0].dataset.createdAt || '');
+    const lastTime = Date.parse(container.dataset.roundLastMessageAt || last.dataset.createdAt || '');
+    const durationText = Number.isFinite(firstTime) && Number.isFinite(lastTime) && lastTime > firstTime
+        ? formatElapsed(lastTime - firstTime)
+        : '';
+    const durationSuffix = durationText ? ` (${durationText})` : '';
+    const label = formatMessage('tool.group.processed', { duration: durationSuffix }).trim();
+
+    const group = document.createElement('details');
+    group.className = 'tool-group';
+    group.innerHTML = `
+        <summary class="tool-group-summary">
+            <span class="tool-group-line" aria-hidden="true"></span>
+            <span class="tool-group-label">${label}</span>
+            <span class="tool-group-toggle" aria-hidden="true">></span>
+            <span class="tool-group-line" aria-hidden="true"></span>
+        </summary>
+    `;
+    const body = document.createElement('div');
+    body.className = 'tool-group-body';
+    group.appendChild(body);
+
+    // Collect all sibling nodes from the first message up to (but not
+    // including) the last message, preserving markers and dividers.
+    container.insertBefore(group, beforeLast[0] || last);
+    let node = group.nextElementSibling;
+    while (node && node !== last) {
+        const next = node.nextElementSibling;
+        body.appendChild(node);
+        node = next;
+    }
+    liftedFromLast.forEach(el => body.appendChild(el));
+
+    // If the last message has no remaining visible content after lifting,
+    // hide it so only the collapsed group is shown.
+    if (lastContent && lastContent.childNodes.length === 0) {
+        last.hidden = true;
+    }
+
+    // Animate open / close via Web Animations API.
+    group.addEventListener('click', (e) => {
+        if (!e.target.closest('.tool-group-summary')) return;
+        e.preventDefault();
+        if (group.open) {
+            body.animate(
+                [
+                    { opacity: 1, maxHeight: body.scrollHeight + 'px' },
+                    { opacity: 0, maxHeight: '0px' },
+                ],
+                { duration: 180, easing: 'ease' },
+            ).onfinish = () => { group.open = false; };
+        } else {
+            group.open = true;
+            body.animate(
+                [
+                    { opacity: 0, maxHeight: '0px' },
+                    { opacity: 1, maxHeight: body.scrollHeight + 'px' },
+                ],
+                { duration: 200, easing: 'ease' },
+            );
+        }
+    });
+}
+
+function formatElapsed(ms) {
+    const totalSeconds = Math.round(ms / 1000);
+    if (totalSeconds < 60) return `${totalSeconds}s`;
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    if (minutes < 60) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    const remainMinutes = minutes % 60;
+    return remainMinutes > 0 ? `${hours}h ${remainMinutes}m` : `${hours}h`;
 }
 
 function wrapperMatchesOverlay(wrapper, options = {}) {

--- a/frontend/dist/js/components/rounds/state.js
+++ b/frontend/dist/js/components/rounds/state.js
@@ -10,7 +10,7 @@ export const roundsState = {
     activeVisibility: 0,
     pendingScrollTargetRunId: null,
     pendingScrollUnlockAt: 0,
-    pageSize: 8,
+    pageSize: 3,
     paging: {
         hasMore: false,
         nextCursor: null,

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -243,6 +243,14 @@ function renderSessionTimeline(rounds, opts = { preserveScroll: true }) {
     if (!container) return;
 
     const oldScroll = container.scrollTop;
+
+    // Hide container during render to prevent flash of content at wrong
+    // scroll position before we reposition.
+    const shouldHideDuringRender = !opts.preserveScroll;
+    if (shouldHideDuringRender) {
+        container.style.visibility = 'hidden';
+    }
+
     container.innerHTML = '';
 
     clearAllStreamState({ preserveOverlay: true });
@@ -260,6 +268,9 @@ function renderSessionTimeline(rounds, opts = { preserveScroll: true }) {
         setRoundPendingApprovals('', [], {});
         renderRoundNavigator([], selectRound);
         syncRetryTimelineTimer();
+        if (shouldHideDuringRender) {
+            container.style.visibility = '';
+        }
         return;
     }
 
@@ -305,6 +316,11 @@ function renderSessionTimeline(rounds, opts = { preserveScroll: true }) {
         container.scrollTop = container.scrollHeight;
         activateLatestRound(rounds);
     }
+
+    if (shouldHideDuringRender) {
+        container.style.visibility = '';
+    }
+
     schedulePostLayoutRoundSync(container);
     syncRetryTimelineTimer();
 }
@@ -386,6 +402,7 @@ function renderRoundSection(round, index) {
     section.className = 'session-round-section';
     section.dataset.runId = round.run_id;
     section.id = roundSectionId(round.run_id);
+    if (round.created_at) section.dataset.roundCreatedAt = round.created_at;
 
     const time = new Date(round.created_at).toLocaleString();
     const stateLabel = roundStateLabel(round);
@@ -722,9 +739,11 @@ async function loadOlderRounds() {
         }
         applyRoundPage(page, { prepend: true });
         syncExportedState();
+        container.style.visibility = 'hidden';
         renderSessionTimeline(roundsState.currentRounds, { preserveScroll: true });
         const newHeight = container.scrollHeight;
         container.scrollTop = newHeight - oldHeight + oldTop;
+        container.style.visibility = '';
     } catch (e) {
         logError(
             'frontend.rounds.load_older_failed',

--- a/frontend/dist/js/components/sidebar.js
+++ b/frontend/dist/js/components/sidebar.js
@@ -23,6 +23,11 @@ import {
     updateSession,
 } from '../core/api.js';
 import { state } from '../core/state.js';
+import { detachActiveStreamForSessionSwitch } from '../core/stream.js';
+import { clearSessionRecovery, stopSessionContinuity } from '../app/recovery.js';
+import { clearAllStreamState } from './messageRenderer.js';
+import { clearAllPanels } from './agentPanel.js';
+import { clearContextIndicators } from './contextIndicators.js';
 import { formatMessage, t } from '../utils/i18n.js';
 import { hideProjectView, openAutomationProjectView, openWorkspaceProjectView } from './projectView.js';
 
@@ -42,6 +47,24 @@ let languageRefreshBound = false;
 
 export function setSelectSessionHandler(handler) {
     selectSessionHandler = handler;
+}
+
+function clearActiveSessionView() {
+    const sessionId = state.currentSessionId;
+    if (state.activeEventSource) {
+        detachActiveStreamForSessionSwitch({ focusPrompt: false });
+    }
+    if (sessionId) {
+        stopSessionContinuity(sessionId);
+    }
+    state.currentSessionId = null;
+    clearSessionRecovery();
+    clearAllPanels();
+    clearContextIndicators();
+    clearAllStreamState();
+    if (els.chatMessages) {
+        els.chatMessages.innerHTML = '';
+    }
 }
 
 function escapeHtml(value) {
@@ -646,6 +669,9 @@ function bindProjectCard(card, group) {
             });
             if (!shouldDelete) return;
             await deleteSession(sessionId);
+            if (state.currentSessionId === sessionId) {
+                clearActiveSessionView();
+            }
             await loadProjects();
         });
     });
@@ -895,6 +921,9 @@ export async function handleRemoveWorkspaceClick(workspace) {
     try {
         const sessions = await fetchSessions();
         const workspaceSessions = Array.isArray(sessions) ? sessions.filter(session => String(session?.workspace_id || '') === workspaceId) : [];
+        const shouldClearView = workspaceSessions.some(
+            session => session.session_id === state.currentSessionId,
+        );
         for (const session of workspaceSessions) {
             await deleteSession(session.session_id);
         }
@@ -903,6 +932,7 @@ export async function handleRemoveWorkspaceClick(workspace) {
         expandedProjectSessionIds.delete(groupKey('workspace', workspaceId));
         initializedProjectIds.delete(groupKey('workspace', workspaceId));
         openProjectMenuId = null;
+        if (shouldClearView) clearActiveSessionView();
         if (state.currentProjectViewWorkspaceId === workspaceId) hideProjectView();
         if (state.currentWorkspaceId === workspaceId) state.currentWorkspaceId = null;
         await loadProjects();

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -2051,6 +2051,7 @@ Object.assign(TRANSLATIONS['en-US'], {
     'tool.status.running': 'Running...',
     'tool.action.copy': 'Copy',
     'tool.action.copied': 'Copied',
+    'tool.group.processed': 'Processed{duration}',
 });
 
 Object.assign(TRANSLATIONS['zh-CN'], {
@@ -2117,6 +2118,7 @@ Object.assign(TRANSLATIONS['zh-CN'], {
     'tool.status.running': '运行中...',
     'tool.action.copy': '复制',
     'tool.action.copied': '已复制',
+    'tool.group.processed': '已处理{duration}',
 });
 
 export function getCurrentLanguage() {


### PR DESCRIPTION
## Summary
- Collapse intermediate messages (tool blocks, thinking blocks) into a collapsible group per round, showing only the final text reply by default
- Display processing duration on the collapsed bar (from round start to last response)
- Animate open/close transitions via Web Animations API
- Fix paging: single-message rounds now also collapse properly; use round-level timestamps for accurate duration
- Reduce initial page size to 3 rounds; hide render flash during timeline redraws
- Clear active session view on session/workspace deletion

## Test plan
- [ ] Open a session with multiple rounds, verify intermediate tool/thinking blocks are collapsed
- [ ] Check the collapsed bar shows accurate duration (round start to last response)
- [ ] Click the collapsed bar to expand/collapse and verify smooth animation
- [ ] Scroll up to trigger paging, verify older rounds also collapse with duration
- [ ] Delete a session/workspace while viewing it, verify the view clears properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)