### PR TITLE
fix: prevent settings modal from closing on pointer leave

### DIFF
--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -25,6 +25,18 @@ import { t, translateDocument } from '../../utils/i18n.js';
 let settingsModal = null;
 let currentTab = 'appearance';
 let initialized = false;
+let settingsOverlayPointerDown = false;
+let settingsModalContent = null;
+let settingsModalPointerStartedInside = false;
+let settingsModalPointerEndedInside = false;
+let settingsSuppressOverlayClose = false;
+let settingsPointerTrackingAttached = false;
+let settingsPointerInsideListener = null;
+let settingsPointerOutsideListener = null;
+let settingsDocumentPointerUpListener = null;
+let settingsDocumentPointerCancelListener = null;
+let settingsDocumentMouseUpListener = null;
+let settingsDocumentTouchEndListener = null;
 
 const TAB_METADATA = {
     appearance: {
@@ -847,6 +859,7 @@ function createModal() {
         </div>
     `;
     document.body.appendChild(settingsModal);
+    settingsModalContent = document.querySelector('.settings-modal-content');
     translateDocument(settingsModal);
 }
 
@@ -856,8 +869,17 @@ function setupEventListeners() {
         closeBtn.onclick = closeSettings;
     }
 
+    attachSettingsPointerTracking();
+
     settingsModal.onclick = (e) => {
-        if (e.target === settingsModal) {
+        if (e.target !== settingsModal) {
+            return;
+        }
+        if (settingsSuppressOverlayClose) {
+            settingsSuppressOverlayClose = false;
+            return;
+        }
+        if (settingsOverlayPointerDown && !settingsModalPointerStartedInside) {
             closeSettings();
         }
     };
@@ -949,6 +971,66 @@ function updatePanelHeading(tab) {
     const meta = TAB_METADATA[tab] || TAB_METADATA.model;
     document.getElementById('settings-panel-title').textContent = t(meta.titleKey);
     document.getElementById('settings-panel-description').textContent = t(meta.descriptionKey);
+}
+
+function attachSettingsPointerTracking() {
+    if (settingsPointerTrackingAttached) {
+        return;
+    }
+    settingsPointerTrackingAttached = true;
+
+    settingsPointerInsideListener = () => {
+        settingsModalPointerEndedInside = true;
+    };
+    settingsPointerOutsideListener = () => {
+        settingsModalPointerEndedInside = false;
+    };
+    settingsDocumentPointerUpListener = () => {
+        finalizeSettingsPointerInteraction();
+    };
+    settingsDocumentPointerCancelListener = () => {
+        finalizeSettingsPointerInteraction();
+    };
+    settingsDocumentMouseUpListener = () => {
+        finalizeSettingsPointerInteraction();
+    };
+    settingsDocumentTouchEndListener = () => {
+        finalizeSettingsPointerInteraction();
+    };
+
+    if (settingsModal && typeof settingsModal.addEventListener === 'function') {
+        settingsModal.addEventListener('pointerdown', event => {
+            settingsOverlayPointerDown = event.target === settingsModal;
+            settingsModalPointerStartedInside = false;
+            settingsModalPointerEndedInside = false;
+            settingsSuppressOverlayClose = false;
+        });
+    }
+
+    if (settingsModalContent && typeof settingsModalContent.addEventListener === 'function') {
+        settingsModalContent.addEventListener('pointerdown', () => {
+            settingsOverlayPointerDown = false;
+            settingsModalPointerStartedInside = true;
+            settingsModalPointerEndedInside = true;
+            settingsSuppressOverlayClose = false;
+        });
+        settingsModalContent.addEventListener('pointerenter', settingsPointerInsideListener);
+        settingsModalContent.addEventListener('pointerleave', settingsPointerOutsideListener);
+    }
+
+    if (typeof document?.addEventListener === 'function') {
+        document.addEventListener('pointerup', settingsDocumentPointerUpListener);
+        document.addEventListener('pointercancel', settingsDocumentPointerCancelListener);
+        document.addEventListener('mouseup', settingsDocumentMouseUpListener);
+        document.addEventListener('touchend', settingsDocumentTouchEndListener);
+    }
+}
+
+function finalizeSettingsPointerInteraction() {
+    settingsSuppressOverlayClose = settingsModalPointerStartedInside && !settingsModalPointerEndedInside;
+    settingsOverlayPointerDown = false;
+    settingsModalPointerStartedInside = false;
+    settingsModalPointerEndedInside = false;
 }
 
 function renderPanelActions(tab) {

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -627,6 +627,7 @@ function createClassList(element) {{
 }}
 
 function createElement(tagName = "div") {{
+    const listeners = new Map();
     const element = {{
         tagName,
         id: "",
@@ -639,6 +640,18 @@ function createElement(tagName = "div") {{
         appendChild(child) {{
             child.parentNode = this;
             this.children.push(child);
+        }},
+        addEventListener(type, listener) {{
+            const existing = listeners.get(type) || [];
+            existing.push(listener);
+            listeners.set(type, existing);
+        }},
+        dispatchEvent(event) {{
+            const handlers = listeners.get(event.type) || [];
+            for (const handler of handlers) {{
+                handler.call(this, event);
+            }}
+            return true;
         }},
         querySelectorAll(selector) {{
             if (selector !== ".settings-action") {{
@@ -678,9 +691,12 @@ function createElement(tagName = "div") {{
 
 function createDocument() {{
     const elements = new Map();
+    const documentListeners = new Map();
     const tabs = [];
     const panels = [];
     const body = createElement("body");
+    const modalContent = createElement("div");
+    modalContent.classList.resetFromString("modal-content settings-modal-content");
 
     function registerElement(id, element) {{
         if (!id) {{
@@ -697,8 +713,12 @@ function createDocument() {{
         panels.length = 0;
 
         const html = target.innerHTML;
+        if (html.includes('class="modal-content settings-modal-content"') && !body.children.includes(modalContent)) {{
+            body.children.push(modalContent);
+        }}
 
         for (const match of html.matchAll(/id="([^"]+)"/g)) {{
+
             registerElement(match[1], createElement());
         }}
 
@@ -725,12 +745,24 @@ function createDocument() {{
         parseInnerHtml(child);
     }};
 
-        return {{
-            body,
-            createElement,
-            getElementById(id) {{
-                return elements.get(id) || null;
-            }},
+            return {{
+        body,
+        createElement,
+        addEventListener(type, listener) {{
+            const existing = documentListeners.get(type) || [];
+            existing.push(listener);
+            documentListeners.set(type, existing);
+        }},
+        dispatchEvent(event) {{
+            const handlers = documentListeners.get(event.type) || [];
+            for (const handler of handlers) {{
+                handler.call(this, event);
+            }}
+            return true;
+        }},
+        getElementById(id) {{
+            return elements.get(id) || null;
+        }},
         querySelectorAll(selector) {{
             if (selector === ".settings-tab") {{
                 return tabs;
@@ -738,7 +770,14 @@ function createDocument() {{
             if (selector === ".settings-panel") {{
                 return panels;
             }}
+            if (selector === ".settings-modal-content") {{
+                return body.children.includes(modalContent) ? [modalContent] : [];
+            }}
             return [];
+        }},
+        querySelector(selector) {{
+            const matches = this.querySelectorAll(selector);
+            return matches[0] || null;
         }},
     }};
 }}
@@ -796,6 +835,35 @@ globalThis.window = {{}};
         )
 
     return json.loads(completed.stdout)
+
+
+def test_settings_modal_does_not_close_when_pointer_starts_inside_and_ends_on_overlay(
+    tmp_path: Path,
+) -> None:
+    payload = _run_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { initSettings, openSettings } = await import("./index.mjs");
+
+initSettings();
+openSettings();
+
+const modal = document.getElementById("settings-modal");
+const content = document.querySelector(".settings-modal-content");
+content.dispatchEvent({ type: "pointerdown", target: content });
+content.dispatchEvent({ type: "pointerleave", target: content });
+document.dispatchEvent({ type: "pointerup", target: modal });
+modal.onclick({ target: modal });
+
+console.log(JSON.stringify({
+    modalDisplay: modal.style.display,
+    modalClassName: modal.className,
+}));
+""".strip(),
+    )
+
+    assert payload["modalDisplay"] == "flex"
+    assert "settings-modal-visible" in str(payload["modalClassName"])
 
 
 def test_environment_settings_tab_uses_add_variable_action(


### PR DESCRIPTION
## Summary
- prevent the settings modal from closing unless the overlay itself was directly clicked
- track pointer interactions that start inside   \' .settings-modal-content \' and suppress the subsequent overlay close
- add a regression test for pointer-down inside content followed by pointer-up on the overlay

## Testing
-   \
no tests ran in 0.00s
-   \

Closes #187
