### PR TITLE
fix: preserve gateway session root conversation history

### DIFF
--- a/src/agent_teams/automation/automation_bound_session_queue_service.py
+++ b/src/agent_teams/automation/automation_bound_session_queue_service.py
@@ -409,7 +409,6 @@ class AutomationBoundSessionQueueService:
             input=content_parts_from_text(prompt),
             execution_mode=run_config.execution_mode,
             yolo=run_config.yolo,
-            reuse_root_instance=False,
             thinking=run_config.thinking,
             conversation_context=RuntimePromptConversationContext(
                 source_provider=FEISHU_PLATFORM,

--- a/src/agent_teams/gateway/session_ingress_service.py
+++ b/src/agent_teams/gateway/session_ingress_service.py
@@ -81,10 +81,7 @@ class GatewaySessionIngressService:
                 blocking_run_id=blocking_run_id,
                 busy_policy=request.busy_policy,
             )
-        safe_intent = request.intent.model_copy(
-            deep=True,
-            update={"reuse_root_instance": False},
-        )
+        safe_intent = request.intent.model_copy(deep=True)
         try:
             run_id, _ = self._create_detached_run(safe_intent)
             self._ensure_run_started(run_id)

--- a/src/agent_teams/sessions/runs/run_manager.py
+++ b/src/agent_teams/sessions/runs/run_manager.py
@@ -355,7 +355,6 @@ class RunManager:
         return self._create_run_local(intent, allow_active_run_attach=True)
 
     def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
-        intent.reuse_root_instance = False
         if self._should_delegate_to_bound_loop():
             delegated_intent = intent.model_copy(deep=True)
             return self._call_in_bound_loop(

--- a/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
@@ -651,7 +651,7 @@ def test_materialize_execution_rebinds_bound_session_workspace_before_start(
 
     assert handle is not None
     assert session_lookup.rebind_calls == [("session-1", "fresh-worktree")]
-    assert run_service.created_intents[0].reuse_root_instance is False
+    assert run_service.created_intents[0].reuse_root_instance is True
 
 
 def test_direct_start_waiting_record_auto_resumes_recoverable_runtime(

--- a/tests/unit_tests/gateway/test_acp_stdio.py
+++ b/tests/unit_tests/gateway/test_acp_stdio.py
@@ -615,6 +615,71 @@ async def test_session_prompt_rejects_busy_active_run(
 
 
 @pytest.mark.asyncio
+async def test_session_prompt_via_ingress_preserves_root_instance_reuse(
+    tmp_path: Path,
+) -> None:
+    session_service = FakeSessionService()
+    repository = GatewaySessionRepository(tmp_path / "gateway.db")
+    gateway_session_service = GatewaySessionService(
+        repository=repository,
+        session_service=cast(SessionService, session_service),
+    )
+    run_manager = FakeRunManager()
+    run_manager.events_by_run["run-1"] = (
+        _event("session-1", "run-1", RunEventType.RUN_COMPLETED, {}),
+    )
+    ingress_service = GatewaySessionIngressService(
+        run_service=cast(RunManager, run_manager),
+        run_runtime_repo=RunRuntimeRepository(tmp_path / "gateway.db"),
+    )
+    notifications: list[dict[str, JsonValue]] = []
+
+    async def notify(message: dict[str, JsonValue]) -> None:
+        notifications.append(message)
+
+    server = AcpGatewayServer(
+        gateway_session_service=gateway_session_service,
+        session_service=cast(SessionService, session_service),
+        run_service=cast(RunManager, run_manager),
+        media_asset_service=cast(MediaAssetService, object()),
+        notify=notify,
+        session_ingress_service=ingress_service,
+    )
+
+    created = await server.handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": str(tmp_path), "mcpServers": []},
+        }
+    )
+    session_id = _require_str(_require_result_object(created), "sessionId")
+
+    response = await server.handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "remember this"}],
+            },
+        }
+    )
+
+    assert _require_result_object(response) == {
+        "stopReason": "end_turn",
+        "runId": "run-1",
+        "runStatus": "completed",
+        "recoverable": False,
+    }
+    assert len(run_manager.create_calls) == 1
+    assert run_manager.create_calls[0].reuse_root_instance is True
+    assert _session_update_name(notifications[0]) == "user_message_chunk"
+
+
+@pytest.mark.asyncio
 async def test_session_resume_restarts_active_run_and_returns_result(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/gateway/test_session_ingress_service.py
+++ b/tests/unit_tests/gateway/test_session_ingress_service.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from agent_teams.gateway.session_ingress_service import (
+    GatewaySessionIngressRequest,
+    GatewaySessionIngressService,
+    GatewaySessionIngressStatus,
+)
+from agent_teams.media import content_parts_from_text
+from agent_teams.sessions.runs.run_models import IntentInput
+from agent_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
+
+
+class _FakeRunService:
+    def __init__(self) -> None:
+        self.created_intents: list[IntentInput] = []
+        self.started_run_ids: list[str] = []
+
+    def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
+        self.created_intents.append(intent.model_copy(deep=True))
+        return "run-1", intent.session_id
+
+    def ensure_run_started(self, run_id: str) -> None:
+        self.started_run_ids.append(run_id)
+
+
+def test_submit_preserves_default_root_instance_reuse(tmp_path) -> None:
+    run_service = _FakeRunService()
+    ingress_service = GatewaySessionIngressService(
+        run_service=run_service,
+        run_runtime_repo=RunRuntimeRepository(tmp_path / "gateway.db"),
+    )
+
+    result = ingress_service.submit(
+        GatewaySessionIngressRequest(
+            intent=IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("hello"),
+            )
+        )
+    )
+
+    assert result.status is GatewaySessionIngressStatus.STARTED
+    assert run_service.created_intents[0].reuse_root_instance is True
+    assert run_service.started_run_ids == ["run-1"]
+
+
+def test_submit_preserves_explicit_root_instance_isolation(tmp_path) -> None:
+    run_service = _FakeRunService()
+    ingress_service = GatewaySessionIngressService(
+        run_service=run_service,
+        run_runtime_repo=RunRuntimeRepository(tmp_path / "gateway.db"),
+    )
+
+    result = ingress_service.submit(
+        GatewaySessionIngressRequest(
+            intent=IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("hello"),
+                reuse_root_instance=False,
+            )
+        )
+    )
+
+    assert result.status is GatewaySessionIngressStatus.STARTED
+    assert run_service.created_intents[0].reuse_root_instance is False

--- a/tests/unit_tests/sessions/runs/test_run_manager_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_manager_recovery.py
@@ -333,7 +333,9 @@ def test_create_run_blocks_when_tool_approval_pending(tmp_path: Path) -> None:
         )
 
 
-def test_create_detached_run_disables_root_instance_reuse(tmp_path: Path) -> None:
+def test_create_detached_run_preserves_default_root_instance_reuse(
+    tmp_path: Path,
+) -> None:
     db_path = tmp_path / "run_detached.db"
     manager = _build_manager(db_path)
 
@@ -341,6 +343,26 @@ def test_create_detached_run_disables_root_instance_reuse(tmp_path: Path) -> Non
         IntentInput(
             session_id="session-1",
             input=content_parts_from_text("fresh automation run"),
+        )
+    )
+
+    persisted = RunIntentRepository(db_path).get(run_id)
+    assert session_id == "session-1"
+    assert manager._pending_runs[run_id].reuse_root_instance is True
+    assert persisted.reuse_root_instance is True
+
+
+def test_create_detached_run_preserves_explicit_root_instance_isolation(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_detached_explicit_isolation.db"
+    manager = _build_manager(db_path)
+
+    run_id, session_id = manager.create_detached_run(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("fresh automation run"),
+            reuse_root_instance=False,
         )
     )
 


### PR DESCRIPTION
Closes #205

## Summary
- preserve root conversation reuse for gateway detached runs instead of forcing a fresh root instance on every turn
- keep bound-session automation runs on the same session conversation history instead of explicitly isolating each scheduled run
- add regression coverage for gateway ingress, ACP prompt execution, detached run intent persistence, and bound-session automation

## Testing
- .\\.venv\\Scripts\\python -m pytest -q tests/unit_tests/gateway/test_session_ingress_service.py tests/unit_tests/gateway/test_acp_stdio.py tests/unit_tests/sessions/runs/test_run_manager_recovery.py tests/unit_tests/automation/test_automation_bound_session_queue_service.py
- .\\.venv\\Scripts\\ruff check src/agent_teams/gateway/session_ingress_service.py src/agent_teams/sessions/runs/run_manager.py src/agent_teams/automation/automation_bound_session_queue_service.py tests/unit_tests/gateway/test_session_ingress_service.py tests/unit_tests/gateway/test_acp_stdio.py tests/unit_tests/sessions/runs/test_run_manager_recovery.py tests/unit_tests/automation/test_automation_bound_session_queue_service.py
- .\\.venv\\Scripts\\basedpyright src/agent_teams/gateway/session_ingress_service.py src/agent_teams/sessions/runs/run_manager.py src/agent_teams/automation/automation_bound_session_queue_service.py tests/unit_tests/gateway/test_session_ingress_service.py tests/unit_tests/gateway/test_acp_stdio.py tests/unit_tests/sessions/runs/test_run_manager_recovery.py tests/unit_tests/automation/test_automation_bound_session_queue_service.py