### PR TITLE
fix: handle same-host HTML redirects without Location in webfetch

### DIFF
--- a/src/agent_teams/tools/web_tools/webfetch.py
+++ b/src/agent_teams/tools/web_tools/webfetch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from enum import StrEnum
 import asyncio
+from html import unescape
 import hashlib
 import ipaddress
 import math
@@ -60,12 +61,29 @@ RANGE_RESET_ERROR_TYPES = {"range_response_invalid", "range_resume_mismatch"}
 REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
 REDIRECT_REQUIRED_ERROR_TYPE = "redirect_required"
 MAX_REDIRECTS = 10
+MAX_REDIRECT_BODY_BYTES = 64 * 1024
 BROWSER_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
 )
 FALLBACK_USER_AGENT = "agent-teams"
 DESCRIPTION = load_tool_description(__file__)
+META_REFRESH_REDIRECT_PATTERN = re.compile(
+    r"""<meta[^>]+http-equiv\s*=\s*["']?refresh["']?[^>]+content\s*=\s*["'][^"']*url\s*=\s*([^"'>\s]+)""",
+    re.IGNORECASE,
+)
+WINDOW_LOCATION_REDIRECT_PATTERN = re.compile(
+    r"""window\.location(?:\.href)?\s*=\s*["']([^"']+)["']""",
+    re.IGNORECASE,
+)
+LOCATION_REPLACE_REDIRECT_PATTERN = re.compile(
+    r"""location\.replace\(\s*["']([^"']+)["']\s*\)""",
+    re.IGNORECASE,
+)
+ANCHOR_REDIRECT_PATTERN = re.compile(
+    r"""<a[^>]+href\s*=\s*["']([^"']+)["']""",
+    re.IGNORECASE,
+)
 
 
 class WebFetchExtractMode(StrEnum):
@@ -446,6 +464,8 @@ async def fetch_url(
         while response.status_code in REDIRECT_STATUS_CODES:
             location = response.headers.get("location")
             if not location:
+                location = await _extract_redirect_location_from_response_body(response)
+            if not location:
                 await response.aclose()
                 raise ToolExecutionError(
                     error_type="upstream_error",
@@ -544,6 +564,67 @@ async def fetch_url(
             },
         )
     return response
+
+
+async def _extract_redirect_location_from_response_body(
+    response: httpx.Response,
+) -> str | None:
+    content_type = normalize_content_type(response.headers.get("content-type", ""))
+    if content_type and content_type not in {"text/html", "application/xhtml+xml"}:
+        return None
+    content_length = _parse_content_length(response)
+    if content_length is not None and content_length > MAX_REDIRECT_BODY_BYTES:
+        return None
+    body = bytearray()
+    async for chunk in response.aiter_bytes():
+        if not chunk:
+            continue
+        remaining = MAX_REDIRECT_BODY_BYTES - len(body)
+        if remaining <= 0:
+            return None
+        body.extend(chunk[:remaining])
+        if len(body) >= MAX_REDIRECT_BODY_BYTES:
+            return None
+    if not body:
+        return None
+    text = body.decode("utf-8", errors="replace")
+    return _extract_redirect_location_from_html(text)
+
+
+def _extract_redirect_location_from_html(body: str) -> str | None:
+    patterns = (
+        META_REFRESH_REDIRECT_PATTERN,
+        WINDOW_LOCATION_REDIRECT_PATTERN,
+        LOCATION_REPLACE_REDIRECT_PATTERN,
+        ANCHOR_REDIRECT_PATTERN,
+    )
+    for pattern in patterns:
+        match = pattern.search(body)
+        if match is None:
+            continue
+        location = _normalize_redirect_location_candidate(match.group(1))
+        if location:
+            return location
+    return None
+
+
+def _normalize_redirect_location_candidate(value: str) -> str | None:
+    candidate = unescape(value).strip()
+    if not candidate:
+        return None
+    if candidate.lower().startswith("url="):
+        candidate = candidate[4:].strip()
+    candidate = candidate.strip("\"' \t\r\n")
+    if not candidate:
+        return None
+    parsed = urlparse(candidate)
+    if parsed.scheme and parsed.scheme not in {"http", "https"}:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    if parsed.scheme and not parsed.netloc:
+        return None
+    return candidate
 
 
 async def _perform_request(

--- a/tests/unit_tests/tools/web_tools/test_webfetch.py
+++ b/tests/unit_tests/tools/web_tools/test_webfetch.py
@@ -430,6 +430,89 @@ async def test_fetch_url_follows_https_default_port_same_host_redirect() -> None
 
 
 @pytest.mark.asyncio
+async def test_fetch_url_follows_same_host_html_redirect_without_location_header() -> (
+    None
+):
+    requested_urls: list[str] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        if str(request.url) == "https://www.huawei.com/en/annual-report/2020":
+            return httpx.Response(
+                301,
+                request=request,
+                content=(
+                    "<!DOCTYPE html>"
+                    '<html><head><meta http-equiv="refresh" '
+                    'content="0; url=https://www.huawei.com/en/annual-report">'
+                    "<script>window.location.href = "
+                    '"https://www.huawei.com/en/annual-report"</script>'
+                    "</head></html>"
+                ),
+                headers={"content-type": "text/html;charset=utf-8"},
+            )
+        return httpx.Response(
+            200,
+            request=request,
+            text="annual report",
+            headers={"content-type": "text/plain"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        response = await webfetch.fetch_url(
+            client=client,
+            url="https://www.huawei.com/en/annual-report/2020",
+            response_format="text",
+        )
+    finally:
+        await client.aclose()
+
+    assert requested_urls == [
+        "https://www.huawei.com/en/annual-report/2020",
+        "https://www.huawei.com/en/annual-report",
+    ]
+    assert str(response.url) == "https://www.huawei.com/en/annual-report"
+    await response.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_requires_explicit_follow_up_for_cross_host_html_redirect_without_location_header() -> (
+    None
+):
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            301,
+            request=request,
+            content=(
+                "<!DOCTYPE html>"
+                '<html><head><meta http-equiv="refresh" '
+                'content="0; url=https://docs.python.org/3/tutorial/">'
+                "</head></html>"
+            ),
+            headers={"content-type": "text/html;charset=utf-8"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await webfetch.fetch_url(
+                client=client,
+                url="https://example.com/start",
+                response_format="text",
+            )
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.error_type == "redirect_required"
+    assert exc_info.value.details == {
+        "original_url": "https://example.com/start",
+        "redirect_url": "https://docs.python.org/3/tutorial/",
+        "status_code": 301,
+    }
+
+
+@pytest.mark.asyncio
 async def test_fetch_url_rejects_http_to_https_non_default_ports() -> None:
     async def _handler(request: httpx.Request) -> httpx.Response:
         if str(request.url) == "http://example.com:8080/start":


### PR DESCRIPTION
## Summary
- follow same-host HTML redirects when a 301/302 page omits the `Location` header but embeds the target in HTML/JS redirect markup
- keep the existing `redirect_required` behavior for cross-host redirects discovered from the response body
- add regression tests for same-host Huawei-style redirects and cross-host protection

## Testing
- `uv run --extra dev ruff check src/agent_teams/tools/web_tools/webfetch.py tests/unit_tests/tools/web_tools/test_webfetch.py`
- `uv run --extra dev basedpyright src/agent_teams/tools/web_tools/webfetch.py tests/unit_tests/tools/web_tools/test_webfetch.py`
- `uv run --extra dev pytest -q tests/unit_tests/tools/web_tools/test_webfetch.py`

## Issue
- Related to #200
- This is a follow-up in the same redirect-hardening area; it does not claim to fully close #200.