### PR TITLE
fix: handle same-host HTML redirects without Location in webfetch

### DIFF
--- a/src/agent_teams/tools/web_tools/webfetch.py
+++ b/src/agent_teams/tools/web_tools/webfetch.py
@@ -579,9 +579,6 @@ async def _extract_redirect_location_from_response_body(
     content_type = normalize_content_type(response.headers.get("content-type", ""))
     if content_type and content_type not in {"text/html", "application/xhtml+xml"}:
         return None
-    content_length = _parse_content_length(response)
-    if content_length is not None and content_length > MAX_REDIRECT_BODY_BYTES:
-        return None
     body = bytearray()
     try:
         async for chunk in response.aiter_bytes():
@@ -589,10 +586,10 @@ async def _extract_redirect_location_from_response_body(
                 continue
             remaining = MAX_REDIRECT_BODY_BYTES - len(body)
             if remaining <= 0:
-                return None
+                break
             body.extend(chunk[:remaining])
             if len(body) >= MAX_REDIRECT_BODY_BYTES:
-                return None
+                break
     except httpx.TimeoutException as exc:
         raise ToolExecutionError(
             error_type="network_timeout",

--- a/tests/unit_tests/tools/web_tools/test_webfetch.py
+++ b/tests/unit_tests/tools/web_tools/test_webfetch.py
@@ -542,6 +542,51 @@ async def test_fetch_url_wraps_redirect_body_read_errors_as_tool_errors() -> Non
 
 
 @pytest.mark.asyncio
+async def test_fetch_url_parses_redirect_from_buffered_prefix_at_size_cap() -> None:
+    requested_urls: list[str] = []
+    redirect_prefix = (
+        "<!DOCTYPE html>"
+        '<html><head><meta http-equiv="refresh" '
+        'content="0; url=https://example.com/finish">'
+        "</head><body>"
+    )
+    redirect_body = (
+        redirect_prefix
+        + ("x" * (webfetch.MAX_REDIRECT_BODY_BYTES - len(redirect_prefix)))
+    ).encode("utf-8")
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        if str(request.url) == "https://example.com/start":
+            return httpx.Response(
+                301,
+                request=request,
+                headers={"content-type": "text/html;charset=utf-8"},
+                content=redirect_body,
+            )
+        return httpx.Response(
+            200,
+            request=request,
+            text="ok",
+            headers={"content-type": "text/plain"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        response = await webfetch.fetch_url(
+            client=client,
+            url="https://example.com/start",
+            response_format="text",
+        )
+    finally:
+        await client.aclose()
+
+    assert requested_urls == ["https://example.com/start", "https://example.com/finish"]
+    assert str(response.url) == "https://example.com/finish"
+    await response.aclose()
+
+
+@pytest.mark.asyncio
 async def test_fetch_url_rejects_http_to_https_non_default_ports() -> None:
     async def _handler(request: httpx.Request) -> httpx.Response:
         if str(request.url) == "http://example.com:8080/start":


### PR DESCRIPTION
## Summary
- follow same-host HTML redirects when a 301/302 page omits the `Location` header but embeds the target in HTML/JS redirect markup
- keep the existing `redirect_required` behavior for cross-host redirects discovered from the response body
- add regression tests for same-host Huawei-style redirects and cross-host protection

## Testing
- `uv run --extra dev ruff check src/agent_teams/tools/web_tools/webfetch.py tests/unit_tests/tools/web_tools/test_webfetch.py`
- `uv run --extra dev basedpyright src/agent_teams/tools/web_tools/webfetch.py tests/unit_tests/tools/web_tools/test_webfetch.py`
- `uv run --extra dev pytest -q tests/unit_tests/tools/web_tools/test_webfetch.py`

## Issue
- Related to #200
- This is a follow-up in the same redirect-hardening area; it does not claim to fully close #200.