### PR TITLE
Fix role skill picker state drift

### DIFF
--- a/frontend/dist/js/components/settings/rolesSettings.js
+++ b/frontend/dist/js/components/settings/rolesSettings.js
@@ -549,14 +549,25 @@ function renderExecutionSurfaceSelect(selectedSurface) {
 function renderSkillsShellAdvisory() {
     const container = document.getElementById('role-skills-picker');
     if (!container) return;
+    const advisoryHtml = `
+        <div class="role-option-empty role-option-advisory">${escapeHtml(t('settings.roles.skills_shell_advisory'))}</div>
+    `;
+    const advisoryPattern = /<div class="role-option-empty role-option-advisory">[\s\S]*?<\/div>/g;
+    const existingAdvisory = typeof container.querySelector === 'function'
+        ? container.querySelector('.role-option-advisory')
+        : null;
+    if (existingAdvisory && typeof existingAdvisory.remove === 'function') {
+        existingAdvisory.remove();
+    } else if (typeof container.innerHTML === 'string' && advisoryPattern.test(container.innerHTML)) {
+        advisoryPattern.lastIndex = 0;
+        container.innerHTML = container.innerHTML.replace(advisoryPattern, '');
+    }
     const hasSkills = Array.isArray(currentSelections.skills) && currentSelections.skills.length > 0;
     const hasShell = Array.isArray(currentSelections.tools) && currentSelections.tools.includes('shell');
     if (!hasSkills || hasShell) {
         return;
     }
-    container.insertAdjacentHTML('beforeend', `
-        <div class="role-option-empty role-option-advisory">${escapeHtml(t('settings.roles.skills_shell_advisory'))}</div>
-    `);
+    container.insertAdjacentHTML('beforeend', advisoryHtml);
 }
 
 function syncOptionSelection(containerId) {
@@ -576,7 +587,7 @@ function syncOptionSelection(containerId) {
         currentSelections.skills = nextValues;
     }
     if (containerId === 'role-tools-picker' || containerId === 'role-skills-picker') {
-        renderRoleOptionPickers();
+        renderSkillsShellAdvisory();
     }
 }
 

--- a/tests/unit_tests/frontend/test_roles_settings_ui.py
+++ b/tests/unit_tests/frontend/test_roles_settings_ui.py
@@ -496,26 +496,135 @@ const initialSkillsHtml = document.getElementById("role-skills-picker").innerHTM
 const initialSkillOptions = document.getElementById("role-skills-picker").querySelectorAll('input[type="checkbox"]');
 initialSkillOptions[1].checked = true;
 await initialSkillOptions[1].onchange();
-const updatedSkillsHtml = document.getElementById("role-skills-picker").innerHTML;
+const advisoryStillPresent = document.getElementById("role-skills-picker").innerHTML.includes(
+    "Roles that use skills usually work better with the shell tool enabled."
+);
 
 await document.getElementById("save-role-btn").onclick();
 
 console.log(JSON.stringify({
     initialSkillsHtml,
-    updatedSkillsHtml,
+    advisoryStillPresent,
     savePayload: globalThis.__saveCalls[0].payload,
 }));
 """.strip(),
     )
 
     initial_skills_html = cast(str, payload["initialSkillsHtml"])
-    updated_skills_html = cast(str, payload["updatedSkillsHtml"])
     save_payload = cast(dict[str, JsonValue], payload["savePayload"])
     assert "Roles that use skills usually work better with the shell tool enabled." in (
         initial_skills_html
     )
-    assert "checked" in updated_skills_html
+    assert payload["advisoryStillPresent"] is True
     assert save_payload["skills"] == ["builtin:diff", "builtin:time"]
+
+
+def test_role_settings_keeps_skill_selection_state_across_multiple_changes(
+    tmp_path: Path,
+) -> None:
+    payload = _run_roles_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindRoleSettingsHandlers, loadRoleSettingsPanel } from "./rolesSettings.mjs";
+
+globalThis.__roleRecordsOverride = {
+    MainAgent: {
+        source_role_id: "MainAgent",
+        role_id: "MainAgent",
+        name: "Main Agent",
+        description: "Handles normal-mode runs directly.",
+        version: "1.0.0",
+        bound_agent_id: null,
+        execution_surface: "api",
+        tools: ["read_file", "shell"],
+        mcp_servers: [],
+        skills: [],
+        model_profile: "default",
+        memory_profile: { enabled: true },
+        system_prompt: "Handle the run directly.",
+        file_name: "main_agent.md",
+        content: "---\\nrole_id: MainAgent\\n---\\n\\nHandle the run directly.\\n",
+        deletable: false,
+    },
+    writer: {
+        source_role_id: "writer",
+        role_id: "writer",
+        name: "Writer",
+        description: "Drafts user-facing content.",
+        version: "1.0.0",
+        bound_agent_id: "codex_local",
+        execution_surface: "desktop",
+        tools: ["read_file"],
+        mcp_servers: [],
+        skills: [],
+        model_profile: "default",
+        memory_profile: { enabled: true },
+        system_prompt: "Write the first draft.",
+        file_name: "writer.md",
+        content: "---\\nrole_id: writer\\n---\\n\\nWrite the first draft.\\n",
+        deletable: true,
+    },
+    reviewer: {
+        source_role_id: "reviewer",
+        role_id: "reviewer",
+        name: "Reviewer",
+        description: "Reviews delivered work.",
+        version: "1.0.0",
+        bound_agent_id: null,
+        execution_surface: "browser",
+        tools: ["read_file", "write_file"],
+        mcp_servers: ["docs"],
+        skills: ["builtin:diff"],
+        model_profile: "default",
+        memory_profile: { enabled: true },
+        system_prompt: "Review the delivered work.",
+        file_name: "reviewer.md",
+        content: "---\\nrole_id: reviewer\\n---\\n\\nReview the delivered work.\\n",
+        deletable: true,
+    },
+    Coordinator: {
+        source_role_id: "Coordinator",
+        role_id: "Coordinator",
+        name: "Coordinator",
+        description: "Coordinates delegated work.",
+        version: "1.0.0",
+        bound_agent_id: null,
+        execution_surface: "api",
+        tools: ["create_tasks", "dispatch_task"],
+        mcp_servers: [],
+        skills: [],
+        model_profile: "default",
+        memory_profile: { enabled: true },
+        system_prompt: "Coordinate the run.",
+        file_name: "coordinator.md",
+        content: "---\\nrole_id: Coordinator\\n---\\n\\nCoordinate the run.\\n",
+        deletable: false,
+    },
+};
+
+installGlobals(createElements());
+bindRoleSettingsHandlers();
+await loadRoleSettingsPanel();
+
+await document.getElementById("roles-list").querySelectorAll(".role-record-edit-btn")[0].onclick({ stopPropagation() {} });
+const initialSkillOptions = document.getElementById("role-skills-picker").querySelectorAll('input[type="checkbox"]');
+initialSkillOptions[0].checked = true;
+await initialSkillOptions[0].onchange();
+initialSkillOptions[1].checked = true;
+await initialSkillOptions[1].onchange();
+
+await document.getElementById("save-role-btn").onclick();
+
+console.log(JSON.stringify({
+    savePayload: globalThis.__saveCalls[0].payload,
+    savedRecordSkills: globalThis.__roleRecordsOverride.MainAgent.skills,
+}));
+""".strip(),
+    )
+
+    save_payload = cast(dict[str, JsonValue], payload["savePayload"])
+    assert save_payload["skills"] == ["builtin:diff", "builtin:time"]
+    assert payload["savedRecordSkills"] == ["builtin:diff", "builtin:time"]
 
 
 def test_role_settings_marks_main_agent_and_keeps_reserved_prompt_editable(


### PR DESCRIPTION
## Summary
- stop re-rendering the full role option pickers on every skill/tool checkbox change
- update the shell advisory rendering to remove and reinsert only the advisory node
- add a regression test covering repeated skill selection changes before save

## Verification
- `uv run --extra dev pytest -q tests/unit_tests/frontend/test_roles_settings_ui.py`
- `uv run --extra dev pytest -q tests/unit_tests tests/integration_tests`
- pre-commit hooks on commit: `ruff-check`, `ruff-format`, `basedpyright-check`

## Repro
Repeatedly toggling skills in the role editor, then clicking validate/save, could eventually send stale `skills` payloads and lead to role skill authorization mismatches.