### PR TITLE
fix: support ACP model profile headers

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -97,23 +97,25 @@ Request field:
 ### `GET /system/configs/model`
 
 Returns the persisted model config with secret-backed profile API keys rehydrated for UI editing.
-Literal profile `api_key` values are migrated out of `model.json` into the unified secret store on read.
+Literal profile `api_key` values and secret header values are migrated out of `model.json` into the unified secret store on read.
 
 ### `GET /system/configs/model/profiles`
 
 Returns normalized model profiles.
-Each profile includes `has_api_key`, the currently stored `api_key` value so the web UI can mask it by default and reveal it on demand, `is_default` to mark the runtime fallback profile, and optional `context_window` for next-send context preview UI.
+Each profile includes `has_api_key`, the currently stored `api_key` value so the web UI can mask it by default and reveal it on demand, `headers[]` for additional request headers, `is_default` to mark the runtime fallback profile, and optional `context_window` for next-send context preview UI.
 `provider` currently supports `openai_compatible`, `bigmodel`, and the internal/testing-only `echo`.
 When no profile is explicitly marked default, the backend resolves the default in this order: a profile named `default`, the only configured profile, then the first profile by name.
 
 ### `PUT /system/configs/model/profiles/{name}`
 
 Upserts a model profile.
-Request body may include optional `source_name` to rename an existing profile while preserving its stored API key when `api_key` is omitted.
+Request body may include optional `source_name` to rename an existing profile while preserving its stored API key and secret headers when `api_key` and `headers` are omitted.
 `provider` accepts `openai_compatible`, `bigmodel`, and `echo`.
 Profiles may also include optional `ssl_verify` to override the global outbound TLS verification default for that model only.
 Profiles may include `is_default` to promote that profile to the runtime default; saving one default clears the flag from all others.
 Profiles may include optional `context_window` to declare the total model context limit separately from `max_tokens`, which remains the output-token cap.
+Profiles may include `headers[]`, where each item has `name`, optional `value`, optional `secret`, and optional `configured`.
+Profiles must provide at least one auth source: `api_key` or one configured header.
 When `context_window` is omitted and the backend recognizes the provider/model pair, it may auto-fill a known context limit during save and runtime load.
 
 ### `DELETE /system/configs/model/profiles/{name}`
@@ -124,19 +126,20 @@ If the deleted profile was the current default and other profiles remain, the ba
 ### `PUT /system/configs/model`
 
 Replaces the full model config object.
-Literal profile `api_key` values are moved into the unified secret store before `model.json` is written.
+Literal profile `api_key` values and secret header values are moved into the unified secret store before `model.json` is written.
 
 ### `POST /system/configs/model:probe`
 
 Tests model connectivity for a saved profile and/or draft override.
 Draft overrides may include optional `ssl_verify`; effective TLS verification resolves as `override.ssl_verify` -> global `SSL_VERIFY` -> default `false`.
+Draft overrides may include `headers[]` and may omit `api_key` when headers are provided.
 If `timeout_ms` is omitted, the backend uses the resolved profile `connect_timeout_seconds` value, or `15s` when no saved profile is involved.
 
 ### `POST /system/configs/model:discover`
 
 Fetches the available model catalog for a saved profile and/or draft override.
-Draft overrides may omit `model`, but must provide `base_url` and `api_key` when `profile_name` is omitted.
-When `profile_name` is provided, the request may override `base_url`, `api_key`, and `ssl_verify` while reusing the saved credentials for any omitted fields.
+Draft overrides may omit `model`, but must provide `base_url` and `api_key` or `headers` when `profile_name` is omitted.
+When `profile_name` is provided, the request may override `base_url`, `api_key`, `headers`, and `ssl_verify` while reusing the saved credentials for any omitted fields.
 If `timeout_ms` is omitted, the backend uses the resolved profile `connect_timeout_seconds` value, or `15s` when no saved profile is involved.
 `openai_compatible` and `bigmodel` both map this call to `GET {base_url}/models` and return the normalized `models` list sorted and deduplicated.
 When the provider exposes per-model context-limit metadata in the catalog payload, the response also includes `model_entries[]` with:

--- a/src/agent_teams/agents/execution/conversation_compaction.py
+++ b/src/agent_teams/agents/execution/conversation_compaction.py
@@ -20,7 +20,6 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings
 from pydantic_ai.profiles.openai import OpenAIModelProfile
-from pydantic_ai.providers.openai import OpenAIProvider
 
 from agent_teams.agents.execution.message_repository import MessageRepository
 from agent_teams.logger import get_logger, log_event
@@ -30,6 +29,7 @@ from agent_teams.providers.model_config import LlmRetryConfig, ModelEndpointConf
 from agent_teams.providers.openai_model_profiles import (
     resolve_openai_chat_model_profile,
 )
+from agent_teams.providers.openai_support import build_openai_provider
 from agent_teams.sessions.session_history_marker_models import (
     SessionHistoryMarkerRecord,
     SessionHistoryMarkerType,
@@ -365,9 +365,8 @@ class ConversationCompactionService:
         )
         return OpenAIChatModel(
             self._config.model,
-            provider=OpenAIProvider(
-                base_url=self._config.base_url,
-                api_key=self._config.api_key,
+            provider=build_openai_provider(
+                config=self._config,
                 http_client=build_llm_http_client(
                     connect_timeout_seconds=self._config.connect_timeout_seconds,
                     ssl_verify=self._config.ssl_verify,

--- a/src/agent_teams/agents/execution/coordination_agent_builder.py
+++ b/src/agent_teams/agents/execution/coordination_agent_builder.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIChatModelSettings
-from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.profiles.openai import OpenAIModelProfile
 
 from agent_teams.mcp.mcp_registry import McpRegistry
@@ -11,7 +10,11 @@ from agent_teams.agents.execution.recoverable_openai_chat_model import (
     RecoverableOpenAIChatModel as OpenAIChatModel,
 )
 from agent_teams.net.llm_client import build_llm_http_client
-from agent_teams.providers.model_config import DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS
+from agent_teams.providers.model_config import (
+    DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
+    ModelRequestHeader,
+)
+from agent_teams.providers.openai_support import build_openai_provider_for_endpoint
 from agent_teams.skills.skill_registry import SkillRegistry
 from agent_teams.tools.registry import ToolRegistry
 from agent_teams.tools.runtime import ToolDeps
@@ -21,7 +24,8 @@ def build_coordination_agent(
     *,
     model_name: str,
     base_url: str,
-    api_key: str,
+    api_key: str | None,
+    headers: tuple[ModelRequestHeader, ...] = (),
     system_prompt: str,
     allowed_tools: tuple[str, ...],
     model_settings: OpenAIChatModelSettings | None = None,
@@ -63,9 +67,10 @@ def build_coordination_agent(
     )
     model = OpenAIChatModel(
         model_name,
-        provider=OpenAIProvider(
+        provider=build_openai_provider_for_endpoint(
             base_url=base_url,
             api_key=api_key,
+            headers=headers,
             http_client=llm_http_client,
         ),
         profile=model_profile,

--- a/src/agent_teams/agents/execution/llm_session.py
+++ b/src/agent_teams/agents/execution/llm_session.py
@@ -320,6 +320,7 @@ class AgentLlmSession:
             model_name=self._config.model,
             base_url=self._config.base_url,
             api_key=self._config.api_key,
+            headers=self._config.headers,
             system_prompt=agent_system_prompt,
             allowed_tools=_resolve_allowed_tools(
                 self._tool_registry,

--- a/src/agent_teams/agents/execution/subagent_reflection.py
+++ b/src/agent_teams/agents/execution/subagent_reflection.py
@@ -19,7 +19,6 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings
 from pydantic_ai.profiles.openai import OpenAIModelProfile
-from pydantic_ai.providers.openai import OpenAIProvider
 
 from agent_teams.agents.execution.message_repository import MessageRepository
 from agent_teams.logger import get_logger, log_event
@@ -29,6 +28,7 @@ from agent_teams.providers.model_config import LlmRetryConfig, ModelEndpointConf
 from agent_teams.providers.openai_model_profiles import (
     resolve_openai_chat_model_profile,
 )
+from agent_teams.providers.openai_support import build_openai_provider
 from agent_teams.roles.memory_models import RoleMemoryRecord
 from agent_teams.roles.memory_service import RoleMemoryService
 from agent_teams.roles.role_models import RoleDefinition
@@ -250,9 +250,8 @@ class SubagentReflectionService:
         )
         return OpenAIChatModel(
             self._config.model,
-            provider=OpenAIProvider(
-                base_url=self._config.base_url,
-                api_key=self._config.api_key,
+            provider=build_openai_provider(
+                config=self._config,
                 http_client=build_llm_http_client(
                     connect_timeout_seconds=self._config.connect_timeout_seconds,
                     ssl_verify=self._config.ssl_verify,

--- a/src/agent_teams/external_agents/provider.py
+++ b/src/agent_teams/external_agents/provider.py
@@ -46,6 +46,7 @@ from agent_teams.logger import get_logger, log_event
 from agent_teams.media import MediaAssetService
 from agent_teams.mcp.mcp_registry import McpRegistry
 from agent_teams.providers.model_config import ModelEndpointConfig, ProviderType
+from agent_teams.providers.openai_support import build_model_request_headers
 from agent_teams.providers.provider_contracts import LLMProvider, LLMRequest
 from agent_teams.roles.role_models import RoleDefinition
 from agent_teams.sessions.runs.enums import RunEventType
@@ -1205,14 +1206,32 @@ def _upsert_env_binding(
 def _build_opencode_runtime_config(
     model_config: ModelEndpointConfig,
 ) -> tuple[str, tuple[tuple[str, str], ...]]:
+    custom_headers = _opencode_custom_headers(model_config)
+    should_emit_api_key = _opencode_should_emit_api_key(model_config)
     if _should_use_opencode_zai_provider(model_config):
         return (
-            _build_opencode_zai_config_content(model_config),
-            ((_OPENCODE_ZAI_API_KEY_ENV, model_config.api_key),),
+            _build_opencode_zai_config_content(
+                model_config,
+                custom_headers=custom_headers,
+                include_api_key=should_emit_api_key,
+            ),
+            (
+                ((_OPENCODE_ZAI_API_KEY_ENV, model_config.api_key),)
+                if should_emit_api_key and model_config.api_key is not None
+                else ()
+            ),
         )
     return (
-        _build_opencode_custom_config_content(model_config),
-        ((_OPENCODE_CUSTOM_API_KEY_ENV, model_config.api_key),),
+        _build_opencode_custom_config_content(
+            model_config,
+            custom_headers=custom_headers,
+            include_api_key=should_emit_api_key,
+        ),
+        (
+            ((_OPENCODE_CUSTOM_API_KEY_ENV, model_config.api_key),)
+            if should_emit_api_key and model_config.api_key is not None
+            else ()
+        ),
     )
 
 
@@ -1223,7 +1242,12 @@ def _should_use_opencode_zai_provider(model_config: ModelEndpointConfig) -> bool
     return "bigmodel.cn" in normalized_base_url or "z.ai" in normalized_base_url
 
 
-def _build_opencode_custom_config_content(model_config: ModelEndpointConfig) -> str:
+def _build_opencode_custom_config_content(
+    model_config: ModelEndpointConfig,
+    *,
+    custom_headers: dict[str, str],
+    include_api_key: bool,
+) -> str:
     model_entry = _build_opencode_model_entry(model_config)
     payload = {
         "$schema": "https://opencode.ai/config.json",
@@ -1231,7 +1255,12 @@ def _build_opencode_custom_config_content(model_config: ModelEndpointConfig) -> 
         "provider": {
             _OPENCODE_CUSTOM_PROVIDER_ID: {
                 "api": model_config.base_url,
-                "env": [_OPENCODE_CUSTOM_API_KEY_ENV],
+                **(
+                    {"env": [_OPENCODE_CUSTOM_API_KEY_ENV]}
+                    if include_api_key and model_config.api_key is not None
+                    else {}
+                ),
+                **({"options": {"headers": custom_headers}} if custom_headers else {}),
                 "npm": "@ai-sdk/openai-compatible",
                 "models": {
                     model_config.model: model_entry,
@@ -1242,7 +1271,12 @@ def _build_opencode_custom_config_content(model_config: ModelEndpointConfig) -> 
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
 
-def _build_opencode_zai_config_content(model_config: ModelEndpointConfig) -> str:
+def _build_opencode_zai_config_content(
+    model_config: ModelEndpointConfig,
+    *,
+    custom_headers: dict[str, str],
+    include_api_key: bool,
+) -> str:
     model_entry = _build_opencode_zai_model_entry(model_config)
     payload = {
         "$schema": "https://opencode.ai/config.json",
@@ -1250,7 +1284,12 @@ def _build_opencode_zai_config_content(model_config: ModelEndpointConfig) -> str
         "provider": {
             _OPENCODE_ZAI_PROVIDER_ID: {
                 "api": model_config.base_url,
-                "env": [_OPENCODE_ZAI_API_KEY_ENV],
+                **(
+                    {"env": [_OPENCODE_ZAI_API_KEY_ENV]}
+                    if include_api_key and model_config.api_key is not None
+                    else {}
+                ),
+                **({"options": {"headers": custom_headers}} if custom_headers else {}),
                 "npm": "@ai-sdk/openai-compatible",
                 "models": {
                     model_config.model: model_entry,
@@ -1311,6 +1350,32 @@ def _build_opencode_limit(
         "context": context_window,
         "output": model_config.sampling.max_tokens,
     }
+
+
+def _opencode_custom_headers(model_config: ModelEndpointConfig) -> dict[str, str]:
+    headers = build_model_request_headers(model_config)
+    if model_config.api_key is not None and "Authorization" in headers:
+        authorization_override = next(
+            (
+                header.value
+                for header in model_config.headers
+                if header.value is not None
+                and header.name.casefold() == "authorization"
+            ),
+            None,
+        )
+        if authorization_override is None:
+            headers.pop("Authorization", None)
+    return headers
+
+
+def _opencode_should_emit_api_key(model_config: ModelEndpointConfig) -> bool:
+    if model_config.api_key is None:
+        return False
+    return not any(
+        header.value is not None and header.name.casefold() == "authorization"
+        for header in model_config.headers
+    )
 
 
 def _opencode_model_supports_attachments(model_name: str) -> bool:

--- a/src/agent_teams/gateway/gateway_model_profile_override.py
+++ b/src/agent_teams/gateway/gateway_model_profile_override.py
@@ -6,9 +6,31 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue
 from agent_teams.providers.model_config import (
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
     ModelEndpointConfig,
+    ModelRequestHeader,
     ProviderType,
     SamplingConfig,
 )
+from agent_teams.providers.model_header_utils import (
+    normalize_model_request_headers_payload,
+)
+
+
+def _normalize_acp_model_profile_headers(
+    raw_value: JsonValue | None,
+) -> tuple[ModelRequestHeader, ...]:
+    if raw_value is None:
+        return ()
+    if isinstance(raw_value, dict):
+        shorthand_headers: list[dict[str, JsonValue]] = []
+        for raw_name, raw_header_value in raw_value.items():
+            shorthand_headers.append(
+                {
+                    "name": str(raw_name),
+                    "value": raw_header_value,
+                }
+            )
+        return normalize_model_request_headers_payload(shorthand_headers)
+    return normalize_model_request_headers_payload(raw_value)
 
 
 class GatewayModelProfileOverride(BaseModel):
@@ -18,7 +40,8 @@ class GatewayModelProfileOverride(BaseModel):
     provider: ProviderType = ProviderType.OPENAI_COMPATIBLE
     model: str = Field(min_length=1)
     base_url: str = Field(min_length=1)
-    api_key: str = Field(min_length=1)
+    api_key: str | None = Field(default=None, min_length=1)
+    headers: tuple[ModelRequestHeader, ...] = ()
     ssl_verify: bool | None = None
     temperature: float | None = Field(default=None, ge=0.0, le=2.0)
     top_p: float | None = Field(default=None, ge=0.0, le=1.0)
@@ -48,8 +71,11 @@ class GatewayModelProfileOverride(BaseModel):
         base_url = _pick_str("baseUrl", "base_url")
         api_key = _pick_str("apiKey", "api_key")
         model = _pick_str("model")
-        if not base_url or not api_key or not model:
-            raise ValueError("modelProfileOverride requires model, baseUrl, and apiKey")
+        headers = _normalize_acp_model_profile_headers(payload.get("headers"))
+        if not base_url or not model or (not api_key and not headers):
+            raise ValueError(
+                "modelProfileOverride requires model, baseUrl, and apiKey or headers"
+            )
 
         ssl_verify_value = payload.get("sslVerify", payload.get("ssl_verify"))
         ssl_verify: bool | None
@@ -64,6 +90,7 @@ class GatewayModelProfileOverride(BaseModel):
             model=model,
             base_url=base_url,
             api_key=api_key,
+            headers=headers,
             ssl_verify=ssl_verify,
             temperature=_pick_number("temperature"),
             top_p=_pick_number("topP", "top_p"),
@@ -97,6 +124,7 @@ class GatewayModelProfileOverride(BaseModel):
             model=self.model,
             base_url=self.base_url,
             api_key=self.api_key,
+            headers=self.headers,
             ssl_verify=self.ssl_verify,
             context_window=self.context_window,
             connect_timeout_seconds=(
@@ -126,6 +154,12 @@ class GatewayModelProfileOverride(BaseModel):
             "provider": self.provider.value,
             "model": self.model,
             "baseUrl": self.base_url,
+            "headers": [
+                header.model_copy(
+                    update={"value": None, "configured": True}
+                ).model_dump(mode="json")
+                for header in self.headers
+            ],
             "sslVerify": self.ssl_verify,
             "temperature": self.temperature,
             "topP": self.top_p,

--- a/src/agent_teams/interfaces/server/routers/system.py
+++ b/src/agent_teams/interfaces/server/routers/system.py
@@ -62,6 +62,7 @@ from agent_teams.notifications.notification_settings_service import (
 )
 from agent_teams.providers.model_config import (
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
+    ModelRequestHeader,
     ProviderType,
 )
 from agent_teams.providers.model_config_service import ModelConfigService
@@ -139,6 +140,7 @@ class ModelProfileRequest(BaseModel):
     model: str
     base_url: str
     api_key: str | None = None
+    headers: tuple[ModelRequestHeader, ...] | None = None
     ssl_verify: bool | None = None
     temperature: float = 0.7
     top_p: float = 1.0
@@ -170,6 +172,10 @@ def save_model_profile(
             profile["ssl_verify"] = req.ssl_verify
         if req.api_key is not None and req.api_key.strip():
             profile["api_key"] = req.api_key
+        if req.headers is not None:
+            profile["headers"] = [
+                header.model_dump(mode="json") for header in req.headers
+            ]
         service.save_model_profile(name, profile, source_name=req.source_name)
         return {"status": "ok"}
     except Exception as exc:

--- a/src/agent_teams/providers/__init__.py
+++ b/src/agent_teams/providers/__init__.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from agent_teams.providers.model_config import (
         LlmRetryConfig,
         ModelEndpointConfig,
+        ModelRequestHeader,
         ProviderModelInfo,
         ProviderType,
         SamplingConfig,
@@ -57,6 +58,7 @@ __all__ = [
     "LlmRetryErrorInfo",
     "LlmRetrySchedule",
     "ModelEndpointConfig",
+    "ModelRequestHeader",
     "ModelConfigManager",
     "ModelConfigService",
     "ModelDiscoveryEntry",
@@ -100,6 +102,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ModelEndpointConfig": (
         "agent_teams.providers.model_config",
         "ModelEndpointConfig",
+    ),
+    "ModelRequestHeader": (
+        "agent_teams.providers.model_config",
+        "ModelRequestHeader",
     ),
     "ModelConfigManager": (
         "agent_teams.providers.model_config_manager",

--- a/src/agent_teams/providers/model_config.py
+++ b/src/agent_teams/providers/model_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from agent_teams.net.constants import DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
 
@@ -29,13 +29,44 @@ class SamplingConfig(BaseModel):
     top_k: int | None = Field(default=None, ge=1)
 
 
+class ModelRequestHeader(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    value: str | None = None
+    secret: bool = False
+    configured: bool = False
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _normalize_name(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _normalize_value(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        normalized = value.strip()
+        return normalized or None
+
+    @model_validator(mode="after")
+    def _sync_configured_flag(self) -> "ModelRequestHeader":
+        if self.value is not None:
+            self.configured = True
+        return self
+
+
 class ModelEndpointConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     provider: ProviderType = ProviderType.OPENAI_COMPATIBLE
     model: str = Field(min_length=1)
     base_url: str = Field(min_length=1)
-    api_key: str = Field(min_length=1)
+    api_key: str | None = Field(default=None, min_length=1)
+    headers: tuple[ModelRequestHeader, ...] = ()
     ssl_verify: bool | None = None
     context_window: int | None = Field(default=None, ge=1)
     connect_timeout_seconds: float = Field(
@@ -49,8 +80,35 @@ class ModelEndpointConfig(BaseModel):
     @classmethod
     def _normalize_string_fields(cls, value: object) -> object:
         if isinstance(value, str):
-            return value.strip()
+            normalized = value.strip()
+            return normalized or None
         return value
+
+    @field_validator("headers")
+    @classmethod
+    def _validate_headers(
+        cls,
+        value: tuple[ModelRequestHeader, ...],
+    ) -> tuple[ModelRequestHeader, ...]:
+        seen_names: set[str] = set()
+        for entry in value:
+            normalized_name = entry.name.casefold()
+            if normalized_name in seen_names:
+                raise ValueError(f"Duplicate model header name: {entry.name}")
+            seen_names.add(normalized_name)
+        return value
+
+    @model_validator(mode="after")
+    def _require_auth_source(self) -> "ModelEndpointConfig":
+        if self.api_key is not None:
+            return self
+        if any(
+            header.configured and header.value is not None for header in self.headers
+        ):
+            return self
+        raise ValueError(
+            "Model endpoint config requires api_key or at least one configured header."
+        )
 
 
 class ProviderModelInfo(BaseModel):

--- a/src/agent_teams/providers/model_config_manager.py
+++ b/src/agent_teams/providers/model_config_manager.py
@@ -9,7 +9,12 @@ from typing import cast
 
 from agent_teams.providers.model_config import (
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
+    ModelRequestHeader,
     ProviderType,
+)
+from agent_teams.providers.model_header_utils import (
+    model_header_secret_field_name,
+    normalize_model_request_headers_payload,
 )
 from agent_teams.providers.known_model_context_windows import (
     infer_known_context_window,
@@ -55,12 +60,14 @@ class ModelConfigManager:
                 continue
             api_key, has_api_key = self._resolve_api_key(name, profile)
             normalized_profile = _normalize_profile_context_window(profile)
+            headers = self._resolve_headers(name, normalized_profile)
             result[name] = {
                 "provider": normalized_profile.get("provider", "openai_compatible"),
                 "model": normalized_profile.get("model", ""),
                 "base_url": normalized_profile.get("base_url", ""),
                 "api_key": api_key,
                 "has_api_key": has_api_key,
+                "headers": [binding.model_dump(mode="json") for binding in headers],
                 "ssl_verify": normalized_profile.get("ssl_verify"),
                 "temperature": normalized_profile.get("temperature", 0.7),
                 "top_p": normalized_profile.get("top_p", 1.0),
@@ -103,6 +110,12 @@ class ModelConfigManager:
                 current_secret=current_secret,
             )
         )
+        config[name] = self._prepare_profile_headers_for_storage(
+            profile_name=name,
+            existing_profile=existing_profile,
+            next_profile=cast(dict[str, JsonValue], config[name]),
+            source_name=source_name,
+        )
         if source_name is not None and source_name != name:
             config.pop(source_name, None)
         _normalize_default_profile_flags(config, preferred_name=name)
@@ -113,18 +126,24 @@ class ModelConfigManager:
             next_secret=next_secret,
             preserve_secret=preserve_secret,
         )
+        self._sync_profile_header_secrets(
+            profile_name=name,
+            existing_profile=existing_profile,
+            next_profile=_normalize_profile_context_window(profile),
+            source_name=source_name,
+        )
 
     def delete_model_profile(self, name: str) -> None:
         model_file = self._config_dir / "model.json"
         if not model_file.exists():
-            self._delete_profile_secret(name)
+            self._delete_profile_secret_owner(name)
             return
         config = _load_json_object(model_file)
         if name in config:
             del config[name]
             _normalize_default_profile_flags(config)
             _ = model_file.write_text(dumps(config, indent=2), encoding="utf-8")
-        self._delete_profile_secret(name)
+        self._delete_profile_secret_owner(name)
 
     def save_model_config(self, config: dict[str, JsonValue]) -> None:
         model_file = self._config_dir / "model.json"
@@ -150,7 +169,12 @@ class ModelConfigManager:
                     current_secret=current_secret,
                 )
             )
-            next_config[name] = next_profile
+            next_config[name] = self._prepare_profile_headers_for_storage(
+                profile_name=name,
+                existing_profile=existing_config.get(name),
+                next_profile=next_profile,
+                source_name=None,
+            )
             secret_updates[name] = (next_secret, preserve_secret)
         _normalize_default_profile_flags(next_config)
         _ = model_file.write_text(dumps(next_config, indent=2), encoding="utf-8")
@@ -165,14 +189,24 @@ class ModelConfigManager:
             if isinstance(profile, dict)
         }
         for removed_name in sorted(existing_profile_names - next_profile_names):
-            self._delete_profile_secret(removed_name)
+            self._delete_profile_secret_owner(removed_name)
         for profile_name, (next_secret, preserve_secret) in secret_updates.items():
             if next_secret is not None:
                 self._set_profile_secret(profile_name, next_secret)
-                continue
-            if preserve_secret:
-                continue
-            self._delete_profile_secret(profile_name)
+            elif not preserve_secret:
+                self._delete_profile_secret(profile_name)
+            next_profile = next_config.get(profile_name)
+            if isinstance(next_profile, dict) and isinstance(
+                config.get(profile_name), dict
+            ):
+                self._sync_profile_header_secrets(
+                    profile_name=profile_name,
+                    existing_profile=existing_config.get(profile_name),
+                    next_profile=_normalize_profile_context_window(
+                        cast(dict[str, JsonValue], config[profile_name])
+                    ),
+                    source_name=None,
+                )
 
     def _hydrate_model_config(
         self,
@@ -188,6 +222,11 @@ class ModelConfigManager:
             api_key, has_api_key = self._resolve_api_key(name, profile)
             if has_api_key:
                 next_profile["api_key"] = api_key
+            headers = self._resolve_headers(name, profile)
+            if headers:
+                next_profile["headers"] = [
+                    binding.model_dump(mode="json") for binding in headers
+                ]
             hydrated[name] = next_profile
         return hydrated
 
@@ -203,6 +242,253 @@ class ModelConfigManager:
         if secret_value is None:
             return "", False
         return secret_value, True
+
+    def _resolve_headers(
+        self,
+        profile_name: str,
+        profile: dict[str, JsonValue],
+    ) -> tuple[ModelRequestHeader, ...]:
+        raw_headers = profile.get("headers")
+        bindings = normalize_model_request_headers_payload(raw_headers)
+        resolved_bindings: list[ModelRequestHeader] = []
+        for binding in bindings:
+            value = binding.value
+            if value is None and binding.secret:
+                value = self._secret_store.get_secret(
+                    self._config_dir,
+                    namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                    owner_id=profile_name,
+                    field_name=model_header_secret_field_name(binding.name),
+                )
+            resolved_bindings.append(
+                binding.model_copy(
+                    update={
+                        "value": value,
+                        "configured": value is not None,
+                    }
+                )
+            )
+        return tuple(resolved_bindings)
+
+    def _prepare_profile_headers_for_storage(
+        self,
+        *,
+        profile_name: str,
+        existing_profile: object,
+        next_profile: dict[str, JsonValue],
+        source_name: str | None,
+    ) -> dict[str, JsonValue]:
+        merged_profile = dict(next_profile)
+        if "headers" not in merged_profile:
+            if isinstance(existing_profile, dict) and "headers" in existing_profile:
+                merged_profile["headers"] = existing_profile["headers"]
+            return merged_profile
+
+        incoming_headers = normalize_model_request_headers_payload(
+            merged_profile.get("headers")
+        )
+        stored_headers: list[dict[str, JsonValue]] = []
+        current_owner = (
+            source_name
+            if source_name is not None and source_name != profile_name
+            else profile_name
+        )
+        existing_bindings = (
+            self._resolve_headers(current_owner, existing_profile)
+            if isinstance(existing_profile, dict)
+            else ()
+        )
+        existing_by_name = {
+            binding.name.casefold(): binding for binding in existing_bindings
+        }
+        for binding in incoming_headers:
+            if binding.secret:
+                existing_binding = existing_by_name.get(binding.name.casefold())
+                if (
+                    binding.value is None
+                    and binding.configured is not False
+                    and (existing_binding is None or existing_binding.value is None)
+                ):
+                    raise ValueError(
+                        f"Header '{binding.name}' requires a value the first time it is configured."
+                    )
+                stored_headers.append(
+                    {
+                        "name": binding.name,
+                        "secret": True,
+                        "configured": False,
+                    }
+                )
+                continue
+            if binding.value is None:
+                raise ValueError(
+                    f"Non-secret header '{binding.name}' requires a value."
+                )
+            stored_headers.append(
+                {
+                    "name": binding.name,
+                    "value": binding.value,
+                    "secret": False,
+                    "configured": True,
+                }
+            )
+        merged_profile["headers"] = cast(JsonValue, stored_headers)
+        return merged_profile
+
+    def _sync_profile_header_secrets(
+        self,
+        *,
+        profile_name: str,
+        existing_profile: object,
+        next_profile: dict[str, JsonValue],
+        source_name: str | None,
+    ) -> None:
+        current_owner = (
+            source_name
+            if source_name is not None and source_name != profile_name
+            else profile_name
+        )
+        if not isinstance(existing_profile, dict):
+            existing_bindings: tuple[ModelRequestHeader, ...] = ()
+        else:
+            existing_bindings = self._resolve_headers(current_owner, existing_profile)
+            if (
+                not existing_bindings
+                and source_name is not None
+                and source_name != profile_name
+            ):
+                existing_bindings = self._resolve_headers(
+                    profile_name, existing_profile
+                )
+
+        if "headers" not in next_profile:
+            if source_name is not None and source_name != profile_name:
+                self._rename_profile_header_secrets(
+                    from_owner_id=source_name,
+                    to_owner_id=profile_name,
+                )
+            return
+
+        next_bindings = normalize_model_request_headers_payload(
+            next_profile.get("headers")
+        )
+        existing_by_name = {
+            binding.name.casefold(): binding for binding in existing_bindings
+        }
+        kept_names: set[str] = set()
+        for binding in next_bindings:
+            normalized_name = binding.name.casefold()
+            kept_names.add(normalized_name)
+            field_name = model_header_secret_field_name(binding.name)
+            if not binding.secret:
+                self._secret_store.delete_secret(
+                    self._config_dir,
+                    namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                    owner_id=profile_name,
+                    field_name=field_name,
+                )
+                continue
+            if binding.value is not None:
+                self._secret_store.set_secret(
+                    self._config_dir,
+                    namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                    owner_id=profile_name,
+                    field_name=field_name,
+                    value=binding.value,
+                )
+                continue
+            existing_binding = existing_by_name.get(normalized_name)
+            if existing_binding is not None and existing_binding.value is not None:
+                self._secret_store.set_secret(
+                    self._config_dir,
+                    namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                    owner_id=profile_name,
+                    field_name=field_name,
+                    value=existing_binding.value,
+                )
+                continue
+            if binding.configured is False:
+                self._secret_store.delete_secret(
+                    self._config_dir,
+                    namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                    owner_id=profile_name,
+                    field_name=field_name,
+                )
+                continue
+            raise ValueError(
+                f"Header '{binding.name}' requires a value the first time it is configured."
+            )
+
+        for binding in existing_bindings:
+            if binding.name.casefold() in kept_names:
+                continue
+            self._secret_store.delete_secret(
+                self._config_dir,
+                namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                owner_id=current_owner,
+                field_name=model_header_secret_field_name(binding.name),
+            )
+        if source_name is not None and source_name != profile_name:
+            self._delete_profile_header_secrets(source_name)
+
+    def _rename_profile_header_secrets(
+        self,
+        *,
+        from_owner_id: str,
+        to_owner_id: str,
+    ) -> None:
+        if from_owner_id == to_owner_id:
+            return
+        existing_fields = self._secret_store.list_owner_fields(
+            self._config_dir,
+            namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+            owner_id=from_owner_id,
+        )
+        header_fields = tuple(
+            field_name
+            for field_name in existing_fields
+            if field_name.startswith("header:")
+        )
+        if not header_fields:
+            return
+        for field_name in header_fields:
+            value = self._secret_store.get_secret(
+                self._config_dir,
+                namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                owner_id=from_owner_id,
+                field_name=field_name,
+            )
+            if value is None:
+                continue
+            self._secret_store.set_secret(
+                self._config_dir,
+                namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                owner_id=to_owner_id,
+                field_name=field_name,
+                value=value,
+            )
+        for field_name in header_fields:
+            self._secret_store.delete_secret(
+                self._config_dir,
+                namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                owner_id=from_owner_id,
+                field_name=field_name,
+            )
+
+    def _delete_profile_header_secrets(self, profile_name: str) -> None:
+        for field_name in self._secret_store.list_owner_fields(
+            self._config_dir,
+            namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+            owner_id=profile_name,
+        ):
+            if not field_name.startswith("header:"):
+                continue
+            self._secret_store.delete_secret(
+                self._config_dir,
+                namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                owner_id=profile_name,
+                field_name=field_name,
+            )
 
     def _migrate_legacy_profile_api_keys(
         self,
@@ -258,6 +544,13 @@ class ModelConfigManager:
             namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
             owner_id=profile_name,
             field_name=_MODEL_PROFILE_SECRET_FIELD,
+        )
+
+    def _delete_profile_secret_owner(self, profile_name: str) -> None:
+        self._secret_store.delete_owner(
+            self._config_dir,
+            namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+            owner_id=profile_name,
         )
 
     def _apply_profile_secret_update(

--- a/src/agent_teams/providers/model_connectivity.py
+++ b/src/agent_teams/providers/model_connectivity.py
@@ -16,9 +16,11 @@ from agent_teams.providers.known_model_context_windows import (
 from agent_teams.providers.model_config import (
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
     ModelEndpointConfig,
+    ModelRequestHeader,
     ProviderType,
     SamplingConfig,
 )
+from agent_teams.providers.openai_support import build_model_request_headers
 from agent_teams.sessions.runs.runtime_config import RuntimeConfig
 
 
@@ -41,6 +43,7 @@ class ModelConnectivityProbeOverride(BaseModel):
     model: str | None = Field(default=None, min_length=1)
     base_url: str | None = Field(default=None, min_length=1)
     api_key: str | None = Field(default=None, min_length=1)
+    headers: tuple[ModelRequestHeader, ...] = ()
     ssl_verify: bool | None = None
     temperature: float | None = Field(default=None, ge=0.0, le=2.0)
     top_p: float | None = Field(default=None, ge=0.0, le=1.0)
@@ -122,7 +125,8 @@ class ModelDiscoveryResolvedConfig(BaseModel):
 
     provider: ProviderType
     base_url: str = Field(min_length=1)
-    api_key: str = Field(min_length=1)
+    api_key: str | None = Field(default=None, min_length=1)
+    headers: tuple[ModelRequestHeader, ...] = ()
     ssl_verify: bool | None = None
     connect_timeout_seconds: float = Field(gt=0.0, le=300.0)
 
@@ -219,8 +223,8 @@ class ModelConnectivityProbeService:
                 missing_fields.append("model")
             if override.base_url is None:
                 missing_fields.append("base_url")
-            if override.api_key is None:
-                missing_fields.append("api_key")
+            if override.api_key is None and not override.headers:
+                missing_fields.append("api_key or headers")
             if missing_fields:
                 joined_fields = ", ".join(missing_fields)
                 raise ValueError(
@@ -228,12 +232,12 @@ class ModelConnectivityProbeService:
                 )
             override_model = cast(str, override.model)
             override_base_url = cast(str, override.base_url)
-            override_api_key = cast(str, override.api_key)
             return ModelEndpointConfig(
                 provider=override.provider or ProviderType.OPENAI_COMPATIBLE,
                 model=override_model,
                 base_url=override_base_url,
-                api_key=override_api_key,
+                api_key=override.api_key,
+                headers=override.headers,
                 ssl_verify=override.ssl_verify,
                 sampling=SamplingConfig(
                     temperature=(
@@ -283,8 +287,8 @@ class ModelConnectivityProbeService:
             missing_fields: list[str] = []
             if override.base_url is None:
                 missing_fields.append("base_url")
-            if override.api_key is None:
-                missing_fields.append("api_key")
+            if override.api_key is None and not override.headers:
+                missing_fields.append("api_key or headers")
             if missing_fields:
                 joined_fields = ", ".join(missing_fields)
                 raise ValueError(
@@ -293,7 +297,8 @@ class ModelConnectivityProbeService:
             return ModelDiscoveryResolvedConfig(
                 provider=override.provider or ProviderType.OPENAI_COMPATIBLE,
                 base_url=cast(str, override.base_url),
-                api_key=cast(str, override.api_key),
+                api_key=override.api_key,
+                headers=override.headers,
                 ssl_verify=override.ssl_verify,
                 connect_timeout_seconds=DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
             )
@@ -303,6 +308,7 @@ class ModelConnectivityProbeService:
             provider=resolved_override.provider or base_config.provider,
             base_url=resolved_override.base_url or base_config.base_url,
             api_key=resolved_override.api_key or base_config.api_key,
+            headers=resolved_override.headers or base_config.headers,
             ssl_verify=(
                 resolved_override.ssl_verify
                 if resolved_override.ssl_verify is not None
@@ -324,6 +330,7 @@ class ModelConnectivityProbeService:
             model=override.model or base_config.model,
             base_url=override.base_url or base_config.base_url,
             api_key=override.api_key or base_config.api_key,
+            headers=override.headers or base_config.headers,
             ssl_verify=(
                 override.ssl_verify
                 if override.ssl_verify is not None
@@ -398,10 +405,10 @@ class ModelConnectivityProbeService:
         timeout_ms: int,
     ) -> ModelConnectivityProbeResult:
         endpoint = f"{config.base_url.rstrip('/')}/chat/completions"
-        headers = {
-            "Authorization": f"Bearer {config.api_key}",
-            "Content-Type": "application/json",
-        }
+        headers = build_model_request_headers(
+            config,
+            extra_headers={"Content-Type": "application/json"},
+        )
         payload = {
             "model": config.model,
             "messages": [{"role": "user", "content": "reply with pong"}],
@@ -510,10 +517,17 @@ class ModelConnectivityProbeService:
         timeout_ms: int,
     ) -> ModelDiscoveryResult:
         endpoint = f"{config.base_url.rstrip('/')}/models"
-        headers = {
-            "Authorization": f"Bearer {config.api_key}",
-            "Content-Type": "application/json",
-        }
+        headers = build_model_request_headers(
+            ModelEndpointConfig(
+                provider=config.provider,
+                model="discovery",
+                base_url=config.base_url,
+                api_key=config.api_key,
+                headers=config.headers,
+                ssl_verify=config.ssl_verify,
+            ),
+            extra_headers={"Content-Type": "application/json"},
+        )
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
         try:

--- a/src/agent_teams/providers/model_header_utils.py
+++ b/src/agent_teams/providers/model_header_utils.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pydantic import JsonValue
+
+from agent_teams.providers.model_config import ModelRequestHeader
+
+_MODEL_HEADER_SECRET_FIELD_PREFIX = "header:"
+
+
+def model_header_secret_field_name(name: str) -> str:
+    return f"{_MODEL_HEADER_SECRET_FIELD_PREFIX}{name.strip().casefold()}"
+
+
+def normalize_model_request_headers_payload(
+    raw_value: object,
+) -> tuple[ModelRequestHeader, ...]:
+    if raw_value is None:
+        return ()
+    if not isinstance(raw_value, list):
+        raise ValueError("headers must be a list")
+    bindings: list[ModelRequestHeader] = []
+    for item in raw_value:
+        if not isinstance(item, dict):
+            raise ValueError("headers items must be objects")
+        payload: dict[str, JsonValue] = {
+            "name": item.get("name"),
+            "value": item.get("value"),
+            "secret": item.get("secret", False),
+            "configured": item.get("configured", False),
+        }
+        bindings.append(ModelRequestHeader.model_validate(payload))
+    return tuple(bindings)

--- a/src/agent_teams/providers/openai_compatible.py
+++ b/src/agent_teams/providers/openai_compatible.py
@@ -20,6 +20,7 @@ from agent_teams.media import ContentPart, MediaAssetService, MediaModality
 from agent_teams.metrics import MetricRecorder
 from agent_teams.net.llm_client import build_llm_http_client
 from agent_teams.providers.model_config import LlmRetryConfig
+from agent_teams.providers.openai_support import build_model_request_headers
 from agent_teams.providers.provider_contracts import (
     LLMProvider,
     LLMRequest,
@@ -313,10 +314,10 @@ class OpenAICompatibleProvider(LLMProvider):
             ssl_verify=self._config.ssl_verify,
             connect_timeout_seconds=self._config.connect_timeout_seconds,
         )
-        headers = {
-            "Authorization": f"Bearer {self._config.api_key}",
-            "Content-Type": "application/json",
-        }
+        headers = build_model_request_headers(
+            self._config,
+            extra_headers={"Content-Type": "application/json"},
+        )
         response = await client.post(
             self._build_endpoint_url(endpoint_path),
             json=payload,

--- a/src/agent_teams/providers/openai_support.py
+++ b/src/agent_teams/providers/openai_support.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import httpx
+from openai import AsyncOpenAI
+from pydantic_ai.providers.openai import OpenAIProvider
+
+from agent_teams.providers.model_config import ModelEndpointConfig, ModelRequestHeader
+
+
+def build_model_request_headers(
+    config: ModelEndpointConfig,
+    *,
+    extra_headers: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if config.api_key is not None:
+        headers["Authorization"] = f"Bearer {config.api_key}"
+    for entry in config.headers:
+        if entry.value is None:
+            continue
+        existing_name = _find_header_name(headers, entry.name)
+        if existing_name is not None:
+            headers.pop(existing_name)
+        headers[entry.name] = entry.value
+    if extra_headers is not None:
+        for name, value in extra_headers.items():
+            existing_name = _find_header_name(headers, name)
+            if existing_name is not None:
+                headers.pop(existing_name)
+            headers[name] = value
+    return headers
+
+
+def build_openai_provider(
+    *,
+    config: ModelEndpointConfig,
+    http_client: httpx.AsyncClient,
+) -> OpenAIProvider:
+    return build_openai_provider_for_endpoint(
+        base_url=config.base_url,
+        api_key=config.api_key,
+        headers=config.headers,
+        http_client=http_client,
+    )
+
+
+def build_openai_provider_for_endpoint(
+    *,
+    base_url: str,
+    api_key: str | None,
+    headers: tuple[ModelRequestHeader, ...],
+    http_client: httpx.AsyncClient,
+) -> OpenAIProvider:
+    custom_headers = _custom_headers_without_authorization(headers)
+    openai_client = AsyncOpenAI(
+        base_url=base_url,
+        api_key=api_key or "",
+        default_headers=custom_headers or None,
+        http_client=http_client,
+    )
+    return OpenAIProvider(openai_client=openai_client)
+
+
+def _custom_headers_without_authorization(
+    config: ModelEndpointConfig | tuple[ModelRequestHeader, ...],
+) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    binding_entries = (
+        config.headers if isinstance(config, ModelEndpointConfig) else config
+    )
+    for entry in binding_entries:
+        if entry.value is None:
+            continue
+        if entry.name.casefold() == "authorization":
+            headers["Authorization"] = entry.value
+            continue
+        existing_name = _find_header_name(headers, entry.name)
+        if existing_name is not None:
+            headers.pop(existing_name)
+        headers[entry.name] = entry.value
+    return headers
+
+
+def _find_header_name(headers: Mapping[str, str], name: str) -> str | None:
+    normalized_name = name.casefold()
+    for existing_name in headers:
+        if existing_name.casefold() == normalized_name:
+            return existing_name
+    return None

--- a/src/agent_teams/sessions/runs/runtime_config.py
+++ b/src/agent_teams/sessions/runs/runtime_config.py
@@ -17,8 +17,13 @@ from agent_teams.providers.model_config import (
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
     LlmRetryConfig,
     ModelEndpointConfig,
+    ModelRequestHeader,
     ProviderType,
     SamplingConfig,
+)
+from agent_teams.providers.model_header_utils import (
+    model_header_secret_field_name,
+    normalize_model_request_headers_payload,
 )
 from agent_teams.providers.known_model_context_windows import (
     infer_known_context_window,
@@ -170,12 +175,18 @@ def load_llm_profile_state(
             raw_value=cfg.get("api_key"),
             env_values=env_values,
         )
+        headers = _resolve_profile_headers(
+            config_dir=config_dir,
+            profile_name=name,
+            raw_value=cfg.get("headers"),
+            env_values=env_values,
+        )
         provider_raw = cfg.get("provider", ProviderType.OPENAI_COMPATIBLE.value)
         provider = ProviderType(provider_raw)
 
-        if not model or not base_url or not api_key:
+        if not model or not base_url or (not api_key and not headers):
             raise ValueError(
-                f"Invalid profile '{name}': missing required fields (model, base_url, api_key)."
+                f"Invalid profile '{name}': missing required fields (model, base_url, api_key or headers)."
             )
 
         temperature = cfg.get("temperature", 0.2)
@@ -196,7 +207,8 @@ def load_llm_profile_state(
             provider=provider,
             model=model,
             base_url=base_url,
-            api_key=api_key,
+            api_key=api_key or None,
+            headers=headers,
             ssl_verify=ssl_verify,
             context_window=(
                 int(context_window_raw)
@@ -315,6 +327,50 @@ def _resolve_profile_api_key(
     if secret_value is None:
         return ""
     return secret_value
+
+
+def _resolve_profile_headers(
+    *,
+    config_dir: Path,
+    profile_name: str,
+    raw_value: object,
+    env_values: Mapping[str, str],
+) -> tuple[ModelRequestHeader, ...]:
+    bindings = normalize_model_request_headers_payload(raw_value)
+    resolved_bindings: list[ModelRequestHeader] = []
+    for binding in bindings:
+        value = binding.value
+        if value is not None:
+            value = _resolve_required_config_value(
+                value,
+                env_values,
+                profile_name=profile_name,
+                field_name=f"headers.{binding.name}",
+            )
+        elif binding.secret:
+            value = get_secret_store().get_secret(
+                config_dir,
+                namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                owner_id=profile_name,
+                field_name=model_header_secret_field_name(binding.name),
+            )
+        elif binding.configured:
+            raise ValueError(
+                f"Invalid profile '{profile_name}': header '{binding.name}' is marked configured but has no value."
+            )
+        if not binding.secret and value is None:
+            raise ValueError(
+                f"Invalid profile '{profile_name}': non-secret header '{binding.name}' requires a value."
+            )
+        resolved_bindings.append(
+            binding.model_copy(
+                update={
+                    "value": value,
+                    "configured": value is not None,
+                }
+            )
+        )
+    return tuple(resolved_bindings)
 
 
 def _coerce_optional_ssl_verify(value: object, *, profile_name: str) -> bool | None:

--- a/tests/unit_tests/agents/execution/test_coordination_agent_builder.py
+++ b/tests/unit_tests/agents/execution/test_coordination_agent_builder.py
@@ -131,8 +131,8 @@ def test_build_coordination_agent_passes_proxy_http_client(
     )
     monkeypatch.setattr(
         coordination_agent,
-        "OpenAIProvider",
-        _fake_openai_provider,
+        "build_openai_provider_for_endpoint",
+        lambda **kwargs: _fake_openai_provider(**kwargs),
     )
     monkeypatch.setattr(
         coordination_agent,
@@ -159,6 +159,7 @@ def test_build_coordination_agent_passes_proxy_http_client(
     assert isinstance(provider, _FakeOpenAIProvider)
     assert provider.kwargs["base_url"] == "https://example.test/v1"
     assert provider.kwargs["api_key"] == "secret"
+    assert provider.kwargs["headers"] == ()
     assert provider.kwargs["http_client"] is sentinel_client
     assert captured["connect_timeout_seconds"] == 22.0
     assert captured["ssl_verify"] is None
@@ -191,7 +192,7 @@ def test_build_coordination_agent_ignores_unknown_skills(
     )
     monkeypatch.setattr(
         coordination_agent,
-        "OpenAIProvider",
+        "build_openai_provider_for_endpoint",
         lambda **kwargs: _FakeOpenAIProvider(**kwargs),
     )
     monkeypatch.setattr(
@@ -243,7 +244,7 @@ def test_build_coordination_agent_ignores_unknown_tools_and_mcp_servers(
     )
     monkeypatch.setattr(
         coordination_agent,
-        "OpenAIProvider",
+        "build_openai_provider_for_endpoint",
         lambda **kwargs: _FakeOpenAIProvider(**kwargs),
     )
     monkeypatch.setattr(

--- a/tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_delivery_e2e.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from agent_teams.automation import (
@@ -251,7 +251,8 @@ def test_bound_queue_and_delivery_services_resume_without_premature_failed(
     _ = queue_repo.update(
         waiting_record.model_copy(
             update={
-                "resume_next_attempt_at": datetime.now(tz=timezone.utc),
+                "updated_at": waiting_record.updated_at - timedelta(seconds=1),
+                "resume_next_attempt_at": waiting_record.updated_at,
             }
         )
     )

--- a/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
+++ b/tests/unit_tests/automation/test_automation_bound_session_queue_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import cast
 
@@ -525,7 +525,8 @@ def test_process_pending_requests_resume_after_backoff_elapsed(
     _ = queue_repo.update(
         waiting.model_copy(
             update={
-                "resume_next_attempt_at": datetime.now(tz=timezone.utc),
+                "updated_at": waiting.updated_at - timedelta(seconds=1),
+                "resume_next_attempt_at": waiting.updated_at,
             }
         )
     )
@@ -608,7 +609,8 @@ def test_process_pending_exhausts_resume_attempts_and_skips_terminal_delivery(
         waiting.model_copy(
             update={
                 "resume_attempts": 4,
-                "resume_next_attempt_at": datetime.now(tz=timezone.utc),
+                "updated_at": waiting.updated_at - timedelta(seconds=1),
+                "resume_next_attempt_at": waiting.updated_at,
             }
         )
     )
@@ -680,7 +682,10 @@ def test_direct_start_waiting_record_auto_resumes_recoverable_runtime(
     )
     _ = queue_repo.update(
         waiting.model_copy(
-            update={"resume_next_attempt_at": datetime.now(tz=timezone.utc)}
+            update={
+                "updated_at": waiting.updated_at - timedelta(seconds=1),
+                "resume_next_attempt_at": waiting.updated_at,
+            }
         )
     )
 

--- a/tests/unit_tests/external_agents/test_provider.py
+++ b/tests/unit_tests/external_agents/test_provider.py
@@ -46,6 +46,7 @@ from agent_teams.notifications import NotificationService
 from agent_teams.persistence.shared_state_repo import SharedStateRepository
 from agent_teams.providers.model_config import (
     ModelEndpointConfig,
+    ModelRequestHeader,
     ProviderType,
     SamplingConfig,
 )
@@ -440,6 +441,7 @@ def _build_model_config(
     model: str = "glm-4.6v",
     base_url: str = "https://open.bigmodel.cn/api/paas/v4",
     api_key: str = "sk-test",
+    headers: tuple[ModelRequestHeader, ...] = (),
     context_window: int | None = 128000,
     max_tokens: int = 4096,
 ) -> ModelEndpointConfig:
@@ -448,6 +450,7 @@ def _build_model_config(
         model=model,
         base_url=base_url,
         api_key=api_key,
+        headers=headers,
         context_window=context_window,
         sampling=SamplingConfig(max_tokens=max_tokens),
     )
@@ -890,6 +893,66 @@ async def test_external_acp_falls_back_to_custom_provider_for_generic_openai_com
     assert provider_config["env"] == ["AGENT_TEAMS_OPENCODE_API_KEY"]
     assert provider_config["npm"] == "@ai-sdk/openai-compatible"
     assert provider_config["models"]["gpt-4o-mini"]["name"] == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_external_acp_injects_custom_headers_into_opencode_provider_options(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    transport = _RequestCapturingTransport()
+    captured: dict[str, object] = {}
+    manager = _build_manager(
+        prompt_text="Answer briefly.",
+        workdir=tmp_path,
+        config_dir=tmp_path / "config",
+        agent=_build_agent(command="opencode", args=("acp",)),
+        resolve_model_config=lambda _role, _request: _build_model_config(
+            provider=ProviderType.OPENAI_COMPATIBLE,
+            model="gpt-4o-mini",
+            base_url="https://example.test/v1",
+            api_key="sk-ignored",
+            headers=(
+                ModelRequestHeader(
+                    name="Authorization",
+                    value="Bearer header-override",
+                ),
+                ModelRequestHeader(
+                    name="anthropic-version",
+                    value="2023-06-01",
+                ),
+            ),
+        ),
+    )
+    _install_transport_builder(
+        monkeypatch=monkeypatch,
+        transport=transport,
+        captured=captured,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_create_host_tool_bridge",
+        lambda: _FakeHostToolBridge(has_tools=False),
+    )
+
+    _ = await manager.prompt(
+        agent_id="agent-1",
+        role=_build_role(),
+        request=_build_request(),
+    )
+
+    runtime_agent = cast(ExternalAgentConfig, captured["config"])
+    runtime_transport = runtime_agent.transport
+    assert isinstance(runtime_transport, StdioTransportConfig)
+    env_by_name = {binding.name: binding.value for binding in runtime_transport.env}
+    assert "AGENT_TEAMS_OPENCODE_API_KEY" not in env_by_name
+    config_content = json.loads(cast(str, env_by_name["OPENCODE_CONFIG_CONTENT"]))
+    provider_config = config_content["provider"]["agent_teams"]
+    assert "env" not in provider_config
+    assert provider_config["options"]["headers"] == {
+        "Authorization": "Bearer header-override",
+        "anthropic-version": "2023-06-01",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/gateway/test_acp_stdio.py
+++ b/tests/unit_tests/gateway/test_acp_stdio.py
@@ -1707,6 +1707,7 @@ async def test_session_new_stores_model_profile_override_without_persisting_api_
         "provider": "openai_compatible",
         "model": "gpt-4.1",
         "baseUrl": "https://api.openai.com/v1",
+        "headers": [],
         "sslVerify": None,
         "temperature": 0.2,
         "topP": None,
@@ -1722,6 +1723,154 @@ async def test_session_new_stores_model_profile_override_without_persisting_api_
     assert runtime_override.base_url == "https://api.openai.com/v1"
     assert runtime_override.api_key == "sk-secret"
     assert notifications == []
+
+
+@pytest.mark.asyncio
+async def test_session_new_stores_redacted_model_profile_override_headers(
+    tmp_path: Path,
+) -> None:
+    session_service = FakeSessionService()
+    repository = GatewaySessionRepository(tmp_path / "gateway.db")
+    session_model_profile_store = GatewaySessionModelProfileStore()
+    gateway_session_service = GatewaySessionService(
+        repository=repository,
+        session_service=cast(SessionService, session_service),
+        session_model_profile_store=session_model_profile_store,
+    )
+
+    async def notify(_message: dict[str, JsonValue]) -> None:
+        return None
+
+    server = AcpGatewayServer(
+        gateway_session_service=gateway_session_service,
+        session_service=cast(SessionService, session_service),
+        run_service=cast(RunManager, FakeRunManager()),
+        media_asset_service=cast(MediaAssetService, object()),
+        notify=notify,
+    )
+
+    created = await server.handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {
+                "modelProfileOverride": {
+                    "name": "default",
+                    "provider": "openai_compatible",
+                    "model": "gpt-4.1",
+                    "baseUrl": "https://api.openai.com/v1",
+                    "headers": [
+                        {
+                            "name": "Authorization",
+                            "value": "Bearer acp-override",
+                        },
+                        {
+                            "name": "anthropic-version",
+                            "value": "2023-06-01",
+                        },
+                    ],
+                }
+            },
+        }
+    )
+
+    session_id = _require_str(_require_result_object(created), "sessionId")
+    record = repository.get(session_id)
+    public_override = record.channel_state["acp_model_profile_override"]
+    assert isinstance(public_override, dict)
+    assert public_override["headers"] == [
+        {
+            "name": "Authorization",
+            "value": None,
+            "secret": False,
+            "configured": True,
+        },
+        {
+            "name": "anthropic-version",
+            "value": None,
+            "secret": False,
+            "configured": True,
+        },
+    ]
+
+    runtime_override = session_model_profile_store.get(record.internal_session_id)
+    assert runtime_override is not None
+    assert runtime_override.api_key is None
+    assert runtime_override.headers[0].value == "Bearer acp-override"
+    assert runtime_override.headers[1].value == "2023-06-01"
+
+
+@pytest.mark.asyncio
+async def test_session_new_accepts_model_profile_override_headers_object_shorthand(
+    tmp_path: Path,
+) -> None:
+    session_service = FakeSessionService()
+    repository = GatewaySessionRepository(tmp_path / "gateway.db")
+    session_model_profile_store = GatewaySessionModelProfileStore()
+    gateway_session_service = GatewaySessionService(
+        repository=repository,
+        session_service=cast(SessionService, session_service),
+        session_model_profile_store=session_model_profile_store,
+    )
+
+    async def notify(_message: dict[str, JsonValue]) -> None:
+        return None
+
+    server = AcpGatewayServer(
+        gateway_session_service=gateway_session_service,
+        session_service=cast(SessionService, session_service),
+        run_service=cast(RunManager, FakeRunManager()),
+        media_asset_service=cast(MediaAssetService, object()),
+        notify=notify,
+    )
+
+    created = await server.handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {
+                "modelProfileOverride": {
+                    "name": "default",
+                    "provider": "openai_compatible",
+                    "model": "gpt-4.1",
+                    "baseUrl": "https://api.openai.com/v1",
+                    "headers": {
+                        "Authorization": "Bearer acp-override",
+                        "anthropic-version": "2023-06-01",
+                    },
+                }
+            },
+        }
+    )
+
+    session_id = _require_str(_require_result_object(created), "sessionId")
+    record = repository.get(session_id)
+    public_override = record.channel_state["acp_model_profile_override"]
+    assert isinstance(public_override, dict)
+    assert public_override["headers"] == [
+        {
+            "name": "Authorization",
+            "value": None,
+            "secret": False,
+            "configured": True,
+        },
+        {
+            "name": "anthropic-version",
+            "value": None,
+            "secret": False,
+            "configured": True,
+        },
+    ]
+
+    runtime_override = session_model_profile_store.get(record.internal_session_id)
+    assert runtime_override is not None
+    assert runtime_override.api_key is None
+    assert runtime_override.headers[0].name == "Authorization"
+    assert runtime_override.headers[0].value == "Bearer acp-override"
+    assert runtime_override.headers[1].name == "anthropic-version"
+    assert runtime_override.headers[1].value == "2023-06-01"
 
 
 def test_acp_trace_messages_require_explicit_env(

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from typing import cast
+
+from pydantic import JsonValue
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -88,6 +91,7 @@ class _FakeSystemService:
                 "base_url": "https://example.test/v1",
                 "api_key": "secret",
                 "has_api_key": True,
+                "headers": [],
                 "is_default": True,
                 "context_window": 128000,
             }
@@ -973,6 +977,40 @@ def test_save_model_profile_includes_default_flag_when_present() -> None:
     assert service.saved_model_profile is not None
     _, saved_profile, _ = service.saved_model_profile
     assert saved_profile["is_default"] is True
+
+
+def test_save_model_profile_forwards_headers() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model/profiles/default",
+        json={
+            "provider": ProviderType.OPENAI_COMPATIBLE.value,
+            "model": "claude-proxy",
+            "base_url": "https://example.test/v1",
+            "headers": [
+                {
+                    "name": "Authorization",
+                    "value": "Bearer from-header",
+                    "secret": True,
+                }
+            ],
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "max_tokens": 2048,
+        },
+    )
+
+    assert response.status_code == 200
+    assert service.saved_model_profile is not None
+    _, saved_profile, _ = service.saved_model_profile
+    saved_headers = saved_profile["headers"]
+    assert isinstance(saved_headers, list)
+    first_header = saved_headers[0]
+    assert isinstance(first_header, dict)
+    first_header_payload = first_header
+    assert cast(dict[str, JsonValue], first_header_payload)["name"] == "Authorization"
 
 
 class _FakeEnvironmentVariableService:

--- a/tests/unit_tests/providers/test_model_config_manager.py
+++ b/tests/unit_tests/providers/test_model_config_manager.py
@@ -70,6 +70,93 @@ def test_save_model_profile_and_get_model_profiles(tmp_path: Path) -> None:
     ]
 
 
+def test_save_model_profile_and_get_model_profiles_with_secret_headers(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+
+    manager.save_model_profile(
+        "default",
+        {
+            "provider": "openai_compatible",
+            "model": "gpt-4o-mini",
+            "base_url": "https://example.test/v1",
+            "headers": [
+                {
+                    "name": "Authorization",
+                    "value": "Bearer header-secret",
+                    "secret": True,
+                }
+            ],
+        },
+    )
+
+    profiles = manager.get_model_profiles()
+
+    assert profiles["default"]["api_key"] == ""
+    assert profiles["default"]["has_api_key"] is False
+    headers = cast(list[dict[str, JsonValue]], profiles["default"]["headers"])
+    assert headers[0]["name"] == "Authorization"
+    assert headers[0]["value"] == "Bearer header-secret"
+    model_payload = json.loads((tmp_path / "model.json").read_text(encoding="utf-8"))
+    assert model_payload["default"]["headers"] == [
+        {
+            "name": "Authorization",
+            "secret": True,
+            "configured": False,
+        }
+    ]
+
+
+def test_save_model_profile_preserves_existing_secret_header_when_blank(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+    manager.save_model_profile(
+        "default",
+        {
+            "provider": "openai_compatible",
+            "model": "gpt-4o-mini",
+            "base_url": "https://example.test/v1",
+            "headers": [
+                {
+                    "name": "Authorization",
+                    "value": "Bearer first-secret",
+                    "secret": True,
+                }
+            ],
+        },
+    )
+
+    manager.save_model_profile(
+        "default",
+        {
+            "provider": "openai_compatible",
+            "model": "kimi-k2.5",
+            "base_url": "https://api.moonshot.cn/v1",
+            "headers": [
+                {
+                    "name": "Authorization",
+                    "secret": True,
+                    "configured": True,
+                }
+            ],
+        },
+    )
+
+    config = manager.get_model_config()
+    saved_profile = cast(dict[str, JsonValue], config["default"])
+    saved_headers = cast(list[dict[str, JsonValue]], saved_profile["headers"])
+    assert saved_profile["model"] == "kimi-k2.5"
+    assert saved_headers[0]["value"] == "Bearer first-secret"
+
+
 def test_get_model_profiles_uses_default_connect_timeout_when_missing(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/providers/test_model_connectivity.py
+++ b/tests/unit_tests/providers/test_model_connectivity.py
@@ -9,6 +9,7 @@ import pytest
 
 from agent_teams.providers.model_config import (
     ModelEndpointConfig,
+    ModelRequestHeader,
     ProviderType,
     SamplingConfig,
 )
@@ -291,6 +292,40 @@ def test_probe_supports_bigmodel_provider(monkeypatch) -> None:
     assert captured["url"] == "https://open.bigmodel.cn/api/paas/v4/chat/completions"
 
 
+def test_probe_allows_header_only_override(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+
+    monkeypatch.setattr(
+        "agent_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or _FakeHttpClient(
+                captured=captured, response=httpx.Response(200, json={"usage": {}})
+            )
+        ),
+    )
+
+    result = service.probe(
+        ModelConnectivityProbeRequest(
+            override=ModelConnectivityProbeOverride(
+                model="draft-model",
+                base_url="https://draft.test/v1",
+                headers=(
+                    ModelRequestHeader(
+                        name="Authorization",
+                        value="Bearer header-only",
+                    ),
+                ),
+            )
+        )
+    )
+
+    assert result.ok is True
+    headers = cast(dict[str, str], captured["headers"])
+    assert headers["Authorization"] == "Bearer header-only"
+
+
 def test_discover_models_uses_saved_profile_and_parses_catalog(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
@@ -461,6 +496,40 @@ def test_discover_models_supports_bigmodel_provider(monkeypatch) -> None:
     assert result.provider == ProviderType.BIGMODEL
     assert result.models == ("glm-4.5",)
     assert captured["url"] == "https://open.bigmodel.cn/api/paas/v4/models"
+
+
+def test_discover_models_allows_header_only_override(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+
+    monkeypatch.setattr(
+        "agent_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or _FakeHttpClient(
+                captured=captured,
+                response=httpx.Response(200, json={"data": [{"id": "draft-model"}]}),
+            )
+        ),
+    )
+
+    result = service.discover_models(
+        ModelDiscoveryRequest(
+            override=ModelConnectivityProbeOverride(
+                base_url="https://draft.test/v1",
+                headers=(
+                    ModelRequestHeader(
+                        name="Authorization",
+                        value="Bearer discovery-header",
+                    ),
+                ),
+            )
+        )
+    )
+
+    assert result.ok is True
+    headers = cast(dict[str, str], captured["headers"])
+    assert headers["Authorization"] == "Bearer discovery-header"
 
 
 def test_discover_models_returns_invalid_response_error(monkeypatch) -> None:

--- a/tests/unit_tests/sessions/runs/test_runtime_config.py
+++ b/tests/unit_tests/sessions/runs/test_runtime_config.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 import pytest
 
+from agent_teams.providers.model_header_utils import model_header_secret_field_name
 from agent_teams.providers.model_config import DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS
+from agent_teams.secrets import get_secret_store
 from agent_teams.sessions.runs import runtime_config
 
 
@@ -402,3 +404,65 @@ def test_load_llm_configs_errors_when_api_key_env_placeholder_is_missing(
         "environment variable 'OPENAI_API_KEY' referenced by api_key is not set"
         in str(exc_info.value)
     )
+
+
+def test_load_llm_configs_allows_header_only_profiles(tmp_path: Path) -> None:
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "default": {
+                    "model": "gpt-4o-mini",
+                    "base_url": "https://example.test/v1",
+                    "headers": [
+                        {
+                            "name": "Authorization",
+                            "value": "Bearer header-only",
+                        }
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    profiles = runtime_config.load_llm_configs(tmp_path, {})
+
+    assert profiles["default"].api_key is None
+    assert profiles["default"].headers[0].name == "Authorization"
+    assert profiles["default"].headers[0].value == "Bearer header-only"
+
+
+def test_load_llm_configs_resolves_secret_headers_from_secret_store(
+    tmp_path: Path,
+) -> None:
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "default": {
+                    "model": "gpt-4o-mini",
+                    "base_url": "https://example.test/v1",
+                    "headers": [
+                        {
+                            "name": "Authorization",
+                            "secret": True,
+                            "configured": False,
+                        }
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    get_secret_store().set_secret(
+        tmp_path,
+        namespace="model_profile",
+        owner_id="default",
+        field_name=model_header_secret_field_name("Authorization"),
+        value="Bearer stored-secret",
+    )
+
+    profiles = runtime_config.load_llm_configs(tmp_path, {})
+
+    assert profiles["default"].headers[0].value == "Bearer stored-secret"

--- a/tests/unit_tests/sessions/test_session_history_markers.py
+++ b/tests/unit_tests/sessions/test_session_history_markers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import sqlite3
 
@@ -94,6 +94,10 @@ def test_session_clear_uses_logical_history_divider(tmp_path: Path) -> None:
     )
 
     cleared_count = service.clear_session_messages("session-1")
+    clear_markers = service._get_session_history_markers("session-1")
+    clear_marker_created_at = datetime.fromisoformat(
+        str(clear_markers[-1]["created_at"]).replace("Z", "+00:00")
+    )
 
     _ = task_repo.create(
         TaskEnvelope(
@@ -106,6 +110,22 @@ def test_session_clear_uses_logical_history_divider(tmp_path: Path) -> None:
             verification=VerificationPlan(checklist=("non_empty_response",)),
         )
     )
+    new_task_created_at = clear_marker_created_at + timedelta(seconds=1)
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        UPDATE tasks
+        SET created_at=?, updated_at=?
+        WHERE task_id=?
+        """,
+        (
+            new_task_created_at.isoformat(),
+            new_task_created_at.isoformat(),
+            "task-new",
+        ),
+    )
+    connection.commit()
+    connection.close()
     message_repo.append(
         session_id="session-1",
         workspace_id="default",


### PR DESCRIPTION
## Summary
- add model profile header support across ACP/openai-compatible runtime paths, including header-only auth
- accept object shorthand for `modelProfileOverride.headers` in ACP and keep public state redacted
- stabilize Windows timing-sensitive automation/session tests so the full suite stays deterministic

## Testing
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`

Fixes #217