### PR TITLE
Fix read scope behavior and clarify write scope errors

### DIFF
--- a/src/agent_teams/sessions/runs/background_tasks/command_runtime.py
+++ b/src/agent_teams/sessions/runs/background_tasks/command_runtime.py
@@ -12,7 +12,9 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
+from typing import IO, Callable, Protocol, cast
 
 from pydantic import BaseModel, ConfigDict
 
@@ -40,6 +42,7 @@ _BASH_STARTUP_ENV_KEYS = frozenset(
 )
 _BASH_STARTUP_ENV_PREFIXES = ("BASH_FUNC_",)
 _SIGKILL_GRACE_SECONDS = 5
+_SIGKILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
 DEFAULT_TIMEOUT_MS = 120_000
 MAX_TIMEOUT_MS = 1_200_000
 _WINDOWS_POWERSHELL_CMDLET_PREFIXES = frozenset(
@@ -115,6 +118,155 @@ class ResolvedCommandRuntime(BaseModel):
     kind: CommandRuntimeKind
     executable: str
     display_name: str
+
+
+class _AsyncProcessWriter(Protocol):
+    def write(self, data: bytes) -> None: ...
+
+    async def drain(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class _PipeProcess(Protocol):
+    @property
+    def pid(self) -> int | None: ...
+
+    @property
+    def returncode(self) -> int | None: ...
+
+    @property
+    def stdin(self) -> _AsyncProcessWriter | None: ...
+
+    @property
+    def stdout(self) -> asyncio.StreamReader | None: ...
+
+    @property
+    def stderr(self) -> asyncio.StreamReader | None: ...
+
+    async def wait(self) -> int | None: ...
+
+    def kill(self) -> None: ...
+
+
+class _WritableBinaryStream(Protocol):
+    def write(self, data: bytes) -> object: ...
+
+    def flush(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class _ThreadedProcessWriter:
+    def __init__(self, stream: _WritableBinaryStream) -> None:
+        self._stream = stream
+        self._pending = bytearray()
+        self._pending_lock = threading.Lock()
+
+    def write(self, data: bytes) -> None:
+        with self._pending_lock:
+            self._pending.extend(data)
+
+    async def drain(self) -> None:
+        payload = self._take_pending()
+        if not payload:
+            return None
+        await asyncio.to_thread(self._write_and_flush, payload)
+
+    def close(self) -> None:
+        self._stream.close()
+
+    def _take_pending(self) -> bytes:
+        with self._pending_lock:
+            if not self._pending:
+                return b""
+            payload = bytes(self._pending)
+            self._pending.clear()
+            return payload
+
+    def _write_and_flush(self, payload: bytes) -> None:
+        self._stream.write(payload)
+        self._stream.flush()
+
+
+class _ThreadedProcessAdapter:
+    def __init__(
+        self,
+        proc: subprocess.Popen[bytes],
+        *,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        self._proc = proc
+        self.stdin = (
+            _ThreadedProcessWriter(cast(_WritableBinaryStream, proc.stdin))
+            if proc.stdin is not None
+            else None
+        )
+        self.stdout = asyncio.StreamReader() if proc.stdout is not None else None
+        self.stderr = asyncio.StreamReader() if proc.stderr is not None else None
+        self._wait_future: asyncio.Future[int | None] = loop.create_future()
+        self._start_reader_thread(proc.stdout, self.stdout, loop)
+        self._start_reader_thread(proc.stderr, self.stderr, loop)
+        threading.Thread(
+            target=self._wait_for_process,
+            args=(loop,),
+            daemon=True,
+        ).start()
+
+    @property
+    def pid(self) -> int | None:
+        return self._proc.pid
+
+    @property
+    def returncode(self) -> int | None:
+        return self._proc.returncode
+
+    async def wait(self) -> int | None:
+        return await asyncio.shield(self._wait_future)
+
+    def kill(self) -> None:
+        self._proc.kill()
+
+    def _start_reader_thread(
+        self,
+        pipe: IO[bytes] | None,
+        reader: asyncio.StreamReader | None,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        if pipe is None or reader is None:
+            return
+        threading.Thread(
+            target=self._pump_pipe,
+            args=(pipe, reader, loop),
+            daemon=True,
+        ).start()
+
+    @staticmethod
+    def _pump_pipe(
+        pipe: IO[bytes],
+        reader: asyncio.StreamReader,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        try:
+            while True:
+                chunk = _read_pipe_chunk(pipe, 4096)
+                if not chunk:
+                    break
+                loop.call_soon_threadsafe(reader.feed_data, chunk)
+        finally:
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(reader.feed_eof)
+            with contextlib.suppress(Exception):
+                pipe.close()
+
+    def _wait_for_process(self, loop: asyncio.AbstractEventLoop) -> None:
+        exit_code = self._proc.wait()
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(self._resolve_wait_future, exit_code)
+
+    def _resolve_wait_future(self, exit_code: int) -> None:
+        if not self._wait_future.done():
+            self._wait_future.set_result(exit_code)
 
 
 def resolve_bash_path() -> str:
@@ -341,6 +493,13 @@ def _prepend_powershell_utf8_prefix(command: str) -> str:
     )
 
 
+def _signal_process_group(pid: int, sig: int) -> None:
+    killpg = getattr(os, "killpg", None)
+    if killpg is None:
+        raise ProcessLookupError(pid)
+    killpg(pid, sig)
+
+
 def kill_process_tree_by_pid(pid: int) -> bool:
     if _is_windows():
         try:
@@ -356,13 +515,13 @@ def kill_process_tree_by_pid(pid: int) -> bool:
         return completed.returncode == 0
 
     try:
-        os.killpg(pid, signal.SIGTERM)
+        _signal_process_group(pid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError):
         return False
     if _wait_for_process_group_exit(pid, timeout_seconds=_SIGKILL_GRACE_SECONDS):
         return True
     try:
-        os.killpg(pid, signal.SIGKILL)
+        _signal_process_group(pid, _SIGKILL_SIGNAL)
     except ProcessLookupError:
         return True
     except PermissionError:
@@ -387,7 +546,7 @@ def _wait_for_process_group_exit(pid: int, *, timeout_seconds: float) -> bool:
 
 def _process_group_exists(pid: int) -> bool:
     try:
-        os.killpg(pid, 0)
+        _signal_process_group(pid, 0)
     except ProcessLookupError:
         return False
     except PermissionError:
@@ -395,7 +554,7 @@ def _process_group_exists(pid: int) -> bool:
     return True
 
 
-async def _kill_process_tree(proc: asyncio.subprocess.Process) -> None:
+async def _kill_process_tree(proc: _PipeProcess) -> None:
     if proc.returncode is not None:
         return
     pid = proc.pid
@@ -420,14 +579,14 @@ async def _kill_process_tree(proc: asyncio.subprocess.Process) -> None:
         return
 
     try:
-        os.killpg(pid, signal.SIGTERM)
+        _signal_process_group(pid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError):
         pass
     try:
         await asyncio.wait_for(proc.wait(), timeout=_SIGKILL_GRACE_SECONDS)
     except asyncio.TimeoutError:
         try:
-            os.killpg(pid, signal.SIGKILL)
+            _signal_process_group(pid, _SIGKILL_SIGNAL)
         except (ProcessLookupError, PermissionError):
             pass
         try:
@@ -481,24 +640,69 @@ async def create_command_subprocess(
     stdin: int | None = None,
     stdout: int | None = None,
     stderr: int | None = None,
-) -> asyncio.subprocess.Process:
+) -> _PipeProcess:
     resolved_runtime = runtime or resolve_command_runtime(command=command)
     command_env = await build_command_env(
         env,
         runtime=resolved_runtime,
         command=command,
     )
-    return await asyncio.create_subprocess_exec(
-        *build_command_argv(
-            runtime=resolved_runtime,
-            command=command,
-            login=login,
-        ),
+    argv = build_command_argv(
+        runtime=resolved_runtime,
+        command=command,
+        login=login,
+    )
+    try:
+        return await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(cwd),
+            env=command_env,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=_start_new_session(),
+            creationflags=_creation_flags(),
+        )
+    except NotImplementedError:
+        if not _is_windows():
+            raise
+        loop = asyncio.get_running_loop()
+        return _create_threaded_subprocess(
+            argv=argv,
+            cwd=cwd,
+            env=command_env,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            loop=loop,
+        )
+
+
+def _create_threaded_subprocess(
+    *,
+    argv: tuple[str, ...],
+    cwd: Path,
+    env: dict[str, str],
+    stdin: int | None,
+    stdout: int | None,
+    stderr: int | None,
+    loop: asyncio.AbstractEventLoop,
+) -> _PipeProcess:
+    proc = subprocess.Popen(
+        list(argv),
         cwd=str(cwd),
-        env=command_env,
+        env=env,
         stdin=stdin,
         stdout=stdout,
         stderr=stderr,
         start_new_session=_start_new_session(),
         creationflags=_creation_flags(),
     )
+    return _ThreadedProcessAdapter(proc, loop=loop)
+
+
+def _read_pipe_chunk(pipe: IO[bytes], size: int) -> bytes:
+    read1 = cast(Callable[[int], bytes] | None, getattr(pipe, "read1", None))
+    if read1 is not None:
+        return read1(size)
+    return pipe.read(size)

--- a/src/agent_teams/sessions/runs/background_tasks/manager.py
+++ b/src/agent_teams/sessions/runs/background_tasks/manager.py
@@ -41,6 +41,7 @@ from agent_teams.sessions.runs.background_tasks.repository import (
 from agent_teams.sessions.runs.run_models import RunEvent
 from agent_teams.sessions.runs.background_tasks.command_runtime import (
     ResolvedCommandRuntime,
+    _PipeProcess,
     _kill_process_tree,
     _kill_process_tree_by_pid,
     _start_new_session,
@@ -201,7 +202,7 @@ class _BackgroundTaskTransport(ABC):
 
 
 class _PipeTransport(_BackgroundTaskTransport):
-    def __init__(self, proc: asyncio.subprocess.Process) -> None:
+    def __init__(self, proc: _PipeProcess) -> None:
         self._proc = proc
 
     @property

--- a/src/agent_teams/tools/workspace_tools/glob.txt
+++ b/src/agent_teams/tools/workspace_tools/glob.txt
@@ -2,6 +2,7 @@ Find workspace files by path pattern.
 
 Usage:
 - `pattern` is a glob matched relative to the workspace execution root.
+- Use `../...` segments in the pattern when you need to search outside the workspace execution root.
 - Use `tmp/...` to search inside the managed workspace tmp directory.
 - Use this tool to discover candidate files when you know naming or directory conventions.
 - Results are returned as relative workspace paths.

--- a/src/agent_teams/tools/workspace_tools/grep.txt
+++ b/src/agent_teams/tools/workspace_tools/grep.txt
@@ -3,6 +3,7 @@ Search workspace file contents with ripgrep.
 Usage:
 - `pattern` is treated as a regular expression.
 - `path` limits the search root and defaults to the workspace execution root.
+- `path` may be absolute or relative and may point anywhere on disk.
 - Use `path="tmp"` to search inside the managed workspace tmp directory.
 - `include` narrows matches to files matching a glob such as `*.py`.
 - Set `case_sensitive=true` only when exact casing matters.

--- a/src/agent_teams/tools/workspace_tools/read.txt
+++ b/src/agent_teams/tools/workspace_tools/read.txt
@@ -1,7 +1,7 @@
 Read a file or directory from disk.
 
 Usage:
-- `path` may be absolute or relative, but it must stay within the workspace read scope.
+- `path` may be absolute or relative and may point anywhere on disk.
 - Relative paths are resolved from the workspace execution root.
 - Use `tmp/...` to read files from the managed workspace tmp directory.
 - Files are returned with line numbers in the format `<line>: <content>`.

--- a/src/agent_teams/tools/workspace_tools/shell.txt
+++ b/src/agent_teams/tools/workspace_tools/shell.txt
@@ -2,6 +2,6 @@ Run a shell command in the managed runtime.
 
 - Pass only `command` for normal synchronous execution and wait for the command to finish.
 - Set `background=true` only when the task should continue after the current tool call returns.
-- Use `workdir` only when the command must run somewhere other than the workspace root.
+- Use `workdir` only when the command must run somewhere other than the default execution root; it may be absolute or relative.
 - Use `tty=true` only for commands that require an interactive terminal.
 - Prefer this tool over older exec-session tools.

--- a/src/agent_teams/tools/workspace_tools/write.txt
+++ b/src/agent_teams/tools/workspace_tools/write.txt
@@ -3,6 +3,7 @@ Write full file contents to the workspace.
 Usage:
 - `path` is resolved relative to the workspace root.
 - Use `tmp/...` to write into the managed workspace tmp directory.
+- Writes must stay within the configured workspace writable roots.
 - This tool creates a file or fully replaces an existing file.
 - Prefer `edit` when you only need a targeted change inside an existing file.
 - Avoid using this tool for partial updates; provide the complete desired file content.

--- a/src/agent_teams/workspace/handle.py
+++ b/src/agent_teams/workspace/handle.py
@@ -70,7 +70,11 @@ class WorkspaceHandle(BaseModel):
             if self._is_path_within_root(resolved_candidate, allowed_root):
                 return resolved_candidate
         action = "write" if write else "read"
-        raise ValueError(f"Path is outside workspace {action} scope: {raw_path}")
+        allowed_roots_text = ", ".join(str(root.resolve()) for root in allowed_roots)
+        raise ValueError(
+            f"Path is outside workspace {action} scope: requested={raw_path}, "
+            f"resolved={resolved_candidate}, allowed_roots=[{allowed_roots_text}]"
+        )
 
     def _resolve_candidate_path(self, raw_path: str) -> Path:
         normalized_path = self._normalize_raw_path(raw_path)
@@ -83,13 +87,17 @@ class WorkspaceHandle(BaseModel):
         return (self.execution_root / normalized_path).resolve()
 
     def resolve_read_path(self, path: str) -> Path:
-        return self.resolve_path(path, write=False)
+        return self._resolve_candidate_path(path)
 
     def resolve_path(self, relative_path: str, *, write: bool = False) -> Path:
         candidate = self._resolve_candidate_path(relative_path)
-        return self._validate_allowed_path(
-            candidate, write=write, raw_path=relative_path
-        )
+        if write:
+            return self._validate_allowed_path(
+                candidate,
+                write=True,
+                raw_path=relative_path,
+            )
+        return candidate
 
     def resolve_tmp_path(self, relative_path: str, *, write: bool = True) -> Path:
         requested_path = Path(relative_path)
@@ -123,4 +131,4 @@ class WorkspaceHandle(BaseModel):
     def resolve_workdir(self, relative_path: str | None = None) -> Path:
         if relative_path is None:
             return self.execution_root
-        return self.resolve_path(relative_path, write=False)
+        return self._resolve_candidate_path(relative_path)

--- a/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
@@ -126,6 +126,7 @@ def test_kill_process_tree_by_pid_waits_for_posix_exit_before_success(
         runtime_module.os,
         "killpg",
         lambda pid, sig: signals.append(sig),
+        raising=False,
     )
 
     assert kill_process_tree_by_pid(3210) is True
@@ -153,8 +154,38 @@ def test_kill_process_tree_by_pid_requires_posix_exit_after_sigkill(
         runtime_module.os,
         "killpg",
         lambda pid, sig: signals.append(sig),
+        raising=False,
     )
 
     assert kill_process_tree_by_pid(3210) is False
-    assert signals == [signal.SIGTERM, signal.SIGKILL]
+    assert signals == [signal.SIGTERM, runtime_module._SIGKILL_SIGNAL]
     assert wait_calls == [runtime_module._SIGKILL_GRACE_SECONDS, 2]
+
+
+@pytest.mark.asyncio
+async def test_threaded_process_writer_defers_blocking_write_to_drain() -> None:
+    writes: list[bytes] = []
+    flush_count = 0
+
+    class _FakeStream:
+        def write(self, data: bytes) -> None:
+            writes.append(data)
+
+        def flush(self) -> None:
+            nonlocal flush_count
+            flush_count += 1
+
+        def close(self) -> None:
+            return None
+
+    writer = runtime_module._ThreadedProcessWriter(_FakeStream())
+    writer.write(b"hello ")
+    writer.write(b"world")
+
+    assert writes == []
+    assert flush_count == 0
+
+    await writer.drain()
+
+    assert writes == [b"hello world"]
+    assert flush_count == 1

--- a/tests/unit_tests/tools/workspace_tools/test_path_utils.py
+++ b/tests/unit_tests/tools/workspace_tools/test_path_utils.py
@@ -175,7 +175,7 @@ def test_resolve_workspace_glob_scope_keeps_execution_root_for_normal_patterns(
     assert logical_prefix is None
 
 
-def test_resolve_workspace_glob_scope_rejects_execution_root_outside_read_scope(
+def test_resolve_workspace_glob_scope_allows_execution_root_outside_read_scope(
     tmp_path: Path,
 ) -> None:
     scope_root = tmp_path / "project"
@@ -191,5 +191,11 @@ def test_resolve_workspace_glob_scope_rejects_execution_root_outside_read_scope(
         ),
     )
 
-    with pytest.raises(ValueError, match="outside workspace read scope"):
-        resolve_workspace_glob_scope(workspace, "**/*.md")
+    root, pattern, logical_prefix = resolve_workspace_glob_scope(
+        workspace,
+        "**/*.md",
+    )
+
+    assert root == execution_root.resolve()
+    assert pattern == "**/*.md"
+    assert logical_prefix is None

--- a/tests/unit_tests/workspace/test_handle.py
+++ b/tests/unit_tests/workspace/test_handle.py
@@ -47,7 +47,7 @@ def _build_workspace_handle(
     )
 
 
-def test_resolve_read_path_rejects_absolute_path_outside_workspace(
+def test_resolve_read_path_allows_absolute_path_outside_workspace(
     tmp_path: Path,
 ) -> None:
     workspace_root = tmp_path / "workspace"
@@ -59,8 +59,9 @@ def test_resolve_read_path_rejects_absolute_path_outside_workspace(
     external_file.parent.mkdir(parents=True)
     external_file.write_text("notes\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="outside workspace read scope"):
-        workspace.resolve_read_path(str(external_file))
+    resolved = workspace.resolve_read_path(str(external_file))
+
+    assert resolved == external_file.resolve()
 
 
 def test_resolve_read_path_allows_absolute_path_inside_workspace(
@@ -79,7 +80,7 @@ def test_resolve_read_path_allows_absolute_path_inside_workspace(
     assert resolved == workspace_file.resolve()
 
 
-def test_resolve_read_path_rejects_relative_escape_outside_workspace(
+def test_resolve_read_path_allows_relative_escape_outside_workspace(
     tmp_path: Path,
 ) -> None:
     workspace_root = tmp_path / "workspace"
@@ -90,11 +91,12 @@ def test_resolve_read_path_rejects_relative_escape_outside_workspace(
     external_file = tmp_path / "outside.txt"
     external_file.write_text("outside\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="outside workspace read scope"):
-        workspace.resolve_read_path("../outside.txt")
+    resolved = workspace.resolve_read_path("../outside.txt")
+
+    assert resolved == external_file.resolve()
 
 
-def test_resolve_workdir_keeps_workspace_boundary_for_outside_path(
+def test_resolve_workdir_allows_outside_path(
     tmp_path: Path,
 ) -> None:
     workspace_root = tmp_path / "workspace"
@@ -103,8 +105,29 @@ def test_resolve_workdir_keeps_workspace_boundary_for_outside_path(
         scope_root=workspace_root,
     )
 
-    with pytest.raises(ValueError, match="outside workspace read scope"):
-        workspace.resolve_workdir("../outside")
+    resolved = workspace.resolve_workdir("../outside")
+
+    assert resolved == (tmp_path / "outside").resolve()
+
+
+def test_resolve_path_rejects_write_outside_workspace_with_allowed_roots(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace = _build_workspace_handle(
+        workspace_dir=workspace_root,
+        scope_root=workspace_root,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        workspace.resolve_path("../outside.txt", write=True)
+
+    message = str(exc_info.value)
+    assert "outside workspace write scope" in message
+    assert "requested=../outside.txt" in message
+    assert f"resolved={(tmp_path / 'outside.txt').resolve()}" in message
+    assert str(workspace_root.resolve()) in message
+    assert str((workspace_root / "tmp").resolve()) in message
 
 
 def test_resolve_path_routes_tmp_prefix_to_managed_tmp_root(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Summary
- allow read-side workspace path resolution to access files outside the workspace while keeping relative paths anchored to the execution root
- keep write-side workspace limits and expand out-of-scope errors with the requested path, resolved path, and allowed writable roots
- update workspace tool docs and tests, and add a Windows selector-loop subprocess fallback so the required test suite stays green

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests

Closes #234
