### PR TITLE
Let providers control default max tokens

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -112,7 +112,7 @@ Request body may include optional `source_name` to rename an existing profile wh
 `provider` accepts `openai_compatible`, `bigmodel`, and `echo`.
 Profiles may also include optional `ssl_verify` to override the global outbound TLS verification default for that model only.
 Profiles may include `is_default` to promote that profile to the runtime default; saving one default clears the flag from all others.
-Profiles may include optional `context_window` to declare the total model context limit separately from `max_tokens`, which remains the output-token cap.
+Profiles may include optional `context_window` to declare the total model context limit separately from `max_tokens`, which remains the output-token cap when explicitly set. If `max_tokens` is omitted, the backend preserves that unset state and lets the provider decide the default output cap for primary LLM requests.
 Profiles may include `headers[]`, where each item has `name`, optional `value`, optional `secret`, and optional `configured`.
 Profiles must provide at least one auth source: `api_key` or one configured header.
 When `context_window` is omitted and the backend recognizes the provider/model pair, it may auto-fill a known context limit during save and runtime load.

--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -301,7 +301,7 @@ function createModal() {
                                                 </div>
                                                 <div class="form-group">
                                                     <label for="profile-max-tokens" data-i18n="settings.model.max_output_tokens">Max Output Tokens</label>
-                                                    <input type="number" id="profile-max-tokens" value="100000" min="1" autocomplete="off">
+                                                    <input type="number" id="profile-max-tokens" value="" min="1" autocomplete="off" placeholder="Optional" data-i18n-placeholder="settings.model.optional">
                                                 </div>
                                                 <div class="form-group">
                                                     <label for="profile-context-window" data-i18n="settings.model.context_window">Context Window</label>

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -171,7 +171,7 @@ function handleAddProfile() {
     document.getElementById('profile-is-default').checked = Object.keys(profiles).length === 0;
     document.getElementById('profile-temperature').value = '0.7';
     document.getElementById('profile-top-p').value = '1.0';
-    document.getElementById('profile-max-tokens').value = '100000';
+    document.getElementById('profile-max-tokens').value = '';
     document.getElementById('profile-context-window').value = '';
     delete document.getElementById('profile-context-window').dataset.autofilledModel;
     document.getElementById('profile-connect-timeout').value = '15';
@@ -207,7 +207,7 @@ function handleEditProfile(name) {
     document.getElementById('profile-is-default').checked = profile.is_default === true;
     document.getElementById('profile-temperature').value = profile.temperature || 0.7;
     document.getElementById('profile-top-p').value = profile.top_p || 1.0;
-    document.getElementById('profile-max-tokens').value = profile.max_tokens || 100000;
+    document.getElementById('profile-max-tokens').value = profile.max_tokens || '';
     document.getElementById('profile-context-window').value = profile.context_window || '';
     delete document.getElementById('profile-context-window').dataset.autofilledModel;
     document.getElementById('profile-connect-timeout').value = profile.connect_timeout_seconds || 15;
@@ -240,7 +240,8 @@ async function handleSaveProfile() {
     const isDefault = document.getElementById('profile-is-default').checked;
     const temperature = parseFloat(document.getElementById('profile-temperature').value) || 0.7;
     const topP = parseFloat(document.getElementById('profile-top-p').value) || 1.0;
-    const maxTokens = parseInt(document.getElementById('profile-max-tokens').value) || 100000;
+    const maxTokensValue = String(document.getElementById('profile-max-tokens').value || '').trim();
+    const maxTokens = maxTokensValue ? parseInt(maxTokensValue) || null : null;
     const contextWindowValue = String(
         document.getElementById('profile-context-window').value || '',
     ).trim();
@@ -275,10 +276,12 @@ async function handleSaveProfile() {
         is_default: isDefault,
         temperature: temperature,
         top_p: topP,
-        max_tokens: maxTokens,
         context_window: contextWindow,
         connect_timeout_seconds: connectTimeoutSeconds,
     };
+    if (maxTokens !== null) {
+        profile.max_tokens = maxTokens;
+    }
     if (sslVerify !== null) {
         profile.ssl_verify = sslVerify;
     }
@@ -430,7 +433,8 @@ function buildDraftProbePayload() {
     const apiKey = readDraftApiKeyValue();
     const temperature = parseFloat(document.getElementById('profile-temperature').value) || 0.7;
     const topP = parseFloat(document.getElementById('profile-top-p').value) || 1.0;
-    const maxTokens = parseInt(document.getElementById('profile-max-tokens').value) || 100000;
+    const maxTokensValue = String(document.getElementById('profile-max-tokens').value || '').trim();
+    const maxTokens = maxTokensValue ? parseInt(maxTokensValue) || null : null;
     const connectTimeoutSeconds = parseFloat(document.getElementById('profile-connect-timeout').value) || 15;
     const sslVerify = parseTriStateValue(document.getElementById('profile-ssl-verify').value);
 
@@ -449,8 +453,10 @@ function buildDraftProbePayload() {
         base_url: baseUrl,
         temperature: temperature,
         top_p: topP,
-        max_tokens: maxTokens,
     };
+    if (maxTokens !== null) {
+        override.max_tokens = maxTokens;
+    }
     if (sslVerify !== null) {
         override.ssl_verify = sslVerify;
     }

--- a/src/agent_teams/agents/execution/conversation_compaction.py
+++ b/src/agent_teams/agents/execution/conversation_compaction.py
@@ -376,7 +376,10 @@ class ConversationCompactionService:
         )
 
     def _model_settings(self) -> OpenAIChatModelSettings:
-        max_tokens = min(self._config.sampling.max_tokens, 400)
+        configured_max_tokens = self._config.sampling.max_tokens
+        max_tokens = (
+            400 if configured_max_tokens is None else min(configured_max_tokens, 400)
+        )
         return {
             "temperature": min(self._config.sampling.temperature, 0.2),
             "top_p": self._config.sampling.top_p,

--- a/src/agent_teams/agents/execution/llm_session.py
+++ b/src/agent_teams/agents/execution/llm_session.py
@@ -1907,17 +1907,19 @@ class AgentLlmSession:
             "openai_continuous_usage_stats": True,
             "temperature": self._config.sampling.temperature,
             "top_p": self._config.sampling.top_p,
-            "max_tokens": self._safe_max_output_tokens(
-                request=request,
-                history=history,
-                system_prompt=system_prompt,
-                reserve_user_prompt_tokens=reserve_user_prompt_tokens,
-                allowed_tools=allowed_tools,
-                allowed_mcp_servers=allowed_mcp_servers,
-                allowed_skills=allowed_skills,
-                estimated_mcp_context_tokens=estimated_mcp_context_tokens,
-            ),
         }
+        max_tokens = self._safe_max_output_tokens(
+            request=request,
+            history=history,
+            system_prompt=system_prompt,
+            reserve_user_prompt_tokens=reserve_user_prompt_tokens,
+            allowed_tools=allowed_tools,
+            allowed_mcp_servers=allowed_mcp_servers,
+            allowed_skills=allowed_skills,
+            estimated_mcp_context_tokens=estimated_mcp_context_tokens,
+        )
+        if max_tokens is not None:
+            model_settings["max_tokens"] = max_tokens
         if request.thinking.enabled and request.thinking.effort is not None:
             model_settings["openai_reasoning_effort"] = request.thinking.effort
         return model_settings
@@ -1933,8 +1935,10 @@ class AgentLlmSession:
         allowed_mcp_servers: tuple[str, ...],
         allowed_skills: tuple[str, ...],
         estimated_mcp_context_tokens: int | None = None,
-    ) -> int:
+    ) -> int | None:
         configured_max_tokens = self._config.sampling.max_tokens
+        if configured_max_tokens is None:
+            return None
         context_window = self._config.context_window
         if context_window is None or context_window <= 0:
             return configured_max_tokens

--- a/src/agent_teams/agents/execution/subagent_reflection.py
+++ b/src/agent_teams/agents/execution/subagent_reflection.py
@@ -261,7 +261,10 @@ class SubagentReflectionService:
         )
 
     def _model_settings(self) -> OpenAIChatModelSettings:
-        max_tokens = min(self._config.sampling.max_tokens, 400)
+        configured_max_tokens = self._config.sampling.max_tokens
+        max_tokens = (
+            400 if configured_max_tokens is None else min(configured_max_tokens, 400)
+        )
         return {
             "temperature": min(self._config.sampling.temperature, 0.2),
             "top_p": self._config.sampling.top_p,

--- a/src/agent_teams/external_agents/provider.py
+++ b/src/agent_teams/external_agents/provider.py
@@ -1346,13 +1346,14 @@ def _build_opencode_limit(
     fallback_context_window: int | None = None,
 ) -> dict[str, int] | None:
     context_window = model_config.context_window
+    max_tokens = model_config.sampling.max_tokens
     if context_window is None:
         context_window = fallback_context_window
-    if context_window is None or model_config.sampling.max_tokens <= 0:
+    if context_window is None or max_tokens is None or max_tokens <= 0:
         return None
     return {
         "context": context_window,
-        "output": model_config.sampling.max_tokens,
+        "output": max_tokens,
     }
 
 

--- a/src/agent_teams/gateway/gateway_model_profile_override.py
+++ b/src/agent_teams/gateway/gateway_model_profile_override.py
@@ -139,11 +139,7 @@ class GatewayModelProfileOverride(BaseModel):
                     else sampling_defaults.temperature
                 ),
                 top_p=self.top_p if self.top_p is not None else sampling_defaults.top_p,
-                max_tokens=(
-                    self.max_tokens
-                    if self.max_tokens is not None
-                    else sampling_defaults.max_tokens
-                ),
+                max_tokens=self.max_tokens,
                 top_k=sampling_defaults.top_k,
             ),
         )

--- a/src/agent_teams/interfaces/server/routers/system.py
+++ b/src/agent_teams/interfaces/server/routers/system.py
@@ -144,7 +144,7 @@ class ModelProfileRequest(BaseModel):
     ssl_verify: bool | None = None
     temperature: float = 0.7
     top_p: float = 1.0
-    max_tokens: int = 100000
+    max_tokens: int | None = None
     context_window: int | None = None
     connect_timeout_seconds: float = DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS
 
@@ -162,10 +162,11 @@ def save_model_profile(
             "base_url": req.base_url,
             "temperature": req.temperature,
             "top_p": req.top_p,
-            "max_tokens": req.max_tokens,
             "context_window": req.context_window,
             "connect_timeout_seconds": req.connect_timeout_seconds,
         }
+        if "max_tokens" in req.model_fields_set:
+            profile["max_tokens"] = req.max_tokens
         if req.is_default is not None:
             profile["is_default"] = req.is_default
         if req.ssl_verify is not None:

--- a/src/agent_teams/providers/model_config.py
+++ b/src/agent_teams/providers/model_config.py
@@ -25,7 +25,7 @@ class SamplingConfig(BaseModel):
 
     temperature: float = Field(default=0.2, ge=0.0, le=2.0)
     top_p: float = Field(default=1.0, ge=0.0, le=1.0)
-    max_tokens: int = Field(default=1024, ge=1)
+    max_tokens: int | None = Field(default=None, ge=1)
     top_k: int | None = Field(default=None, ge=1)
 
 

--- a/src/agent_teams/providers/model_config_manager.py
+++ b/src/agent_teams/providers/model_config_manager.py
@@ -71,7 +71,7 @@ class ModelConfigManager:
                 "ssl_verify": normalized_profile.get("ssl_verify"),
                 "temperature": normalized_profile.get("temperature", 0.7),
                 "top_p": normalized_profile.get("top_p", 1.0),
-                "max_tokens": normalized_profile.get("max_tokens", 100000),
+                "max_tokens": normalized_profile.get("max_tokens"),
                 "context_window": normalized_profile.get("context_window"),
                 "is_default": name == default_profile_name,
                 "connect_timeout_seconds": normalized_profile.get(
@@ -116,6 +116,8 @@ class ModelConfigManager:
             next_profile=cast(dict[str, JsonValue], config[name]),
             source_name=source_name,
         )
+        if cast(dict[str, JsonValue], config[name]).get("max_tokens") is None:
+            cast(dict[str, JsonValue], config[name]).pop("max_tokens", None)
         if source_name is not None and source_name != name:
             config.pop(source_name, None)
         _normalize_default_profile_flags(config, preferred_name=name)

--- a/src/agent_teams/providers/model_connectivity.py
+++ b/src/agent_teams/providers/model_connectivity.py
@@ -246,9 +246,7 @@ class ModelConnectivityProbeService:
                         else 0.2
                     ),
                     top_p=override.top_p if override.top_p is not None else 1.0,
-                    max_tokens=(
-                        override.max_tokens if override.max_tokens is not None else 1
-                    ),
+                    max_tokens=override.max_tokens,
                 ),
             )
 

--- a/src/agent_teams/sessions/runs/runtime_config.py
+++ b/src/agent_teams/sessions/runs/runtime_config.py
@@ -191,7 +191,7 @@ def load_llm_profile_state(
 
         temperature = cfg.get("temperature", 0.2)
         top_p = cfg.get("top_p", 1.0)
-        max_tokens = cfg.get("max_tokens", 1024)
+        max_tokens = cfg.get("max_tokens")
         top_k = cfg.get("top_k")
         context_window_raw = cfg.get("context_window")
         ssl_verify = _coerce_optional_ssl_verify(

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -314,7 +314,8 @@ console.log(JSON.stringify({
         "Fetch the endpoint catalog for quick selection, or enter a model name manually."
         not in modal_html
     )
-    assert 'value="100000"' in modal_html
+    assert 'id="profile-max-tokens" value=""' in modal_html
+    assert 'placeholder="Optional"' in modal_html
     assert "Max Tokens</label>" not in modal_html
     assert ">Test</button>" in modal_html
     assert ">Test URL</button>" in modal_html

--- a/tests/unit_tests/gateway/test_acp_stdio.py
+++ b/tests/unit_tests/gateway/test_acp_stdio.py
@@ -1787,6 +1787,7 @@ async def test_session_new_stores_model_profile_override_without_persisting_api_
     assert runtime_override.model == "gpt-4.1"
     assert runtime_override.base_url == "https://api.openai.com/v1"
     assert runtime_override.api_key == "sk-secret"
+    assert runtime_override.sampling.max_tokens is None
     assert notifications == []
 
 

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -882,6 +882,50 @@ def test_save_model_profile_allows_missing_api_key_for_edit() -> None:
     assert source_name is None
 
 
+def test_save_model_profile_omits_max_tokens_when_not_provided() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model/profiles/default",
+        json={
+            "provider": ProviderType.OPENAI_COMPATIBLE.value,
+            "model": "kimi-k2.5",
+            "base_url": "https://api.moonshot.cn/v1",
+            "temperature": 1.0,
+            "top_p": 0.95,
+        },
+    )
+
+    assert response.status_code == 200
+    assert service.saved_model_profile is not None
+    _, saved_profile, _ = service.saved_model_profile
+    assert "max_tokens" not in saved_profile
+
+
+def test_save_model_profile_allows_clearing_max_tokens_with_null() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model/profiles/default",
+        json={
+            "provider": ProviderType.OPENAI_COMPATIBLE.value,
+            "model": "kimi-k2.5",
+            "base_url": "https://api.moonshot.cn/v1",
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "max_tokens": None,
+        },
+    )
+
+    assert response.status_code == 200
+    assert service.saved_model_profile is not None
+    _, saved_profile, _ = service.saved_model_profile
+    assert "max_tokens" in saved_profile
+    assert saved_profile["max_tokens"] is None
+
+
 def test_save_model_profile_accepts_bigmodel_provider() -> None:
     service = _FakeSystemService()
     client = _create_test_client(service)

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -863,7 +863,9 @@ async def test_generate_counts_current_user_prompt_in_context_budget(
     assert isinstance(settings_obj, dict)
     bounded_max_tokens = settings_obj.get("max_tokens")
     assert isinstance(bounded_max_tokens, int)
-    assert 1 <= bounded_max_tokens < provider._config.sampling.max_tokens
+    configured_max_tokens = provider._config.sampling.max_tokens
+    assert isinstance(configured_max_tokens, int)
+    assert 1 <= bounded_max_tokens < configured_max_tokens
 
 
 def test_safe_max_output_tokens_does_not_double_count_persisted_user_prompt(
@@ -1041,6 +1043,8 @@ async def test_generate_recomputes_budget_after_injection_restart(
         allowed_mcp_servers=(),
         allowed_skills=(),
     )
+    assert isinstance(first_budget, int)
+    assert isinstance(second_budget, int)
     assert second_budget < first_budget
 
 
@@ -1187,6 +1191,8 @@ async def test_generate_recovery_does_not_rereserve_original_user_prompt_tokens(
         allowed_skills=(),
     )
 
+    assert isinstance(expected_without_rereserve, int)
+    assert isinstance(expected_with_rereserve, int)
     assert captured_model_settings[1]["max_tokens"] == expected_without_rereserve
     assert expected_without_rereserve > expected_with_rereserve
 
@@ -1360,6 +1366,8 @@ async def test_generate_reserves_context_for_registered_tools_and_skills(
         allowed_mcp_servers=(),
         allowed_skills=(),
     )
+    assert isinstance(capped_with_tools, int)
+    assert isinstance(uncapped_without_tools, int)
     assert capped_with_tools < uncapped_without_tools
     assert bounded_max_tokens == capped_with_tools
 
@@ -1567,6 +1575,55 @@ async def test_generate_passes_reasoning_effort_when_thinking_enabled(
     settings_obj = captured_kwargs.get("model_settings")
     assert isinstance(settings_obj, dict)
     assert settings_obj.get("openai_reasoning_effort") == "high"
+
+
+@pytest.mark.asyncio
+async def test_generate_omits_max_tokens_when_config_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    fake_hub = _FakeRunEventHub()
+    provider, _message_repo = _build_provider(
+        tmp_path / "unset_max_tokens.db", fake_hub
+    )
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_builder(**kwargs: object) -> _FakeAgent:
+        captured_kwargs.update(kwargs)
+        return fake_agent
+
+    monkeypatch.setattr(llm_module, "build_coordination_agent", _fake_builder)
+
+    request = LLMRequest(
+        run_id="run-unset-max-tokens",
+        trace_id="run-unset-max-tokens",
+        task_id="task-unset-max-tokens",
+        session_id="session-unset-max-tokens",
+        workspace_id="default",
+        instance_id="inst-unset-max-tokens",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="current turn",
+    )
+
+    _ = await provider.generate(request)
+
+    settings_obj = captured_kwargs.get("model_settings")
+    assert isinstance(settings_obj, dict)
+    assert "max_tokens" not in settings_obj
+    assert (
+        provider._session._safe_max_output_tokens(
+            request=request,
+            history=[],
+            system_prompt="system",
+            reserve_user_prompt_tokens=True,
+            allowed_tools=(),
+            allowed_mcp_servers=(),
+            allowed_skills=(),
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_model_config_manager.py
+++ b/tests/unit_tests/providers/test_model_config_manager.py
@@ -182,6 +182,7 @@ def test_get_model_profiles_uses_default_connect_timeout_when_missing(
         profiles["default"]["connect_timeout_seconds"]
         == DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS
     )
+    assert profiles["default"]["max_tokens"] is None
 
 
 def test_get_model_profiles_infers_known_context_window_when_missing(
@@ -206,6 +207,28 @@ def test_get_model_profiles_infers_known_context_window_when_missing(
     profiles = manager.get_model_profiles()
 
     assert profiles["default"]["context_window"] == 128000
+
+
+def test_save_model_profile_omits_max_tokens_when_unset(tmp_path: Path) -> None:
+    manager = ModelConfigManager(config_dir=tmp_path)
+
+    manager.save_model_profile(
+        "default",
+        {
+            "provider": "openai_compatible",
+            "model": "gpt-4.1",
+            "base_url": "https://example.test/v1",
+            "api_key": "secret-key",
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "max_tokens": None,
+        },
+    )
+
+    config = manager.get_model_config()
+    saved_profile = cast(dict[str, JsonValue], config["default"])
+
+    assert "max_tokens" not in saved_profile
 
 
 def test_delete_model_profile_removes_entry(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove implicit max token defaults from the main runtime, ACP overrides, and profile persistence
- omit max token request fields when they are unset so providers choose the default output cap
- keep probe and internal compaction/reflection safety caps while updating UI/docs/tests for nullable max token settings

Fixes #245

## Validation
- uv run --extra dev pytest -q tests/unit_tests/providers/test_llm_multi_turn_prompt.py tests/unit_tests/providers/test_model_config_manager.py tests/unit_tests/interfaces/server/test_system_router.py tests/unit_tests/gateway/test_acp_stdio.py tests/unit_tests/frontend/test_settings_shell_ui.py tests/unit_tests/frontend/test_model_profiles_ui.py tests/unit_tests/frontend/test_settings_accessibility_ui.py
- uv run --extra dev ruff check src/agent_teams/providers/model_config.py src/agent_teams/sessions/runs/runtime_config.py src/agent_teams/gateway/gateway_model_profile_override.py src/agent_teams/agents/execution/llm_session.py src/agent_teams/providers/model_config_manager.py src/agent_teams/interfaces/server/routers/system.py src/agent_teams/external_agents/provider.py src/agent_teams/providers/model_connectivity.py src/agent_teams/agents/execution/conversation_compaction.py src/agent_teams/agents/execution/subagent_reflection.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py tests/unit_tests/providers/test_model_config_manager.py tests/unit_tests/interfaces/server/test_system_router.py tests/unit_tests/gateway/test_acp_stdio.py tests/unit_tests/frontend/test_settings_shell_ui.py
- uv run --extra dev basedpyright src/agent_teams/providers/model_config.py src/agent_teams/sessions/runs/runtime_config.py src/agent_teams/gateway/gateway_model_profile_override.py src/agent_teams/agents/execution/llm_session.py src/agent_teams/providers/model_config_manager.py src/agent_teams/interfaces/server/routers/system.py src/agent_teams/external_agents/provider.py src/agent_teams/providers/model_connectivity.py src/agent_teams/agents/execution/conversation_compaction.py src/agent_teams/agents/execution/subagent_reflection.py