### PR TITLE
Handle tool input validation failures without ending runs

### DIFF
--- a/src/agent_teams/agents/execution/llm_session.py
+++ b/src/agent_teams/agents/execution/llm_session.py
@@ -571,6 +571,7 @@ class AgentLlmSession:
                                 history,
                                 buffered_messages,
                                 committed_tool_events_published,
+                                committed_tool_validation_failures,
                             ) = self._commit_ready_messages(
                                 request=request,
                                 history=history,
@@ -580,6 +581,23 @@ class AgentLlmSession:
                                 attempt_tool_event_emitted = True
                             if len(history) > previous_history_size:
                                 attempt_messages_committed = True
+                            if committed_tool_validation_failures:
+                                log_event(
+                                    LOGGER,
+                                    logging.INFO,
+                                    event="llm.tool_input_validation.continue_after_failure",
+                                    message=(
+                                        "Restarting agent iteration after tool input validation failure"
+                                    ),
+                                    payload={
+                                        "role_id": request.role_id,
+                                        "instance_id": request.instance_id,
+                                    },
+                                )
+                                seen_count = 0
+                                buffered_messages = []
+                                restarted = True
+                                break
                         seen_count += len(new_batch)
 
                         # Drain pending user injections at this boundary (already handled in previous version, check if needed here)
@@ -698,6 +716,7 @@ class AgentLlmSession:
                         history,
                         buffered_messages,
                         committed_tool_events_published,
+                        _committed_tool_validation_failures,
                     ) = self._commit_all_safe_messages(
                         request=request,
                         history=history,
@@ -2217,11 +2236,16 @@ class AgentLlmSession:
         list[ModelRequest | ModelResponse],
         list[ModelRequest | ModelResponse],
         bool,
+        bool,
     ]:
         safe_index = self._last_committable_index(pending_messages)
         if safe_index <= 0:
-            return history, pending_messages, False
-        ready = self._normalize_committable_messages(pending_messages[:safe_index])
+            return history, pending_messages, False, False
+        raw_ready = pending_messages[:safe_index]
+        committed_tool_validation_failures = self._has_tool_input_validation_failures(
+            raw_ready
+        )
+        ready = self._normalize_committable_messages(raw_ready)
         self._message_repo.append(
             session_id=request.session_id,
             workspace_id=self._workspace_id(request),
@@ -2245,6 +2269,7 @@ class AgentLlmSession:
             next_history,
             pending_messages[safe_index:],
             self._has_tool_side_effect_messages(ready),
+            committed_tool_validation_failures,
         )
 
     def _commit_all_safe_messages(
@@ -2257,10 +2282,12 @@ class AgentLlmSession:
         list[ModelRequest | ModelResponse],
         list[ModelRequest | ModelResponse],
         bool,
+        bool,
     ]:
         next_history = history
         remaining = list(pending_messages)
         tool_events_published = False
+        tool_validation_failures_committed = False
         while remaining:
             safe_index = self._last_committable_index(remaining)
             if safe_index <= 0:
@@ -2269,6 +2296,7 @@ class AgentLlmSession:
                 next_history,
                 remaining,
                 committed_tool_events_published,
+                committed_tool_validation_failures,
             ) = self._commit_ready_messages(
                 request=request,
                 history=next_history,
@@ -2276,7 +2304,26 @@ class AgentLlmSession:
             )
             if committed_tool_events_published:
                 tool_events_published = True
-        return next_history, remaining, tool_events_published
+            if committed_tool_validation_failures:
+                tool_validation_failures_committed = True
+        return (
+            next_history,
+            remaining,
+            tool_events_published,
+            tool_validation_failures_committed,
+        )
+
+    @staticmethod
+    def _has_tool_input_validation_failures(
+        messages: Sequence[ModelRequest | ModelResponse],
+    ) -> bool:
+        for message in messages:
+            if not isinstance(message, ModelRequest):
+                continue
+            for part in message.parts:
+                if isinstance(part, RetryPromptPart) and part.tool_name:
+                    return True
+        return False
 
     def _normalize_committable_messages(
         self,

--- a/src/agent_teams/tools/runtime/execution.py
+++ b/src/agent_teams/tools/runtime/execution.py
@@ -283,7 +283,7 @@ def _error_payload(exc: Exception) -> ToolError:
 
     if isinstance(exc, ValueError):
         err_type = "validation_error"
-        retryable = True
+        retryable = False
     elif isinstance(exc, KeyError):
         err_type = "not_found"
         retryable = True

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -17,6 +17,7 @@ from pydantic_ai.messages import (
     PartDeltaEvent,
     PartEndEvent,
     PartStartEvent,
+    RetryPromptPart,
     TextPartDelta,
     TextPart,
     ThinkingPart,
@@ -2951,6 +2952,102 @@ async def test_generate_bounds_repeated_streamed_tool_call_parse_recovery(
     assert len(scripted_agent.histories) == 2
     event_types = [event.event_type for event in fake_hub.events]
     assert RunEventType.LLM_RETRY_SCHEDULED not in event_types
+
+
+@pytest.mark.asyncio
+async def test_generate_continues_after_tool_input_validation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "tool_input_validation_continue.db",
+        fake_hub,
+    )
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[object()],
+                messages_by_step=[
+                    [
+                        ModelResponse(
+                            parts=[
+                                ToolCallPart(
+                                    tool_name="write",
+                                    args={"content": "broken"},
+                                    tool_call_id="call-invalid-write",
+                                )
+                            ]
+                        ),
+                        ModelRequest(
+                            parts=[
+                                RetryPromptPart(
+                                    tool_name="write",
+                                    tool_call_id="call-invalid-write",
+                                    content="Field required: path",
+                                )
+                            ]
+                        ),
+                    ]
+                ],
+                result=_ScriptedResult(response="unused", messages=[]),
+            ),
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(parts=[TextPart(content="continued")]),
+                    messages=[ModelResponse(parts=[TextPart(content="continued")])],
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+    request = LLMRequest(
+        run_id="run-tool-input-validation-continue",
+        trace_id="run-tool-input-validation-continue",
+        task_id="task-tool-input-validation-continue",
+        session_id="session-tool-input-validation-continue",
+        workspace_id="default",
+        instance_id="inst-tool-input-validation-continue",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="continue",
+    )
+
+    result = await provider.generate(request)
+
+    assert result == "continued"
+    assert len(scripted_agent.histories) == 2
+    second_history = scripted_agent.histories[1]
+    normalized_tool_errors = [
+        part
+        for message in second_history
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+    assert len(normalized_tool_errors) == 1
+    assert normalized_tool_errors[0].tool_call_id == "call-invalid-write"
+    assert isinstance(normalized_tool_errors[0].content, dict)
+    error_result = cast(dict[str, object], normalized_tool_errors[0].content)
+    assert error_result["ok"] is False
+    error_payload = cast(dict[str, object], error_result["error"])
+    assert error_payload["code"] == "tool_input_validation_failed"
+    assert error_payload["message"] == "Field required: path"
+    event_types = [event.event_type for event in fake_hub.events]
+    assert RunEventType.TOOL_RESULT in event_types
+    assert RunEventType.TOOL_INPUT_VALIDATION_FAILED not in event_types
+    history = message_repo.get_history("inst-tool-input-validation-continue")
+    assert any(
+        isinstance(message, ModelRequest)
+        and any(isinstance(part, ToolReturnPart) for part in message.parts)
+        for message in history
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_llm_tool_events.py
+++ b/tests/unit_tests/providers/test_llm_tool_events.py
@@ -263,25 +263,28 @@ def test_commit_ready_messages_defers_tool_call_event_until_safe_commit() -> Non
         cast(object, fake_repo),
     )
 
-    history, pending, tool_events_published = provider._session._commit_ready_messages(
-        request=_request(),
-        history=[],
-        pending_messages=[
-            ModelResponse(
-                parts=[
-                    ToolCallPart(
-                        tool_name="create_tasks",
-                        args={"objective": "x"},
-                        tool_call_id="call-unsafe",
-                    )
-                ]
-            )
-        ],
+    history, pending, tool_events_published, committed_tool_validation_failures = (
+        provider._session._commit_ready_messages(
+            request=_request(),
+            history=[],
+            pending_messages=[
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(
+                            tool_name="create_tasks",
+                            args={"objective": "x"},
+                            tool_call_id="call-unsafe",
+                        )
+                    ]
+                )
+            ],
+        )
     )
 
     assert history == []
     assert len(pending) == 1
     assert tool_events_published is False
+    assert committed_tool_validation_failures is False
     assert hub.events == []
 
 
@@ -294,34 +297,37 @@ def test_commit_ready_messages_publishes_only_tool_outcomes_after_safe_commit() 
         cast(object, fake_repo),
     )
 
-    history, pending, tool_events_published = provider._session._commit_ready_messages(
-        request=_request(),
-        history=[],
-        pending_messages=[
-            ModelResponse(
-                parts=[
-                    ToolCallPart(
-                        tool_name="create_tasks",
-                        args={"objective": "x"},
-                        tool_call_id="call-safe",
-                    )
-                ]
-            ),
-            ModelRequest(
-                parts=[
-                    ToolReturnPart(
-                        tool_name="create_tasks",
-                        content={"ok": True},
-                        tool_call_id="call-safe",
-                    )
-                ]
-            ),
-        ],
+    history, pending, tool_events_published, committed_tool_validation_failures = (
+        provider._session._commit_ready_messages(
+            request=_request(),
+            history=[],
+            pending_messages=[
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(
+                            tool_name="create_tasks",
+                            args={"objective": "x"},
+                            tool_call_id="call-safe",
+                        )
+                    ]
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            tool_name="create_tasks",
+                            content={"ok": True},
+                            tool_call_id="call-safe",
+                        )
+                    ]
+                ),
+            ],
+        )
     )
 
     assert len(history) == 2
     assert pending == []
     assert tool_events_published is True
+    assert committed_tool_validation_failures is False
     assert [event.event_type for event in hub.events] == [RunEventType.TOOL_RESULT]
 
 

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -373,6 +373,29 @@ def test_execute_tool_preserves_custom_tool_error_details() -> None:
     }
 
 
+def test_execute_tool_marks_value_error_as_non_retryable() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-validation-error-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="write",
+            args_summary={"path": "notes.txt"},
+            action=lambda: (_ for _ in ()).throw(ValueError("missing path")),
+        )
+    )
+
+    error = cast(dict[str, JsonValue], result["error"])
+    assert result["ok"] is False
+    assert error["type"] == "validation_error"
+    assert error["retryable"] is False
+
+
 def _raise_tool_execution_error() -> object:
     raise ToolExecutionError(
         error_type="source_access_denied",

--- a/tests/unit_tests/tools/runtime/test_models.py
+++ b/tests/unit_tests/tools/runtime/test_models.py
@@ -39,7 +39,7 @@ def test_tool_result_envelope_serializes_nested_error() -> None:
     error = ToolError(
         type="validation_error",
         message="bad input",
-        retryable=True,
+        retryable=False,
     )
 
     envelope = ToolResultEnvelope(
@@ -52,7 +52,7 @@ def test_tool_result_envelope_serializes_nested_error() -> None:
     assert payload["error"] == {
         "type": "validation_error",
         "message": "bad input",
-        "retryable": True,
+        "retryable": False,
     }
 
 


### PR DESCRIPTION
## Summary
- convert committed tool input validation failures into failed tool results and restart the agent iteration from persisted history
- keep the run alive so the next model turn can recover from `tool_input_validation_failed`
- mark `ValueError` tool envelopes as non-retryable and add regression coverage

## Validation
- `uv run --extra dev pytest -q tests/unit_tests/providers/test_llm_multi_turn_prompt.py tests/unit_tests/providers/test_llm_tool_events.py tests/unit_tests/tools/runtime/test_execution.py tests/unit_tests/tools/runtime/test_models.py`
- `uv run --extra dev pytest -q tests/integration_tests`
- `uv run --extra dev ruff check src/agent_teams/agents/execution/llm_session.py src/agent_teams/tools/runtime/execution.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py tests/unit_tests/providers/test_llm_tool_events.py tests/unit_tests/tools/runtime/test_execution.py tests/unit_tests/tools/runtime/test_models.py`
- `uv run --extra dev basedpyright src/agent_teams/agents/execution/llm_session.py src/agent_teams/tools/runtime/execution.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py tests/unit_tests/providers/test_llm_tool_events.py tests/unit_tests/tools/runtime/test_execution.py tests/unit_tests/tools/runtime/test_models.py`

Fixes #254