### PR TITLE
Add current date to runtime environment prompt

### DIFF
--- a/src/agent_teams/agents/execution/system_prompts.py
+++ b/src/agent_teams/agents/execution/system_prompts.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import date
 import os
 import platform
 from collections.abc import Sequence
@@ -119,6 +120,7 @@ def build_environment_info_prompt(*, working_directory: Path | None = None) -> s
     """Gather current runtime environment information for the system prompt.
     Linked with the workspace command runtime to ensure consistency.
     """
+    current_date = date.today().isoformat()
     system = platform.system()
     release = platform.release()
     machine = platform.machine()
@@ -136,6 +138,7 @@ def build_environment_info_prompt(*, working_directory: Path | None = None) -> s
 
     lines = [
         "## Runtime Environment Information",
+        f"- Current Date: {current_date}",
         f"- Operating System: {system} ({release}) {machine}",
         f"- Working Directory: {cwd}",
         f"- Shell Type: {shell_info} (Path: {shell_path})",

--- a/tests/unit_tests/agents/execution/test_prompts.py
+++ b/tests/unit_tests/agents/execution/test_prompts.py
@@ -379,6 +379,29 @@ def test_runtime_environment_prompt_uses_runtime_shell_summary(
     assert "powershell.exe" in prompt
 
 
+def test_runtime_environment_prompt_includes_current_date_without_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeDate:
+        @staticmethod
+        def today() -> object:
+            return type("_IsoDate", (), {"isoformat": lambda self: "2026-04-02"})()
+
+    monkeypatch.setattr(system_prompts, "date", _FakeDate)
+    monkeypatch.setattr(
+        system_prompts,
+        "_get_github_cli_environment_status",
+        lambda: (False, None),
+    )
+
+    prompt = system_prompts.build_environment_info_prompt(
+        working_directory=Path("/tmp/project")
+    )
+
+    assert "- Current Date: 2026-04-02" in prompt
+    assert "2026-04-02T" not in prompt
+
+
 def test_runtime_system_prompt_layers_keep_base_instructions_before_workspace_context() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- add the current local date to the runtime environment prompt
- keep the value date-only in YYYY-MM-DD format
- cover the new prompt field with a unit test

## Validation
- uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_prompts.py`n- uv run --extra dev ruff check --fix`n- uv run --extra dev ruff format --no-cache --force-exclude`n- uv run --extra dev basedpyright`n
Closes #256