### PR TITLE
Fix system prompt replay and add runtime date context

### DIFF
--- a/src/agent_teams/agents/execution/llm_session.py
+++ b/src/agent_teams/agents/execution/llm_session.py
@@ -44,6 +44,9 @@ from agent_teams.providers.model_config import LlmRetryConfig, ModelEndpointConf
 from agent_teams.providers.openai_model_profiles import (
     resolve_openai_chat_model_profile,
 )
+from agent_teams.agents.execution.tool_call_history import (
+    clone_model_request_with_parts,
+)
 from agent_teams.sessions.runs.enums import RunEventType
 from agent_teams.sessions.runs.event_log import EventLog
 from agent_teams.sessions.runs.assistant_errors import (
@@ -2353,7 +2356,7 @@ class AgentLlmSession:
                     continue
                 next_parts.append(part)
             if changed:
-                normalized.append(ModelRequest(parts=next_parts))
+                normalized.append(clone_model_request_with_parts(message, next_parts))
                 continue
             normalized.append(message)
         return normalized

--- a/src/agent_teams/agents/execution/system_prompts.py
+++ b/src/agent_teams/agents/execution/system_prompts.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta
 import os
 import platform
 from collections.abc import Sequence
@@ -74,6 +75,12 @@ AVAILABLE_SKILLS_HEADING = "## Available Skills"
 AVAILABLE_SKILL_ITEM_PREFIX = "- "
 NONE_LABEL = "none"
 AUTHORIZED_RUNTIME_TOOLS_HEADING = "## Authorized Runtime Tools"
+TIME_TRUST_RULE = (
+    "- Time Trust Rule: Do not trust your internal knowledge for the current date or "
+    "time. When the user asks about today, current, recent, yesterday, tomorrow, or "
+    "this week, use the runtime date in this section as the default source of truth "
+    "and verify with tools when higher precision is needed."
+)
 
 
 class RuntimePromptBuildInput(BaseModel):
@@ -133,17 +140,41 @@ def build_environment_info_prompt(*, working_directory: Path | None = None) -> s
     runtime_shell = describe_runtime_shell()
     shell_info = runtime_shell.shell_info
     shell_path = runtime_shell.shell_path
+    current_date, runtime_timezone = _get_runtime_date_context()
 
     lines = [
         "## Runtime Environment Information",
         f"- Operating System: {system} ({release}) {machine}",
         f"- Working Directory: {cwd}",
         f"- Shell Type: {shell_info} (Path: {shell_path})",
+        f"- Current Date: {current_date}",
+        f"- Runtime Timezone: {runtime_timezone}",
+        TIME_TRUST_RULE,
     ]
     github_line = _build_github_cli_environment_line()
     if github_line:
         lines.append(github_line)
     return "\n".join(lines)
+
+
+def _get_runtime_date_context() -> tuple[str, str]:
+    now = datetime.now().astimezone()
+    current_date = now.date().isoformat()
+    timezone_name = now.tzname() or "local"
+    utc_offset = now.utcoffset()
+    if utc_offset is None:
+        return current_date, timezone_name
+    offset_text = _format_utc_offset(utc_offset)
+    if timezone_name == offset_text:
+        return current_date, f"UTC{offset_text}"
+    return current_date, f"{timezone_name} (UTC{offset_text})"
+
+
+def _format_utc_offset(offset: timedelta) -> str:
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    hours, minutes = divmod(abs(total_minutes), 60)
+    return f"{sign}{hours:02d}:{minutes:02d}"
 
 
 def _build_github_cli_environment_line() -> str | None:

--- a/src/agent_teams/agents/execution/tool_call_history.py
+++ b/src/agent_teams/agents/execution/tool_call_history.py
@@ -16,6 +16,19 @@ from pydantic_ai.messages import (
 ToolResultDropLogger = Callable[[ModelRequestPart, bool], None]
 
 
+def clone_model_request_with_parts(
+    message: ModelRequest,
+    parts: Sequence[ModelRequestPart],
+) -> ModelRequest:
+    return ModelRequest(
+        parts=parts,
+        timestamp=message.timestamp,
+        instructions=message.instructions,
+        run_id=message.run_id,
+        metadata=message.metadata,
+    )
+
+
 def normalize_replayed_messages(
     messages: Sequence[ModelMessage],
     *,
@@ -43,7 +56,9 @@ def normalize_replayed_messages(
             on_drop=on_drop,
         )
         if next_parts:
-            sanitized_messages.append(ModelRequest(parts=next_parts))
+            sanitized_messages.append(
+                clone_model_request_with_parts(message, next_parts)
+            )
     return sanitized_messages
 
 
@@ -116,7 +131,9 @@ def normalize_replayed_messages_against_pending(
             on_drop=on_drop,
         )
         if next_parts:
-            sanitized_messages.append(ModelRequest(parts=next_parts))
+            sanitized_messages.append(
+                clone_model_request_with_parts(message, next_parts)
+            )
     return sanitized_messages
 
 

--- a/tests/unit_tests/agents/execution/test_llm_session.py
+++ b/tests/unit_tests/agents/execution/test_llm_session.py
@@ -2,11 +2,17 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 
 from agent_teams.agents.execution.llm_session import AgentLlmSession
 from agent_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
 from agent_teams.mcp.mcp_registry import McpRegistry
-from pydantic_ai.messages import ModelResponse, ToolCallPart
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    RetryPromptPart,
+    ToolCallPart,
+)
 
 
 def test_maybe_enrich_tool_result_payload_wraps_builtin_computer_results() -> None:
@@ -79,3 +85,30 @@ def test_normalize_tool_call_args_for_replay_updates_live_messages() -> None:
         "background": True,
         "yield_time_ms": None,
     }
+
+
+def test_normalize_committable_messages_keeps_request_fields() -> None:
+    session = object.__new__(AgentLlmSession)
+    request = ModelRequest(
+        parts=[
+            RetryPromptPart(
+                content="validation failed",
+                tool_name="shell",
+                tool_call_id="call-1",
+            )
+        ],
+        timestamp=datetime(2026, 4, 2, 22, 44, 3, tzinfo=UTC),
+        instructions="System instructions",
+        run_id="run-123",
+        metadata={"source": "test"},
+    )
+
+    normalized = AgentLlmSession._normalize_committable_messages(session, [request])
+
+    assert len(normalized) == 1
+    normalized_request = normalized[0]
+    assert isinstance(normalized_request, ModelRequest)
+    assert normalized_request.instructions == "System instructions"
+    assert normalized_request.timestamp == datetime(2026, 4, 2, 22, 44, 3, tzinfo=UTC)
+    assert normalized_request.run_id == "run-123"
+    assert normalized_request.metadata == {"source": "test"}

--- a/tests/unit_tests/agents/execution/test_prompts.py
+++ b/tests/unit_tests/agents/execution/test_prompts.py
@@ -44,6 +44,15 @@ def _suppress_host_github_prompt_line(
     )
 
 
+@pytest.fixture(autouse=True)
+def _freeze_runtime_date_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        system_prompts,
+        "_get_runtime_date_context",
+        lambda: ("2026-04-02", "HKT (UTC+08:00)"),
+    )
+
+
 def _role(role_id: str) -> RoleDefinition:
     tools = ()
     if role_id.casefold() == "coordinator":
@@ -316,6 +325,11 @@ def test_runtime_system_prompt_for_worker_skips_runtime_contract() -> None:
     assert "## Runtime Environment Information" in prompt
     assert "- Operating System:" in prompt
     assert f"- Working Directory: {working_directory.resolve()}" in prompt
+    assert "- Current Date: 2026-04-02" in prompt
+    assert "- Runtime Timezone: HKT (UTC+08:00)" in prompt
+    assert (
+        "Do not trust your internal knowledge for the current date or time." in prompt
+    )
 
 
 def test_runtime_environment_prompt_mentions_github_when_token_and_system_gh_exist(
@@ -335,6 +349,11 @@ def test_runtime_environment_prompt_mentions_github_when_token_and_system_gh_exi
     assert (
         f"- GitHub CLI: token configured; using system gh at {system_gh_path}" in prompt
     )
+    assert "- Current Date: 2026-04-02" in prompt
+    assert "- Runtime Timezone: HKT (UTC+08:00)" in prompt
+    assert (
+        "use the runtime date in this section as the default source of truth" in prompt
+    )
 
 
 def test_runtime_environment_prompt_mentions_on_demand_gh_when_only_token_exists(
@@ -351,6 +370,8 @@ def test_runtime_environment_prompt_mentions_on_demand_gh_when_only_token_exists
     )
 
     assert "- GitHub CLI: token configured; gh will be resolved on demand" in prompt
+    assert "- Current Date: 2026-04-02" in prompt
+    assert "- Runtime Timezone: HKT (UTC+08:00)" in prompt
 
 
 def test_runtime_environment_prompt_uses_runtime_shell_summary(
@@ -377,6 +398,11 @@ def test_runtime_environment_prompt_uses_runtime_shell_summary(
 
     assert "Shell Type: PowerShell" in prompt
     assert "powershell.exe" in prompt
+    assert "- Current Date: 2026-04-02" in prompt
+    assert "- Runtime Timezone: HKT (UTC+08:00)" in prompt
+    assert (
+        "Do not trust your internal knowledge for the current date or time." in prompt
+    )
 
 
 def test_runtime_system_prompt_layers_keep_base_instructions_before_workspace_context() -> (
@@ -409,6 +435,8 @@ def test_runtime_system_prompt_layers_keep_base_instructions_before_workspace_co
     assert "## Available Roles" in result.capability_summary
     assert "## Runtime Environment Information" in result.workspace_context
     assert "## Orchestration Prompt" in result.workspace_context
+    assert "- Current Date: 2026-04-02" in result.workspace_context
+    assert "- Runtime Timezone: HKT (UTC+08:00)" in result.workspace_context
     assert result.prompt.index("## Orchestration Rules") < result.prompt.index(
         "## Available Roles"
     )

--- a/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
+++ b/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import json
+import pytest
 
 from agent_teams.agents.execution.recoverable_openai_chat_model import (
     RecoverableOpenAIChatModel,
 )
+from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
@@ -13,6 +15,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.providers.openai import OpenAIProvider
 
 
 def test_map_tool_call_keeps_valid_json_arguments() -> None:
@@ -165,3 +168,38 @@ def test_sanitize_replayed_messages_drops_duplicate_late_tool_results() -> None:
     assert len(sanitized[2].parts) == 1
     assert isinstance(sanitized[2].parts[0], UserPromptPart)
     assert sanitized[2].parts[0].content == "optimize it"
+
+
+@pytest.mark.asyncio
+async def test_map_messages_keeps_system_message_when_replay_sanitizes_history() -> (
+    None
+):
+    model = RecoverableOpenAIChatModel(
+        "gpt-5.4",
+        provider=OpenAIProvider(base_url="https://example.test/v1", api_key="test"),
+    )
+    messages = [
+        ModelRequest(
+            parts=[UserPromptPart(content="你能使用哪些技能")],
+            instructions="System instructions",
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="write",
+                    tool_call_id="call-missing",
+                    content={"ok": False},
+                )
+            ]
+        ),
+    ]
+
+    mapped = await model._map_messages(messages, ModelRequestParameters())
+
+    system_messages = [
+        message
+        for message in mapped
+        if isinstance(message, dict) and message.get("role") == "system"
+    ]
+    assert len(system_messages) == 1
+    assert system_messages[0].get("content") == "System instructions"

--- a/tests/unit_tests/agents/execution/test_tool_call_history.py
+++ b/tests/unit_tests/agents/execution/test_tool_call_history.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelRequestPart,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from agent_teams.agents.execution.tool_call_history import (
+    normalize_replayed_messages,
+    normalize_replayed_messages_against_pending,
+)
+
+
+def _request_with_metadata(*parts: ModelRequestPart) -> ModelRequest:
+    return ModelRequest(
+        parts=list(parts),
+        timestamp=datetime(2026, 4, 2, 22, 44, 3, tzinfo=UTC),
+        instructions="System instructions",
+        run_id="run-123",
+        metadata={"source": "test"},
+    )
+
+
+def test_normalize_replayed_messages_keeps_request_fields_after_dropping_orphan_tool_results() -> (
+    None
+):
+    messages = [
+        _request_with_metadata(UserPromptPart(content="continue")),
+        _request_with_metadata(
+            ToolReturnPart(
+                tool_name="write",
+                tool_call_id="call-missing",
+                content={"ok": False},
+            )
+        ),
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="write",
+                    args={"content": "hello"},
+                    tool_call_id="call-real",
+                )
+            ]
+        ),
+    ]
+
+    sanitized = normalize_replayed_messages(messages)
+
+    assert len(sanitized) == 2
+    request = sanitized[0]
+    assert isinstance(request, ModelRequest)
+    assert request.instructions == "System instructions"
+    assert request.timestamp == datetime(2026, 4, 2, 22, 44, 3, tzinfo=UTC)
+    assert request.run_id == "run-123"
+    assert request.metadata == {"source": "test"}
+
+
+def test_normalize_replayed_messages_keeps_request_fields_after_dropping_duplicate_tool_results() -> (
+    None
+):
+    messages = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="write",
+                    args={"content": "hello"},
+                    tool_call_id="call-real",
+                )
+            ]
+        ),
+        _request_with_metadata(
+            ToolReturnPart(
+                tool_name="write",
+                tool_call_id="call-real",
+                content={"ok": True},
+            )
+        ),
+        _request_with_metadata(
+            ToolReturnPart(
+                tool_name="write",
+                tool_call_id="call-real",
+                content={"ok": True},
+            ),
+            UserPromptPart(content="optimize it"),
+        ),
+    ]
+
+    sanitized = normalize_replayed_messages(messages)
+
+    assert len(sanitized) == 3
+    request = sanitized[2]
+    assert isinstance(request, ModelRequest)
+    assert len(request.parts) == 1
+    assert isinstance(request.parts[0], UserPromptPart)
+    assert request.parts[0].content == "optimize it"
+    assert request.instructions == "System instructions"
+    assert request.timestamp == datetime(2026, 4, 2, 22, 44, 3, tzinfo=UTC)
+    assert request.run_id == "run-123"
+    assert request.metadata == {"source": "test"}
+
+
+def test_normalize_replayed_messages_against_pending_keeps_request_fields() -> None:
+    pending_tool_call_ids = {"call-real"}
+    seen_tool_call_ids = {"call-real"}
+    messages = [
+        _request_with_metadata(
+            ToolReturnPart(
+                tool_name="write",
+                tool_call_id="call-real",
+                content={"ok": True},
+            ),
+            UserPromptPart(content="continue"),
+        )
+    ]
+
+    sanitized = normalize_replayed_messages_against_pending(
+        messages,
+        pending_tool_call_ids=pending_tool_call_ids,
+        seen_tool_call_ids=seen_tool_call_ids,
+    )
+
+    assert len(sanitized) == 1
+    request = sanitized[0]
+    assert isinstance(request, ModelRequest)
+    assert request.instructions == "System instructions"
+    assert request.timestamp == datetime(2026, 4, 2, 22, 44, 3, tzinfo=UTC)
+    assert request.run_id == "run-123"
+    assert request.metadata == {"source": "test"}


### PR DESCRIPTION
Fixes #256

## Summary
- preserve `ModelRequest` instructions and metadata when replay/normalize paths rebuild requests
- add current local date and timezone to runtime system prompt
- warn the model not to trust its internal knowledge for current time-sensitive questions

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_tool_call_history.py tests/unit_tests/agents/execution/test_llm_session.py tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py`
- `uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_prompts.py`

## Notes
- Windows local `tests/unit_tests` has 3 unrelated existing failures outside the touched areas; PR CI on Ubuntu is the source of truth for merge.