### PR TITLE
Bind shell subprocesses to a stable Python runtime

### DIFF
--- a/src/agent_teams/env/__init__.py
+++ b/src/agent_teams/env/__init__.py
@@ -40,6 +40,11 @@ from agent_teams.env.github_connectivity import (
     GitHubConnectivityProbeResult,
     GitHubConnectivityProbeService,
 )
+from agent_teams.env.python_env import (
+    AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY,
+    bind_subprocess_python_env,
+    resolve_subprocess_python_executable,
+)
 from agent_teams.env.github_env import (
     GH_NO_EXTENSION_UPDATE_NOTIFIER_ENV_KEY,
     GH_NO_UPDATE_NOTIFIER_ENV_KEY,
@@ -88,6 +93,7 @@ __all__ = [
     "ProxyConfigService",
     "apply_proxy_env_to_process_env",
     "build_subprocess_env",
+    "bind_subprocess_python_env",
     "extract_proxy_env_vars",
     "build_github_cli_env",
     "get_app_env_file_path",
@@ -104,9 +110,11 @@ __all__ = [
     "parse_no_proxy_rules",
     "proxy_applies_to_url",
     "resolve_proxy_env_config",
+    "resolve_subprocess_python_executable",
     "normalize_github_token",
     "resolve_github_token_from_env",
     "sync_proxy_env_to_process_env",
+    "AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY",
     "WebConnectivityProbeDiagnostics",
     "WebConnectivityProbeRequest",
     "WebConnectivityProbeResult",

--- a/src/agent_teams/env/python_env.py
+++ b/src/agent_teams/env/python_env.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Mapping
+import os
+from pathlib import Path
+import shutil
+import sys
+
+AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY = "AGENT_TEAMS_PYTHON_EXECUTABLE"
+
+
+def bind_subprocess_python_env(env: Mapping[str, str]) -> dict[str, str]:
+    bound_env = dict(env)
+    python_executable = resolve_subprocess_python_executable(bound_env)
+    bound_env[AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY] = str(python_executable)
+    bound_env["PATH"] = _prepend_to_path(
+        bound_env.get("PATH"), python_executable.parent
+    )
+    return bound_env
+
+
+def resolve_subprocess_python_executable(env: Mapping[str, str]) -> Path:
+    search_path = env.get("PATH")
+    resolved_python = (
+        None if search_path is None else shutil.which("python", path=search_path)
+    )
+    if resolved_python:
+        return Path(resolved_python).expanduser().resolve()
+    return Path(sys.executable).expanduser().resolve()
+
+
+def _prepend_to_path(existing_path: str | None, directory: Path) -> str:
+    directory_str = str(directory)
+    if existing_path:
+        path_parts = existing_path.split(os.pathsep)
+        if path_parts and _normalize_path_entry(path_parts[0]) == _normalize_path_entry(
+            directory_str
+        ):
+            return existing_path
+        return os.pathsep.join((directory_str, existing_path))
+    return directory_str
+
+
+def _normalize_path_entry(path_entry: str) -> str:
+    normalized = path_entry.strip().strip('"')
+    if not normalized:
+        return ""
+    return os.path.normcase(os.path.normpath(str(Path(normalized).expanduser())))

--- a/src/agent_teams/sessions/runs/background_tasks/command_runtime.py
+++ b/src/agent_teams/sessions/runs/background_tasks/command_runtime.py
@@ -18,7 +18,12 @@ from typing import IO, Callable, Protocol, cast
 
 from pydantic import BaseModel, ConfigDict
 
-from agent_teams.env import build_github_cli_env, build_subprocess_env, get_env_var
+from agent_teams.env import (
+    build_github_cli_env,
+    build_subprocess_env,
+    bind_subprocess_python_env,
+    get_env_var,
+)
 from agent_teams.env.github_config_service import GitHubConfigService
 from agent_teams.env.runtime_env import get_app_config_dir
 from agent_teams.sessions.runs.background_tasks.github_cli import get_gh_path
@@ -627,6 +632,7 @@ async def build_command_env(
     gh_path = await _resolve_gh_path()
     if gh_path is not None:
         command_env["PATH"] = _prepend_to_path(command_env.get("PATH"), gh_path.parent)
+    command_env = bind_subprocess_python_env(command_env)
     return _sanitize_command_env(command_env, runtime=resolved_runtime)
 
 

--- a/src/agent_teams/sessions/runs/background_tasks/repository.py
+++ b/src/agent_teams/sessions/runs/background_tasks/repository.py
@@ -183,7 +183,7 @@ class BackgroundTaskRepository:
                 SELECT *
                 FROM background_tasks
                 WHERE run_id=?
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (run_id,),
             ).fetchall()
@@ -196,7 +196,7 @@ class BackgroundTaskRepository:
                 SELECT *
                 FROM background_tasks
                 WHERE session_id=?
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (session_id,),
             ).fetchall()
@@ -208,7 +208,7 @@ class BackgroundTaskRepository:
                 """
                 SELECT *
                 FROM background_tasks
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """
             ).fetchall()
         return tuple(_row_to_record(row) for row in rows)
@@ -220,7 +220,7 @@ class BackgroundTaskRepository:
                 SELECT *
                 FROM background_tasks
                 WHERE status IN (?, ?)
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (
                     BackgroundTaskStatus.RUNNING.value,

--- a/src/agent_teams/tools/workspace_tools/shell_executor.py
+++ b/src/agent_teams/tools/workspace_tools/shell_executor.py
@@ -16,7 +16,12 @@ import sys
 
 from pydantic import BaseModel, ConfigDict
 
-from agent_teams.env import build_github_cli_env, build_subprocess_env, get_env_var
+from agent_teams.env import (
+    build_github_cli_env,
+    build_subprocess_env,
+    bind_subprocess_python_env,
+    get_env_var,
+)
 from agent_teams.env.github_config_service import GitHubConfigService
 from agent_teams.env.runtime_env import get_app_config_dir
 from agent_teams.tools.workspace_tools.github_cli import get_gh_path
@@ -571,6 +576,7 @@ async def build_shell_env(
     gh_path = await _resolve_gh_path()
     if gh_path is not None:
         shell_env["PATH"] = _prepend_to_path(shell_env.get("PATH"), gh_path.parent)
+    shell_env = bind_subprocess_python_env(shell_env)
     return _sanitize_shell_env(shell_env, shell=resolved_shell)
 
 
@@ -585,6 +591,7 @@ def build_shell_env_sync(
     gh_path = _resolve_gh_path_sync()
     if gh_path is not None:
         shell_env["PATH"] = _prepend_to_path(shell_env.get("PATH"), gh_path.parent)
+    shell_env = bind_subprocess_python_env(shell_env)
     return _sanitize_shell_env(shell_env, shell=resolved_shell)
 
 

--- a/tests/unit_tests/env/test_python_env.py
+++ b/tests/unit_tests/env/test_python_env.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+import agent_teams.env.python_env as python_env_module
+
+from agent_teams.env import (
+    AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY,
+    bind_subprocess_python_env,
+)
+
+
+def test_bind_subprocess_python_env_prefers_python_from_target_path(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    system_python = tmp_path / "system" / "python"
+    system_python.parent.mkdir(parents=True)
+    system_python.write_text("", encoding="utf-8")
+    fallback_python = tmp_path / "fallback" / "python"
+    fallback_python.parent.mkdir(parents=True)
+    fallback_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        python_env_module.shutil,
+        "which",
+        lambda command, path=None: (
+            str(system_python)
+            if command == "python" and path == str(system_python.parent)
+            else None
+        ),
+    )
+    monkeypatch.setattr(python_env_module.sys, "executable", str(fallback_python))
+
+    env = bind_subprocess_python_env({"PATH": str(system_python.parent)})
+
+    assert env[AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY] == str(system_python.resolve())
+    assert env["PATH"] == str(system_python.parent)
+
+
+def test_bind_subprocess_python_env_falls_back_to_current_runtime(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    fallback_python = tmp_path / "fallback" / "python"
+    fallback_python.parent.mkdir(parents=True)
+    fallback_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        python_env_module.shutil,
+        "which",
+        lambda command, path=None: None,
+    )
+    monkeypatch.setattr(python_env_module.sys, "executable", str(fallback_python))
+
+    env = bind_subprocess_python_env({"PATH": str(tmp_path / "bin")})
+
+    assert env[AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY] == str(fallback_python.resolve())
+    assert env["PATH"].split(python_env_module.os.pathsep)[0] == str(
+        fallback_python.parent
+    )

--- a/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 import signal
+from unittest.mock import AsyncMock
 
 import pytest
+import agent_teams.env.python_env as python_env_module
 
+from agent_teams.env import AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY
 from agent_teams.sessions.runs.background_tasks import command_runtime as runtime_module
 from agent_teams.sessions.runs.background_tasks.command_runtime import (
     CommandRuntimeKind,
@@ -160,6 +164,89 @@ def test_kill_process_tree_by_pid_requires_posix_exit_after_sigkill(
     assert kill_process_tree_by_pid(3210) is False
     assert signals == [signal.SIGTERM, runtime_module._SIGKILL_SIGNAL]
     assert wait_calls == [runtime_module._SIGKILL_GRACE_SECONDS, 2]
+
+
+@pytest.mark.asyncio
+async def test_build_command_env_prefers_python_from_target_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    system_python = tmp_path / "system" / "python"
+    system_python.parent.mkdir(parents=True)
+    system_python.write_text("", encoding="utf-8")
+    fallback_python = tmp_path / "fallback" / "python"
+    fallback_python.parent.mkdir(parents=True)
+    fallback_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(
+        runtime_module,
+        "_resolve_gh_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        runtime_module.os, "environ", {"PATH": str(system_python.parent)}
+    )
+    monkeypatch.setattr(
+        python_env_module.shutil,
+        "which",
+        lambda command, path=None: (
+            str(system_python)
+            if command == "python" and path == str(system_python.parent)
+            else None
+        ),
+    )
+    monkeypatch.setattr(python_env_module.sys, "executable", str(fallback_python))
+
+    env = await runtime_module.build_command_env(
+        runtime=ResolvedCommandRuntime(
+            kind=CommandRuntimeKind.BASH,
+            executable="bash",
+            display_name="Bash",
+        )
+    )
+
+    assert env[AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY] == str(system_python.resolve())
+    assert env["PATH"] == str(system_python.parent)
+
+
+@pytest.mark.asyncio
+async def test_build_command_env_does_not_duplicate_current_python_dir_at_path_front(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fallback_python = tmp_path / "fallback" / "python"
+    fallback_python.parent.mkdir(parents=True)
+    fallback_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(
+        runtime_module,
+        "_resolve_gh_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        runtime_module.os,
+        "environ",
+        {"PATH": str(fallback_python.parent)},
+    )
+    monkeypatch.setattr(
+        python_env_module.shutil,
+        "which",
+        lambda command, path=None: None,
+    )
+    monkeypatch.setattr(python_env_module.sys, "executable", str(fallback_python))
+
+    env = await runtime_module.build_command_env(
+        runtime=ResolvedCommandRuntime(
+            kind=CommandRuntimeKind.POWERSHELL,
+            executable="powershell.exe",
+            display_name="PowerShell",
+        )
+    )
+
+    assert env[AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY] == str(fallback_python.resolve())
+    assert env["PATH"] == str(fallback_python.parent)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/background_tasks/test_repository.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_repository.py
@@ -194,3 +194,44 @@ def test_background_task_repository_can_interrupt_specific_records(
     assert interrupted is not None
     assert interrupted.status == BackgroundTaskStatus.STOPPED
     assert interrupted.pid is None
+
+
+def test_background_task_repository_uses_rowid_as_stable_tiebreak_for_equal_timestamps(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "background-terminals-ordering.db"
+    repo = BackgroundTaskRepository(db_path)
+    shared_time = datetime.now(tz=timezone.utc)
+
+    first = BackgroundTaskRecord(
+        background_task_id="exec-1",
+        run_id="run-1",
+        session_id="session-1",
+        command="sleep 30",
+        cwd="/tmp/project",
+        status=BackgroundTaskStatus.RUNNING,
+        log_path="tmp/background_tasks/exec-1.log",
+        created_at=shared_time,
+        updated_at=shared_time,
+    )
+    second = BackgroundTaskRecord(
+        background_task_id="exec-2",
+        run_id="run-1",
+        session_id="session-1",
+        command="echo done",
+        cwd="/tmp/project",
+        status=BackgroundTaskStatus.COMPLETED,
+        log_path="tmp/background_tasks/exec-2.log",
+        created_at=shared_time,
+        updated_at=shared_time,
+    )
+
+    repo.upsert(first)
+    repo.upsert(second)
+
+    listed = repo.list_by_run("run-1")
+
+    assert tuple(record.background_task_id for record in listed) == (
+        "exec-2",
+        "exec-1",
+    )

--- a/tests/unit_tests/tools/workspace_tools/test_shell.py
+++ b/tests/unit_tests/tools/workspace_tools/test_shell.py
@@ -9,6 +9,9 @@ from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
+import agent_teams.env.python_env as python_env_module
+
+from agent_teams.env import AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY
 
 
 class TestExtractPathsFromCommand:
@@ -242,6 +245,83 @@ def test_describe_runtime_shell_reports_powershell_when_git_bash_is_missing(
 
     assert summary.shell_info == "PowerShell"
     assert summary.shell_path.endswith("powershell.exe")
+
+
+def test_build_shell_env_sync_prefers_python_from_target_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from agent_teams.tools.workspace_tools import shell_executor
+
+    system_python = tmp_path / "system" / "python"
+    system_python.parent.mkdir(parents=True)
+    system_python.write_text("", encoding="utf-8")
+    fallback_python = tmp_path / "fallback" / "python"
+    fallback_python.parent.mkdir(parents=True)
+    fallback_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(shell_executor, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(shell_executor, "_resolve_gh_path_sync", lambda: None)
+    monkeypatch.setattr(
+        shell_executor.os, "environ", {"PATH": str(system_python.parent)}
+    )
+    monkeypatch.setattr(
+        python_env_module.shutil,
+        "which",
+        lambda command, path=None: (
+            str(system_python)
+            if command == "python" and path == str(system_python.parent)
+            else None
+        ),
+    )
+    monkeypatch.setattr(python_env_module.sys, "executable", str(fallback_python))
+
+    env = shell_executor.build_shell_env_sync(
+        shell=shell_executor.ResolvedShell(
+            kind=shell_executor.ShellKind.BASH,
+            executable="bash",
+            display_name="Bash",
+        )
+    )
+
+    assert env[AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY] == str(system_python.resolve())
+    assert env["PATH"] == str(system_python.parent)
+
+
+def test_build_shell_env_sync_does_not_duplicate_current_python_dir_at_path_front(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from agent_teams.tools.workspace_tools import shell_executor
+
+    fallback_python = tmp_path / "fallback" / "python"
+    fallback_python.parent.mkdir(parents=True)
+    fallback_python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(shell_executor, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(shell_executor, "_resolve_gh_path_sync", lambda: None)
+    monkeypatch.setattr(
+        shell_executor.os,
+        "environ",
+        {"PATH": str(fallback_python.parent)},
+    )
+    monkeypatch.setattr(
+        python_env_module.shutil,
+        "which",
+        lambda command, path=None: None,
+    )
+    monkeypatch.setattr(python_env_module.sys, "executable", str(fallback_python))
+
+    env = shell_executor.build_shell_env_sync(
+        shell=shell_executor.ResolvedShell(
+            kind=shell_executor.ShellKind.BASH,
+            executable="bash",
+            display_name="Bash",
+        )
+    )
+
+    assert env[AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY] == str(fallback_python.resolve())
+    assert env["PATH"] == str(fallback_python.parent)
 
 
 # ---------------------------------------------------------------------------
@@ -519,7 +599,8 @@ async def test_spawn_shell_injects_github_token_and_bundled_path(
     assert env["GH_TOKEN"] == "ghp_secret"
     assert env["GITHUB_TOKEN"] == "ghp_secret"
     assert env["GH_PROMPT_DISABLED"] == "1"
-    assert str(gh.parent) == env["PATH"].split(os.pathsep)[0]
+    assert env[AGENT_TEAMS_PYTHON_EXECUTABLE_ENV_KEY]
+    assert str(gh.parent) in env["PATH"].split(os.pathsep)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- bind shell and background command subprocess environments to a stable Python executable
- expose `AGENT_TEAMS_PYTHON_EXECUTABLE` and front-load its directory in `PATH`
- add a deterministic background-task ordering tiebreak so the existing recovery snapshot/unit suite is stable

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude --check`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`

Closes #262