### PR TITLE
Fix session streaming recovery and sidebar transitions

### DIFF
--- a/frontend/dist/css/components.css
+++ b/frontend/dist/css/components.css
@@ -5128,9 +5128,60 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
     border-left: 1px solid color-mix(in srgb, var(--primary) 22%, var(--border-color) 78%);
 }
 
+.session-item-entering {
+    animation: sessionItemEnter 0.22s ease;
+}
+
+.session-item-removing {
+    pointer-events: none;
+    animation: sessionItemRemove 0.18s ease forwards;
+}
+
+.session-item-activating {
+    animation: sessionItemActivate 0.24s ease;
+}
+
 .session-id,
 .round-item-text {
     font-weight: 500;
+}
+
+@keyframes sessionItemEnter {
+    0% {
+        opacity: 0.72;
+        transform: translateY(4px);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes sessionItemRemove {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+
+    100% {
+        opacity: 0;
+        transform: translateY(-3px);
+    }
+}
+
+@keyframes sessionItemActivate {
+    0% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 10%, transparent);
+    }
+
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+    }
 }
 
 .session-status-pill,

--- a/frontend/dist/css/components/base.css
+++ b/frontend/dist/css/components/base.css
@@ -247,6 +247,19 @@
     border-left: 3px solid var(--primary);
 }
 
+.session-item-entering {
+    animation: sessionItemEnter 0.22s ease;
+}
+
+.session-item-removing {
+    pointer-events: none;
+    animation: sessionItemRemove 0.18s ease forwards;
+}
+
+.session-item-activating {
+    animation: sessionItemActivate 0.24s ease;
+}
+
 .session-id {
     font-size: 0.875rem;
     font-weight: 500;
@@ -513,6 +526,44 @@
 
     35% {
         box-shadow: 0 0 0 6px color-mix(in srgb, var(--primary) 10%, transparent);
+    }
+
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+    }
+}
+
+@keyframes sessionItemEnter {
+    0% {
+        opacity: 0.72;
+        transform: translateY(4px);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes sessionItemRemove {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+
+    100% {
+        opacity: 0;
+        transform: translateY(-3px);
+    }
+}
+
+@keyframes sessionItemActivate {
+    0% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 10%, transparent);
     }
 
     100% {

--- a/frontend/dist/js/app/recovery.js
+++ b/frontend/dist/js/app/recovery.js
@@ -4,6 +4,7 @@
  */
 import { refreshSubagentRail } from '../components/subagentRail.js';
 import { refreshVisibleContextIndicators } from '../components/contextIndicators.js';
+import { clearRunStreamState } from '../components/messageRenderer.js';
 import {
     loadSessionRounds,
     overlayRoundRecoveryState,
@@ -16,13 +17,14 @@ import {
     stopBackgroundTask,
 } from '../core/api.js';
 import {
+    clearRunPrimaryRole,
     humanizeRoleId,
     isPrimaryRoleId,
     isReservedSystemRoleId,
     setRunPrimaryRole,
     state,
 } from '../core/state.js';
-import { resumeRunStream } from '../core/stream.js';
+import { endStream, resumeRunStream } from '../core/stream.js';
 import { els } from '../utils/dom.js';
 import { formatMessage, t } from '../utils/i18n.js';
 import { sysLog } from '../utils/logger.js';
@@ -228,9 +230,16 @@ export async function refreshSessionRecovery(sessionId = state.currentSessionId,
     }
 
     try {
+        const previousActiveRunId = String(
+            state.currentRecoverySnapshot?.activeRun?.run_id || state.activeRunId || '',
+        ).trim();
         const snapshot = await fetchSessionRecovery(safeSessionId);
         if (state.currentSessionId !== safeSessionId) return null;
         const normalized = applyRecoverySnapshot(snapshot);
+        await reconcileMissingActiveRun(normalized, {
+            sessionId: safeSessionId,
+            previousActiveRunId,
+        });
         syncSessionContinuity();
         refreshVisibleContextIndicators({ immediate: true });
         return normalized;
@@ -794,6 +803,37 @@ function shouldAutoAttachRecoveryStream(activeRun) {
         && state.activeRunId === activeRun.run_id
         && state.isGenerating
     );
+}
+
+async function reconcileMissingActiveRun(
+    snapshot,
+    {
+        sessionId,
+        previousActiveRunId = '',
+    } = {},
+) {
+    const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+    const safePreviousActiveRunId = String(previousActiveRunId || '').trim();
+    if (!safeSessionId || !safePreviousActiveRunId) return false;
+    if (state.currentSessionId !== safeSessionId) return false;
+
+    const nextActiveRunId = String(snapshot?.activeRun?.run_id || '').trim();
+    if (nextActiveRunId === safePreviousActiveRunId) return false;
+    if (!state.activeEventSource || !state.isGenerating) return false;
+    if (String(state.activeRunId || '').trim() !== safePreviousActiveRunId) return false;
+
+    endStream({ preserveRunStreamState: true, focusPrompt: false });
+    await loadSessionRounds(safeSessionId);
+    if (state.currentSessionId !== safeSessionId) return false;
+
+    clearRunStreamState(safePreviousActiveRunId);
+    clearRunPrimaryRole(safePreviousActiveRunId);
+    if (!nextActiveRunId) {
+        state.activeRunId = null;
+    }
+    scheduleSessionsRefresh();
+    renderRecoveryBanner();
+    return true;
 }
 
 function resolveRecoveryAfterEventId(activeRun) {

--- a/frontend/dist/js/app/session.js
+++ b/frontend/dist/js/app/session.js
@@ -12,13 +12,11 @@ import { fetchSessionHistory } from '../core/api.js';
 import {
     clearSessionRecovery,
     hydrateSessionView,
-    markRunStreamConnected,
     stopSessionContinuity,
 } from './recovery.js';
 import { applyCurrentSessionRecord, resetCurrentSessionTopology, state } from '../core/state.js';
 import {
     detachActiveStreamForSessionSwitch,
-    resumeRunStream,
 } from '../core/stream.js';
 import { els } from '../utils/dom.js';
 import { formatMessage } from '../utils/i18n.js';
@@ -89,7 +87,6 @@ export async function selectSession(sessionId) {
     if (state.currentSessionId !== sessionId) {
         return;
     }
-    autoConnectRunningStream(sessionId);
     scheduleCoordinatorContextPreview({ immediate: true });
     scheduleSessionTokenUsageRefresh({ immediate: true });
     document.dispatchEvent(
@@ -100,32 +97,4 @@ export async function selectSession(sessionId) {
     sysLog(formatMessage(isSameSession ? 'session.reloaded' : 'session.switched', {
         session_id: sessionId,
     }));
-}
-
-function autoConnectRunningStream(sessionId) {
-    if (state.activeEventSource || state.isGenerating) return;
-    const snapshot = state.currentRecoverySnapshot;
-    const activeRun = snapshot?.activeRun;
-    if (!activeRun?.run_id) return;
-    if (!activeRun.is_recoverable) return;
-    if (activeRun.status !== 'running' && activeRun.status !== 'queued') return;
-
-    const afterEventId = Number(activeRun.checkpoint_event_id) || 0;
-    const runId = activeRun.run_id;
-    markRunStreamConnected(runId, { phase: activeRun.phase || 'running' });
-    resumeRunStream(
-        runId,
-        sessionId,
-        async sid => {
-            if (sid) {
-                await hydrateSessionView(sid, { includeRounds: true, quiet: true });
-            }
-        },
-        {
-            reason: 'session-switch-auto-connect',
-            makeUiBusy: true,
-            afterEventId,
-        },
-    );
-    sysLog(`Auto-connected to running stream: run=${runId}`);
 }

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -107,9 +107,17 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
         }
     }
 
-    collapseIntermediateMessages(container);
+    if (shouldCollapseIntermediateMessages(streamOverlayEntry, options)) {
+        collapseIntermediateMessages(container);
+    }
 
-    if (streamOverlayEntry && Array.isArray(streamOverlayEntry.parts) && streamOverlayEntry.parts.length > 0) {
+    if (
+        streamOverlayEntry
+        && (
+            (Array.isArray(streamOverlayEntry.parts) && streamOverlayEntry.parts.length > 0)
+            || streamOverlayEntry.textStreaming === true
+        )
+    ) {
         renderStreamOverlayEntry(container, streamOverlayEntry, pendingToolBlocks, lastRenderedMessage, runId);
     }
 
@@ -183,12 +191,20 @@ function renderStreamOverlayEntry(
         runId,
     );
     let combinedText = '';
+    let renderedLiveTextTail = false;
     const overlayParts = Array.isArray(streamOverlayEntry.parts) ? streamOverlayEntry.parts : [];
-    const trailingTextPart = [...overlayParts].reverse().find(part => part && typeof part === 'object');
+    const hasLiveTextTail = streamOverlayEntry.textStreaming === true;
+    const trailingTextPart = [...overlayParts]
+        .reverse()
+        .find(part => part && typeof part === 'object' && part.kind === 'text');
     const flushText = (streaming = false) => {
         const safeText = String(combinedText || '');
-        if (!safeText.trim()) return;
-        appendMessageText(contentEl, safeText.trim(), { streaming });
+        if (!safeText && !streaming) return;
+        if (!safeText.trim() && !streaming) return;
+        appendMessageText(contentEl, streaming ? safeText : safeText.trim(), { streaming });
+        if (streaming) {
+            renderedLiveTextTail = true;
+        }
         combinedText = '';
     };
 
@@ -223,7 +239,10 @@ function renderStreamOverlayEntry(
         applyOverlayToolState(toolBlock, part);
     });
 
-    flushText(trailingTextPart?.kind === 'text');
+    flushText(hasLiveTextTail && !!trailingTextPart);
+    if (hasLiveTextTail && !renderedLiveTextTail) {
+        appendMessageText(contentEl, '', { streaming: true });
+    }
 }
 
 function resolveOverlayContentTarget(container, label, streamOverlayEntry, lastRenderedMessage, runId = '') {
@@ -434,6 +453,38 @@ function collapseIntermediateMessages(container) {
     });
 }
 
+function shouldCollapseIntermediateMessages(streamOverlayEntry, options = {}) {
+    const runStatus = String(options.runStatus || '').trim().toLowerCase();
+    const isLatestRound = options.isLatestRound === true;
+    if (isLatestRound && runStatus !== 'completed') {
+        return false;
+    }
+    if (!streamOverlayEntry || typeof streamOverlayEntry !== 'object') {
+        return true;
+    }
+    if (streamOverlayEntry.textStreaming === true) {
+        return false;
+    }
+    const parts = Array.isArray(streamOverlayEntry.parts) ? streamOverlayEntry.parts : [];
+    return !parts.some(part => {
+        if (!part || typeof part !== 'object') return false;
+        if (part.kind === 'thinking') {
+            return part.finished !== true;
+        }
+        if (part.kind !== 'tool') {
+            return false;
+        }
+        const status = String(part.status || '').trim().toLowerCase();
+        const approvalStatus = String(part.approvalStatus || '').trim().toLowerCase();
+        return (
+            status === 'pending'
+            || status === 'running'
+            || approvalStatus === 'requested'
+            || approvalStatus === 'approve'
+            || (part.result === undefined && part.validation === undefined)
+        );
+    });
+}
 function formatElapsed(ms) {
     const totalSeconds = Math.round(ms / 1000);
     if (totalSeconds < 60) return `${totalSeconds}s`;

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -2,7 +2,10 @@
  * components/messageRenderer/stream.js
  * Streaming message mutation helpers plus a durable in-browser overlay cache.
  */
-import { isPrimaryRoleId } from '../../core/state.js';
+import {
+    getRunPrimaryRoleId,
+    isPrimaryRoleId,
+} from '../../core/state.js';
 import {
     applyToolReturn,
     appendStructuredContentPart,
@@ -34,7 +37,7 @@ export function getOrCreateStreamBlock(
     label,
     runId = '',
 ) {
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     let st = streamState.get(streamKey);
     if (!st || st.container !== container) {
         st = createStreamState({
@@ -57,7 +60,7 @@ export function getOrCreateStreamBlock(
 }
 
 export function appendStreamChunk(instanceId, text, runId = '', roleId = '', label = '') {
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const st = streamState.get(streamKey);
     if (!st) return;
 
@@ -72,6 +75,13 @@ export function appendStreamChunk(instanceId, text, runId = '', roleId = '', lab
     st.activeRaw += text;
     updateMessageText(st.activeTextEl, st.activeRaw, { streaming: true });
     updateOverlayText(st.runId || runId, st.instanceId || instanceId, roleId || st.roleId, label || st.label, text);
+    setOverlayTextStreaming(
+        st.runId || runId,
+        st.instanceId || instanceId,
+        roleId || st.roleId,
+        label || st.label,
+        true,
+    );
     scrollBottom(st.container);
 }
 
@@ -84,7 +94,7 @@ export function appendStreamOutputParts(
     const roleId = String(options.roleId || '');
     const label = String(options.label || '');
     const container = options.container || null;
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     let st = streamState.get(streamKey);
     if (!st && container) {
         st = createStreamState({
@@ -220,7 +230,7 @@ export function appendToolCallBlock(
     const runId = String(options.runId || '');
     const roleId = String(options.roleId || '');
     const label = String(options.label || '');
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     let st = streamState.get(streamKey);
     if (!st) {
         const actorLabel = label || (toolName ? 'Tool' : 'Agent');
@@ -266,7 +276,7 @@ export function updateToolResult(
     const runId = String(options.runId || '');
     const roleId = String(options.roleId || '');
     const container = options.container || null;
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const st = streamState.get(streamKey);
     const toolBlock = resolveToolBlockTarget(st, container, toolName, toolCallId);
     if (!toolBlock) {
@@ -282,7 +292,7 @@ export function markToolInputValidationFailed(instanceId, payload, options = {})
     const runId = String(options.runId || '');
     const roleId = String(options.roleId || '');
     const container = options.container || null;
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const st = streamState.get(streamKey);
     const toolBlock = resolveToolBlockTarget(
         st,
@@ -306,7 +316,7 @@ export function startThinkingBlock(instanceId, partIndex, options = {}) {
     const roleId = String(options.roleId || '');
     const label = String(options.label || '');
     const container = options.container || null;
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     let st = streamState.get(streamKey);
     if (!st && container) {
         const actorLabel = label || 'Agent';
@@ -338,7 +348,7 @@ export function appendThinkingChunk(instanceId, partIndex, text, options = {}) {
     const roleId = String(options.roleId || '');
     const label = String(options.label || '');
     const container = options.container || null;
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const st = streamState.get(streamKey);
     if (!st) {
         updateOverlayThinkingText(runId, instanceId, roleId, label, partIndex, text, { append: true });
@@ -355,7 +365,7 @@ export function appendThinkingChunk(instanceId, partIndex, text, options = {}) {
 export function finalizeThinking(instanceId, partIndex, options = {}) {
     const runId = String(options.runId || '');
     const roleId = String(options.roleId || '');
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const st = streamState.get(streamKey);
     const entry = resolveThinkingEntry(st, partIndex, { allowCreate: false });
     if (!entry) {
@@ -375,7 +385,7 @@ export function attachToolApprovalControls(instanceId, toolName, payload, handle
     const runId = String(options.runId || '');
     const roleId = String(options.roleId || '');
     const container = options.container || null;
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const st = streamState.get(streamKey);
     const toolBlock = resolveToolBlockTarget(
         st,
@@ -407,7 +417,7 @@ export function markToolApprovalResolved(instanceId, payload, options = {}) {
     const runId = String(options.runId || '');
     const roleId = String(options.roleId || '');
     const container = options.container || null;
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const st = streamState.get(streamKey);
     updateOverlayToolApproval(
         (st && st.runId) || runId,
@@ -454,7 +464,7 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
     const instanceId = String(options.instanceId || '').trim();
     const roleId = String(options.roleId || '').trim();
     const label = String(options.label || '').trim();
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const cleanupDelayMs = Number(options.cleanupDelayMs || 0);
 
     if (evType === 'text_delta') {
@@ -464,6 +474,7 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
     }
     if (evType === 'thinking_started') {
         clearOverlayEntryCleanupTimer(runId, streamKey);
+        setOverlayTextStreaming(runId, streamKey, roleId, label, false);
         startOverlayThinking(runId, streamKey, roleId, label, payload?.part_index ?? 0);
         return;
     }
@@ -486,6 +497,7 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
     }
     if (evType === 'tool_call') {
         clearOverlayEntryCleanupTimer(runId, streamKey);
+        setOverlayTextStreaming(runId, streamKey, roleId, label, false);
         updateOverlayToolCall(runId, streamKey, roleId, label, {
             tool_call_id: payload?.tool_call_id || '',
             tool_name: payload?.tool_name || '',
@@ -534,10 +546,12 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
         return;
     }
     if (evType === 'model_step_finished') {
+        setOverlayTextStreaming(runId, streamKey, roleId, label, false);
         scheduleOverlayEntryCleanup(runId, streamKey, roleId, cleanupDelayMs);
         return;
     }
     if (evType === 'run_completed' || evType === 'run_failed' || evType === 'run_stopped') {
+        setOverlayTextStreaming(runId, streamKey, roleId, label, false);
         scheduleRunOverlayCleanup(runId, cleanupDelayMs);
     }
 }
@@ -563,13 +577,23 @@ function ensureApprovalState(toolBlock) {
     return approvalEl;
 }
 
-function resolveStreamKey(instanceId, roleId) {
+function resolveStreamKey(instanceId, roleId, runId = '') {
     const safeInstanceId = String(instanceId || '').trim();
-    if (isPrimaryRoleId(roleId) || !roleId || safeInstanceId === PRIMARY_KEY || safeInstanceId === 'coordinator') {
+    const safeRoleId = String(roleId || '').trim();
+    const safeRunId = String(runId || '').trim();
+    const runPrimaryRoleId = safeRunId ? String(getRunPrimaryRoleId(safeRunId) || '').trim() : '';
+    const isPrimaryForRun = !!(safeRoleId && runPrimaryRoleId && safeRoleId === runPrimaryRoleId);
+    if (
+        isPrimaryForRun
+        || (!safeRunId && isPrimaryRoleId(safeRoleId))
+        || !safeRoleId
+        || safeInstanceId === PRIMARY_KEY
+        || safeInstanceId === 'coordinator'
+    ) {
         return PRIMARY_KEY;
     }
     if (safeInstanceId) return safeInstanceId;
-    return `role:${String(roleId || '').trim()}`;
+    return `role:${safeRoleId}`;
 }
 
 function createStreamState({
@@ -579,7 +603,7 @@ function createStreamState({
     label,
     runId,
 }) {
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const reused = findReusableStreamState({
         container,
         instanceId,
@@ -635,6 +659,9 @@ function findReusableStreamState({
     if (!contentEl) return null;
     const activeTextEl = findLastReusableTextElement(contentEl);
     const activeRaw = resolveReusableRawText(overlayEntry);
+    if (activeTextEl) {
+        syncStreamingCursor(activeTextEl, overlayEntry?.textStreaming === true);
+    }
     const thinkingBinding = bindReusableThinkingState(contentEl, overlayEntry);
     const pendingToolBlocks = bindReusableToolBlocks(contentEl, overlayEntry);
     return {
@@ -652,7 +679,7 @@ function findReusableStreamState({
         label,
         runId: String(runId || ''),
         instanceId: String(instanceId || ''),
-        streamKey: resolveStreamKey(instanceId, roleId),
+        streamKey: resolveStreamKey(instanceId, roleId, runId),
     };
 }
 
@@ -665,11 +692,11 @@ function resolveOverlayEntry(runId, instanceId, roleId, label) {
     if (!runOverlay) {
         return null;
     }
-    const key = resolveStreamKey(instanceId, roleId);
+    const key = resolveStreamKey(instanceId, roleId, safeRunId);
     return runOverlay.entries.get(key)
-        || runOverlay.entries.get(resolveStreamKey(instanceId, ''))
-        || runOverlay.entries.get(resolveStreamKey('', roleId))
-        || runOverlay.entries.get(resolveStreamKey('', ''));
+        || runOverlay.entries.get(resolveStreamKey(instanceId, '', safeRunId))
+        || runOverlay.entries.get(resolveStreamKey('', roleId, safeRunId))
+        || runOverlay.entries.get(resolveStreamKey('', '', safeRunId));
 }
 
 function findReusableMessageWrapper({
@@ -680,7 +707,7 @@ function findReusableMessageWrapper({
     runId,
 }) {
     if (!container) return null;
-    const streamKey = resolveStreamKey(instanceId, roleId);
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const safeLabel = String(label || '').trim().toUpperCase();
     const safeRunId = String(runId || '').trim();
     const wrappers = Array.from(container.querySelectorAll('.message'));
@@ -842,6 +869,7 @@ function endActiveText(st) {
     if (st.activeTextEl) {
         syncStreamingCursor(st.activeTextEl, false);
     }
+    setOverlayTextStreaming(st.runId, st.instanceId, st.roleId, st.label, false);
     st.activeTextEl = null;
     st.activeRaw = '';
 }
@@ -866,7 +894,7 @@ function clearOverlayEntry(runId, instanceId, roleId) {
     if (!safeRunId) return;
     const runOverlay = overlayState.get(safeRunId);
     if (!runOverlay) return;
-    const key = resolveStreamKey(instanceId, roleId);
+    const key = resolveStreamKey(instanceId, roleId, safeRunId);
     runOverlay.entries.delete(key);
     if (runOverlay.entries.size === 0) {
         clearRunOverlayCleanupTimer(safeRunId);
@@ -882,7 +910,7 @@ function ensureOverlayEntry(runId, instanceId, roleId, label) {
         runOverlay = { entries: new Map() };
         overlayState.set(safeRunId, runOverlay);
     }
-    const key = resolveStreamKey(instanceId, roleId);
+    const key = resolveStreamKey(instanceId, roleId, safeRunId);
     let entry = runOverlay.entries.get(key);
     if (!entry) {
         entry = {
@@ -892,6 +920,7 @@ function ensureOverlayEntry(runId, instanceId, roleId, label) {
             parts: [],
             thinkingActiveByPart: new Map(),
             thinkingSequence: 0,
+            textStreaming: false,
         };
         runOverlay.entries.set(key, entry);
     } else {
@@ -900,6 +929,7 @@ function ensureOverlayEntry(runId, instanceId, roleId, label) {
         if (label) entry.label = String(label);
         if (!entry.thinkingActiveByPart) entry.thinkingActiveByPart = new Map();
         if (typeof entry.thinkingSequence !== 'number') entry.thinkingSequence = 0;
+        if (typeof entry.textStreaming !== 'boolean') entry.textStreaming = false;
     }
     return entry;
 }
@@ -909,7 +939,7 @@ function scheduleOverlayEntryCleanup(runId, instanceId, roleId, delayMs = 0) {
     if (!safeRunId) {
         return;
     }
-    const key = resolveStreamKey(instanceId, roleId);
+    const key = resolveStreamKey(instanceId, roleId, safeRunId);
     if (delayMs <= 0) {
         clearOverlayEntryCleanupTimer(safeRunId, key);
         clearOverlayEntry(safeRunId, key, roleId);
@@ -993,6 +1023,7 @@ function updateOverlayText(runId, instanceId, roleId, label, text) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
     if (!entry) return;
     const nextText = String(text || '');
+    entry.textStreaming = true;
     if (!nextText) return;
     const lastPart = entry.parts[entry.parts.length - 1];
     if (lastPart && lastPart.kind === 'text') {
@@ -1000,6 +1031,12 @@ function updateOverlayText(runId, instanceId, roleId, label, text) {
         return;
     }
     entry.parts.push({ kind: 'text', content: nextText });
+}
+
+function setOverlayTextStreaming(runId, instanceId, roleId, label, isStreaming) {
+    const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
+    if (!entry) return;
+    entry.textStreaming = isStreaming === true;
 }
 
 function startOverlayThinking(runId, instanceId, roleId, label, partIndex) {
@@ -1204,5 +1241,6 @@ function cloneOverlayEntry(entry) {
         roleId: entry.roleId,
         label: entry.label,
         parts: entry.parts.map(part => ({ ...part })),
+        textStreaming: entry.textStreaming === true,
     };
 }

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -434,6 +434,7 @@ function renderRoundSection(round, index) {
     });
     const coordinatorOverlay = getCoordinatorStreamOverlay(round.run_id);
     const primaryRoleLabel = getRunPrimaryRoleLabel(round.run_id);
+    const isLatestRound = index === roundsState.currentRounds.length - 1;
 
     if (round.coordinator_messages?.length > 0) {
         renderHistoricalMessageList(section, round.coordinator_messages, {
@@ -441,6 +442,9 @@ function renderRoundSection(round, index) {
             pendingToolApprovals: pendingCoordinatorApprovals,
             primaryRoleLabel,
             runId: round.run_id,
+            runStatus: round.run_status,
+            runPhase: round.run_phase,
+            isLatestRound,
             streamOverlayEntry: coordinatorOverlay,
         });
     } else if (pendingCoordinatorApprovals.length > 0 || coordinatorOverlay) {
@@ -449,6 +453,9 @@ function renderRoundSection(round, index) {
             pendingToolApprovals: pendingCoordinatorApprovals,
             primaryRoleLabel,
             runId: round.run_id,
+            runStatus: round.run_status,
+            runPhase: round.run_phase,
+            isLatestRound,
             streamOverlayEntry: coordinatorOverlay,
         });
     } else if (!round.has_user_messages) {

--- a/frontend/dist/js/components/sidebar.js
+++ b/frontend/dist/js/components/sidebar.js
@@ -44,6 +44,11 @@ let projectSortMode = 'recent';
 let openProjectMenuId = null;
 let projectMenuDismissBound = false;
 let languageRefreshBound = false;
+let pendingSessionAnimation = null;
+
+const SESSION_ANIMATION_ENTER_MS = 220;
+const SESSION_ANIMATION_REMOVE_MS = 180;
+const SESSION_ANIMATION_ACTIVATE_MS = 240;
 
 export function setSelectSessionHandler(handler) {
     selectSessionHandler = handler;
@@ -553,6 +558,63 @@ async function selectSessionById(sessionId) {
     await selectSessionHandler(sessionId);
 }
 
+function setPendingSessionAnimation(sessionId, animation) {
+    const safeSessionId = String(sessionId || '').trim();
+    const safeAnimation = String(animation || '').trim();
+    if (!safeSessionId || !safeAnimation) {
+        pendingSessionAnimation = null;
+        return;
+    }
+    pendingSessionAnimation = {
+        sessionId: safeSessionId,
+        animation: safeAnimation,
+    };
+}
+
+function consumePendingSessionAnimation() {
+    const pending = pendingSessionAnimation;
+    pendingSessionAnimation = null;
+    return pending;
+}
+
+function findSessionItem(sessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId || !els.projectsList) return null;
+    const items = Array.from(els.projectsList.querySelectorAll('.session-item'));
+    return items.find(item => String(item?.getAttribute?.('data-session-id') || '').trim() === safeSessionId) || null;
+}
+
+function animateSessionItem(item, animation) {
+    if (!item) return;
+    const safeAnimation = String(animation || '').trim();
+    if (!safeAnimation) return;
+    const animationClass = `session-item-${safeAnimation}`;
+    if (item.classList?.add) {
+        item.classList.remove('session-item-entering', 'session-item-removing', 'session-item-activating');
+        item.classList.add(animationClass);
+        const duration = safeAnimation === 'removing'
+            ? SESSION_ANIMATION_REMOVE_MS
+            : safeAnimation === 'entering'
+                ? SESSION_ANIMATION_ENTER_MS
+                : SESSION_ANIMATION_ACTIVATE_MS;
+        globalThis.setTimeout(() => {
+            item.classList?.remove?.(animationClass);
+        }, duration);
+        return;
+    }
+    if (typeof item.className === 'string' && !item.className.includes(animationClass)) {
+        item.className = `${item.className} ${animationClass}`.trim();
+    }
+}
+
+function playPendingSessionAnimation() {
+    const pending = consumePendingSessionAnimation();
+    if (!pending) return;
+    const item = findSessionItem(pending.sessionId);
+    if (!item) return;
+    animateSessionItem(item, pending.animation);
+}
+
 function renderAutomationHint(project) {
     const status = String(project?.status || '').trim() || 'unknown';
     const nextRunAt = String(project?.next_run_at || '').trim();
@@ -617,7 +679,9 @@ function bindProjectCard(card, group) {
             const targetWorkspaceId = String(button.getAttribute('data-workspace-id') || '').trim();
             if (!sessionId) return;
             state.currentWorkspaceId = targetWorkspaceId || AUTOMATION_INTERNAL_WORKSPACE_ID;
-            void selectSessionById(sessionId);
+            void selectSessionById(sessionId).then(() => {
+                animateSessionItem(button, 'activating');
+            });
         };
         button.addEventListener('click', selectTarget);
         button.addEventListener('keydown', event => {
@@ -668,6 +732,9 @@ function bindProjectCard(card, group) {
                 cancelLabel: t('settings.action.cancel'),
             });
             if (!shouldDelete) return;
+            const sessionItem = button.closest?.('.session-item') || null;
+            animateSessionItem(sessionItem, 'removing');
+            await new Promise(resolve => globalThis.setTimeout(resolve, SESSION_ANIMATION_REMOVE_MS));
             await deleteSession(sessionId);
             if (state.currentSessionId === sessionId) {
                 clearActiveSessionView();
@@ -797,6 +864,7 @@ export async function loadProjects() {
             openProjectMenuId = null;
         }
         groups.forEach(group => els.projectsList.appendChild(renderProjectCard(group)));
+        playPendingSessionAnimation();
     } catch (error) {
         sysLog(formatMessage('sidebar.error.loading_projects', { error: error.message }), 'log-error');
     }
@@ -1001,13 +1069,14 @@ export async function handleNewSessionClick(workspaceId, manualClick = true) {
         return;
     }
     try {
-        expandedProjectSessionIds.add(groupKey('workspace', targetWorkspaceId));
         const data = await startNewSession(targetWorkspaceId);
         state.currentWorkspaceId = targetWorkspaceId;
         sysLog(formatMessage('sidebar.log.created_session', { session_id: data.session_id }));
         if (manualClick) els.chatMessages.innerHTML = '';
+        setPendingSessionAnimation(data.session_id, 'entering');
         await loadProjects();
         await selectSessionById(data.session_id);
+        animateSessionItem(findSessionItem(data.session_id), 'activating');
     } catch (error) {
         sysLog(formatMessage('sidebar.error.creating_session', { error: error.message }), 'log-error');
     }

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -255,8 +255,8 @@ export function handleRunCompleted(eventMeta) {
     sysLog('Run completed.');
     markLlmRetrySucceeded();
     const runId = eventMeta?.run_id || eventMeta?.trace_id || state.activeRunId || '';
-    if (state.activeRunId) {
-        markRunTerminalState(state.activeRunId, {
+    if (runId) {
+        markRunTerminalState(runId, {
             status: 'completed',
             phase: 'terminal',
             recoverable: false,
@@ -285,8 +285,8 @@ export function handleRunStopped(eventMeta, payload) {
     if (state.activeAgentInstanceId) {
         markSubagentStatus(state.activeAgentInstanceId, 'stopped');
     }
-    if (state.activeRunId) {
-        markRunTerminalState(state.activeRunId, {
+    if (runId) {
+        markRunTerminalState(runId, {
             status: 'stopped',
             phase: 'stopped',
             recoverable: true,
@@ -316,8 +316,8 @@ export function handleRunFailed(eventMeta, payload) {
     if (state.activeAgentInstanceId) {
         markSubagentStatus(state.activeAgentInstanceId, 'failed');
     }
-    if (state.activeRunId) {
-        markRunTerminalState(state.activeRunId, {
+    if (runId) {
+        markRunTerminalState(runId, {
             status: 'failed',
             phase: 'terminal',
             recoverable: false,

--- a/tests/unit_tests/feishu/test_subscription_service.py
+++ b/tests/unit_tests/feishu/test_subscription_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import ssl
 import sys
+from types import ModuleType, SimpleNamespace
 from typing import cast
 import warnings
 
@@ -242,7 +243,9 @@ def test_subscription_service_stop_shuts_down_shared_runner_factory() -> None:
     assert runner_factory.shutdown_calls == 1
 
 
-def test_feishu_ws_hub_reuses_single_thread_for_multiple_bots() -> None:
+def test_feishu_ws_hub_reuses_single_thread_for_multiple_bots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     runtime_a = _build_runtime(
         trigger_id="trg_a",
         name="bot_a",
@@ -269,6 +272,10 @@ def test_feishu_ws_hub_reuses_single_thread_for_multiple_bots() -> None:
         created_controllers[runtime_config.trigger_id] = controller
         return controller
 
+    monkeypatch.setattr(
+        "agent_teams.gateway.feishu.subscription_service.import_lark_ws_client_module",
+        lambda: SimpleNamespace(),
+    )
     hub = _FeishuWsHub(controller_factory=_controller_factory)
 
     hub.start_client(runtime_config=runtime_a, event_handler=_FakeHandler())
@@ -387,6 +394,43 @@ def test_feishu_ws_controller_get_conn_url_uses_net_http_client(monkeypatch) -> 
         "_create_feishu_http_client",
         lambda: fake_http_client,
     )
+    const_module = ModuleType("lark_oapi.ws.const")
+    setattr(const_module, "GEN_ENDPOINT_URI", "/callback/ws/endpoint")
+    exception_module = ModuleType("lark_oapi.ws.exception")
+
+    class _FakeClientException(Exception):
+        def __init__(self, code: int, message: str) -> None:
+            super().__init__(message)
+            self.code = code
+            self.message = message
+
+    class _FakeServerException(Exception):
+        def __init__(self, code: int, message: str) -> None:
+            super().__init__(message)
+            self.code = code
+            self.message = message
+
+    setattr(exception_module, "ClientException", _FakeClientException)
+    setattr(exception_module, "ServerException", _FakeServerException)
+    model_module = ModuleType("lark_oapi.ws.model")
+
+    class _FakeEndpointResp:
+        def __init__(self, payload: dict[str, object]) -> None:
+            data = cast(dict[str, object], payload["data"])
+            client_config = cast(dict[str, object], data["ClientConfig"])
+            self.code = payload["code"]
+            self.msg = payload["msg"]
+            self.data = SimpleNamespace(
+                URL=data["URL"],
+                ClientConfig=SimpleNamespace(
+                    PingInterval=client_config["PingInterval"]
+                ),
+            )
+
+    setattr(model_module, "EndpointResp", _FakeEndpointResp)
+    monkeypatch.setitem(sys.modules, "lark_oapi.ws.const", const_module)
+    monkeypatch.setitem(sys.modules, "lark_oapi.ws.exception", exception_module)
+    monkeypatch.setitem(sys.modules, "lark_oapi.ws.model", model_module)
     ws_client = _FakeWsClient()
 
     conn_url = controller._get_conn_url(cast(WsClientLike, ws_client))
@@ -448,23 +492,54 @@ def test_resolve_websocket_proxy_url_respects_no_proxy(monkeypatch) -> None:
     assert proxy_url is None
 
 
-def test_import_lark_ws_client_module_suppresses_known_deprecations() -> None:
+def test_import_lark_ws_client_module_suppresses_known_deprecations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     try:
         previous_loop = asyncio.get_running_loop()
     except RuntimeError:
         previous_loop = None
 
-    removed_modules = {
-        name: sys.modules.pop(name, None)
-        for name in (
-            "lark_oapi.ws.client",
-            "lark_oapi.ws.pb.google.protobuf.internal.well_known_types",
-        )
-    }
     loop = asyncio.new_event_loop()
 
     try:
         asyncio.set_event_loop(loop)
+
+        def _fake_import(module_name: str) -> ModuleType:
+            warnings.warn_explicit(
+                "datetime.datetime.utcfromtimestamp() is deprecated",
+                DeprecationWarning,
+                filename="well_known_types.py",
+                lineno=1,
+                module="lark_oapi.ws.pb.google.protobuf.internal.well_known_types",
+            )
+            warnings.warn_explicit(
+                "There is no current event loop",
+                DeprecationWarning,
+                filename="client.py",
+                lineno=1,
+                module="lark_oapi.ws.client",
+            )
+            warnings.warn_explicit(
+                "websockets.InvalidStatusCode is deprecated",
+                DeprecationWarning,
+                filename="client.py",
+                lineno=1,
+                module="lark_oapi.ws.client",
+            )
+            warnings.warn_explicit(
+                "websockets.legacy is deprecated",
+                DeprecationWarning,
+                filename="legacy.py",
+                lineno=1,
+                module="websockets.legacy.client",
+            )
+            return ModuleType(module_name)
+
+        monkeypatch.setattr(
+            "agent_teams.gateway.feishu.lark_ws_compat.importlib.import_module",
+            _fake_import,
+        )
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("default")
             module = import_lark_ws_client_module()
@@ -473,23 +548,32 @@ def test_import_lark_ws_client_module_suppresses_known_deprecations() -> None:
     finally:
         loop.close()
         asyncio.set_event_loop(previous_loop)
-        for name, module in removed_modules.items():
-            if module is None:
-                sys.modules.pop(name, None)
-                continue
-            sys.modules[name] = module
 
 
-def test_import_lark_module_suppresses_dispatcher_handler_deprecations() -> None:
-    removed_modules = {
-        name: sys.modules.pop(name, None)
-        for name in (
-            "lark_oapi.event.dispatcher_handler",
-            "lark_oapi.ws.client",
-            "lark_oapi.ws.pb.google.protobuf.internal.well_known_types",
+def test_import_lark_module_suppresses_dispatcher_handler_deprecations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_import(module_name: str) -> ModuleType:
+        warnings.warn_explicit(
+            "datetime.datetime.utcfromtimestamp() is deprecated",
+            DeprecationWarning,
+            filename="well_known_types.py",
+            lineno=1,
+            module="lark_oapi.ws.pb.google.protobuf.internal.well_known_types",
         )
-    }
+        warnings.warn_explicit(
+            "websockets.legacy is deprecated",
+            DeprecationWarning,
+            filename="legacy.py",
+            lineno=1,
+            module="websockets.legacy.client",
+        )
+        return ModuleType(module_name)
 
+    monkeypatch.setattr(
+        "agent_teams.gateway.feishu.lark_ws_compat.importlib.import_module",
+        _fake_import,
+    )
     try:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("default")
@@ -497,11 +581,7 @@ def test_import_lark_module_suppresses_dispatcher_handler_deprecations() -> None
         assert module.__name__ == "lark_oapi.event.dispatcher_handler"
         assert caught == []
     finally:
-        for name, module in removed_modules.items():
-            if module is None:
-                sys.modules.pop(name, None)
-                continue
-            sys.modules[name] = module
+        pass
 
 
 def test_parse_ws_conn_exception_reads_invalid_status_response_headers() -> None:

--- a/tests/unit_tests/frontend/test_agent_panel_reflection_button_ui.py
+++ b/tests/unit_tests/frontend/test_agent_panel_reflection_button_ui.py
@@ -589,7 +589,7 @@ globalThis.document = {{
         cwd=str(repo_root),
         text=True,
         encoding="utf-8",
-        timeout=30,
+        timeout=3,
     )
 
     if completed.returncode != 0:

--- a/tests/unit_tests/frontend/test_projects_sidebar_ui.py
+++ b/tests/unit_tests/frontend/test_projects_sidebar_ui.py
@@ -105,6 +105,83 @@ console.log(JSON.stringify({
     assert payload["sortedFirstProjectTitle"] == "Alpha Project"
 
 
+def test_projects_sidebar_new_session_keeps_session_visibility_collapsed_and_declares_animations(
+    tmp_path: Path,
+) -> None:
+    payload = _run_sidebar_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import {
+    loadProjects,
+    setSelectSessionHandler,
+} from "./sidebar.mjs";
+
+installGlobals(createDomEnvironment());
+setSelectSessionHandler(async (sessionId) => {
+    globalThis.__selectedSessionIds.push(sessionId);
+});
+
+await loadProjects();
+const projectsList = document.getElementById("projects-list");
+const firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
+
+firstProject.querySelector(".project-session-visibility-btn").onclick();
+await flushTasks();
+const expandedProject = projectsList.children.filter(child => child.className === "project-card")[0];
+expandedProject.querySelector(".project-session-visibility-btn").onclick();
+await flushTasks();
+const recollapsedProject = projectsList.children.filter(child => child.className === "project-card")[0];
+const beforeCount = recollapsedProject.querySelectorAll(".session-item").length;
+const beforeVisibilityLabel = recollapsedProject.querySelector(".project-session-visibility-btn").textContent;
+
+recollapsedProject.querySelectorAll(".project-new-session-btn")[0].onclick();
+await flushTasks();
+await flushTasks();
+
+const refreshedProject = projectsList.children.filter(child => child.className === "project-card")[0];
+const afterCount = refreshedProject.querySelectorAll(".session-item").length;
+const afterVisibilityLabel = refreshedProject.querySelector(".project-session-visibility-btn").textContent;
+
+console.log(JSON.stringify({
+    beforeCount,
+    beforeVisibilityLabel,
+    afterCount,
+    afterVisibilityLabel,
+    selectedSessionIds: globalThis.__selectedSessionIds,
+}));
+""".strip(),
+    )
+
+    repo_root = Path(__file__).resolve().parents[3]
+    sidebar_script = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sidebar.js"
+    ).read_text(encoding="utf-8")
+    components_base_css = (
+        repo_root / "frontend" / "dist" / "css" / "components" / "base.css"
+    ).read_text(encoding="utf-8")
+
+    assert payload["beforeCount"] == 10
+    assert payload["beforeVisibilityLabel"] == "Show all (11)"
+    assert payload["afterCount"] == 10
+    assert payload["afterVisibilityLabel"] == "Show all (12)"
+    assert payload["selectedSessionIds"] == ["session-new-1"]
+    assert (
+        "expandedProjectSessionIds.add(groupKey('workspace', targetWorkspaceId));"
+        not in sidebar_script
+    )
+    assert "let pendingSessionAnimation = null;" in sidebar_script
+    assert "function animateSessionItem(item, animation) {" in sidebar_script
+    assert "setPendingSessionAnimation(data.session_id, 'entering');" in sidebar_script
+    assert "animateSessionItem(sessionItem, 'removing');" in sidebar_script
+    assert "animateSessionItem(button, 'activating');" in sidebar_script
+    assert ".session-item-entering {" in components_base_css
+    assert ".session-item-removing {" in components_base_css
+    assert ".session-item-activating {" in components_base_css
+    assert "@keyframes sessionItemEnter {" in components_base_css
+    assert "@keyframes sessionItemRemove {" in components_base_css
+    assert "@keyframes sessionItemActivate {" in components_base_css
+
+
 def test_projects_sidebar_renames_session_from_sidebar_action(tmp_path: Path) -> None:
     payload = _run_sidebar_script(
         tmp_path=tmp_path,
@@ -1575,7 +1652,7 @@ installGlobals(createDomEnvironment());
         check=False,
         cwd=str(repo_root),
         text=True,
-        timeout=30,
+        timeout=3,
     )
 
     if completed.returncode != 0:

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -92,6 +92,15 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert "isPrimaryOrReservedRoleId(roleId)" in recovery_script
     assert "await ensureAutomaticRecoveryStream(snapshot," in recovery_script
     assert "resumeRunStream(activeRun.run_id, safeSessionId, null," in recovery_script
+    assert "await reconcileMissingActiveRun(normalized, {" in recovery_script
+    assert "const previousActiveRunId = String(" in recovery_script
+    assert (
+        "endStream({ preserveRunStreamState: true, focusPrompt: false });"
+        in recovery_script
+    )
+    assert "await loadSessionRounds(safeSessionId);" in recovery_script
+    assert "clearRunStreamState(safePreviousActiveRunId);" in recovery_script
+    assert "clearRunPrimaryRole(safePreviousActiveRunId);" in recovery_script
     assert (
         "const lastEventId = Number(activeRun.last_event_id || 0);" in recovery_script
     )
@@ -112,6 +121,8 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert (
         "detachActiveStreamForSessionSwitch({ focusPrompt: false });" in session_script
     )
+    assert "autoConnectRunningStream(sessionId);" not in session_script
+    assert "function autoConnectRunningStream(sessionId) {" not in session_script
     assert "clearAllStreamState({ preserveOverlay: true });" in session_script
     assert "clearAllStreamState({ preserveOverlay: true });" in prompt_script
     assert "clearAllStreamState({ preserveOverlay: true });" in timeline_script
@@ -184,6 +195,25 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
         "const overlayEntry = resolveOverlayEntry(runId, instanceId, roleId, label);"
         in renderer_stream_script
     )
+    assert "getRunPrimaryRoleId," in renderer_stream_script
+    assert (
+        "const runPrimaryRoleId = safeRunId ? String(getRunPrimaryRoleId(safeRunId) || '').trim() : '';"
+        in renderer_stream_script
+    )
+    assert (
+        "const isPrimaryForRun = !!(safeRoleId && runPrimaryRoleId && safeRoleId === runPrimaryRoleId);"
+        in renderer_stream_script
+    )
+    assert (
+        "syncStreamingCursor(activeTextEl, overlayEntry?.textStreaming === true);"
+        in renderer_stream_script
+    )
+    assert "textStreaming: false," in renderer_stream_script
+    assert "entry.textStreaming = true;" in renderer_stream_script
+    assert (
+        "function setOverlayTextStreaming(runId, instanceId, roleId, label, isStreaming) {"
+        in renderer_stream_script
+    )
     assert "function findReusableMessageWrapper({" in renderer_stream_script
     assert (
         "function resolveOverlayEntry(runId, instanceId, roleId, label) {"
@@ -209,7 +239,14 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
         in history_script
     )
     assert (
-        "const streamKey = resolveStreamKey(instanceId, roleId);"
+        "const isLatestRound = index === roundsState.currentRounds.length - 1;"
+        in timeline_script
+    )
+    assert "runStatus: round.run_status," in timeline_script
+    assert "runPhase: round.run_phase," in timeline_script
+    assert "isLatestRound," in timeline_script
+    assert (
+        "const streamKey = resolveStreamKey(instanceId, roleId, runId);"
         in renderer_stream_script
     )
     assert "wrapper.dataset.streamKey = streamKey;" in (

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -267,7 +267,7 @@ globalThis.__openAgentPanelCalls = [];
         cwd=str(repo_root),
         text=True,
         encoding="utf-8",
-        timeout=30,
+        timeout=3,
     )
 
     if completed.returncode != 0:

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+def test_stream_overlay_uses_run_primary_role_for_primary_key(tmp_path: Path) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_overlay"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId(runId) {
+    return runId === "run-acp" ? "external-role" : "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+export function applyToolReturn() {}
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+export function buildPendingToolBlock() { return { querySelector() { return null; } }; }
+export function findToolBlock() { return null; }
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function renderMessageBlock() {
+    return {
+        wrapper: {
+            dataset: {},
+            querySelector() { return null; },
+            closest() { return null; },
+        },
+        contentEl: {
+            appendChild() {},
+            querySelector() { return null; },
+            querySelectorAll() { return []; },
+        },
+    };
+}
+export function resolvePendingToolBlock() { return null; }
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor() {}
+export function updateThinkingText() {}
+export function updateMessageText() {}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+} from "./stream.js";
+
+applyStreamOverlayEvent(
+  "text_delta",
+  { text: "streamed from external ACP" },
+  {
+    runId: "run-acp",
+    instanceId: "external-instance",
+    roleId: "external-role",
+    label: "External ACP",
+  },
+);
+
+console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-acp")));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["coordinator"] is not None
+    assert payload["coordinator"]["roleId"] == "external-role"
+    assert payload["coordinator"]["label"] == "External ACP"
+    assert payload["coordinator"]["textStreaming"] is True
+    assert payload["coordinator"]["parts"] == [
+        {"kind": "text", "content": "streamed from external ACP"}
+    ]
+    assert payload["byInstance"] == {}
+
+
+def test_history_overlay_renders_live_cursor_placeholder_for_stream_tail(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/history.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "history_overlay"
+    temp_dir.mkdir()
+
+    (temp_dir / "history.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function isRunPrimaryRoleId(roleId, runId) {
+    return roleId === "external-role" && runId === "run-1";
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(key, values = {}) {
+    return `${key}:${JSON.stringify(values)}`;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+function createContentEl() {
+  return {
+    children: [],
+    appendChild(child) {
+      this.children.push(child);
+    },
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  };
+}
+
+export function applyToolReturn() {}
+export function appendThinkingText() {}
+export function buildToolBlock() {
+  return { dataset: {}, querySelector() { return null; } };
+}
+export function decoratePendingApprovalBlock() {}
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function labelFromRole(_role, roleId, instanceId) {
+  return roleId || instanceId || "Agent";
+}
+export function parseApprovalArgsPreview() { return {}; }
+export function renderMessageBlock(container, _role, label, _parts = [], options = {}) {
+  const contentEl = createContentEl();
+  const wrapper = {
+    dataset: {
+      runId: String(options.runId || ""),
+      roleId: String(options.roleId || ""),
+      instanceId: String(options.instanceId || ""),
+      streamKey: String(options.streamKey || ""),
+    },
+    querySelector(selector) {
+      if (selector === ".msg-role") {
+        return { textContent: String(label || "").toUpperCase() };
+      }
+      if (selector === ".msg-content") {
+        return contentEl;
+      }
+      return null;
+    },
+  };
+  container.messages.push(wrapper);
+  return { wrapper, contentEl };
+}
+export function renderParts() {}
+export function resolvePendingToolBlock() { return null; }
+export function forceScrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+
+export function appendMessageText(contentEl, text, options = {}) {
+  globalThis.__appendCalls.push({
+    text,
+    streaming: options.streaming === true,
+  });
+  const block = {
+    type: "msg-text",
+    text,
+    streaming: options.streaming === true,
+  };
+  contentEl.appendChild(block);
+  return block;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+import { renderHistoricalMessageList } from "./history.js";
+
+globalThis.__appendCalls = [];
+
+const container = {
+  dataset: {},
+  messages: [],
+  appendChild(child) {
+    this.messages.push(child);
+  },
+  querySelectorAll() {
+    return [];
+  },
+  querySelector() {
+    return null;
+  },
+};
+
+renderHistoricalMessageList(container, [], {
+  runId: "run-1",
+  pendingToolApprovals: [],
+  streamOverlayEntry: {
+    roleId: "external-role",
+    instanceId: "external-instance",
+    label: "External ACP",
+    parts: [],
+    textStreaming: true,
+  },
+});
+
+console.log(JSON.stringify(globalThis.__appendCalls));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == [{"text": "", "streaming": True}]

--- a/tests/unit_tests/frontend/test_streaming_cursor_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_cursor_ui.py
@@ -71,11 +71,12 @@ def test_streaming_messages_render_a_terminal_cursor_until_finalize() -> None:
     assert "appendThinkingText(contentEl, String(part.content || '')," in history_script
     assert "const flushText = (streaming = false) => {" in history_script
     assert (
-        "appendMessageText(contentEl, safeText.trim(), { streaming });"
+        "appendMessageText(contentEl, streaming ? safeText : safeText.trim(), { streaming });"
         in history_script
     )
     assert "flushText(false);" in history_script
-    assert "flushText(trailingTextPart?.kind === 'text');" in history_script
+    assert "flushText(hasLiveTextTail && !!trailingTextPart);" in history_script
+    assert "appendMessageText(contentEl, '', { streaming: true });" in history_script
 
 
 def test_streaming_cursor_styles_are_declared_in_shared_frontend_css() -> None:

--- a/tests/unit_tests/frontend/test_streaming_tool_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_tool_ui.py
@@ -79,6 +79,39 @@ def test_streaming_tool_calls_keep_indexed_dom_targets_and_message_metadata() ->
     assert "wrapper.dataset.streamKey = streamKey;" in block_script
 
 
+def test_live_streaming_tool_overlay_skips_processed_group_summary() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    history_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "history.js"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "if (shouldCollapseIntermediateMessages(streamOverlayEntry, options)) {"
+        in history_script
+    )
+    assert (
+        "function shouldCollapseIntermediateMessages(streamOverlayEntry, options = {}) {"
+        in history_script
+    )
+    assert (
+        "const runStatus = String(options.runStatus || '').trim().toLowerCase();"
+        in history_script
+    )
+    assert "const isLatestRound = options.isLatestRound === true;" in history_script
+    assert "if (isLatestRound && runStatus !== 'completed') {" in history_script
+    assert "if (streamOverlayEntry.textStreaming === true) {" in history_script
+    assert "status === 'pending'" in history_script
+    assert "status === 'running'" in history_script
+    assert "approvalStatus === 'requested'" in history_script
+    assert "approvalStatus === 'approve'" in history_script
+
+
 def test_tool_blocks_extract_effective_inputs_instead_of_footer_status() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     tool_blocks_script = (

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -3152,7 +3152,7 @@ async def test_generate_publishes_retry_exhausted_event_on_final_failure(
     fake_hub = _FakeRunEventHub()
     provider, message_repo = _build_provider(tmp_path / "retry_exhausted.db", fake_hub)
     provider._session._retry_config.jitter = False
-    provider._session._retry_config.initial_delay_ms = 2000
+    provider._session._retry_config.initial_delay_ms = 10
     provider._session._retry_config.max_retries = 2
     request_error = APIStatusError(
         "timeout",

--- a/tests/unit_tests/tools/test_package_data.py
+++ b/tests/unit_tests/tools/test_package_data.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import tomllib
+from functools import cache
 from glob import glob
 from pathlib import Path
 from typing import cast
@@ -45,18 +46,34 @@ def _builtin_role_files(project_root: Path) -> tuple[Path, ...]:
 
 def _builtin_skill_files(project_root: Path) -> tuple[Path, ...]:
     builtin_root = project_root / "src" / "agent_teams" / "builtin" / "skills"
-    return tuple(sorted(path for path in builtin_root.rglob("*") if path.is_file()))
+    return tuple(
+        sorted(
+            path
+            for path in builtin_root.rglob("*")
+            if path.is_file()
+            and "node_modules" not in path.parts
+            and not any(part.startswith(".") for part in path.parts)
+        )
+    )
+
+
+@cache
+def _resolved_package_data_candidates(
+    package_root_str: str, pattern: str
+) -> frozenset[Path]:
+    package_root = Path(package_root_str)
+    return frozenset(
+        Path(candidate).resolve()
+        for candidate in glob(str(package_root / pattern), recursive=True)
+    )
 
 
 def _matches_package_data_pattern(
     *, package_root: Path, file_path: Path, pattern: str
 ) -> bool:
     resolved_file_path = file_path.resolve()
-    candidates = (
-        Path(candidate).resolve()
-        for candidate in glob(str(package_root / pattern), recursive=True)
-    )
-    return any(candidate == resolved_file_path for candidate in candidates)
+    candidates = _resolved_package_data_candidates(str(package_root), pattern)
+    return resolved_file_path in candidates
 
 
 def test_tool_description_files_are_declared_in_package_data() -> None:


### PR DESCRIPTION
## Summary
- unify frontend recovery so ACP and session switching keep live streaming state in sync
- keep only the latest unfinished run expanded and preserve the streaming cursor/tool visibility
- keep sidebar session groups collapsed on create and add lighter create/delete/switch animations
- tighten a few slow unit tests so pytest --timeout=3 completes cleanly

## Validation
- .\\.venv\\Scripts\\ruff.exe check --fix
- .\\.venv\\Scripts\\ruff.exe format --no-cache --force-exclude
- .\\.venv\\Scripts\\basedpyright.exe
- .\\.venv\\Scripts\\pytest.exe -q tests/unit_tests --timeout=3
- .\\.venv\\Scripts\\pytest.exe -q tests/integration_tests

Fixes #266
