### PR TITLE
[codex] docs: add 416 quality hardening notes

### DIFF
--- a/docs/头脑风暴-2026-4-7.md
+++ b/docs/头脑风暴-2026-4-7.md
@@ -1,0 +1,21 @@
+# 416版本质量加固项：
+1. office claw 与agent-teams acp 加固: MCP over ACP
+2. 通过ACP方式启动agent-teams，首次启动时延优化
+3. 上下文压缩管理优化，单session长时任务处理
+4. 普通模式，增加动态创建sub agent功能
+5. 工具打磨：弱网场景下断流超时问题解决
+6. 支持更高token缓存命中率：支持response和chat API切换
+7. miniMax/deepseek/qwen3.5模型兼容性
+8. 可观测性：仅单机版，分析还需要哪些关键指标，尤其关注ACP协议相关指标
+9. 可观测性：对接OpenTelemetry
+10. shell工具：权限控制，避免大模型通过脚本或者代码方式绕过权限控制
+11. 排查日志：不能打印明文敏感信息
+12. 日志打印：统一到office claw目录
+13. 可定位性：1）office claw提供按钮上传关键日志
+14. 测试问题筛选修改
+15. 支持windows+mac
+16. office claw打包问题：使用pip install有可能安装agent teams旧版本，需要每次获取agent teams最新版本
+17. office claw打包问题：打包后agent team无法正常调用cat cafe工具，AI分析是打包时mcp sdk包版本漂移导致
+18. office claw侧配置代理，agent teams需要同步生效。
+19. 验收范围：内部使用，秘书节推广，支持绿区+蓝区。
+20. 外部资源统一管理（clawhub， gh） ，提供skillhub运行时加载  


### PR DESCRIPTION
﻿## What changed
Added a planning note document for the 4/16 quality hardening items in `docs/头脑风暴-2026-4-7.md`.

## Why
This captures the current hardening scope and packaging/compatibility considerations in one place for follow-up work.

## Impact
This is a docs-only change. No runtime behavior is changed.

## Validation
No code checks were run. The diff is documentation only.

Fixes #271
