### PR TITLE
Harden shell blocking and reusable approvals

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -706,7 +706,7 @@ Notes:
   - video: `kind`, `count`, `resolution`, `duration_ms`, `seed`
 - `yolo` is optional.
 - `yolo: false` preserves the existing tool approval flow.
-- `yolo: true` skips tool approval for all tools in that run, including resumed recoverable runs.
+- `yolo: true` skips human tool approval for that run, including resumed recoverable runs, but tool-local validation still applies.
 - `thinking` is optional.
 - `thinking.enabled` enables model thinking streams for providers that emit thinking parts.
 - `thinking.effort` optionally sets provider reasoning effort (`minimal`, `low`, `medium`, `high`); when set, it is forwarded to OpenAI-compatible providers as `openai_reasoning_effort`.
@@ -819,6 +819,17 @@ Request:
 ```json
 {"action": "approve", "feedback": ""}
 ```
+
+Allowed `action` values:
+- `approve`: legacy one-time approval, equivalent to `approve_once`
+- `approve_once`: execute this pending tool call once
+- `approve_exact`: for shell, also save an exact reusable approval for the normalized command
+- `approve_prefix`: for shell, also save reusable prefix approvals such as `git status`
+- `deny`: deny the pending tool call
+
+Notes:
+- Shell exact/prefix approvals are project-scoped and shell-runtime-scoped. Git Bash approvals do not automatically apply to PowerShell, and vice versa.
+- Shell `workdir` values must stay inside the workspace writable roots even when the command itself targets external executables or scripts.
 
 ### `POST /runs/{run_id}/stop`
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -638,6 +638,7 @@ Primary query keys used by repositories:
 - `agent_teams.agents.tasks`: `tasks`.
 - `agent_teams.agents.execution`: `messages`.
 - `agent_teams.tools.runtime`: `approval_tickets`.
+- `agent_teams.tools.workspace_tools`: `shell_approval_grants`.
 - `agent_teams.providers`: `token_usage`.
 - `agent_teams.gateway.feishu`: `feishu_gateway_accounts`, `feishu_message_pool`.
 - `agent_teams.automation`: `automation_execution_events`.
@@ -684,6 +685,20 @@ Notes:
 - `target_role_id` stores an optional one-run direct-chat override, such as a leading `@Role` mention from the web composer.
 - `session_mode` and `topology_json` snapshot the resolved root-agent topology, including the selected normal-mode root role, used when the run was created, so recoverable resumes do not drift when global orchestration settings change later.
 - `conversation_context_json` stores optional source-channel context, including Feishu group-chat markers used by runtime prompt assembly and the automation direct-send override used by IM-bound scheduled runs.
+
+---
+
+### 2.9.0 `approval_tickets` and `shell_approval_grants`
+
+`approval_tickets` persists pending and reusable tool-approval records. Shell tickets also store `metadata_json`, which carries normalized command data used when the operator resolves a pending shell approval as `approve_exact` or `approve_prefix`.
+
+`shell_approval_grants` stores project-scoped reusable shell approvals keyed by:
+- `workspace_key`
+- `runtime_family`
+- `scope` (`exact` or `prefix`)
+- `value`
+
+These grants are local-only runtime permissions. They are separate from per-run approval tickets and are used only by the shell tool in non-`yolo` runs.
 
 ---
 

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -329,7 +329,7 @@ function applyOverlayToolState(toolBlock, part) {
         return;
     }
 
-    if (part.approvalStatus === 'approve' && part.result === undefined) {
+    if (isApprovedApprovalStatus(part.approvalStatus) && part.result === undefined) {
         setToolStatus(toolBlock, 'running');
         outputEl.classList.remove('error-text');
         outputEl.classList.add('warning-text');
@@ -480,10 +480,19 @@ function shouldCollapseIntermediateMessages(streamOverlayEntry, options = {}) {
             status === 'pending'
             || status === 'running'
             || approvalStatus === 'requested'
-            || approvalStatus === 'approve'
+            || isApprovedApprovalStatus(approvalStatus)
             || (part.result === undefined && part.validation === undefined)
         );
     });
+}
+function isApprovedApprovalStatus(value) {
+    const approvalStatus = String(value || '').trim().toLowerCase();
+    return (
+        approvalStatus === 'approve'
+        || approvalStatus === 'approve_once'
+        || approvalStatus === 'approve_exact'
+        || approvalStatus === 'approve_prefix'
+    );
 }
 function formatElapsed(ms) {
     const totalSeconds = Math.round(ms / 1000);

--- a/src/agent_teams/agents/execution/llm_session.py
+++ b/src/agent_teams/agents/execution/llm_session.py
@@ -112,6 +112,9 @@ from agent_teams.tools.runtime import (
     ToolApprovalPolicy,
     ToolDeps,
 )
+from agent_teams.tools.workspace_tools.shell_approval_repo import (
+    ShellApprovalRepository,
+)
 from agent_teams.mcp.mcp_models import McpToolSchema
 from agent_teams.mcp.mcp_registry import McpRegistry
 from agent_teams.notifications import NotificationService
@@ -236,6 +239,7 @@ class AgentLlmSession:
         retry_config: LlmRetryConfig | None = None,
         im_tool_service: "ImToolService | None" = None,
         computer_runtime: "ComputerRuntime | None" = None,
+        shell_approval_repo: ShellApprovalRepository | None = None,
     ) -> None:
         self._config = config
         self._task_repo = task_repo
@@ -272,6 +276,7 @@ class AgentLlmSession:
         self._retry_config = retry_config or LlmRetryConfig()
         self._im_tool_service = im_tool_service
         self._computer_runtime = computer_runtime
+        self._shell_approval_repo = shell_approval_repo
         self._mcp_tool_context_token_cache: dict[str, int] = {}
 
     async def run(self, request: LLMRequest) -> str:
@@ -409,6 +414,7 @@ class AgentLlmSession:
             run_control_manager=self._run_control_manager,
             tool_approval_manager=self._tool_approval_manager,
             tool_approval_policy=self._resolve_tool_approval_policy(request.run_id),
+            shell_approval_repo=self._shell_approval_repo,
             metric_recorder=self._metric_recorder,
             notification_service=self._notification_service,
             im_tool_service=self._im_tool_service,

--- a/src/agent_teams/external_agents/host_tool_bridge.py
+++ b/src/agent_teams/external_agents/host_tool_bridge.py
@@ -49,6 +49,9 @@ from agent_teams.tools.runtime import (
     ToolDeps,
 )
 from agent_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from agent_teams.tools.workspace_tools.shell_approval_repo import (
+    ShellApprovalRepository,
+)
 from agent_teams.workspace import WorkspaceManager, build_conversation_id
 
 if TYPE_CHECKING:
@@ -134,6 +137,7 @@ class ExternalAcpHostToolBridge:
         metric_recorder: MetricRecorder | None = None,
         im_tool_service: ImToolService | None = None,
         computer_runtime: ComputerRuntime | None = None,
+        shell_approval_repo: ShellApprovalRepository | None = None,
     ) -> None:
         self._task_repo = task_repo
         self._shared_store = shared_store
@@ -162,6 +166,7 @@ class ExternalAcpHostToolBridge:
         self._metric_recorder = metric_recorder
         self._im_tool_service = im_tool_service
         self._computer_runtime = computer_runtime
+        self._shell_approval_repo = shell_approval_repo
 
         self._catalog_by_name: dict[str, HostedToolDefinition] = {}
         self._catalog_signature = ""
@@ -483,6 +488,7 @@ class ExternalAcpHostToolBridge:
             run_control_manager=self._run_control_manager,
             tool_approval_manager=self._tool_approval_manager,
             tool_approval_policy=self._tool_approval_policy.with_yolo(yolo),
+            shell_approval_repo=self._shell_approval_repo,
             metric_recorder=self._metric_recorder,
             notification_service=self._get_notification_service(),
             im_tool_service=self._im_tool_service,

--- a/src/agent_teams/external_agents/host_tool_stdio_server.py
+++ b/src/agent_teams/external_agents/host_tool_stdio_server.py
@@ -68,6 +68,7 @@ async def _run_stdio_server() -> None:
         run_control_manager=container.run_control_manager,
         tool_approval_manager=container.tool_approval_manager,
         tool_approval_policy=container.tool_approval_policy,
+        shell_approval_repo=container.shell_approval_repo,
         get_notification_service=lambda: container.notification_service,
         metric_recorder=container.metric_recorder,
         im_tool_service=container.im_tool_service,

--- a/src/agent_teams/external_agents/provider.py
+++ b/src/agent_teams/external_agents/provider.py
@@ -82,6 +82,9 @@ if TYPE_CHECKING:
     from agent_teams.tools.runtime.approval_ticket_repo import (
         ApprovalTicketRepository,
     )
+    from agent_teams.tools.workspace_tools.shell_approval_repo import (
+        ShellApprovalRepository,
+    )
 
 LOGGER = get_logger(__name__)
 _EXTERNAL_ACP_PROMPT_INACTIVITY_TIMEOUT_SECONDS = 60.0
@@ -151,6 +154,7 @@ class ExternalAcpSessionManager:
         tool_approval_manager: ToolApprovalManager,
         tool_approval_policy: ToolApprovalPolicy,
         get_notification_service: Callable[[], NotificationService | None],
+        shell_approval_repo: ShellApprovalRepository | None = None,
         resolve_model_config: (
             Callable[[RoleDefinition, LLMRequest], ModelEndpointConfig | None] | None
         ) = None,
@@ -185,6 +189,7 @@ class ExternalAcpSessionManager:
         self._run_control_manager = run_control_manager
         self._tool_approval_manager = tool_approval_manager
         self._tool_approval_policy = tool_approval_policy
+        self._shell_approval_repo = shell_approval_repo
         self._get_notification_service = get_notification_service
         self._resolve_model_config = resolve_model_config
         self._metric_recorder = metric_recorder
@@ -941,6 +946,7 @@ class ExternalAcpSessionManager:
             run_control_manager=self._run_control_manager,
             tool_approval_manager=self._tool_approval_manager,
             tool_approval_policy=self._tool_approval_policy,
+            shell_approval_repo=self._shell_approval_repo,
             get_notification_service=self._get_notification_service,
             metric_recorder=self._metric_recorder,
             im_tool_service=self._im_tool_service,

--- a/src/agent_teams/interfaces/cli/approvals_cli.py
+++ b/src/agent_teams/interfaces/cli/approvals_cli.py
@@ -37,14 +37,27 @@ def build_approvals_app(
     def tool_approvals_resolve(
         run_id: str = typer.Option(..., "--run-id"),
         tool_call_id: str = typer.Option(..., "--tool-call-id"),
-        action: str = typer.Option(..., "--action", help="approve or deny"),
+        action: str = typer.Option(
+            ...,
+            "--action",
+            help="approve, approve_once, approve_exact, approve_prefix, or deny",
+        ),
         feedback: str = typer.Option("", "--feedback"),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
     ) -> None:
         auto_start_if_needed(base_url, autostart)
-        if action not in {"approve", "deny"}:
-            raise typer.BadParameter("action must be approve or deny")
+        if action not in {
+            "approve",
+            "approve_once",
+            "approve_exact",
+            "approve_prefix",
+            "deny",
+        }:
+            raise typer.BadParameter(
+                "action must be approve, approve_once, approve_exact, "
+                "approve_prefix, or deny"
+            )
         result = request_json(
             base_url,
             "POST",

--- a/src/agent_teams/interfaces/server/container.py
+++ b/src/agent_teams/interfaces/server/container.py
@@ -161,6 +161,9 @@ from agent_teams.tools.runtime import (
     ToolApprovalManager,
     ToolApprovalPolicy,
 )
+from agent_teams.tools.workspace_tools.shell_approval_repo import (
+    ShellApprovalRepository,
+)
 from agent_teams.gateway.wechat import (
     WeChatAccountRepository,
     WeChatClient,
@@ -285,6 +288,9 @@ class ServerContainer:
             session_history_marker_repo=self.session_history_marker_repo,
         )
         self.approval_ticket_repo: ApprovalTicketRepository = ApprovalTicketRepository(
+            runtime.paths.db_path
+        )
+        self.shell_approval_repo: ShellApprovalRepository = ShellApprovalRepository(
             runtime.paths.db_path
         )
         self.run_runtime_repo: RunRuntimeRepository = RunRuntimeRepository(
@@ -474,6 +480,7 @@ class ServerContainer:
             run_control_manager=self.run_control_manager,
             tool_approval_manager=self.tool_approval_manager,
             tool_approval_policy=self.tool_approval_policy,
+            shell_approval_repo=self.shell_approval_repo,
             get_notification_service=lambda: self.notification_service,
             resolve_model_config=self._resolve_external_agent_model_config,
             metric_recorder=self.metric_recorder,
@@ -542,6 +549,7 @@ class ServerContainer:
             orchestration_settings_service=self.orchestration_settings_service,
             media_asset_service=self.media_asset_service,
             runtime_role_resolver=self.runtime_role_resolver,
+            shell_approval_repo=self.shell_approval_repo,
         )
         self.session_service: SessionService = SessionService(
             session_repo=self.session_repo,
@@ -769,6 +777,7 @@ class ServerContainer:
             run_control_manager=self.run_control_manager,
             tool_approval_manager=self.tool_approval_manager,
             tool_approval_policy=self.tool_approval_policy,
+            shell_approval_repo=self.shell_approval_repo,
             notification_service=self.notification_service,
             get_task_execution_service=get_task_execution_service,
             token_usage_repo=self.token_usage_repo,

--- a/src/agent_teams/interfaces/server/routers/runs.py
+++ b/src/agent_teams/interfaces/server/routers/runs.py
@@ -61,7 +61,13 @@ class InjectMessageRequest(BaseModel):
 class ResolveToolApprovalRequest(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
-    action: Literal["approve", "deny"]
+    action: Literal[
+        "approve",
+        "approve_once",
+        "approve_exact",
+        "approve_prefix",
+        "deny",
+    ]
     feedback: str = ""
 
 

--- a/src/agent_teams/providers/openai_compatible.py
+++ b/src/agent_teams/providers/openai_compatible.py
@@ -69,6 +69,9 @@ if TYPE_CHECKING:
         ToolApprovalManager,
         ToolApprovalPolicy,
     )
+    from agent_teams.tools.workspace_tools.shell_approval_repo import (
+        ShellApprovalRepository,
+    )
     from agent_teams.workspace import WorkspaceManager
     from agent_teams.gateway.im import ImToolService
 
@@ -108,6 +111,7 @@ class OpenAICompatibleProvider(LLMProvider):
         tool_approval_manager: ToolApprovalManager,
         tool_approval_policy: ToolApprovalPolicy,
         notification_service: NotificationService | None = None,
+        shell_approval_repo: ShellApprovalRepository | None = None,
         token_usage_repo: TokenUsageRepository | None = None,
         metric_recorder: MetricRecorder | None = None,
         retry_config: LlmRetryConfig | None = None,
@@ -151,6 +155,7 @@ class OpenAICompatibleProvider(LLMProvider):
             run_control_manager=run_control_manager,
             tool_approval_manager=tool_approval_manager,
             tool_approval_policy=tool_approval_policy,
+            shell_approval_repo=shell_approval_repo,
             notification_service=notification_service,
             token_usage_repo=token_usage_repo,
             metric_recorder=metric_recorder,

--- a/src/agent_teams/providers/provider_factory.py
+++ b/src/agent_teams/providers/provider_factory.py
@@ -48,6 +48,9 @@ from agent_teams.agents.tasks.task_repository import TaskRepository
 from agent_teams.providers.token_usage_repo import TokenUsageRepository
 from agent_teams.tools.registry import ToolRegistry, ToolResolutionContext
 from agent_teams.tools.runtime import ToolApprovalManager, ToolApprovalPolicy
+from agent_teams.tools.workspace_tools.shell_approval_repo import (
+    ShellApprovalRepository,
+)
 from agent_teams.workspace import WorkspaceManager
 
 if TYPE_CHECKING:
@@ -83,6 +86,7 @@ def create_provider_factory(
     tool_approval_policy: ToolApprovalPolicy,
     notification_service: NotificationService | None,
     get_task_execution_service: Callable[[], TaskExecutionService],
+    shell_approval_repo: ShellApprovalRepository | None = None,
     computer_runtime: ComputerRuntime | None = None,
     token_usage_repo: TokenUsageRepository | None = None,
     metric_recorder: MetricRecorder | None = None,
@@ -169,6 +173,7 @@ def create_provider_factory(
                 run_control_manager=run_control_manager,
                 tool_approval_manager=tool_approval_manager,
                 tool_approval_policy=tool_approval_policy,
+                shell_approval_repo=shell_approval_repo,
                 notification_service=notification_service,
                 token_usage_repo=token_usage_repo,
                 metric_recorder=metric_recorder,

--- a/src/agent_teams/sessions/runs/background_tasks/command_runtime.py
+++ b/src/agent_teams/sessions/runs/background_tasks/command_runtime.py
@@ -21,7 +21,9 @@ from pydantic import BaseModel, ConfigDict
 from agent_teams.env import build_github_cli_env, build_subprocess_env, get_env_var
 from agent_teams.env.github_config_service import GitHubConfigService
 from agent_teams.env.runtime_env import get_app_config_dir
-from agent_teams.sessions.runs.background_tasks.github_cli import get_gh_path
+from agent_teams.sessions.runs.background_tasks.github_cli import (
+    resolve_existing_gh_path,
+)
 
 WINDOWS_GIT_BASH_CANDIDATES = (
     Path(r"C:\Program Files\Git\bin\bash.exe"),
@@ -81,6 +83,7 @@ _WINDOWS_POWERSHELL_CMDLET_PREFIXES = frozenset(
         "Write",
     }
 )
+_WINDOWS_POWERSHELL_ALIASES = frozenset({"curl", "irm", "iwr", "wget"})
 _EXPLICIT_WINDOWS_SHELL_NAMES = frozenset(
     {
         "bash",
@@ -345,12 +348,42 @@ def _command_prefers_powershell(command: str | None) -> bool:
         return True
     if _POWERSHELL_MEMBER_PATTERN.search(normalized) is not None:
         return True
+    if command_name in _WINDOWS_POWERSHELL_ALIASES:
+        return True
+    if _starts_powershell_script_invocation(normalized):
+        return True
     for match in _POWERSHELL_CMDLET_PATTERN.finditer(normalized):
         cmdlet = match.group("cmdlet")
         prefix = cmdlet.split("-", 1)[0]
         if prefix in _WINDOWS_POWERSHELL_CMDLET_PREFIXES:
             return True
     return False
+
+
+def _starts_powershell_script_invocation(command: str) -> bool:
+    normalized = command.strip()
+    if not normalized:
+        return False
+    if normalized.startswith("&"):
+        remainder = normalized[1:].lstrip()
+        token = _extract_windows_shell_token(remainder)
+        return token.lower().endswith(".ps1")
+    token = _extract_windows_shell_token(normalized)
+    return token.lower().endswith(".ps1")
+
+
+def _extract_windows_shell_token(command: str) -> str:
+    stripped = command.lstrip()
+    if not stripped:
+        return ""
+    quote = stripped[0]
+    if quote in {"'", '"'}:
+        end_index = stripped.find(quote, 1)
+        if end_index == -1:
+            return stripped[1:]
+        return stripped[1:end_index]
+    token, *_ = stripped.split(maxsplit=1)
+    return token
 
 
 def _resolve_windows_bash_path() -> str:
@@ -603,7 +636,7 @@ def _load_github_cli_env() -> dict[str, str]:
 
 async def _resolve_gh_path() -> Path | None:
     try:
-        return await get_gh_path()
+        return resolve_existing_gh_path()
     except Exception:
         return None
 

--- a/src/agent_teams/sessions/runs/background_tasks/github_cli.py
+++ b/src/agent_teams/sessions/runs/background_tasks/github_cli.py
@@ -69,33 +69,15 @@ def _get_platform_key() -> str:
 async def get_gh_path() -> Path:
     global _gh_path_cache
 
-    if _gh_path_cache and _gh_path_cache.is_file():
-        return _gh_path_cache
-
-    system_path = resolve_system_gh_path()
-    if system_path is not None:
-        LOGGER.info("Using system GitHub CLI at %s", system_path)
-        _gh_path_cache = system_path
-        return system_path
-
-    local_path = get_bundled_gh_path()
-    if local_path is not None:
-        _gh_path_cache = local_path
-        return local_path
+    existing_path = resolve_existing_gh_path()
+    if existing_path is not None:
+        return existing_path
 
     async with _gh_path_lock:
-        if _gh_path_cache and _gh_path_cache.is_file():
-            return _gh_path_cache
-        system_path = resolve_system_gh_path()
-        if system_path is not None:
-            LOGGER.info("Using system GitHub CLI at %s", system_path)
-            _gh_path_cache = system_path
-            return system_path
-        local_path = get_bundled_gh_path()
-        if local_path is not None:
-            _gh_path_cache = local_path
-            return local_path
-        download_target = _bundled_gh_target_path()
+        existing_path = resolve_existing_gh_path()
+        if existing_path is not None:
+            return existing_path
+        download_target = _bundled_gh_target_path(ensure_parent=True)
         try:
             await _download_gh(download_target)
             _gh_path_cache = download_target
@@ -109,6 +91,28 @@ async def get_gh_path() -> Path:
 def clear_gh_path_cache() -> None:
     global _gh_path_cache
     _gh_path_cache = None
+
+
+def resolve_existing_gh_path() -> Path | None:
+    global _gh_path_cache
+
+    try:
+        if _gh_path_cache and _gh_path_cache.is_file():
+            return _gh_path_cache
+
+        system_path = resolve_system_gh_path()
+        if system_path is not None:
+            LOGGER.info("Using system GitHub CLI at %s", system_path)
+            _gh_path_cache = system_path
+            return system_path
+
+        local_path = get_bundled_gh_path()
+        if local_path is not None:
+            _gh_path_cache = local_path
+            return local_path
+    except Exception:
+        return None
+    return None
 
 
 def resolve_system_gh_path() -> Path | None:
@@ -128,8 +132,9 @@ def get_bundled_gh_path() -> Path | None:
     return None
 
 
-def _bundled_gh_target_path() -> Path:
-    BIN_DIR.mkdir(parents=True, exist_ok=True)
+def _bundled_gh_target_path(*, ensure_parent: bool = False) -> Path:
+    if ensure_parent:
+        BIN_DIR.mkdir(parents=True, exist_ok=True)
     extension = ".exe" if os.name == "nt" else ""
     return BIN_DIR / f"gh{extension}"
 

--- a/src/agent_teams/sessions/runs/run_manager.py
+++ b/src/agent_teams/sessions/runs/run_manager.py
@@ -66,6 +66,7 @@ from agent_teams.sessions.runs.run_models import (
 )
 from agent_teams.agents.instances.instance_repository import AgentInstanceRepository
 from agent_teams.tools.runtime.approval_ticket_repo import (
+    ApprovalTicketRecord,
     ApprovalTicketRepository,
     ApprovalTicketStatus,
 )
@@ -84,6 +85,11 @@ from agent_teams.sessions.runs.run_state_repo import RunStateRepository
 from agent_teams.sessions.session_repository import SessionRepository
 from agent_teams.agents.tasks.task_repository import TaskRepository
 from agent_teams.tools.runtime import ToolApprovalAction, ToolApprovalManager
+from agent_teams.tools.workspace_tools.shell_approval_repo import (
+    ShellApprovalRepository,
+    ShellApprovalScope,
+)
+from agent_teams.tools.workspace_tools.shell_policy import ShellRuntimeFamily
 from agent_teams.trace import bind_trace_context
 from agent_teams.agents.tasks.models import TaskRecord
 from agent_teams.agents.tasks.enums import TaskStatus
@@ -96,6 +102,48 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _T = TypeVar("_T")
+
+
+def _approval_action_is_approved(action: str) -> bool:
+    return action in {"approve", "approve_once", "approve_exact", "approve_prefix"}
+
+
+def _approval_action_requires_shell_grant(action: str) -> bool:
+    return action in {"approve_exact", "approve_prefix"}
+
+
+def _normalize_shell_prefix_candidates(raw_value: object) -> tuple[str, ...]:
+    if not isinstance(raw_value, list):
+        return ()
+    normalized: list[str] = []
+    for item in raw_value:
+        if not isinstance(item, str):
+            continue
+        candidate = item.strip()
+        if candidate:
+            normalized.append(candidate)
+    return tuple(normalized)
+
+
+def _extract_shell_grant_metadata(
+    ticket: ApprovalTicketRecord,
+) -> tuple[str, ShellRuntimeFamily, str, tuple[str, ...]] | None:
+    if ticket.tool_name != "shell":
+        return None
+    metadata = ticket.metadata
+    workspace_key = str(metadata.get("workspace_key") or "").strip()
+    runtime_family = str(metadata.get("runtime_family") or "").strip()
+    normalized_command = str(metadata.get("normalized_command") or "").strip()
+    prefix_candidates = _normalize_shell_prefix_candidates(
+        metadata.get("prefix_candidates")
+    )
+    if not workspace_key or not runtime_family:
+        return None
+    try:
+        resolved_runtime_family = ShellRuntimeFamily(runtime_family)
+    except ValueError:
+        return None
+    return workspace_key, resolved_runtime_family, normalized_command, prefix_candidates
 
 
 class AutoRecoveryReason(StrEnum):
@@ -171,6 +219,7 @@ class RunManager:
         orchestration_settings_service: OrchestrationSettingsService | None = None,
         media_asset_service: MediaAssetService | None = None,
         runtime_role_resolver: RuntimeRoleResolver | None = None,
+        shell_approval_repo: ShellApprovalRepository | None = None,
     ) -> None:
         self._meta_agent: MetaAgent = meta_agent
         self._provider_factory = provider_factory or (
@@ -199,6 +248,7 @@ class RunManager:
         self._orchestration_settings_service = orchestration_settings_service
         self._media_asset_service = media_asset_service
         self._runtime_role_resolver = runtime_role_resolver
+        self._shell_approval_repo = shell_approval_repo
         self._pending_runs: dict[str, IntentInput] = {}
         self._running_run_ids: set[str] = set()
         self._resume_requested_runs: set[str] = set()
@@ -1705,7 +1755,13 @@ class RunManager:
         action: str,
         feedback: str = "",
     ) -> None:
-        if action not in {"approve", "deny"}:
+        if action not in {
+            "approve",
+            "approve_once",
+            "approve_exact",
+            "approve_prefix",
+            "deny",
+        }:
             raise ValueError(f"Unsupported action: {action}")
         runtime = self._runtime_for_run(run_id)
         if (
@@ -1725,12 +1781,21 @@ class RunManager:
             run_id=run_id,
             tool_call_id=tool_call_id,
         )
+        ticket = (
+            self._approval_ticket_repo.get(tool_call_id)
+            if self._approval_ticket_repo is not None
+            else None
+        )
+        if ticket is not None and ticket.run_id != run_id:
+            raise KeyError(f"Tool approval {tool_call_id} not found for run {run_id}")
+        if _approval_action_requires_shell_grant(action):
+            self._persist_shell_approval_grants(ticket=ticket, action=action)
         if self._approval_ticket_repo is not None:
             self._approval_ticket_repo.resolve(
                 tool_call_id=tool_call_id,
                 status=(
                     ApprovalTicketStatus.APPROVED
-                    if action == "approve"
+                    if _approval_action_is_approved(action)
                     else ApprovalTicketStatus.DENIED
                 ),
                 feedback=feedback,
@@ -1769,6 +1834,36 @@ class RunManager:
                 ),
             )
         )
+
+    def _persist_shell_approval_grants(
+        self,
+        *,
+        ticket: ApprovalTicketRecord | None,
+        action: str,
+    ) -> None:
+        if ticket is None or self._shell_approval_repo is None:
+            return
+        if ticket.status != ApprovalTicketStatus.REQUESTED:
+            return
+        resolved = _extract_shell_grant_metadata(ticket)
+        if resolved is None:
+            return
+        workspace_key, runtime_family, normalized_command, prefix_candidates = resolved
+        if action == "approve_exact" and normalized_command:
+            self._shell_approval_repo.grant(
+                workspace_key=workspace_key,
+                runtime_family=runtime_family,
+                scope=ShellApprovalScope.EXACT,
+                value=normalized_command,
+            )
+        if action == "approve_prefix":
+            for candidate in prefix_candidates:
+                self._shell_approval_repo.grant(
+                    workspace_key=workspace_key,
+                    runtime_family=runtime_family,
+                    scope=ShellApprovalScope.PREFIX,
+                    value=candidate,
+                )
 
     def list_open_tool_approvals(self, run_id: str) -> list[dict[str, str]]:
         if self._approval_ticket_repo is None:

--- a/src/agent_teams/tools/runtime/approval_state.py
+++ b/src/agent_teams/tools/runtime/approval_state.py
@@ -7,7 +7,13 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 
-ToolApprovalAction = Literal["approve", "deny"]
+ToolApprovalAction = Literal[
+    "approve",
+    "approve_once",
+    "approve_exact",
+    "approve_prefix",
+    "deny",
+]
 
 
 class _ToolApprovalEntry(BaseModel):

--- a/src/agent_teams/tools/runtime/approval_ticket_repo.py
+++ b/src/agent_teams/tools/runtime/approval_ticket_repo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 import logging
 from datetime import datetime, timezone
@@ -42,6 +43,7 @@ class ApprovalTicketRecord(BaseModel):
     role_id: RequiredIdentifierStr
     tool_name: RequiredIdentifierStr
     args_preview: str = ""
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
     status: ApprovalTicketStatus = ApprovalTicketStatus.REQUESTED
     feedback: str = ""
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
@@ -95,6 +97,7 @@ class ApprovalTicketRepository:
                     role_id        TEXT NOT NULL,
                     tool_name      TEXT NOT NULL,
                     args_preview   TEXT NOT NULL DEFAULT '',
+                    metadata_json  TEXT NOT NULL DEFAULT '{}',
                     status         TEXT NOT NULL,
                     feedback       TEXT NOT NULL DEFAULT '',
                     created_at     TEXT NOT NULL,
@@ -103,6 +106,17 @@ class ApprovalTicketRepository:
                 )
                 """
             )
+            columns = {
+                str(row["name"])
+                for row in self._conn.execute(
+                    "PRAGMA table_info(approval_tickets)"
+                ).fetchall()
+            }
+            if "metadata_json" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE approval_tickets "
+                    "ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'"
+                )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_approval_tickets_run_status ON approval_tickets(run_id, status, created_at ASC)"
             )
@@ -133,10 +147,16 @@ class ApprovalTicketRepository:
         role_id: str,
         tool_name: str,
         args_preview: str,
+        metadata: dict[str, JsonValue] | None = None,
         cache_key: str = "",
         signature_args_preview: str | None = None,
     ) -> ApprovalTicketRecord:
         now = datetime.now(tz=timezone.utc).isoformat()
+        metadata_json = json.dumps(
+            {} if metadata is None else metadata,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
         signature_key = approval_signature_key(
             run_id=run_id,
             task_id=task_id,
@@ -164,8 +184,8 @@ class ApprovalTicketRepository:
             self._conn.execute(
                 """
                 INSERT INTO approval_tickets(tool_call_id, signature_key, run_id, session_id, task_id, instance_id,
-                                             role_id, tool_name, args_preview, status, feedback, created_at, updated_at, resolved_at)
-                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                             role_id, tool_name, args_preview, metadata_json, status, feedback, created_at, updated_at, resolved_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(tool_call_id)
                 DO UPDATE SET
                     signature_key=excluded.signature_key,
@@ -176,6 +196,7 @@ class ApprovalTicketRepository:
                     role_id=excluded.role_id,
                     tool_name=excluded.tool_name,
                     args_preview=excluded.args_preview,
+                    metadata_json=excluded.metadata_json,
                     status=excluded.status,
                     updated_at=excluded.updated_at
                 """,
@@ -189,6 +210,7 @@ class ApprovalTicketRepository:
                     role_id,
                     tool_name,
                     args_preview,
+                    metadata_json,
                     ApprovalTicketStatus.REQUESTED.value,
                     "",
                     created_at,
@@ -383,6 +405,7 @@ class ApprovalTicketRepository:
                 field_name="tool_name",
             ),
             args_preview=str(row["args_preview"]),
+            metadata=_load_ticket_metadata(row["metadata_json"]),
             status=status,
             feedback=str(row["feedback"]),
             created_at=created_at,
@@ -484,6 +507,22 @@ def _optional_ticket_timestamp(
     raise ValueError(f"Invalid persisted {field_name}")
 
 
+def _load_ticket_metadata(raw_value: object) -> dict[str, JsonValue]:
+    normalized = normalize_persisted_text(raw_value)
+    if normalized is None:
+        return {}
+    try:
+        decoded = json.loads(normalized)
+    except ValueError as exc:
+        raise ValueError("Invalid persisted metadata_json") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError("Approval ticket metadata_json must decode to an object")
+    metadata: dict[str, JsonValue] = {}
+    for key, value in decoded.items():
+        metadata[str(key)] = value
+    return metadata
+
+
 def _persisted_value_preview(value: object) -> str:
     if value is None:
         return "<null>"
@@ -524,6 +563,7 @@ def _log_invalid_ticket_row(*, row: sqlite3.Row, error: Exception) -> None:
         "created_at": _persisted_value_preview(row["created_at"]),
         "updated_at": _persisted_value_preview(row["updated_at"]),
         "resolved_at": _persisted_value_preview(row["resolved_at"]),
+        "metadata_json": _persisted_value_preview(row["metadata_json"]),
         "error_type": type(error).__name__,
         "error": str(error),
     }

--- a/src/agent_teams/tools/runtime/context.py
+++ b/src/agent_teams/tools/runtime/context.py
@@ -34,6 +34,9 @@ from agent_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from agent_teams.tools.runtime.approval_state import ToolApprovalManager
 from agent_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from agent_teams.tools.runtime.policy import ToolApprovalPolicy
+from agent_teams.tools.workspace_tools.shell_approval_repo import (
+    ShellApprovalRepository,
+)
 from agent_teams.workspace import WorkspaceHandle
 
 
@@ -143,6 +146,7 @@ class ToolDeps(BaseModel):
     run_control_manager: SkipValidation[RunControlManager]
     tool_approval_manager: SkipValidation[ToolApprovalManager]
     tool_approval_policy: SkipValidation[ToolApprovalPolicy]
+    shell_approval_repo: SkipValidation[ShellApprovalRepository | None] = None
     metric_recorder: SkipValidation[MetricRecorder | None] = None
     notification_service: SkipValidation[NotificationService | None] = None
     im_tool_service: SkipValidation[ImToolServiceLike | None] = None

--- a/src/agent_teams/tools/runtime/execution.py
+++ b/src/agent_teams/tools/runtime/execution.py
@@ -441,6 +441,7 @@ async def _handle_tool_approval(
         role_id=ctx.deps.role_id,
         tool_name=tool_name,
         args_preview=args_preview,
+        metadata=approval_request.metadata if approval_request is not None else None,
         cache_key=cache_key,
         signature_args_preview=approval_preview,
     )
@@ -604,7 +605,7 @@ async def _wait_for_ticket_resolution(
     )
     resolved_status = (
         ApprovalTicketStatus.APPROVED
-        if action == "approve"
+        if _approval_action_is_approved(action)
         else ApprovalTicketStatus.DENIED
     )
     ctx.deps.approval_ticket_repo.resolve(
@@ -617,7 +618,7 @@ async def _wait_for_ticket_resolution(
         meta["approval_feedback"] = feedback
     log_event(
         LOGGER,
-        logging.INFO if action == "approve" else logging.WARNING,
+        logging.INFO if _approval_action_is_approved(action) else logging.WARNING,
         event="tool.approval.resolved",
         message="Tool approval resolved",
         payload={
@@ -656,6 +657,10 @@ async def _wait_for_ticket_resolution(
         )
 
     return ticket_id, None
+
+
+def _approval_action_is_approved(action: str) -> bool:
+    return action in {"approve", "approve_once", "approve_exact", "approve_prefix"}
 
 
 def _publish_tool_approval_notification(
@@ -814,7 +819,12 @@ def _approval_status_from_meta(
     runtime_meta: dict[str, JsonValue],
 ) -> ToolApprovalStatus | None:
     approval_text = str(runtime_meta.get("approval_status") or "").strip().lower()
-    if approval_text == ToolApprovalStatus.APPROVE.value:
+    if approval_text in {
+        ToolApprovalStatus.APPROVE.value,
+        "approve_once",
+        "approve_exact",
+        "approve_prefix",
+    }:
         return ToolApprovalStatus.APPROVE
     if approval_text == ToolApprovalStatus.DENY.value:
         return ToolApprovalStatus.DENY

--- a/src/agent_teams/tools/runtime/models.py
+++ b/src/agent_teams/tools/runtime/models.py
@@ -74,6 +74,7 @@ class ToolApprovalRequest(BaseModel):
     source: str = ""
     execution_surface: ExecutionSurface | None = None
     cache_key: str = ""
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
 
 
 class ToolApprovalDecision(BaseModel):

--- a/src/agent_teams/tools/runtime/persisted_state.py
+++ b/src/agent_teams/tools/runtime/persisted_state.py
@@ -297,7 +297,7 @@ def recover_tool_call_state_from_event_log(
             )
         elif event_type == RunEventType.TOOL_APPROVAL_RESOLVED.value:
             action = str(payload.get("action") or "").strip().lower()
-            if action == "approve":
+            if action in {"approve", "approve_once", "approve_exact", "approve_prefix"}:
                 state = state.model_copy(
                     update={
                         "approval_status": ToolApprovalStatus.APPROVE,

--- a/src/agent_teams/tools/workspace_tools/github_cli.py
+++ b/src/agent_teams/tools/workspace_tools/github_cli.py
@@ -69,33 +69,15 @@ def _get_platform_key() -> str:
 async def get_gh_path() -> Path:
     global _gh_path_cache
 
-    if _gh_path_cache and _gh_path_cache.is_file():
-        return _gh_path_cache
-
-    system_path = resolve_system_gh_path()
-    if system_path is not None:
-        LOGGER.info("Using system GitHub CLI at %s", system_path)
-        _gh_path_cache = system_path
-        return system_path
-
-    local_path = get_bundled_gh_path()
-    if local_path is not None:
-        _gh_path_cache = local_path
-        return local_path
+    existing_path = resolve_existing_gh_path()
+    if existing_path is not None:
+        return existing_path
 
     async with _gh_path_lock:
-        if _gh_path_cache and _gh_path_cache.is_file():
-            return _gh_path_cache
-        system_path = resolve_system_gh_path()
-        if system_path is not None:
-            LOGGER.info("Using system GitHub CLI at %s", system_path)
-            _gh_path_cache = system_path
-            return system_path
-        local_path = get_bundled_gh_path()
-        if local_path is not None:
-            _gh_path_cache = local_path
-            return local_path
-        download_target = _bundled_gh_target_path()
+        existing_path = resolve_existing_gh_path()
+        if existing_path is not None:
+            return existing_path
+        download_target = _bundled_gh_target_path(ensure_parent=True)
         try:
             await _download_gh(download_target)
             _gh_path_cache = download_target
@@ -109,6 +91,28 @@ async def get_gh_path() -> Path:
 def clear_gh_path_cache() -> None:
     global _gh_path_cache
     _gh_path_cache = None
+
+
+def resolve_existing_gh_path() -> Path | None:
+    global _gh_path_cache
+
+    try:
+        if _gh_path_cache and _gh_path_cache.is_file():
+            return _gh_path_cache
+
+        system_path = resolve_system_gh_path()
+        if system_path is not None:
+            LOGGER.info("Using system GitHub CLI at %s", system_path)
+            _gh_path_cache = system_path
+            return system_path
+
+        local_path = get_bundled_gh_path()
+        if local_path is not None:
+            _gh_path_cache = local_path
+            return local_path
+    except Exception:
+        return None
+    return None
 
 
 def resolve_system_gh_path() -> Path | None:
@@ -128,8 +132,9 @@ def get_bundled_gh_path() -> Path | None:
     return None
 
 
-def _bundled_gh_target_path() -> Path:
-    BIN_DIR.mkdir(parents=True, exist_ok=True)
+def _bundled_gh_target_path(*, ensure_parent: bool = False) -> Path:
+    if ensure_parent:
+        BIN_DIR.mkdir(parents=True, exist_ok=True)
     extension = ".exe" if os.name == "nt" else ""
     return BIN_DIR / f"gh{extension}"
 

--- a/src/agent_teams/tools/workspace_tools/shell.py
+++ b/src/agent_teams/tools/workspace_tools/shell.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
+from agent_teams.computer import ComputerActionRisk
 from pydantic import JsonValue
 from pydantic_ai import Agent
 
@@ -11,6 +13,7 @@ from agent_teams.tools.runtime import (
     ToolApprovalRequest,
     ToolContext,
     ToolDeps,
+    ToolExecutionError,
     execute_tool,
 )
 from agent_teams.tools.workspace_tools.background_task_tool_support import (
@@ -20,7 +23,11 @@ from agent_teams.tools.workspace_tools.background_task_tool_support import (
 from agent_teams.tools.workspace_tools.command_canonicalization import (
     canonicalize_shell_command,
 )
-from agent_teams.tools.workspace_tools.shell_policy import validate_shell_command
+from agent_teams.tools.workspace_tools.shell_approval_repo import ShellApprovalScope
+from agent_teams.tools.workspace_tools.shell_policy import (
+    ShellPolicyDecision,
+    validate_shell_command,
+)
 
 CURRENT_ROLE_ENV_KEY = "AGENT_TEAMS_CURRENT_ROLE_ID"
 DESCRIPTION = load_tool_description(__file__)
@@ -37,9 +44,24 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         workdir: str | None = None,
         tty: bool = False,
     ) -> dict[str, JsonValue]:
-        approval_request = ToolApprovalRequest(
-            cache_key=build_shell_cache_key(
-                command,
+        blocked_error: ToolExecutionError | None = None
+        shell_policy: ShellPolicyDecision | None = None
+        cwd: Path | None = None
+        try:
+            shell_policy, cwd = prepare_shell_execution(
+                ctx,
+                command=command,
+                workdir=workdir,
+            )
+        except ToolExecutionError as exc:
+            blocked_error = exc
+        approval_request = (
+            build_shell_blocked_approval_request()
+            if blocked_error is not None
+            else build_shell_approval_request(
+                ctx,
+                shell_policy=_require_shell_policy(shell_policy),
+                command=command,
                 workdir=workdir,
                 tty=tty,
                 background=background,
@@ -47,9 +69,11 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         )
 
         async def _action():
-            validate_shell_command(command)
+            if blocked_error is not None:
+                raise blocked_error
+            if cwd is None:
+                raise RuntimeError("shell execution cwd was not prepared")
             service = require_background_task_service(ctx)
-            cwd = resolve_cwd(ctx, workdir)
             record, completed = await service.execute_command(
                 run_id=ctx.deps.run_id,
                 session_id=ctx.deps.session_id,
@@ -110,6 +134,78 @@ def build_shell_cache_key(
     )
 
 
+def build_shell_approval_request(
+    ctx: ToolContext,
+    *,
+    shell_policy: ShellPolicyDecision,
+    command: str,
+    workdir: str | None,
+    tty: bool,
+    background: bool,
+) -> ToolApprovalRequest:
+    cache_key = build_shell_cache_key(
+        command,
+        workdir=workdir,
+        tty=tty,
+        background=background,
+    )
+    metadata = build_shell_approval_metadata(ctx, shell_policy=shell_policy)
+    repo = ctx.deps.shell_approval_repo
+    if repo is not None and not ctx.deps.tool_approval_policy.yolo:
+        workspace_key = str(metadata["workspace_key"])
+        runtime_family = shell_policy.runtime_family
+        normalized_command = shell_policy.normalized_command
+        prefix_candidates = shell_policy.prefix_candidates
+        if repo.has_exact_grant(
+            workspace_key=workspace_key,
+            runtime_family=runtime_family,
+            normalized_command=normalized_command,
+        ) or repo.has_prefix_grants(
+            workspace_key=workspace_key,
+            runtime_family=runtime_family,
+            prefix_candidates=prefix_candidates,
+        ):
+            return ToolApprovalRequest(
+                cache_key=cache_key,
+                risk_level=ComputerActionRisk.SAFE,
+                source="shell_saved_permission",
+                target_summary=", ".join(prefix_candidates)[:200],
+                metadata=metadata,
+            )
+    return ToolApprovalRequest(
+        cache_key=cache_key,
+        source="shell",
+        target_summary=", ".join(shell_policy.prefix_candidates)[:200],
+        metadata=metadata,
+    )
+
+
+def build_shell_blocked_approval_request() -> ToolApprovalRequest:
+    return ToolApprovalRequest(
+        risk_level=ComputerActionRisk.SAFE,
+        source="shell_local_policy",
+    )
+
+
+def build_shell_approval_metadata(
+    ctx: ToolContext,
+    *,
+    shell_policy: ShellPolicyDecision,
+) -> dict[str, JsonValue]:
+    return {
+        "workspace_key": str(ctx.deps.workspace.execution_root.resolve()),
+        "runtime_family": shell_policy.runtime_family.value,
+        "normalized_command": shell_policy.normalized_command,
+        "prefix_candidates": cast(
+            list[JsonValue], list(shell_policy.prefix_candidates)
+        ),
+        "approval_scope_values": [
+            ShellApprovalScope.EXACT.value,
+            ShellApprovalScope.PREFIX.value,
+        ],
+    }
+
+
 def resolve_cwd(
     ctx: ToolContext,
     workdir: str | None,
@@ -123,3 +219,33 @@ def resolve_cwd(
     if ensure_tmp_root and cwd == ctx.deps.workspace.tmp_root and not cwd.exists():
         cwd.mkdir(parents=True, exist_ok=True)
     return cwd
+
+
+def prepare_shell_execution(
+    ctx: ToolContext,
+    *,
+    command: str,
+    workdir: str | None,
+) -> tuple[ShellPolicyDecision, Path]:
+    try:
+        cwd = resolve_cwd(ctx, workdir)
+        shell_policy = validate_shell_command(
+            command,
+            yolo=ctx.deps.tool_approval_policy.yolo,
+            effective_cwd=cwd,
+        )
+    except ValueError as exc:
+        raise ToolExecutionError(
+            error_type="tool_blocked",
+            message=str(exc),
+            retryable=False,
+        ) from exc
+    return shell_policy, cwd
+
+
+def _require_shell_policy(
+    shell_policy: ShellPolicyDecision | None,
+) -> ShellPolicyDecision:
+    if shell_policy is None:
+        raise RuntimeError("shell execution preparation produced incomplete state")
+    return shell_policy

--- a/src/agent_teams/tools/workspace_tools/shell.txt
+++ b/src/agent_teams/tools/workspace_tools/shell.txt
@@ -2,6 +2,6 @@ Run a shell command in the managed runtime.
 
 - Pass only `command` for normal synchronous execution and wait for the command to finish.
 - Set `background=true` only when the task should continue after the current tool call returns.
-- Use `workdir` only when the command must run somewhere other than the default execution root; it may be absolute or relative.
+- Use `workdir` only when the command must run somewhere other than the default execution root; it may be absolute or relative, but it must still resolve inside the workspace writable roots.
 - Use `tty=true` only for commands that require an interactive terminal.
 - Prefer this tool over older exec-session tools.

--- a/src/agent_teams/tools/workspace_tools/shell_approval_repo.py
+++ b/src/agent_teams/tools/workspace_tools/shell_approval_repo.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from threading import RLock
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+from agent_teams.logger import get_logger, log_event
+from agent_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from agent_teams.tools.workspace_tools.shell_policy import ShellRuntimeFamily
+from agent_teams.validation import (
+    parse_persisted_datetime_or_none,
+    require_persisted_identifier,
+)
+
+LOGGER = get_logger(__name__)
+
+
+class ShellApprovalScope(str, Enum):
+    EXACT = "exact"
+    PREFIX = "prefix"
+
+
+class ShellApprovalGrant(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_key: str = Field(min_length=1)
+    runtime_family: ShellRuntimeFamily
+    scope: ShellApprovalScope
+    value: str = Field(min_length=1)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class ShellApprovalRepository:
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = Path(db_path)
+        self._conn = open_sqlite(db_path)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = RLock()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        def operation() -> None:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS shell_approval_grants (
+                    workspace_key   TEXT NOT NULL,
+                    runtime_family  TEXT NOT NULL,
+                    scope           TEXT NOT NULL,
+                    value           TEXT NOT NULL,
+                    created_at      TEXT NOT NULL,
+                    updated_at      TEXT NOT NULL,
+                    PRIMARY KEY(workspace_key, runtime_family, scope, value)
+                )
+                """
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_shell_approval_grants_lookup "
+                "ON shell_approval_grants(workspace_key, runtime_family, scope)"
+            )
+
+        run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=operation,
+            lock=self._lock,
+            repository_name="ShellApprovalRepository",
+            operation_name="init_tables",
+        )
+
+    def grant(
+        self,
+        *,
+        workspace_key: str,
+        runtime_family: ShellRuntimeFamily,
+        scope: ShellApprovalScope,
+        value: str,
+    ) -> ShellApprovalGrant:
+        normalized_value = value.strip()
+        if not normalized_value:
+            raise ValueError("shell approval value must not be empty")
+        now = datetime.now(timezone.utc).isoformat()
+
+        def operation() -> None:
+            self._conn.execute(
+                """
+                INSERT INTO shell_approval_grants(
+                    workspace_key, runtime_family, scope, value, created_at, updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?)
+                ON CONFLICT(workspace_key, runtime_family, scope, value)
+                DO UPDATE SET updated_at=excluded.updated_at
+                """,
+                (
+                    workspace_key,
+                    runtime_family.value,
+                    scope.value,
+                    normalized_value,
+                    now,
+                    now,
+                ),
+            )
+
+        run_sqlite_write_with_retry(
+            conn=self._conn,
+            db_path=self._db_path,
+            operation=operation,
+            lock=self._lock,
+            repository_name="ShellApprovalRepository",
+            operation_name="grant",
+        )
+        record = self.get(
+            workspace_key=workspace_key,
+            runtime_family=runtime_family,
+            scope=scope,
+            value=normalized_value,
+        )
+        if record is None:
+            raise RuntimeError("Failed to persist shell approval grant")
+        return record
+
+    def get(
+        self,
+        *,
+        workspace_key: str,
+        runtime_family: ShellRuntimeFamily,
+        scope: ShellApprovalScope,
+        value: str,
+    ) -> ShellApprovalGrant | None:
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT * FROM shell_approval_grants
+                WHERE workspace_key=? AND runtime_family=? AND scope=? AND value=?
+                """,
+                (
+                    workspace_key,
+                    runtime_family.value,
+                    scope.value,
+                    value,
+                ),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_record(row)
+
+    def has_exact_grant(
+        self,
+        *,
+        workspace_key: str,
+        runtime_family: ShellRuntimeFamily,
+        normalized_command: str,
+    ) -> bool:
+        return (
+            self.get(
+                workspace_key=workspace_key,
+                runtime_family=runtime_family,
+                scope=ShellApprovalScope.EXACT,
+                value=normalized_command,
+            )
+            is not None
+        )
+
+    def has_prefix_grants(
+        self,
+        *,
+        workspace_key: str,
+        runtime_family: ShellRuntimeFamily,
+        prefix_candidates: tuple[str, ...],
+    ) -> bool:
+        if not prefix_candidates:
+            return False
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT value FROM shell_approval_grants
+                WHERE workspace_key=? AND runtime_family=? AND scope=?
+                """,
+                (
+                    workspace_key,
+                    runtime_family.value,
+                    ShellApprovalScope.PREFIX.value,
+                ),
+            ).fetchall()
+        granted_values = {str(row["value"]) for row in rows}
+        return all(candidate in granted_values for candidate in prefix_candidates)
+
+    def _row_to_record(self, row: sqlite3.Row) -> ShellApprovalGrant:
+        created_at = parse_persisted_datetime_or_none(row["created_at"])
+        updated_at = parse_persisted_datetime_or_none(row["updated_at"])
+        if created_at is None or updated_at is None:
+            payload: dict[str, JsonValue] = {
+                "workspace_key": str(row["workspace_key"]),
+                "runtime_family": str(row["runtime_family"]),
+                "scope": str(row["scope"]),
+                "value": str(row["value"]),
+            }
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="tools.shell_approval_repo.invalid_timestamp",
+                message="Skipping invalid shell approval row timestamps",
+                payload=payload,
+            )
+            raise ValueError("Invalid persisted shell approval timestamps")
+        return ShellApprovalGrant(
+            workspace_key=require_persisted_identifier(
+                row["workspace_key"],
+                field_name="workspace_key",
+            ),
+            runtime_family=ShellRuntimeFamily(str(row["runtime_family"])),
+            scope=ShellApprovalScope(str(row["scope"])),
+            value=require_persisted_identifier(row["value"], field_name="value"),
+            created_at=created_at,
+            updated_at=updated_at,
+        )

--- a/src/agent_teams/tools/workspace_tools/shell_executor.py
+++ b/src/agent_teams/tools/workspace_tools/shell_executor.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, ConfigDict
 from agent_teams.env import build_github_cli_env, build_subprocess_env, get_env_var
 from agent_teams.env.github_config_service import GitHubConfigService
 from agent_teams.env.runtime_env import get_app_config_dir
-from agent_teams.tools.workspace_tools.github_cli import get_gh_path
+from agent_teams.tools.workspace_tools.github_cli import resolve_existing_gh_path
 from agent_teams.tools.workspace_tools.shell_policy import (
     DEFAULT_TIMEOUT_SECONDS,
     MAX_TIMEOUT_SECONDS,
@@ -541,14 +541,14 @@ def _load_github_cli_env() -> dict[str, str]:
 
 async def _resolve_gh_path() -> Path | None:
     try:
-        return await get_gh_path()
+        return resolve_existing_gh_path()
     except Exception:
         return None
 
 
 def _resolve_gh_path_sync() -> Path | None:
     try:
-        return asyncio.run(get_gh_path())
+        return resolve_existing_gh_path()
     except Exception:
         return None
 

--- a/src/agent_teams/tools/workspace_tools/shell_policy.py
+++ b/src/agent_teams/tools/workspace_tools/shell_policy.py
@@ -1,9 +1,96 @@
 from __future__ import annotations
+import re
+import shlex
+from enum import Enum
+from pathlib import Path, PureWindowsPath
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent_teams.sessions.runs.background_tasks.command_runtime import (
+    CommandRuntimeKind,
+    ResolvedCommandRuntime,
+    resolve_command_runtime,
+)
+from agent_teams.tools.workspace_tools.command_canonicalization import (
+    canonicalize_shell_command,
+)
 
 DEFAULT_TIMEOUT_SECONDS = 120
 MAX_TIMEOUT_SECONDS = 1200
 
 MAX_COMMAND_LENGTH = 16_000
+
+_BASH_BANNED_COMMANDS = frozenset(
+    {
+        "alias",
+        "aria2c",
+        "axel",
+        "chrome",
+        "chrome.exe",
+        "curl",
+        "curlie",
+        "firefox",
+        "firefox.exe",
+        "http-prompt",
+        "httpie",
+        "links",
+        "lynx",
+        "nc",
+        "safari",
+        "safari.exe",
+        "telnet",
+        "w3m",
+        "wget",
+        "xh",
+    }
+)
+_POWERSHELL_BANNED_COMMANDS = frozenset(
+    {
+        "chrome",
+        "chrome.exe",
+        "curl",
+        "curl.exe",
+        "firefox",
+        "firefox.exe",
+        "invoke-restmethod",
+        "invoke-webrequest",
+        "irm",
+        "iwr",
+        "msedge",
+        "msedge.exe",
+        "safari",
+        "safari.exe",
+        "start-bitstransfer",
+        "wget",
+        "wget.exe",
+    }
+)
+_SPECIAL_SUBCOMMAND_PREFIXES = frozenset({"gh", "git", "npm", "pnpm", "yarn"})
+_SIMPLE_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9_./:\\-]+$")
+_ENV_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+_CMDLET_PATTERN = re.compile(r"^[A-Za-z]+-[A-Za-z][A-Za-z0-9-]*$")
+_POWERSHELL_DIRECTORY_COMMANDS = frozenset(
+    {"cd", "chdir", "push-location", "pushd", "set-location", "sl"}
+)
+_BASH_DIRECTORY_COMMANDS = frozenset({"cd", "pushd"})
+_BASH_COMMAND_WRAPPERS = frozenset({"builtin", "command", "env", "noglob"})
+_BASH_DYNAMIC_DIRECTORY_PATTERNS = ("$", "~", "`", "*", "?", "[", "]", "{", "}")
+_POWERSHELL_DYNAMIC_DIRECTORY_PATTERNS = ("$", "`", "*", "?", "[", "]", "{", "}")
+
+
+class ShellRuntimeFamily(str, Enum):
+    BASH = "bash"
+    GIT_BASH = "git-bash"
+    POWERSHELL = "powershell"
+
+
+class ShellPolicyDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    runtime_family: ShellRuntimeFamily
+    normalized_command: str = Field(min_length=1)
+    subcommands: tuple[str, ...] = Field(default_factory=tuple)
+    prefix_candidates: tuple[str, ...] = Field(default_factory=tuple)
 
 
 def normalize_timeout(timeout_seconds: int | None) -> int:
@@ -16,11 +103,700 @@ def normalize_timeout(timeout_seconds: int | None) -> int:
     return timeout_seconds
 
 
-def validate_shell_command(command: str) -> None:
-    text = command.strip()
-    if not text:
+def validate_shell_command(
+    command: str,
+    *,
+    yolo: bool = False,
+    effective_cwd: Path | None = None,
+) -> ShellPolicyDecision:
+    normalized_command = canonicalize_shell_command(command).strip()
+    if not normalized_command:
         raise ValueError("command must not be empty")
-    if len(text) > MAX_COMMAND_LENGTH:
+    if len(normalized_command) > MAX_COMMAND_LENGTH:
         raise ValueError(
-            f"command is too long ({len(text)} chars, max {MAX_COMMAND_LENGTH})"
+            "command is too long "
+            f"({len(normalized_command)} chars, max {MAX_COMMAND_LENGTH})"
         )
+    runtime = resolve_command_runtime(command=normalized_command)
+    runtime_family = _runtime_family(runtime)
+    subcommands = _split_subcommands(
+        normalized_command,
+        runtime_family=runtime_family,
+    )
+    if not subcommands:
+        raise ValueError("command must not be empty")
+    prefixes: list[str] = []
+    normalized_subcommands: list[str] = []
+    for index, subcommand in enumerate(subcommands):
+        if (
+            yolo
+            and effective_cwd is not None
+            and _validate_directory_change(
+                subcommand=subcommand,
+                runtime_family=runtime_family,
+                effective_cwd=effective_cwd,
+            )
+            and index == 0
+            and len(subcommands) > 1
+        ):
+            continue
+        blocked_name = _blocked_command_name(
+            subcommand=subcommand,
+            runtime_family=runtime_family,
+        )
+        if blocked_name is not None:
+            raise ValueError(
+                f"command is blocked by local shell policy: {blocked_name}"
+            )
+        prefixes.append(
+            _build_prefix_candidate(
+                subcommand=subcommand,
+                runtime_family=runtime_family,
+            )
+        )
+        normalized_subcommands.append(subcommand)
+    if not normalized_subcommands:
+        normalized_subcommands = subcommands
+    return ShellPolicyDecision(
+        runtime_family=runtime_family,
+        normalized_command=normalized_command,
+        subcommands=tuple(normalized_subcommands),
+        prefix_candidates=tuple(prefixes),
+    )
+
+
+def _runtime_family(runtime: ResolvedCommandRuntime) -> ShellRuntimeFamily:
+    if runtime.kind == CommandRuntimeKind.POWERSHELL:
+        return ShellRuntimeFamily.POWERSHELL
+    if runtime.display_name.lower() == "git bash":
+        return ShellRuntimeFamily.GIT_BASH
+    return ShellRuntimeFamily.BASH
+
+
+def _split_subcommands(
+    command: str,
+    *,
+    runtime_family: ShellRuntimeFamily,
+) -> list[str]:
+    segments: list[str] = []
+    current: list[str] = []
+    in_single = False
+    in_double = False
+    escape_next = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escape_next:
+            current.append(char)
+            escape_next = False
+            index += 1
+            continue
+        if char == "\\" and not in_single:
+            current.append(char)
+            escape_next = True
+            index += 1
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            current.append(char)
+            index += 1
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            current.append(char)
+            index += 1
+            continue
+        if in_single or in_double:
+            current.append(char)
+            index += 1
+            continue
+        next_char = command[index + 1] if index + 1 < len(command) else ""
+        if char == "&" and next_char == "&":
+            segment = "".join(current).strip()
+            if segment:
+                segments.append(segment)
+            current = []
+            index += 2
+            continue
+        if (
+            runtime_family in {ShellRuntimeFamily.BASH, ShellRuntimeFamily.GIT_BASH}
+            and char == "&"
+        ):
+            prev_char = command[index - 1] if index > 0 else ""
+            if prev_char != ">" and next_char != ">":
+                segment = "".join(current).strip()
+                if segment:
+                    segments.append(segment)
+                current = []
+                index += 1
+                continue
+        if char == "|" and next_char == "|":
+            segment = "".join(current).strip()
+            if segment:
+                segments.append(segment)
+            current = []
+            index += 2
+            continue
+        if char in {";", "|", "\n"}:
+            segment = "".join(current).strip()
+            if segment:
+                segments.append(segment)
+            current = []
+            index += 1
+            continue
+        current.append(char)
+        index += 1
+    tail = "".join(current).strip()
+    if tail:
+        segments.append(tail)
+    return segments
+
+
+def _blocked_command_name(
+    *,
+    subcommand: str,
+    runtime_family: ShellRuntimeFamily,
+) -> str | None:
+    _command_name, normalized_name, tokens = _extract_command_identity(
+        subcommand=subcommand,
+        runtime_family=runtime_family,
+    )
+    if runtime_family in {ShellRuntimeFamily.BASH, ShellRuntimeFamily.GIT_BASH}:
+        stripped_exe_name = (
+            normalized_name.removesuffix(".exe")
+            if normalized_name.endswith(".exe")
+            else normalized_name
+        )
+        if (
+            normalized_name in _BASH_BANNED_COMMANDS
+            or stripped_exe_name in _BASH_BANNED_COMMANDS
+        ):
+            return normalized_name
+        substitution_blocked = _blocked_bash_substitution_command_name(subcommand)
+        if substitution_blocked is not None:
+            return substitution_blocked
+        return None
+    if normalized_name in _POWERSHELL_BANNED_COMMANDS:
+        return normalized_name
+    if normalized_name == "start-process" and _targets_browser(tokens[1:]):
+        return "start-process"
+    return None
+
+
+def _validate_directory_change(
+    *,
+    subcommand: str,
+    runtime_family: ShellRuntimeFamily,
+    effective_cwd: Path,
+) -> bool:
+    _command_name, normalized_name, tokens = _extract_command_identity(
+        subcommand=subcommand,
+        runtime_family=runtime_family,
+    )
+    if runtime_family in {ShellRuntimeFamily.BASH, ShellRuntimeFamily.GIT_BASH}:
+        if normalized_name not in _BASH_DIRECTORY_COMMANDS:
+            return False
+        if _bash_directory_uses_cdpath(subcommand):
+            raise ValueError(
+                "directory change is blocked by local shell policy: "
+                "CDPATH requires shell expansion"
+            )
+        target = _extract_bash_directory_target(
+            subcommand=subcommand,
+            command_name=normalized_name,
+        )
+        if target is None:
+            return False
+        if not _is_static_directory_target(
+            raw_target=target,
+            runtime_family=runtime_family,
+        ):
+            raise ValueError(
+                "directory change is blocked by local shell policy: "
+                f"{target} requires shell expansion"
+            )
+    else:
+        if normalized_name not in _POWERSHELL_DIRECTORY_COMMANDS:
+            return False
+        target = _extract_powershell_directory_target(tokens[1:])
+        if target is None:
+            return False
+        if not _is_static_directory_target(
+            raw_target=target,
+            runtime_family=runtime_family,
+        ):
+            raise ValueError(
+                "directory change is blocked by local shell policy: "
+                f"{target} requires shell expansion"
+            )
+    resolved_cwd = effective_cwd.resolve()
+    resolved_target = _resolve_directory_target(
+        raw_target=target,
+        effective_cwd=resolved_cwd,
+    )
+    if resolved_target == resolved_cwd:
+        return True
+    if resolved_cwd not in resolved_target.parents:
+        raise ValueError(
+            "directory change is blocked by local shell policy: "
+            f"{resolved_target} is outside {resolved_cwd}"
+        )
+    return False
+
+
+def _build_prefix_candidate(
+    *,
+    subcommand: str,
+    runtime_family: ShellRuntimeFamily,
+) -> str:
+    _command_name, normalized_name, tokens = _extract_command_identity(
+        subcommand=subcommand,
+        runtime_family=runtime_family,
+    )
+    if not tokens:
+        return normalized_name
+    if normalized_name in _SPECIAL_SUBCOMMAND_PREFIXES:
+        subcommand_name = _extract_first_simple_argument(tokens[1:])
+        if subcommand_name is not None:
+            return f"{normalized_name} {subcommand_name.lower()}"
+    return normalized_name
+
+
+def _extract_command_identity(
+    *,
+    subcommand: str,
+    runtime_family: ShellRuntimeFamily,
+) -> tuple[str, str, list[str]]:
+    command_name, tokens = _extract_command_tokens(
+        subcommand=subcommand,
+        runtime_family=runtime_family,
+    )
+    return command_name, _normalize_command_name(command_name), tokens
+
+
+def _extract_command_tokens(
+    *,
+    subcommand: str,
+    runtime_family: ShellRuntimeFamily,
+) -> tuple[str, list[str]]:
+    tokens = _split_command_tokens(subcommand, runtime_family=runtime_family)
+    if runtime_family in {ShellRuntimeFamily.BASH, ShellRuntimeFamily.GIT_BASH}:
+        tokens = _strip_bash_leading_wrappers(tokens)
+    if runtime_family == ShellRuntimeFamily.POWERSHELL and tokens and tokens[0] == "&":
+        tokens = tokens[1:]
+    if not tokens:
+        return "", []
+    return tokens[0], tokens
+
+
+def _split_command_tokens(
+    command: str,
+    *,
+    runtime_family: ShellRuntimeFamily,
+) -> list[str]:
+    if runtime_family in {ShellRuntimeFamily.BASH, ShellRuntimeFamily.GIT_BASH}:
+        try:
+            return shlex.split(command, posix=True)
+        except ValueError:
+            return _fallback_tokenize(command)
+    return _powershell_tokenize(command)
+
+
+def _strip_bash_env_assignments(tokens: list[str]) -> list[str]:
+    index = 0
+    while (
+        index < len(tokens) and _ENV_ASSIGNMENT_PATTERN.match(tokens[index]) is not None
+    ):
+        index += 1
+    return tokens[index:]
+
+
+def _strip_bash_leading_wrappers(tokens: list[str]) -> list[str]:
+    current = _strip_bash_env_assignments(tokens)
+    while current:
+        wrapper = _normalize_command_name(current[0])
+        if wrapper not in _BASH_COMMAND_WRAPPERS:
+            return current
+        if wrapper == "env":
+            updated = _strip_bash_env_wrapper(current)
+        else:
+            updated = _strip_bash_command_wrapper(current)
+        if updated == current:
+            return current
+        current = _strip_bash_env_assignments(updated)
+    return current
+
+
+def _strip_bash_env_wrapper(tokens: list[str]) -> list[str]:
+    if not tokens or _normalize_command_name(tokens[0]) != "env":
+        return tokens
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token.startswith("-") and token != "-":
+            index += 1
+            continue
+        if _ENV_ASSIGNMENT_PATTERN.match(token) is not None:
+            index += 1
+            continue
+        break
+    return tokens[index:] or tokens
+
+
+def _strip_bash_command_wrapper(tokens: list[str]) -> list[str]:
+    if not tokens:
+        return tokens
+    wrapper = _normalize_command_name(tokens[0])
+    if wrapper not in {"builtin", "command", "noglob"}:
+        return tokens
+    index = 1
+    if wrapper == "command":
+        while index < len(tokens):
+            token = tokens[index]
+            if token == "--":
+                index += 1
+                break
+            if token.startswith("-") and token != "-":
+                index += 1
+                continue
+            break
+    return tokens[index:] or tokens
+
+
+def _powershell_tokenize(command: str) -> list[str]:
+    tokens: list[str] = []
+    current: list[str] = []
+    in_single = False
+    in_double = False
+    escape_next = False
+    for char in command:
+        if escape_next:
+            current.append(char)
+            escape_next = False
+            continue
+        if char == "`":
+            escape_next = True
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            continue
+        if char.isspace() and not in_single and not in_double:
+            if current:
+                tokens.append("".join(current))
+                current = []
+            continue
+        current.append(char)
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+
+def _fallback_tokenize(command: str) -> list[str]:
+    tokens: list[str] = []
+    current: list[str] = []
+    for char in command:
+        if char.isspace():
+            if current:
+                tokens.append("".join(current))
+                current = []
+            continue
+        current.append(char)
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+
+def _extract_first_simple_argument(tokens: list[str]) -> str | None:
+    for token in tokens:
+        if token.startswith("-"):
+            continue
+        if _SIMPLE_IDENTIFIER_PATTERN.fullmatch(token) is None:
+            return None
+        return _extract_path_basename(token)
+    return None
+
+
+def _normalize_command_name(command_name: str) -> str:
+    stripped = command_name.strip().strip("\"'")
+    if not stripped:
+        return ""
+    if _CMDLET_PATTERN.fullmatch(stripped) is not None:
+        return stripped.lower()
+    basename = _extract_path_basename(stripped)
+    return basename.lower() if basename else stripped.lower()
+
+
+def _extract_path_basename(raw_path: str) -> str:
+    basename = Path(raw_path).name
+    if basename != raw_path:
+        return basename
+    return PureWindowsPath(raw_path).name
+
+
+def _targets_browser(tokens: list[str]) -> bool:
+    browser_names = {
+        "chrome",
+        "chrome.exe",
+        "firefox",
+        "firefox.exe",
+        "msedge",
+        "msedge.exe",
+        "safari",
+        "safari.exe",
+    }
+    for token in tokens:
+        if token.startswith("-"):
+            continue
+        if Path(token.strip("\"'")).name.lower() in browser_names:
+            return True
+    return False
+
+
+def _extract_powershell_directory_target(tokens: list[str]) -> str | None:
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        normalized = token.lower()
+        if normalized in {"-path", "-literalpath"}:
+            next_index = index + 1
+            if next_index < len(tokens):
+                return tokens[next_index]
+            return None
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token
+    return None
+
+
+def _extract_bash_directory_target(
+    *,
+    subcommand: str,
+    command_name: str,
+) -> str | None:
+    tokens = _split_bash_tokens_preserving_windows_paths(subcommand)
+    tokens = _strip_bash_leading_wrappers(tokens)
+    if not tokens or command_name not in _BASH_DIRECTORY_COMMANDS:
+        return None
+    tokens = tokens[1:]
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if command_name == "cd" and token.startswith("-") and token != "-":
+            index += 1
+            continue
+        return token
+    if index < len(tokens):
+        return tokens[index]
+    return None
+
+
+def _split_bash_tokens_preserving_windows_paths(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=False)
+    except ValueError:
+        return _fallback_tokenize(command)
+
+
+def _bash_directory_uses_cdpath(subcommand: str) -> bool:
+    tokens = _split_bash_tokens_preserving_windows_paths(subcommand)
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        assignment_name = _extract_env_assignment_name(token)
+        if assignment_name is not None:
+            if assignment_name == "CDPATH":
+                return True
+            index += 1
+            continue
+        wrapper = _normalize_command_name(token)
+        if wrapper == "env":
+            index += 1
+            while index < len(tokens):
+                env_token = tokens[index]
+                if env_token == "--":
+                    index += 1
+                    break
+                if env_token.startswith("-") and env_token != "-":
+                    index += 1
+                    continue
+                assignment_name = _extract_env_assignment_name(env_token)
+                if assignment_name is None:
+                    break
+                if assignment_name == "CDPATH":
+                    return True
+                index += 1
+            continue
+        if wrapper in {"builtin", "noglob"}:
+            index += 1
+            continue
+        if wrapper == "command":
+            index += 1
+            while index < len(tokens):
+                option = tokens[index]
+                if option == "--":
+                    index += 1
+                    break
+                if option.startswith("-") and option != "-":
+                    index += 1
+                    continue
+                break
+            continue
+        break
+    return False
+
+
+def _is_static_directory_target(
+    *,
+    raw_target: str,
+    runtime_family: ShellRuntimeFamily,
+) -> bool:
+    stripped = raw_target.strip().strip("\"'")
+    if not stripped:
+        return True
+    if runtime_family in {ShellRuntimeFamily.BASH, ShellRuntimeFamily.GIT_BASH}:
+        if stripped in {"-", "~"} or stripped.startswith(("~", "+")):
+            return False
+        return not any(
+            marker in stripped for marker in _BASH_DYNAMIC_DIRECTORY_PATTERNS
+        )
+    return not any(
+        marker in stripped for marker in _POWERSHELL_DYNAMIC_DIRECTORY_PATTERNS
+    )
+
+
+def _resolve_directory_target(*, raw_target: str, effective_cwd: Path) -> Path:
+    target = raw_target.strip().strip("\"'")
+    if not target:
+        return effective_cwd.resolve()
+    normalized_target = _normalize_shell_path(target)
+    candidate = Path(normalized_target)
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (effective_cwd / normalized_target).resolve()
+
+
+def _normalize_shell_path(raw_target: str) -> str:
+    match = re.match(r"^/([a-zA-Z])/(.*)", raw_target)
+    if match is None:
+        return raw_target
+    return f"{match.group(1)}:/{match.group(2)}"
+
+
+def _extract_env_assignment_name(token: str) -> str | None:
+    if _ENV_ASSIGNMENT_PATTERN.match(token) is None:
+        return None
+    return token.split("=", 1)[0]
+
+
+def _blocked_bash_substitution_command_name(subcommand: str) -> str | None:
+    for substitution in _extract_bash_command_substitutions(subcommand):
+        for nested in _split_subcommands(
+            substitution,
+            runtime_family=ShellRuntimeFamily.BASH,
+        ):
+            blocked_name = _blocked_command_name(
+                subcommand=nested,
+                runtime_family=ShellRuntimeFamily.BASH,
+            )
+            if blocked_name is not None:
+                return blocked_name
+    return None
+
+
+def _extract_bash_command_substitutions(command: str) -> list[str]:
+    substitutions: list[str] = []
+    in_single = False
+    in_double = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if char == "'" and not in_double:
+            in_single = not in_single
+            index += 1
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            index += 1
+            continue
+        if in_single:
+            index += 1
+            continue
+        if char == "`":
+            end_index = _find_unescaped_backtick(command, index + 1)
+            if end_index == -1:
+                break
+            substitutions.append(command[index + 1 : end_index])
+            index = end_index + 1
+            continue
+        if char == "$" and index + 1 < len(command) and command[index + 1] == "(":
+            content, next_index = _extract_dollar_substitution(command, index + 2)
+            if content is None:
+                break
+            substitutions.append(content)
+            index = next_index
+            continue
+        index += 1
+    return substitutions
+
+
+def _find_unescaped_backtick(command: str, start_index: int) -> int:
+    index = start_index
+    while index < len(command):
+        if command[index] == "\\":
+            index += 2
+            continue
+        if command[index] == "`":
+            return index
+        index += 1
+    return -1
+
+
+def _extract_dollar_substitution(
+    command: str,
+    start_index: int,
+) -> tuple[str | None, int]:
+    depth = 1
+    index = start_index
+    in_single = False
+    in_double = False
+    while index < len(command):
+        char = command[index]
+        if char == "'" and not in_double:
+            in_single = not in_single
+            index += 1
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            index += 1
+            continue
+        if in_single:
+            index += 1
+            continue
+        if char == "\\":
+            index += 2
+            continue
+        if char == "$" and not in_double and index + 1 < len(command):
+            next_char = command[index + 1]
+            if next_char == "(":
+                depth += 1
+                index += 2
+                continue
+        if char == "(" and not in_double:
+            index += 1
+            continue
+        if char == ")":
+            depth -= 1
+            if depth == 0:
+                return command[start_index:index], index + 1
+        index += 1
+    return None, len(command)

--- a/src/agent_teams/workspace/handle.py
+++ b/src/agent_teams/workspace/handle.py
@@ -129,6 +129,14 @@ class WorkspaceHandle(BaseModel):
         return Path("tmp", relative_path).as_posix()
 
     def resolve_workdir(self, relative_path: str | None = None) -> Path:
-        if relative_path is None:
-            return self.execution_root
-        return self._resolve_candidate_path(relative_path)
+        raw_path = "." if relative_path is None else relative_path
+        candidate = (
+            self.execution_root
+            if relative_path is None
+            else self._resolve_candidate_path(relative_path)
+        )
+        return self._validate_allowed_path(
+            candidate,
+            write=True,
+            raw_path=raw_path,
+        )

--- a/tests/unit_tests/frontend/test_streaming_tool_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_tool_ui.py
@@ -109,7 +109,8 @@ def test_live_streaming_tool_overlay_skips_processed_group_summary() -> None:
     assert "status === 'pending'" in history_script
     assert "status === 'running'" in history_script
     assert "approvalStatus === 'requested'" in history_script
-    assert "approvalStatus === 'approve'" in history_script
+    assert "function isApprovedApprovalStatus(value)" in history_script
+    assert "approvalStatus === 'approve_exact'" in history_script
 
 
 def test_tool_blocks_extract_effective_inputs_instead_of_footer_status() -> None:

--- a/tests/unit_tests/interfaces/server/test_runs_router.py
+++ b/tests/unit_tests/interfaces/server/test_runs_router.py
@@ -13,6 +13,7 @@ class _FakeRunService:
     def __init__(self) -> None:
         self.resumed_run_ids: list[str] = []
         self.started_run_ids: list[str] = []
+        self.resolved_tool_approvals: list[tuple[str, str, str, str]] = []
         self.raise_on_tool_approval = False
         self.created_run_inputs: list[IntentInput] = []
         self.background_tasks: dict[str, dict[str, object]] = {
@@ -43,6 +44,7 @@ class _FakeRunService:
             raise RuntimeError(
                 "Run run-1 is stopped. Resume the run before resolving tool approval."
             )
+        self.resolved_tool_approvals.append((run_id, tool_call_id, action, feedback))
 
     def ensure_run_started(self, run_id: str) -> None:
         self.started_run_ids.append(run_id)
@@ -218,6 +220,22 @@ def test_resolve_tool_approval_route_returns_conflict_for_stopped_run() -> None:
     assert response.json()["detail"] == (
         "Run run-1 is stopped. Resume the run before resolving tool approval."
     )
+
+
+def test_resolve_tool_approval_route_accepts_approve_exact() -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/runs/run-1/tool-approvals/call-1/resolve",
+        json={"action": "approve_exact", "feedback": "persist this"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "action": "approve_exact"}
+    assert fake_service.resolved_tool_approvals == [
+        ("run-1", "call-1", "approve_exact", "persist this")
+    ]
 
 
 def test_resume_route_rejects_none_like_run_id() -> None:

--- a/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import signal
+import os
 
 import pytest
 
@@ -9,6 +10,7 @@ from agent_teams.sessions.runs.background_tasks.command_runtime import (
     CommandRuntimeKind,
     ResolvedCommandRuntime,
     kill_process_tree_by_pid,
+    build_command_env,
     resolve_command_runtime,
 )
 
@@ -105,6 +107,113 @@ def test_resolve_command_runtime_prefers_powershell_for_env_and_member_access(
         )
         == powershell_runtime
     )
+
+
+@pytest.mark.asyncio
+async def test_build_command_env_does_not_download_gh_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bash_runtime = ResolvedCommandRuntime(
+        kind=CommandRuntimeKind.BASH,
+        executable="/bin/bash",
+        display_name="Bash",
+    )
+
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_gh_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "_load_github_cli_env",
+        lambda: {
+            "GH_TOKEN": "ghp_secret",
+            "GITHUB_TOKEN": "ghp_secret",
+            "GH_PROMPT_DISABLED": "1",
+        },
+    )
+    monkeypatch.setattr(
+        runtime_module.os,
+        "environ",
+        {"PATH": "/usr/bin"},
+    )
+
+    env = await build_command_env(
+        {"EXTRA_VAR": "1"},
+        runtime=bash_runtime,
+        command="node script.js",
+    )
+
+    assert env["GH_TOKEN"] == "ghp_secret"
+    assert env["GITHUB_TOKEN"] == "ghp_secret"
+    assert env["GH_PROMPT_DISABLED"] == "1"
+    assert env["EXTRA_VAR"] == "1"
+    assert env["PATH"] == "/usr/bin"
+
+
+@pytest.mark.asyncio
+async def test_build_command_env_prepends_existing_gh_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    bash_runtime = ResolvedCommandRuntime(
+        kind=CommandRuntimeKind.BASH,
+        executable="/bin/bash",
+        display_name="Bash",
+    )
+    gh = tmp_path / "bin" / "gh"
+    gh.parent.mkdir()
+    gh.write_text("fake", encoding="utf-8")
+
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_gh_path",
+        lambda: gh,
+    )
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(
+        runtime_module.os,
+        "environ",
+        {"PATH": "/usr/bin"},
+    )
+
+    env = await build_command_env(
+        runtime=bash_runtime,
+        command="gh auth status",
+    )
+
+    assert env["PATH"].split(os.pathsep)[0] == str(gh.parent)
+
+
+@pytest.mark.asyncio
+async def test_build_command_env_ignores_gh_lookup_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bash_runtime = ResolvedCommandRuntime(
+        kind=CommandRuntimeKind.BASH,
+        executable="/bin/bash",
+        display_name="Bash",
+    )
+
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_gh_path",
+        lambda: (_ for _ in ()).throw(OSError("read-only")),
+    )
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(
+        runtime_module.os,
+        "environ",
+        {"PATH": "/usr/bin"},
+    )
+
+    env = await build_command_env(
+        runtime=bash_runtime,
+        command="node script.js",
+    )
+
+    assert env["PATH"] == "/usr/bin"
 
 
 def test_kill_process_tree_by_pid_waits_for_posix_exit_before_success(

--- a/tests/unit_tests/sessions/runs/test_run_manager_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_manager_recovery.py
@@ -35,6 +35,7 @@ from agent_teams.sessions.runs.recoverable_pause import (
 )
 from agent_teams.agents.instances.instance_repository import AgentInstanceRepository
 from agent_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from agent_teams.tools.runtime.approval_ticket_repo import ApprovalTicketStatus
 from agent_teams.sessions.runs.event_log import EventLog
 from agent_teams.agents.execution.message_repository import MessageRepository
 from agent_teams.sessions.runs.run_intent_repo import RunIntentRepository
@@ -49,6 +50,11 @@ from agent_teams.sessions.session_repository import SessionRepository
 from agent_teams.agents.tasks.enums import TaskStatus
 from agent_teams.agents.tasks.task_repository import TaskRepository
 from agent_teams.tools.runtime import ToolApprovalManager
+from agent_teams.tools.workspace_tools.shell_approval_repo import (
+    ShellApprovalRepository,
+    ShellApprovalScope,
+)
+from agent_teams.tools.workspace_tools.shell_policy import ShellRuntimeFamily
 from agent_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
 
 
@@ -106,6 +112,7 @@ def _build_manager(
     run_state_repo = RunStateRepository(db_path)
     run_runtime_repo = RunRuntimeRepository(db_path)
     approval_ticket_repo = ApprovalTicketRepository(db_path)
+    shell_approval_repo = ShellApprovalRepository(db_path)
     hub = RunEventHub(event_log=event_log, run_state_repo=run_state_repo)
     active_run_registry = ActiveSessionRunRegistry(run_runtime_repo=run_runtime_repo)
     control.bind_runtime(
@@ -136,6 +143,7 @@ def _build_manager(
         background_task_manager=background_task_manager,
         background_task_service=background_task_service,
         notification_service=None,
+        shell_approval_repo=shell_approval_repo,
     )
 
 
@@ -981,6 +989,138 @@ def test_resume_run_allows_stopped_run_with_pending_tool_approval(
 
     assert session_id == "session-1"
     assert "run-existing" in manager._resume_requested_runs
+
+
+def test_resolve_tool_approval_persists_shell_exact_grant(tmp_path: Path) -> None:
+    db_path = tmp_path / "run_shell_approval.db"
+    manager = _build_manager(db_path)
+    RunRuntimeRepository(db_path).ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+    )
+    workspace_key = str((tmp_path / "workspace").resolve())
+    ApprovalTicketRepository(db_path).upsert_requested(
+        tool_call_id="call-shell-1",
+        run_id="run-existing",
+        session_id="session-1",
+        task_id="task-root-1",
+        instance_id="inst-1",
+        role_id="Coordinator",
+        tool_name="shell",
+        args_preview='{"command":"git status"}',
+        metadata={
+            "workspace_key": workspace_key,
+            "runtime_family": "git-bash",
+            "normalized_command": "git status",
+            "prefix_candidates": ["git status"],
+        },
+    )
+
+    manager.resolve_tool_approval("run-existing", "call-shell-1", "approve_exact")
+
+    shell_repo = ShellApprovalRepository(db_path)
+    assert (
+        shell_repo.get(
+            workspace_key=workspace_key,
+            runtime_family=ShellRuntimeFamily.GIT_BASH,
+            scope=ShellApprovalScope.EXACT,
+            value="git status",
+        )
+        is not None
+    )
+
+
+def test_resolve_tool_approval_does_not_persist_shell_grant_from_resolved_ticket(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_shell_resolved_ticket.db"
+    manager = _build_manager(db_path)
+    RunRuntimeRepository(db_path).ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+    )
+    workspace_key = str((tmp_path / "workspace").resolve())
+    ticket_repo = ApprovalTicketRepository(db_path)
+    created = ticket_repo.upsert_requested(
+        tool_call_id="call-shell-1",
+        run_id="run-existing",
+        session_id="session-1",
+        task_id="task-root-1",
+        instance_id="inst-1",
+        role_id="Coordinator",
+        tool_name="shell",
+        args_preview='{"command":"git status"}',
+        metadata={
+            "workspace_key": workspace_key,
+            "runtime_family": "git-bash",
+            "normalized_command": "git status",
+            "prefix_candidates": ["git status"],
+        },
+    )
+    ticket_repo.resolve(
+        tool_call_id=created.tool_call_id,
+        status=ApprovalTicketStatus.APPROVED,
+    )
+
+    manager.resolve_tool_approval("run-existing", "call-shell-1", "approve_exact")
+
+    shell_repo = ShellApprovalRepository(db_path)
+    assert (
+        shell_repo.get(
+            workspace_key=workspace_key,
+            runtime_family=ShellRuntimeFamily.GIT_BASH,
+            scope=ShellApprovalScope.EXACT,
+            value="git status",
+        )
+        is None
+    )
+
+
+def test_resolve_tool_approval_rejects_cross_run_ticket_for_shell_grant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_shell_cross_run_ticket.db"
+    manager = _build_manager(db_path)
+    RunRuntimeRepository(db_path).ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+    )
+    workspace_key = str((tmp_path / "workspace").resolve())
+    ApprovalTicketRepository(db_path).upsert_requested(
+        tool_call_id="call-shell-other",
+        run_id="run-other",
+        session_id="session-1",
+        task_id="task-root-1",
+        instance_id="inst-1",
+        role_id="Coordinator",
+        tool_name="shell",
+        args_preview='{"command":"git status"}',
+        metadata={
+            "workspace_key": workspace_key,
+            "runtime_family": "git-bash",
+            "normalized_command": "git status",
+            "prefix_candidates": ["git status"],
+        },
+    )
+
+    with pytest.raises(KeyError, match="call-shell-other"):
+        manager.resolve_tool_approval(
+            "run-existing", "call-shell-other", "approve_exact"
+        )
+
+    shell_repo = ShellApprovalRepository(db_path)
+    assert (
+        shell_repo.get(
+            workspace_key=workspace_key,
+            runtime_family=ShellRuntimeFamily.GIT_BASH,
+            scope=ShellApprovalScope.EXACT,
+            value="git status",
+        )
+        is None
+    )
 
 
 def test_resume_run_rejects_running_run(tmp_path: Path) -> None:

--- a/tests/unit_tests/tools/runtime/test_approval_ticket_repo.py
+++ b/tests/unit_tests/tools/runtime/test_approval_ticket_repo.py
@@ -172,6 +172,30 @@ def test_find_reusable_matches_approved_ticket_by_cache_key(tmp_path: Path) -> N
     assert record.tool_call_id == "call-approved"
 
 
+def test_approval_ticket_repo_persists_metadata_json(tmp_path: Path) -> None:
+    repository = ApprovalTicketRepository(tmp_path / "approval_ticket_metadata.db")
+
+    created = repository.upsert_requested(
+        tool_call_id="call-shell",
+        run_id="run-1",
+        session_id="session-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="writer",
+        tool_name="shell",
+        args_preview='{"command": "git status"}',
+        metadata={
+            "runtime_family": "git-bash",
+            "normalized_command": "git status",
+            "prefix_candidates": ["git status"],
+        },
+    )
+
+    assert created.metadata["runtime_family"] == "git-bash"
+    assert created.metadata["normalized_command"] == "git status"
+    assert created.metadata["prefix_candidates"] == ["git status"]
+
+
 def test_find_reusable_does_not_cross_exec_context_boundaries(tmp_path: Path) -> None:
     repository = ApprovalTicketRepository(tmp_path / "approval_ticket_exec_context.db")
     approved_cache_key = build_shell_cache_key(

--- a/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
+++ b/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
@@ -14,7 +14,8 @@ from agent_teams.sessions.runs.background_tasks.models import (
     BackgroundTaskRecord,
     BackgroundTaskStatus,
 )
-from agent_teams.tools.runtime import ToolDeps, ToolResultProjection
+from agent_teams.tools.runtime import ToolDeps, ToolExecutionError, ToolResultProjection
+from agent_teams.tools.runtime.models import ToolApprovalRequest
 from agent_teams.tools.workspace_tools import (
     register_background_tasks,
     register_list_background_tasks,
@@ -95,6 +96,8 @@ async def test_shell_passes_none_tool_call_id_without_validation_error(
             session_id="session-1",
             instance_id="inst-1",
             role_id="writer",
+            shell_approval_repo=None,
+            tool_approval_policy=SimpleNamespace(yolo=False),
         ),
     )
 
@@ -150,7 +153,7 @@ def test_build_shell_cache_key_includes_cwd_background_and_tty() -> None:
 
 
 @pytest.mark.asyncio
-async def test_shell_defers_workdir_resolution_until_execute_tool_runs_action(
+async def test_shell_builds_approval_request_after_resolving_workdir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -161,11 +164,16 @@ async def test_shell_defers_workdir_resolution_until_execute_tool_runs_action(
         fake_agent.tools["shell"],
     )
 
-    class _ExplodingWorkspace(_FakeWorkspace):
-        def resolve_workdir(self, relative_path: str | None = None) -> Path:
-            raise AssertionError(f"unexpected workdir resolution: {relative_path}")
+    class _RecordingWorkspace(_FakeWorkspace):
+        def __init__(self, root: Path) -> None:
+            super().__init__(root)
+            self.calls: list[str | None] = []
 
-    workspace = _ExplodingWorkspace(tmp_path)
+        def resolve_workdir(self, relative_path: str | None = None) -> Path:
+            self.calls.append(relative_path)
+            return super().resolve_workdir(relative_path)
+
+    workspace = _RecordingWorkspace(tmp_path)
     ctx = SimpleNamespace(
         tool_call_id="call-1",
         deps=SimpleNamespace(
@@ -174,12 +182,15 @@ async def test_shell_defers_workdir_resolution_until_execute_tool_runs_action(
             session_id="session-1",
             instance_id="inst-1",
             role_id="writer",
+            shell_approval_repo=None,
+            tool_approval_policy=SimpleNamespace(yolo=False),
         ),
     )
 
     async def _fake_execute_tool(_ctx: object, **kwargs: object) -> dict[str, object]:
         del _ctx
-        assert kwargs["approval_request"] is not None
+        approval_request = cast(ToolApprovalRequest, kwargs["approval_request"])
+        assert approval_request.cache_key
         return {"delegated": True}
 
     monkeypatch.setattr(shell_module, "execute_tool", _fake_execute_tool)
@@ -187,6 +198,7 @@ async def test_shell_defers_workdir_resolution_until_execute_tool_runs_action(
     result = await tool(ctx, command="pwd", workdir="../outside")
 
     assert result == {"delegated": True}
+    assert workspace.calls == ["../outside"]
 
 
 def test_register_background_tasks_is_idempotent_per_agent(
@@ -235,3 +247,175 @@ def test_register_list_background_tasks_only_registers_requested_tool(
     register_list_background_tasks(cast(Agent[ToolDeps, str], fake_agent))
 
     assert captured == ["list_background_tasks"]
+
+
+@pytest.mark.asyncio
+async def test_shell_returns_blocked_tool_result_for_local_policy_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_background_tasks(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["shell"],
+    )
+    service = _CapturingBackgroundTaskService()
+    workspace = _FakeWorkspace(tmp_path)
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            background_task_service=service,
+            workspace=workspace,
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+            shell_approval_repo=None,
+            tool_approval_policy=SimpleNamespace(yolo=True),
+        ),
+    )
+
+    async def _fake_execute_tool(
+        _ctx: object,
+        *,
+        action: Callable[[], Awaitable[ToolResultProjection]],
+        approval_request=None,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        assert approval_request is not None
+        assert approval_request.source == "shell_local_policy"
+        try:
+            await action()
+        except ToolExecutionError as exc:
+            return {"ok": False, "error": {"type": exc.error_type, "message": str(exc)}}
+        raise AssertionError("expected local shell policy to block action")
+
+    monkeypatch.setattr(shell_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, command="curl https://example.com")
+
+    assert result == {
+        "ok": False,
+        "error": {
+            "type": "tool_blocked",
+            "message": "command is blocked by local shell policy: curl",
+        },
+    }
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_shell_yolo_blocks_parent_directory_change_in_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_background_tasks(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["shell"],
+    )
+    service = _CapturingBackgroundTaskService()
+    workspace = _FakeWorkspace(tmp_path)
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            background_task_service=service,
+            workspace=workspace,
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+            shell_approval_repo=None,
+            tool_approval_policy=SimpleNamespace(yolo=True),
+        ),
+    )
+
+    async def _fake_execute_tool(
+        _ctx: object,
+        *,
+        action: Callable[[], Awaitable[ToolResultProjection]],
+        approval_request=None,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        assert approval_request is not None
+        assert approval_request.source == "shell_local_policy"
+        try:
+            await action()
+        except ToolExecutionError as exc:
+            return {"ok": False, "error": {"type": exc.error_type, "message": str(exc)}}
+        raise AssertionError("expected yolo directory change to block action")
+
+    monkeypatch.setattr(shell_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, command="cd .. && pwd")
+
+    assert result == {
+        "ok": False,
+        "error": {
+            "type": "tool_blocked",
+            "message": (
+                "directory change is blocked by local shell policy: "
+                f"{tmp_path.parent.resolve()} is outside {tmp_path.resolve()}"
+            ),
+        },
+    }
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_shell_returns_blocked_tool_result_for_workdir_escape(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_background_tasks(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["shell"],
+    )
+
+    class _BlockedWorkspace(_FakeWorkspace):
+        def resolve_workdir(self, relative_path: str | None = None) -> Path:
+            raise ValueError(f"Path is outside workspace write scope: {relative_path}")
+
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            workspace=_BlockedWorkspace(tmp_path),
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+            shell_approval_repo=None,
+            tool_approval_policy=SimpleNamespace(yolo=True),
+        ),
+    )
+
+    async def _fake_execute_tool(
+        _ctx: object,
+        *,
+        action: Callable[[], Awaitable[ToolResultProjection]],
+        approval_request=None,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        assert approval_request is not None
+        assert approval_request.source == "shell_local_policy"
+        try:
+            await action()
+        except ToolExecutionError as exc:
+            return {"ok": False, "error": {"type": exc.error_type, "message": str(exc)}}
+        raise AssertionError("expected workdir validation to block action")
+
+    monkeypatch.setattr(shell_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, command="pwd", workdir="../outside")
+
+    assert result == {
+        "ok": False,
+        "error": {
+            "type": "tool_blocked",
+            "message": "Path is outside workspace write scope: ../outside",
+        },
+    }

--- a/tests/unit_tests/tools/workspace_tools/test_github_cli.py
+++ b/tests/unit_tests/tools/workspace_tools/test_github_cli.py
@@ -128,6 +128,73 @@ class TestGitHubCliPath:
         assert path == system_gh
         assert mock_download.await_count == 0
 
+    @pytest.mark.asyncio
+    async def test_resolve_existing_gh_path_does_not_attempt_download(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cache_dir = tmp_path / "bin"
+        cache_dir.mkdir()
+
+        with patch("shutil.which", return_value=None):
+            with patch(
+                "agent_teams.tools.workspace_tools.github_cli.BIN_DIR",
+                cache_dir,
+            ):
+                from agent_teams.tools.workspace_tools import github_cli
+
+                github_cli.clear_gh_path_cache()
+                with patch(
+                    "agent_teams.tools.workspace_tools.github_cli._download_gh",
+                    new=AsyncMock(side_effect=RuntimeError("no network")),
+                ) as mock_download:
+                    path = github_cli.resolve_existing_gh_path()
+
+        assert path is None
+        assert mock_download.await_count == 0
+
+    def test_resolve_existing_gh_path_does_not_create_bin_dir(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cache_dir = tmp_path / "missing-bin"
+
+        with patch("shutil.which", return_value=None):
+            with patch(
+                "agent_teams.tools.workspace_tools.github_cli.BIN_DIR",
+                cache_dir,
+            ):
+                from agent_teams.tools.workspace_tools import github_cli
+
+                github_cli.clear_gh_path_cache()
+                path = github_cli.resolve_existing_gh_path()
+
+        assert path is None
+        assert not cache_dir.exists()
+
+    def test_resolve_existing_gh_path_swallow_lookup_errors(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cache_dir = tmp_path / "bin"
+
+        with patch("shutil.which", return_value=None):
+            with patch(
+                "agent_teams.tools.workspace_tools.github_cli.BIN_DIR",
+                cache_dir,
+            ):
+                from agent_teams.tools.workspace_tools import github_cli
+
+                github_cli.clear_gh_path_cache()
+                with patch.object(
+                    github_cli.Path,
+                    "is_file",
+                    side_effect=OSError("read-only"),
+                ):
+                    path = github_cli.resolve_existing_gh_path()
+
+        assert path is None
+
 
 class TestGitHubCliDownload:
     @pytest.mark.asyncio

--- a/tests/unit_tests/tools/workspace_tools/test_shell.py
+++ b/tests/unit_tests/tools/workspace_tools/test_shell.py
@@ -585,6 +585,33 @@ async def test_spawn_shell_strips_bash_startup_env(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_build_shell_env_ignores_gh_lookup_errors(monkeypatch) -> None:
+    from agent_teams.tools.workspace_tools import shell_executor
+
+    shell = shell_executor.ResolvedShell(
+        kind=shell_executor.ShellKind.BASH,
+        executable="bash",
+        display_name="Bash",
+    )
+
+    monkeypatch.setattr(shell_executor, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(
+        shell_executor,
+        "resolve_existing_gh_path",
+        lambda: (_ for _ in ()).throw(OSError("read-only")),
+    )
+    monkeypatch.setattr(
+        shell_executor.os,
+        "environ",
+        {"PATH": "/usr/bin"},
+    )
+
+    env = await shell_executor.build_shell_env(shell=shell)
+
+    assert env["PATH"] == "/usr/bin"
+
+
+@pytest.mark.asyncio
 async def test_create_shell_subprocess_uses_powershell_wrapper_and_keeps_env(
     monkeypatch,
 ) -> None:

--- a/tests/unit_tests/tools/workspace_tools/test_shell_policy.py
+++ b/tests/unit_tests/tools/workspace_tools/test_shell_policy.py
@@ -1,19 +1,349 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
 import pytest
 
+from agent_teams.sessions.runs.background_tasks.command_runtime import (
+    CommandRuntimeKind,
+    ResolvedCommandRuntime,
+)
+from agent_teams.tools.workspace_tools import shell_policy as shell_policy_module
 from agent_teams.tools.workspace_tools.shell_policy import (
     MAX_TIMEOUT_SECONDS,
+    ShellRuntimeFamily,
     normalize_timeout,
     validate_shell_command,
 )
 
 
-def test_shell_policy_allows_more_command() -> None:
-    validate_shell_command("more README.md")
+def _mock_powershell_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        shell_policy_module,
+        "resolve_command_runtime",
+        lambda *, command=None: ResolvedCommandRuntime(
+            kind=CommandRuntimeKind.POWERSHELL,
+            executable="powershell.exe",
+            display_name="PowerShell",
+        ),
+    )
+
+
+def test_shell_policy_allows_python_inline_command() -> None:
+    decision = validate_shell_command('python -c "print(1)"')
+
+    assert decision.normalized_command == 'python -c "print(1)"'
+    assert decision.prefix_candidates == ("python",)
 
 
 def test_shell_policy_rejects_empty_command() -> None:
     with pytest.raises(ValueError, match="must not be empty"):
         validate_shell_command("   ")
+
+
+def test_shell_policy_rejects_banned_bash_download_command() -> None:
+    with pytest.raises(ValueError, match="curl"):
+        validate_shell_command("curl https://example.com")
+
+
+def test_shell_policy_rejects_banned_bash_download_exe_command() -> None:
+    with pytest.raises(ValueError, match="curl\\.exe"):
+        validate_shell_command("curl.exe https://example.com")
+
+
+def test_shell_policy_rejects_banned_bash_download_env_wrapper() -> None:
+    with pytest.raises(ValueError, match="curl"):
+        validate_shell_command("env curl https://example.com")
+
+
+def test_shell_policy_rejects_banned_bash_download_path_qualified_env_wrapper() -> None:
+    with pytest.raises(ValueError, match="curl"):
+        validate_shell_command("/usr/bin/env curl https://example.com")
+
+
+def test_shell_policy_rejects_banned_bash_download_command_wrapper() -> None:
+    with pytest.raises(ValueError, match="curl"):
+        validate_shell_command("command curl https://example.com")
+
+
+def test_shell_policy_rejects_banned_bash_download_noglob_wrapper() -> None:
+    with pytest.raises(ValueError, match="curl"):
+        validate_shell_command("noglob curl https://example.com")
+
+
+def test_shell_policy_rejects_banned_bash_download_in_dollar_substitution() -> None:
+    with pytest.raises(ValueError, match="curl"):
+        validate_shell_command("echo $(curl https://example.com)")
+
+
+def test_shell_policy_rejects_banned_bash_download_in_backtick_substitution() -> None:
+    with pytest.raises(ValueError, match="curl"):
+        validate_shell_command("echo `curl https://example.com`")
+
+
+def test_shell_policy_rejects_powershell_download_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_powershell_runtime(monkeypatch)
+    with pytest.raises(ValueError, match="iwr"):
+        validate_shell_command("iwr https://example.com")
+
+
+def test_shell_policy_tracks_git_prefixes_across_compound_command() -> None:
+    decision = validate_shell_command("git status && git diff --stat")
+
+    assert decision.runtime_family in {
+        ShellRuntimeFamily.BASH,
+        ShellRuntimeFamily.GIT_BASH,
+    }
+    assert decision.prefix_candidates == ("git status", "git diff")
+
+
+def test_shell_policy_rejects_banned_bash_command_after_single_ampersand() -> None:
+    with pytest.raises(ValueError, match="curl"):
+        validate_shell_command("echo ok & curl https://example.com")
+
+
+def test_shell_policy_tracks_direct_powershell_script_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_powershell_runtime(monkeypatch)
+    decision = validate_shell_command("& 'C:\\Tools\\job.ps1' -Flag value")
+
+    assert decision.runtime_family == ShellRuntimeFamily.POWERSHELL
+    assert decision.prefix_candidates == ("job.ps1",)
+
+
+def test_shell_policy_yolo_rejects_parent_directory_change_for_bash(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "cd .. && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_allows_child_directory_change_for_bash(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+    decision = validate_shell_command(
+        "cd tests && pytest",
+        yolo=True,
+        effective_cwd=cwd,
+    )
+
+    assert decision.prefix_candidates == ("cd", "pytest")
+
+
+def test_shell_policy_yolo_rejects_parent_directory_change_for_bash_cd_dash_dash(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "cd -- .. && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_parent_directory_change_for_command_wrapped_bash_cd(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "command cd .. && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_parent_directory_change_for_bash_cd_dash_p(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "cd -P .. && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_parent_directory_change_for_bash_pushd(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "pushd .. && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_home_directory_shorthand_for_bash(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "cd ~ && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_oldpwd_shorthand_for_bash(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "cd - && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_env_var_directory_change_for_bash(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+
+    with pytest.raises(ValueError, match="requires shell expansion"):
+        validate_shell_command(
+            "cd $HOME && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_cdpath_directory_change_for_bash(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+
+    with pytest.raises(ValueError, match="CDPATH requires shell expansion"):
+        validate_shell_command(
+            "CDPATH=/ cd tmp && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_braced_env_var_directory_change_for_bash(
+    tmp_path: Path,
+) -> None:
+    cwd = (tmp_path / "project").resolve()
+
+    with pytest.raises(ValueError, match="requires shell expansion"):
+        validate_shell_command(
+            "cd ${OLDPWD} && pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_strips_leading_noop_cd_prefix(tmp_path: Path) -> None:
+    cwd = (tmp_path / "project").resolve()
+
+    decision = validate_shell_command(
+        f"cd {cwd} && git status",
+        yolo=True,
+        effective_cwd=cwd,
+    )
+
+    assert decision.subcommands == ("git status",)
+    assert decision.prefix_candidates == ("git status",)
+
+
+def test_shell_policy_approval_mode_keeps_parent_directory_change_allowed() -> None:
+    decision = validate_shell_command("cd .. && pwd")
+
+    assert decision.prefix_candidates == ("cd", "pwd")
+
+
+def test_shell_policy_yolo_rejects_parent_directory_change_for_powershell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _mock_powershell_runtime(monkeypatch)
+    cwd = (tmp_path / "project").resolve()
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "Set-Location ..; pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_allows_child_directory_change_for_powershell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _mock_powershell_runtime(monkeypatch)
+    cwd = (tmp_path / "project").resolve()
+    decision = validate_shell_command(
+        "Set-Location -Path tests; pytest",
+        yolo=True,
+        effective_cwd=cwd,
+    )
+
+    assert decision.runtime_family == ShellRuntimeFamily.POWERSHELL
+    assert decision.prefix_candidates == ("set-location", "pytest")
+
+
+def test_shell_policy_yolo_rejects_parent_directory_change_for_powershell_pushd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _mock_powershell_runtime(monkeypatch)
+    cwd = (tmp_path / "project").resolve()
+    with pytest.raises(ValueError, match="directory change is blocked"):
+        validate_shell_command(
+            "pushd ..; pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_home_directory_change_for_powershell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _mock_powershell_runtime(monkeypatch)
+    cwd = (tmp_path / "project").resolve()
+
+    with pytest.raises(ValueError, match="requires shell expansion"):
+        validate_shell_command(
+            "Set-Location $HOME; pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
+
+
+def test_shell_policy_yolo_rejects_env_directory_change_for_powershell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _mock_powershell_runtime(monkeypatch)
+    cwd = (tmp_path / "project").resolve()
+
+    with pytest.raises(ValueError, match="requires shell expansion"):
+        validate_shell_command(
+            "Set-Location $env:USERPROFILE; pytest",
+            yolo=True,
+            effective_cwd=cwd,
+        )
 
 
 def test_shell_timeout_normalization() -> None:

--- a/tests/unit_tests/workspace/test_handle.py
+++ b/tests/unit_tests/workspace/test_handle.py
@@ -96,7 +96,7 @@ def test_resolve_read_path_allows_relative_escape_outside_workspace(
     assert resolved == external_file.resolve()
 
 
-def test_resolve_workdir_allows_outside_path(
+def test_resolve_workdir_rejects_outside_path(
     tmp_path: Path,
 ) -> None:
     workspace_root = tmp_path / "workspace"
@@ -105,9 +105,8 @@ def test_resolve_workdir_allows_outside_path(
         scope_root=workspace_root,
     )
 
-    resolved = workspace.resolve_workdir("../outside")
-
-    assert resolved == (tmp_path / "outside").resolve()
+    with pytest.raises(ValueError, match="outside workspace write scope"):
+        workspace.resolve_workdir("../outside")
 
 
 def test_resolve_path_rejects_write_outside_workspace_with_allowed_roots(

--- a/tests/unit_tests/workspace/test_manager.py
+++ b/tests/unit_tests/workspace/test_manager.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from agent_teams.workspace import (
     FileScopeBackend,
     WorkspaceFileScope,
@@ -109,10 +111,8 @@ def test_workspace_manager_includes_builtin_and_app_skill_roots_in_read_scope(
         app_skills_dir.resolve(),
     )
     assert handle.locations.writable_roots == (project_root.resolve(), tmp_root)
-    assert (
+    with pytest.raises(ValueError, match="outside workspace write scope"):
         handle.resolve_workdir(app_skills_dir.resolve().as_posix())
-        == app_skills_dir.resolve()
-    )
 
 
 def test_workspace_manager_resolves_execution_root_under_worktree_working_directory(


### PR DESCRIPTION
﻿﻿## Summary
- return blocked shell validations as `tool_blocked` results instead of aborting runs
- add reusable shell approval grants for exact and prefix approvals
- persist shell approval metadata and grants, and tighten workspace `workdir` handling
- update API, CLI, frontend, docs, and test coverage for the new shell approval flow

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests

Closes #272
