### PR TITLE
Add daily AI report source entries

### DIFF
--- a/src/relay_teams/builtin/roles/daily-ai-report.md
+++ b/src/relay_teams/builtin/roles/daily-ai-report.md
@@ -130,11 +130,16 @@ skills:
 
 - [AI Digest 中文](https://ai-digest.liziran.com/zh/)
 - [AI Brief 中文](https://ai-brief.liziran.com/zh/)
+- [a16z news](https://www.a16z.news/)
+- [alphaxiv](https://www.alphaxiv.org/)
 
 ## RSS 博客池
 
 ### Blogs
 
+- `a16z.news`  
+  RSS: <https://www.a16z.news/feed>  
+  Site: <https://www.a16z.news>
 - `simonwillison.net`  
   RSS: <https://simonwillison.net/atom/everything/>  
   Site: <https://simonwillison.net>


### PR DESCRIPTION
## Summary
- add 16z.news to the fixed sources for daily-ai-report
- add the 16z.news RSS feed to the blog pool
- add lphaxiv to the fixed sources after verifying the site is reachable

## Verification
- verified https://www.a16z.news/ is reachable
- verified https://www.a16z.news/feed returns XML
- verified https://www.alphaxiv.org/ is reachable
- checked common lphaxiv feed URLs and did not find a working public RSS feed

Closes #279