### PR TITLE
[codex] Add configurable logger desensitize rules

### DIFF
--- a/docs/logger-desensitize-design.md
+++ b/docs/logger-desensitize-design.md
@@ -1,0 +1,301 @@
+﻿# Logger Desensitize 方案说明
+
+## 1. 目标
+
+当前 `logger` 模块的脱敏方案只覆盖文件日志落盘路径，目标是：
+
+- 防止 `backend.log`、`debug.log`、`frontend.log` 落入明文敏感信息。
+- 尽量保留排障信息，只对高风险字段和值模式做统一替换。
+- 不改变现有 logger 的对外使用方式，调用方继续使用 `log_event()`、`logger.error()`、`logger.exception()` 即可。
+
+## 2. 实现入口
+
+核心实现位于 `src/agent_teams/logger/logger.py`。
+
+### 2.1 落盘前统一脱敏
+
+文件日志最终通过 `HumanReadableFormatter.format()` 输出。在这里会统一处理：
+
+- `message`：通过 `_sanitize_log_message()` 做字符串级脱敏。
+- `payload`：通过 `_render_payload()` 做结构化递归脱敏后再序列化。
+- `error_detail`：同样通过 `_render_payload()` 脱敏。
+
+也就是说，只要日志最终写入文件，就一定会经过这套 redactor。
+
+### 2.2 `log_event()` 只负责传递原始 payload
+
+当前 `log_event()` 不提前脱敏，只把原始 `payload` 放进 `LogRecord.extra`：
+
+```python
+logger.log(
+    level,
+    message,
+    extra={
+        "event": event,
+        "payload": payload or {},
+        "duration_ms": duration_ms,
+    },
+    exc_info=exc_info,
+)
+```
+
+真正的脱敏发生在 formatter 阶段，因此文件日志只会脱敏一次。
+
+## 3. 脱敏实现方式
+
+### 3.1 结构化递归脱敏
+
+`payload` 和 `error_detail` 的结构化脱敏由 `_sanitize_json_value()` 完成。
+
+处理规则：
+
+- `dict`：递归处理每个键值对。
+- `list`：递归处理每个元素。
+- `tuple`：递归处理每个元素，最终按 JSON 数组样式输出。
+- `None / bool / int / float`：原样保留。
+- 其他值：转成字符串后做字符串级脱敏。
+
+因此，多级 `map`、嵌套数组、元组都可以正常脱敏。
+
+### 3.2 键名归一化
+
+敏感键判断使用 `_normalize_redaction_key()`。归一化规则如下：
+
+- 去掉首尾空格
+- 转成小写
+- `-` 替换成 `_`
+
+例如：
+
+- `API_KEY` -> `api_key`
+- `api-key` -> `api_key`
+- ` Api-Key ` -> `api_key`
+
+### 3.3 键名命中时整值替换
+
+当结构化字段的 key 命中敏感键集合时，整个 value 直接替换为占位符。
+
+示例：
+
+输入：
+
+```json
+{
+  "api_key": "k-123",
+  "client_secret": "s-456",
+  "safe": "ok"
+}
+```
+
+输出：
+
+```json
+{
+  "api_key": "***",
+  "client_secret": "***",
+  "safe": "ok"
+}
+```
+
+### 3.4 字符串级脱敏
+
+字符串脱敏由 `_redact_string()` 完成。它用于：
+
+- 普通日志 `message`
+- `payload` 中未命中敏感 key 的字符串值
+- `error_detail` 中的异常 message / stack 文本
+
+当前默认模式包括：
+
+1. `Bearer <token>`
+2. `Basic <token>`
+3. URL 中的 `user:pass@host`
+4. URL query 中命中敏感键的参数值
+5. `sk-...` 形态 token
+6. 自定义 regex 规则
+
+注意：当前默认规则已经移除了“普通文本中裸 `token=...` / `api_key=...` 片段”的独立匹配；如果这类内容不在 URL 中，则不会被默认规则单独替换。
+
+### 3.5 URL 脱敏
+
+URL 脱敏由 `_redact_url()` 完成。
+
+它会：
+
+- 保留 scheme、host、path、fragment
+- 将 `user:pass@` 替换为 `***@`
+- 仅对 query 中命中敏感键的 value 做替换
+
+示例：
+
+输入：
+
+```text
+https://user:pass@example.test/path?token=abc&x=1
+```
+
+输出：
+
+```text
+https://***@example.test/path?token=***&x=1
+```
+
+## 4. 默认敏感键与默认行为
+
+### 4.1 默认敏感键
+
+当前内置敏感键集合为：
+
+- `password`
+- `passwd`
+- `secret`
+- `api_key`
+- `apikey`
+- `token`
+- `access_token`
+- `refresh_token`
+- `authorization`
+- `client_secret`
+- `proxy_password`
+
+
+## 5. 配置方式
+
+所有脱敏配置均通过环境变量生效，运行时由 `configure_logging()` 调用 `_refresh_redaction_settings()` 读取。
+
+### 5.1 占位符配置
+
+- `AGENT_TEAMS_LOG_REDACTION_PLACEHOLDER`
+
+默认值：
+
+```text
+***
+```
+
+示例：
+
+```text
+AGENT_TEAMS_LOG_REDACTION_PLACEHOLDER=[REDACTED]
+```
+
+### 5.2 敏感键追加
+
+- `AGENT_TEAMS_LOG_REDACTION_KEYS_ADD`
+
+格式要求：JSON 字符串数组。
+
+示例：
+
+```text
+AGENT_TEAMS_LOG_REDACTION_KEYS_ADD=["webhook_signature", "private_key"]
+```
+
+效果：在内置敏感键基础上追加。
+
+### 5.3 敏感键整体替换
+
+- `AGENT_TEAMS_LOG_REDACTION_KEYS_REPLACE`
+
+格式要求：JSON 字符串数组。
+
+示例：
+
+```text
+AGENT_TEAMS_LOG_REDACTION_KEYS_REPLACE=["webhook_signature"]
+```
+
+效果：完全替换内置敏感键集合。
+
+### 5.4 自定义正则追加
+
+- `AGENT_TEAMS_LOG_REDACTION_PATTERNS_ADD`
+
+格式要求：JSON 字符串数组，每个元素是一条 regex。
+
+示例：
+
+```text
+AGENT_TEAMS_LOG_REDACTION_PATTERNS_ADD=["CUST-[A-Z0-9]{6,}"]
+```
+
+效果：在默认字符串模式基础上额外增加匹配规则。
+
+### 5.5 自定义正则整体替换
+
+- `AGENT_TEAMS_LOG_REDACTION_PATTERNS_REPLACE`
+
+格式要求：JSON 字符串数组。
+
+示例：
+
+```text
+AGENT_TEAMS_LOG_REDACTION_PATTERNS_REPLACE=["CUST-[A-Z0-9]{6,}"]
+```
+
+效果：完全替换默认字符串模式集合。
+
+## 6. 配置错误时的行为
+
+配置容错策略如下：
+
+- 非法 JSON：回退到默认规则
+- 数组中出现非字符串元素：回退到默认规则
+- 自定义 regex 编译失败：回退到默认规则
+- 记录 warning，但不会阻止 logger 初始化
+
+因此，错误配置不会导致 `configure_logging()` 失败。
+
+## 7. 示例
+
+### 7.1 普通 message
+
+输入：
+
+```text
+request failed with Bearer abcdef while calling https://user:pass@example.test?a=1&token=xyz
+```
+
+输出：
+
+```text
+request failed with Bearer *** while calling https://***@example.test?a=1&token=***
+```
+
+### 7.2 多级 payload
+
+输入：
+
+```json
+{
+  "provider": {
+    "auth": {
+      "api_key": "nested-key",
+      "client_secret": "nested-secret"
+    },
+    "endpoints": [
+      {
+        "url": "https://user:pass@example.test/path?token=query-token"
+      }
+    ]
+  }
+}
+```
+
+输出：
+
+```json
+{
+  "provider": {
+    "auth": {
+      "api_key": "***",
+      "client_secret": "***"
+    },
+    "endpoints": [
+      {
+        "url": "https://***@example.test/path?token=***"
+      }
+    ]
+  }
+}
+```

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -13,8 +13,8 @@ from uuid import uuid4
 
 import mcp.types as mcp_types
 from fastmcp.server.server import FastMCP
-from fastmcp.tools.base import Tool as FastMcpTool
-from fastmcp.tools.base import ToolResult
+from fastmcp.tools import Tool as FastMcpTool
+from fastmcp.tools import ToolResult
 from mcp.shared.exceptions import McpError
 from mcp.shared.memory import create_client_server_memory_streams
 from mcp.shared.message import SessionMessage

--- a/src/relay_teams/logger/logger.py
+++ b/src/relay_teams/logger/logger.py
@@ -8,6 +8,7 @@ import configparser
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 import traceback
@@ -18,6 +19,7 @@ from queue import SimpleQueue
 from threading import Lock
 from types import TracebackType
 from typing import Literal, cast, override
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from relay_teams.builtin import (
     get_builtin_logger_ini_path,
@@ -38,11 +40,40 @@ DEFAULT_DEBUG_LOG_LEVEL = "DEBUG"
 DEFAULT_LOG_CONSOLE = "1"
 DEFAULT_BACKUP_COUNT = 14
 _LOGGER_INI_NAME = "logger.ini"
+DEFAULT_LOG_REDACTION_PLACEHOLDER = "***"
+_REDACTION_KEYS_ADD_ENV = "AGENT_TEAMS_LOG_REDACTION_KEYS_ADD"
+_REDACTION_KEYS_REPLACE_ENV = "AGENT_TEAMS_LOG_REDACTION_KEYS_REPLACE"
+_REDACTION_PATTERNS_ADD_ENV = "AGENT_TEAMS_LOG_REDACTION_PATTERNS_ADD"
+_REDACTION_PATTERNS_REPLACE_ENV = "AGENT_TEAMS_LOG_REDACTION_PATTERNS_REPLACE"
+_REDACTION_PLACEHOLDER_ENV = "AGENT_TEAMS_LOG_REDACTION_PLACEHOLDER"
+
+_DEFAULT_REDACTION_KEYS = frozenset(
+    {
+        "password",
+        "passwd",
+        "secret",
+        "api_key",
+        "apikey",
+        "token",
+        "access_token",
+        "refresh_token",
+        "authorization",
+        "client_secret",
+        "proxy_password",
+    }
+)
+_HEADER_TOKEN_PATTERN = re.compile(
+    r"(?P<scheme>Bearer|Basic)\s+[^\s\"';,]+",
+    re.IGNORECASE,
+)
+_URL_PATTERN = re.compile(r"\b(?:https?|wss?)://[^\s\"'<>]+", re.IGNORECASE)
+_OPENAI_TOKEN_PATTERN = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
 
 _RUNTIME_ENV_VALUES: dict[str, str] | None = None
 _LOGGING_LOCK = Lock()
 _LOGGING_RUNTIME: "_LoggingRuntime | None" = None
 _DEFAULT_RECORD_FACTORY = logging.getLogRecordFactory()
+_REDACTION_WARNING_CACHE: set[str] = set()
 
 type LogSource = Literal["backend", "frontend"]
 type LogExcInfo = (
@@ -51,6 +82,29 @@ type LogExcInfo = (
     | tuple[type[BaseException], BaseException, TracebackType | None]
     | tuple[None, None, None]
     | None
+)
+
+
+class _RedactionSettings:
+    def __init__(
+        self,
+        *,
+        sensitive_keys: frozenset[str],
+        custom_patterns: tuple[re.Pattern[str], ...],
+        use_default_patterns: bool,
+        placeholder: str,
+    ) -> None:
+        self.sensitive_keys = sensitive_keys
+        self.custom_patterns = custom_patterns
+        self.use_default_patterns = use_default_patterns
+        self.placeholder = placeholder
+
+
+_REDACTION_SETTINGS = _RedactionSettings(
+    sensitive_keys=_DEFAULT_REDACTION_KEYS,
+    custom_patterns=(),
+    use_default_patterns=True,
+    placeholder=DEFAULT_LOG_REDACTION_PLACEHOLDER,
 )
 
 
@@ -144,7 +198,7 @@ class HumanReadableFormatter(logging.Formatter):
         source = _resolve_log_source(record)
         logger_name = _display_logger_name(record.name, source)
         event = str(getattr(record, "event", "-") or "-")
-        message = record.getMessage()
+        message = _sanitize_log_message(record.getMessage())
 
         parts = [
             timestamp,
@@ -197,6 +251,7 @@ def configure_logging(
     with _LOGGING_LOCK:
         shutdown_logging()
         _refresh_runtime_env_values()
+        redaction_warnings = _refresh_redaction_settings()
 
         resolved_config_dir = (
             get_app_config_dir()
@@ -314,6 +369,7 @@ def configure_logging(
             frontend_queue_handler=frontend_queue_handler,
             managed_handlers=tuple(managed_handlers),
         )
+        _log_redaction_warnings(redaction_warnings)
 
 
 def shutdown_logging() -> None:
@@ -411,7 +467,7 @@ def log_event(
         message,
         extra={
             "event": event,
-            "payload": sanitize_payload(payload or {}),
+            "payload": _snapshot_json_value(payload or {}),
             "duration_ms": duration_ms,
         },
         exc_info=exc_info,
@@ -419,20 +475,52 @@ def log_event(
 
 
 def sanitize_payload(payload: JsonValue) -> JsonValue:
+    return _sanitize_json_value(payload)
+
+
+def _snapshot_json_value(payload: JsonValue) -> JsonValue:
     if isinstance(payload, dict):
         dict_payload = cast(dict[object, JsonValue], payload)
         return {
-            str(key): sanitize_payload(value) for key, value in dict_payload.items()
+            str(item_key): _snapshot_json_value(item_value)
+            for item_key, item_value in dict_payload.items()
         }
     if isinstance(payload, list):
         list_payload = cast(list[JsonValue], payload)
-        return [sanitize_payload(value) for value in list_payload]
+        return [_snapshot_json_value(value) for value in list_payload]
     if isinstance(payload, tuple):
         tuple_payload = cast(tuple[JsonValue, ...], payload)
-        return [sanitize_payload(value) for value in tuple_payload]
-    if isinstance(payload, str):
-        return _truncate(_mask_sensitive(payload))
+        return [_snapshot_json_value(value) for value in tuple_payload]
     return payload
+
+
+def _sanitize_json_value(
+    payload: object,
+    *,
+    key: str | None = None,
+) -> JsonValue:
+    settings = _get_redaction_settings()
+    if key is not None and _is_sensitive_key(key, settings):
+        return settings.placeholder
+    if isinstance(payload, dict):
+        dict_payload = cast(dict[object, object], payload)
+        return {
+            str(item_key): _sanitize_json_value(item_value, key=str(item_key))
+            for item_key, item_value in dict_payload.items()
+        }
+    if isinstance(payload, list):
+        list_payload = cast(list[object], payload)
+        return [_sanitize_json_value(value) for value in list_payload]
+    if isinstance(payload, tuple):
+        tuple_payload = cast(tuple[object, ...], payload)
+        return [_sanitize_json_value(value) for value in tuple_payload]
+    if payload is None or isinstance(payload, bool | int | float):
+        return cast(JsonValue, payload)
+    return _truncate(_redact_string(str(payload), settings=settings))
+
+
+def _sanitize_log_message(message: str) -> str:
+    return _truncate(_redact_string(message, settings=_get_redaction_settings()))
 
 
 def _refresh_runtime_env_values() -> None:
@@ -448,6 +536,128 @@ def _get_runtime_env_value(key: str, default: str) -> str:
     if values is None:
         return default
     return values.get(key, default)
+
+
+def _get_redaction_settings() -> _RedactionSettings:
+    return _REDACTION_SETTINGS
+
+
+def _refresh_redaction_settings() -> tuple[str, ...]:
+    global _REDACTION_SETTINGS
+
+    warnings: list[str] = []
+    placeholder = _resolve_redaction_placeholder()
+    sensitive_keys = _resolve_redaction_keys(warnings)
+    custom_patterns, use_default_patterns = _resolve_redaction_patterns(warnings)
+    _REDACTION_SETTINGS = _RedactionSettings(
+        sensitive_keys=sensitive_keys,
+        custom_patterns=custom_patterns,
+        use_default_patterns=use_default_patterns,
+        placeholder=placeholder,
+    )
+    return tuple(warnings)
+
+
+def _resolve_redaction_placeholder() -> str:
+    raw = _get_runtime_env_value(
+        _REDACTION_PLACEHOLDER_ENV,
+        DEFAULT_LOG_REDACTION_PLACEHOLDER,
+    ).strip()
+    return raw or DEFAULT_LOG_REDACTION_PLACEHOLDER
+
+
+def _resolve_redaction_keys(warnings: list[str]) -> frozenset[str]:
+    replace_raw = _get_runtime_env_value(_REDACTION_KEYS_REPLACE_ENV, "").strip()
+    if replace_raw:
+        replaced = _parse_env_string_list(
+            replace_raw, env_key=_REDACTION_KEYS_REPLACE_ENV
+        )
+        if replaced is None:
+            warnings.append(
+                f"Invalid {_REDACTION_KEYS_REPLACE_ENV}; using default redaction keys."
+            )
+            return _DEFAULT_REDACTION_KEYS
+        return frozenset(
+            _normalize_redaction_key(value) for value in replaced if value.strip()
+        )
+
+    add_raw = _get_runtime_env_value(_REDACTION_KEYS_ADD_ENV, "").strip()
+    if not add_raw:
+        return _DEFAULT_REDACTION_KEYS
+
+    added = _parse_env_string_list(add_raw, env_key=_REDACTION_KEYS_ADD_ENV)
+    if added is None:
+        warnings.append(
+            f"Invalid {_REDACTION_KEYS_ADD_ENV}; using default redaction keys only."
+        )
+        return _DEFAULT_REDACTION_KEYS
+
+    return _DEFAULT_REDACTION_KEYS | frozenset(
+        _normalize_redaction_key(value) for value in added if value.strip()
+    )
+
+
+def _resolve_redaction_patterns(
+    warnings: list[str],
+) -> tuple[tuple[re.Pattern[str], ...], bool]:
+    replace_raw = _get_runtime_env_value(_REDACTION_PATTERNS_REPLACE_ENV, "").strip()
+    if replace_raw:
+        replaced = _parse_env_regex_list(
+            replace_raw,
+            env_key=_REDACTION_PATTERNS_REPLACE_ENV,
+        )
+        if replaced is None:
+            warnings.append(
+                f"Invalid {_REDACTION_PATTERNS_REPLACE_ENV}; using default redaction patterns."
+            )
+            return (), True
+        return replaced, False
+
+    add_raw = _get_runtime_env_value(_REDACTION_PATTERNS_ADD_ENV, "").strip()
+    if not add_raw:
+        return (), True
+
+    added = _parse_env_regex_list(add_raw, env_key=_REDACTION_PATTERNS_ADD_ENV)
+    if added is None:
+        warnings.append(
+            f"Invalid {_REDACTION_PATTERNS_ADD_ENV}; using default redaction patterns only."
+        )
+        return (), True
+    return added, True
+
+
+def _parse_env_string_list(raw: str, *, env_key: str) -> list[str] | None:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, list):
+        return None
+
+    values: list[str] = []
+    for item in parsed:
+        if not isinstance(item, str):
+            return None
+        normalized = item.strip()
+        if normalized:
+            values.append(normalized)
+    return values
+
+
+def _parse_env_regex_list(
+    raw: str, *, env_key: str
+) -> tuple[re.Pattern[str], ...] | None:
+    values = _parse_env_string_list(raw, env_key=env_key)
+    if values is None:
+        return None
+
+    patterns: list[re.Pattern[str]] = []
+    try:
+        for value in values:
+            patterns.append(re.compile(value))
+    except re.error:
+        return None
+    return tuple(patterns)
 
 
 class _LoggerSettings:
@@ -624,10 +834,11 @@ def _display_logger_name(name: str, source: LogSource) -> str:
 
 
 def _render_payload(payload: object) -> str:
+    sanitized = _sanitize_json_value(payload)
     try:
-        text = json.dumps(payload, ensure_ascii=False, default=str)
+        text = json.dumps(sanitized, ensure_ascii=False, default=str)
     except TypeError:
-        text = str(payload)
+        text = str(sanitized)
     return _truncate(text, limit=500)
 
 
@@ -651,11 +862,72 @@ def _configure_uvicorn_loggers() -> None:
         logger.setLevel(logging.DEBUG)
 
 
-def _mask_sensitive(value: str) -> str:
-    lowered = value.lower()
-    if "sk-" in lowered or "bearer " in lowered:
-        return "***"
-    return value
+def _redact_string(value: str, *, settings: _RedactionSettings) -> str:
+    redacted = value
+    if settings.use_default_patterns:
+        redacted = _HEADER_TOKEN_PATTERN.sub(
+            lambda match: f"{match.group('scheme')} {settings.placeholder}",
+            redacted,
+        )
+        redacted = _URL_PATTERN.sub(
+            lambda match: _redact_url(match.group(0), settings),
+            redacted,
+        )
+        redacted = _OPENAI_TOKEN_PATTERN.sub(
+            lambda _match: settings.placeholder, redacted
+        )
+    for pattern in settings.custom_patterns:
+        redacted = pattern.sub(lambda _match: settings.placeholder, redacted)
+    return redacted
+
+
+def _redact_url(url: str, settings: _RedactionSettings) -> str:
+    try:
+        split_result = urlsplit(url)
+    except ValueError:
+        return settings.placeholder
+    netloc = split_result.netloc
+    if "@" in netloc:
+        host_port = netloc.rsplit("@", 1)[1]
+        netloc = f"{settings.placeholder}@{host_port}"
+
+    query_pairs = parse_qsl(split_result.query, keep_blank_values=True)
+    redacted_pairs = [
+        (
+            key,
+            settings.placeholder if _is_sensitive_key(key, settings) else value,
+        )
+        for key, value in query_pairs
+    ]
+    query = urlencode(redacted_pairs, doseq=True)
+    return urlunsplit(
+        (
+            split_result.scheme,
+            netloc,
+            split_result.path,
+            query,
+            split_result.fragment,
+        )
+    )
+
+
+def _is_sensitive_key(key: str, settings: _RedactionSettings) -> bool:
+    return _normalize_redaction_key(key) in settings.sensitive_keys
+
+
+def _normalize_redaction_key(key: str) -> str:
+    return key.strip().lower().replace("-", "_")
+
+
+def _log_redaction_warnings(warnings: tuple[str, ...]) -> None:
+    if not warnings:
+        return
+    logger = logging.getLogger(f"{BACKEND_LOGGER_NAMESPACE}.logger")
+    for warning in warnings:
+        if warning in _REDACTION_WARNING_CACHE:
+            continue
+        _REDACTION_WARNING_CACHE.add(warning)
+        logger.warning(warning)
 
 
 def _truncate(value: str, limit: int = 2000) -> str:

--- a/tests/unit_tests/logger/test_logging.py
+++ b/tests/unit_tests/logger/test_logging.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from threading import Thread
+from typing import cast
 from unittest.mock import patch
 
 import pytest
+from pydantic import JsonValue
 
 from relay_teams.logger import (
     configure_logging,
     get_logger,
     log_event,
+    log_model_output,
+    log_tool_error,
     shutdown_logging,
 )
 from relay_teams.logger import logger as logger_module
@@ -343,6 +347,405 @@ def test_windows_safe_handler_removes_existing_dest_before_copy(
 
     assert dest.read_text(encoding="utf-8") == "new content"
     assert log_file.read_text(encoding="utf-8") == ""
+
+
+def test_default_redaction_masks_sensitive_message_and_payload_values(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.redaction")
+        log_event(
+            logger,
+            logging.INFO,
+            event="unit.redaction",
+            message="structured redaction",
+            payload={
+                "authorization": "Bearer test-token",
+                "client_secret": "top-secret",
+                "url": "https://user:pass@example.test/path?api_key=query-secret",
+                "safe": "ok",
+            },
+        )
+        logger.error(
+            "Authorization: Bearer direct-token Cookie: sessionid=abc123; csrftoken=def456 https://user:pass@example.test/path?api_key=query-secret"
+        )
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert '"authorization": "***"' in backend_text
+        assert '"client_secret": "***"' in backend_text
+        assert "Bearer ***" in backend_text
+        assert "Cookie: sessionid=abc123; csrftoken=def456" in backend_text
+        assert "example.test/path?api_key=" in backend_text
+        assert "direct-token" not in backend_text
+        assert "abc123" in backend_text
+        assert "def456" in backend_text
+        assert "query-secret" not in backend_text
+        assert "user:pass@" not in backend_text
+        assert '"safe": "ok"' in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_nested_payload_redaction_masks_multi_level_maps(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.nested.redaction")
+        nested_payload: JsonValue = {
+            "provider": {
+                "auth": {
+                    "api_key": "nested-api-key",
+                    "client_secret": "nested-client-secret",
+                },
+                "endpoints": [
+                    {
+                        "url": "https://user:pass@example.test/path?token=query-token",
+                    },
+                    {
+                        "safe": "visible",
+                    },
+                ],
+                "tuple_payload": [
+                    {"authorization": "Bearer tuple-token"},
+                    "sk-tuple-secret",
+                ],
+            }
+        }
+        log_event(
+            logger,
+            logging.INFO,
+            event="unit.nested.redaction",
+            message="nested payload redaction",
+            payload=nested_payload,
+        )
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert '"api_key": "***"' in backend_text
+        assert '"client_secret": "***"' in backend_text
+        assert '"authorization": "***"' in backend_text
+        assert "example.test/path?token=" in backend_text
+        assert '"safe": "visible"' in backend_text
+        assert "nested-api-key" not in backend_text
+        assert "nested-client-secret" not in backend_text
+        assert "tuple-token" not in backend_text
+        assert "query-token" not in backend_text
+        assert "sk-tuple-secret" not in backend_text
+        assert "user:pass@" not in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_log_model_output_and_tool_error_redact_sensitive_content(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    try:
+        configure_logging(config_dir=config_dir)
+        log_model_output(
+            "role-1",
+            "Authorization: Bearer model-token https://user:pass@example.test/path?api_key=query-secret",
+        )
+        log_tool_error(
+            "role-1",
+            '{"Authorization": "Bearer tool-token", "url": "https://user:pass@example.test/path?api_key=query-secret"}',
+        )
+
+        shutdown_logging()
+
+        debug_text = (config_dir / "log" / "debug.log").read_text(encoding="utf-8")
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert "model-token" not in debug_text
+        assert "tool-token" not in backend_text
+        assert "query-secret" not in debug_text
+        assert "query-secret" not in backend_text
+        assert "example.test/path?api_key=" in debug_text
+        assert "example.test/path?api_key=" in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_exception_error_detail_is_redacted(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.exception")
+        try:
+            raise RuntimeError(
+                "failed calling https://user:pass@example.test/path?api_key=query-secret with sk-secret-token"
+            )
+        except RuntimeError:
+            logger.exception("request failed")
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert "request failed" in backend_text
+        assert "query-secret" not in backend_text
+        assert "sk-secret-token" not in backend_text
+        assert "user:pass@" not in backend_text
+        assert "example.test/path?api_key=" in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_log_event_snapshots_payload_before_async_formatting(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.payload.snapshot")
+        payload: JsonValue = {
+            "safe": "before",
+            "nested": {"safe": "inner-before"},
+            "items": ["before"],
+        }
+        log_event(
+            logger,
+            logging.INFO,
+            event="unit.payload.snapshot",
+            message="payload snapshot",
+            payload=payload,
+        )
+
+        payload_dict = cast(dict[str, JsonValue], payload)
+        payload_dict["safe"] = "after"
+        nested_payload = cast(dict[str, JsonValue], payload_dict["nested"])
+        nested_payload["safe"] = "inner-after"
+        items_payload = cast(list[JsonValue], payload_dict["items"])
+        items_payload[0] = "after"
+        payload_dict["secret"] = "mutated-secret"
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert '"safe": "before"' in backend_text
+        assert '"safe": "inner-before"' in backend_text
+        assert '"items": ["before"]' in backend_text
+        assert "mutated-secret" not in backend_text
+        assert '"safe": "after"' not in backend_text
+        assert '"safe": "inner-after"' not in backend_text
+        assert '"items": ["after"]' not in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_malformed_url_redaction_falls_back_without_dropping_log(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.malformed.url")
+        logger.error(
+            "request failed for http://[::1?token=query-secret but message still logs"
+        )
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert "request failed for" in backend_text
+        assert "but message still logs" in backend_text
+        assert "http://[::1?token=query-secret" not in backend_text
+        assert "query-secret" not in backend_text
+        assert "***" in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_redaction_keys_add_env_masks_custom_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    monkeypatch.setenv(
+        "AGENT_TEAMS_LOG_REDACTION_KEYS_ADD",
+        '["webhook_signature"]',
+    )
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.keys.add")
+        log_event(
+            logger,
+            logging.INFO,
+            event="unit.keys.add",
+            message="custom key redaction",
+            payload={"webhook_signature": "sig-12345", "safe": "ok"},
+        )
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert '"webhook_signature": "***"' in backend_text
+        assert "sig-12345" not in backend_text
+        assert '"safe": "ok"' in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_redaction_keys_replace_env_overrides_default_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    monkeypatch.setenv(
+        "AGENT_TEAMS_LOG_REDACTION_KEYS_REPLACE",
+        '["webhook_signature"]',
+    )
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.keys.replace")
+        log_event(
+            logger,
+            logging.INFO,
+            event="unit.keys.replace",
+            message="replace key redaction",
+            payload={"secret": "plainvalue", "webhook_signature": "sig-67890"},
+        )
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert '"secret": "plainvalue"' in backend_text
+        assert '"webhook_signature": "***"' in backend_text
+        assert "sig-67890" not in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_redaction_patterns_add_env_masks_custom_patterns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    monkeypatch.setenv(
+        "AGENT_TEAMS_LOG_REDACTION_PATTERNS_ADD",
+        '["CUST-[A-Z0-9]{6,}"]',
+    )
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.patterns.add")
+        logger.error("custom token CUST-ABC123XYZ")
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert "CUST-ABC123XYZ" not in backend_text
+        assert "***" in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_redaction_patterns_replace_env_overrides_default_patterns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    monkeypatch.setenv(
+        "AGENT_TEAMS_LOG_REDACTION_PATTERNS_REPLACE",
+        '["CUST-[A-Z0-9]{6,}"]',
+    )
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.patterns.replace")
+        logger.error("Bearer visible-token CUST-ABC123XYZ")
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert "Bearer visible-token" in backend_text
+        assert "CUST-ABC123XYZ" not in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_placeholder_is_treated_literally_for_default_patterns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    monkeypatch.setenv("AGENT_TEAMS_LOG_REDACTION_PLACEHOLDER", r"\1")
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.placeholder.default")
+        logger.error("secret sk-test-token")
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert "sk-test-token" not in backend_text
+        assert r"\1" in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_placeholder_is_treated_literally_for_custom_patterns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    monkeypatch.setenv("AGENT_TEAMS_LOG_REDACTION_PLACEHOLDER", "\\")
+    monkeypatch.setenv(
+        "AGENT_TEAMS_LOG_REDACTION_PATTERNS_ADD",
+        '["CUST-[A-Z0-9]{6,}"]',
+    )
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.placeholder.custom")
+        logger.error("custom token CUST-ABC123XYZ")
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert "CUST-ABC123XYZ" not in backend_text
+        assert "\\" in backend_text
+    finally:
+        snapshot.restore()
+
+
+def test_invalid_redaction_config_falls_back_to_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    monkeypatch.setenv("AGENT_TEAMS_LOG_REDACTION_KEYS_REPLACE", "not-json")
+    try:
+        configure_logging(config_dir=config_dir)
+        logger = get_logger("tests.unit.invalid.redaction")
+        log_event(
+            logger,
+            logging.INFO,
+            event="unit.invalid.redaction",
+            message="fallback redaction",
+            payload={"secret": "fallback-secret"},
+        )
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        assert "fallback-secret" not in backend_text
+        assert "Invalid AGENT_TEAMS_LOG_REDACTION_KEYS_REPLACE" in backend_text
+    finally:
+        snapshot.restore()
 
 
 class _RootLoggerSnapshot:


### PR DESCRIPTION
Fixes #290

## Summary
- add configurable logger desensitize rules before writing `backend.log`, `debug.log`, and `frontend.log`
- recursively redact structured payload and error detail values by sensitive keys, while also masking selected token and URL patterns in plain strings
- add design documentation and unit coverage for nested payloads, model/tool output, exception text, and URL/query redaction

## Why
Current file logging can persist cleartext secrets in messages, payloads, and exception details. The change centralizes redaction in the logger formatter so callers can keep using the existing logging APIs.

## Impact
- sensitive structured fields such as `api_key`, `client_secret`, and `authorization` are replaced with the configured placeholder
- string redaction covers auth headers, URL userinfo, sensitive query parameter values inside URLs, and `sk-...` style tokens
- operators can extend redaction keys and regex patterns through environment configuration

## Validation
- `uv run --extra dev pytest -q tests/unit_tests/logger/test_logging.py`