### PR TITLE
Fix host tool bridge compatibility with legacy FastMCP

### DIFF
--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import importlib
 import inspect
 import json
 import sys
@@ -13,8 +14,6 @@ from uuid import uuid4
 
 import mcp.types as mcp_types
 from fastmcp.server.server import FastMCP
-from fastmcp.tools import Tool as FastMcpTool
-from fastmcp.tools import ToolResult
 from mcp.shared.exceptions import McpError
 from mcp.shared.memory import create_client_server_memory_streams
 from mcp.shared.message import SessionMessage
@@ -56,6 +55,8 @@ from relay_teams.workspace import WorkspaceManager, build_conversation_id
 
 if TYPE_CHECKING:
     from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+    from fastmcp.tools import Tool as FastMcpTool
+    from fastmcp.tools import ToolResult
 
     from relay_teams.agents.execution.message_repository import MessageRepository
     from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
@@ -70,6 +71,33 @@ if TYPE_CHECKING:
     from relay_teams.notifications import NotificationService
     from relay_teams.persistence.shared_state_repo import SharedStateRepository
     from relay_teams.gateway.im import ImToolService
+
+
+def _load_fastmcp_tool_types() -> tuple[type[object], type[object]]:
+    try:
+        public_module = importlib.import_module("fastmcp.tools")
+    except ImportError:
+        return _load_legacy_fastmcp_tool_types()
+
+    tool_cls = getattr(public_module, "Tool", None)
+    tool_result_cls = getattr(public_module, "ToolResult", None)
+    if isinstance(tool_cls, type) and isinstance(tool_result_cls, type):
+        return tool_cls, tool_result_cls
+    return _load_legacy_fastmcp_tool_types()
+
+
+def _load_legacy_fastmcp_tool_types() -> tuple[type[object], type[object]]:
+    legacy_module = importlib.import_module("fastmcp.tools.tool")
+    tool_cls = getattr(legacy_module, "Tool", None)
+    tool_result_cls = getattr(legacy_module, "ToolResult", None)
+    if not isinstance(tool_cls, type) or not isinstance(tool_result_cls, type):
+        msg = "fastmcp tool module did not expose Tool and ToolResult classes"
+        raise TypeError(msg)
+    return tool_cls, tool_result_cls
+
+
+if not TYPE_CHECKING:
+    FastMcpTool, ToolResult = _load_fastmcp_tool_types()
 
 
 HOST_TOOL_SERVER_ID = "agent_teams_host_tools"

--- a/tests/unit_tests/external_agents/test_host_tool_bridge.py
+++ b/tests/unit_tests/external_agents/test_host_tool_bridge.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from types import ModuleType
+
+import relay_teams.external_agents.host_tool_bridge as host_tool_bridge_module
+
+
+class _PublicTool:
+    pass
+
+
+class _PublicToolResult:
+    pass
+
+
+class _LegacyTool:
+    pass
+
+
+class _LegacyToolResult:
+    pass
+
+
+def test_load_fastmcp_tool_types_prefers_public_exports(monkeypatch) -> None:
+    public_module = ModuleType("fastmcp.tools")
+    setattr(public_module, "Tool", _PublicTool)
+    setattr(public_module, "ToolResult", _PublicToolResult)
+
+    def fake_import_module(name: str) -> ModuleType:
+        assert name == "fastmcp.tools"
+        return public_module
+
+    monkeypatch.setattr(
+        host_tool_bridge_module.importlib, "import_module", fake_import_module
+    )
+
+    tool_cls, tool_result_cls = host_tool_bridge_module._load_fastmcp_tool_types()
+
+    assert tool_cls is _PublicTool
+    assert tool_result_cls is _PublicToolResult
+
+
+def test_load_fastmcp_tool_types_falls_back_to_legacy_module(monkeypatch) -> None:
+    public_module = ModuleType("fastmcp.tools")
+    legacy_module = ModuleType("fastmcp.tools.tool")
+    setattr(legacy_module, "Tool", _LegacyTool)
+    setattr(legacy_module, "ToolResult", _LegacyToolResult)
+    requested_modules: list[str] = []
+
+    def fake_import_module(name: str) -> ModuleType:
+        requested_modules.append(name)
+        if name == "fastmcp.tools":
+            return public_module
+        if name == "fastmcp.tools.tool":
+            return legacy_module
+        raise AssertionError(f"unexpected module import: {name}")
+
+    monkeypatch.setattr(
+        host_tool_bridge_module.importlib, "import_module", fake_import_module
+    )
+
+    tool_cls, tool_result_cls = host_tool_bridge_module._load_fastmcp_tool_types()
+
+    assert requested_modules == ["fastmcp.tools", "fastmcp.tools.tool"]
+    assert tool_cls is _LegacyTool
+    assert tool_result_cls is _LegacyToolResult


### PR DESCRIPTION
## Summary
- make `host_tool_bridge` load `Tool` and `ToolResult` from `fastmcp.tools` when available
- fall back to `fastmcp.tools.tool` for older FastMCP versions
- add unit tests covering both the public-export path and the legacy fallback path

## Why
Older FastMCP versions do not expose the same import path as newer releases. The host tool bridge should keep working across both layouts instead of being pinned to one module path.

## Linked Issue
Closes #299

## Validation
- `uv run --extra dev basedpyright src/relay_teams/external_agents/host_tool_bridge.py tests/unit_tests/external_agents/test_host_tool_bridge.py`
- `uv run --extra dev pytest -q tests/unit_tests/external_agents/test_host_tool_bridge.py`