### PR TITLE
Support MAAS model discovery

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -140,7 +140,8 @@ Fetches the available model catalog for a saved profile and/or draft override.
 Draft overrides may omit `model`, but must provide `base_url` and `api_key` or `headers` when `profile_name` is omitted. For `provider = "maas"`, the override must provide `base_url` and `maas_auth`.
 When `profile_name` is provided, the request may override `base_url`, `api_key`, `headers`, and `ssl_verify` while reusing the saved credentials for any omitted fields.
 If `timeout_ms` is omitted, the backend uses the resolved profile `connect_timeout_seconds` value, or `15s` when no saved profile is involved.
-`openai_compatible`, `bigmodel`, and `minimax` map this call to `GET {base_url}/models` and return the normalized `models` list sorted and deduplicated. `maas` does not support catalog discovery through this API and returns `error_code = "unsupported_provider"`, so callers must enter the model name manually.
+`openai_compatible`, `bigmodel`, and `minimax` map this call to `GET {base_url}/models` and return the normalized `models` list sorted and deduplicated. `maas` maps this call to the fixed PromptCenter discovery endpoint after MAAS login, using the returned `X-Auth-Token` plus department info from `userInfo` to build the discovery request payload.
+For `maas`, the backend merges model ids from top-level `user_model_list` and nested `plugin_config[].config` payloads, filters invalid ids, then returns sorted deduplicated ids in `models[]` and `model_entries[]`.
 When the provider exposes per-model context-limit metadata in the catalog payload, the response also includes `model_entries[]` with:
 - `model`
 - optional `context_window`

--- a/docs/maas-provider-design.md
+++ b/docs/maas-provider-design.md
@@ -1,35 +1,36 @@
-﻿# MAAS Provider 对接设计说明
+# MAAS Provider 对接设计说明
 
 ## 1. 背景
 
 当前仓库已经支持 `openai_compatible`、`bigmodel`、`minimax` 和内部测试用 `echo` provider。
-MAAS 对接不是引入一套新的推理协议，而是在保留现有 OpenAI-compatible `/chat/completions` 主链路的前提下，补充 MAAS 专用的登录、token 注入、配置持久化和前端设置页行为。
-本文描述的是当前已经落地的实现设计，而不是待实现 proposal。
+MAAS 对接不是引入新的推理协议，而是在保留 OpenAI-compatible `/chat/completions` 主链路的前提下，补充 MAAS 专用的登录、token 注入、模型发现、配置持久化和前端设置页行为。
+本文档描述的是当前已经落地的实现设计。
 
 ## 2. 目标
 
 - 将 `maas` 作为正式 provider 暴露给后端运行时和前端设置页。
-- 在实际推理前，按需调用固定的 `secureLogin` 接口获取 token。
+- 在实际推理前按需调用固定 `secureLogin` 接口获取 token。
 - 在推理请求中自动注入 `X-Auth-Token` 和固定 `app-id`。
 - 继续复用现有 OpenAI-compatible `/chat/completions` 执行链路。
 - 确保 MAAS 密码不写入 `model.json`。
 - 已保存的 MAAS profile 在前端再次编辑或测试时，不要求用户重新输入密码。
-- 支持 MAAS 连通性测试，但不支持 MAAS 模型发现。
+- 支持 MAAS 连通性测试和 MAAS 可用模型发现。
 
 ## 3. 非目标
 
 - 不抽象成通用 OAuth / SSO / 任意登录框架。
-- 不支持 MAAS 模型目录发现。
 - 不支持在前端自定义 MAAS 登录 URL。
 - 不支持在前端自定义 MAAS 推理 base URL。
+- 不支持在前端自定义 MAAS 模型发现 endpoint 或 fixed payload 字段。
 - 不支持在前端自定义 `app-id`。
 - 不支持 external ACP agent 绑定 MAAS profile。
 
 ## 4. 固定约束
 
-- 登录 URL 固定为：`http://rnd-idea-api.huawei.com/ideaclientservice/login/v4/secureLogin`
-- 推理基础 URL 固定为：`http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/`
-- 推理请求固定注入：`app-id: RelayTeams`
+- 登录 URL 固定：`http://rnd-idea-api.huawei.com/ideaclientservice/login/v4/secureLogin`
+- 推理 base URL 固定：`http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/`
+- 模型发现 URL 固定：`https://promptcenter.aims.cce.prod.dragon.tools.huawei.com/PromptCenterService/v1/policy/bundle`
+- 推理请求头固定注入：`app-id: RelayTeams`
 
 这些值由后端强制控制，前端只能展示结果，不能修改。
 
@@ -42,7 +43,7 @@ MAAS 对接不是引入一套新的推理协议，而是在保留现有 OpenAI-c
 ### 5.2 MAAS 认证结构
 
 MAAS 使用 `MaaSAuthConfig`，包含 `username` 和 `password` 两个字段。
-其中 `username` 写入 `model.json`，`password` 只写入统一 secret store，读取接口只返回 `username` 和 `has_password`。
+其中 `username` 写入 `model.json`，`password` 只写入 unified secret store。读取接口默认只返回 `username` 和 `has_password`，不回显已保存密码。
 
 ### 5.3 持久化规则
 
@@ -62,17 +63,46 @@ MAAS 使用 `MaaSAuthConfig`，包含 `username` 和 `password` 两个字段。
 - `src/relay_teams/sessions/runs/runtime_config.py`
 - `src/relay_teams/interfaces/server/routers/system.py`
 
-职责：定义 `ProviderType.MAAS` 和 `MaaSAuthConfig`，强制 MAAS 使用固定 base URL，保存时将密码写入 secret store，读取时从 secret store 恢复密码，返回前端时只暴露 `username` 和 `has_password`。
+职责：
+- 定义 `ProviderType.MAAS` 和 `MaaSAuthConfig`
+- 强制 MAAS 使用固定 base URL
+- 保存时将密码写入 secret store
+- 运行时从 secret store 恢复密码
+- 对前端返回 `username` 和 `has_password`
 
 ### 6.2 MAAS 鉴权层
 
 主要模块：`src/relay_teams/providers/maas_auth.py`。
-职责：发起固定 `secureLogin`，提取 `cloudDragonTokens.authToken`，token 仅在内存中缓存，支持临近过期刷新，在 `401/403` 时强制刷新一次，并构造注入 `X-Auth-Token` 和 `app-id` 的认证对象。
+
+职责：
+- 发起固定 `secureLogin`
+- 提取 `cloudDragonTokens.authToken`
+- 从 `userInfo.hwDepartName` 或部门层级字段中提取 `department`
+- 在内存中缓存 MAAS auth context
+- 支持临近过期刷新，在 `401/403` 时强制刷新一次
+- 构造 MAAS 推理请求使用的鉴权对象
 
 ### 6.3 OpenAI-compatible 复用层
 
-主要模块：`src/relay_teams/providers/openai_support.py` 和 `src/relay_teams/providers/openai_compatible.py`。
-职责：保持 MAAS 继续走 OpenAI-compatible chat/completions 协议，将 Bearer API key 认证替换为 MAAS request auth，同时过滤 `authorization`、`x-auth-token`、`app-id` 这些 MAAS 保留头。
+主要模块：
+- `src/relay_teams/providers/openai_support.py`
+- `src/relay_teams/providers/openai_compatible.py`
+
+职责：
+- 保持 MAAS 推理继续走 OpenAI-compatible `/chat/completions`
+- 将 Bearer API key 认证替换为 MAAS request auth
+- 过滤 `authorization`、`x-auth-token`、`app-id` 等 MAAS 保留头
+
+### 6.4 MAAS 模型发现层
+
+主要模块：`src/relay_teams/providers/model_connectivity.py`。
+
+职责：
+- 为 `POST /api/system/configs/model:discover` 增加 `provider = "maas"` 分支
+- 复用 MAAS 登录拿到 token 和 department
+- 调用固定 PromptCenter 模型发现接口
+- 合并顶层和嵌套配置中的模型 id
+- 过滤非法模型 id，去重、排序并返回标准化结果
 
 ## 7. 请求链路
 
@@ -81,7 +111,7 @@ MAAS 使用 `MaaSAuthConfig`，包含 `username` 和 `password` 两个字段。
 1. 读取 profile，得到 `model`、固定 `base_url` 和 `maas_auth`。
 2. 调用 `MaaSTokenService.get_token_sync()` 或异步版本。
 3. 若本地没有有效 token，则先发起登录。
-4. 登录成功后在内存中缓存 token。
+4. 登录成功后在内存中缓存 auth context。
 5. 调用 `POST {base_url}/chat/completions`。
 6. 注入请求头：`X-Auth-Token` 和 `app-id: RelayTeams`。
 7. 若响应是 `401/403`，则强制刷新 token 后重试一次。
@@ -91,49 +121,91 @@ MAAS 使用 `MaaSAuthConfig`，包含 `username` 和 `password` 两个字段。
 前端在模型配置页点击“测试”时，MAAS 使用 probe 路径：
 1. 前端构造 `override`。
 2. 如果是编辑已有 MAAS profile 且用户没有重新输入密码，前端只会发送 `username`。
-3. 后端 probe merge 逻辑会把 override 中的 `username` 与已保存 profile 中的 `password` 合并。
+3. 后端 merge 逻辑会把 override 中的 `username` 与已保存 profile 中的 `password` 合并。
 4. 后端先进行 MAAS 登录。
 5. 然后请求 `/chat/completions`。
 6. 返回标准化的 `ModelConnectivityProbeResult`。
 
-### 7.3 event-stream 包装响应兼容
+### 7.3 模型发现链路
+
+前端在模型配置页点击“获取模型列表”时，MAAS 使用 discovery 路径：
+1. 前端发送 `provider`、固定 `base_url` 和 `maas_auth`。
+2. 如果是编辑已有 MAAS profile 且用户没有重新输入密码，前端只会发送 `username` 和 `profile_name`。
+3. 后端 merge 逻辑会复用已保存密码。
+4. 后端执行 MAAS 登录，获取 token 和 department。
+5. 后端调用固定 PromptCenter `policy/bundle` endpoint，并通过 `X-Auth-Token` 鉴权。
+6. 后端解析并标准化返回的模型目录。
+7. 后端返回标准 `ModelDiscoveryResult`。
+
+### 7.4 event-stream 包装响应兼容
 
 部分 MAAS probe 响应不是普通 JSON body，而是如下形式：
+
 ```text
 data: {"id":"cmpl-test","usage":{"total_tokens":3}}
 
 data: [DONE]
 ```
+
 为了兼容该行为，`model_connectivity.py` 的 probe 解析采用 fallback 策略：先尝试 `response.json()`；如果失败，再按 `data:` event-stream chunk 进行解析；忽略 `[DONE]`；从最后一个可解析的 `data:` chunk 中提取 JSON。
 
 ## 8. 前端设置页行为
 
-主要模块：`frontend/dist/js/components/settings/index.js` 和 `frontend/dist/js/components/settings/modelProfiles.js`。
-当 provider 切换为 `maas` 时，隐藏 API Key 输入区，显示 MAAS 用户名和密码字段，自动填充固定 base URL，并将 base URL 输入框设为禁用态，同时禁用模型发现。
-当从 `maas` 切换到其他 provider 时，会立即清空 base URL，恢复可编辑状态，回到普通 provider 的交互流程。
+主要模块：
+- `frontend/dist/js/components/settings/index.js`
+- `frontend/dist/js/components/settings/modelProfiles.js`
+
+当 provider 切换为 `maas` 时：
+- 隐藏 API Key 输入区
+- 显示 MAAS 用户名和密码字段
+- 自动填充固定 base URL
+- 将 base URL 输入框设为禁用态
+- 保持模型发现按钮可用，并走 MAAS 专用 discovery 链路
+
+当从 `maas` 切换到其他 provider 时，前端会清空固定 base URL，恢复普通 provider 的交互流程。
 
 ## 9. 模型发现策略
 
-当前 MAAS 不支持 `POST /api/system/configs/model:discover`。后端返回 `unsupported_provider`，前端禁用“获取模型列表”按钮，并提示用户手动填写 model name。
+MAAS 模型发现不复用 OpenAI-compatible `GET /models`。
+后端在登录后调用固定 PromptCenter endpoint，并从以下位置提取模型：
+- 顶层 `user_model_list[*].model_id`
+- 解析后的 `plugin_config[*].config[].composor_act_mode_model_list[*].model_id`
+- 解析后的 `plugin_config[*].config[].composor_plan_mode_model_list[*].model_id`
+- 解析后的 `plugin_config[*].config[].user_model_list[*].model_id`
+
+过滤规则：
+- 只保留非空字符串
+- 过滤纯数字 id
+- 过滤包含 `:` 的 id
+- 对剩余 id 去重并排序
 
 ## 10. 安全设计
 
-- MAAS 密码不写入 `model.json`，只写入统一 secret store。
-- token 只在内存中缓存，不写回任何持久化配置。
-- MAAS 会过滤 `Authorization`、`X-Auth-Token`、`app-id` 这些保留头，避免用户自定义 header 与系统鉴权冲突。
+- MAAS 密码不写入 `model.json`，只写入 unified secret store。
+- auth token 和 department 只在内存中缓存，不写回持久化配置。
+- 保留头会被过滤，避免用户自定义请求头和系统鉴权冲突。
 
 ## 11. 已知限制
 
-- 登录 URL 写死，不支持多环境切换。
-- 推理 base URL 写死，不支持多集群切换。
+- 登录 URL 固定，不支持多环境切换。
+- 推理 base URL 固定，不支持多集群切换。
+- 模型发现 endpoint 和请求字段固定，不支持前端自定义。
 - `app-id` 固定为 `RelayTeams`。
-- 不支持模型发现。
-- probe 对 event-stream 的支持是最小兼容解析，不是通用 SSE 框架。
-- external ACP agent 路径不支持 MAAS profile。
+- probe 的 event-stream 解析是最小兼容实现，不是通用 SSE 框架。
+- external ACP agent 路径仍不支持 MAAS profile。
 
 ## 12. 测试覆盖
 
-当前 MAAS 相关测试主要覆盖：provider registry 能识别 `maas`；model profile 保存和读取时密码进入 secret store；runtime config 能从 secret store 恢复 MAAS 密码；probe 能完成 MAAS 登录和 `/chat/completions` 测试；编辑已有 profile 时能复用已保存密码；probe 能兼容 `data: {...}` 包装响应；前端设置页在 `maas` 下展示固定 base URL、禁用编辑、禁用模型发现；从 `maas` 切回其他 provider 时 base URL 会被清空。
+当前 MAAS 相关覆盖包括：
+- provider registry 能识别 `maas`
+- model profile 保存和读取时密码进入 secret store
+- runtime config 能从 secret store 恢复 MAAS 密码
+- probe 能完成 MAAS 登录和 `/chat/completions`
+- 编辑已有 profile 时能复用已保存密码
+- probe 能兼容 `data: {...}` 包装响应
+- discovery 能完成 MAAS 登录、构造 PromptCenter 请求、在 `401/403` 后重试一次，并提取标准化模型 id 列表
+- 前端设置页在 `maas` 下展示固定 base URL、禁用编辑并允许模型发现
+- 从 `maas` 切回其他 provider 时会清空固定 base URL
 
 ## 13. 相关文件
 
@@ -150,6 +222,7 @@ data: [DONE]
 
 主要测试文件：
 - `tests/unit_tests/providers/test_model_config_manager.py`
+- `tests/unit_tests/providers/test_maas_auth.py`
 - `tests/unit_tests/providers/test_model_connectivity.py`
 - `tests/unit_tests/providers/test_provider_registry.py`
 - `tests/unit_tests/sessions/runs/test_runtime_config.py`

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -25,7 +25,6 @@ let draftMaasPasswordState = createDraftSecretState();
 let isModelMenuOpen = false;
 
 const DEFAULT_MAAS_BASE_URL = 'http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/';
-const MAAS_DISCOVERY_UNSUPPORTED_MESSAGE = 'MAAS model discovery is not supported. Enter the model name manually.';
 
 const PROVIDER_DEFAULT_BASE_URLS = {
     bigmodel: 'https://open.bigmodel.cn/api/coding/paas/v4',
@@ -558,21 +557,22 @@ function buildDraftModelDiscoveryPayload() {
     const provider = getDraftProvider();
     const baseUrl = document.getElementById('profile-base-url').value.trim();
     const apiKey = readDraftApiKeyValue();
+    const maasAuth = readDraftMaasAuth();
     const connectTimeoutSeconds = parseFloat(document.getElementById('profile-connect-timeout').value) || 15;
     const sslVerify = parseTriStateValue(document.getElementById('profile-ssl-verify').value);
 
     if (isMaaSProvider(provider)) {
-        draftDiscoveredModels = [];
-        draftModelDiscoveryState = {
-            status: 'failed',
-            message: MAAS_DISCOVERY_UNSUPPORTED_MESSAGE,
-        };
-        renderDiscoveredModels();
-        renderDraftModelDiscoveryState();
-        return null;
-    }
-
-    if (!baseUrl || (!apiKey && !editingProfile)) {
+        if (!baseUrl || !maasAuth.username || !hasDraftMaasPassword(maasAuth)) {
+            draftDiscoveredModels = [];
+            draftModelDiscoveryState = {
+                status: 'failed',
+                message: 'Base URL, username, and password are required before fetching models for a MAAS profile.',
+            };
+            renderDiscoveredModels();
+            renderDraftModelDiscoveryState();
+            return null;
+        }
+    } else if (!baseUrl || (!apiKey && !editingProfile)) {
         draftDiscoveredModels = [];
         draftModelDiscoveryState = {
             status: 'failed',
@@ -590,7 +590,14 @@ function buildDraftModelDiscoveryPayload() {
     if (sslVerify !== null) {
         override.ssl_verify = sslVerify;
     }
-    if (apiKey) {
+    if (isMaaSProvider(provider)) {
+        override.maas_auth = {
+            username: maasAuth.username,
+        };
+        if (maasAuth.password) {
+            override.maas_auth.password = maasAuth.password;
+        }
+    } else if (apiKey) {
         override.api_key = apiKey;
     }
 
@@ -655,16 +662,13 @@ function renderDraftModelDiscoveryState() {
         return;
     }
 
-    const maasProvider = isMaaSProvider(getDraftProvider());
-    const defaultTitle = maasProvider
-        ? MAAS_DISCOVERY_UNSUPPORTED_MESSAGE
-        : t('settings.model.fetch_models');
+    const defaultTitle = t('settings.model.fetch_models');
 
     if (!draftModelDiscoveryState) {
         statusEl.style.display = 'none';
         statusEl.textContent = '';
         statusEl.className = 'profile-model-discovery-status';
-        fetchBtn.disabled = maasProvider;
+        fetchBtn.disabled = false;
         fetchBtn.className = 'secure-input-btn profile-discovery-btn';
         fetchBtn.title = defaultTitle;
         if (typeof fetchBtn.setAttribute === 'function') {
@@ -678,15 +682,13 @@ function renderDraftModelDiscoveryState() {
     statusEl.style.display = 'block';
     statusEl.textContent = draftModelDiscoveryState.message;
     statusEl.className = `profile-model-discovery-status probe-status probe-status-${draftModelDiscoveryState.status}`;
-    fetchBtn.disabled = maasProvider || draftModelDiscoveryState.status === 'probing';
+    fetchBtn.disabled = draftModelDiscoveryState.status === 'probing';
     fetchBtn.className = draftModelDiscoveryState.status === 'probing'
         ? 'secure-input-btn profile-discovery-btn is-loading'
         : 'secure-input-btn profile-discovery-btn';
-    fetchBtn.title = maasProvider
-        ? defaultTitle
-        : draftModelDiscoveryState.status === 'probing'
-            ? t('settings.model.fetching_models')
-            : t('settings.model.fetch_models');
+    fetchBtn.title = draftModelDiscoveryState.status === 'probing'
+        ? t('settings.model.fetching_models')
+        : t('settings.model.fetch_models');
     if (typeof fetchBtn.setAttribute === 'function') {
         fetchBtn.setAttribute('aria-label', fetchBtn.title);
     } else {

--- a/src/relay_teams/providers/maas_auth.py
+++ b/src/relay_teams/providers/maas_auth.py
@@ -9,6 +9,7 @@ from threading import Lock
 
 import httpx
 from openai import AsyncOpenAI
+from pydantic import BaseModel, ConfigDict, Field
 
 from relay_teams.net.clients import create_async_http_client, create_sync_http_client
 from relay_teams.providers.model_config import (
@@ -23,6 +24,7 @@ __all__ = [
     "build_maas_openai_client",
     "clear_maas_token_service_cache",
     "get_maas_token_service",
+    "MaaSAuthContext",
     "MaaSLoginError",
     "is_maas_provider",
     "maas_password_secret_field_name",
@@ -31,12 +33,24 @@ __all__ = [
 
 MAAS_PASSWORD_SECRET_FIELD = "maas_password"
 _MAAS_TOKEN_TTL = timedelta(hours=24)
-_MAAS_REFRESH_SKEW = timedelta(minutes=5)
+_MAAS_REFRESH_SKEW = timedelta(hours=1)
+
+
+class MaaSAuthContext(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    token: str = Field(min_length=1)
+    department: str | None = Field(default=None, min_length=1)
 
 
 class _MaaSTokenRecord:
-    def __init__(self, *, token: str, expires_at: datetime) -> None:
-        self.token = token
+    def __init__(
+        self,
+        *,
+        auth_context: MaaSAuthContext,
+        expires_at: datetime,
+    ) -> None:
+        self.auth_context = auth_context
         self.expires_at = expires_at
 
 
@@ -65,6 +79,21 @@ class MaaSTokenService:
         connect_timeout_seconds: float,
         force_refresh: bool = False,
     ) -> str:
+        return self.get_auth_context_sync(
+            auth_config=auth_config,
+            ssl_verify=ssl_verify,
+            connect_timeout_seconds=connect_timeout_seconds,
+            force_refresh=force_refresh,
+        ).token
+
+    def get_auth_context_sync(
+        self,
+        *,
+        auth_config: MaaSAuthConfig,
+        ssl_verify: bool | None,
+        connect_timeout_seconds: float,
+        force_refresh: bool = False,
+    ) -> MaaSAuthContext:
         cache_key = self._cache_key(auth_config)
         cached = self._tokens.get(cache_key)
         if (
@@ -72,7 +101,7 @@ class MaaSTokenService:
             and cached is not None
             and not self._should_refresh(cached)
         ):
-            return cached.token
+            return cached.auth_context
         lock = self._sync_locks.setdefault(cache_key, Lock())
         with lock:
             cached = self._tokens.get(cache_key)
@@ -81,14 +110,14 @@ class MaaSTokenService:
                 and cached is not None
                 and not self._should_refresh(cached)
             ):
-                return cached.token
+                return cached.auth_context
             record = self._login_sync(
                 auth_config=auth_config,
                 ssl_verify=ssl_verify,
                 connect_timeout_seconds=connect_timeout_seconds,
             )
             self._tokens[cache_key] = record
-            return record.token
+            return record.auth_context
 
     async def get_token(
         self,
@@ -98,6 +127,23 @@ class MaaSTokenService:
         connect_timeout_seconds: float,
         force_refresh: bool = False,
     ) -> str:
+        return (
+            await self.get_auth_context(
+                auth_config=auth_config,
+                ssl_verify=ssl_verify,
+                connect_timeout_seconds=connect_timeout_seconds,
+                force_refresh=force_refresh,
+            )
+        ).token
+
+    async def get_auth_context(
+        self,
+        *,
+        auth_config: MaaSAuthConfig,
+        ssl_verify: bool | None,
+        connect_timeout_seconds: float,
+        force_refresh: bool = False,
+    ) -> MaaSAuthContext:
         cache_key = self._cache_key(auth_config)
         cached = self._tokens.get(cache_key)
         if (
@@ -105,7 +151,7 @@ class MaaSTokenService:
             and cached is not None
             and not self._should_refresh(cached)
         ):
-            return cached.token
+            return cached.auth_context
         lock = self._async_locks.setdefault(cache_key, asyncio.Lock())
         async with lock:
             cached = self._tokens.get(cache_key)
@@ -114,14 +160,14 @@ class MaaSTokenService:
                 and cached is not None
                 and not self._should_refresh(cached)
             ):
-                return cached.token
+                return cached.auth_context
             record = await self._login_async(
                 auth_config=auth_config,
                 ssl_verify=ssl_verify,
                 connect_timeout_seconds=connect_timeout_seconds,
             )
             self._tokens[cache_key] = record
-            return record.token
+            return record.auth_context
 
     def _cache_key(self, auth_config: MaaSAuthConfig) -> str:
         password = auth_config.password or ""
@@ -347,7 +393,13 @@ def _build_token_record(response: httpx.Response) -> _MaaSTokenRecord:
             "MAAS login response did not include cloudDragonTokens.authToken.",
             status_code=response.status_code,
         )
-    return _MaaSTokenRecord(token=token, expires_at=datetime.now(UTC) + _MAAS_TOKEN_TTL)
+    return _MaaSTokenRecord(
+        auth_context=MaaSAuthContext(
+            token=token,
+            department=_extract_department(payload),
+        ),
+        expires_at=datetime.now(UTC) + _MAAS_TOKEN_TTL,
+    )
 
 
 def _extract_token(payload: object) -> str | None:
@@ -377,6 +429,30 @@ def _extract_error_message(payload: object) -> str | None:
         if isinstance(error, str) and error.strip():
             return error.strip()
     return None
+
+
+def _extract_department(payload: object) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    user_info = payload.get("userInfo")
+    if not isinstance(user_info, dict):
+        return None
+    direct_department = user_info.get("hwDepartName")
+    if isinstance(direct_department, str):
+        normalized = direct_department.strip()
+        if normalized:
+            return normalized
+    segments: list[str] = []
+    for index in range(1, 7):
+        segment = user_info.get(f"hwDepartName{index}")
+        if not isinstance(segment, str):
+            continue
+        normalized = segment.strip()
+        if normalized:
+            segments.append(normalized)
+    if len(segments) == 0:
+        return None
+    return "/".join(segments)
 
 
 def _response_json(response: httpx.Response) -> object:

--- a/src/relay_teams/providers/model_config.py
+++ b/src/relay_teams/providers/model_config.py
@@ -27,6 +27,15 @@ DEFAULT_MAAS_LOGIN_URL = (
 DEFAULT_MAAS_BASE_URL = (
     "http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/"
 )
+DEFAULT_MAAS_DISCOVERY_URL = (
+    "https://promptcenter.aims.cce.prod.dragon.tools.huawei.com/"
+    "PromptCenterService/v1/policy/bundle"
+)
+DEFAULT_MAAS_DISCOVERY_AREA = "green"
+DEFAULT_MAAS_DISCOVERY_PLUGIN_VERSION = "1.0.4"
+DEFAULT_MAAS_DISCOVERY_APPLICATION = "RelayAgent"
+DEFAULT_MAAS_DISCOVERY_IDE = "RelayAgent"
+DEFAULT_MAAS_DISCOVERY_PLUGIN_NAME = "maas_relay"
 DEFAULT_MAAS_APP_ID = "RelayTeams"
 
 

--- a/src/relay_teams/providers/model_connectivity.py
+++ b/src/relay_teams/providers/model_connectivity.py
@@ -10,14 +10,25 @@ from typing import cast
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
+from relay_teams.logger import get_logger
 from relay_teams.net.clients import create_sync_http_client
-from relay_teams.providers.maas_auth import MaaSLoginError, get_maas_token_service
+from relay_teams.providers.maas_auth import (
+    MaaSAuthContext,
+    MaaSLoginError,
+    get_maas_token_service,
+)
 from relay_teams.providers.known_model_context_windows import (
     infer_known_context_window,
 )
 from relay_teams.providers.model_config import (
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
     DEFAULT_MAAS_APP_ID,
+    DEFAULT_MAAS_DISCOVERY_APPLICATION,
+    DEFAULT_MAAS_DISCOVERY_AREA,
+    DEFAULT_MAAS_DISCOVERY_IDE,
+    DEFAULT_MAAS_DISCOVERY_PLUGIN_NAME,
+    DEFAULT_MAAS_DISCOVERY_PLUGIN_VERSION,
+    DEFAULT_MAAS_DISCOVERY_URL,
     MaaSAuthConfig,
     ModelEndpointConfig,
     ModelRequestHeader,
@@ -30,6 +41,8 @@ from relay_teams.sessions.runs.runtime_config import RuntimeConfig
 
 _INVALID_RESPONSE_PAYLOAD = object()
 _MAX_PROBE_TIMEOUT_MS = 300_000
+
+LOGGER = get_logger(__name__)
 
 
 def _uses_openai_compatible_transport(provider: ProviderType) -> bool:
@@ -191,20 +204,9 @@ class ModelConnectivityProbeService:
                 models=("echo",),
             )
         if resolved_config.provider == ProviderType.MAAS:
-            return ModelDiscoveryResult(
-                ok=False,
-                provider=resolved_config.provider,
-                base_url=resolved_config.base_url,
-                latency_ms=0,
-                checked_at=datetime.now(timezone.utc),
-                diagnostics=ModelConnectivityDiagnostics(
-                    endpoint_reachable=True,
-                    auth_valid=True,
-                    rate_limited=False,
-                ),
-                error_code="unsupported_provider",
-                error_message="MAAS model discovery is not supported. Enter the model name manually.",
-                retryable=False,
+            return self._discover_maas_models(
+                config=resolved_config,
+                timeout_ms=timeout_ms,
             )
         if _uses_openai_compatible_transport(resolved_config.provider):
             return self._discover_openai_compatible_models(
@@ -635,6 +637,85 @@ class ModelConnectivityProbeService:
             started=started,
         )
 
+    def _discover_maas_models(
+        self,
+        *,
+        config: ModelDiscoveryResolvedConfig,
+        timeout_ms: int,
+    ) -> ModelDiscoveryResult:
+        if config.maas_auth is None:
+            raise ValueError("MAAS model discovery requires maas_auth configuration.")
+        started = perf_counter()
+        checked_at = datetime.now(timezone.utc)
+        auth_context_or_result = self._get_maas_model_discovery_auth_context(
+            config=config,
+            checked_at=checked_at,
+            started=started,
+            timeout_ms=timeout_ms,
+        )
+        if isinstance(auth_context_or_result, ModelDiscoveryResult):
+            return auth_context_or_result
+        auth_context = auth_context_or_result
+
+        department = auth_context.department
+        assert department is not None
+        headers = {
+            "Content-Type": "application/json",
+            "X-Auth-Token": auth_context.token,
+        }
+        payload = self._build_maas_model_discovery_payload(department=department)
+        response = self._post_model_discovery_request(
+            config=config,
+            endpoint=DEFAULT_MAAS_DISCOVERY_URL,
+            headers=headers,
+            payload=payload,
+            checked_at=checked_at,
+            started=started,
+            timeout_ms=timeout_ms,
+        )
+        if isinstance(response, ModelDiscoveryResult):
+            return response
+
+        if response.status_code in {401, 403}:
+            refreshed_auth_context_or_result = (
+                self._get_maas_model_discovery_auth_context(
+                    config=config,
+                    checked_at=checked_at,
+                    started=started,
+                    timeout_ms=timeout_ms,
+                    force_refresh=True,
+                )
+            )
+            if isinstance(refreshed_auth_context_or_result, ModelDiscoveryResult):
+                return refreshed_auth_context_or_result
+            refreshed_auth_context = refreshed_auth_context_or_result
+
+            refreshed_department = refreshed_auth_context.department
+            assert refreshed_department is not None
+            retry_headers = dict(headers)
+            retry_headers["X-Auth-Token"] = refreshed_auth_context.token
+            retry_payload = self._build_maas_model_discovery_payload(
+                department=refreshed_department
+            )
+            response = self._post_model_discovery_request(
+                config=config,
+                endpoint=DEFAULT_MAAS_DISCOVERY_URL,
+                headers=retry_headers,
+                payload=retry_payload,
+                checked_at=checked_at,
+                started=started,
+                timeout_ms=timeout_ms,
+            )
+            if isinstance(response, ModelDiscoveryResult):
+                return response
+
+        return self._build_model_discovery_result_from_response(
+            config=config,
+            response=response,
+            checked_at=checked_at,
+            started=started,
+        )
+
     def _discover_openai_compatible_models(
         self,
         *,
@@ -682,6 +763,233 @@ class ModelConnectivityProbeService:
                 error_message=str(exc) or "Failed to reach model endpoint.",
             )
 
+        latency_ms = self._latency_ms(started)
+        response_payload = self._response_payload(response)
+        if response.status_code >= 400:
+            error_message = (
+                self._extract_error_message(response_payload) or response.text
+            )
+            return self._build_model_discovery_http_error_result(
+                config=config,
+                checked_at=checked_at,
+                latency_ms=latency_ms,
+                status_code=response.status_code,
+                error_message=error_message or "Model discovery failed.",
+            )
+
+        if response_payload is _INVALID_RESPONSE_PAYLOAD:
+            return ModelDiscoveryResult(
+                ok=False,
+                provider=config.provider,
+                base_url=config.base_url,
+                latency_ms=latency_ms,
+                checked_at=checked_at,
+                diagnostics=ModelConnectivityDiagnostics(
+                    endpoint_reachable=True,
+                    auth_valid=True,
+                    rate_limited=False,
+                ),
+                error_code="invalid_response",
+                error_message="Provider returned invalid JSON.",
+                retryable=False,
+            )
+
+        if not isinstance(response_payload, dict):
+            return ModelDiscoveryResult(
+                ok=False,
+                provider=config.provider,
+                base_url=config.base_url,
+                latency_ms=latency_ms,
+                checked_at=checked_at,
+                diagnostics=ModelConnectivityDiagnostics(
+                    endpoint_reachable=True,
+                    auth_valid=True,
+                    rate_limited=False,
+                ),
+                error_code="invalid_response",
+                error_message="Provider returned a non-object JSON payload.",
+                retryable=False,
+            )
+
+        model_entries = self._extract_model_entries(
+            payload=response_payload,
+            provider=config.provider,
+        )
+        if model_entries is None:
+            return ModelDiscoveryResult(
+                ok=False,
+                provider=config.provider,
+                base_url=config.base_url,
+                latency_ms=latency_ms,
+                checked_at=checked_at,
+                diagnostics=ModelConnectivityDiagnostics(
+                    endpoint_reachable=True,
+                    auth_valid=True,
+                    rate_limited=False,
+                ),
+                error_code="invalid_response",
+                error_message="Provider returned an invalid model catalog payload.",
+                retryable=False,
+            )
+
+        return ModelDiscoveryResult(
+            ok=True,
+            provider=config.provider,
+            base_url=config.base_url,
+            latency_ms=latency_ms,
+            checked_at=checked_at,
+            diagnostics=ModelConnectivityDiagnostics(
+                endpoint_reachable=True,
+                auth_valid=True,
+                rate_limited=False,
+            ),
+            models=tuple(entry.model for entry in model_entries),
+            model_entries=model_entries,
+        )
+
+    def _get_maas_model_discovery_auth_context(
+        self,
+        *,
+        config: ModelDiscoveryResolvedConfig,
+        checked_at: datetime,
+        started: float,
+        timeout_ms: int,
+        force_refresh: bool = False,
+    ) -> MaaSAuthContext | ModelDiscoveryResult:
+        auth_config = cast(MaaSAuthConfig, config.maas_auth)
+        try:
+            auth_context = get_maas_token_service().get_auth_context_sync(
+                auth_config=auth_config,
+                ssl_verify=config.ssl_verify,
+                connect_timeout_seconds=timeout_ms / 1000,
+                force_refresh=force_refresh,
+            )
+        except httpx.TimeoutException as exc:
+            return self._build_model_discovery_transport_error_result(
+                config=config,
+                checked_at=checked_at,
+                started=started,
+                error_code="network_timeout",
+                error_message=str(exc) or "Connection timed out.",
+            )
+        except httpx.RequestError as exc:
+            return self._build_model_discovery_transport_error_result(
+                config=config,
+                checked_at=checked_at,
+                started=started,
+                error_code="network_error",
+                error_message=str(exc) or "Failed to reach model endpoint.",
+            )
+        except MaaSLoginError as exc:
+            return self._build_model_discovery_maas_login_error_result(
+                config=config,
+                checked_at=checked_at,
+                started=started,
+                error=exc,
+            )
+
+        if auth_context.department is not None:
+            return auth_context
+        if not force_refresh:
+            return self._get_maas_model_discovery_auth_context(
+                config=config,
+                checked_at=checked_at,
+                started=started,
+                timeout_ms=timeout_ms,
+                force_refresh=True,
+            )
+        return self._build_model_discovery_missing_maas_department_result(
+            config=config,
+            checked_at=checked_at,
+            started=started,
+        )
+
+    def _build_model_discovery_missing_maas_department_result(
+        self,
+        *,
+        config: ModelDiscoveryResolvedConfig,
+        checked_at: datetime,
+        started: float,
+    ) -> ModelDiscoveryResult:
+        return ModelDiscoveryResult(
+            ok=False,
+            provider=config.provider,
+            base_url=config.base_url,
+            latency_ms=self._latency_ms(started),
+            checked_at=checked_at,
+            diagnostics=ModelConnectivityDiagnostics(
+                endpoint_reachable=True,
+                auth_valid=True,
+                rate_limited=False,
+            ),
+            error_code="invalid_response",
+            error_message=(
+                "MAAS login response did not include user department information."
+            ),
+            retryable=False,
+        )
+
+    def _build_maas_model_discovery_payload(
+        self,
+        *,
+        department: str,
+    ) -> dict[str, object]:
+        return {
+            "area": DEFAULT_MAAS_DISCOVERY_AREA,
+            "plugin_version": DEFAULT_MAAS_DISCOVERY_PLUGIN_VERSION,
+            "application": DEFAULT_MAAS_DISCOVERY_APPLICATION,
+            "ide": DEFAULT_MAAS_DISCOVERY_IDE,
+            "plugin_name": DEFAULT_MAAS_DISCOVERY_PLUGIN_NAME,
+            "department": department,
+        }
+
+    def _post_model_discovery_request(
+        self,
+        *,
+        config: ModelDiscoveryResolvedConfig,
+        endpoint: str,
+        headers: dict[str, str],
+        payload: dict[str, object],
+        checked_at: datetime,
+        started: float,
+        timeout_ms: int,
+    ) -> httpx.Response | ModelDiscoveryResult:
+        try:
+            with create_sync_http_client(
+                timeout_seconds=timeout_ms / 1000,
+                connect_timeout_seconds=timeout_ms / 1000,
+                ssl_verify=config.ssl_verify,
+            ) as client:
+                return client.post(
+                    endpoint,
+                    headers=headers,
+                    json=payload,
+                )
+        except httpx.TimeoutException as exc:
+            return self._build_model_discovery_transport_error_result(
+                config=config,
+                checked_at=checked_at,
+                started=started,
+                error_code="network_timeout",
+                error_message=str(exc) or "Connection timed out.",
+            )
+        except httpx.RequestError as exc:
+            return self._build_model_discovery_transport_error_result(
+                config=config,
+                checked_at=checked_at,
+                started=started,
+                error_code="network_error",
+                error_message=str(exc) or "Failed to reach model endpoint.",
+            )
+
+    def _build_model_discovery_result_from_response(
+        self,
+        *,
+        config: ModelDiscoveryResolvedConfig,
+        response: httpx.Response,
+        checked_at: datetime,
+        started: float,
+    ) -> ModelDiscoveryResult:
         latency_ms = self._latency_ms(started)
         response_payload = self._response_payload(response)
         if response.status_code >= 400:
@@ -841,6 +1149,54 @@ class ModelConnectivityProbeService:
             ok=False,
             provider=config.provider,
             model=config.model,
+            latency_ms=self._latency_ms(started),
+            checked_at=checked_at,
+            diagnostics=ModelConnectivityDiagnostics(
+                endpoint_reachable=True,
+                auth_valid=auth_valid,
+                rate_limited=rate_limited,
+            ),
+            error_code=error_code,
+            error_message=error_message,
+            retryable=retryable,
+        )
+
+    def _build_model_discovery_maas_login_error_result(
+        self,
+        *,
+        config: ModelDiscoveryResolvedConfig,
+        checked_at: datetime,
+        started: float,
+        error: MaaSLoginError,
+    ) -> ModelDiscoveryResult:
+        status_code = error.status_code
+        error_message = str(error) or "MAAS login failed."
+        if status_code is None or status_code < 400:
+            return ModelDiscoveryResult(
+                ok=False,
+                provider=config.provider,
+                base_url=config.base_url,
+                latency_ms=self._latency_ms(started),
+                checked_at=checked_at,
+                diagnostics=ModelConnectivityDiagnostics(
+                    endpoint_reachable=True,
+                    auth_valid=True,
+                    rate_limited=False,
+                ),
+                error_code="invalid_response",
+                error_message=error_message,
+                retryable=False,
+            )
+        auth_valid = status_code not in {400, 401, 403}
+        rate_limited = status_code == 429
+        retryable = rate_limited or status_code >= 500
+        error_code = (
+            "auth_invalid" if not auth_valid else self._http_error_code(status_code)
+        )
+        return ModelDiscoveryResult(
+            ok=False,
+            provider=config.provider,
+            base_url=config.base_url,
             latency_ms=self._latency_ms(started),
             checked_at=checked_at,
             diagnostics=ModelConnectivityDiagnostics(
@@ -1069,6 +1425,8 @@ class ModelConnectivityProbeService:
         payload: dict[str, object],
         provider: ProviderType,
     ) -> tuple[ModelDiscoveryEntry, ...] | None:
+        if provider == ProviderType.MAAS:
+            return self._extract_maas_model_entries(payload)
         data = payload.get("data")
         if not isinstance(data, list):
             return None
@@ -1098,6 +1456,112 @@ class ModelConnectivityProbeService:
             )
         model_entries.sort(key=lambda item: item.model)
         return tuple(model_entries)
+
+    def _extract_maas_model_entries(
+        self,
+        payload: dict[str, object],
+    ) -> tuple[ModelDiscoveryEntry, ...] | None:
+        has_supported_section = False
+        model_ids: set[str] = set()
+
+        user_model_list = payload.get("user_model_list")
+        if isinstance(user_model_list, list):
+            has_supported_section = True
+            self._collect_maas_model_ids(
+                models=user_model_list,
+                target=model_ids,
+            )
+
+        plugin_config = payload.get("plugin_config")
+        if isinstance(plugin_config, list):
+            has_supported_section = True
+            for plugin_index, plugin_entry in enumerate(plugin_config):
+                if not isinstance(plugin_entry, dict):
+                    continue
+                config_payload = plugin_entry.get("config")
+                if not isinstance(config_payload, str):
+                    continue
+                parsed_config = self._parse_maas_plugin_config(
+                    raw_config=config_payload,
+                    plugin_index=plugin_index,
+                )
+                if parsed_config is None:
+                    continue
+                for config_item in parsed_config:
+                    if not isinstance(config_item, dict):
+                        continue
+                    for field_name in (
+                        "composor_act_mode_model_list",
+                        "composor_plan_mode_model_list",
+                        "user_model_list",
+                    ):
+                        nested_models = config_item.get(field_name)
+                        if not isinstance(nested_models, list):
+                            continue
+                        self._collect_maas_model_ids(
+                            models=nested_models,
+                            target=model_ids,
+                        )
+
+        if not has_supported_section:
+            return None
+
+        return tuple(
+            ModelDiscoveryEntry(model=model_id) for model_id in sorted(model_ids)
+        )
+
+    def _parse_maas_plugin_config(
+        self,
+        *,
+        raw_config: str,
+        plugin_index: int,
+    ) -> list[object] | None:
+        try:
+            parsed = cast(object, json.loads(raw_config))
+        except ValueError:
+            LOGGER.warning(
+                "Ignoring invalid MAAS discovery plugin config JSON.",
+                extra={
+                    "event": "providers.maas.discovery.invalid_plugin_config",
+                    "plugin_index": plugin_index,
+                },
+            )
+            return None
+        if not isinstance(parsed, list):
+            LOGGER.warning(
+                "Ignoring MAAS discovery plugin config with non-list payload.",
+                extra={
+                    "event": "providers.maas.discovery.invalid_plugin_config_shape",
+                    "plugin_index": plugin_index,
+                },
+            )
+            return None
+        return parsed
+
+    def _collect_maas_model_ids(
+        self,
+        *,
+        models: list[object],
+        target: set[str],
+    ) -> None:
+        for model_entry in models:
+            if not isinstance(model_entry, dict):
+                continue
+            model_id = model_entry.get("model_id")
+            if not isinstance(model_id, str):
+                continue
+            normalized = model_id.strip()
+            if self._is_valid_maas_model_id(normalized):
+                target.add(normalized)
+
+    def _is_valid_maas_model_id(self, model_id: str) -> bool:
+        if not model_id:
+            return False
+        if model_id.isdigit():
+            return False
+        if ":" in model_id:
+            return False
+        return True
 
     def _extract_context_window(self, entry: dict[str, object]) -> int | None:
         direct_keys = (

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -1113,7 +1113,7 @@ console.log(JSON.stringify({
     assert payload["maasFieldDisplay"] == "grid"
 
 
-def test_selecting_maas_disables_model_discovery(tmp_path: Path) -> None:
+def test_selecting_maas_keeps_model_discovery_enabled(tmp_path: Path) -> None:
     payload = _run_model_profiles_script(
         tmp_path=tmp_path,
         runner_source="""
@@ -1136,11 +1136,125 @@ console.log(JSON.stringify({
 """.strip(),
     )
 
-    assert payload["fetchDisabled"] is True
-    assert (
-        payload["fetchTitle"]
-        == "MAAS model discovery is not supported. Enter the model name manually."
+    assert payload["fetchDisabled"] is False
+    assert payload["fetchTitle"] == "Fetch Models"
+
+
+def test_discover_models_for_new_maas_profile_sends_maas_auth(tmp_path: Path) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+document.getElementById("add-profile-btn").onclick();
+document.getElementById("profile-provider").value = "maas";
+document.getElementById("profile-provider").onchange();
+document.getElementById("profile-maas-username").value = "relay-user";
+document.getElementById("profile-maas-password").value = "relay-password";
+document.getElementById("profile-maas-password").oninput();
+
+await document.getElementById("fetch-profile-models-btn").onclick();
+
+console.log(JSON.stringify({
+    discoverPayload: globalThis.__discoverPayload,
+    discoveryStatusText: document.getElementById("profile-model-discovery-status").textContent,
+}));
+""".strip(),
     )
+
+    discover_payload = cast(dict[str, JsonValue], payload["discoverPayload"])
+    discover_override = cast(dict[str, JsonValue], discover_payload["override"])
+    maas_auth = cast(dict[str, JsonValue], discover_override["maas_auth"])
+    assert discover_override["provider"] == "maas"
+    assert discover_override["base_url"] == (
+        "http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/"
+    )
+    assert maas_auth == {
+        "username": "relay-user",
+        "password": "relay-password",
+    }
+    assert payload["discoveryStatusText"] == "Fetched 2 models in 37ms."
+
+
+def test_discover_models_for_existing_maas_profile_reuses_saved_password(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+await loadModelProfilesPanel();
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "maas-profile").onclick();
+await document.getElementById("fetch-profile-models-btn").onclick();
+
+console.log(JSON.stringify({
+    discoverPayload: globalThis.__discoverPayload,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "maas-profile": {
+            provider: "maas",
+            model: "maas-chat",
+            base_url: "http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/",
+            maas_auth: {
+                username: "saved-user",
+                password: "saved-password",
+                has_password: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function probeModelConnection(payload) {
+    globalThis.__probePayload = payload;
+    return { ok: true, latency_ms: 42, token_usage: { total_tokens: 9 } };
+}
+
+export async function discoverModelCatalog(payload) {
+    globalThis.__discoverPayload = payload;
+    return { ok: true, latency_ms: 37, models: ["maas-chat"] };
+}
+
+export async function saveModelProfile(name, profile) {
+    globalThis.__savedProfile = { name, profile };
+}
+
+export async function reloadModelConfig() {
+    globalThis.__reloadCalled = true;
+}
+
+export async function deleteModelProfile(name) {
+    globalThis.__deletedProfileName = name;
+}
+""".strip(),
+    )
+
+    discover_payload = cast(dict[str, JsonValue], payload["discoverPayload"])
+    discover_override = cast(dict[str, JsonValue], discover_payload["override"])
+    maas_auth = cast(dict[str, JsonValue], discover_override["maas_auth"])
+    assert discover_payload["profile_name"] == "maas-profile"
+    assert maas_auth == {
+        "username": "saved-user",
+    }
 
 
 def _run_model_profiles_script(

--- a/tests/unit_tests/providers/test_maas_auth.py
+++ b/tests/unit_tests/providers/test_maas_auth.py
@@ -2,11 +2,40 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 
 import httpx
 
-from relay_teams.providers.maas_auth import build_maas_openai_client
+from relay_teams.providers.maas_auth import (
+    MaaSTokenService,
+    build_maas_openai_client,
+)
 from relay_teams.providers.model_config import MaaSAuthConfig
+
+
+class _FakeSyncHttpClient:
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+        self.calls = 0
+
+    def __enter__(self) -> _FakeSyncHttpClient:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, str],
+    ) -> httpx.Response:
+        _ = url
+        _ = headers
+        _ = json
+        self.calls += 1
+        return self._response
 
 
 def test_build_maas_openai_client_disables_sdk_retries() -> None:
@@ -26,3 +55,165 @@ def test_build_maas_openai_client_disables_sdk_retries() -> None:
         assert client.max_retries == 0
     finally:
         asyncio.run(http_client.aclose())
+
+
+def test_get_auth_context_sync_extracts_department_from_direct_field(
+    monkeypatch,
+) -> None:
+    client = _FakeSyncHttpClient(
+        httpx.Response(
+            200,
+            json={
+                "cloudDragonTokens": {"authToken": "maas-token"},
+                "userInfo": {"hwDepartName": "Direct Department"},
+            },
+        )
+    )
+    service = MaaSTokenService()
+
+    monkeypatch.setattr(
+        "relay_teams.providers.maas_auth.create_sync_http_client",
+        lambda **_kwargs: client,
+    )
+
+    auth_context = service.get_auth_context_sync(
+        auth_config=MaaSAuthConfig(
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=None,
+        connect_timeout_seconds=15,
+    )
+
+    assert auth_context.token == "maas-token"
+    assert auth_context.department == "Direct Department"
+    assert client.calls == 1
+
+
+def test_get_auth_context_sync_falls_back_to_department_segments(monkeypatch) -> None:
+    client = _FakeSyncHttpClient(
+        httpx.Response(
+            200,
+            json={
+                "cloudDragonTokens": {"authToken": "maas-token"},
+                "userInfo": {
+                    "hwDepartName1": "Level1",
+                    "hwDepartName2": "Level2",
+                    "hwDepartName4": "Level4",
+                },
+            },
+        )
+    )
+    service = MaaSTokenService()
+
+    monkeypatch.setattr(
+        "relay_teams.providers.maas_auth.create_sync_http_client",
+        lambda **_kwargs: client,
+    )
+
+    auth_context = service.get_auth_context_sync(
+        auth_config=MaaSAuthConfig(
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=None,
+        connect_timeout_seconds=15,
+    )
+
+    assert auth_context.department == "Level1/Level2/Level4"
+    assert client.calls == 1
+
+
+def test_get_auth_context_sync_refreshes_one_hour_before_expiry(monkeypatch) -> None:
+    client = _FakeSyncHttpClient(
+        httpx.Response(
+            200,
+            json={
+                "cloudDragonTokens": {"authToken": "maas-token"},
+                "userInfo": {"hwDepartName": "Direct Department"},
+            },
+        )
+    )
+    service = MaaSTokenService()
+
+    monkeypatch.setattr(
+        "relay_teams.providers.maas_auth.create_sync_http_client",
+        lambda **_kwargs: client,
+    )
+
+    cache_key = service._cache_key(
+        MaaSAuthConfig(
+            username="relay-user",
+            password="relay-password",
+        )
+    )
+    service._tokens[cache_key] = service._login_sync(
+        auth_config=MaaSAuthConfig(
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=None,
+        connect_timeout_seconds=15,
+    )
+    assert client.calls == 1
+
+    service._tokens[cache_key].expires_at = datetime.now(UTC) + timedelta(minutes=59)
+    service.get_auth_context_sync(
+        auth_config=MaaSAuthConfig(
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=None,
+        connect_timeout_seconds=15,
+    )
+    assert client.calls == 2
+
+    service._tokens[cache_key].expires_at = datetime.now(UTC) + timedelta(minutes=61)
+    service.get_auth_context_sync(
+        auth_config=MaaSAuthConfig(
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=None,
+        connect_timeout_seconds=15,
+    )
+    assert client.calls == 2
+
+
+def test_get_auth_context_sync_reuses_cached_department(monkeypatch) -> None:
+    client = _FakeSyncHttpClient(
+        httpx.Response(
+            200,
+            json={
+                "cloudDragonTokens": {"authToken": "maas-token"},
+                "userInfo": {"hwDepartName": "Direct Department"},
+            },
+        )
+    )
+    service = MaaSTokenService()
+
+    monkeypatch.setattr(
+        "relay_teams.providers.maas_auth.create_sync_http_client",
+        lambda **_kwargs: client,
+    )
+
+    first = service.get_auth_context_sync(
+        auth_config=MaaSAuthConfig(
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=None,
+        connect_timeout_seconds=15,
+    )
+    second = service.get_auth_context_sync(
+        auth_config=MaaSAuthConfig(
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=None,
+        connect_timeout_seconds=15,
+    )
+
+    assert first == second
+    assert second.department == "Direct Department"
+    assert client.calls == 1

--- a/tests/unit_tests/providers/test_model_connectivity.py
+++ b/tests/unit_tests/providers/test_model_connectivity.py
@@ -7,7 +7,7 @@ from typing import cast
 import httpx
 import pytest
 
-from relay_teams.providers.maas_auth import MaaSLoginError
+from relay_teams.providers.maas_auth import MaaSAuthContext, MaaSLoginError
 from relay_teams.providers.model_config import (
     MaaSAuthConfig,
     ModelEndpointConfig,
@@ -72,9 +72,16 @@ class _FakeHttpClient:
 
 
 class _FakeMaaSTokenService:
-    def __init__(self, tokens: list[str], captured: dict[str, object]) -> None:
+    def __init__(
+        self,
+        tokens: list[str],
+        captured: dict[str, object],
+        *,
+        departments: list[str | None] | None = None,
+    ) -> None:
         self._tokens = tokens
         self._captured = captured
+        self._departments = departments or ["Relay/Department"] * len(tokens)
 
     def get_token_sync(
         self,
@@ -84,6 +91,21 @@ class _FakeMaaSTokenService:
         connect_timeout_seconds: float,
         force_refresh: bool = False,
     ) -> str:
+        return self.get_auth_context_sync(
+            auth_config=auth_config,
+            ssl_verify=ssl_verify,
+            connect_timeout_seconds=connect_timeout_seconds,
+            force_refresh=force_refresh,
+        ).token
+
+    def get_auth_context_sync(
+        self,
+        *,
+        auth_config: MaaSAuthConfig,
+        ssl_verify: bool | None,
+        connect_timeout_seconds: float,
+        force_refresh: bool = False,
+    ) -> MaaSAuthContext:
         calls = self._captured.setdefault("maas_token_calls", [])
         assert isinstance(calls, list)
         calls.append(
@@ -95,7 +117,9 @@ class _FakeMaaSTokenService:
                 "force_refresh": force_refresh,
             }
         )
-        return self._tokens.pop(0)
+        token = self._tokens.pop(0)
+        department = self._departments.pop(0)
+        return MaaSAuthContext(token=token, department=department)
 
 
 def test_probe_uses_saved_profile_and_returns_usage(monkeypatch) -> None:
@@ -580,8 +604,248 @@ def test_probe_refreshes_maas_token_after_unauthorized_response(monkeypatch) -> 
     assert token_calls[1]["force_refresh"] is True
 
 
-def test_discover_models_returns_unsupported_for_maas() -> None:
+def test_discover_models_supports_maas_provider(monkeypatch) -> None:
+    captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_maas_token_service",
+        lambda: _FakeMaaSTokenService(["maas-token"], captured),
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or _FakeHttpClient(
+                captured=captured,
+                response=httpx.Response(
+                    200,
+                    json={
+                        "user_model_list": [
+                            {"model_id": "gpt-4"},
+                            {"model_id": "123"},
+                        ],
+                        "plugin_config": [
+                            {
+                                "config": (
+                                    '[{"composor_act_mode_model_list":[{"model_id":"gpt-4.5"}],'
+                                    '"composor_plan_mode_model_list":[{"model_id":"model:ignored"}],'
+                                    '"user_model_list":[{"model_id":"gpt-4.1"},{"model_id":"gpt-4"}]}]'
+                                )
+                            },
+                            {"config": "{not-valid-json}"},
+                        ],
+                    },
+                ),
+            )
+        ),
+    )
+
+    result = service.discover_models(
+        ModelDiscoveryRequest(
+            override=ModelConnectivityProbeOverride(
+                provider=ProviderType.MAAS,
+                base_url="https://maas.example/api/v2",
+                maas_auth=MaaSAuthConfig(
+                    username="relay-user",
+                    password="relay-password",
+                ),
+            ),
+            timeout_ms=2800,
+        )
+    )
+
+    assert result.ok is True
+    assert result.provider == ProviderType.MAAS
+    assert result.models == ("gpt-4", "gpt-4.1", "gpt-4.5")
+    assert (
+        captured["url"]
+        == "https://promptcenter.aims.cce.prod.dragon.tools.huawei.com/PromptCenterService/v1/policy/bundle"
+    )
+    headers = cast(dict[str, str], captured["headers"])
+    assert headers["X-Auth-Token"] == "maas-token"
+    request_payload = cast(dict[str, str], captured["json"])
+    assert request_payload == {
+        "area": "green",
+        "plugin_version": "1.0.4",
+        "application": "RelayAgent",
+        "ide": "RelayAgent",
+        "plugin_name": "maas_relay",
+        "department": "Relay/Department",
+    }
+    assert tuple(entry.model for entry in result.model_entries) == (
+        "gpt-4",
+        "gpt-4.1",
+        "gpt-4.5",
+    )
+
+
+def test_discover_models_merges_saved_maas_password_when_override_omits_it(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            profile_name="maas-profile",
+            provider=ProviderType.MAAS,
+            model="maas-chat",
+            base_url="https://maas.example/api/v2",
+            api_key=None,
+            maas_auth=MaaSAuthConfig(
+                username="saved-user",
+                password="saved-password",
+            ),
+        )
+    )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_maas_token_service",
+        lambda: _FakeMaaSTokenService(["maas-token"], captured),
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or _FakeHttpClient(
+                captured=captured,
+                response=httpx.Response(
+                    200,
+                    json={"user_model_list": [{"model_id": "maas-chat"}]},
+                ),
+            )
+        ),
+    )
+
+    result = service.discover_models(
+        ModelDiscoveryRequest(
+            profile_name="maas-profile",
+            override=ModelConnectivityProbeOverride(
+                maas_auth=MaaSAuthConfig(username="edited-user"),
+            ),
+        )
+    )
+
+    assert result.ok is True
+    token_calls = cast(list[dict[str, object]], captured["maas_token_calls"])
+    assert token_calls[0]["username"] == "edited-user"
+    assert token_calls[0]["password"] == "saved-password"
+
+
+def test_discover_models_refreshes_maas_token_after_unauthorized_response(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {"requests": []}
+    responses = [
+        httpx.Response(401, json={"error": {"message": "expired"}}),
+        httpx.Response(200, json={"user_model_list": [{"model_id": "maas-chat"}]}),
+    ]
+    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+
+    token_service = _FakeMaaSTokenService(["expired-token", "fresh-token"], captured)
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_maas_token_service",
+        lambda: token_service,
+    )
+
+    def build_client(**_kwargs: object) -> _FakeHttpClient:
+        requests = cast(list[dict[str, object]], captured["requests"])
+        local_capture: dict[str, object] = {}
+        requests.append(local_capture)
+        return _FakeHttpClient(captured=local_capture, response=responses.pop(0))
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        build_client,
+    )
+
+    result = service.discover_models(
+        ModelDiscoveryRequest(
+            override=ModelConnectivityProbeOverride(
+                provider=ProviderType.MAAS,
+                base_url="https://maas.example/api/v2",
+                maas_auth=MaaSAuthConfig(
+                    username="relay-user",
+                    password="relay-password",
+                ),
+            )
+        )
+    )
+
+    assert result.ok is True
+    requests = cast(list[dict[str, object]], captured["requests"])
+    first_headers = cast(dict[str, str], requests[0]["headers"])
+    second_headers = cast(dict[str, str], requests[1]["headers"])
+    assert first_headers["X-Auth-Token"] == "expired-token"
+    assert second_headers["X-Auth-Token"] == "fresh-token"
+    token_calls = cast(list[dict[str, object]], captured["maas_token_calls"])
+    assert token_calls[0]["force_refresh"] is False
+    assert token_calls[1]["force_refresh"] is True
+
+
+def test_discover_models_refreshes_maas_auth_when_department_missing(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+
+    token_service = _FakeMaaSTokenService(
+        ["stale-token", "fresh-token"],
+        captured,
+        departments=[None, "Relay/Department"],
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_maas_token_service",
+        lambda: token_service,
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **kwargs: (
+            captured.update(kwargs)
+            or _FakeHttpClient(
+                captured=captured,
+                response=httpx.Response(
+                    200,
+                    json={"user_model_list": [{"model_id": "maas-chat"}]},
+                ),
+            )
+        ),
+    )
+
+    result = service.discover_models(
+        ModelDiscoveryRequest(
+            override=ModelConnectivityProbeOverride(
+                provider=ProviderType.MAAS,
+                base_url="https://maas.example/api/v2",
+                maas_auth=MaaSAuthConfig(
+                    username="relay-user",
+                    password="relay-password",
+                ),
+            )
+        )
+    )
+
+    assert result.ok is True
+    headers = cast(dict[str, str], captured["headers"])
+    assert headers["X-Auth-Token"] == "fresh-token"
+    token_calls = cast(list[dict[str, object]], captured["maas_token_calls"])
+    assert token_calls[0]["force_refresh"] is False
+    assert token_calls[1]["force_refresh"] is True
+
+
+def test_discover_models_returns_invalid_response_when_maas_department_missing(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_maas_token_service",
+        lambda: _FakeMaaSTokenService(
+            ["stale-token", "fresh-token"],
+            captured,
+            departments=[None, None],
+        ),
+    )
 
     result = service.discover_models(
         ModelDiscoveryRequest(
@@ -597,11 +861,13 @@ def test_discover_models_returns_unsupported_for_maas() -> None:
     )
 
     assert result.ok is False
-    assert result.error_code == "unsupported_provider"
-    assert (
-        result.error_message
-        == "MAAS model discovery is not supported. Enter the model name manually."
+    assert result.error_code == "invalid_response"
+    assert result.error_message == (
+        "MAAS login response did not include user department information."
     )
+    token_calls = cast(list[dict[str, object]], captured["maas_token_calls"])
+    assert token_calls[0]["force_refresh"] is False
+    assert token_calls[1]["force_refresh"] is True
 
 
 def test_discover_models_uses_saved_profile_and_parses_catalog(monkeypatch) -> None:


### PR DESCRIPTION
Closes #308

## Summary
- add MAAS model discovery support through PromptCenter instead of returning `unsupported_provider`
- enable MAAS model discovery in the settings UI and reuse saved MAAS credentials when editing profiles
- cache MAAS auth context with department metadata and refresh tokens 1 hour before expiry, with retry-on-401/403 behavior
- update tests and docs, including the MAAS provider design document in Chinese

## Testing
- `uv run --extra dev pytest -q tests/unit_tests/providers/test_maas_auth.py`
- `uv run --extra dev pytest -q tests/unit_tests/providers/test_model_connectivity.py tests/unit_tests/frontend/test_model_profiles_ui.py tests/unit_tests/interfaces/server/test_system_router.py`
- `uv run --extra dev ruff check --fix src/relay_teams/providers/maas_auth.py tests/unit_tests/providers/test_maas_auth.py`
- `uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/providers/maas_auth.py tests/unit_tests/providers/test_maas_auth.py`
- `uv run --extra dev basedpyright`
