### PR TITLE
Fix BigModel base URL sync in model editor

### DIFF
--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -767,12 +767,13 @@ function applyProviderDefaultBaseUrl() {
     const initialValue = String(baseUrlInput.dataset.initialValue || '').trim();
     const currentBaseUrl = String(baseUrlInput.value || '').trim();
     const previousDefaultBaseUrl = PROVIDER_DEFAULT_BASE_URLS[previousProvider] || '';
+    const providerChanged = provider !== previousProvider;
     if (isMaaSProvider(provider)) {
         baseUrlInput.value = DEFAULT_MAAS_BASE_URL;
         baseUrlInput.dataset.previousProvider = provider;
         return;
     }
-    if (isMaaSProvider(previousProvider)) {
+    if (providerChanged && isMaaSProvider(previousProvider)) {
         baseUrlInput.value = '';
         baseUrlInput.dataset.previousProvider = provider;
         return;
@@ -780,6 +781,9 @@ function applyProviderDefaultBaseUrl() {
     baseUrlInput.dataset.previousProvider = provider;
     const defaultBaseUrl = PROVIDER_DEFAULT_BASE_URLS[provider];
     if (!defaultBaseUrl) {
+        return;
+    }
+    if (!providerChanged) {
         return;
     }
     if (!currentBaseUrl) {

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -187,6 +187,7 @@ function handleAddProfile() {
     document.getElementById('profile-provider').value = 'openai_compatible';
     setDraftModelValue('');
     document.getElementById('profile-base-url').value = '';
+    delete document.getElementById('profile-base-url').dataset.initialValue;
     delete document.getElementById('profile-base-url').dataset.previousProvider;
     draftApiKeyState = createDraftSecretState();
     draftMaasPasswordState = createDraftSecretState();
@@ -222,6 +223,7 @@ function handleEditProfile(name) {
     document.getElementById('profile-provider').value = profile.provider || 'openai_compatible';
     setDraftModelValue(profile.model || '');
     document.getElementById('profile-base-url').value = profile.base_url || '';
+    document.getElementById('profile-base-url').dataset.initialValue = profile.base_url || '';
     document.getElementById('profile-base-url').dataset.previousProvider = profile.provider || 'openai_compatible';
     draftApiKeyState = {
         persistedValue: typeof profile.api_key === 'string' ? profile.api_key : '',
@@ -762,6 +764,9 @@ function applyProviderDefaultBaseUrl() {
     }
     const provider = String(providerInput.value || '').trim();
     const previousProvider = String(baseUrlInput.dataset.previousProvider || '').trim();
+    const initialValue = String(baseUrlInput.dataset.initialValue || '').trim();
+    const currentBaseUrl = String(baseUrlInput.value || '').trim();
+    const previousDefaultBaseUrl = PROVIDER_DEFAULT_BASE_URLS[previousProvider] || '';
     if (isMaaSProvider(provider)) {
         baseUrlInput.value = DEFAULT_MAAS_BASE_URL;
         baseUrlInput.dataset.previousProvider = provider;
@@ -773,12 +778,18 @@ function applyProviderDefaultBaseUrl() {
         return;
     }
     baseUrlInput.dataset.previousProvider = provider;
-    if (editingProfile) {
+    const defaultBaseUrl = PROVIDER_DEFAULT_BASE_URLS[provider];
+    if (!defaultBaseUrl) {
         return;
     }
-    const defaultBaseUrl = PROVIDER_DEFAULT_BASE_URLS[provider];
-    const currentBaseUrl = String(baseUrlInput.value || '').trim();
-    if (!defaultBaseUrl || currentBaseUrl) {
+    if (!currentBaseUrl) {
+        baseUrlInput.value = defaultBaseUrl;
+        return;
+    }
+    if (!editingProfile) {
+        return;
+    }
+    if (currentBaseUrl !== initialValue && currentBaseUrl !== previousDefaultBaseUrl) {
         return;
     }
     baseUrlInput.value = defaultBaseUrl;

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -455,6 +455,40 @@ def test_browser_shell_settings_and_session_management(
     assert _wait_for_session_ids_snapshot(page) == baseline_session_ids
 
 
+def test_browser_model_profile_switching_to_bigmodel_prefills_base_url(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+) -> None:
+    page = browser_page
+    _open_app(page, integration_env)
+
+    page.locator("#settings-btn").click()
+    expect(page.locator("#settings-modal")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "GET"
+            and response.url
+            == f"{integration_env.api_base_url}/api/system/configs/model/profiles"
+            and response.ok
+        )
+    ):
+        page.locator('.settings-tab[data-tab="model"]').click()
+    expect(page.locator("#model-panel")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    page.locator(".edit-profile-btn").first.click()
+    expect(page.locator("#profile-editor")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    expect(page.locator("#profile-base-url")).to_have_value(
+        integration_env.fake_llm_v1_base_url,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+
+    page.locator("#profile-provider").select_option("bigmodel")
+
+    expect(page.locator("#profile-base-url")).to_have_value(
+        "https://open.bigmodel.cn/api/coding/paas/v4",
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+
+
 def test_browser_environment_variables_and_session_topology(
     browser_page: Page,
     integration_env: IntegrationEnvironment,

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -435,6 +435,82 @@ console.log(JSON.stringify({
     assert payload["baseUrlValue"] == "https://custom.example/v1"
 
 
+def test_edit_bigmodel_profile_non_provider_changes_do_not_reset_custom_base_url(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+await loadModelProfilesPanel();
+
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn")[0].onclick();
+document.getElementById("profile-api-key").value = "updated-secret";
+document.getElementById("profile-api-key").oninput();
+
+console.log(JSON.stringify({
+    providerValue: document.getElementById("profile-provider").value,
+    baseUrlValue: document.getElementById("profile-base-url").value,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        default: {
+            provider: "bigmodel",
+            model: "glm-4.5",
+            base_url: "https://custom.bigmodel.example/v4",
+            api_key: "saved-secret-key",
+            has_api_key: true,
+            is_default: true,
+            temperature: 0.3,
+            top_p: 0.8,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function probeModelConnection(payload) {
+    globalThis.__probePayload = payload;
+    return {
+        ok: true,
+        latency_ms: 42,
+    };
+}
+
+export async function discoverModelCatalog(payload) {
+    globalThis.__discoverPayload = payload;
+    return {
+        ok: true,
+        latency_ms: 37,
+        models: [],
+    };
+}
+
+export async function saveModelProfile(name, profile) {
+    globalThis.__savedProfile = { name, profile };
+}
+
+export async function reloadModelConfig() {
+    globalThis.__reloadCalled = true;
+}
+
+export async function deleteModelProfile(name) {
+    globalThis.__deletedProfileName = name;
+}
+""".strip(),
+    )
+
+    assert payload["providerValue"] == "bigmodel"
+    assert payload["baseUrlValue"] == "https://custom.bigmodel.example/v4"
+
+
 def test_selecting_minimax_prefills_default_base_url(tmp_path: Path) -> None:
     payload = _run_model_profiles_script(
         tmp_path=tmp_path,

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -375,6 +375,66 @@ console.log(JSON.stringify({
     assert payload["baseUrlValue"] == "https://custom.example/v1"
 
 
+def test_edit_profile_switching_to_bigmodel_prefills_default_base_url(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+await loadModelProfilesPanel();
+
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn")[0].onclick();
+document.getElementById("profile-provider").value = "bigmodel";
+document.getElementById("profile-provider").onchange();
+
+console.log(JSON.stringify({
+    providerValue: document.getElementById("profile-provider").value,
+    baseUrlValue: document.getElementById("profile-base-url").value,
+}));
+""".strip(),
+    )
+
+    assert payload["providerValue"] == "bigmodel"
+    assert payload["baseUrlValue"] == "https://open.bigmodel.cn/api/coding/paas/v4"
+
+
+def test_edit_profile_switching_provider_keeps_manually_changed_base_url(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+await loadModelProfilesPanel();
+
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn")[0].onclick();
+document.getElementById("profile-base-url").value = "https://custom.example/v1";
+document.getElementById("profile-base-url").oninput();
+document.getElementById("profile-provider").value = "bigmodel";
+document.getElementById("profile-provider").onchange();
+
+console.log(JSON.stringify({
+    baseUrlValue: document.getElementById("profile-base-url").value,
+}));
+""".strip(),
+    )
+
+    assert payload["baseUrlValue"] == "https://custom.example/v1"
+
+
 def test_selecting_minimax_prefills_default_base_url(tmp_path: Path) -> None:
     payload = _run_model_profiles_script(
         tmp_path=tmp_path,


### PR DESCRIPTION
## Summary
- fix the model editor so switching an existing profile to `bigmodel` re-applies the built-in BigModel base URL
- preserve manually edited base URLs instead of overwriting user input during provider switches
- add frontend unit coverage and a browser smoke regression for the edit-flow provider switch

## Testing
- `uv run --extra dev pytest -q tests/unit_tests/frontend/test_model_profiles_ui.py`
- `uv run --extra dev pytest -q tests/integration_tests/browser/test_browser_smoke.py -k "shell_settings_and_session_management or bigmodel_prefills_base_url"`
- `uv run --extra dev ruff check tests/unit_tests/frontend/test_model_profiles_ui.py`
- `uv run --extra dev ruff check tests/integration_tests/browser/test_browser_smoke.py`

Fixes #315