### PR TITLE
Normalize semicolon-separated NO_PROXY for subprocess export

### DIFF
--- a/src/relay_teams/env/proxy_env.py
+++ b/src/relay_teams/env/proxy_env.py
@@ -51,8 +51,10 @@ class ProxyEnvConfig(BaseModel):
             env_values["ALL_PROXY"] = self.all_proxy
             env_values["all_proxy"] = self.all_proxy
         if self.no_proxy:
-            env_values["NO_PROXY"] = self.no_proxy
-            env_values["no_proxy"] = self.no_proxy
+            exported_no_proxy = _normalize_no_proxy_for_export(self.no_proxy)
+            if exported_no_proxy:
+                env_values["NO_PROXY"] = exported_no_proxy
+                env_values["no_proxy"] = exported_no_proxy
         if self.ssl_verify is not None:
             env_values["SSL_VERIFY"] = "true" if self.ssl_verify else "false"
         return env_values
@@ -310,6 +312,20 @@ def _normalize_proxy_value(value: str | None) -> str | None:
     if not normalized:
         return None
     return normalized
+
+
+def _normalize_no_proxy_for_export(value: str | None) -> str | None:
+    normalized = _normalize_proxy_value(value)
+    if normalized is None:
+        return None
+    tokens: list[str] = []
+    for raw_candidate in normalized.replace(";", ",").split(","):
+        candidate = raw_candidate.strip()
+        if candidate:
+            tokens.append(candidate)
+    if not tokens:
+        return None
+    return ",".join(tokens)
 
 
 def host_matches_no_proxy(host: str, no_proxy: str | None) -> bool:

--- a/tests/unit_tests/env/test_proxy_env.py
+++ b/tests/unit_tests/env/test_proxy_env.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import os
@@ -148,6 +147,127 @@ def test_parse_no_proxy_rules_normalizes_semicolon_separated_entries() -> None:
         ("wildcard", "192.168.*"),
         ("local", None),
     ]
+
+
+def test_extract_proxy_env_vars_converts_semicolons_to_commas_for_no_proxy() -> None:
+    proxy_env = extract_proxy_env_vars(
+        {
+            "HTTP_PROXY": "http://proxy.example:8080",
+            "NO_PROXY": "localhost;127.*;<local>",
+        }
+    )
+
+    assert proxy_env["NO_PROXY"] == "localhost,127.*,<local>"
+    assert proxy_env["no_proxy"] == "localhost,127.*,<local>"
+
+
+def test_extract_proxy_env_vars_strips_empty_no_proxy_tokens() -> None:
+    proxy_env = extract_proxy_env_vars(
+        {
+            "HTTP_PROXY": "http://proxy.example:8080",
+            "NO_PROXY": "a,,b; ;c",
+        }
+    )
+
+    assert proxy_env["NO_PROXY"] == "a,b,c"
+
+
+def test_extract_proxy_env_vars_omits_no_proxy_when_only_separators() -> None:
+    proxy_env = extract_proxy_env_vars(
+        {
+            "HTTP_PROXY": "http://proxy.example:8080",
+            "NO_PROXY": " ; , ",
+        }
+    )
+
+    assert "NO_PROXY" not in proxy_env
+    assert "no_proxy" not in proxy_env
+
+
+def test_build_subprocess_env_keeps_username_only_proxy_url_unchanged(
+    monkeypatch,
+) -> None:
+    for key in (
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://alice@proxy.example:8443")
+    monkeypatch.setenv("ALL_PROXY", "http://alice@proxy.example:1080")
+
+    subprocess_env = build_subprocess_env()
+
+    assert subprocess_env["HTTPS_PROXY"] == "http://alice@proxy.example:8443"
+    assert subprocess_env["https_proxy"] == "http://alice@proxy.example:8443"
+    assert subprocess_env["ALL_PROXY"] == "http://alice@proxy.example:1080"
+    assert subprocess_env["all_proxy"] == "http://alice@proxy.example:1080"
+
+
+def test_build_subprocess_env_leaves_url_without_username_unchanged(
+    monkeypatch,
+) -> None:
+    for key in (
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8443")
+
+    subprocess_env = build_subprocess_env()
+
+    assert subprocess_env["HTTPS_PROXY"] == "http://proxy.example:8443"
+
+
+def test_build_subprocess_env_keeps_inline_password_when_already_present(
+    monkeypatch,
+) -> None:
+    for key in (
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://alice:inline-pw@proxy.example:8443")
+
+    subprocess_env = build_subprocess_env()
+
+    assert subprocess_env["HTTPS_PROXY"] == "http://alice:inline-pw@proxy.example:8443"
+
+
+def test_build_subprocess_env_exports_comma_separated_no_proxy(monkeypatch) -> None:
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    monkeypatch.delenv("ALL_PROXY", raising=False)
+    monkeypatch.delenv("all_proxy", raising=False)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.example:8080")
+    monkeypatch.setenv("NO_PROXY", "localhost;127.*;example.com")
+
+    subprocess_env = build_subprocess_env()
+
+    assert subprocess_env["NO_PROXY"] == "localhost,127.*,example.com"
+    assert subprocess_env["no_proxy"] == "localhost,127.*,example.com"
 
 
 def test_proxy_env_input_splits_and_rebuilds_shared_proxy_credentials() -> None:


### PR DESCRIPTION
## Summary
- `ProxyEnvConfig.normalized_env()` forwarded `no_proxy` to child processes verbatim, but the project treats `;` as a valid separator internally (`parse_no_proxy_rules` does `replace(";", ",")`). Shell subprocess targets (libwebsockets/libcurl, curl, git, gh, npm, pip, requests, ...) only understand comma-separated NO_PROXY, so a value like `127.0.0.1;localhost` was interpreted as a single unmatchable host and `no_proxy` silently failed — every request went through the proxy.
- Canonicalize the exported value to comma-separated form via a new `_normalize_no_proxy_for_export` helper (splits on both `;` and `,`, trims whitespace, drops empty tokens). Internal parsing remains lenient, so stored `.env` values and existing fixtures keep working unchanged.
- Touches `src/relay_teams/env/proxy_env.py` and its unit tests; ships a manual end-to-end reproducer under `scripts/manual_no_proxy_demo.py`. No storage format or API contract change.

## End-to-end reproduction

`scripts/manual_no_proxy_demo.py` starts a listener on `127.0.0.1:14000`, points `HTTP(S)_PROXY` at a dead port (`127.0.0.1:59999`) so any non-bypassed request fails immediately, sets `NO_PROXY=127.0.0.1;localhost` (semicolons — the exact user-reported scenario), then runs `curl` through `run_git_bash` from the shell executor.

**Before the fix** (`git revert` applied locally, then script run):
```
Step 1 - build_subprocess_env output
  NO_PROXY='127.0.0.1;localhost'
  no_proxy='127.0.0.1;localhost'

Step 2 - run curl via run_git_bash
exit_code=7 timed_out=False
--- stderr ---
curl: (7) Failed to connect to 127.0.0.1 port 14000 via 127.0.0.1 after 2034 ms: Could not connect to server

RESULT: FAIL (proxy was not bypassed)
```
curl tried to reach the target *through* the dead proxy because it could not parse the semicolon-joined `no_proxy`.

**After the fix** (HEAD):
```
Step 1 - build_subprocess_env output
  NO_PROXY='127.0.0.1,localhost'
  no_proxy='127.0.0.1,localhost'

Step 2 - run curl via run_git_bash
exit_code=0 timed_out=False
--- stdout ---
env no_proxy=127.0.0.1,localhost
no-proxy-demo-ok
HTTP_CODE=200

RESULT: PASS (no_proxy bypass works)
```
libcurl now sees the canonical comma-separated form and bypasses the proxy.

## Test plan
- [x] `uv run ruff check --fix` on changed files
- [x] `uv run ruff format --no-cache --force-exclude` on changed files
- [x] `uv run basedpyright src/relay_teams/env/proxy_env.py tests/unit_tests/env/test_proxy_env.py scripts/manual_no_proxy_demo.py` — 0 errors
- [x] `uv run pytest -q tests/unit_tests/env/test_proxy_env.py` — 20 passed (4 new regression cases)
- [x] `uv run pytest -q tests/unit_tests/env tests/unit_tests/net tests/unit_tests/tools/workspace_tools` — only a preexisting Windows path-separator failure in `test_clawhub_connectivity.py::test_clawhub_probe_reads_version` (reproduced on main without this patch), unrelated to this change
- [x] `uv run python scripts/manual_no_proxy_demo.py` — before: FAIL (curl error 7), after: PASS (HTTP 200, sentinel body received)

New regression coverage in `tests/unit_tests/env/test_proxy_env.py`:
- `test_extract_proxy_env_vars_converts_semicolons_to_commas_for_no_proxy`
- `test_extract_proxy_env_vars_strips_empty_no_proxy_tokens`
- `test_extract_proxy_env_vars_omits_no_proxy_when_only_separators`
- `test_build_subprocess_env_exports_comma_separated_no_proxy`

Fixes #324