### PR TITLE
Strengthen high-risk API write validation

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -98,6 +98,7 @@ Request field:
 
 Returns the persisted model config with secret-backed profile API keys rehydrated for UI editing.
 Literal profile `api_key` values and secret header values are migrated out of `model.json` into the unified secret store on read.
+The response body is a root object whose keys are profile ids and whose values use the same typed profile schema as `PUT /system/configs/model`, without any legacy top-level `config` wrapper.
 
 ### `GET /system/configs/model/profiles`
 
@@ -110,6 +111,7 @@ When no profile is explicitly marked default, the backend resolves the default i
 
 Upserts a model profile.
 Request body may include optional `source_name` to rename an existing profile while preserving its stored API key and secret headers when `api_key` and `headers` are omitted.
+If `source_name` does not exist, the backend returns `404`. Profile-level semantic validation failures that occur after request parsing, such as invalid secret-header state or missing MAAS password on first configuration, return `400`.
 `provider` accepts `openai_compatible`, `bigmodel`, `minimax`, `maas`, and `echo`.
 Profiles may also include optional `ssl_verify` to override the global outbound TLS verification default for that model only.
 Profiles may include `is_default` to promote that profile to the runtime default; saving one default clears the flag from all others.
@@ -121,12 +123,15 @@ When `provider = "maas"`, `maas_auth` must include `username`; `password` is acc
 ### `DELETE /system/configs/model/profiles/{name}`
 
 Deletes a model profile.
+If the profile does not exist, the backend returns `404`.
 If the deleted profile was the current default and other profiles remain, the backend promotes the first remaining profile by name to stay default.
 
 ### `PUT /system/configs/model`
 
 Replaces the full model config object.
+The request body must be a root object keyed by profile id. Each profile value uses the explicit model-profile schema (`provider`, `model`, `base_url`, optional `api_key`, optional `headers[]`, optional `maas_auth`, sampling fields, and optional `is_default`/`ssl_verify`). The legacy `{ "config": { ... } }` wrapper is rejected.
 Literal profile `api_key` values and secret header values are moved into the unified secret store before `model.json` is written.
+Unknown profile fields and invalid profile ids are rejected at request validation time. Profile-level semantic validation failures that occur during save return `400`.
 
 ### `POST /system/configs/model:probe`
 
@@ -153,6 +158,7 @@ For a small set of known provider/model pairs, the backend also applies a built-
 ### `POST /system/configs/model:reload`
 
 Reloads model config into runtime.
+If persisted model config is syntactically valid JSON but semantically invalid for runtime loading, the backend returns `400`.
 
 ### `GET /system/configs/proxy`
 
@@ -461,10 +467,12 @@ This updates process-level proxy variables for future HTTP requests and shell/MC
 ### `POST /system/configs/mcp:reload`
 
 Reloads MCP config into runtime.
+If persisted MCP config is semantically invalid, the backend returns `400`.
 
 ### `POST /system/configs/skills:reload`
 
 Reloads skills config into runtime.
+If persisted skills config is semantically invalid, the backend returns `400`.
 
 ### `GET /system/configs/notifications`
 
@@ -477,6 +485,7 @@ Each rule includes:
 ### `PUT /system/configs/notifications`
 
 Replaces notification rules.
+The request body is the `NotificationConfig` object directly; the backend no longer accepts an extra top-level `config` field. Unknown top-level fields are rejected.
 Notes:
 - `feishu` delivery is best-effort and only applies when the session/run has Feishu chat context.
 - Feishu credentials are resolved from the Feishu gateway account bound to that session, not from `notifications.json`.
@@ -497,6 +506,7 @@ Response fields:
 ### `PUT /system/configs/orchestration`
 
 Replaces global orchestration settings.
+The request body is the `OrchestrationSettings` object directly; the backend no longer accepts an extra top-level `config` field. Unknown top-level fields are rejected.
 
 Rules:
 - `presets[].role_ids` may contain only normal roles; reserved system roles are rejected.
@@ -551,7 +561,12 @@ Request:
 {
   "session_id": null,
   "workspace_id": "default",
-  "metadata": {"project": "demo"}
+  "metadata": {
+    "title": "Customer Support",
+    "source_label": "Group Chat",
+    "source_icon": "im",
+    "custom_metadata": {"project": "demo"}
+  }
 }
 ```
 
@@ -560,6 +575,9 @@ Notes:
 - New sessions default to `normal_root_role_id = "MainAgent"`.
 - New sessions also store the current default orchestration preset id so they can be switched to orchestration before the first run.
 - Omitting `session_id` or sending `session_id = null` auto-generates a session id. Sending `"None"` or `"null"` as a string is rejected with `422`.
+- `metadata` uses the same explicit fields as session metadata updates: `title`, `title_source`, `source_label`, `source_icon`, and `custom_metadata`.
+- `custom_metadata` cannot overwrite reserved session keys such as `title`, `title_source`, `source_label`, `source_icon`, `source_kind`, `source_provider`, or any key with the `feishu_` prefix.
+- `title_source` requires `title`. When `title` is provided and `title_source` is omitted, the backend stores `title_source = "manual"`.
 
 ### `GET /sessions`
 
@@ -578,7 +596,30 @@ Response fields also include:
 
 ### `PATCH /sessions/{session_id}`
 
-Updates session metadata.
+Updates session metadata with an explicit patch body.
+
+Request:
+
+```json
+{
+  "title": "Renamed Session",
+  "title_source": "manual",
+  "source_label": "Customer Support",
+  "source_icon": "support-bot",
+  "custom_metadata": {
+    "project": "demo",
+    "ticket_id": "A-1024"
+  }
+}
+```
+
+Rules:
+- The request body must contain at least one field.
+- `title`, `title_source`, `source_label`, and `source_icon` are optional patch fields. Sending `null` clears that value.
+- `title_source` requires the resulting session title to be set. Sending `title_source` without a non-empty `title` returns `422`.
+- `custom_metadata` replaces only the caller-managed custom metadata subset. System-managed metadata keys remain intact.
+- `custom_metadata` keys must be non-empty and cannot overwrite reserved keys such as `title`, `title_source`, `source_label`, `source_icon`, `source_kind`, `source_provider`, or any key with the `feishu_` prefix.
+- `custom_metadata` values must be non-empty strings.
 
 ### `PATCH /sessions/{session_id}/topology`
 
@@ -605,6 +646,10 @@ Rules:
 
 Deletes a session and all persisted runtime data under that session.
 The bound workspace record is preserved.
+Request body may include:
+- optional `force`: required when the session still has an active or recoverable run
+- optional `cascade`: required when persisted session-scoped data already exists and the caller wants the backend to remove messages, tasks, agents, runtime rows, background-task logs, bindings, and other related session data
+If a session still has related data and `cascade` is omitted or `false`, the backend returns `409` instead of performing an implicit cascading delete.
 
 ### `GET /sessions/{session_id}/rounds`
 
@@ -1616,8 +1661,12 @@ Deletes one registered execution workspace.
 Query:
 - `remove_worktree`: `true|false`
 
+Request body:
+- optional `force`: required when `remove_worktree=true`
+
 Rules:
 - `remove_worktree=true` only affects workspaces with `file_scope.backend = "git_worktree"`.
+- When `remove_worktree=true` and `force` is omitted or `false`, the backend returns `409` instead of removing the worktree.
 - When `remove_worktree=true`, the backend runs `git worktree remove --force` before deleting the workspace record.
 - When `remove_worktree=false`, the backend deletes only the workspace record.
 
@@ -1651,6 +1700,7 @@ Notes:
 - `workspace_id` is optional.
 - `orchestration_prompt` is optional and participates in skill routing; coordinator preview also renders it into the prompt layers that normally receive runtime orchestration prompt context.
 - `conversation_context` is optional.
+- `shared_state` remains a free-form key/value object, but keys are trimmed and blank keys are rejected with `422`.
 - When `workspace_id` is provided, `runtime_system_prompt` resolves `Working Directory` from the workspace execution root using the same workspace path resolution as real agent execution.
 - `runtime_system_prompt` also includes any resolved instruction files loaded from the workspace/project chain, user-level prompt files, and `prompts.json` in the resolved config dir, by default `~/.relay-teams/prompts.json`.
 - When `conversation_context.source_provider = "feishu"` and `conversation_context.feishu_chat_type = "group"`, both `runtime_system_prompt` and `provider_system_prompt` append the extra Feishu-group instruction:
@@ -1722,9 +1772,20 @@ Each record includes:
 Creates a Feishu gateway account and persists its secret config.
 The request `name` and all `account_id` path parameters follow the common identifier validation rules above.
 
+Rules:
+- `source_config`, `target_config`, and `secret_config` use explicit nested Feishu models with `extra = forbid`; unknown nested fields return `422`.
+- Omitting `target_config` uses the default Feishu trigger target settings.
+- `secret_config.app_secret` is required on create.
+
 ### `PATCH /gateway/feishu/accounts/{account_id}`
 
 Updates a Feishu gateway account. If the runtime credential signature changes, the backend reloads the Feishu long-connection runtime. If the target session preset changes, the backend clears the existing external chat bindings for that account.
+
+Rules:
+- The request body must include at least one field.
+- `source_config`, `target_config`, and `secret_config` are explicit nested patch fields, not loose dictionaries.
+- Empty config objects such as `{"target_config": {}}` or `{"secret_config": {}}` are rejected with `422`.
+- Unknown nested fields return `422`.
 
 ### `POST /gateway/feishu/accounts/{account_id}:enable`
 
@@ -1911,6 +1972,9 @@ Mutable fields:
 - `thinking`
 
 Notes:
+- The request body must contain at least one field.
+- `display_name`, `base_url`, `cdn_base_url`, and `route_tag` are trimmed. Blank strings are rejected with `422`.
+- Sending `route_tag = null` clears the stored route tag.
 - `session_mode = "orchestration"` requires `orchestration_preset_id` or a configured default orchestration preset.
 - Saving account settings immediately reloads the WeChat gateway workers.
 
@@ -2057,6 +2121,10 @@ Updates automation project definition, schedule, stored run config, and optional
 ### `DELETE /automation/projects/{automation_project_id}`
 
 Deletes the automation project and its backing trigger. Historical sessions are preserved.
+Request body may include:
+- optional `force`: required when the project is still enabled
+- optional `cascade`: required when delivery records or bound-session queue records already exist and the caller wants the backend to remove them together with the project
+If related delivery or queue data exists and `cascade` is omitted or `false`, the backend returns `409` instead of performing an implicit cascading delete.
 
 ### `POST /automation/projects/{automation_project_id}:run`
 

--- a/frontend/dist/js/core/api/automation.js
+++ b/frontend/dist/js/core/api/automation.js
@@ -51,7 +51,11 @@ export async function updateAutomationProject(automationProjectId, payload) {
 export async function deleteAutomationProject(automationProjectId) {
     return requestJson(
         `/api/automation/projects/${encodeURIComponent(automationProjectId)}`,
-        { method: 'DELETE' },
+        {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ force: true, cascade: true }),
+        },
         'Failed to delete automation project',
     );
 }

--- a/frontend/dist/js/core/api/gateway.js
+++ b/frontend/dist/js/core/api/gateway.js
@@ -63,7 +63,11 @@ export async function disableWeChatGatewayAccount(accountId) {
 export async function deleteWeChatGatewayAccount(accountId) {
     return requestJson(
         `/api/gateway/wechat/accounts/${encodeURIComponent(accountId)}`,
-        { method: 'DELETE' },
+        {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ force: true }),
+        },
         'Failed to delete WeChat account',
     );
 }

--- a/frontend/dist/js/core/api/sessions.js
+++ b/frontend/dist/js/core/api/sessions.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * core/api/sessions.js
  * Session and history related API wrappers.
  */
@@ -24,13 +24,13 @@ export async function fetchSessionHistory(sessionId) {
     return requestJson(`/api/sessions/${sessionId}`, undefined, 'Failed to fetch session history');
 }
 
-export async function updateSession(sessionId, metadata) {
+export async function updateSession(sessionId, patch) {
     return requestJson(
         `/api/sessions/${sessionId}`,
         {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ metadata }),
+            body: JSON.stringify(patch),
         },
         'Failed to update session',
     );
@@ -138,7 +138,11 @@ export async function deleteAgentReflection(sessionId, instanceId) {
 export async function deleteSession(sessionId) {
     return requestJson(
         `/api/sessions/${sessionId}`,
-        { method: 'DELETE' },
+        {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ force: true, cascade: true }),
+        },
         'Failed to delete session',
     );
 }

--- a/frontend/dist/js/core/api/triggers.js
+++ b/frontend/dist/js/core/api/triggers.js
@@ -43,7 +43,11 @@ export async function updateTrigger(triggerId, payload) {
 export async function deleteTrigger(triggerId) {
     return requestJson(
         `/api/gateway/feishu/accounts/${encodeURIComponent(triggerId)}`,
-        { method: 'DELETE' },
+        {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ force: true }),
+        },
         'Failed to delete Feishu gateway account',
     );
 }

--- a/frontend/dist/js/core/api/workspaces.js
+++ b/frontend/dist/js/core/api/workspaces.js
@@ -82,11 +82,16 @@ export async function forkWorkspace(workspaceId, name) {
 export async function deleteWorkspace(workspaceId, options = {}) {
     const removeWorktree = options?.removeWorktree === true;
     const query = removeWorktree ? '?remove_worktree=true' : '';
+    const requestOptions = {
+        method: 'DELETE',
+    };
+    if (removeWorktree) {
+        requestOptions.headers = { 'Content-Type': 'application/json' };
+        requestOptions.body = JSON.stringify({ force: true });
+    }
     return requestJson(
         `/api/workspaces/${encodeURIComponent(workspaceId)}${query}`,
-        {
-            method: 'DELETE',
-        },
+        requestOptions,
         'Failed to remove project',
     );
 }

--- a/src/relay_teams/agents/orchestration/settings_service.py
+++ b/src/relay_teams/agents/orchestration/settings_service.py
@@ -33,17 +33,19 @@ class OrchestrationSettingsService:
         self._session_repo = session_repo
         self._get_role_registry = get_role_registry
 
-    def get_orchestration_config(self) -> dict[str, JsonValue]:
-        settings = self._config_manager.get_orchestration_settings()
+    def get_orchestration_config(self) -> OrchestrationSettings:
+        return self._config_manager.get_orchestration_settings()
+
+    def get_orchestration_config_payload(self) -> dict[str, JsonValue]:
+        settings = self.get_orchestration_config()
         return cast(dict[str, JsonValue], settings.model_dump(mode="json"))
 
-    def save_orchestration_config(self, config: dict[str, JsonValue]) -> None:
-        settings = OrchestrationSettings.model_validate(config)
-        self._validate_roles(settings)
-        self._config_manager.save_orchestration_settings(settings)
+    def save_orchestration_config(self, config: OrchestrationSettings) -> None:
+        self._validate_roles(config)
+        self._config_manager.save_orchestration_settings(config)
         self._session_repo.reconcile_orchestration_presets(
-            valid_preset_ids=tuple(preset.preset_id for preset in settings.presets),
-            default_preset_id=settings.default_orchestration_preset_id or None,
+            valid_preset_ids=tuple(preset.preset_id for preset in config.presets),
+            default_preset_id=config.default_orchestration_preset_id or None,
         )
 
     def default_session_mode(self) -> SessionMode:

--- a/src/relay_teams/automation/automation_bound_session_queue_repository.py
+++ b/src/relay_teams/automation/automation_bound_session_queue_repository.py
@@ -473,6 +473,14 @@ class AutomationBoundSessionQueueRepository:
             return None
         return self.get(automation_queue_id)
 
+    def has_project_records(self, automation_project_id: str) -> bool:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM automation_bound_session_queue WHERE automation_project_id=? LIMIT 1",
+                (automation_project_id,),
+            ).fetchone()
+        return row is not None
+
     def delete_by_project(self, automation_project_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,

--- a/src/relay_teams/automation/automation_bound_session_queue_service.py
+++ b/src/relay_teams/automation/automation_bound_session_queue_service.py
@@ -245,6 +245,9 @@ class AutomationBoundSessionQueueService:
         progress = self._cleanup_queue_receipts(limit=limit) or progress
         return progress
 
+    def has_project_queue(self, automation_project_id: str) -> bool:
+        return self._repository.has_project_records(automation_project_id)
+
     def delete_project_queue(self, automation_project_id: str) -> None:
         self._repository.delete_by_project(automation_project_id)
 

--- a/src/relay_teams/automation/automation_delivery_repository.py
+++ b/src/relay_teams/automation/automation_delivery_repository.py
@@ -496,6 +496,14 @@ class AutomationDeliveryRepository:
             return None
         return self._to_record(row)
 
+    def has_project_records(self, automation_project_id: str) -> bool:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM automation_deliveries WHERE automation_project_id=? LIMIT 1",
+                (automation_project_id,),
+            ).fetchone()
+        return row is not None
+
     def delete_by_project(self, automation_project_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,

--- a/src/relay_teams/automation/automation_delivery_service.py
+++ b/src/relay_teams/automation/automation_delivery_service.py
@@ -189,6 +189,9 @@ class AutomationDeliveryService:
             progress = self._attempt_started_cleanup(record) or progress
         return progress
 
+    def has_project_deliveries(self, automation_project_id: str) -> bool:
+        return self._repository.has_project_records(automation_project_id)
+
     def delete_project_deliveries(self, automation_project_id: str) -> None:
         self._repository.delete_by_project(automation_project_id)
 

--- a/src/relay_teams/automation/automation_models.py
+++ b/src/relay_teams/automation/automation_models.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from relay_teams.interfaces.server.api_write_validation import require_non_empty_patch
 from relay_teams.sessions.runs.enums import ExecutionMode
 from relay_teams.sessions.runs.run_models import RunThinkingConfig
 from relay_teams.sessions.session_models import SessionMode
@@ -138,6 +139,22 @@ class AutomationProjectUpdateInput(BaseModel):
     delivery_binding: AutomationFeishuBinding | None = None
     delivery_events: tuple[AutomationDeliveryEvent, ...] | None = None
     enabled: bool | None = None
+
+    @model_validator(mode="after")
+    def _validate_patch(self) -> AutomationProjectUpdateInput:
+        require_non_empty_patch(self)
+        if (
+            self.schedule_mode == AutomationScheduleMode.CRON
+            and self.run_at is not None
+        ):
+            raise ValueError("run_at is not supported for cron schedules")
+        if (
+            self.schedule_mode == AutomationScheduleMode.ONE_SHOT
+            and self.cron_expression is not None
+            and self.cron_expression.strip()
+        ):
+            raise ValueError("cron_expression is not supported for one-shot schedules")
+        return self
 
 
 class AutomationProjectRecord(BaseModel):

--- a/src/relay_teams/automation/automation_service.py
+++ b/src/relay_teams/automation/automation_service.py
@@ -7,6 +7,11 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pydantic import JsonValue
 
+from relay_teams.interfaces.server.api_write_validation import (
+    require_cascade_delete,
+    require_force_delete,
+)
+
 from relay_teams.automation.automation_bound_session_queue_service import (
     AutomationBoundSessionQueueService,
 )
@@ -244,8 +249,24 @@ class AutomationService:
         )
         return self._repository.update(updated)
 
-    def delete_project(self, automation_project_id: str) -> None:
-        _ = self._repository.get(automation_project_id)
+    def delete_project(
+        self,
+        automation_project_id: str,
+        *,
+        force: bool = False,
+        cascade: bool = False,
+    ) -> None:
+        project = self._repository.get(automation_project_id)
+        if project.status == AutomationProjectStatus.ENABLED:
+            require_force_delete(
+                force,
+                message="Cannot delete enabled automation project without force",
+            )
+        if self._has_dependent_project_data(automation_project_id):
+            require_cascade_delete(
+                cascade,
+                message="Cannot delete automation project without cascade while deliveries or queue records exist",
+            )
         if self._delivery_service is not None:
             self._delivery_service.delete_project_deliveries(automation_project_id)
         if self._bound_session_queue_service is not None:
@@ -253,6 +274,21 @@ class AutomationService:
                 automation_project_id
             )
         self._repository.delete(automation_project_id)
+
+    def _has_dependent_project_data(self, automation_project_id: str) -> bool:
+        if (
+            self._delivery_service is not None
+            and self._delivery_service.has_project_deliveries(automation_project_id)
+        ):
+            return True
+        if (
+            self._bound_session_queue_service is not None
+            and self._bound_session_queue_service.has_project_queue(
+                automation_project_id
+            )
+        ):
+            return True
+        return False
 
     def run_now(self, automation_project_id: str) -> dict[str, JsonValue]:
         project = self._repository.get(automation_project_id)

--- a/src/relay_teams/gateway/feishu/gateway_service.py
+++ b/src/relay_teams/gateway/feishu/gateway_service.py
@@ -29,6 +29,7 @@ from relay_teams.gateway.feishu.secret_store import (
     FeishuTriggerSecretStore,
     get_feishu_trigger_secret_store,
 )
+from relay_teams.interfaces.server.api_write_validation import require_force_delete
 from relay_teams.logger import get_logger, log_event
 from relay_teams.roles import RoleRegistry
 from relay_teams.sessions.external_session_binding_repository import (
@@ -38,6 +39,26 @@ from relay_teams.sessions.session_models import SessionMode, SessionRecord
 from relay_teams.workspace import WorkspaceService
 
 LOGGER = get_logger(__name__)
+
+
+def _secret_config_payload(
+    payload: FeishuTriggerSecretConfig | Mapping[str, str | None] | None,
+) -> dict[str, str | None] | None:
+    if payload is None:
+        return None
+    if isinstance(payload, FeishuTriggerSecretConfig):
+        return payload.model_dump(mode="json", exclude_unset=True)
+    return dict(payload.items())
+
+
+def _feishu_config_payload(
+    payload: (
+        Mapping[str, object] | FeishuTriggerSourceConfig | FeishuTriggerTargetConfig
+    ),
+) -> dict[str, object]:
+    if isinstance(payload, (FeishuTriggerSourceConfig, FeishuTriggerTargetConfig)):
+        return payload.model_dump(mode="json")
+    return dict(payload.items())
 
 
 class FeishuGatewayService:
@@ -89,15 +110,15 @@ class FeishuGatewayService:
                 if payload.enabled
                 else FeishuGatewayAccountStatus.DISABLED
             ),
-            source_config=payload.source_config,
-            target_config=payload.target_config,
+            source_config=payload.source_config.model_dump(mode="json"),
+            target_config=payload.target_config.model_dump(mode="json"),
             created_at=now,
             updated_at=now,
         )
         created = self._repository.create_account(record)
         self.save_secret_config(
             account_id=created.account_id,
-            secret_config_payload=payload.secret_config,
+            secret_config_payload=_secret_config_payload(payload.secret_config),
             require_app_secret=True,
         )
         return self.get_account(created.account_id)
@@ -118,12 +139,12 @@ class FeishuGatewayService:
                     else existing.display_name
                 ),
                 "source_config": (
-                    payload.source_config
+                    payload.source_config.model_dump(mode="json")
                     if payload.source_config is not None
                     else existing.source_config
                 ),
                 "target_config": (
-                    payload.target_config
+                    payload.target_config.model_dump(mode="json")
                     if payload.target_config is not None
                     else existing.target_config
                 ),
@@ -133,7 +154,7 @@ class FeishuGatewayService:
         stored = self._repository.update_account(updated)
         self.save_secret_config(
             account_id=stored.account_id,
-            secret_config_payload=payload.secret_config,
+            secret_config_payload=_secret_config_payload(payload.secret_config),
             require_app_secret=False,
         )
         if self.runtime_settings_changed(existing, stored):
@@ -161,8 +182,18 @@ class FeishuGatewayService:
         _ = self._repository.update_account(updated)
         return self.get_account(account_id)
 
-    def delete_account(self, account_id: str) -> None:
+    def delete_account(self, account_id: str, *, force: bool = False) -> None:
         _ = self._repository.get_account(account_id)
+        if any(
+            binding.trigger_id == account_id
+            for binding in self._external_session_binding_repo.list_by_platform(
+                "feishu"
+            )
+        ):
+            require_force_delete(
+                force,
+                message="Cannot delete Feishu account while external session bindings exist",
+            )
         self.clear_bindings(account_id)
         self.delete_secret_config(account_id)
         self._repository.delete_account(account_id)
@@ -211,7 +242,7 @@ class FeishuGatewayService:
         )
         _ = self._merge_secret_config(
             account_id=None,
-            secret_config_payload=request.secret_config,
+            secret_config_payload=_secret_config_payload(request.secret_config),
             require_app_secret=True,
         )
 
@@ -222,12 +253,12 @@ class FeishuGatewayService:
         request: FeishuGatewayAccountUpdateInput,
     ) -> None:
         merged_source = (
-            request.source_config
+            request.source_config.model_dump(mode="json")
             if request.source_config is not None
             else existing.source_config
         )
         merged_target = (
-            request.target_config
+            request.target_config.model_dump(mode="json")
             if request.target_config is not None
             else existing.target_config
         )
@@ -238,7 +269,7 @@ class FeishuGatewayService:
         if request.secret_config is not None:
             _ = self._merge_secret_config(
                 account_id=existing.account_id,
-                secret_config_payload=request.secret_config,
+                secret_config_payload=_secret_config_payload(request.secret_config),
                 require_app_secret=False,
             )
 
@@ -246,7 +277,7 @@ class FeishuGatewayService:
         self,
         *,
         account_id: str,
-        secret_config_payload: Mapping[str, str] | None,
+        secret_config_payload: Mapping[str, str | None] | None,
         require_app_secret: bool,
     ) -> None:
         if secret_config_payload is None:
@@ -355,11 +386,11 @@ class FeishuGatewayService:
         after_source_config = (
             existing.source_config
             if request.source_config is None
-            else request.source_config
+            else request.source_config.model_dump(mode="json")
         )
         after_secret_config = self._merge_secret_config(
             account_id=existing.account_id,
-            secret_config_payload=request.secret_config,
+            secret_config_payload=_secret_config_payload(request.secret_config),
             require_app_secret=False,
         )
         after_signature = self._subscription_runtime_signature(
@@ -381,12 +412,14 @@ class FeishuGatewayService:
     def _validate_source_and_target(
         self,
         *,
-        source_config: Mapping[str, object],
-        target_config: Mapping[str, object] | None,
+        source_config: Mapping[str, object] | FeishuTriggerSourceConfig,
+        target_config: Mapping[str, object] | FeishuTriggerTargetConfig | None,
     ) -> None:
-        source = FeishuTriggerSourceConfig.model_validate(dict(source_config.items()))
+        source = FeishuTriggerSourceConfig.model_validate(
+            _feishu_config_payload(source_config)
+        )
         target = FeishuTriggerTargetConfig.model_validate(
-            {} if target_config is None else dict(target_config.items())
+            {} if target_config is None else _feishu_config_payload(target_config)
         )
         self._require_workspace(target.workspace_id)
         normalized_root_role_id = self._resolve_normal_root_role_id(
@@ -468,7 +501,7 @@ class FeishuGatewayService:
         self,
         *,
         account_id: str | None,
-        secret_config_payload: Mapping[str, str] | None,
+        secret_config_payload: Mapping[str, str | None] | None,
         require_app_secret: bool,
     ) -> FeishuTriggerSecretConfig:
         payload = (

--- a/src/relay_teams/gateway/feishu/inbound_runtime.py
+++ b/src/relay_teams/gateway/feishu/inbound_runtime.py
@@ -57,7 +57,9 @@ class SessionServiceLike(Protocol):
 
     def get_session(self, session_id: str) -> SessionRecord: ...
 
-    def update_session(self, session_id: str, metadata: dict[str, str]) -> None: ...
+    def sync_session_metadata(
+        self, session_id: str, metadata: dict[str, str]
+    ) -> None: ...
 
     def get_session_messages(self, session_id: str) -> list[dict[str, object]]: ...
 
@@ -174,7 +176,9 @@ class FeishuInboundRuntime:
                 current_metadata=session.metadata,
                 next_metadata=metadata,
             )
-            self._session_service.update_session(session.session_id, merged_metadata)
+            self._session_service.sync_session_metadata(
+                session.session_id, merged_metadata
+            )
             return session.session_id
 
         session = self._create_session(runtime_config=runtime_config, metadata=metadata)

--- a/src/relay_teams/gateway/feishu/models.py
+++ b/src/relay_teams/gateway/feishu/models.py
@@ -5,8 +5,20 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    field_validator,
+    model_validator,
+)
 
+from relay_teams.interfaces.server.api_write_validation import (
+    normalize_optional_string,
+    reject_empty_mapping_patch,
+    require_non_empty_patch,
+)
 from relay_teams.sessions.runs.run_models import RunThinkingConfig
 from relay_teams.sessions.session_models import SessionMode
 from relay_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
@@ -132,10 +144,17 @@ class FeishuGatewayAccountCreateInput(BaseModel):
 
     name: RequiredIdentifierStr
     display_name: str | None = None
-    source_config: dict[str, JsonValue] = Field(default_factory=dict)
-    target_config: dict[str, JsonValue] | None = None
-    secret_config: dict[str, str] | None = None
+    source_config: FeishuTriggerSourceConfig
+    target_config: FeishuTriggerTargetConfig = Field(
+        default_factory=FeishuTriggerTargetConfig
+    )
+    secret_config: FeishuTriggerSecretConfig | None = None
     enabled: bool = True
+
+    @field_validator("display_name")
+    @classmethod
+    def _normalize_display_name(cls, value: str | None) -> str | None:
+        return normalize_optional_string(value, field_name="display_name")
 
 
 class FeishuGatewayAccountUpdateInput(BaseModel):
@@ -143,9 +162,25 @@ class FeishuGatewayAccountUpdateInput(BaseModel):
 
     name: OptionalIdentifierStr = None
     display_name: str | None = None
-    source_config: dict[str, JsonValue] | None = None
-    target_config: dict[str, JsonValue] | None = None
-    secret_config: dict[str, str] | None = None
+    source_config: FeishuTriggerSourceConfig | None = None
+    target_config: FeishuTriggerTargetConfig | None = None
+    secret_config: FeishuTriggerSecretConfig | None = None
+
+    @field_validator("display_name")
+    @classmethod
+    def _normalize_patch_display_name(cls, value: str | None) -> str | None:
+        return normalize_optional_string(value, field_name="display_name")
+
+    @field_validator("source_config", "target_config", "secret_config", mode="before")
+    @classmethod
+    def _reject_empty_config_patch(cls, value: object) -> object:
+        return reject_empty_mapping_patch(
+            value, message="config patch must not be empty"
+        )
+
+    @model_validator(mode="after")
+    def _validate_patch(self) -> FeishuGatewayAccountUpdateInput:
+        return require_non_empty_patch(self)
 
 
 class FeishuGatewayAccountRecord(BaseModel):

--- a/src/relay_teams/gateway/gateway_cli.py
+++ b/src/relay_teams/gateway/gateway_cli.py
@@ -138,6 +138,7 @@ def build_gateway_app(
         @feishu_app.command("delete")
         def feishu_delete(
             account_id: str = typer.Option(..., "--account-id"),
+            force: bool = typer.Option(True, "--force/--no-force"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
         ) -> None:
@@ -146,7 +147,7 @@ def build_gateway_app(
                 base_url,
                 "DELETE",
                 f"/api/gateway/feishu/accounts/{account_id}",
-                None,
+                {"force": force},
             )
             typer.echo(json.dumps(result, ensure_ascii=False))
 
@@ -264,6 +265,7 @@ def build_gateway_app(
         @wechat_app.command("delete")
         def wechat_delete(
             account_id: str = typer.Option(..., "--account-id"),
+            force: bool = typer.Option(True, "--force/--no-force"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
         ) -> None:
@@ -272,7 +274,7 @@ def build_gateway_app(
                 base_url,
                 "DELETE",
                 f"/api/gateway/wechat/accounts/{account_id}",
-                None,
+                {"force": force},
             )
             typer.echo(json.dumps(result, ensure_ascii=False))
 

--- a/src/relay_teams/gateway/wechat/models.py
+++ b/src/relay_teams/gateway/wechat/models.py
@@ -5,8 +5,12 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from relay_teams.interfaces.server.api_write_validation import (
+    normalize_optional_string,
+    require_non_empty_patch,
+)
 from relay_teams.sessions.runs.run_models import RunThinkingConfig
 from relay_teams.sessions.session_models import SessionMode
 from relay_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
@@ -83,6 +87,27 @@ class WeChatAccountUpdateInput(BaseModel):
     orchestration_preset_id: OptionalIdentifierStr = None
     yolo: bool | None = None
     thinking: RunThinkingConfig | None = None
+
+    @field_validator("display_name", "base_url", "cdn_base_url")
+    @classmethod
+    def _normalize_optional_text(cls, value: str | None, info) -> str | None:
+        return normalize_optional_string(
+            value,
+            field_name=info.field_name,
+        )
+
+    @field_validator("route_tag")
+    @classmethod
+    def _normalize_route_tag(cls, value: str | None) -> str | None:
+        return normalize_optional_string(
+            value,
+            field_name="route_tag",
+            empty_to_none=True,
+        )
+
+    @model_validator(mode="after")
+    def _validate_patch(self) -> WeChatAccountUpdateInput:
+        return require_non_empty_patch(self)
 
 
 class WeChatLoginStartRequest(BaseModel):

--- a/src/relay_teams/gateway/wechat/service.py
+++ b/src/relay_teams/gateway/wechat/service.py
@@ -20,6 +20,7 @@ import qrcode
 import qrcode.image.svg
 
 from relay_teams.gateway.gateway_models import GatewayChannelType
+from relay_teams.interfaces.server.api_write_validation import require_force_delete
 from relay_teams.gateway.gateway_session_service import GatewaySessionService
 from relay_teams.gateway.session_ingress_service import (
     GatewaySessionIngressBusyPolicy,
@@ -294,11 +295,8 @@ class WeChatGatewayService:
             if not preset_id:
                 raise ValueError("orchestration_preset_id is required")
             settings = self._orchestration_settings_service.get_orchestration_config()
-            presets = settings.get("presets")
-            if not isinstance(presets, list) or not any(
-                isinstance(item, dict) and item.get("preset_id") == preset_id
-                for item in presets
-            ):
+            presets = settings.presets
+            if not any(item.preset_id == preset_id for item in presets):
                 raise ValueError(f"Unknown orchestration preset: {preset_id}")
             orchestration_preset_id = preset_id
         updated = existing.model_copy(
@@ -307,7 +305,7 @@ class WeChatGatewayService:
                 "base_url": request.base_url or existing.base_url,
                 "cdn_base_url": request.cdn_base_url or existing.cdn_base_url,
                 "route_tag": request.route_tag
-                if request.route_tag is not None
+                if "route_tag" in request.model_fields_set
                 else existing.route_tag,
                 "status": (
                     WeChatAccountStatus.ENABLED
@@ -337,7 +335,13 @@ class WeChatGatewayService:
             WeChatAccountUpdateInput(enabled=enabled),
         )
 
-    def delete_account(self, account_id: str) -> None:
+    def delete_account(self, account_id: str, *, force: bool = False) -> None:
+        account = self._repository.get_account(account_id)
+        if account.status == WeChatAccountStatus.ENABLED:
+            require_force_delete(
+                force,
+                message="Cannot delete enabled WeChat account without force",
+            )
         self._stop_account_worker(account_id)
         self._secret_store.delete_bot_token(self._config_dir, account_id)
         self._repository.delete_account(account_id)

--- a/src/relay_teams/interfaces/sdk/client.py
+++ b/src/relay_teams/interfaces/sdk/client.py
@@ -534,10 +534,16 @@ class AgentTeamsClient:
             {},
         )
 
-    def delete_feishu_gateway_account(self, account_id: str) -> dict[str, JsonValue]:
+    def delete_feishu_gateway_account(
+        self,
+        account_id: str,
+        *,
+        force: bool = True,
+    ) -> dict[str, JsonValue]:
         return self._request_json(
             "DELETE",
             f"/api/gateway/feishu/accounts/{quote(account_id, safe='')}",
+            {"force": force},
         )
 
     def reload_feishu_gateway(self) -> dict[str, JsonValue]:
@@ -742,10 +748,16 @@ class AgentTeamsClient:
             {},
         )
 
-    def delete_wechat_gateway_account(self, account_id: str) -> dict[str, JsonValue]:
+    def delete_wechat_gateway_account(
+        self,
+        account_id: str,
+        *,
+        force: bool = True,
+    ) -> dict[str, JsonValue]:
         return self._request_json(
             "DELETE",
             f"/api/gateway/wechat/accounts/{account_id}",
+            {"force": force},
         )
 
     def reload_wechat_gateway(self) -> dict[str, JsonValue]:

--- a/src/relay_teams/interfaces/server/api_write_validation.py
+++ b/src/relay_teams/interfaces/server/api_write_validation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Protocol, TypeVar, cast
+
+
+class _HasModelFieldsSet(Protocol):
+    @property
+    def model_fields_set(self) -> set[str]: ...
+
+
+ModelT = TypeVar("ModelT", bound=_HasModelFieldsSet)
+
+
+def require_non_empty_patch(
+    model: ModelT,
+    *,
+    message: str = "update must include at least one field",
+) -> ModelT:
+    if not model.model_fields_set:
+        raise ValueError(message)
+    return model
+
+
+def normalize_optional_text_field(
+    value: object,
+    *,
+    field_name: str,
+    empty_to_none: bool = False,
+) -> object:
+    if not isinstance(value, str):
+        return value
+    normalized = value.strip()
+    if normalized:
+        return normalized
+    if empty_to_none:
+        return None
+    raise ValueError(f"{field_name} must not be empty")
+
+
+def normalize_optional_string(
+    value: str | None,
+    *,
+    field_name: str,
+    empty_to_none: bool = False,
+) -> str | None:
+    return cast(
+        str | None,
+        normalize_optional_text_field(
+            value,
+            field_name=field_name,
+            empty_to_none=empty_to_none,
+        ),
+    )
+
+
+def reject_empty_mapping_patch(value: object, *, message: str) -> object:
+    if isinstance(value, dict) and not value:
+        raise ValueError(message)
+    return value
+
+
+def require_force_delete(force: bool, *, message: str) -> None:
+    if not force:
+        raise RuntimeError(message)
+
+
+def require_cascade_delete(cascade: bool, *, message: str) -> None:
+    if not cascade:
+        raise RuntimeError(message)

--- a/src/relay_teams/interfaces/server/router_error_mapping.py
+++ b/src/relay_teams/interfaces/server/router_error_mapping.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+
+def http_exception_for(
+    exc: Exception,
+    *,
+    key_error_detail: str | None = None,
+    mappings: tuple[tuple[type[Exception], int], ...] = (),
+) -> HTTPException:
+    if isinstance(exc, KeyError):
+        return HTTPException(status_code=404, detail=key_error_detail or str(exc))
+    for exc_type, status_code in mappings:
+        if isinstance(exc, exc_type):
+            return HTTPException(status_code=status_code, detail=str(exc))
+    raise TypeError(f"Unsupported exception mapping: {type(exc).__name__}")

--- a/src/relay_teams/interfaces/server/routers/automation.py
+++ b/src/relay_teams/interfaces/server/routers/automation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import JsonValue
 
 from relay_teams.automation import (
@@ -15,6 +15,8 @@ from relay_teams.automation import (
     AutomationService,
 )
 from relay_teams.interfaces.server.deps import get_automation_service
+from relay_teams.interfaces.server.router_error_mapping import http_exception_for
+from relay_teams.interfaces.server.write_models import DeleteRequest
 from relay_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/automation", tags=["Automation"])
@@ -34,10 +36,11 @@ def create_project(
 ) -> AutomationProjectRecord:
     try:
         return service.create_project(req)
-    except AutomationProjectNameConflictError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (AutomationProjectNameConflictError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((AutomationProjectNameConflictError, 409), (ValueError, 422)),
+        ) from exc
 
 
 @router.get("/projects", response_model=list[AutomationProjectRecord])
@@ -55,7 +58,7 @@ def get_project(
     try:
         return service.get_project(automation_project_id)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise http_exception_for(exc) from exc
 
 
 @router.patch(
@@ -68,24 +71,31 @@ def update_project(
 ) -> AutomationProjectRecord:
     try:
         return service.update_project(automation_project_id, req)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except AutomationProjectNameConflictError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (KeyError, AutomationProjectNameConflictError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((AutomationProjectNameConflictError, 409), (ValueError, 422)),
+        ) from exc
 
 
 @router.delete("/projects/{automation_project_id}")
 def delete_project(
     automation_project_id: RequiredIdentifierStr,
     service: Annotated[AutomationService, Depends(get_automation_service)],
+    req: DeleteRequest | None = Body(default=None),
 ) -> dict[str, JsonValue]:
     try:
-        service.delete_project(automation_project_id)
+        service.delete_project(
+            automation_project_id,
+            force=req.force if req is not None else False,
+            cascade=req.cascade if req is not None else False,
+        )
         return {"status": "ok"}
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (KeyError, RuntimeError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((RuntimeError, 409),),
+        ) from exc
 
 
 @router.post("/projects/{automation_project_id}:run")
@@ -95,10 +105,11 @@ async def run_project(
 ) -> dict[str, JsonValue]:
     try:
         return service.run_now(automation_project_id)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (KeyError, RuntimeError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((RuntimeError, 409),),
+        ) from exc
 
 
 @router.post(
@@ -113,10 +124,11 @@ def enable_project(
             automation_project_id,
             AutomationProjectStatus.ENABLED,
         )
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 422),),
+        ) from exc
 
 
 @router.post(

--- a/src/relay_teams/interfaces/server/routers/feishu_gateway.py
+++ b/src/relay_teams/interfaces/server/routers/feishu_gateway.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 
 from relay_teams.gateway.feishu import (
     FeishuAccountNameConflictError,
@@ -17,6 +17,8 @@ from relay_teams.interfaces.server.deps import (
     get_feishu_gateway_service,
     get_feishu_subscription_service,
 )
+from relay_teams.interfaces.server.router_error_mapping import http_exception_for
+from relay_teams.interfaces.server.write_models import DeleteRequest
 from relay_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/gateway/feishu", tags=["Gateway"])
@@ -42,10 +44,11 @@ def create_feishu_account(
         created = service.create_account(req)
         subscription_service.reload()
         return created
-    except FeishuAccountNameConflictError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (FeishuAccountNameConflictError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((FeishuAccountNameConflictError, 409), (ValueError, 422)),
+        ) from exc
 
 
 @router.patch("/accounts/{account_id}", response_model=FeishuGatewayAccountRecord)
@@ -69,12 +72,11 @@ def update_feishu_account(
         if reload_required:
             subscription_service.reload()
         return updated
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except FeishuAccountNameConflictError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (KeyError, FeishuAccountNameConflictError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((FeishuAccountNameConflictError, 409), (ValueError, 422)),
+        ) from exc
 
 
 @router.post("/accounts/{account_id}:enable", response_model=FeishuGatewayAccountRecord)
@@ -90,10 +92,11 @@ def enable_feishu_account(
         updated = service.set_account_enabled(account_id, True)
         subscription_service.reload()
         return updated
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 422),),
+        ) from exc
 
 
 @router.post(
@@ -123,13 +126,19 @@ def delete_feishu_account(
         FeishuSubscriptionService,
         Depends(get_feishu_subscription_service),
     ],
+    req: DeleteRequest | None = Body(default=None),
 ) -> dict[str, str]:
     try:
-        service.delete_account(account_id)
+        service.delete_account(
+            account_id, force=req.force if req is not None else False
+        )
         subscription_service.reload()
         return {"status": "ok"}
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (KeyError, RuntimeError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((RuntimeError, 409),),
+        ) from exc
 
 
 @router.post("/reload")

--- a/src/relay_teams/interfaces/server/routers/gateway.py
+++ b/src/relay_teams/interfaces/server/routers/gateway.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 
-from relay_teams.interfaces.server.deps import get_wechat_gateway_service
 from relay_teams.gateway.wechat import (
     WeChatAccountRecord,
     WeChatAccountUpdateInput,
@@ -14,6 +13,9 @@ from relay_teams.gateway.wechat import (
     WeChatLoginWaitRequest,
     WeChatLoginWaitResponse,
 )
+from relay_teams.interfaces.server.deps import get_wechat_gateway_service
+from relay_teams.interfaces.server.router_error_mapping import http_exception_for
+from relay_teams.interfaces.server.write_models import DeleteRequest
 from relay_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/gateway", tags=["Gateway"])
@@ -34,7 +36,7 @@ def start_wechat_login(
     try:
         return service.start_login(req)
     except RuntimeError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise http_exception_for(exc, mappings=((RuntimeError, 400),)) from exc
 
 
 @router.post("/wechat/login/wait", response_model=WeChatLoginWaitResponse)
@@ -44,10 +46,11 @@ def wait_wechat_login(
 ) -> WeChatLoginWaitResponse:
     try:
         return service.wait_login(req)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (KeyError, RuntimeError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((RuntimeError, 400),),
+        ) from exc
 
 
 @router.patch("/wechat/accounts/{account_id}", response_model=WeChatAccountRecord)
@@ -58,10 +61,11 @@ def update_wechat_account(
 ) -> WeChatAccountRecord:
     try:
         return service.update_account(account_id, req)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 422),),
+        ) from exc
 
 
 @router.post("/wechat/accounts/{account_id}:enable", response_model=WeChatAccountRecord)
@@ -71,10 +75,11 @@ def enable_wechat_account(
 ) -> WeChatAccountRecord:
     try:
         return service.set_account_enabled(account_id, True)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 422),),
+        ) from exc
 
 
 @router.post(
@@ -86,22 +91,28 @@ def disable_wechat_account(
 ) -> WeChatAccountRecord:
     try:
         return service.set_account_enabled(account_id, False)
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 422),),
+        ) from exc
 
 
 @router.delete("/wechat/accounts/{account_id}")
 def delete_wechat_account(
     account_id: RequiredIdentifierStr,
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
+    req: DeleteRequest | None = Body(default=None),
 ) -> dict[str, str]:
     try:
-        service.delete_account(account_id)
+        service.delete_account(
+            account_id, force=req.force if req is not None else False
+        )
         return {"status": "ok"}
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise http_exception_for(exc, mappings=((RuntimeError, 409),)) from exc
 
 
 @router.post("/wechat/reload")

--- a/src/relay_teams/interfaces/server/routers/prompts.py
+++ b/src/relay_teams/interfaces/server/routers/prompts.py
@@ -5,7 +5,7 @@ import json
 from typing import Annotated, ClassVar
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, RootModel, model_validator
 
 from relay_teams.agents.execution.prompt_instructions import PromptInstructionResolver
 from relay_teams.interfaces.server.deps import (
@@ -43,13 +43,35 @@ from relay_teams.workspace import WorkspaceManager, WorkspaceService
 router = APIRouter(prefix="/prompts", tags=["Prompts"])
 
 
+class PromptSharedState(RootModel[dict[str, JsonValue]]):
+    @model_validator(mode="after")
+    def _normalize_keys(self) -> "PromptSharedState":
+        normalized: dict[str, JsonValue] = {}
+        for key, value in self.root.items():
+            normalized_key = str(key).strip()
+            if not normalized_key:
+                raise ValueError("shared_state keys must not be blank")
+            normalized[normalized_key] = value
+        self.root = normalized
+        return self
+
+    def to_snapshot(self) -> tuple[tuple[str, str], ...]:
+        normalized_items = [
+            (str(key), _json_value_to_text(value)) for key, value in self.root.items()
+        ]
+        normalized_items.sort(key=lambda item: item[0])
+        return tuple(normalized_items)
+
+
 class PromptPreviewRequest(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     role_id: RequiredIdentifierStr
     workspace_id: OptionalIdentifierStr = None
     objective: str | None = None
-    shared_state: dict[str, JsonValue] = Field(default_factory=dict)
+    shared_state: PromptSharedState = Field(
+        default_factory=lambda: PromptSharedState({})
+    )
     tools: tuple[str, ...] | None = None
     skills: tuple[str, ...] | None = None
     conversation_context: RuntimePromptConversationContext | None = None
@@ -116,7 +138,7 @@ async def preview_prompts(
             consumer="interfaces.server.routers.prompts.preview",
         )
     objective = req.objective.strip() if req.objective else ""
-    shared_state_snapshot = _to_shared_state_snapshot(req.shared_state)
+    shared_state_snapshot = req.shared_state.to_snapshot()
 
     working_directory = None
     worktree_root = None
@@ -187,16 +209,6 @@ async def preview_prompts(
         user_prompt=user_prompt,
         skill_routing=skill_prompt_result.routing.diagnostics,
     )
-
-
-def _to_shared_state_snapshot(
-    shared_state: dict[str, JsonValue],
-) -> tuple[tuple[str, str], ...]:
-    normalized_items = [
-        (str(key), _json_value_to_text(value)) for key, value in shared_state.items()
-    ]
-    normalized_items.sort(key=lambda item: item[0])
-    return tuple(normalized_items)
 
 
 def _json_value_to_text(value: JsonValue) -> str:

--- a/src/relay_teams/interfaces/server/routers/roles.py
+++ b/src/relay_teams/interfaces/server/routers/roles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 
 from relay_teams.computer import ExecutionSurface
 from relay_teams.interfaces.server.deps import (
@@ -28,6 +28,7 @@ from relay_teams.roles import (
     ensure_required_system_roles,
 )
 from relay_teams.external_agents import ExternalAgentConfigService
+from relay_teams.interfaces.server.router_error_mapping import http_exception_for
 from relay_teams.roles.settings_service import RoleSettingsService
 from relay_teams.skills.config_reload_service import SkillsConfigReloadService
 from relay_teams.skills.skill_registry import SkillRegistry
@@ -96,10 +97,11 @@ def get_role_config_options(
             ),
             execution_surfaces=tuple(surface for surface in ExecutionSurface),
         )
-    except SystemRolesUnavailableError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except (SystemRolesUnavailableError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((SystemRolesUnavailableError, 503), (ValueError, 503)),
+        ) from exc
 
 
 @router.get(
@@ -125,7 +127,7 @@ def get_role_config(
     try:
         return service.get_role_document(role_id)
     except ValueError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise http_exception_for(exc, mappings=((ValueError, 404),)) from exc
 
 
 @router.put(
@@ -141,7 +143,7 @@ def save_role_config(
     try:
         return service.save_role_document(role_id, draft)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise http_exception_for(exc, mappings=((ValueError, 400),)) from exc
 
 
 @router.delete("/configs/{role_id}")
@@ -154,8 +156,8 @@ def delete_role_config(
         return {"status": "ok"}
     except ValueError as exc:
         if str(exc).startswith("Role not found:"):
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise http_exception_for(exc, mappings=((ValueError, 404),)) from exc
+        raise http_exception_for(exc, mappings=((ValueError, 400),)) from exc
 
 
 @router.post(":validate", response_model=dict[str, int | bool])
@@ -164,10 +166,11 @@ def validate_roles(
 ) -> dict[str, int | bool]:
     try:
         return service.validate_all_roles()
-    except SystemRolesUnavailableError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (SystemRolesUnavailableError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((SystemRolesUnavailableError, 503), (ValueError, 400)),
+        ) from exc
 
 
 @router.post(
@@ -182,7 +185,7 @@ def validate_role_config(
     try:
         return service.validate_role_document(draft)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise http_exception_for(exc, mappings=((ValueError, 400),)) from exc
 
 
 def _load_role_skill_options(

--- a/src/relay_teams/interfaces/server/routers/runs.py
+++ b/src/relay_teams/interfaces/server/routers/runs.py
@@ -10,6 +10,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from relay_teams.interfaces.server.deps import get_run_service
+from relay_teams.interfaces.server.router_error_mapping import http_exception_for
 from relay_teams.logger import get_logger, log_event
 from relay_teams.media import (
     ContentPart,
@@ -323,7 +324,7 @@ def inject_message(
             )
         return result.model_dump()
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise http_exception_for(exc) from exc
 
 
 @router.get("/{run_id}/tool-approvals")
@@ -351,7 +352,7 @@ def list_background_tasks(
     try:
         return {"items": list(service.list_background_tasks(run_id))}
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise http_exception_for(exc) from exc
 
 
 @router.get("/{run_id}/background-tasks/{background_task_id}")
@@ -368,7 +369,7 @@ def get_background_task(
             )
         }
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise http_exception_for(exc) from exc
 
 
 @router.post(
@@ -387,7 +388,7 @@ async def stop_background_task(
         )
         return StopBackgroundTaskResponse(background_task=result)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise http_exception_for(exc) from exc
 
 
 @router.post("/{run_id}/tool-approvals/{tool_call_id}/resolve")
@@ -416,7 +417,7 @@ def resolve_tool_approval(
             )
         return {"status": "ok", "action": req.action}
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise http_exception_for(exc) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
@@ -458,10 +459,11 @@ def stop_run(
             "scope": "subagent",
             "instance_id": payload["instance_id"],
         }
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 400),),
+        ) from exc
 
 
 @router.post("/{run_id}:resume")
@@ -480,10 +482,11 @@ async def resume_run(
                 message="Run resume requested",
             )
         return {"status": "ok", "run_id": run_id, "session_id": session_id}
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (KeyError, RuntimeError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((RuntimeError, 409),),
+        ) from exc
 
 
 @router.post("/{run_id}/subagents/{instance_id}/inject")
@@ -510,7 +513,8 @@ def inject_subagent(
                 payload={"length": len(req.content)},
             )
         return {"status": "ok", "instance_id": instance_id}
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (KeyError, RuntimeError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((RuntimeError, 409),),
+        ) from exc

--- a/src/relay_teams/interfaces/server/routers/sessions.py
+++ b/src/relay_teams/interfaces/server/routers/sessions.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from relay_teams.interfaces.server.deps import get_session_service
+from relay_teams.interfaces.server.router_error_mapping import http_exception_for
+from relay_teams.interfaces.server.write_models import DeleteRequest
 from relay_teams.roles import SystemRolesUnavailableError
 from relay_teams.sessions import SessionService
-from relay_teams.sessions.session_models import SessionMode, SessionRecord
+from relay_teams.sessions.session_models import (
+    SessionCreateMetadata,
+    SessionMetadataPatch,
+    SessionMode,
+    SessionRecord,
+    normalize_session_create_metadata_input,
+)
 from relay_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 router = APIRouter(prefix="/sessions", tags=["Sessions"])
@@ -17,13 +25,12 @@ class CreateSessionRequest(BaseModel):
 
     session_id: OptionalIdentifierStr = None
     workspace_id: RequiredIdentifierStr
-    metadata: dict[str, str] | None = None
+    metadata: SessionCreateMetadata | None = None
 
-
-class UpdateSessionRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    metadata: dict[str, str]
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _normalize_metadata(cls, value: object) -> object:
+        return normalize_session_create_metadata_input(value)
 
 
 class UpdateSessionTopologyRequest(BaseModel):
@@ -49,10 +56,15 @@ def create_session(
         return service.create_session(
             session_id=req.session_id,
             workspace_id=req.workspace_id,
-            metadata=req.metadata,
+            metadata=(
+                None if req.metadata is None else req.metadata.to_metadata_dict()
+            ),
         )
-    except SystemRolesUnavailableError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except (SystemRolesUnavailableError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((SystemRolesUnavailableError, 503), (ValueError, 422)),
+        ) from exc
 
 
 @router.get("", response_model=list[SessionRecord])
@@ -70,20 +82,22 @@ def get_session(
     try:
         return service.get_session(session_id)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="Session not found") from exc
+        raise http_exception_for(exc, key_error_detail="Session not found") from exc
 
 
 @router.patch("/{session_id}")
 def update_session(
     session_id: RequiredIdentifierStr,
-    req: UpdateSessionRequest,
+    req: SessionMetadataPatch,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, str]:
     try:
-        service.update_session(session_id, req.metadata)
+        service.update_session(session_id, req)
         return {"status": "ok"}
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="Session not found") from exc
+        raise http_exception_for(exc, key_error_detail="Session not found") from exc
+    except ValueError as exc:
+        raise http_exception_for(exc, mappings=((ValueError, 422),)) from exc
 
 
 @router.patch("/{session_id}/topology", response_model=SessionRecord)
@@ -100,9 +114,12 @@ def update_session_topology(
             orchestration_preset_id=req.orchestration_preset_id,
         )
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="Session not found") from exc
+        raise http_exception_for(exc, key_error_detail="Session not found") from exc
     except SystemRolesUnavailableError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        raise http_exception_for(
+            exc,
+            mappings=((SystemRolesUnavailableError, 503),),
+        ) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
@@ -112,13 +129,20 @@ def update_session_topology(
 @router.delete("/{session_id}")
 def delete_session(
     session_id: RequiredIdentifierStr,
+    req: DeleteRequest | None = Body(default=None),
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, str]:
     try:
-        service.delete_session(session_id)
+        service.delete_session(
+            session_id,
+            force=req.force if req is not None else False,
+            cascade=req.cascade if req is not None else False,
+        )
         return {"status": "ok"}
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="Session not found") from exc
+        raise http_exception_for(exc, key_error_detail="Session not found") from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.get("/{session_id}/rounds")
@@ -143,7 +167,7 @@ def get_session_recovery(
     try:
         return service.get_recovery_snapshot(session_id)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="Session not found") from exc
+        raise http_exception_for(exc, key_error_detail="Session not found") from exc
 
 
 @router.get("/{session_id}/rounds/{run_id}")

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from typing import NoReturn
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, JsonValue
 
@@ -58,6 +60,7 @@ from relay_teams.interfaces.server.deps import (
 )
 from relay_teams.interfaces.server.ui_language_models import UiLanguageSettings
 from relay_teams.interfaces.server.ui_language_service import UiLanguageSettingsService
+from relay_teams.agents.orchestration.settings_models import OrchestrationSettings
 from relay_teams.agents.orchestration.settings_service import (
     OrchestrationSettingsService,
 )
@@ -67,14 +70,14 @@ from relay_teams.interfaces.server.runtime_identity import (
     build_server_health_payload,
 )
 from relay_teams.mcp.config_reload_service import McpConfigReloadService
+from relay_teams.notifications.models import NotificationConfig
 from relay_teams.notifications.notification_settings_service import (
     NotificationSettingsService,
 )
 from relay_teams.providers.model_config import (
-    DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
     DEFAULT_MAAS_BASE_URL,
-    MaaSAuthConfig,
-    ModelRequestHeader,
+    ModelConfigPayload,
+    ModelProfileConfigPayload,
     ProviderType,
 )
 from relay_teams.providers.model_config_service import ModelConfigService
@@ -100,6 +103,50 @@ from relay_teams.skills.clawhub_skill_service import ClawHubSkillService
 from relay_teams.validation import RequiredIdentifierStr
 
 router = APIRouter(prefix="/system", tags=["System"])
+
+
+class NotificationConfigRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    config: NotificationConfig
+
+
+class ModelConfigRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    config: ModelConfigPayload
+
+
+class OrchestrationConfigRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    config: OrchestrationSettings
+
+
+def _raise_system_http_error(
+    exc: Exception,
+    *,
+    key_error_status: int | None = None,
+    key_error_detail: str | None = None,
+    permission_error_status: int | None = None,
+    value_error_status: int | None = None,
+    runtime_error_status: int | None = None,
+    os_error_status: int | None = None,
+) -> NoReturn:
+    if permission_error_status is not None and isinstance(exc, PermissionError):
+        raise HTTPException(
+            status_code=permission_error_status, detail=str(exc)
+        ) from exc
+    if key_error_status is not None and isinstance(exc, KeyError):
+        detail = key_error_detail if key_error_detail is not None else str(exc)
+        raise HTTPException(status_code=key_error_status, detail=detail) from exc
+    if value_error_status is not None and isinstance(exc, ValueError):
+        raise HTTPException(status_code=value_error_status, detail=str(exc)) from exc
+    if runtime_error_status is not None and isinstance(exc, RuntimeError):
+        raise HTTPException(status_code=runtime_error_status, detail=str(exc)) from exc
+    if os_error_status is not None and isinstance(exc, OSError):
+        raise HTTPException(status_code=os_error_status, detail=str(exc)) from exc
+    raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.get("/health")
@@ -137,7 +184,7 @@ def save_ui_language_settings(
     try:
         service.save_ui_language_settings(req)
         return {"status": "ok"}
-    except Exception as exc:
+    except OSError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
@@ -155,23 +202,10 @@ def get_model_profiles(
     return service.get_model_profiles()
 
 
-class ModelProfileRequest(BaseModel):
+class ModelProfileRequest(ModelProfileConfigPayload):
     model_config = ConfigDict(extra="forbid")
 
     source_name: str | None = None
-    provider: ProviderType = ProviderType.OPENAI_COMPATIBLE
-    is_default: bool | None = None
-    model: str
-    base_url: str
-    api_key: str | None = None
-    headers: tuple[ModelRequestHeader, ...] | None = None
-    maas_auth: MaaSAuthConfig | None = None
-    ssl_verify: bool | None = None
-    temperature: float = 0.7
-    top_p: float = 1.0
-    max_tokens: int | None = None
-    context_window: int | None = None
-    connect_timeout_seconds: float = DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS
 
 
 @router.put("/configs/model/profiles/{name}")
@@ -211,7 +245,11 @@ def save_model_profile(
         service.save_model_profile(name, profile, source_name=req.source_name)
         return {"status": "ok"}
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        _raise_system_http_error(
+            exc,
+            key_error_status=404,
+            value_error_status=400,
+        )
 
 
 @router.get("/configs/model/providers/models")
@@ -234,25 +272,24 @@ def delete_model_profile(
         service.delete_model_profile(name)
         return {"status": "ok"}
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-
-class ModelConfigRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    config: dict[str, JsonValue]
+        _raise_system_http_error(
+            exc,
+            key_error_status=404,
+            value_error_status=400,
+        )
 
 
 @router.put("/configs/model")
 def save_model_config(
-    req: ModelConfigRequest,
+    req: ModelConfigPayload | ModelConfigRequest,
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> dict[str, str]:
     try:
-        service.save_model_config(req.config)
+        config = req.config if isinstance(req, ModelConfigRequest) else req
+        service.save_model_config(config)
         return {"status": "ok"}
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        _raise_system_http_error(exc, value_error_status=400)
 
 
 @router.post("/configs/model:probe")
@@ -280,7 +317,7 @@ def discover_model_catalog(
 @router.get("/configs/notifications")
 def get_notification_config(
     service: NotificationSettingsService = Depends(get_notification_settings_service),
-) -> dict[str, JsonValue]:
+) -> NotificationConfig:
     return service.get_notification_config()
 
 
@@ -303,12 +340,13 @@ def save_environment_variable(
 ) -> EnvironmentVariableRecord:
     try:
         return service.save_environment_variable(scope=scope, key=key, request=req)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        _raise_system_http_error(
+            exc,
+            permission_error_status=403,
+            value_error_status=400,
+            runtime_error_status=400,
+        )
 
 
 @router.delete("/configs/environment-variables/{scope}/{key}")
@@ -320,12 +358,13 @@ def delete_environment_variable(
     try:
         service.delete_environment_variable(scope=scope, key=key)
         return {"status": "ok"}
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except PermissionError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        _raise_system_http_error(
+            exc,
+            permission_error_status=403,
+            value_error_status=400,
+            runtime_error_status=400,
+        )
 
 
 @router.get("/configs/proxy")
@@ -343,10 +382,12 @@ def save_proxy_config(
     try:
         service.save_proxy_config(req)
         return {"status": "ok"}
-    except (ValueError, RuntimeError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        _raise_system_http_error(
+            exc,
+            value_error_status=400,
+            runtime_error_status=400,
+        )
 
 
 @router.get("/configs/web")
@@ -364,10 +405,12 @@ def save_web_config(
     try:
         service.save_web_config(req)
         return {"status": "ok"}
-    except (ValueError, RuntimeError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        _raise_system_http_error(
+            exc,
+            value_error_status=400,
+            runtime_error_status=400,
+        )
 
 
 @router.get("/configs/agents", response_model=list[ExternalAgentSummary])
@@ -442,10 +485,12 @@ def save_github_config(
     try:
         service.save_github_config(req)
         return {"status": "ok"}
-    except (ValueError, RuntimeError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        _raise_system_http_error(
+            exc,
+            value_error_status=400,
+            runtime_error_status=400,
+        )
 
 
 @router.get("/configs/clawhub")
@@ -463,10 +508,12 @@ def save_clawhub_config(
     try:
         service.save_clawhub_config(req)
         return {"status": "ok"}
-    except (ValueError, RuntimeError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        _raise_system_http_error(
+            exc,
+            value_error_status=400,
+            runtime_error_status=400,
+        )
 
 
 @router.post("/configs/clawhub:probe")
@@ -563,44 +610,34 @@ def delete_clawhub_skill(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-class NotificationConfigRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    config: dict[str, JsonValue]
-
-
-class OrchestrationConfigRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    config: dict[str, JsonValue]
-
-
 @router.put("/configs/notifications")
 def save_notification_config(
-    req: NotificationConfigRequest,
+    req: NotificationConfig | NotificationConfigRequest,
     service: NotificationSettingsService = Depends(get_notification_settings_service),
 ) -> dict[str, str]:
     try:
-        service.save_notification_config(req.config)
+        config = req.config if isinstance(req, NotificationConfigRequest) else req
+        service.save_notification_config(config)
         return {"status": "ok"}
-    except Exception as exc:
+    except OSError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.get("/configs/orchestration")
 def get_orchestration_config(
     service: OrchestrationSettingsService = Depends(get_orchestration_settings_service),
-) -> dict[str, JsonValue]:
+) -> OrchestrationSettings:
     return service.get_orchestration_config()
 
 
 @router.put("/configs/orchestration")
 def save_orchestration_config(
-    req: OrchestrationConfigRequest,
+    req: OrchestrationSettings | OrchestrationConfigRequest,
     service: OrchestrationSettingsService = Depends(get_orchestration_settings_service),
 ) -> dict[str, str]:
     try:
-        service.save_orchestration_config(req.config)
+        config = req.config if isinstance(req, OrchestrationConfigRequest) else req
+        service.save_orchestration_config(config)
         return {"status": "ok"}
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -614,7 +651,11 @@ def reload_model_config(
         service.reload_model_config()
         return {"status": "ok"}
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        _raise_system_http_error(
+            exc,
+            value_error_status=400,
+            runtime_error_status=400,
+        )
 
 
 @router.post("/configs/proxy:reload")
@@ -625,7 +666,11 @@ def reload_proxy_config(
         service.reload_proxy_config()
         return {"status": "ok"}
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        _raise_system_http_error(
+            exc,
+            value_error_status=400,
+            runtime_error_status=400,
+        )
 
 
 @router.post("/configs/web:probe")
@@ -657,6 +702,8 @@ def reload_mcp_config(
     try:
         service.reload_mcp_config()
         return {"status": "ok"}
+    except (ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
@@ -668,5 +715,7 @@ def reload_skills_config(
     try:
         service.reload_skills_config()
         return {"status": "ok"}
+    except (ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/relay_teams/interfaces/server/routers/tasks.py
+++ b/src/relay_teams/interfaces/server/routers/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 from relay_teams.agents.orchestration.task_orchestration_service import (
@@ -10,6 +10,7 @@ from relay_teams.agents.orchestration.task_orchestration_service import (
     TaskUpdate,
 )
 from relay_teams.interfaces.server.deps import get_task_repo, get_task_service
+from relay_teams.interfaces.server.router_error_mapping import http_exception_for
 from relay_teams.validation import RequiredIdentifierStr
 
 from relay_teams.agents.tasks.task_repository import TaskRepository
@@ -54,10 +55,11 @@ async def create_tasks_for_run(
             run_id=run_id,
             tasks=req.tasks,
         )
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 400),),
+        ) from exc
 
 
 @router.get("/runs/{run_id}")
@@ -69,7 +71,7 @@ def list_tasks_for_run(
     try:
         return service.list_delegated_tasks(run_id=run_id, include_root=include_root)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise http_exception_for(exc) from exc
 
 
 @router.get("/{task_id}", response_model=TaskRecord)
@@ -80,7 +82,7 @@ def get_task(
     try:
         return task_repo.get(task_id)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="Task not found") from exc
+        raise http_exception_for(exc, key_error_detail="Task not found") from exc
 
 
 @router.patch("/{task_id}")
@@ -98,10 +100,11 @@ def update_task_by_id(
                 title=req.title,
             ),
         )
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 400),),
+        ) from exc
 
 
 @router.post("/{task_id}/dispatch")
@@ -117,7 +120,8 @@ async def dispatch_task_by_id(
             role_id=req.role_id,
             prompt=req.prompt,
         )
-    except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 400),),
+        ) from exc

--- a/src/relay_teams/interfaces/server/routers/workspaces.py
+++ b/src/relay_teams/interfaces/server/routers/workspaces.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
 from urllib.parse import unquote
 from pydantic import BaseModel, ConfigDict, Field
 
+from relay_teams.interfaces.server.api_write_validation import require_force_delete
 from relay_teams.interfaces.server.deps import get_workspace_service
+from relay_teams.interfaces.server.write_models import DeleteRequest
 from relay_teams.validation import RequiredIdentifierStr
 from relay_teams.workspace import (
     WorkspaceDiffFile,
@@ -194,9 +196,15 @@ def get_workspace_preview_file(
 def delete_workspace(
     workspace_id: RequiredIdentifierStr,
     remove_worktree: Annotated[bool, Query()] = False,
+    req: DeleteRequest | None = Body(default=None),
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> dict[str, str]:
     try:
+        if remove_worktree:
+            require_force_delete(
+                req.force if req is not None else False,
+                message="Cannot remove workspace git worktree without force",
+            )
         service.delete_workspace_with_options(
             workspace_id=workspace_id,
             remove_worktree=remove_worktree,
@@ -204,6 +212,8 @@ def delete_workspace(
         return {"status": "ok"}
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Workspace not found") from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/relay_teams/interfaces/server/write_models.py
+++ b/src/relay_teams/interfaces/server/write_models.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DeleteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    force: bool = False
+    cascade: bool = False
+    reason: str | None = Field(default=None, min_length=1)

--- a/src/relay_teams/notifications/notification_settings_service.py
+++ b/src/relay_teams/notifications/notification_settings_service.py
@@ -21,10 +21,12 @@ class NotificationSettingsService:
             notification_config_manager
         )
 
-    def get_notification_config(self) -> dict[str, JsonValue]:
-        config = self._notification_config_manager.get_notification_config()
+    def get_notification_config(self) -> NotificationConfig:
+        return self._notification_config_manager.get_notification_config()
+
+    def get_notification_config_payload(self) -> dict[str, JsonValue]:
+        config = self.get_notification_config()
         return cast(dict[str, JsonValue], config.model_dump(mode="json"))
 
-    def save_notification_config(self, config: dict[str, JsonValue]) -> None:
-        validated = NotificationConfig.model_validate(config)
-        self._notification_config_manager.save_notification_config(validated)
+    def save_notification_config(self, config: NotificationConfig) -> None:
+        self._notification_config_manager.save_notification_config(config)

--- a/src/relay_teams/providers/__init__.py
+++ b/src/relay_teams/providers/__init__.py
@@ -9,7 +9,9 @@ if TYPE_CHECKING:
     from relay_teams.providers.model_config import (
         LlmRetryConfig,
         MaaSAuthConfig,
+        ModelConfigPayload,
         ModelEndpointConfig,
+        ModelProfileConfigPayload,
         ModelRequestHeader,
         ProviderModelInfo,
         ProviderType,
@@ -57,9 +59,11 @@ __all__ = [
     "LLMProvider",
     "LlmRetryConfig",
     "MaaSAuthConfig",
+    "ModelConfigPayload",
     "LlmRetryErrorInfo",
     "LlmRetrySchedule",
     "ModelEndpointConfig",
+    "ModelProfileConfigPayload",
     "ModelRequestHeader",
     "ModelConfigManager",
     "ModelConfigService",
@@ -97,6 +101,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LLMProvider": ("relay_teams.providers.provider_contracts", "LLMProvider"),
     "LlmRetryConfig": ("relay_teams.providers.model_config", "LlmRetryConfig"),
     "MaaSAuthConfig": ("relay_teams.providers.model_config", "MaaSAuthConfig"),
+    "ModelConfigPayload": ("relay_teams.providers.model_config", "ModelConfigPayload"),
     "LlmRetryErrorInfo": (
         "relay_teams.providers.llm_retry",
         "LlmRetryErrorInfo",
@@ -105,6 +110,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ModelEndpointConfig": (
         "relay_teams.providers.model_config",
         "ModelEndpointConfig",
+    ),
+    "ModelProfileConfigPayload": (
+        "relay_teams.providers.model_config",
+        "ModelProfileConfigPayload",
     ),
     "ModelRequestHeader": (
         "relay_teams.providers.model_config",

--- a/src/relay_teams/providers/model_config.py
+++ b/src/relay_teams/providers/model_config.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator,
+    model_validator,
+)
 
 from relay_teams.net.constants import DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
+from relay_teams.validation import RequiredIdentifierStr
 
 DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
 DEFAULT_LLM_RETRY_MAX_RETRIES = 5
@@ -155,6 +163,42 @@ class ModelEndpointConfig(BaseModel):
         raise ValueError(
             "Model endpoint config requires api_key or at least one configured header."
         )
+
+
+class ModelProfileConfigPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: ProviderType = ProviderType.OPENAI_COMPATIBLE
+    is_default: bool | None = None
+    model: str = Field(min_length=1)
+    base_url: str = Field(min_length=1)
+    api_key: str | None = Field(default=None, min_length=1)
+    headers: tuple[ModelRequestHeader, ...] | None = None
+    maas_auth: MaaSAuthConfig | None = None
+    ssl_verify: bool | None = None
+    temperature: float = Field(default=0.7, ge=0.0, le=2.0)
+    top_p: float = Field(default=1.0, ge=0.0, le=1.0)
+    max_tokens: int | None = Field(default=None, ge=1)
+    context_window: int | None = Field(default=None, ge=1)
+    connect_timeout_seconds: float = Field(
+        default=DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
+        gt=0.0,
+        le=300.0,
+    )
+
+    @field_validator("model", "base_url", "api_key", mode="before")
+    @classmethod
+    def _normalize_string_fields(cls, value: object) -> object:
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or None
+        return value
+
+
+class ModelConfigPayload(
+    RootModel[dict[RequiredIdentifierStr, ModelProfileConfigPayload]]
+):
+    root: dict[RequiredIdentifierStr, ModelProfileConfigPayload]
 
 
 class ProviderModelInfo(BaseModel):

--- a/src/relay_teams/providers/model_config_manager.py
+++ b/src/relay_teams/providers/model_config_manager.py
@@ -107,6 +107,8 @@ class ModelConfigManager:
             )
         existing_profile = config.get(name)
         if source_name is not None and source_name != name:
+            if source_name not in config:
+                raise KeyError(f"Model profile not found: {source_name}")
             existing_profile = config.get(source_name, existing_profile)
         current_secret = (
             self._get_profile_secret(source_name)
@@ -176,13 +178,13 @@ class ModelConfigManager:
     def delete_model_profile(self, name: str) -> None:
         model_file = self._config_dir / "model.json"
         if not model_file.exists():
-            self._delete_profile_secret_owner(name)
-            return
+            raise KeyError(f"Model profile not found: {name}")
         config = _load_json_object(model_file)
-        if name in config:
-            del config[name]
-            _normalize_default_profile_flags(config)
-            _ = model_file.write_text(dumps(config, indent=2), encoding="utf-8")
+        if name not in config:
+            raise KeyError(f"Model profile not found: {name}")
+        del config[name]
+        _normalize_default_profile_flags(config)
+        _ = model_file.write_text(dumps(config, indent=2), encoding="utf-8")
         self._delete_profile_secret_owner(name)
 
     def save_model_config(self, config: dict[str, JsonValue]) -> None:

--- a/src/relay_teams/providers/model_config_service.py
+++ b/src/relay_teams/providers/model_config_service.py
@@ -6,13 +6,17 @@ from pydantic import JsonValue
 from collections.abc import Callable
 from pathlib import Path
 
-from relay_teams.providers.model_config import ProviderModelInfo, ProviderType
+from relay_teams.providers.model_config import (
+    ModelConfigPayload,
+    ProviderModelInfo,
+    ProviderType,
+)
 from relay_teams.providers.model_connectivity import (
-    ModelDiscoveryRequest,
-    ModelDiscoveryResult,
     ModelConnectivityProbeRequest,
     ModelConnectivityProbeResult,
     ModelConnectivityProbeService,
+    ModelDiscoveryRequest,
+    ModelDiscoveryResult,
 )
 from relay_teams.providers.model_config_manager import ModelConfigManager
 from relay_teams.providers.provider_registry import list_provider_models
@@ -75,8 +79,10 @@ class ModelConfigService:
         self._model_config_manager.delete_model_profile(name)
         self.reload_model_config()
 
-    def save_model_config(self, config: dict[str, JsonValue]) -> None:
-        self._model_config_manager.save_model_config(config)
+    def save_model_config(self, config: ModelConfigPayload) -> None:
+        self._model_config_manager.save_model_config(
+            config.model_dump(mode="json", exclude_unset=True)
+        )
         self.reload_model_config()
 
     def probe_connectivity(

--- a/src/relay_teams/sessions/session_models.py
+++ b/src/relay_teams/sessions/session_models.py
@@ -114,13 +114,22 @@ def normalize_session_metadata_patch_input(value: object) -> object:
         return payload
     normalized: dict[str, object] = {}
     legacy_custom_metadata: dict[str, object] = {}
+    saw_legacy_reserved_metadata = False
     for key, item in payload.items():
         if key in _SESSION_PATCH_METADATA_FIELDS:
             normalized[key] = item
             continue
         if key in _RESERVED_SESSION_METADATA_KEYS or key.startswith("feishu_"):
+            saw_legacy_reserved_metadata = True
             continue
         legacy_custom_metadata[key] = item
+    if "title" not in payload and (
+        "title_source" in payload or saw_legacy_reserved_metadata
+    ):
+        # Legacy sidebar snapshots clear the title by omitting it while still
+        # sending reserved metadata keys such as title_source/source_provider.
+        normalized["title"] = None
+        normalized.pop("title_source", None)
     if not legacy_custom_metadata:
         return normalized
     existing_custom_metadata = normalized.get("custom_metadata")

--- a/src/relay_teams/sessions/session_models.py
+++ b/src/relay_teams/sessions/session_models.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from relay_teams.interfaces.server.api_write_validation import (
+    normalize_optional_text_field,
+    require_non_empty_patch,
+)
 from relay_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 
@@ -17,6 +21,209 @@ class SessionMode(str, Enum):
 class ProjectKind(str, Enum):
     WORKSPACE = "workspace"
     AUTOMATION = "automation"
+
+
+_RESERVED_SESSION_METADATA_KEYS = {
+    "title",
+    "title_source",
+    "source_label",
+    "source_icon",
+    "source_kind",
+    "source_provider",
+}
+
+_SESSION_CREATE_METADATA_FIELDS = {
+    "title",
+    "title_source",
+    "source_label",
+    "source_icon",
+    "custom_metadata",
+}
+
+_SESSION_PATCH_METADATA_FIELDS = {
+    "title",
+    "title_source",
+    "source_label",
+    "source_icon",
+    "custom_metadata",
+}
+
+
+def _validate_session_custom_metadata(
+    value: dict[str, str] | None,
+) -> dict[str, str] | None:
+    if value is None:
+        return None
+    normalized: dict[str, str] = {}
+    for key, raw_value in value.items():
+        normalized_key = str(key).strip()
+        if not normalized_key:
+            raise ValueError("custom_metadata keys must not be blank")
+        if (
+            normalized_key in _RESERVED_SESSION_METADATA_KEYS
+            or normalized_key.startswith("feishu_")
+        ):
+            raise ValueError(f"custom_metadata key is reserved: {normalized_key}")
+        normalized_value = str(raw_value).strip()
+        if not normalized_value:
+            raise ValueError(
+                f"custom_metadata value must not be blank: {normalized_key}"
+            )
+        normalized[normalized_key] = normalized_value
+    return normalized
+
+
+def normalize_session_create_metadata_input(value: object) -> object:
+    if not isinstance(value, dict):
+        return value
+    payload = {str(key): item for key, item in value.items()}
+    if all(key in _SESSION_CREATE_METADATA_FIELDS for key in payload):
+        return payload
+    normalized: dict[str, object] = {}
+    legacy_custom_metadata: dict[str, object] = {}
+    for key, item in payload.items():
+        if key in _SESSION_CREATE_METADATA_FIELDS:
+            normalized[key] = item
+            continue
+        if key in _RESERVED_SESSION_METADATA_KEYS or key.startswith("feishu_"):
+            continue
+        legacy_custom_metadata[key] = item
+    if not legacy_custom_metadata:
+        return normalized
+    existing_custom_metadata = normalized.get("custom_metadata")
+    if existing_custom_metadata is None:
+        normalized["custom_metadata"] = legacy_custom_metadata
+        return normalized
+    if not isinstance(existing_custom_metadata, dict):
+        return value
+    merged_custom_metadata = {
+        str(key): item for key, item in existing_custom_metadata.items()
+    }
+    merged_custom_metadata.update(legacy_custom_metadata)
+    normalized["custom_metadata"] = merged_custom_metadata
+    return normalized
+
+
+def normalize_session_metadata_patch_input(value: object) -> object:
+    if not isinstance(value, dict):
+        return value
+    payload = {str(key): item for key, item in value.items()}
+    if set(payload) == {"metadata"} and isinstance(payload.get("metadata"), dict):
+        payload = {str(key): item for key, item in payload["metadata"].items()}
+    if all(key in _SESSION_PATCH_METADATA_FIELDS for key in payload):
+        return payload
+    normalized: dict[str, object] = {}
+    legacy_custom_metadata: dict[str, object] = {}
+    for key, item in payload.items():
+        if key in _SESSION_PATCH_METADATA_FIELDS:
+            normalized[key] = item
+            continue
+        if key in _RESERVED_SESSION_METADATA_KEYS or key.startswith("feishu_"):
+            continue
+        legacy_custom_metadata[key] = item
+    if not legacy_custom_metadata:
+        return normalized
+    existing_custom_metadata = normalized.get("custom_metadata")
+    if existing_custom_metadata is None:
+        normalized["custom_metadata"] = legacy_custom_metadata
+        return normalized
+    if not isinstance(existing_custom_metadata, dict):
+        return value
+    merged_custom_metadata = {
+        str(key): item for key, item in existing_custom_metadata.items()
+    }
+    merged_custom_metadata.update(legacy_custom_metadata)
+    normalized["custom_metadata"] = merged_custom_metadata
+    return normalized
+
+
+class SessionCreateMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = None
+    title_source: str | None = None
+    source_label: str | None = None
+    source_icon: str | None = None
+    custom_metadata: dict[str, str] | None = None
+
+    @field_validator(
+        "title", "title_source", "source_label", "source_icon", mode="before"
+    )
+    @classmethod
+    def _normalize_optional_text(cls, value: object) -> object:
+        return normalize_optional_text_field(
+            value,
+            field_name="session metadata field",
+            empty_to_none=True,
+        )
+
+    @field_validator("custom_metadata")
+    @classmethod
+    def _validate_custom_metadata(
+        cls, value: dict[str, str] | None
+    ) -> dict[str, str] | None:
+        return _validate_session_custom_metadata(value)
+
+    @model_validator(mode="after")
+    def _validate_title_source(self) -> "SessionCreateMetadata":
+        if self.title_source is not None and not str(self.title or "").strip():
+            raise ValueError("title_source requires title to be set")
+        return self
+
+    def to_metadata_dict(self) -> dict[str, str]:
+        metadata = {} if self.custom_metadata is None else dict(self.custom_metadata)
+        if self.title is not None:
+            metadata["title"] = self.title
+            metadata["title_source"] = (
+                self.title_source if self.title_source is not None else "manual"
+            )
+        elif self.title_source is not None:
+            metadata["title_source"] = self.title_source
+        if self.source_label is not None:
+            metadata["source_label"] = self.source_label
+        if self.source_icon is not None:
+            metadata["source_icon"] = self.source_icon
+        return metadata
+
+
+class SessionMetadataPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = None
+    title_source: str | None = None
+    source_label: str | None = None
+    source_icon: str | None = None
+    custom_metadata: dict[str, str] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_legacy_payload(cls, value: object) -> object:
+        return normalize_session_metadata_patch_input(value)
+
+    @field_validator(
+        "title", "title_source", "source_label", "source_icon", mode="before"
+    )
+    @classmethod
+    def _normalize_optional_text(cls, value: object) -> object:
+        return normalize_optional_text_field(
+            value,
+            field_name="session metadata field",
+            empty_to_none=True,
+        )
+
+    @field_validator("custom_metadata")
+    @classmethod
+    def _validate_custom_metadata(
+        cls, value: dict[str, str] | None
+    ) -> dict[str, str] | None:
+        return _validate_session_custom_metadata(value)
+
+    @model_validator(mode="after")
+    def _require_non_empty_patch(self) -> "SessionMetadataPatch":
+        return require_non_empty_patch(
+            self,
+            message="session update must include at least one field",
+        )
 
 
 class SessionRecord(BaseModel):

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -11,6 +11,10 @@ from relay_teams.agents.instances.models import AgentRuntimeRecord
 from relay_teams.metrics import SqliteMetricAggregateStore
 from relay_teams.monitors.repository import MonitorRepository
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType
+from relay_teams.interfaces.server.api_write_validation import (
+    require_cascade_delete,
+    require_force_delete,
+)
 from relay_teams.gateway.feishu import (
     SESSION_METADATA_TITLE_SOURCE_KEY,
     SESSION_TITLE_SOURCE_MANUAL,
@@ -43,7 +47,12 @@ from relay_teams.sessions.runs.run_runtime_repo import (
 from relay_teams.sessions.external_session_binding_repository import (
     ExternalSessionBindingRepository,
 )
-from relay_teams.sessions.session_models import ProjectKind, SessionMode, SessionRecord
+from relay_teams.sessions.session_models import (
+    ProjectKind,
+    SessionMetadataPatch,
+    SessionMode,
+    SessionRecord,
+)
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )
@@ -240,20 +249,100 @@ class SessionService:
             orchestration_preset_id=resolved_orchestration_preset_id,
         )
 
-    def update_session(self, session_id: str, metadata: dict[str, str]) -> None:
+    def update_session(self, session_id: str, patch: SessionMetadataPatch) -> None:
         current = self._session_repo.get(session_id)
-        normalized_metadata = dict(metadata)
-        title_value = str(normalized_metadata.get("title") or "").strip()
-        current_title = str(current.metadata.get("title") or "").strip()
-        if title_value:
-            normalized_metadata["title"] = title_value
-            if SESSION_METADATA_TITLE_SOURCE_KEY not in normalized_metadata:
-                normalized_metadata[SESSION_METADATA_TITLE_SOURCE_KEY] = (
-                    SESSION_TITLE_SOURCE_MANUAL
-                )
-        elif current_title:
-            normalized_metadata.pop(SESSION_METADATA_TITLE_SOURCE_KEY, None)
-        self._session_repo.update_metadata(session_id, normalized_metadata)
+        next_metadata = dict(current.metadata)
+
+        if "custom_metadata" in patch.model_fields_set:
+            next_metadata = self._replace_custom_metadata(
+                next_metadata,
+                patch.custom_metadata,
+            )
+
+        if "source_label" in patch.model_fields_set:
+            self._apply_optional_metadata_value(
+                next_metadata,
+                key="source_label",
+                value=patch.source_label,
+            )
+
+        if "source_icon" in patch.model_fields_set:
+            self._apply_optional_metadata_value(
+                next_metadata,
+                key="source_icon",
+                value=patch.source_icon,
+            )
+
+        if "title" in patch.model_fields_set:
+            title_value = str(patch.title or "").strip()
+            if title_value:
+                next_metadata["title"] = title_value
+                if "title_source" not in patch.model_fields_set:
+                    next_metadata[SESSION_METADATA_TITLE_SOURCE_KEY] = (
+                        SESSION_TITLE_SOURCE_MANUAL
+                    )
+            else:
+                next_metadata.pop("title", None)
+                next_metadata.pop(SESSION_METADATA_TITLE_SOURCE_KEY, None)
+
+        if "title_source" in patch.model_fields_set:
+            title_value = str(next_metadata.get("title") or "").strip()
+            if not title_value:
+                raise ValueError("title_source requires title to be set")
+            title_source = str(patch.title_source or "").strip()
+            if not title_source:
+                next_metadata.pop(SESSION_METADATA_TITLE_SOURCE_KEY, None)
+            else:
+                next_metadata[SESSION_METADATA_TITLE_SOURCE_KEY] = title_source
+
+        self._session_repo.update_metadata(session_id, next_metadata)
+
+    def sync_session_metadata(
+        self,
+        session_id: str,
+        metadata: dict[str, str],
+    ) -> None:
+        _ = self._session_repo.get(session_id)
+        self._session_repo.update_metadata(session_id, dict(metadata))
+
+    def _replace_custom_metadata(
+        self,
+        metadata: dict[str, str],
+        custom_metadata: dict[str, str] | None,
+    ) -> dict[str, str]:
+        next_metadata = {
+            key: value
+            for key, value in metadata.items()
+            if self._is_reserved_session_metadata_key(key)
+        }
+        if custom_metadata is None:
+            return next_metadata
+        next_metadata.update(custom_metadata)
+        return next_metadata
+
+    def _apply_optional_metadata_value(
+        self,
+        metadata: dict[str, str],
+        *,
+        key: str,
+        value: str | None,
+    ) -> None:
+        normalized_value = str(value or "").strip()
+        if normalized_value:
+            metadata[key] = normalized_value
+            return
+        metadata.pop(key, None)
+
+    @staticmethod
+    def _is_reserved_session_metadata_key(key: str) -> bool:
+        return key in {
+            "title",
+            SESSION_METADATA_TITLE_SOURCE_KEY,
+            "source_label",
+            "source_icon",
+            "source_kind",
+            "source_provider",
+        } or key.startswith("feishu_")
 
     def update_session_topology(
         self,
@@ -338,10 +427,36 @@ class SessionService:
                 f"Required system roles are unavailable: main_agent: {exc}"
             ) from exc
 
-    def delete_session(self, session_id: str) -> None:
+    def delete_session(
+        self,
+        session_id: str,
+        *,
+        force: bool = False,
+        cascade: bool = False,
+    ) -> None:
         session = self._session_repo.get(session_id)
+        if self._select_active_run(session_id) is not None:
+            require_force_delete(
+                force,
+                message="Cannot delete session while it has active or recoverable run",
+            )
         task_records = self._task_repo.list_by_session(session_id)
         agent_records = self._agent_repo.list_by_session(session_id)
+        background_task_records: tuple[BackgroundTaskRecord, ...] = ()
+        if self._background_task_repository is not None:
+            background_task_records = self._background_task_repository.list_by_session(
+                session_id
+            )
+        if self._has_dependent_session_data(
+            session_id,
+            task_records=task_records,
+            agent_records=agent_records,
+            background_task_records=background_task_records,
+        ):
+            require_cascade_delete(
+                cascade,
+                message="Cannot delete session without cascade while related session data exists",
+            )
         task_ids = [record.envelope.task_id for record in task_records]
         instance_ids = [record.instance_id for record in agent_records]
         role_scope_ids = sorted(
@@ -392,11 +507,7 @@ class SessionService:
                 workspace_ids=[],
             )
         self._approval_ticket_repo.delete_by_session(session_id)
-        background_task_records: tuple[BackgroundTaskRecord, ...] = ()
         if self._background_task_repository is not None:
-            background_task_records = self._background_task_repository.list_by_session(
-                session_id
-            )
             self._background_task_repository.delete_by_session(session_id)
         self._delete_background_task_logs(
             session=session,
@@ -424,6 +535,36 @@ class SessionService:
             )
             if session_dir.exists():
                 shutil.rmtree(session_dir, ignore_errors=True)
+
+    def _has_dependent_session_data(
+        self,
+        session_id: str,
+        *,
+        task_records: tuple[object, ...],
+        agent_records: tuple[object, ...],
+        background_task_records: tuple[BackgroundTaskRecord, ...],
+    ) -> bool:
+        if task_records or agent_records or background_task_records:
+            return True
+        if self._message_repo.get_messages_by_session(session_id):
+            return True
+        if self._run_runtime_repo.list_by_session(session_id):
+            return True
+        if self._event_log is not None and self._event_log.list_by_session(session_id):
+            return True
+        if (
+            self._session_history_marker_repo is not None
+            and self._session_history_marker_repo.list_by_session(session_id)
+        ):
+            return True
+        if self._external_session_binding_repo is not None and any(
+            binding.session_id == session_id
+            for binding in self._external_session_binding_repo.list_by_platform(
+                "feishu"
+            )
+        ):
+            return True
+        return False
 
     def delete_normal_mode_subagent(self, session_id: str, instance_id: str) -> None:
         session = self._session_repo.get(session_id)

--- a/tests/unit_tests/automation/test_automation_service.py
+++ b/tests/unit_tests/automation/test_automation_service.py
@@ -6,12 +6,14 @@ import sqlite3
 from typing import cast
 
 import pytest
+from pydantic import ValidationError
 
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.automation import (
     AutomationBoundSessionQueueService,
+    AutomationDeliveryService,
     AutomationExecutionHandle,
     AutomationEventRepository,
     AutomationFeishuBinding,
@@ -47,8 +49,14 @@ class _FakeRunManager:
 
 
 class _FakeBoundSessionQueueService:
-    def __init__(self, handle: AutomationExecutionHandle | None = None) -> None:
+    def __init__(
+        self,
+        handle: AutomationExecutionHandle | None = None,
+        *,
+        has_project_queue: bool = False,
+    ) -> None:
         self._handle = handle
+        self._has_project_queue = has_project_queue
         self.materialize_calls: list[tuple[str, str]] = []
         self.deleted_project_ids: list[str] = []
 
@@ -62,6 +70,9 @@ class _FakeBoundSessionQueueService:
         self.materialize_calls.append((cast(str, automation_project_id), reason))
         return self._handle
 
+    def has_project_queue(self, automation_project_id: str) -> bool:
+        return self._has_project_queue
+
     def delete_project_queue(self, automation_project_id: str) -> None:
         self.deleted_project_ids.append(automation_project_id)
 
@@ -69,6 +80,18 @@ class _FakeBoundSessionQueueService:
 class _FakeFeishuBindingService:
     def validate_binding(self, binding: object) -> object:
         return binding
+
+
+class _FakeDeliveryService:
+    def __init__(self, *, has_project_deliveries: bool = False) -> None:
+        self._has_project_deliveries = has_project_deliveries
+        self.deleted_project_ids: list[str] = []
+
+    def has_project_deliveries(self, automation_project_id: str) -> bool:
+        return self._has_project_deliveries
+
+    def delete_project_deliveries(self, automation_project_id: str) -> None:
+        self.deleted_project_ids.append(automation_project_id)
 
 
 def _build_session_service(db_path: Path) -> SessionService:
@@ -87,6 +110,7 @@ def _build_service(
     tmp_path: Path,
     *,
     bound_session_queue_service: _FakeBoundSessionQueueService | None = None,
+    delivery_service: _FakeDeliveryService | None = None,
     feishu_binding_service: object | None = None,
 ) -> tuple[AutomationService, _FakeRunManager, SessionService]:
     db_path = tmp_path / "automation.db"
@@ -106,6 +130,7 @@ def _build_service(
             AutomationFeishuBindingService | None,
             feishu_binding_service,
         ),
+        delivery_service=cast(AutomationDeliveryService | None, delivery_service),
         bound_session_queue_service=cast(
             AutomationBoundSessionQueueService | None,
             bound_session_queue_service,
@@ -443,3 +468,99 @@ def test_enable_project_rejects_unknown_workspace_on_persisted_record(
             created.automation_project_id,
             status=AutomationProjectStatus.ENABLED,
         )
+
+
+def test_update_project_input_rejects_empty_patch() -> None:
+    with pytest.raises(ValidationError, match="update must include at least one field"):
+        AutomationProjectUpdateInput()
+
+
+def test_update_project_input_rejects_cron_run_at_combo() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="run_at is not supported for cron schedules",
+    ):
+        AutomationProjectUpdateInput(
+            schedule_mode=AutomationScheduleMode.CRON,
+            run_at=datetime.now(tz=UTC),
+        )
+
+
+def test_delete_enabled_project_requires_force(tmp_path: Path) -> None:
+    service, _, _ = _build_service(tmp_path)
+    created = service.create_project(
+        AutomationProjectCreateInput(
+            name="daily-briefing",
+            workspace_id="default",
+            prompt="Summarize the day.",
+            schedule_mode=AutomationScheduleMode.CRON,
+            cron_expression="0 9 * * 1-5",
+            timezone="UTC",
+        )
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot delete enabled automation project without force",
+    ):
+        service.delete_project(created.automation_project_id)
+
+    service.delete_project(created.automation_project_id, force=True)
+
+    with pytest.raises(KeyError):
+        service.get_project(created.automation_project_id)
+
+
+def test_delete_project_rejects_related_records_without_cascade(tmp_path: Path) -> None:
+    delivery_service = _FakeDeliveryService(has_project_deliveries=True)
+    bound_queue_service = _FakeBoundSessionQueueService(has_project_queue=True)
+    service, _, _ = _build_service(
+        tmp_path,
+        delivery_service=delivery_service,
+        bound_session_queue_service=bound_queue_service,
+    )
+    created = service.create_project(
+        AutomationProjectCreateInput(
+            name="daily-briefing",
+            workspace_id="default",
+            prompt="Summarize the day.",
+            schedule_mode=AutomationScheduleMode.CRON,
+            cron_expression="0 9 * * 1-5",
+            timezone="UTC",
+            enabled=False,
+        )
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot delete automation project without cascade while deliveries or queue records exist",
+    ):
+        service.delete_project(created.automation_project_id)
+
+
+def test_delete_project_cascade_cleans_related_records(tmp_path: Path) -> None:
+    delivery_service = _FakeDeliveryService(has_project_deliveries=True)
+    bound_queue_service = _FakeBoundSessionQueueService(has_project_queue=True)
+    service, _, _ = _build_service(
+        tmp_path,
+        delivery_service=delivery_service,
+        bound_session_queue_service=bound_queue_service,
+    )
+    created = service.create_project(
+        AutomationProjectCreateInput(
+            name="daily-briefing",
+            workspace_id="default",
+            prompt="Summarize the day.",
+            schedule_mode=AutomationScheduleMode.CRON,
+            cron_expression="0 9 * * 1-5",
+            timezone="UTC",
+            enabled=False,
+        )
+    )
+
+    service.delete_project(created.automation_project_id, cascade=True)
+
+    assert delivery_service.deleted_project_ids == [created.automation_project_id]
+    assert bound_queue_service.deleted_project_ids == [created.automation_project_id]
+    with pytest.raises(KeyError):
+        service.get_project(created.automation_project_id)

--- a/tests/unit_tests/feishu/test_inbound_runtime.py
+++ b/tests/unit_tests/feishu/test_inbound_runtime.py
@@ -58,7 +58,7 @@ class _FakeSessionService:
             raise KeyError(session_id)
         return self.sessions[session_id]
 
-    def update_session(self, session_id: str, metadata: dict[str, str]) -> None:
+    def sync_session_metadata(self, session_id: str, metadata: dict[str, str]) -> None:
         record = self.get_session(session_id)
         self.sessions[session_id] = record.model_copy(update={"metadata": metadata})
 

--- a/tests/unit_tests/feishu/test_message_pool_service.py
+++ b/tests/unit_tests/feishu/test_message_pool_service.py
@@ -8,7 +8,11 @@ from relay_teams.gateway.feishu.inbound_runtime import FeishuInboundRuntime
 from relay_teams.gateway.feishu.message_pool_repository import (
     FeishuMessagePoolRepository,
 )
-from relay_teams.gateway.feishu.message_pool_service import FeishuMessagePoolService
+from relay_teams.gateway.feishu.message_pool_service import (
+    FeishuMessagePoolService,
+    _build_pause_reply,
+    _build_queue_reply_text,
+)
 from relay_teams.gateway.feishu.models import (
     FeishuEnvironment,
     FeishuMessageDeliveryStatus,
@@ -70,7 +74,7 @@ class _FakeSessionService:
             raise KeyError(session_id)
         return self.sessions[session_id]
 
-    def update_session(self, session_id: str, metadata: dict[str, str]) -> None:
+    def sync_session_metadata(self, session_id: str, metadata: dict[str, str]) -> None:
         record = self.get_session(session_id)
         self.sessions[session_id] = record.model_copy(update={"metadata": metadata})
 
@@ -279,11 +283,10 @@ def test_enqueue_message_uses_queue_aware_ack(tmp_path: Path) -> None:
         headers={},
         remote_addr=None,
     )
-
     assert first.status == "accepted"
     assert second.status == "accepted"
     assert feishu_client.reactions == [("om_1", "OK"), ("om_2", "OK")]
-    assert feishu_client.reply_messages == [("om_2", "已进入队列，前面还有 1 条消息。")]
+    assert feishu_client.reply_messages == [("om_2", _build_queue_reply_text(1))]
     assert feishu_client.sent_messages == []
     first_record = repo.get_by_message_key(
         trigger_id="trg_feishu",
@@ -333,13 +336,10 @@ def test_enqueue_p2p_message_uses_reaction_and_queue_text(tmp_path: Path) -> Non
         headers={},
         remote_addr=None,
     )
-
     assert first.status == "accepted"
     assert second.status == "accepted"
     assert feishu_client.reactions == [("om_p2p_1", "OK"), ("om_p2p_2", "OK")]
-    assert feishu_client.reply_messages == [
-        ("om_p2p_2", "已进入队列，前面还有 1 条消息。")
-    ]
+    assert feishu_client.reply_messages == [("om_p2p_2", _build_queue_reply_text(1))]
     assert feishu_client.sent_messages == []
     first_record = repo.get_by_message_key(
         trigger_id="trg_feishu",
@@ -596,7 +596,7 @@ def test_finalize_waiting_result_sends_recovery_pause_notice_once(
     assert record.processing_status == FeishuMessageProcessingStatus.WAITING_RESULT
     assert feishu_client.reply_messages[-1] == (
         "om_1",
-        "运行已暂停：stream interrupted\n发送 resume 继续。",
+        _build_pause_reply(run_id="run-1", error_message="stream interrupted"),
     )
     assert service._finalize_waiting_results() is False
 

--- a/tests/unit_tests/feishu/test_trigger_handler.py
+++ b/tests/unit_tests/feishu/test_trigger_handler.py
@@ -78,7 +78,7 @@ class _FakeSessionService:
     def get_session(self, session_id: str) -> SessionRecord:
         return self.sessions[session_id]
 
-    def update_session(self, session_id: str, metadata: dict[str, str]) -> None:
+    def sync_session_metadata(self, session_id: str, metadata: dict[str, str]) -> None:
         self.sessions[session_id] = self.sessions[session_id].model_copy(
             update={"metadata": metadata}
         )

--- a/tests/unit_tests/gateway/test_feishu_gateway_service.py
+++ b/tests/unit_tests/gateway/test_feishu_gateway_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from relay_teams.agents.orchestration.settings_service import (
     OrchestrationSettingsService,
@@ -11,8 +12,11 @@ from relay_teams.gateway.feishu.account_repository import FeishuAccountRepositor
 from relay_teams.gateway.feishu.gateway_service import FeishuGatewayService
 from relay_teams.gateway.feishu.models import (
     FeishuGatewayAccountCreateInput,
+    FeishuGatewayAccountUpdateInput,
     FeishuGatewayAccountStatus,
     FeishuTriggerSecretConfig,
+    FeishuTriggerSourceConfig,
+    FeishuTriggerTargetConfig,
 )
 from relay_teams.gateway.feishu.secret_store import FeishuTriggerSecretStore
 from relay_teams.roles.role_models import RoleDefinition
@@ -119,14 +123,14 @@ def test_set_account_enabled_rejects_invalid_persisted_workspace(
         FeishuGatewayAccountCreateInput(
             name="feishu-main",
             enabled=False,
-            source_config={
-                "provider": "feishu",
-                "trigger_rule": "mention_only",
-                "app_id": "cli_123",
-                "app_name": "Feishu Bot",
-            },
-            target_config={"workspace_id": "default"},
-            secret_config={"app_secret": "secret-1"},
+            source_config=FeishuTriggerSourceConfig(
+                provider="feishu",
+                trigger_rule="mention_only",
+                app_id="cli_123",
+                app_name="Feishu Bot",
+            ),
+            target_config=FeishuTriggerTargetConfig(workspace_id="default"),
+            secret_config=FeishuTriggerSecretConfig(app_secret="secret-1"),
         )
     )
     _ = service._repository.update_account(
@@ -150,14 +154,14 @@ def test_get_account_exposes_last_error_for_invalid_persisted_preset(
         FeishuGatewayAccountCreateInput(
             name="feishu-main",
             enabled=False,
-            source_config={
-                "provider": "feishu",
-                "trigger_rule": "mention_only",
-                "app_id": "cli_123",
-                "app_name": "Feishu Bot",
-            },
-            target_config={"workspace_id": "default"},
-            secret_config={"app_secret": "secret-1"},
+            source_config=FeishuTriggerSourceConfig(
+                provider="feishu",
+                trigger_rule="mention_only",
+                app_id="cli_123",
+                app_name="Feishu Bot",
+            ),
+            target_config=FeishuTriggerTargetConfig(workspace_id="default"),
+            secret_config=FeishuTriggerSecretConfig(app_secret="secret-1"),
         )
     )
     _ = service._repository.update_account(
@@ -186,28 +190,28 @@ def test_list_enabled_runtime_configs_skips_invalid_persisted_accounts(
         FeishuGatewayAccountCreateInput(
             name="feishu-valid",
             enabled=True,
-            source_config={
-                "provider": "feishu",
-                "trigger_rule": "mention_only",
-                "app_id": "cli_valid",
-                "app_name": "Valid Bot",
-            },
-            target_config={"workspace_id": "default"},
-            secret_config={"app_secret": "secret-valid"},
+            source_config=FeishuTriggerSourceConfig(
+                provider="feishu",
+                trigger_rule="mention_only",
+                app_id="cli_valid",
+                app_name="Valid Bot",
+            ),
+            target_config=FeishuTriggerTargetConfig(workspace_id="default"),
+            secret_config=FeishuTriggerSecretConfig(app_secret="secret-valid"),
         )
     )
     invalid = service.create_account(
         FeishuGatewayAccountCreateInput(
             name="feishu-invalid",
             enabled=False,
-            source_config={
-                "provider": "feishu",
-                "trigger_rule": "mention_only",
-                "app_id": "cli_invalid",
-                "app_name": "Invalid Bot",
-            },
-            target_config={"workspace_id": "default"},
-            secret_config={"app_secret": "secret-invalid"},
+            source_config=FeishuTriggerSourceConfig(
+                provider="feishu",
+                trigger_rule="mention_only",
+                app_id="cli_invalid",
+                app_name="Invalid Bot",
+            ),
+            target_config=FeishuTriggerTargetConfig(workspace_id="default"),
+            secret_config=FeishuTriggerSecretConfig(app_secret="secret-invalid"),
         )
     )
     _ = service._repository.update_account(
@@ -223,3 +227,98 @@ def test_list_enabled_runtime_configs_skips_invalid_persisted_accounts(
 
     assert len(runtime_configs) == 1
     assert runtime_configs[0].trigger_id == valid.account_id
+
+
+def test_feishu_account_update_input_rejects_empty_patch() -> None:
+    with pytest.raises(ValidationError, match="update must include at least one field"):
+        FeishuGatewayAccountUpdateInput()
+
+
+@pytest.mark.parametrize(
+    ("field_name", "payload"),
+    (
+        ("source_config", {}),
+        ("target_config", {}),
+        ("secret_config", {}),
+    ),
+)
+def test_feishu_account_update_input_rejects_empty_config_patch(
+    field_name: str,
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="config patch must not be empty"):
+        FeishuGatewayAccountUpdateInput.model_validate({field_name: payload})
+
+
+def test_delete_account_rejects_bound_trigger_without_force(tmp_path: Path) -> None:
+    service = _build_service(tmp_path)
+    created = service.create_account(
+        FeishuGatewayAccountCreateInput(
+            name="feishu-main",
+            enabled=False,
+            source_config=FeishuTriggerSourceConfig(
+                provider="feishu",
+                trigger_rule="mention_only",
+                app_id="cli_123",
+                app_name="Feishu Bot",
+            ),
+            target_config=FeishuTriggerTargetConfig(workspace_id="default"),
+            secret_config=FeishuTriggerSecretConfig(app_secret="secret-1"),
+        )
+    )
+    service._external_session_binding_repo.upsert_binding(
+        platform="feishu",
+        trigger_id=created.account_id,
+        tenant_key="tenant-1",
+        external_chat_id="chat-1",
+        session_id="session-1",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot delete Feishu account while external session bindings exist",
+    ):
+        service.delete_account(created.account_id)
+
+    service.delete_account(created.account_id, force=True)
+
+    with pytest.raises(KeyError):
+        service.get_account(created.account_id)
+
+
+def test_update_account_allows_clearing_verification_token_with_null(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    created = service.create_account(
+        FeishuGatewayAccountCreateInput(
+            name="feishu-main",
+            enabled=False,
+            source_config=FeishuTriggerSourceConfig(
+                provider="feishu",
+                trigger_rule="mention_only",
+                app_id="cli_123",
+                app_name="Feishu Bot",
+            ),
+            target_config=FeishuTriggerTargetConfig(workspace_id="default"),
+            secret_config=FeishuTriggerSecretConfig(
+                app_secret="secret-1",
+                verification_token="token-1",
+            ),
+        )
+    )
+
+    _ = service.update_account(
+        created.account_id,
+        FeishuGatewayAccountUpdateInput.model_validate(
+            {"secret_config": {"verification_token": None}}
+        ),
+    )
+
+    stored_secret = service._secret_store.get_secret_config(
+        service._config_dir,
+        created.account_id,
+    )
+
+    assert stored_secret.app_secret == "secret-1"
+    assert stored_secret.verification_token is None

--- a/tests/unit_tests/interfaces/sdk/test_client.py
+++ b/tests/unit_tests/interfaces/sdk/test_client.py
@@ -454,6 +454,92 @@ def test_probe_github_connectivity_passes_payload(monkeypatch) -> None:
     }
 
 
+def test_create_session_preserves_legacy_flat_metadata_payload(monkeypatch) -> None:
+    client = AgentTeamsClient()
+    captured: dict[str, object] = {}
+
+    def fake_request_json(
+        method: str,
+        path: str,
+        payload: object | None = None,
+    ) -> dict[str, object]:
+        captured["method"] = method
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"session_id": "session-1", "workspace_id": "default"}
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    response = client.create_session(
+        workspace_id="default",
+        session_id="session-1",
+        metadata={"project": "demo"},
+    )
+
+    assert response == {"session_id": "session-1", "workspace_id": "default"}
+    assert captured == {
+        "method": "POST",
+        "path": "/api/sessions",
+        "payload": {
+            "session_id": "session-1",
+            "workspace_id": "default",
+            "metadata": {"project": "demo"},
+        },
+    }
+
+
+def test_delete_feishu_gateway_account_forces_delete_by_default(monkeypatch) -> None:
+    client = AgentTeamsClient()
+    captured: dict[str, object] = {}
+
+    def fake_request_json(
+        method: str,
+        path: str,
+        payload: object | None = None,
+    ) -> dict[str, object]:
+        captured["method"] = method
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"status": "ok"}
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    response = client.delete_feishu_gateway_account("fsg_main")
+
+    assert response == {"status": "ok"}
+    assert captured == {
+        "method": "DELETE",
+        "path": "/api/gateway/feishu/accounts/fsg_main",
+        "payload": {"force": True},
+    }
+
+
+def test_delete_wechat_gateway_account_forces_delete_by_default(monkeypatch) -> None:
+    client = AgentTeamsClient()
+    captured: dict[str, object] = {}
+
+    def fake_request_json(
+        method: str,
+        path: str,
+        payload: object | None = None,
+    ) -> dict[str, object]:
+        captured["method"] = method
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"status": "ok"}
+
+    monkeypatch.setattr(client, "_request_json", fake_request_json)
+
+    response = client.delete_wechat_gateway_account("wx-account-1")
+
+    assert response == {"status": "ok"}
+    assert captured == {
+        "method": "DELETE",
+        "path": "/api/gateway/wechat/accounts/wx-account-1",
+        "payload": {"force": True},
+    }
+
+
 def test_create_run_includes_target_role_id(monkeypatch) -> None:
     client = AgentTeamsClient()
     captured: dict[str, object] = {}

--- a/tests/unit_tests/interfaces/server/test_api_write_validation.py
+++ b/tests/unit_tests/interfaces/server/test_api_write_validation.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from relay_teams.interfaces.server.api_write_validation import (
+    normalize_optional_text_field,
+    reject_empty_mapping_patch,
+    require_cascade_delete,
+    require_force_delete,
+    require_non_empty_patch,
+)
+
+
+class _FakePatch:
+    model_fields_set: set[str]
+
+    def __init__(self, fields: set[str]) -> None:
+        self.model_fields_set = fields
+
+
+def test_require_non_empty_patch_rejects_empty_fields() -> None:
+    with pytest.raises(ValueError, match="update must include at least one field"):
+        require_non_empty_patch(_FakePatch(set()))
+
+
+def test_normalize_optional_text_field_supports_empty_to_none() -> None:
+    assert (
+        normalize_optional_text_field(
+            "   ",
+            field_name="display_name",
+            empty_to_none=True,
+        )
+        is None
+    )
+
+
+def test_reject_empty_mapping_patch_rejects_empty_dict() -> None:
+    with pytest.raises(ValueError, match="config patch must not be empty"):
+        reject_empty_mapping_patch({}, message="config patch must not be empty")
+
+
+def test_require_force_delete_raises_runtime_error() -> None:
+    with pytest.raises(RuntimeError, match="force required"):
+        require_force_delete(False, message="force required")
+
+
+def test_require_cascade_delete_raises_runtime_error() -> None:
+    with pytest.raises(RuntimeError, match="cascade required"):
+        require_cascade_delete(False, message="cascade required")

--- a/tests/unit_tests/interfaces/server/test_automation_router.py
+++ b/tests/unit_tests/interfaces/server/test_automation_router.py
@@ -26,7 +26,8 @@ class _FakeAutomationService:
         self.created_payloads: list[AutomationProjectCreateInput] = []
         self.run_calls: list[str] = []
         self.status_calls: list[tuple[str, AutomationProjectStatus]] = []
-        self.deleted_project_ids: list[str] = []
+        self.deleted_calls: list[tuple[str, bool, bool]] = []
+        self.delete_error: Exception | None = None
         self.list_feishu_bindings_calls = 0
 
     def create_project(
@@ -116,10 +117,18 @@ class _FakeAutomationService:
     ) -> AutomationProjectRecord:  # pragma: no cover
         raise AssertionError(f"not used: {automation_project_id}")
 
-    def delete_project(self, automation_project_id: str) -> None:
+    def delete_project(
+        self,
+        automation_project_id: str,
+        *,
+        force: bool = False,
+        cascade: bool = False,
+    ) -> None:
+        if self.delete_error is not None:
+            raise self.delete_error
         if automation_project_id != "aut_1":
             raise KeyError(f"Unknown automation_project_id: {automation_project_id}")
-        self.deleted_project_ids.append(automation_project_id)
+        self.deleted_calls.append((automation_project_id, force, cascade))
 
     def run_now(self, automation_project_id: str) -> dict[str, str | bool | None]:
         self.run_calls.append(automation_project_id)
@@ -352,4 +361,32 @@ def test_delete_project_route_returns_ok() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
-    assert fake_service.deleted_project_ids == ["aut_1"]
+    assert fake_service.deleted_calls == [("aut_1", False, False)]
+
+
+def test_delete_project_route_forwards_force_and_cascade() -> None:
+    fake_service = _FakeAutomationService()
+    client = _client(fake_service)
+
+    response = client.request(
+        "DELETE",
+        "/api/automation/projects/aut_1",
+        json={"force": True, "cascade": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert fake_service.deleted_calls == [("aut_1", True, True)]
+
+
+def test_delete_project_route_returns_conflict_for_missing_cascade() -> None:
+    fake_service = _FakeAutomationService()
+    fake_service.delete_error = RuntimeError(
+        "Cannot delete automation project without cascade while deliveries or queue records exist"
+    )
+    client = _client(fake_service)
+
+    response = client.delete("/api/automation/projects/aut_1")
+
+    assert response.status_code == 409
+    assert "without cascade" in response.json()["detail"]

--- a/tests/unit_tests/interfaces/server/test_feishu_gateway_router.py
+++ b/tests/unit_tests/interfaces/server/test_feishu_gateway_router.py
@@ -24,6 +24,7 @@ class _FakeFeishuGatewayService:
         self.created_payloads: list[FeishuGatewayAccountCreateInput] = []
         self.updated_payloads: list[tuple[str, FeishuGatewayAccountUpdateInput]] = []
         self.deleted_account_ids: list[str] = []
+        self.deleted_force_flags: list[bool] = []
 
     def list_accounts(self) -> tuple[FeishuGatewayAccountRecord, ...]:
         return (self._record(),)
@@ -85,10 +86,11 @@ class _FakeFeishuGatewayService:
             }
         )
 
-    def delete_account(self, account_id: str) -> None:
+    def delete_account(self, account_id: str, *, force: bool = False) -> None:
         if account_id == "missing":
             raise KeyError("Unknown Feishu account: missing")
         self.deleted_account_ids.append(account_id)
+        self.deleted_force_flags.append(force)
 
     @staticmethod
     def _record() -> FeishuGatewayAccountRecord:
@@ -195,6 +197,30 @@ def test_create_feishu_account_route_rejects_none_like_name() -> None:
     assert gateway_service.created_payloads == []
 
 
+def test_create_feishu_account_route_rejects_unknown_nested_config_field() -> None:
+    gateway_service = _FakeFeishuGatewayService()
+    subscription_service = _FakeSubscriptionService()
+    client = _client(gateway_service, subscription_service)
+
+    response = client.post(
+        "/api/gateway/feishu/accounts",
+        json={
+            "name": "feishu_ops",
+            "source_config": {
+                "provider": "feishu",
+                "trigger_rule": "mention_only",
+                "app_id": "cli_demo",
+                "app_name": "Agent Teams Bot",
+            },
+            "target_config": {"workspace_id": "default", "unknown_field": True},
+            "secret_config": {"app_secret": "secret-demo"},
+        },
+    )
+
+    assert response.status_code == 422
+    assert gateway_service.created_payloads == []
+
+
 def test_update_feishu_account_route_reloads_when_runtime_changes() -> None:
     gateway_service = _FakeFeishuGatewayService()
     subscription_service = _FakeSubscriptionService()
@@ -219,6 +245,18 @@ def test_update_feishu_account_route_reloads_when_runtime_changes() -> None:
     assert gateway_service.updated_payloads[0][0] == "fsg_main"
 
 
+def test_update_feishu_account_route_rejects_empty_typed_config_patch() -> None:
+    client = _client(_FakeFeishuGatewayService(), _FakeSubscriptionService())
+
+    response = client.patch(
+        "/api/gateway/feishu/accounts/fsg_main",
+        json={"target_config": {}},
+    )
+
+    assert response.status_code == 422
+    assert "config patch must not be empty" in response.text
+
+
 def test_delete_feishu_account_route_maps_missing_account_to_404() -> None:
     client = _client(_FakeFeishuGatewayService(), _FakeSubscriptionService())
 
@@ -226,6 +264,24 @@ def test_delete_feishu_account_route_maps_missing_account_to_404() -> None:
 
     assert response.status_code == 404
     assert "Unknown Feishu account" in response.json()["detail"]
+
+
+def test_delete_feishu_account_route_forwards_force_flag() -> None:
+    gateway_service = _FakeFeishuGatewayService()
+    subscription_service = _FakeSubscriptionService()
+    client = _client(gateway_service, subscription_service)
+
+    response = client.request(
+        "DELETE",
+        "/api/gateway/feishu/accounts/fsg_main",
+        json={"force": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert gateway_service.deleted_account_ids == ["fsg_main"]
+    assert gateway_service.deleted_force_flags == [True]
+    assert subscription_service.reload_calls == 1
 
 
 def test_enable_feishu_account_route_maps_validation_error_to_422() -> None:

--- a/tests/unit_tests/interfaces/server/test_gateway_router.py
+++ b/tests/unit_tests/interfaces/server/test_gateway_router.py
@@ -166,6 +166,20 @@ def test_update_wechat_account_route_maps_validation_error_to_422() -> None:
     assert response.json()["detail"] == "orchestration_preset_id is required"
 
 
+def test_update_wechat_account_route_allows_blank_route_tag_to_clear_value() -> None:
+    fake_service = _FakeWeChatGatewayService()
+    client = _client(fake_service)
+
+    response = client.patch(
+        "/api/gateway/wechat/accounts/wx_123",
+        json={"route_tag": "   "},
+    )
+
+    assert response.status_code == 200
+    assert fake_service.updated_payloads[0][1].route_tag is None
+    assert "route_tag" in fake_service.updated_payloads[0][1].model_fields_set
+
+
 def test_reload_wechat_gateway_route_calls_service() -> None:
     fake_service = _FakeWeChatGatewayService()
     client = _client(fake_service)

--- a/tests/unit_tests/interfaces/server/test_prompts_router.py
+++ b/tests/unit_tests/interfaces/server/test_prompts_router.py
@@ -299,7 +299,8 @@ def _create_client(
 
 
 def test_prompts_preview_returns_runtime_provider_and_user_sections() -> None:
-    client = _create_client()
+    skill_runtime_service = _FakeSkillRuntimeService()
+    client = _create_client(skill_runtime_service=skill_runtime_service)
 
     response = client.post(
         "/api/prompts:preview",
@@ -353,6 +354,41 @@ def test_prompts_preview_returns_runtime_provider_and_user_sections() -> None:
     assert payload["skill_routing"]["mode"] == "passthrough"
     assert payload["skill_routing"]["visible_skills"] == ["time"]
     assert "## Available Roles" in payload["provider_system_prompt"]
+    assert skill_runtime_service.calls[0]["shared_state_snapshot"] == (
+        ("priority", "1"),
+    )
+
+
+def test_prompts_preview_trims_shared_state_keys() -> None:
+    skill_runtime_service = _FakeSkillRuntimeService()
+    client = _create_client(skill_runtime_service=skill_runtime_service)
+
+    response = client.post(
+        "/api/prompts:preview",
+        json={
+            "role_id": "Coordinator",
+            "shared_state": {"  priority  ": 1},
+        },
+    )
+
+    assert response.status_code == 200
+    assert skill_runtime_service.calls[0]["shared_state_snapshot"] == (
+        ("priority", "1"),
+    )
+
+
+def test_prompts_preview_rejects_blank_shared_state_key() -> None:
+    client = _create_client()
+
+    response = client.post(
+        "/api/prompts:preview",
+        json={
+            "role_id": "Coordinator",
+            "shared_state": {"   ": 1},
+        },
+    )
+
+    assert response.status_code == 422
 
 
 def test_prompts_preview_uses_workspace_execution_root_when_workspace_is_provided(

--- a/tests/unit_tests/interfaces/server/test_router_error_mapping.py
+++ b/tests/unit_tests/interfaces/server/test_router_error_mapping.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+import pytest
+
+from relay_teams.interfaces.server.router_error_mapping import http_exception_for
+
+
+class _CustomError(Exception):
+    pass
+
+
+def test_http_exception_for_key_error_uses_override_detail() -> None:
+    exc = http_exception_for(KeyError("missing"), key_error_detail="Session not found")
+
+    assert isinstance(exc, HTTPException)
+    assert exc.status_code == 404
+    assert exc.detail == "Session not found"
+
+
+def test_http_exception_for_uses_configured_mapping() -> None:
+    exc = http_exception_for(ValueError("bad input"), mappings=((ValueError, 422),))
+
+    assert exc.status_code == 422
+    assert exc.detail == "bad input"
+
+
+def test_http_exception_for_rejects_unmapped_exception() -> None:
+    with pytest.raises(TypeError, match="Unsupported exception mapping"):
+        http_exception_for(_CustomError("boom"))

--- a/tests/unit_tests/interfaces/server/test_sessions_router.py
+++ b/tests/unit_tests/interfaces/server/test_sessions_router.py
@@ -515,6 +515,32 @@ def test_update_session_route_accepts_legacy_wrapped_metadata_snapshot() -> None
     ]
 
 
+def test_update_session_route_clears_title_for_legacy_snapshot_without_title() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.patch(
+        "/api/sessions/session-1",
+        json={
+            "title_source": "manual",
+            "source_provider": "feishu",
+            "feishu_chat_id": "chat-1",
+            "project": "demo",
+        },
+    )
+
+    assert response.status_code == 200
+    assert fake_service.updated_calls == [
+        (
+            "session-1",
+            SessionMetadataPatch(
+                title=None,
+                custom_metadata={"project": "demo"},
+            ),
+        )
+    ]
+
+
 def test_update_session_route_rejects_reserved_custom_metadata_key() -> None:
     fake_service = _FakeSessionService()
     client = _create_client(fake_service)

--- a/tests/unit_tests/interfaces/server/test_sessions_router.py
+++ b/tests/unit_tests/interfaces/server/test_sessions_router.py
@@ -7,13 +7,18 @@ from relay_teams.interfaces.server.deps import get_session_service
 from relay_teams.interfaces.server.routers import sessions
 from relay_teams.providers import AgentTokenSummary, RunTokenUsage, SessionTokenUsage
 from relay_teams.roles import SystemRolesUnavailableError
-from relay_teams.sessions.session_models import SessionMode, SessionRecord
+from relay_teams.sessions.session_models import (
+    SessionCreateMetadata,
+    SessionMetadataPatch,
+    SessionMode,
+    SessionRecord,
+)
 
 
 class _FakeSessionService:
     def __init__(self) -> None:
         self.created_calls: list[tuple[str | None, str, dict[str, str] | None]] = []
-        self.updated_calls: list[tuple[str, dict[str, str]]] = []
+        self.updated_calls: list[tuple[str, SessionMetadataPatch]] = []
         self.topology_update_calls: list[tuple[str, str, str | None, str | None]] = []
         self.delete_subagent_calls: list[tuple[str, str]] = []
         self.reflection_refresh_calls: list[tuple[str, str]] = []
@@ -21,6 +26,9 @@ class _FakeSessionService:
         self.reflection_delete_calls: list[tuple[str, str]] = []
         self.create_session_error: Exception | None = None
         self.raise_missing = False
+        self.raise_missing = False
+        self.deleted_calls: list[tuple[str, bool, bool]] = []
+        self.delete_error: Exception | None = None
         self.raise_missing_list_agents = False
         self.raise_missing_list_subagents = False
         self.delete_subagent_error: Exception | None = None
@@ -41,10 +49,10 @@ class _FakeSessionService:
             metadata={} if metadata is None else dict(metadata),
         )
 
-    def update_session(self, session_id: str, metadata: dict[str, str]) -> None:
+    def update_session(self, session_id: str, patch: SessionMetadataPatch) -> None:
         if self.raise_missing:
             raise KeyError(session_id)
-        self.updated_calls.append((session_id, metadata))
+        self.updated_calls.append((session_id, patch))
 
     def list_sessions(self) -> tuple[SessionRecord, ...]:  # pragma: no cover
         raise AssertionError("not used")
@@ -86,8 +94,16 @@ class _FakeSessionService:
     def get_session(self, session_id: str) -> SessionRecord:  # pragma: no cover
         raise AssertionError(f"not used: {session_id}")
 
-    def delete_session(self, session_id: str) -> None:  # pragma: no cover
-        raise AssertionError(f"not used: {session_id}")
+    def delete_session(
+        self,
+        session_id: str,
+        *,
+        force: bool = False,
+        cascade: bool = False,
+    ) -> None:
+        if self.delete_error is not None:
+            raise self.delete_error
+        self.deleted_calls.append((session_id, force, cascade))
 
     def delete_normal_mode_subagent(
         self,
@@ -241,12 +257,19 @@ def test_update_session_route_accepts_metadata_payload() -> None:
 
     response = client.patch(
         "/api/sessions/session-1",
-        json={"metadata": {"title": "Renamed Session"}},
+        json={"title": "Renamed Session", "custom_metadata": {"label": "visible-name"}},
     )
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
-    assert fake_service.updated_calls == [("session-1", {"title": "Renamed Session"})]
+    assert fake_service.updated_calls == [
+        (
+            "session-1",
+            SessionMetadataPatch(
+                title="Renamed Session", custom_metadata={"label": "visible-name"}
+            ),
+        )
+    ]
 
 
 def test_create_session_route_returns_created_session() -> None:
@@ -261,6 +284,135 @@ def test_create_session_route_returns_created_session() -> None:
     assert response.status_code == 200
     assert response.json()["session_id"] == "session-1"
     assert fake_service.created_calls == [("session-1", "default", None)]
+
+
+def test_create_session_route_accepts_explicit_metadata_payload() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/sessions",
+        json={
+            "session_id": "session-1",
+            "workspace_id": "default",
+            "metadata": {
+                "title": "Customer Support",
+                "source_label": "Group Chat",
+                "custom_metadata": {"project": "demo"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert fake_service.created_calls == [
+        (
+            "session-1",
+            "default",
+            SessionCreateMetadata(
+                title="Customer Support",
+                source_label="Group Chat",
+                custom_metadata={"project": "demo"},
+            ).to_metadata_dict(),
+        )
+    ]
+
+
+def test_create_session_route_accepts_legacy_flat_metadata_payload() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/sessions",
+        json={
+            "session_id": "session-1",
+            "workspace_id": "default",
+            "metadata": {
+                "title": "Customer Support",
+                "project": "demo",
+                "channel": "feishu",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert fake_service.created_calls == [
+        (
+            "session-1",
+            "default",
+            {
+                "title": "Customer Support",
+                "title_source": "manual",
+                "project": "demo",
+                "channel": "feishu",
+            },
+        )
+    ]
+
+
+def test_create_session_route_ignores_reserved_keys_in_legacy_flat_metadata_payload() -> (
+    None
+):
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/sessions",
+        json={
+            "session_id": "session-1",
+            "workspace_id": "default",
+            "metadata": {
+                "title": "Customer Support",
+                "project": "demo",
+                "source_provider": "feishu",
+                "feishu_chat_id": "chat-1",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert fake_service.created_calls == [
+        (
+            "session-1",
+            "default",
+            {
+                "title": "Customer Support",
+                "title_source": "manual",
+                "project": "demo",
+            },
+        )
+    ]
+
+
+def test_create_session_route_rejects_reserved_custom_metadata_key() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/sessions",
+        json={
+            "workspace_id": "default",
+            "metadata": {"custom_metadata": {"source_label": "bad"}},
+        },
+    )
+
+    assert response.status_code == 422
+    assert fake_service.created_calls == []
+
+
+def test_create_session_route_rejects_title_source_without_title() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/sessions",
+        json={
+            "workspace_id": "default",
+            "metadata": {"title_source": "manual"},
+        },
+    )
+
+    assert response.status_code == 422
+    assert fake_service.created_calls == []
 
 
 def test_create_session_route_rejects_none_like_session_id() -> None:
@@ -296,11 +448,84 @@ def test_update_session_route_returns_not_found_for_missing_session() -> None:
 
     response = client.patch(
         "/api/sessions/missing-session",
-        json={"metadata": {"title": "Renamed Session"}},
+        json={"title": "Renamed Session", "custom_metadata": {"label": "visible-name"}},
     )
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Session not found"}
+
+
+def test_update_session_route_accepts_legacy_flat_metadata_snapshot() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.patch(
+        "/api/sessions/session-1",
+        json={
+            "title": "Renamed Session",
+            "title_source": "manual",
+            "source_label": "Feishu",
+            "source_icon": "message",
+            "source_provider": "feishu",
+            "feishu_chat_id": "chat-1",
+            "project": "demo",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert fake_service.updated_calls == [
+        (
+            "session-1",
+            SessionMetadataPatch(
+                title="Renamed Session",
+                title_source="manual",
+                source_label="Feishu",
+                source_icon="message",
+                custom_metadata={"project": "demo"},
+            ),
+        )
+    ]
+
+
+def test_update_session_route_accepts_legacy_wrapped_metadata_snapshot() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.patch(
+        "/api/sessions/session-1",
+        json={
+            "metadata": {
+                "title": "Renamed Session",
+                "source_provider": "feishu",
+                "project": "demo",
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert fake_service.updated_calls == [
+        (
+            "session-1",
+            SessionMetadataPatch(
+                title="Renamed Session",
+                custom_metadata={"project": "demo"},
+            ),
+        )
+    ]
+
+
+def test_update_session_route_rejects_reserved_custom_metadata_key() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.patch(
+        "/api/sessions/session-1",
+        json={"custom_metadata": {"source_label": "bad"}},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.updated_calls == []
 
 
 def test_list_session_subagents_route_returns_projected_subagents() -> None:
@@ -390,7 +615,7 @@ def test_update_session_route_rejects_none_like_path_identifier() -> None:
 
     response = client.patch(
         "/api/sessions/None",
-        json={"metadata": {"title": "Renamed Session"}},
+        json={"title": "Renamed Session", "custom_metadata": {"label": "visible-name"}},
     )
 
     assert response.status_code == 422
@@ -550,3 +775,42 @@ def test_delete_agent_reflection_route_returns_projection() -> None:
     assert response.status_code == 200
     assert response.json()["source"] == "manual_delete"
     assert fake_service.reflection_delete_calls == [("session-1", "inst-1")]
+
+
+def test_delete_session_route_forwards_force_and_cascade() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    response = client.request(
+        "DELETE",
+        "/api/sessions/session-1",
+        json={"force": True, "cascade": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert fake_service.deleted_calls == [("session-1", True, True)]
+
+
+def test_delete_session_route_returns_conflict_for_missing_cascade() -> None:
+    fake_service = _FakeSessionService()
+    fake_service.delete_error = RuntimeError(
+        "Cannot delete session without cascade while related session data exists"
+    )
+    client = _create_client(fake_service)
+
+    response = client.request("DELETE", "/api/sessions/session-1")
+
+    assert response.status_code == 409
+    assert "without cascade" in response.json()["detail"]
+
+
+def test_delete_session_route_returns_not_found() -> None:
+    fake_service = _FakeSessionService()
+    fake_service.delete_error = KeyError("session-1")
+    client = _create_client(fake_service)
+
+    response = client.request("DELETE", "/api/sessions/session-1")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Session not found"}

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -60,6 +60,7 @@ from relay_teams.providers.model_connectivity import (
 )
 from relay_teams.providers.model_config import (
     DEFAULT_MAAS_BASE_URL,
+    ModelConfigPayload,
     ProviderModelInfo,
     ProviderType,
 )
@@ -73,21 +74,31 @@ from relay_teams.skills.clawhub_models import (
     ClawHubSkillWriteRequest,
 )
 from relay_teams.skills.skill_models import SkillScope
+from relay_teams.notifications.models import NotificationConfig
+from relay_teams.agents.orchestration.settings_models import OrchestrationSettings
 
 
 class _FakeSystemService:
     def __init__(self) -> None:
         self.saved_notification_config: dict[str, object] | None = None
         self.saved_orchestration_config: dict[str, object] | None = None
+        self.saved_model_config: dict[str, object] | None = None
         self.saved_model_profile: tuple[str, dict[str, object], str | None] | None = (
             None
         )
+        self.model_profile_error: Exception | None = None
+        self.model_profile_delete_error: Exception | None = None
+        self.model_config_error: Exception | None = None
         self.saved_proxy_config: dict[str, object] | None = None
         self.saved_web_config: dict[str, object] | None = None
         self.saved_clawhub_config: dict[str, object] | None = None
         self.saved_github_config: dict[str, object] | None = None
         self.saved_ui_language_settings: dict[str, object] | None = None
         self.proxy_save_error: RuntimeError | None = None
+        self.model_reload_error: Exception | None = None
+        self.proxy_reload_error: Exception | None = None
+        self.mcp_reload_error: Exception | None = None
+        self.skills_reload_error: Exception | None = None
         self.external_agents: dict[str, ExternalAgentConfig] = {
             "codex_local": ExternalAgentConfig(
                 agent_id="codex_local",
@@ -127,7 +138,23 @@ class _FakeSystemService:
         return settings
 
     def get_model_config(self) -> dict[str, object]:
-        return {}
+        return {
+            "default": {
+                "provider": "openai_compatible",
+                "model": "gpt-4o-mini",
+                "base_url": "https://example.test/v1",
+                "api_key": "secret",
+                "headers": [],
+                "temperature": 0.2,
+                "top_p": 1.0,
+                "max_tokens": 2048,
+                "context_window": 128000,
+                "connect_timeout_seconds": 25.0,
+                "is_default": True,
+                "maas_auth": None,
+                "ssl_verify": None,
+            }
+        }
 
     def get_model_profiles(self) -> dict[str, object]:
         return {
@@ -150,18 +177,28 @@ class _FakeSystemService:
         *,
         source_name: str | None = None,
     ) -> None:
+        if self.model_profile_error is not None:
+            raise self.model_profile_error
         self.saved_model_profile = (name, profile, source_name)
 
     def delete_model_profile(self, _name: str) -> None:
+        if self.model_profile_delete_error is not None:
+            raise self.model_profile_delete_error
         return None
 
-    def save_model_config(self, _config: dict[str, object]) -> None:
-        return None
+    def save_model_config(self, config: ModelConfigPayload) -> None:
+        if self.model_config_error is not None:
+            raise self.model_config_error
+        self.saved_model_config = config.model_dump(mode="json")
 
     def reload_model_config(self) -> None:
+        if self.model_reload_error is not None:
+            raise self.model_reload_error
         return None
 
     def reload_proxy_config(self) -> None:
+        if self.proxy_reload_error is not None:
+            raise self.proxy_reload_error
         return None
 
     def get_saved_proxy_config(self) -> dict[str, object]:
@@ -340,54 +377,62 @@ class _FakeSystemService:
         self.clawhub_skills.pop(skill_id)
 
     def reload_mcp_config(self) -> None:
+        if self.mcp_reload_error is not None:
+            raise self.mcp_reload_error
         return None
 
     def reload_skills_config(self) -> None:
+        if self.skills_reload_error is not None:
+            raise self.skills_reload_error
         return None
 
-    def get_notification_config(self) -> dict[str, object]:
-        return {
-            "tool_approval_requested": {
-                "enabled": True,
-                "channels": ["browser", "toast"],
-                "feishu_format": "text",
-            },
-            "run_completed": {
-                "enabled": False,
-                "channels": ["toast"],
-                "feishu_format": "text",
-            },
-            "run_failed": {
-                "enabled": True,
-                "channels": ["browser", "toast"],
-                "feishu_format": "text",
-            },
-            "run_stopped": {
-                "enabled": False,
-                "channels": ["toast"],
-                "feishu_format": "text",
-            },
-        }
+    def get_notification_config(self) -> NotificationConfig:
+        return NotificationConfig.model_validate(
+            {
+                "tool_approval_requested": {
+                    "enabled": True,
+                    "channels": ["browser", "toast"],
+                    "feishu_format": "text",
+                },
+                "run_completed": {
+                    "enabled": False,
+                    "channels": ["toast"],
+                    "feishu_format": "text",
+                },
+                "run_failed": {
+                    "enabled": True,
+                    "channels": ["browser", "toast"],
+                    "feishu_format": "text",
+                },
+                "run_stopped": {
+                    "enabled": False,
+                    "channels": ["toast"],
+                    "feishu_format": "text",
+                },
+            }
+        )
 
-    def save_notification_config(self, config: dict[str, object]) -> None:
-        self.saved_notification_config = config
+    def save_notification_config(self, config: NotificationConfig) -> None:
+        self.saved_notification_config = config.model_dump(mode="json")
 
-    def get_orchestration_config(self) -> dict[str, object]:
-        return {
-            "default_orchestration_preset_id": "default",
-            "presets": [
-                {
-                    "preset_id": "default",
-                    "name": "Default",
-                    "description": "General delegation flow.",
-                    "role_ids": ["writer", "reviewer"],
-                    "orchestration_prompt": "Delegate by capability and keep the final answer concise.",
-                }
-            ],
-        }
+    def get_orchestration_config(self) -> OrchestrationSettings:
+        return OrchestrationSettings.model_validate(
+            {
+                "default_orchestration_preset_id": "default",
+                "presets": [
+                    {
+                        "preset_id": "default",
+                        "name": "Default",
+                        "description": "General delegation flow.",
+                        "role_ids": ["writer", "reviewer"],
+                        "orchestration_prompt": "Delegate by capability and keep the final answer concise.",
+                    }
+                ],
+            }
+        )
 
-    def save_orchestration_config(self, config: dict[str, object]) -> None:
-        self.saved_orchestration_config = config
+    def save_orchestration_config(self, config: OrchestrationSettings) -> None:
+        self.saved_orchestration_config = config.model_dump(mode="json")
 
     def get_provider_models(
         self,
@@ -641,28 +686,26 @@ def test_save_notification_config() -> None:
     service = _FakeSystemService()
     client = _create_test_client(service)
     request_payload = {
-        "config": {
-            "tool_approval_requested": {
-                "enabled": True,
-                "channels": ["browser", "toast"],
-                "feishu_format": "text",
-            },
-            "run_completed": {
-                "enabled": True,
-                "channels": ["toast", "feishu"],
-                "feishu_format": "card",
-            },
-            "run_failed": {
-                "enabled": True,
-                "channels": ["browser", "toast"],
-                "feishu_format": "text",
-            },
-            "run_stopped": {
-                "enabled": True,
-                "channels": ["toast"],
-                "feishu_format": "text",
-            },
-        }
+        "tool_approval_requested": {
+            "enabled": True,
+            "channels": ["browser", "toast"],
+            "feishu_format": "text",
+        },
+        "run_completed": {
+            "enabled": True,
+            "channels": ["toast", "feishu"],
+            "feishu_format": "card",
+        },
+        "run_failed": {
+            "enabled": True,
+            "channels": ["browser", "toast"],
+            "feishu_format": "text",
+        },
+        "run_stopped": {
+            "enabled": True,
+            "channels": ["toast"],
+            "feishu_format": "text",
+        },
     }
     response = client.put("/api/system/configs/notifications", json=request_payload)
     assert response.status_code == 200
@@ -882,6 +925,34 @@ def test_save_orchestration_config() -> None:
     response = client.put(
         "/api/system/configs/orchestration",
         json={
+            "default_orchestration_preset_id": "shipping",
+            "presets": [
+                {
+                    "preset_id": "shipping",
+                    "name": "Shipping",
+                    "description": "Release work.",
+                    "role_ids": ["writer"],
+                    "orchestration_prompt": "Use writer for outward-facing updates.",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert service.saved_orchestration_config is not None
+    assert service.saved_orchestration_config["default_orchestration_preset_id"] == (
+        "shipping"
+    )
+
+
+def test_save_orchestration_config_accepts_legacy_wrapper_payload() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/orchestration",
+        json={
             "config": {
                 "default_orchestration_preset_id": "shipping",
                 "presets": [
@@ -914,6 +985,120 @@ def test_get_provider_models() -> None:
     payload = response.json()
     assert len(payload) == 3
     assert payload[0]["profile"] == "default"
+
+
+def test_get_model_config() -> None:
+    client = _create_test_client(_FakeSystemService())
+
+    response = client.get("/api/system/configs/model")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "default": {
+            "provider": "openai_compatible",
+            "model": "gpt-4o-mini",
+            "base_url": "https://example.test/v1",
+            "api_key": "secret",
+            "headers": [],
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "max_tokens": 2048,
+            "context_window": 128000,
+            "connect_timeout_seconds": 25.0,
+            "is_default": True,
+            "maas_auth": None,
+            "ssl_verify": None,
+        }
+    }
+
+
+def test_save_model_config() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model",
+        json={
+            "default": {
+                "provider": "openai_compatible",
+                "model": "gpt-4o-mini",
+                "base_url": "https://example.test/v1",
+                "api_key": "secret",
+                "headers": [],
+                "temperature": 0.2,
+                "top_p": 1.0,
+                "max_tokens": 2048,
+                "context_window": 128000,
+                "connect_timeout_seconds": 25.0,
+                "is_default": True,
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert service.saved_model_config == {
+        "default": {
+            "provider": "openai_compatible",
+            "model": "gpt-4o-mini",
+            "base_url": "https://example.test/v1",
+            "api_key": "secret",
+            "headers": [],
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "max_tokens": 2048,
+            "context_window": 128000,
+            "connect_timeout_seconds": 25.0,
+            "is_default": True,
+            "maas_auth": None,
+            "ssl_verify": None,
+        }
+    }
+
+
+def test_save_model_config_accepts_legacy_wrapper_payload() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+    response = client.put(
+        "/api/system/configs/model",
+        json={
+            "config": {
+                "default": {
+                    "provider": "openai_compatible",
+                    "model": "gpt-4o-mini",
+                    "base_url": "https://example.test/v1",
+                    "api_key": "secret",
+                }
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert service.saved_model_config is not None
+    saved_default = cast(dict[str, object], service.saved_model_config["default"])
+    assert saved_default["model"] == "gpt-4o-mini"
+
+
+def test_save_model_config_rejects_unknown_profile_field() -> None:
+    client = _create_test_client(_FakeSystemService())
+
+    response = client.put(
+        "/api/system/configs/model",
+        json={
+            "default": {
+                "provider": "openai_compatible",
+                "model": "gpt-4o-mini",
+                "base_url": "https://example.test/v1",
+                "api_key": "secret",
+                "temperature": 0.2,
+                "top_p": 1.0,
+                "unexpected": True,
+            }
+        },
+    )
+
+    assert response.status_code == 422
 
 
 def test_get_model_profiles_returns_api_key() -> None:
@@ -1007,6 +1192,17 @@ def test_discover_model_catalog() -> None:
     assert payload["ok"] is True
     assert payload["latency_ms"] == 37
     assert payload["models"] == ["fake-chat-model", "reasoning-model"]
+
+
+def test_reload_model_config_returns_bad_request_for_invalid_config() -> None:
+    service = _FakeSystemService()
+    service.model_reload_error = ValueError("Invalid model config")
+    client = _create_test_client(service)
+
+    response = client.post("/api/system/configs/model:reload")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid model config"}
 
 
 def test_reload_proxy_config() -> None:
@@ -1250,6 +1446,39 @@ def test_save_proxy_config_returns_user_error_for_missing_keyring() -> None:
     assert "system keyring backend" in response.json()["detail"]
 
 
+def test_reload_proxy_config_returns_bad_request_for_invalid_config() -> None:
+    service = _FakeSystemService()
+    service.proxy_reload_error = RuntimeError("Invalid proxy config")
+    client = _create_test_client(service)
+
+    response = client.post("/api/system/configs/proxy:reload")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid proxy config"}
+
+
+def test_reload_mcp_config_returns_bad_request_for_invalid_config() -> None:
+    service = _FakeSystemService()
+    service.mcp_reload_error = ValueError("Invalid MCP config")
+    client = _create_test_client(service)
+
+    response = client.post("/api/system/configs/mcp:reload")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid MCP config"}
+
+
+def test_reload_skills_config_returns_bad_request_for_invalid_config() -> None:
+    service = _FakeSystemService()
+    service.skills_reload_error = RuntimeError("Invalid skills config")
+    client = _create_test_client(service)
+
+    response = client.post("/api/system/configs/skills:reload")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid skills config"}
+
+
 def test_probe_web_connectivity() -> None:
     client = _create_test_client(_FakeSystemService())
 
@@ -1284,6 +1513,84 @@ def test_probe_web_connectivity_accepts_proxy_override() -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True
+
+
+def test_save_model_profile_returns_not_found_for_missing_source_name() -> None:
+    service = _FakeSystemService()
+    service.model_profile_error = KeyError("Model profile not found: default")
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model/profiles/renamed",
+        json={
+            "source_name": "default",
+            "provider": ProviderType.OPENAI_COMPATIBLE.value,
+            "model": "kimi-k2.5",
+            "base_url": "https://api.moonshot.cn/v1",
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "max_tokens": 4096,
+        },
+    )
+
+    assert response.status_code == 404
+    assert "Model profile not found" in response.json()["detail"]
+
+
+def test_save_model_profile_returns_bad_request_for_service_validation_error() -> None:
+    service = _FakeSystemService()
+    service.model_profile_error = ValueError("Header 'Authorization' requires a value.")
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model/profiles/default",
+        json={
+            "provider": ProviderType.OPENAI_COMPATIBLE.value,
+            "model": "kimi-k2.5",
+            "base_url": "https://api.moonshot.cn/v1",
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "max_tokens": 4096,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "requires a value" in response.json()["detail"]
+
+
+def test_delete_model_profile_returns_not_found_when_missing() -> None:
+    service = _FakeSystemService()
+    service.model_profile_delete_error = KeyError("Model profile not found: default")
+    client = _create_test_client(service)
+
+    response = client.delete("/api/system/configs/model/profiles/default")
+
+    assert response.status_code == 404
+    assert "Model profile not found" in response.json()["detail"]
+
+
+def test_save_model_config_returns_bad_request_for_service_validation_error() -> None:
+    service = _FakeSystemService()
+    service.model_config_error = ValueError(
+        "MAAS model profile requires maas_auth configuration."
+    )
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model",
+        json={
+            "maas": {
+                "provider": "maas",
+                "model": "maas-chat",
+                "base_url": "https://maas.example/api/v2",
+                "temperature": 0.2,
+                "top_p": 1.0,
+            }
+        },
+    )
+
+    assert response.status_code == 400
+    assert "maas_auth" in response.json()["detail"]
 
 
 def test_save_model_profile_allows_missing_api_key_for_edit() -> None:
@@ -1631,3 +1938,86 @@ def test_delete_environment_variable_returns_forbidden_on_permission_error() -> 
 
     assert response.status_code == 403
     assert "access denied" in response.json()["detail"].lower()
+
+
+def test_save_notification_config_rejects_unknown_top_level_field() -> None:
+    client = _create_test_client(_FakeSystemService())
+
+    response = client.put(
+        "/api/system/configs/notifications",
+        json={
+            "tool_approval_requested": {
+                "enabled": True,
+                "channels": ["browser", "toast"],
+                "feishu_format": "text",
+            },
+            "run_completed": {
+                "enabled": True,
+                "channels": ["toast", "feishu"],
+                "feishu_format": "card",
+            },
+            "run_failed": {
+                "enabled": True,
+                "channels": ["browser", "toast"],
+                "feishu_format": "text",
+            },
+            "run_stopped": {
+                "enabled": True,
+                "channels": ["toast"],
+                "feishu_format": "text",
+            },
+            "unexpected": {},
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_save_orchestration_config_rejects_unknown_top_level_field() -> None:
+    client = _create_test_client(_FakeSystemService())
+
+    response = client.put(
+        "/api/system/configs/orchestration",
+        json={
+            "default_orchestration_preset_id": "shipping",
+            "presets": [
+                {
+                    "preset_id": "shipping",
+                    "name": "Shipping",
+                    "description": "Release work.",
+                    "role_ids": ["writer"],
+                    "orchestration_prompt": "Use writer for outward-facing updates.",
+                }
+            ],
+            "unexpected": True,
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_get_model_config_preserves_omitted_sparse_fields() -> None:
+    class _SparseSystemService(_FakeSystemService):
+        def get_model_config(self) -> dict[str, object]:
+            return {
+                "default": {
+                    "provider": "openai_compatible",
+                    "model": "gpt-4o-mini",
+                    "base_url": "https://example.test/v1",
+                    "api_key": "secret",
+                }
+            }
+
+    client = _create_test_client(_SparseSystemService())
+
+    response = client.get("/api/system/configs/model")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "default": {
+            "provider": "openai_compatible",
+            "model": "gpt-4o-mini",
+            "base_url": "https://example.test/v1",
+            "api_key": "secret",
+        }
+    }

--- a/tests/unit_tests/interfaces/server/test_workspaces_router.py
+++ b/tests/unit_tests/interfaces/server/test_workspaces_router.py
@@ -448,7 +448,7 @@ def test_fork_workspace_forwards_start_ref(tmp_path: Path) -> None:
     assert service.calls == [("project-alpha", "Alpha Project Fork", "origin/release")]
 
 
-def test_delete_workspace_supports_remove_worktree_query(tmp_path: Path) -> None:
+def test_delete_workspace_requires_force_for_remove_worktree(tmp_path: Path) -> None:
     root_path = tmp_path / "storage" / "alpha-project-fork" / "worktree"
     root_path.mkdir(parents=True)
     git_client = FakeGitWorktreeClient()
@@ -472,6 +472,42 @@ def test_delete_workspace_supports_remove_worktree_query(tmp_path: Path) -> None
     client, _ = _create_test_client(tmp_path, service=service)
 
     response = client.delete("/api/workspaces/alpha-project-fork?remove_worktree=true")
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": "Cannot remove workspace git worktree without force"
+    }
+    assert git_client.remove_calls == []
+
+
+def test_delete_workspace_supports_remove_worktree_query(tmp_path: Path) -> None:
+    root_path = tmp_path / "storage" / "alpha-project-fork" / "worktree"
+    root_path.mkdir(parents=True)
+    git_client = FakeGitWorktreeClient()
+    service = StorageScopedWorkspaceService(
+        repository=WorkspaceRepository(tmp_path / "workspaces_router.db"),
+        storage_root=tmp_path / "storage",
+        git_worktree_client=git_client,
+    )
+    _ = service.create_workspace(
+        workspace_id="alpha-project-fork",
+        root_path=root_path,
+        profile=WorkspaceProfile(
+            file_scope=WorkspaceFileScope(
+                backend=FileScopeBackend.GIT_WORKTREE,
+                branch_name="fork/alpha-project-fork",
+                source_root_path=str((tmp_path / "workspace-root").resolve()),
+                forked_from_workspace_id="project-alpha",
+            )
+        ),
+    )
+    client, _ = _create_test_client(tmp_path, service=service)
+
+    response = client.request(
+        "DELETE",
+        "/api/workspaces/alpha-project-fork?remove_worktree=true",
+        json={"force": True},
+    )
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}

--- a/tests/unit_tests/providers/test_model_config_service.py
+++ b/tests/unit_tests/providers/test_model_config_service.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from relay_teams.providers.model_config import ModelConfigPayload
+from relay_teams.providers.model_config_manager import ModelConfigManager
+from relay_teams.providers.model_config_service import ModelConfigService
+from relay_teams.sessions.runs.runtime_config import RuntimeConfig
+
+
+class _RecordingModelConfigManager:
+    def __init__(self) -> None:
+        self.saved_config: dict[str, object] | None = None
+
+    def get_model_config(self) -> dict[str, object]:
+        return {}
+
+    def get_model_profiles(self) -> dict[str, dict[str, object]]:
+        return {}
+
+    def save_model_profile(
+        self,
+        name: str,
+        profile: dict[str, object],
+        *,
+        source_name: str | None = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def delete_model_profile(self, name: str) -> None:
+        raise NotImplementedError
+
+    def save_model_config(self, config: dict[str, object]) -> None:
+        self.saved_config = config
+
+
+def test_save_model_config_preserves_omitted_optional_fields() -> None:
+    manager = _RecordingModelConfigManager()
+    service = ModelConfigService(
+        config_dir=Path("."),
+        roles_dir=Path("."),
+        db_path=Path("relay-teams.db"),
+        model_config_manager=cast(ModelConfigManager, manager),
+        get_runtime=lambda: RuntimeConfig.model_construct(),
+        on_runtime_reloaded=lambda runtime: None,
+    )
+
+    service.save_model_config(
+        ModelConfigPayload.model_validate(
+            {
+                "default": {
+                    "provider": "openai_compatible",
+                    "model": "gpt-4.1",
+                    "base_url": "https://example.test/v1",
+                    "temperature": 0.2,
+                    "top_p": 1.0,
+                },
+                "kimi": {
+                    "provider": "openai_compatible",
+                    "model": "kimi-k2.5",
+                    "base_url": "https://example.test/v1",
+                    "temperature": 0.2,
+                    "top_p": 1.0,
+                    "max_tokens": None,
+                },
+            }
+        )
+    )
+
+    assert manager.saved_config == {
+        "default": {
+            "provider": "openai_compatible",
+            "model": "gpt-4.1",
+            "base_url": "https://example.test/v1",
+            "temperature": 0.2,
+            "top_p": 1.0,
+        },
+        "kimi": {
+            "provider": "openai_compatible",
+            "model": "kimi-k2.5",
+            "base_url": "https://example.test/v1",
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "max_tokens": None,
+        },
+    }

--- a/tests/unit_tests/sessions/test_session_delete_workspace_cleanup.py
+++ b/tests/unit_tests/sessions/test_session_delete_workspace_cleanup.py
@@ -267,7 +267,7 @@ def test_delete_session_cleans_workspace_and_role_state(tmp_path: Path) -> None:
         )
     )
 
-    service.delete_session("session-1")
+    service.delete_session("session-1", cascade=True)
 
     workspace_snapshot = shared_store.snapshot(
         ScopeRef(scope_type=ScopeType.WORKSPACE, scope_id=workspace_id)

--- a/tests/unit_tests/sessions/test_session_update.py
+++ b/tests/unit_tests/sessions/test_session_update.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
@@ -12,7 +13,7 @@ from relay_teams.providers.token_usage_repo import TokenUsageRepository
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.sessions.session_service import SessionService
 from relay_teams.sessions.session_repository import SessionRepository
-from relay_teams.sessions.session_models import SessionMode
+from relay_teams.sessions.session_models import SessionMetadataPatch, SessionMode
 from relay_teams.gateway.feishu import (
     SESSION_METADATA_TITLE_SOURCE_KEY,
     SESSION_TITLE_SOURCE_AUTO,
@@ -91,10 +92,10 @@ def test_update_session_replaces_metadata_and_refreshes_updated_at(
 
     service.update_session(
         "session-1",
-        {
-            "title": "Renamed Session",
-            "label": "visible-name",
-        },
+        SessionMetadataPatch(
+            title="Renamed Session",
+            custom_metadata={"label": "visible-name"},
+        ),
     )
 
     updated = service.get_session("session-1")
@@ -107,12 +108,44 @@ def test_update_session_replaces_metadata_and_refreshes_updated_at(
     assert updated.updated_at >= created.updated_at
 
 
+def test_sync_session_metadata_replaces_internal_metadata_and_refreshes_updated_at(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_sync_metadata.db"
+    service = _build_service(db_path)
+    created = service.create_session(
+        session_id="session-1",
+        workspace_id="default",
+        metadata={"title": "Initial Name", "label": "visible-name"},
+    )
+
+    service.sync_session_metadata(
+        "session-1",
+        {
+            "title": "Feishu Bot - Ops",
+            SESSION_METADATA_TITLE_SOURCE_KEY: SESSION_TITLE_SOURCE_AUTO,
+            "feishu_message_id": "om_2",
+            "source_label": "Ops",
+        },
+    )
+
+    updated = service.get_session("session-1")
+
+    assert updated.metadata == {
+        "title": "Feishu Bot - Ops",
+        SESSION_METADATA_TITLE_SOURCE_KEY: SESSION_TITLE_SOURCE_AUTO,
+        "feishu_message_id": "om_2",
+        "source_label": "Ops",
+    }
+    assert updated.updated_at >= created.updated_at
+
+
 def test_update_session_raises_for_unknown_session(tmp_path: Path) -> None:
     db_path = tmp_path / "session_update_missing.db"
     service = _build_service(db_path)
 
     with pytest.raises(KeyError, match="missing-session"):
-        service.update_session("missing-session", {"title": "Nope"})
+        service.update_session("missing-session", SessionMetadataPatch(title="Nope"))
 
 
 def test_create_session_raises_when_main_agent_role_is_unavailable(
@@ -156,10 +189,10 @@ def test_update_session_preserves_explicit_auto_title_source(tmp_path: Path) -> 
 
     service.update_session(
         "session-1",
-        {
-            "title": "Feishu Bot ? Ops",
-            SESSION_METADATA_TITLE_SOURCE_KEY: SESSION_TITLE_SOURCE_AUTO,
-        },
+        SessionMetadataPatch(
+            title="Feishu Bot ? Ops",
+            title_source=SESSION_TITLE_SOURCE_AUTO,
+        ),
     )
 
     updated = service.get_session("session-1")
@@ -184,11 +217,58 @@ def test_update_session_clears_title_source_when_title_is_removed(
         },
     )
 
-    service.update_session("session-1", {})
+    service.update_session("session-1", SessionMetadataPatch(title=None))
 
     updated = service.get_session("session-1")
 
     assert updated.metadata == {}
+
+
+def test_update_session_replaces_only_custom_metadata_subset(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_update_custom_subset.db"
+    service = _build_service(db_path)
+    _ = service.create_session(
+        session_id="session-1",
+        workspace_id="default",
+        metadata={
+            "title": "Initial Name",
+            SESSION_METADATA_TITLE_SOURCE_KEY: SESSION_TITLE_SOURCE_MANUAL,
+            "source_label": "Feishu Group",
+            "label": "visible-name",
+            "favorite": "yes",
+        },
+    )
+
+    service.update_session(
+        "session-1",
+        SessionMetadataPatch(custom_metadata={"favorite": "no"}),
+    )
+
+    updated = service.get_session("session-1")
+
+    assert updated.metadata == {
+        "title": "Initial Name",
+        SESSION_METADATA_TITLE_SOURCE_KEY: SESSION_TITLE_SOURCE_MANUAL,
+        "source_label": "Feishu Group",
+        "favorite": "no",
+    }
+
+
+def test_session_metadata_patch_rejects_reserved_custom_key() -> None:
+    with pytest.raises(ValidationError, match="custom_metadata key is reserved"):
+        SessionMetadataPatch(custom_metadata={"source_label": "Bad"})
+
+
+def test_update_session_rejects_title_source_without_title(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_update_title_source_only.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    with pytest.raises(ValueError, match="title_source requires title to be set"):
+        service.update_session(
+            "session-1",
+            SessionMetadataPatch(title_source=SESSION_TITLE_SOURCE_MANUAL),
+        )
 
 
 def test_create_session_defaults_normal_root_role_to_main_agent(tmp_path: Path) -> None:
@@ -320,3 +400,57 @@ def test_rebind_session_workspace_rejects_recoverable_run(tmp_path: Path) -> Non
     assert (
         service.get_session("session-1").workspace_id == default_workspace.workspace_id
     )
+
+
+def test_delete_session_rejects_active_run_without_force(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_delete_active_run.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-1",
+        session_id="session-1",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot delete session while it has active or recoverable run",
+    ):
+        service.delete_session("session-1")
+
+
+def test_delete_session_rejects_related_data_without_cascade(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_delete_needs_cascade.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    message_repo = MessageRepository(db_path)
+    _ = message_repo.append_user_prompt_if_missing(
+        session_id="session-1",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        content="hello",
+        workspace_id="default",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot delete session without cascade while related session data exists",
+    ):
+        service.delete_session("session-1")
+
+
+def test_delete_session_force_allows_active_run_cleanup(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_delete_force.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-1",
+        session_id="session-1",
+    )
+
+    service.delete_session("session-1", force=True, cascade=True)
+
+    with pytest.raises(KeyError, match="session-1"):
+        service.get_session("session-1")

--- a/tests/unit_tests/sessions/test_session_update.py
+++ b/tests/unit_tests/sessions/test_session_update.py
@@ -224,6 +224,44 @@ def test_update_session_clears_title_source_when_title_is_removed(
     assert updated.metadata == {}
 
 
+def test_update_session_clears_title_for_legacy_snapshot_without_title(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_update_legacy_snapshot_clear_title.db"
+    service = _build_service(db_path)
+    _ = service.create_session(
+        session_id="session-1",
+        workspace_id="default",
+        metadata={
+            "title": "Feishu Bot - Ops",
+            SESSION_METADATA_TITLE_SOURCE_KEY: SESSION_TITLE_SOURCE_AUTO,
+            "source_provider": "feishu",
+            "feishu_chat_id": "chat-1",
+            "project": "demo",
+        },
+    )
+
+    service.update_session(
+        "session-1",
+        SessionMetadataPatch.model_validate(
+            {
+                "title_source": SESSION_TITLE_SOURCE_AUTO,
+                "source_provider": "feishu",
+                "feishu_chat_id": "chat-1",
+                "project": "demo",
+            }
+        ),
+    )
+
+    updated = service.get_session("session-1")
+
+    assert updated.metadata == {
+        "source_provider": "feishu",
+        "feishu_chat_id": "chat-1",
+        "project": "demo",
+    }
+
+
 def test_update_session_replaces_only_custom_metadata_subset(tmp_path: Path) -> None:
     db_path = tmp_path / "session_update_custom_subset.db"
     service = _build_service(db_path)

--- a/tests/unit_tests/wechat/test_service.py
+++ b/tests/unit_tests/wechat/test_service.py
@@ -11,6 +11,7 @@ from threading import Lock
 from typing import cast
 
 import pytest
+from pydantic import ValidationError
 
 from pydantic import JsonValue
 
@@ -24,6 +25,7 @@ from relay_teams.gateway.wechat.inbound_queue_repository import (
 )
 from relay_teams.gateway.wechat.models import (
     WeChatAccountRecord,
+    WeChatAccountUpdateInput,
     WeChatInboundMessage,
     WeChatInboundQueueRecord,
     WeChatInboundQueueStatus,
@@ -1081,3 +1083,65 @@ def _event(
         payload_json=json.dumps(payload, ensure_ascii=False),
         occurred_at=datetime.now(tz=timezone.utc),
     )
+
+
+def test_wechat_account_update_input_rejects_empty_patch() -> None:
+    with pytest.raises(ValidationError, match="update must include at least one field"):
+        WeChatAccountUpdateInput()
+
+
+def test_wechat_account_update_input_trims_route_tag() -> None:
+    req = WeChatAccountUpdateInput(route_tag="  route-a  ")
+
+    assert req.route_tag == "route-a"
+
+
+def test_wechat_account_update_input_allows_blank_route_tag_to_clear_value() -> None:
+    req = WeChatAccountUpdateInput(route_tag="   ")
+
+    assert req.route_tag is None
+    assert "route_tag" in req.model_fields_set
+
+
+class _DeleteAccountRepository:
+    def __init__(self, account: WeChatAccountRecord) -> None:
+        self.account = account
+        self.deleted_account_ids: list[str] = []
+
+    def get_account(self, account_id: str) -> WeChatAccountRecord:
+        if account_id != self.account.account_id:
+            raise KeyError(account_id)
+        return self.account
+
+    def delete_account(self, account_id: str) -> None:
+        self.deleted_account_ids.append(account_id)
+
+
+class _DeleteSecretStore:
+    def __init__(self) -> None:
+        self.deleted_account_ids: list[str] = []
+
+    def delete_bot_token(self, config_dir: Path, account_id: str) -> None:
+        _ = config_dir
+        self.deleted_account_ids.append(account_id)
+
+
+def test_delete_account_rejects_enabled_account_without_force() -> None:
+    repository = _DeleteAccountRepository(_account())
+    secret_store = _DeleteSecretStore()
+    service = object.__new__(WeChatGatewayService)
+    service._repository = cast(WeChatAccountRepository, repository)
+    service._secret_store = cast(WeChatSecretStore, secret_store)
+    service._config_dir = Path("C:/config")
+    service._stop_account_worker = lambda account_id: None
+
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot delete enabled WeChat account without force",
+    ):
+        service.delete_account("wx-account-1")
+
+    service.delete_account("wx-account-1", force=True)
+
+    assert repository.deleted_account_ids == ["wx-account-1"]
+    assert secret_store.deleted_account_ids == ["wx-account-1"]


### PR DESCRIPTION
• 本次 PR 主要是在补齐高风险写接口的参数校验，同时修复前后端兼容性回归，确保“显式修改”和“历史脏数据容忍”这两类场景分开处理。

  核心内容可以概括成几块：

  1. 写接口收口与强校验
     对网关、会话、工作区等高风险变更接口补了统一的写入校验和错误映射，避免不完整 payload、危险删除、隐式覆盖这类问题直接落库。对应地新增了服务端校验模型、错误映射逻辑和一组单测。
  2. 网关能力修复
     补了 Feishu / WeChat 相关更新与删除语义：

  - 删除已绑定或启用中的账号时，需要显式 force
  - 前端、SDK、CLI 都同步带上 force
  - Feishu 的密钥字段支持显式传 null
  - WeChat 的 route_tag 现在支持前端传空字符串来“清空值”，不会再被误判为非法输入

  3. Sessions / System Config 兼容性修复
     修复了 session 创建、更新时的旧字段兼容问题，保留 metadata 快照语义；同时补了 system config 在 model / orchestration / notifications 等包装 payload 下的兼容处理，避免新旧请求格式混用时出错。
  4. Workspace 危险操作保护
     remove_worktree=true 现在必须显式配合 force，防止误删工作树。前端调用和文档也同步更新了。
  5. 测试与文档
     针对上述改动补了对应单测，覆盖了：

  - 参数校验失败路径
  - 显式清空字段
  - force 删除保护
  - 包装 payload 兼容
  - 路由层 422/200 行为映射
    相关文档也做了同步更新，避免实现和接口说明脱节。

## Summary
- extract shared API write/delete validation helpers and router error mapping
- tighten typed request contracts for sessions, automation, Feishu gateway, WeChat gateway, prompt preview, and system config writes
- enforce force/cascade delete preconditions, update API docs, and add focused unit coverage

## Validation
- pre-commit during commit: ruff-check, ruff-format, basedpyright-check
- uv run --extra dev pytest -q tests/unit_tests/interfaces/server tests/unit_tests/sessions tests/unit_tests/automation tests/unit_tests/gateway tests/unit_tests/wechat

Closes #326