### PR TITLE
Fix settings modal overlay close behavior

### DIFF
--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -24,6 +24,7 @@ import { t, translateDocument } from '../../utils/i18n.js';
 let settingsModal = null;
 let currentTab = 'appearance';
 let initialized = false;
+let overlayPointerDown = false;
 
 const TAB_METADATA = {
     appearance: {
@@ -925,8 +926,14 @@ function setupEventListeners() {
         closeBtn.onclick = closeSettings;
     }
 
+    settingsModal.onmousedown = (e) => {
+        overlayPointerDown = e.target === settingsModal;
+    };
+
     settingsModal.onclick = (e) => {
-        if (e.target === settingsModal) {
+        const shouldClose = overlayPointerDown && e.target === settingsModal;
+        overlayPointerDown = false;
+        if (shouldClose) {
             closeSettings();
         }
     };
@@ -1082,6 +1089,7 @@ export function openSettings() {
 
 export function closeSettings() {
     if (!settingsModal) return;
+    overlayPointerDown = false;
     settingsModal.classList.remove('settings-modal-visible');
     settingsModal.style.display = 'none';
 }

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -483,6 +483,39 @@ def test_browser_model_profile_switching_to_bigmodel_prefills_base_url(
     )
 
 
+def test_browser_settings_modal_does_not_close_after_dragging_out_of_content(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+) -> None:
+    page = browser_page
+    _open_app(page, integration_env)
+
+    page.locator("#settings-btn").click()
+    settings_modal = page.locator("#settings-modal")
+    settings_content = page.locator(".settings-modal-content")
+    expect(settings_modal).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+    content_box = settings_content.bounding_box()
+    modal_box = settings_modal.bounding_box()
+    assert content_box is not None
+    assert modal_box is not None
+
+    start_x = content_box["x"] + content_box["width"] / 2
+    start_y = content_box["y"] + content_box["height"] / 2
+    end_x = modal_box["x"] + 8
+    end_y = modal_box["y"] + 8
+
+    page.mouse.move(start_x, start_y)
+    page.mouse.down()
+    page.mouse.move(end_x, end_y)
+    page.mouse.up()
+
+    expect(settings_modal).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+    page.mouse.click(end_x, end_y)
+    expect(settings_modal).to_be_hidden(timeout=_WAIT_TIMEOUT_MS)
+
+
 @pytest.mark.skip(reason="Flaky on CI - timing issues with browser automation")
 def test_browser_environment_variables_and_session_topology(
     browser_page: Page,

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -862,3 +862,35 @@ console.log(JSON.stringify({
     assert payload["envPanelDisplay"] == "block"
     assert payload["envAddDisplay"] == "inline-flex"
     assert load_calls["environment"] == 1
+
+
+def test_settings_modal_only_closes_for_direct_overlay_click(tmp_path: Path) -> None:
+    payload = _run_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { initSettings, openSettings } = await import("./index.mjs");
+
+initSettings();
+openSettings();
+
+const settingsModal = document.getElementById("settings-modal");
+const modalContent = settingsModal.children[0];
+
+settingsModal.onmousedown({ target: modalContent });
+settingsModal.onclick({ target: settingsModal });
+const afterDraggedReleaseDisplay = settingsModal.style.display;
+
+openSettings();
+settingsModal.onmousedown({ target: settingsModal });
+settingsModal.onclick({ target: settingsModal });
+const afterDirectOverlayClickDisplay = settingsModal.style.display;
+
+console.log(JSON.stringify({
+    afterDraggedReleaseDisplay,
+    afterDirectOverlayClickDisplay,
+}));
+""".strip(),
+    )
+
+    assert payload["afterDraggedReleaseDisplay"] == "flex"
+    assert payload["afterDirectOverlayClickDisplay"] == "none"


### PR DESCRIPTION
## Summary
- only close the settings modal when the pointer interaction starts on the overlay
- keep the modal open when a drag starts inside modal content and ends on the overlay
- add frontend unit and browser regression coverage

Fixes #187

## Testing
- python -m uv run ruff check --fix
- python -m uv run ruff format --no-cache --force-exclude
- python -m uv run basedpyright
- python -m uv run pytest -q tests/unit_tests/frontend/test_settings_shell_ui.py -q
- python -m uv run pytest -q tests/integration_tests/browser/test_browser_smoke.py -k "settings_modal_does_not_close_after_dragging_out_of_content" -q