### PR TITLE
Use the current directory as the default CLI workspace

### DIFF
--- a/src/relay_teams/interfaces/cli/app.py
+++ b/src/relay_teams/interfaces/cli/app.py
@@ -275,7 +275,10 @@ def root_command(
     workspace: Path | None = typer.Option(
         None,
         "--workspace",
-        help="Create or reuse a workspace for the given workspace root path. Requires --message.",
+        help=(
+            "Create or reuse a workspace for the given workspace root path. "
+            "Defaults to the current directory. Requires --message."
+        ),
     ),
     yolo: bool = typer.Option(
         True,

--- a/src/relay_teams/interfaces/cli/run_prompt_cli.py
+++ b/src/relay_teams/interfaces/cli/run_prompt_cli.py
@@ -24,7 +24,8 @@ type ExecutePromptCallable = Callable[..., None]
 QUICK_PROMPT_OPTIONS_HINT = (
     "Available quick prompt options: --message <text>, "
     "--mode <normal|orchestration>, --role <role_id>, "
-    "--orchestration <id>, --workspace <path>, --yolo/--no-yolo."
+    "--orchestration <id>, --workspace <path> (defaults to current directory), "
+    "--yolo/--no-yolo."
 )
 
 
@@ -226,10 +227,9 @@ def _resolve_workspace_id(
     workspace: Path | None,
     request_json: RequestJsonCallable,
 ) -> str:
-    if workspace is None:
-        return "default"
-
-    resolved_workspace = workspace.expanduser().resolve()
+    resolved_workspace = (
+        Path.cwd().resolve() if workspace is None else workspace.expanduser().resolve()
+    )
     response = request_json(
         base_url,
         "POST",

--- a/tests/integration_tests/cli/test_prompt_output.py
+++ b/tests/integration_tests/cli/test_prompt_output.py
@@ -11,6 +11,15 @@ from integration_tests.support.environment import IntegrationEnvironment
 runner = CliRunner()
 
 
+def _workspace_response(root_path: Path) -> dict[str, object]:
+    return {
+        "workspace": {
+            "workspace_id": "workspace-1",
+            "root_path": str(root_path.resolve()),
+        }
+    }
+
+
 def test_root_message_prints_fake_llm_output(
     integration_env: IntegrationEnvironment,
     monkeypatch,
@@ -55,7 +64,32 @@ def test_root_message_supports_workspace_selection(
     assert any(item["root_path"] == str(project_root.resolve()) for item in payload)
 
 
-def test_root_message_uses_yolo_by_default(monkeypatch) -> None:
+def test_root_message_uses_current_directory_as_default_workspace(
+    integration_env: IntegrationEnvironment,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "default-cli-workspace"
+    project_root.mkdir()
+    monkeypatch.chdir(project_root)
+    monkeypatch.setattr(cli_app, "DEFAULT_BASE_URL", integration_env.api_base_url)
+
+    result = runner.invoke(cli_app.app, ["-m", "hello default workspace"])
+
+    assert result.exit_code == 0
+    assert "[fake-llm] hello default workspace" in result.output
+
+    response = httpx.get(
+        f"{integration_env.api_base_url}/api/workspaces",
+        timeout=5.0,
+        trust_env=False,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    assert any(item["root_path"] == str(project_root.resolve()) for item in payload)
+
+
+def test_root_message_uses_yolo_by_default(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
     def fake_autostart(base_url: str, autostart: bool) -> None:
@@ -70,6 +104,8 @@ def test_root_message_uses_yolo_by_default(monkeypatch) -> None:
     ) -> dict[str, object] | list[object]:
         _ = (base_url, timeout_seconds)
         calls.append((method, path, payload))
+        if path == "/api/workspaces/pick":
+            return _workspace_response(tmp_path)
         if path == "/api/sessions":
             return {"session_id": "session-1"}
         if path == "/api/runs":
@@ -82,6 +118,7 @@ def test_root_message_uses_yolo_by_default(monkeypatch) -> None:
     monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
     monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
     monkeypatch.setattr(cli_app, "_stream_events", fake_stream)
+    monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(cli_app.app, ["-m", "hello"])
 

--- a/tests/unit_tests/interfaces/cli/test_command_tree.py
+++ b/tests/unit_tests/interfaces/cli/test_command_tree.py
@@ -16,7 +16,20 @@ def _normalized_output(text: str) -> str:
     return " ".join(_ANSI_ESCAPE_RE.sub("", text).split())
 
 
-def test_root_message_runs_single_prompt(monkeypatch) -> None:
+def _workspace_response(
+    root_path: Path,
+    *,
+    workspace_id: str = "workspace-1",
+) -> dict[str, object]:
+    return {
+        "workspace": {
+            "workspace_id": workspace_id,
+            "root_path": str(root_path.resolve()),
+        }
+    }
+
+
+def test_root_message_runs_single_prompt(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
     streamed: dict[str, object] = {}
 
@@ -33,6 +46,8 @@ def test_root_message_runs_single_prompt(monkeypatch) -> None:
     ) -> dict[str, object] | list[object]:
         _ = (base_url, timeout_seconds)
         calls.append((method, path, payload))
+        if path == "/api/workspaces/pick":
+            return _workspace_response(tmp_path)
         if path == "/api/sessions":
             return {"session_id": "session-1"}
         if path == "/api/runs":
@@ -47,12 +62,18 @@ def test_root_message_runs_single_prompt(monkeypatch) -> None:
     monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
     monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
     monkeypatch.setattr(cli_app, "_stream_events", fake_stream)
+    monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(cli_app.app, ["-m", "hello"])
 
     assert result.exit_code == 0
     assert calls == [
-        ("POST", "/api/sessions", {"workspace_id": "default"}),
+        (
+            "POST",
+            "/api/workspaces/pick",
+            {"root_path": str(tmp_path.resolve())},
+        ),
+        ("POST", "/api/sessions", {"workspace_id": "workspace-1"}),
         (
             "POST",
             "/api/runs",
@@ -90,12 +111,7 @@ def test_root_message_supports_workspace_selection(monkeypatch, tmp_path: Path) 
         _ = (base_url, timeout_seconds)
         calls.append((method, path, payload))
         if path == "/api/workspaces/pick":
-            return {
-                "workspace": {
-                    "workspace_id": "workspace-1",
-                    "root_path": str(tmp_path.resolve()),
-                }
-            }
+            return _workspace_response(tmp_path)
         if path == "/api/sessions":
             return {"session_id": "session-1"}
         if path == "/api/runs":
@@ -134,7 +150,10 @@ def test_root_message_supports_workspace_selection(monkeypatch, tmp_path: Path) 
     assert streamed == {"run_id": "run-1", "debug": False}
 
 
-def test_root_message_supports_normal_role_selection(monkeypatch) -> None:
+def test_root_message_supports_normal_role_selection(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
     def fake_autostart(base_url: str, autostart: bool) -> None:
@@ -149,12 +168,14 @@ def test_root_message_supports_normal_role_selection(monkeypatch) -> None:
     ) -> dict[str, object] | list[object]:
         _ = (base_url, timeout_seconds)
         calls.append((method, path, payload))
+        if path == "/api/workspaces/pick":
+            return _workspace_response(tmp_path)
         if path == "/api/sessions":
             return {"session_id": "session-1"}
         if path == "/api/sessions/session-1/topology":
             return {
                 "session_id": "session-1",
-                "workspace_id": "default",
+                "workspace_id": "workspace-1",
                 "metadata": {},
                 "session_mode": "normal",
                 "normal_root_role_id": "Crafter",
@@ -170,12 +191,18 @@ def test_root_message_supports_normal_role_selection(monkeypatch) -> None:
     monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
     monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
     monkeypatch.setattr(cli_app, "_stream_events", fake_stream)
+    monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(cli_app.app, ["-m", "hello", "--role", "Crafter"])
 
     assert result.exit_code == 0
     assert calls == [
-        ("POST", "/api/sessions", {"workspace_id": "default"}),
+        (
+            "POST",
+            "/api/workspaces/pick",
+            {"root_path": str(tmp_path.resolve())},
+        ),
+        ("POST", "/api/sessions", {"workspace_id": "workspace-1"}),
         (
             "PATCH",
             "/api/sessions/session-1/topology",
@@ -198,7 +225,10 @@ def test_root_message_supports_normal_role_selection(monkeypatch) -> None:
     ]
 
 
-def test_root_message_supports_orchestration_mode(monkeypatch) -> None:
+def test_root_message_supports_orchestration_mode(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
     def fake_autostart(base_url: str, autostart: bool) -> None:
@@ -213,12 +243,14 @@ def test_root_message_supports_orchestration_mode(monkeypatch) -> None:
     ) -> dict[str, object] | list[object]:
         _ = (base_url, timeout_seconds)
         calls.append((method, path, payload))
+        if path == "/api/workspaces/pick":
+            return _workspace_response(tmp_path)
         if path == "/api/sessions":
             return {"session_id": "session-1"}
         if path == "/api/sessions/session-1/topology":
             return {
                 "session_id": "session-1",
-                "workspace_id": "default",
+                "workspace_id": "workspace-1",
                 "metadata": {},
                 "session_mode": "orchestration",
                 "orchestration_preset_id": "default",
@@ -233,6 +265,7 @@ def test_root_message_supports_orchestration_mode(monkeypatch) -> None:
     monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
     monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
     monkeypatch.setattr(cli_app, "_stream_events", fake_stream)
+    monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(
         cli_app.app,
@@ -248,7 +281,12 @@ def test_root_message_supports_orchestration_mode(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert calls == [
-        ("POST", "/api/sessions", {"workspace_id": "default"}),
+        (
+            "POST",
+            "/api/workspaces/pick",
+            {"root_path": str(tmp_path.resolve())},
+        ),
+        ("POST", "/api/sessions", {"workspace_id": "workspace-1"}),
         (
             "PATCH",
             "/api/sessions/session-1/topology",
@@ -270,7 +308,7 @@ def test_root_message_supports_orchestration_mode(monkeypatch) -> None:
     ]
 
 
-def test_root_message_allows_no_yolo_override(monkeypatch) -> None:
+def test_root_message_allows_no_yolo_override(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
     def fake_autostart(base_url: str, autostart: bool) -> None:
@@ -285,6 +323,8 @@ def test_root_message_allows_no_yolo_override(monkeypatch) -> None:
     ) -> dict[str, object] | list[object]:
         _ = (base_url, timeout_seconds)
         calls.append((method, path, payload))
+        if path == "/api/workspaces/pick":
+            return _workspace_response(tmp_path)
         if path == "/api/sessions":
             return {"session_id": "session-1"}
         if path == "/api/runs":
@@ -297,6 +337,7 @@ def test_root_message_allows_no_yolo_override(monkeypatch) -> None:
     monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
     monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
     monkeypatch.setattr(cli_app, "_stream_events", fake_stream)
+    monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(
         cli_app.app,
@@ -343,7 +384,10 @@ def test_root_message_rejects_role_with_orchestration_mode() -> None:
     assert "--role can only be used with --mode normal" in normalized_output
 
 
-def test_root_message_invalid_role_lists_available_ids(monkeypatch) -> None:
+def test_root_message_invalid_role_lists_available_ids(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
     def fake_autostart(base_url: str, autostart: bool) -> None:
@@ -358,6 +402,8 @@ def test_root_message_invalid_role_lists_available_ids(monkeypatch) -> None:
     ) -> dict[str, object] | list[object]:
         _ = (base_url, timeout_seconds)
         calls.append((method, path, payload))
+        if path == "/api/workspaces/pick":
+            return _workspace_response(tmp_path)
         if path == "/api/sessions":
             return {"session_id": "session-1"}
         if path == "/api/sessions/session-1/topology":
@@ -385,6 +431,7 @@ def test_root_message_invalid_role_lists_available_ids(monkeypatch) -> None:
 
     monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
     monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
+    monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(cli_app.app, ["-m", "hello", "--role", "Missing"])
 
@@ -392,10 +439,29 @@ def test_root_message_invalid_role_lists_available_ids(monkeypatch) -> None:
     assert result.exit_code == 2
     assert "Invalid --role 'Missing'" in normalized_output
     assert "MainAgent, Crafter." in normalized_output
+    assert calls == [
+        (
+            "POST",
+            "/api/workspaces/pick",
+            {"root_path": str(tmp_path.resolve())},
+        ),
+        ("POST", "/api/sessions", {"workspace_id": "workspace-1"}),
+        (
+            "PATCH",
+            "/api/sessions/session-1/topology",
+            {
+                "session_mode": "normal",
+                "normal_root_role_id": "Missing",
+                "orchestration_preset_id": None,
+            },
+        ),
+        ("GET", "/api/roles:options", None),
+    ]
 
 
 def test_root_message_invalid_orchestration_id_lists_available_ids(
     monkeypatch,
+    tmp_path: Path,
 ) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
@@ -411,6 +477,8 @@ def test_root_message_invalid_orchestration_id_lists_available_ids(
     ) -> dict[str, object] | list[object]:
         _ = (base_url, timeout_seconds)
         calls.append((method, path, payload))
+        if path == "/api/workspaces/pick":
+            return _workspace_response(tmp_path)
         if path == "/api/sessions":
             return {"session_id": "session-1"}
         if path == "/api/sessions/session-1/topology":
@@ -429,6 +497,7 @@ def test_root_message_invalid_orchestration_id_lists_available_ids(
 
     monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
     monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
+    monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(
         cli_app.app,
@@ -448,7 +517,12 @@ def test_root_message_invalid_orchestration_id_lists_available_ids(
     assert "Available orchestration" in normalized_output
     assert "ids: default, release." in normalized_output
     assert calls == [
-        ("POST", "/api/sessions", {"workspace_id": "default"}),
+        (
+            "POST",
+            "/api/workspaces/pick",
+            {"root_path": str(tmp_path.resolve())},
+        ),
+        ("POST", "/api/sessions", {"workspace_id": "workspace-1"}),
         (
             "PATCH",
             "/api/sessions/session-1/topology",
@@ -475,6 +549,8 @@ def test_root_help_lists_env_module() -> None:
     assert "--role" in normalized_output
     assert "--orchestration" in normalized_output
     assert "--workspace" in normalized_output
+    assert "Defaults" in normalized_output
+    assert "directory. Requires" in normalized_output
     assert "env" in normalized_output
     assert "mcp" in normalized_output
     assert "agents" in normalized_output


### PR DESCRIPTION
﻿﻿Closes #330

## Summary
- resolve the current working directory as the default workspace root for CLI prompt runs when `--workspace` is omitted
- update quick prompt help text to explain the new default
- add unit and integration coverage for implicit current-directory workspace selection

## Testing
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/interfaces/cli/test_command_tree.py`
- `uv run --extra dev pytest -q tests/integration_tests/cli/test_prompt_output.py`
- `uv run --extra dev pytest -q tests/integration_tests`
