### PR TITLE
Harden secret settings inputs and stabilize ClawHub auth

### DIFF
--- a/frontend/dist/js/components/projectView.js
+++ b/frontend/dist/js/components/projectView.js
@@ -2925,7 +2925,7 @@ function renderSkillsFeatureView() {
                         <div class="form-group proxy-inline-field">
                             <label for="${escapeHtml(FEATURE_CLAWHUB_FIELD_IDS.tokenInputId)}">${escapeHtml(t('settings.clawhub.token'))}</label>
                             <div class="secure-input-row">
-                                <input type="password" id="${escapeHtml(FEATURE_CLAWHUB_FIELD_IDS.tokenInputId)}" placeholder="${escapeHtml(t('settings.clawhub.token_placeholder'))}" autocomplete="current-password">
+                                <input type="password" id="${escapeHtml(FEATURE_CLAWHUB_FIELD_IDS.tokenInputId)}" placeholder="${escapeHtml(t('settings.clawhub.token_placeholder'))}" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
                                 <button class="secure-input-btn" id="${escapeHtml(FEATURE_CLAWHUB_FIELD_IDS.toggleTokenButtonId)}" type="button" title="${escapeHtml(t('settings.clawhub.show_token'))}" aria-label="${escapeHtml(t('settings.clawhub.show_token'))}" style="display:none;">
                                     <svg viewBox="0 0 24 24" fill="none" class="icon-sm" aria-hidden="true">
                                         <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>

--- a/frontend/dist/js/components/settings/clawhubSettings.js
+++ b/frontend/dist/js/components/settings/clawhubSettings.js
@@ -240,7 +240,7 @@ function readClawHubTokenValue(fieldIds) {
     if (clawhubTokenState.isDirty) {
         return inputValue || null;
     }
-    return inputValue || clawhubTokenState.persistedValue || null;
+    return clawhubTokenState.persistedValue || null;
 }
 
 function renderClawHubTokenField(fieldIds) {

--- a/frontend/dist/js/components/settings/clawhubSettings.js
+++ b/frontend/dist/js/components/settings/clawhubSettings.js
@@ -48,6 +48,10 @@ export function bindClawHubSettingsHandlers(fieldIds = DEFAULT_CLAWHUB_FIELD_IDS
         tokenInput.onchange = () => {
             handleClawHubTokenInput(ids);
         };
+        tokenInput.onfocus = armClawHubTokenInput;
+        tokenInput.onpointerdown = armClawHubTokenInput;
+        tokenInput.onkeydown = armClawHubTokenInput;
+        tokenInput.onblur = disarmClawHubTokenInput;
     }
 
     const toggleTokenBtn = document.getElementById(ids.toggleTokenButtonId);
@@ -206,6 +210,7 @@ function createClawHubTokenState(persistedValue = null) {
         draftValue: '',
         hasPersistedValue: Boolean(normalizedValue.trim()),
         isDirty: false,
+        armedForInput: false,
         revealed: false,
     };
 }
@@ -213,6 +218,18 @@ function createClawHubTokenState(persistedValue = null) {
 function handleClawHubTokenInput(fieldIds) {
     const tokenInput = document.getElementById(fieldIds.tokenInputId);
     const nextValue = tokenInput ? tokenInput.value : '';
+    if (
+        clawhubTokenState.hasPersistedValue
+        && !clawhubTokenState.revealed
+        && !canAcceptClawHubTokenInput(tokenInput)
+    ) {
+        clawhubTokenState.draftValue = '';
+        clawhubTokenState.isDirty = false;
+        clawhubTokenState.armedForInput = false;
+        clawhubTokenState.revealed = false;
+        renderClawHubTokenField(fieldIds);
+        return;
+    }
     clawhubTokenState.draftValue = nextValue;
     clawhubTokenState.isDirty = clawhubTokenState.hasPersistedValue
         ? nextValue !== clawhubTokenState.persistedValue
@@ -241,6 +258,30 @@ function readClawHubTokenValue(fieldIds) {
         return inputValue || null;
     }
     return clawhubTokenState.persistedValue || null;
+}
+
+function armClawHubTokenInput() {
+    clawhubTokenState.armedForInput = true;
+}
+
+function disarmClawHubTokenInput() {
+    clawhubTokenState.armedForInput = false;
+}
+
+function canAcceptClawHubTokenInput(tokenInput) {
+    if (!tokenInput) {
+        return false;
+    }
+    if (clawhubTokenState.armedForInput) {
+        return true;
+    }
+    if (typeof document !== 'object' || document === null) {
+        return false;
+    }
+    if (!('activeElement' in document)) {
+        return true;
+    }
+    return document.activeElement === tokenInput;
 }
 
 function renderClawHubTokenField(fieldIds) {

--- a/frontend/dist/js/components/settings/githubSettings.js
+++ b/frontend/dist/js/components/settings/githubSettings.js
@@ -79,6 +79,18 @@ export function bindGitHubSettingsHandlers(fieldIds = DEFAULT_GITHUB_FIELD_IDS) 
         tokenInput.onchange = () => {
             handleGitHubTokenInput(ids);
         };
+        tokenInput.onfocus = () => {
+            armGitHubTokenInput();
+        };
+        tokenInput.onpointerdown = () => {
+            armGitHubTokenInput();
+        };
+        tokenInput.onkeydown = () => {
+            armGitHubTokenInput();
+        };
+        tokenInput.onblur = () => {
+            disarmGitHubTokenInput();
+        };
     }
 
     const webhookBaseUrlInput = document.getElementById(ids.webhookBaseUrlInputId);
@@ -591,6 +603,7 @@ function createGitHubTokenState(persistedValue = null, hasPersistedValue = false
         hasPersistedValue: hasPersistedValue === true || Boolean(normalizedValue.trim()),
         isDirty: false,
         isLoadingReveal: false,
+        armedForInput: false,
         revealed: false,
     };
 }
@@ -602,10 +615,11 @@ function handleGitHubTokenInput(fieldIds) {
         githubTokenState.hasPersistedValue
         && !githubTokenState.persistedValueLoaded
         && !githubTokenState.revealed
-        && !isGitHubTokenInputActive(tokenInput)
+        && !canAcceptGitHubTokenInput(tokenInput)
     ) {
         githubTokenState.draftValue = '';
         githubTokenState.isDirty = false;
+        githubTokenState.armedForInput = false;
         githubTokenState.revealed = false;
         renderGitHubTokenField(fieldIds);
         return;
@@ -677,8 +691,22 @@ function normalizeGitHubWebhookBaseUrl(value) {
         : null;
 }
 
-function isGitHubTokenInputActive(tokenInput) {
-    if (!tokenInput || typeof document !== 'object' || document === null) {
+function armGitHubTokenInput() {
+    githubTokenState.armedForInput = true;
+}
+
+function disarmGitHubTokenInput() {
+    githubTokenState.armedForInput = false;
+}
+
+function canAcceptGitHubTokenInput(tokenInput) {
+    if (!tokenInput) {
+        return false;
+    }
+    if (githubTokenState.armedForInput) {
+        return true;
+    }
+    if (typeof document !== 'object' || document === null) {
         return false;
     }
     return document.activeElement === tokenInput;

--- a/frontend/dist/js/components/settings/githubSettings.js
+++ b/frontend/dist/js/components/settings/githubSettings.js
@@ -152,7 +152,7 @@ export function renderGitHubAccessPanelMarkup(
                     <div class="form-group proxy-inline-field">
                         <label for="${escapeHtml(ids.tokenInputId)}" data-i18n="settings.github.token">GitHub Token</label>
                         <div class="secure-input-row">
-                            <input type="password" id="${escapeHtml(ids.tokenInputId)}" placeholder="ghp_..." data-i18n-placeholder="settings.github.token_placeholder" autocomplete="current-password">
+                            <input type="password" id="${escapeHtml(ids.tokenInputId)}" placeholder="ghp_..." data-i18n-placeholder="settings.github.token_placeholder" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
                             <button class="secure-input-btn" id="${escapeHtml(ids.toggleTokenButtonId)}" type="button" title="Show GitHub token" aria-label="Show GitHub token" style="display:none;">
                                 <svg viewBox="0 0 24 24" fill="none" class="icon-sm" aria-hidden="true">
                                     <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
@@ -598,9 +598,23 @@ function createGitHubTokenState(persistedValue = null, hasPersistedValue = false
 function handleGitHubTokenInput(fieldIds) {
     const tokenInput = document.getElementById(fieldIds.tokenInputId);
     const nextValue = tokenInput ? tokenInput.value : '';
+    if (
+        githubTokenState.hasPersistedValue
+        && !githubTokenState.persistedValueLoaded
+        && !githubTokenState.revealed
+        && !isGitHubTokenInputActive(tokenInput)
+    ) {
+        githubTokenState.draftValue = '';
+        githubTokenState.isDirty = false;
+        githubTokenState.revealed = false;
+        renderGitHubTokenField(fieldIds);
+        return;
+    }
     githubTokenState.draftValue = nextValue;
     githubTokenState.isDirty = githubTokenState.hasPersistedValue
-        ? nextValue !== githubTokenState.persistedValue
+        ? githubTokenState.persistedValueLoaded
+            ? nextValue !== githubTokenState.persistedValue
+            : nextValue.trim().length > 0
         : nextValue.trim().length > 0;
     if (!readGitHubTokenValue(fieldIds)) {
         githubTokenState.revealed = false;
@@ -661,6 +675,13 @@ function normalizeGitHubWebhookBaseUrl(value) {
     return typeof value === 'string' && value.trim()
         ? value.trim()
         : null;
+}
+
+function isGitHubTokenInputActive(tokenInput) {
+    if (!tokenInput || typeof document !== 'object' || document === null) {
+        return false;
+    }
+    return document.activeElement === tokenInput;
 }
 
 function renderGitHubCallbackPreview(fieldIds) {

--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -237,7 +237,7 @@ function createModal() {
                                                 <div class="form-group" id="profile-api-key-group">
                                                     <label for="profile-api-key" data-i18n="settings.model.api_key">API Key</label>
                                                     <div class="secure-input-row">
-                                                        <input type="password" id="profile-api-key" placeholder="sk-..." autocomplete="current-password">
+                                                        <input type="password" id="profile-api-key" placeholder="sk-..." autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
                                                         <button class="secure-input-btn" id="toggle-profile-api-key-btn" type="button" title="Show API key" aria-label="Show API key" style="display:none;">
                                                             <svg viewBox="0 0 24 24" fill="none" class="icon-sm" aria-hidden="true">
                                                                 <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
@@ -273,7 +273,7 @@ function createModal() {
                                                 <div class="form-group">
                                                     <label for="profile-maas-password">MAAS Password</label>
                                                     <div class="secure-input-row">
-                                                        <input type="password" id="profile-maas-password" placeholder="password" autocomplete="current-password">
+                                                        <input type="password" id="profile-maas-password" placeholder="password" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
                                                         <button class="secure-input-btn" id="toggle-profile-maas-password-btn" type="button" title="Show password" aria-label="Show password" style="display:none;">
                                                             <svg viewBox="0 0 24 24" fill="none" class="icon-sm" aria-hidden="true">
                                                                 <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
@@ -701,7 +701,7 @@ function createModal() {
                                             <div class="form-group proxy-inline-field">
                                                 <label for="proxy-password" data-i18n="settings.proxy.password">Password</label>
                                                 <div class="secure-input-row">
-                                                    <input type="password" id="proxy-password" placeholder="Optional proxy password" data-i18n-placeholder="settings.proxy.password_placeholder" autocomplete="current-password">
+                                                    <input type="password" id="proxy-password" placeholder="Optional proxy password" data-i18n-placeholder="settings.proxy.password_placeholder" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
                                                     <button class="secure-input-btn" id="toggle-proxy-password-btn" type="button" title="Show password" aria-label="Show password" style="display:none;">
                                                         <svg viewBox="0 0 24 24" fill="none" class="icon-sm" aria-hidden="true">
                                                             <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
@@ -763,7 +763,7 @@ function createModal() {
                                             <div class="form-group proxy-inline-field">
                                                 <label for="web-api-key" id="web-api-key-label" data-i18n="settings.web.exa_api_key">Exa API Key</label>
                                                 <div class="secure-input-row">
-                                                    <input type="password" id="web-api-key" placeholder="可选，用于更高频率限制" data-i18n-placeholder="settings.web.api_key_placeholder" autocomplete="current-password">
+                                                    <input type="password" id="web-api-key" placeholder="可选，用于更高频率限制" data-i18n-placeholder="settings.web.api_key_placeholder" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
                                                     <button class="secure-input-btn" id="toggle-web-api-key-btn" type="button" title="Show API key" aria-label="Show API key">
                                                         <svg viewBox="0 0 24 24" fill="none" class="icon-sm" aria-hidden="true">
                                                             <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -84,6 +84,10 @@ export function bindModelProfileHandlers() {
     const apiKeyInput = document.getElementById('profile-api-key');
     if (apiKeyInput) {
         apiKeyInput.oninput = handleDraftApiKeyInput;
+        apiKeyInput.onfocus = armDraftApiKeyInput;
+        apiKeyInput.onpointerdown = armDraftApiKeyInput;
+        apiKeyInput.onkeydown = armDraftApiKeyInput;
+        apiKeyInput.onblur = disarmDraftApiKeyInput;
     }
 
     const maasUsernameInput = document.getElementById('profile-maas-username');
@@ -94,6 +98,10 @@ export function bindModelProfileHandlers() {
     const maasPasswordInput = document.getElementById('profile-maas-password');
     if (maasPasswordInput) {
         maasPasswordInput.oninput = handleDraftMaasPasswordInput;
+        maasPasswordInput.onfocus = armDraftMaasPasswordInput;
+        maasPasswordInput.onpointerdown = armDraftMaasPasswordInput;
+        maasPasswordInput.onkeydown = armDraftMaasPasswordInput;
+        maasPasswordInput.onblur = disarmDraftMaasPasswordInput;
     }
 
     const toggleApiKeyBtn = document.getElementById('toggle-profile-api-key-btn');
@@ -231,6 +239,7 @@ function handleEditProfile(name) {
         draftValue: '',
         hasPersistedValue: Boolean(profile.has_api_key),
         isDirty: false,
+        armedForInput: false,
         revealed: false,
     };
     draftMaasPasswordState = {
@@ -238,6 +247,7 @@ function handleEditProfile(name) {
         draftValue: '',
         hasPersistedValue: Boolean(profile.maas_auth?.has_password),
         isDirty: false,
+        armedForInput: false,
         revealed: false,
     };
     document.getElementById('profile-maas-username').value = profile.maas_auth?.username || '';
@@ -814,10 +824,11 @@ function handleDraftApiKeyInput() {
     if (
         draftApiKeyState.hasPersistedValue
         && !draftApiKeyState.revealed
-        && !isDraftSecretInputActive(apiKeyInput)
+        && !canAcceptDraftApiKeyInput(apiKeyInput)
     ) {
         draftApiKeyState.draftValue = '';
         draftApiKeyState.isDirty = false;
+        draftApiKeyState.armedForInput = false;
         draftApiKeyState.revealed = false;
         renderDraftApiKeyField();
         return;
@@ -837,10 +848,11 @@ function handleDraftMaasPasswordInput() {
     if (
         draftMaasPasswordState.hasPersistedValue
         && !draftMaasPasswordState.revealed
-        && !isDraftSecretInputActive(maasPasswordInput)
+        && !canAcceptDraftMaasPasswordInput(maasPasswordInput)
     ) {
         draftMaasPasswordState.draftValue = '';
         draftMaasPasswordState.isDirty = false;
+        draftMaasPasswordState.armedForInput = false;
         draftMaasPasswordState.revealed = false;
         renderDraftMaaSPasswordField();
         return;
@@ -1188,6 +1200,7 @@ function createDraftSecretState() {
         draftValue: '',
         hasPersistedValue: false,
         isDirty: false,
+        armedForInput: false,
         revealed: false,
     };
 }
@@ -1204,8 +1217,46 @@ function readDraftApiKeyValue() {
     return '';
 }
 
-function isDraftSecretInputActive(secretInput) {
-    if (!secretInput || typeof document !== 'object' || document === null) {
+function armDraftApiKeyInput() {
+    draftApiKeyState.armedForInput = true;
+}
+
+function disarmDraftApiKeyInput() {
+    draftApiKeyState.armedForInput = false;
+}
+
+function canAcceptDraftApiKeyInput(secretInput) {
+    if (!secretInput) {
+        return false;
+    }
+    if (draftApiKeyState.armedForInput) {
+        return true;
+    }
+    if (typeof document !== 'object' || document === null) {
+        return false;
+    }
+    if (!('activeElement' in document)) {
+        return true;
+    }
+    return document.activeElement === secretInput;
+}
+
+function armDraftMaasPasswordInput() {
+    draftMaasPasswordState.armedForInput = true;
+}
+
+function disarmDraftMaasPasswordInput() {
+    draftMaasPasswordState.armedForInput = false;
+}
+
+function canAcceptDraftMaasPasswordInput(secretInput) {
+    if (!secretInput) {
+        return false;
+    }
+    if (draftMaasPasswordState.armedForInput) {
+        return true;
+    }
+    if (typeof document !== 'object' || document === null) {
         return false;
     }
     if (!('activeElement' in document)) {

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -811,6 +811,17 @@ function handleDraftApiKeyInput() {
     if (!apiKeyInput) {
         return;
     }
+    if (
+        draftApiKeyState.hasPersistedValue
+        && !draftApiKeyState.revealed
+        && !isDraftSecretInputActive(apiKeyInput)
+    ) {
+        draftApiKeyState.draftValue = '';
+        draftApiKeyState.isDirty = false;
+        draftApiKeyState.revealed = false;
+        renderDraftApiKeyField();
+        return;
+    }
 
     draftApiKeyState.draftValue = apiKeyInput.value;
     draftApiKeyState.isDirty = draftApiKeyState.draftValue !== draftApiKeyState.persistedValue;
@@ -821,6 +832,17 @@ function handleDraftApiKeyInput() {
 function handleDraftMaasPasswordInput() {
     const maasPasswordInput = document.getElementById('profile-maas-password');
     if (!maasPasswordInput) {
+        return;
+    }
+    if (
+        draftMaasPasswordState.hasPersistedValue
+        && !draftMaasPasswordState.revealed
+        && !isDraftSecretInputActive(maasPasswordInput)
+    ) {
+        draftMaasPasswordState.draftValue = '';
+        draftMaasPasswordState.isDirty = false;
+        draftMaasPasswordState.revealed = false;
+        renderDraftMaaSPasswordField();
         return;
     }
 
@@ -1084,7 +1106,7 @@ function readDraftMaasPasswordValue() {
     if (!draftMaasPasswordState.hasPersistedValue) {
         return inputValue || draftMaasPasswordState.draftValue.trim();
     }
-    if (draftMaasPasswordState.isDirty || inputValue) {
+    if (draftMaasPasswordState.isDirty) {
         return inputValue || draftMaasPasswordState.draftValue.trim();
     }
     return '';
@@ -1152,10 +1174,20 @@ function readDraftApiKeyValue() {
     if (!draftApiKeyState.hasPersistedValue) {
         return inputValue || draftApiKeyState.draftValue.trim();
     }
-    if (draftApiKeyState.isDirty || inputValue) {
+    if (draftApiKeyState.isDirty) {
         return inputValue || draftApiKeyState.draftValue.trim();
     }
     return '';
+}
+
+function isDraftSecretInputActive(secretInput) {
+    if (!secretInput || typeof document !== 'object' || document === null) {
+        return false;
+    }
+    if (!('activeElement' in document)) {
+        return true;
+    }
+    return document.activeElement === secretInput;
 }
 
 function renderDraftApiKeyField() {

--- a/frontend/dist/js/components/settings/proxySettings.js
+++ b/frontend/dist/js/components/settings/proxySettings.js
@@ -252,6 +252,17 @@ function createProxyPasswordState(persistedValue = null) {
 function handleProxyPasswordInput() {
     const passwordInput = document.getElementById('proxy-password');
     const nextValue = passwordInput ? passwordInput.value : '';
+    if (
+        proxyPasswordState.hasPersistedValue
+        && !proxyPasswordState.revealed
+        && !isProxyPasswordInputActive(passwordInput)
+    ) {
+        proxyPasswordState.draftValue = '';
+        proxyPasswordState.isDirty = false;
+        proxyPasswordState.revealed = false;
+        renderProxyPasswordField();
+        return;
+    }
     proxyPasswordState.draftValue = nextValue;
     proxyPasswordState.isDirty = proxyPasswordState.hasPersistedValue
         ? nextValue !== proxyPasswordState.persistedValue
@@ -279,7 +290,7 @@ function readProxyPasswordValue() {
     if (proxyPasswordState.isDirty) {
         return inputValue || null;
     }
-    return inputValue || proxyPasswordState.persistedValue || null;
+    return proxyPasswordState.persistedValue || null;
 }
 
 function renderProxyPasswordField() {
@@ -329,7 +340,17 @@ function hasProxyPasswordValue() {
     const passwordInput = document.getElementById('proxy-password');
     const inputValue = passwordInput ? passwordInput.value.trim() : '';
     if (proxyPasswordState.hasPersistedValue && !proxyPasswordState.isDirty) {
-        return Boolean(proxyPasswordState.persistedValue || inputValue);
+        return Boolean(proxyPasswordState.persistedValue);
     }
     return Boolean(proxyPasswordState.draftValue.trim() || inputValue);
+}
+
+function isProxyPasswordInputActive(passwordInput) {
+    if (!passwordInput || typeof document !== 'object' || document === null) {
+        return false;
+    }
+    if (!('activeElement' in document)) {
+        return true;
+    }
+    return document.activeElement === passwordInput;
 }

--- a/frontend/dist/js/components/settings/proxySettings.js
+++ b/frontend/dist/js/components/settings/proxySettings.js
@@ -32,6 +32,10 @@ export function bindProxySettingsHandlers() {
     if (passwordInput) {
         passwordInput.oninput = handleProxyPasswordInput;
         passwordInput.onchange = handleProxyPasswordInput;
+        passwordInput.onfocus = armProxyPasswordInput;
+        passwordInput.onpointerdown = armProxyPasswordInput;
+        passwordInput.onkeydown = armProxyPasswordInput;
+        passwordInput.onblur = disarmProxyPasswordInput;
     }
 
     const togglePasswordBtn = document.getElementById('toggle-proxy-password-btn');
@@ -245,6 +249,7 @@ function createProxyPasswordState(persistedValue = null) {
         draftValue: '',
         hasPersistedValue: Boolean(normalizedValue.trim()),
         isDirty: false,
+        armedForInput: false,
         revealed: false,
     };
 }
@@ -255,10 +260,11 @@ function handleProxyPasswordInput() {
     if (
         proxyPasswordState.hasPersistedValue
         && !proxyPasswordState.revealed
-        && !isProxyPasswordInputActive(passwordInput)
+        && !canAcceptProxyPasswordInput(passwordInput)
     ) {
         proxyPasswordState.draftValue = '';
         proxyPasswordState.isDirty = false;
+        proxyPasswordState.armedForInput = false;
         proxyPasswordState.revealed = false;
         renderProxyPasswordField();
         return;
@@ -345,8 +351,22 @@ function hasProxyPasswordValue() {
     return Boolean(proxyPasswordState.draftValue.trim() || inputValue);
 }
 
-function isProxyPasswordInputActive(passwordInput) {
-    if (!passwordInput || typeof document !== 'object' || document === null) {
+function armProxyPasswordInput() {
+    proxyPasswordState.armedForInput = true;
+}
+
+function disarmProxyPasswordInput() {
+    proxyPasswordState.armedForInput = false;
+}
+
+function canAcceptProxyPasswordInput(passwordInput) {
+    if (!passwordInput) {
+        return false;
+    }
+    if (proxyPasswordState.armedForInput) {
+        return true;
+    }
+    if (typeof document !== 'object' || document === null) {
         return false;
     }
     if (!('activeElement' in document)) {

--- a/frontend/dist/js/components/settings/webSettings.js
+++ b/frontend/dist/js/components/settings/webSettings.js
@@ -52,6 +52,10 @@ export function bindWebSettingsHandlers() {
     if (apiKeyInput) {
         apiKeyInput.oninput = handleWebApiKeyInput;
         apiKeyInput.onchange = handleWebApiKeyInput;
+        apiKeyInput.onfocus = armWebApiKeyInput;
+        apiKeyInput.onpointerdown = armWebApiKeyInput;
+        apiKeyInput.onkeydown = armWebApiKeyInput;
+        apiKeyInput.onblur = disarmWebApiKeyInput;
     }
 
     const toggleApiKeyBtn = document.getElementById('toggle-web-api-key-btn');
@@ -164,6 +168,7 @@ function createWebApiKeyState(persistedValue = null) {
         draftValue: '',
         hasPersistedValue: Boolean(normalizedValue.trim()),
         isDirty: false,
+        armedForInput: false,
         revealed: false,
     };
 }
@@ -281,10 +286,11 @@ function handleWebApiKeyInput() {
     if (
         nextState.hasPersistedValue
         && !nextState.revealed
-        && !isWebApiKeyInputActive(apiKeyInput)
+        && !canAcceptWebApiKeyInput(apiKeyInput)
     ) {
         nextState.draftValue = '';
         nextState.isDirty = false;
+        nextState.armedForInput = false;
         nextState.revealed = false;
         webApiKeyStates[provider] = nextState;
         renderWebApiKeyField();
@@ -413,8 +419,29 @@ function hasWebApiKeyValue(provider = getSelectedProvider()) {
     return Boolean(state.draftValue.trim() || inputValue);
 }
 
-function isWebApiKeyInputActive(apiKeyInput) {
-    if (!apiKeyInput || typeof document !== 'object' || document === null) {
+function armWebApiKeyInput() {
+    const provider = getSelectedProvider();
+    const nextState = getWebApiKeyState(provider);
+    nextState.armedForInput = true;
+    webApiKeyStates[provider] = nextState;
+}
+
+function disarmWebApiKeyInput() {
+    const provider = getSelectedProvider();
+    const nextState = getWebApiKeyState(provider);
+    nextState.armedForInput = false;
+    webApiKeyStates[provider] = nextState;
+}
+
+function canAcceptWebApiKeyInput(apiKeyInput) {
+    if (!apiKeyInput) {
+        return false;
+    }
+    const state = getWebApiKeyState();
+    if (state.armedForInput) {
+        return true;
+    }
+    if (typeof document !== 'object' || document === null) {
         return false;
     }
     if (!('activeElement' in document)) {

--- a/frontend/dist/js/components/settings/webSettings.js
+++ b/frontend/dist/js/components/settings/webSettings.js
@@ -278,6 +278,18 @@ function handleWebApiKeyInput() {
     const nextValue = apiKeyInput ? apiKeyInput.value : '';
     const provider = getSelectedProvider();
     const nextState = getWebApiKeyState(provider);
+    if (
+        nextState.hasPersistedValue
+        && !nextState.revealed
+        && !isWebApiKeyInputActive(apiKeyInput)
+    ) {
+        nextState.draftValue = '';
+        nextState.isDirty = false;
+        nextState.revealed = false;
+        webApiKeyStates[provider] = nextState;
+        renderWebApiKeyField();
+        return;
+    }
     nextState.draftValue = nextValue;
     nextState.isDirty = nextState.hasPersistedValue
         ? nextValue !== nextState.persistedValue
@@ -340,7 +352,7 @@ function readWebApiKeyValueForProvider(provider) {
     if (state.isDirty) {
         return inputValue || null;
     }
-    return inputValue || state.persistedValue || null;
+    return state.persistedValue || null;
 }
 
 function renderWebApiKeyField() {
@@ -396,7 +408,17 @@ function hasWebApiKeyValue(provider = getSelectedProvider()) {
             : state.draftValue.trim()
     );
     if (state.hasPersistedValue && !state.isDirty) {
-        return Boolean(state.persistedValue || inputValue);
+        return Boolean(state.persistedValue);
     }
     return Boolean(state.draftValue.trim() || inputValue);
+}
+
+function isWebApiKeyInputActive(apiKeyInput) {
+    if (!apiKeyInput || typeof document !== 'object' || document === null) {
+        return false;
+    }
+    if (!('activeElement' in document)) {
+        return true;
+    }
+    return document.activeElement === apiKeyInput;
 }

--- a/src/relay_teams/env/__init__.py
+++ b/src/relay_teams/env/__init__.py
@@ -26,6 +26,14 @@ from relay_teams.env.clawhub_cli import (
     install_clawhub_via_npm,
     resolve_existing_clawhub_path,
 )
+from relay_teams.env.clawhub_auth import (
+    ClawHubCliLoginResult,
+    build_clawhub_managed_subprocess_env,
+    clear_clawhub_runtime_home,
+    ensure_clawhub_cli_login,
+    get_clawhub_runtime_config_path,
+    get_clawhub_runtime_home,
+)
 from relay_teams.env.clawhub_config_models import ClawHubConfig
 from relay_teams.env.clawhub_config_service import ClawHubConfigService
 from relay_teams.env.clawhub_env import (
@@ -107,6 +115,7 @@ __all__ = [
     "CLAWHUB_SITE_ENV_KEY",
     "CLAWHUB_TOKEN_ENV_KEY",
     "ClawHubCliInstallResult",
+    "ClawHubCliLoginResult",
     "ClawHubConfig",
     "ClawHubConfigService",
     "GitHubConfig",
@@ -126,15 +135,20 @@ __all__ = [
     "apply_proxy_env_to_process_env",
     "build_subprocess_env",
     "build_clawhub_cli_env",
+    "build_clawhub_managed_subprocess_env",
     "build_clawhub_subprocess_env",
     "extract_proxy_env_vars",
     "build_github_cli_env",
     "clawhub_env_keys",
     "clear_clawhub_path_cache",
+    "clear_clawhub_runtime_home",
     "install_clawhub_via_npm",
+    "ensure_clawhub_cli_login",
     "get_app_env_file_path",
     "get_env_var",
     "get_project_env_file_path",
+    "get_clawhub_runtime_config_path",
+    "get_clawhub_runtime_home",
     "get_user_env_file_path",
     "github_env_keys",
     "host_matches_no_proxy",

--- a/src/relay_teams/env/clawhub_auth.py
+++ b/src/relay_teams/env/clawhub_auth.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from relay_teams.env.clawhub_cli import resolve_existing_clawhub_path
+from relay_teams.env.clawhub_command_errors import (
+    combine_clawhub_failure_messages,
+    explain_clawhub_failure,
+    should_retry_clawhub_without_endpoint_overrides,
+    summarize_clawhub_command_failure,
+)
+from relay_teams.env.clawhub_env import (
+    build_clawhub_subprocess_env,
+    normalize_clawhub_token,
+    resolve_clawhub_registry_from_env,
+    strip_clawhub_endpoint_overrides,
+)
+
+_DEFAULT_CLAWHUB_LOGIN_TIMEOUT_SECONDS = 30.0
+_CLAWHUB_RUNTIME_HOME_PARTS = ("runtime", "clawhub-home")
+
+
+class ClawHubCliLoginResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+    env: dict[str, str] = Field(default_factory=dict)
+    registry: str | None = None
+    endpoint_fallback_used: bool = False
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+def get_clawhub_runtime_home(config_dir: Path) -> Path:
+    resolved_config_dir = config_dir.expanduser().resolve()
+    return resolved_config_dir.joinpath(*_CLAWHUB_RUNTIME_HOME_PARTS)
+
+
+def get_clawhub_runtime_config_path(config_dir: Path) -> Path:
+    return get_clawhub_runtime_home(config_dir) / ".config" / "clawhub" / "config.json"
+
+
+def clear_clawhub_runtime_home(config_dir: Path) -> None:
+    runtime_home = get_clawhub_runtime_home(config_dir)
+    shutil.rmtree(runtime_home, ignore_errors=True)
+
+
+def build_clawhub_managed_subprocess_env(
+    token: str | None,
+    *,
+    config_dir: Path,
+    base_env: Mapping[str, str] | None = None,
+    site: str | None = None,
+    registry: str | None = None,
+) -> dict[str, str]:
+    resolved_env = build_clawhub_subprocess_env(
+        token,
+        config_dir=config_dir,
+        base_env=base_env,
+        site=site,
+        registry=registry,
+    )
+    runtime_home = get_clawhub_runtime_home(config_dir)
+    xdg_config_home = runtime_home / ".config"
+    resolved_env["HOME"] = str(runtime_home)
+    resolved_env["USERPROFILE"] = str(runtime_home)
+    resolved_env["XDG_CONFIG_HOME"] = str(xdg_config_home)
+    return resolved_env
+
+
+def ensure_clawhub_cli_login(
+    token: str | None,
+    *,
+    config_dir: Path,
+    base_env: Mapping[str, str] | None = None,
+    clawhub_path: Path | None = None,
+    timeout_seconds: float = _DEFAULT_CLAWHUB_LOGIN_TIMEOUT_SECONDS,
+) -> ClawHubCliLoginResult:
+    normalized_token = normalize_clawhub_token(token)
+    if normalized_token is None:
+        return ClawHubCliLoginResult(
+            ok=False,
+            error_code="missing_token",
+            error_message="Configure a ClawHub token before authenticating the CLI.",
+        )
+
+    resolved_clawhub_path = (
+        resolve_existing_clawhub_path() if clawhub_path is None else clawhub_path
+    )
+    if resolved_clawhub_path is None:
+        return ClawHubCliLoginResult(
+            ok=False,
+            error_code="clawhub_unavailable",
+            error_message="ClawHub CLI is not available on PATH.",
+        )
+
+    resolved_config_dir = config_dir.expanduser().resolve()
+    resolved_env = build_clawhub_managed_subprocess_env(
+        normalized_token,
+        config_dir=resolved_config_dir,
+        base_env=base_env,
+    )
+    resolved_env["PATH"] = _prepend_to_path(
+        resolved_env.get("PATH"),
+        resolved_clawhub_path.parent,
+    )
+    registry = resolve_clawhub_registry_from_env(resolved_env)
+    if _stored_runtime_token_matches(resolved_config_dir, normalized_token):
+        return ClawHubCliLoginResult(
+            ok=True,
+            env=resolved_env,
+            registry=registry,
+        )
+
+    command = [
+        str(resolved_clawhub_path),
+        "login",
+        "--token",
+        normalized_token,
+        "--no-browser",
+    ]
+    completed = _run_login_command(
+        command,
+        env=resolved_env,
+        timeout_seconds=timeout_seconds,
+    )
+    if completed.returncode == 0:
+        return ClawHubCliLoginResult(
+            ok=True,
+            env=resolved_env,
+            registry=registry,
+        )
+
+    reason = (
+        summarize_clawhub_command_failure(completed.stderr, completed.stdout)
+        or "ClawHub login failed."
+    )
+    if should_retry_clawhub_without_endpoint_overrides(
+        reason,
+        endpoint_overrides_configured=registry is not None,
+    ):
+        fallback_env = dict(resolved_env)
+        strip_clawhub_endpoint_overrides(fallback_env)
+        fallback_completed = _run_login_command(
+            command,
+            env=fallback_env,
+            timeout_seconds=timeout_seconds,
+        )
+        if fallback_completed.returncode == 0:
+            return ClawHubCliLoginResult(
+                ok=True,
+                env=fallback_env,
+                registry=registry,
+                endpoint_fallback_used=True,
+            )
+        fallback_reason = (
+            summarize_clawhub_command_failure(
+                fallback_completed.stderr,
+                fallback_completed.stdout,
+            )
+            or "ClawHub login failed."
+        )
+        reason = combine_clawhub_failure_messages(reason, fallback_reason)
+        return ClawHubCliLoginResult(
+            ok=False,
+            env=fallback_env,
+            registry=registry,
+            endpoint_fallback_used=True,
+            error_code="auth_failed",
+            error_message=explain_clawhub_failure(
+                reason,
+                endpoint_overrides_configured=registry is not None,
+                endpoint_fallback_used=True,
+            ),
+        )
+
+    return ClawHubCliLoginResult(
+        ok=False,
+        env=resolved_env,
+        registry=registry,
+        error_code="auth_failed",
+        error_message=reason,
+    )
+
+
+def _run_login_command(
+    command: list[str],
+    *,
+    env: dict[str, str],
+    timeout_seconds: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        timeout=timeout_seconds,
+        check=False,
+    )
+
+
+def _stored_runtime_token_matches(config_dir: Path, token: str) -> bool:
+    config_file = get_clawhub_runtime_config_path(config_dir)
+    if not config_file.exists() or not config_file.is_file():
+        return False
+    try:
+        payload = json.loads(config_file.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    stored_token = normalize_clawhub_token(_read_text_field(payload, "token"))
+    return stored_token == token
+
+
+def _read_text_field(payload: dict[str, object], key: str) -> str | None:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        return None
+    return value
+
+
+def _prepend_to_path(existing_path: str | None, directory: Path) -> str:
+    path_parts = [str(directory)]
+    if existing_path:
+        path_parts.append(existing_path)
+    return os.pathsep.join(path_parts)

--- a/src/relay_teams/env/clawhub_config_service.py
+++ b/src/relay_teams/env/clawhub_config_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from relay_teams.env.clawhub_config_models import ClawHubConfig
+from relay_teams.env.clawhub_auth import clear_clawhub_runtime_home
 from relay_teams.env.clawhub_connectivity import (
     ClawHubConnectivityProbeRequest,
     ClawHubConnectivityProbeResult,
@@ -52,6 +53,8 @@ class ClawHubConfigService:
         normalized_token = normalize_clawhub_token(config.token)
         self._write_env_file(token=None)
         self._secret_store.set_token(self._config_dir, normalized_token)
+        if normalized_token is None:
+            clear_clawhub_runtime_home(self._config_dir)
         sync_app_env_to_process_env(self._config_dir / ".env")
 
     def probe_connectivity(

--- a/src/relay_teams/env/clawhub_connectivity.py
+++ b/src/relay_teams/env/clawhub_connectivity.py
@@ -14,6 +14,10 @@ from relay_teams.env.clawhub_cli import (
     install_clawhub_via_npm,
     resolve_existing_clawhub_path,
 )
+from relay_teams.env.clawhub_auth import (
+    build_clawhub_managed_subprocess_env,
+    ensure_clawhub_cli_login,
+)
 from relay_teams.env.clawhub_config_models import ClawHubConfig
 from relay_teams.env.clawhub_command_errors import (
     combine_clawhub_failure_messages,
@@ -155,7 +159,7 @@ class ClawHubConnectivityProbeService:
                     or "ClawHub CLI is not available on PATH.",
                 )
 
-        env = build_clawhub_subprocess_env(
+        env = build_clawhub_managed_subprocess_env(
             token,
             config_dir=self._config_dir,
             base_env=os.environ,
@@ -170,6 +174,56 @@ class ClawHubConnectivityProbeService:
                 clawhub_path,
                 env=env,
                 timeout_seconds=version_timeout_seconds,
+            )
+
+        auth_timeout_seconds = _resolve_remaining_timeout_seconds(probe_deadline)
+        if auth_timeout_seconds is None:
+            return self._build_result(
+                ok=False,
+                checked_at=checked_at,
+                started=started,
+                binary_available=True,
+                token_configured=True,
+                clawhub_path=clawhub_path,
+                clawhub_version=version_text,
+                installation_attempted=installation_attempted,
+                installed_during_probe=installed_during_probe,
+                registry=registry,
+                endpoint_fallback_used=endpoint_fallback_used,
+                retryable=True,
+                error_code="auth_timeout",
+                error_message="ClawHub CLI auth bootstrap timed out.",
+            )
+        auth_result = ensure_clawhub_cli_login(
+            token,
+            config_dir=self._config_dir,
+            base_env=os.environ,
+            clawhub_path=clawhub_path,
+            timeout_seconds=auth_timeout_seconds,
+        )
+        registry = auth_result.registry
+        endpoint_fallback_used = auth_result.endpoint_fallback_used
+        env = auth_result.env or env
+        if not auth_result.ok:
+            error_code, retryable = _classify_probe_error(
+                auth_result.error_message or "ClawHub CLI auth bootstrap failed.",
+                default_error_code=auth_result.error_code or "auth_failed",
+            )
+            return self._build_result(
+                ok=False,
+                checked_at=checked_at,
+                started=started,
+                binary_available=True,
+                token_configured=True,
+                clawhub_path=clawhub_path,
+                clawhub_version=version_text,
+                installation_attempted=installation_attempted,
+                installed_during_probe=installed_during_probe,
+                registry=registry,
+                endpoint_fallback_used=endpoint_fallback_used,
+                retryable=retryable,
+                error_code=error_code,
+                error_message=auth_result.error_message,
             )
 
         whoami_timeout_seconds = _resolve_remaining_timeout_seconds(probe_deadline)
@@ -228,7 +282,9 @@ class ClawHubConnectivityProbeService:
                 )
                 or "ClawHub CLI auth verification failed."
             )
-            if should_retry_clawhub_without_endpoint_overrides(
+            if (
+                not endpoint_fallback_used
+            ) and should_retry_clawhub_without_endpoint_overrides(
                 reason,
                 endpoint_overrides_configured=registry is not None,
             ):

--- a/tests/integration_tests/browser/test_clawhub_browser_flow.py
+++ b/tests/integration_tests/browser/test_clawhub_browser_flow.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+import os
+from pathlib import Path
+
+import httpx
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+from playwright.sync_api import sync_playwright
+import pytest
+
+from integration_tests.support.environment import IntegrationEnvironment
+
+
+_VIEWPORT_WIDTH = 1600
+_VIEWPORT_HEIGHT = 1200
+_WAIT_TIMEOUT_MS = 30_000
+
+
+@pytest.fixture()
+def browser_page() -> Iterator[Page]:
+    browser_root = _resolve_playwright_browser_root()
+    previous_browser_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_root)
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            context = browser.new_context(
+                viewport={"width": _VIEWPORT_WIDTH, "height": _VIEWPORT_HEIGHT},
+                color_scheme="dark",
+            )
+            page = context.new_page()
+            try:
+                yield page
+            finally:
+                context.close()
+                browser.close()
+    finally:
+        if previous_browser_root is None:
+            os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
+        else:
+            os.environ["PLAYWRIGHT_BROWSERS_PATH"] = previous_browser_root
+
+
+def test_browser_clawhub_saved_token_wins_over_autofilled_dom_value(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+    api_client: httpx.Client,
+) -> None:
+    saved_token = "ch_browser_saved_token"
+    response = api_client.put(
+        "/api/system/configs/clawhub",
+        json={"token": saved_token},
+    )
+    response.raise_for_status()
+
+    page = browser_page
+    page.goto(integration_env.api_base_url, wait_until="domcontentloaded")
+    expect(page.locator("#projects-list")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+    with page.expect_response(
+        lambda response: (
+            response.request.method == "GET"
+            and response.url
+            == f"{integration_env.api_base_url}/api/system/configs/clawhub"
+            and response.ok
+        ),
+        timeout=_WAIT_TIMEOUT_MS,
+    ):
+        page.locator('.home-feature-item[data-feature-id="skills"]').click()
+
+    expect(page.locator("#project-view")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    token_input = page.locator("#feature-clawhub-token")
+    expect(token_input).to_have_attribute("autocomplete", "new-password")
+    expect(token_input).to_have_value("", timeout=_WAIT_TIMEOUT_MS)
+
+    token_input.evaluate("(input) => { input.value = 'browser_password'; }")
+
+    captured_probe_payload: dict[str, object] = {}
+
+    def handle_probe(route) -> None:
+        request = route.request
+        captured_probe_payload.update(json.loads(request.post_data or "{}"))
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "ok": True,
+                    "clawhub_version": "clawhub 0.4.2",
+                    "latency_ms": 12,
+                    "diagnostics": {"installed_during_probe": False},
+                }
+            ),
+        )
+
+    probe_url = f"{integration_env.api_base_url}/api/system/configs/clawhub:probe"
+    page.route(probe_url, handle_probe)
+    try:
+        page.locator("#feature-test-clawhub-btn").click()
+        expect(page.locator("#feature-clawhub-probe-status")).to_contain_text(
+            "clawhub 0.4.2",
+            timeout=_WAIT_TIMEOUT_MS,
+        )
+    finally:
+        page.unroute(probe_url, handle_probe)
+
+    assert captured_probe_payload == {"token": saved_token}
+
+    with page.expect_request(
+        lambda request: (
+            request.method == "PUT"
+            and request.url
+            == f"{integration_env.api_base_url}/api/system/configs/clawhub"
+        ),
+        timeout=_WAIT_TIMEOUT_MS,
+    ) as save_request_info:
+        page.locator("#feature-save-clawhub-token-btn").click()
+
+    save_payload = json.loads(save_request_info.value.post_data or "{}")
+    assert save_payload == {"token": saved_token}
+
+
+def _resolve_playwright_browser_root() -> Path:
+    candidates: list[Path] = []
+
+    configured_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    if configured_root:
+        candidates.append(Path(configured_root).expanduser())
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        candidates.append(Path(local_app_data).expanduser() / "ms-playwright")
+    user_profile = os.environ.get("USERPROFILE")
+    if user_profile:
+        candidates.append(
+            Path(user_profile).expanduser() / "AppData" / "Local" / "ms-playwright"
+        )
+
+    try:
+        import pwd
+
+        candidates.append(
+            Path(pwd.getpwuid(os.getuid()).pw_dir) / ".cache" / "ms-playwright"
+        )
+    except (ImportError, KeyError, OSError):
+        pass
+
+    for candidate in candidates:
+        if any(candidate.glob("chromium-*")):
+            return candidate
+
+    raise AssertionError("Playwright browser cache was not found on this machine.")

--- a/tests/integration_tests/browser/test_github_browser_flow.py
+++ b/tests/integration_tests/browser/test_github_browser_flow.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+import os
+from pathlib import Path
+
+import httpx
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+from playwright.sync_api import sync_playwright
+import pytest
+
+from integration_tests.support.environment import IntegrationEnvironment
+
+
+_VIEWPORT_WIDTH = 1600
+_VIEWPORT_HEIGHT = 1200
+_WAIT_TIMEOUT_MS = 30_000
+
+
+@pytest.fixture()
+def browser_page() -> Iterator[Page]:
+    browser_root = _resolve_playwright_browser_root()
+    previous_browser_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_root)
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            context = browser.new_context(
+                viewport={"width": _VIEWPORT_WIDTH, "height": _VIEWPORT_HEIGHT},
+                color_scheme="dark",
+            )
+            page = context.new_page()
+            try:
+                yield page
+            finally:
+                context.close()
+                browser.close()
+    finally:
+        if previous_browser_root is None:
+            os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
+        else:
+            os.environ["PLAYWRIGHT_BROWSERS_PATH"] = previous_browser_root
+
+
+def test_browser_github_saved_token_wins_over_autofilled_dom_value(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+    api_client: httpx.Client,
+) -> None:
+    saved_token = "ghp_browser_saved_token"
+    response = api_client.put(
+        "/api/system/configs/github",
+        json={"token": saved_token},
+    )
+    response.raise_for_status()
+
+    page = browser_page
+    page.goto(integration_env.api_base_url, wait_until="domcontentloaded")
+    expect(page.locator("#projects-list")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+    page.locator('.home-feature-item[data-feature-id="automation"]').click()
+    expect(page.locator("#project-view")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    page.locator('[data-automation-section="github"]').click()
+    token_input = page.locator("#feature-github-token")
+    expect(token_input).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    expect(token_input).to_have_attribute("autocomplete", "new-password")
+    expect(token_input).to_have_value("", timeout=_WAIT_TIMEOUT_MS)
+
+    token_input.evaluate(
+        "(input) => { input.value = 'browser_password'; input.dispatchEvent(new Event('input', { bubbles: true })); }"
+    )
+    expect(token_input).to_have_value("", timeout=_WAIT_TIMEOUT_MS)
+
+    captured_probe_payload: dict[str, object] = {}
+
+    def handle_probe(route) -> None:
+        request = route.request
+        captured_probe_payload.update(json.loads(request.post_data or "{}"))
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "ok": True,
+                    "username": "octocat",
+                    "gh_version": "2.88.1",
+                    "latency_ms": 12,
+                }
+            ),
+        )
+
+    probe_url = f"{integration_env.api_base_url}/api/system/configs/github:probe"
+    page.route(probe_url, handle_probe)
+    try:
+        page.locator("#feature-test-github-btn").click()
+        expect(page.locator("#feature-github-probe-status")).to_contain_text(
+            "octocat",
+            timeout=_WAIT_TIMEOUT_MS,
+        )
+    finally:
+        page.unroute(probe_url, handle_probe)
+
+    assert captured_probe_payload == {}
+
+    with page.expect_request(
+        lambda request: (
+            request.method == "PUT"
+            and request.url
+            == f"{integration_env.api_base_url}/api/system/configs/github"
+        ),
+        timeout=_WAIT_TIMEOUT_MS,
+    ) as save_request_info:
+        page.locator("#feature-save-github-btn").click()
+
+    save_payload = json.loads(save_request_info.value.post_data or "{}")
+    assert save_payload == {}
+
+
+def _resolve_playwright_browser_root() -> Path:
+    candidates: list[Path] = []
+
+    configured_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    if configured_root:
+        candidates.append(Path(configured_root).expanduser())
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        candidates.append(Path(local_app_data).expanduser() / "ms-playwright")
+    user_profile = os.environ.get("USERPROFILE")
+    if user_profile:
+        candidates.append(
+            Path(user_profile).expanduser() / "AppData" / "Local" / "ms-playwright"
+        )
+
+    try:
+        import pwd
+
+        candidates.append(
+            Path(pwd.getpwuid(os.getuid()).pw_dir) / ".cache" / "ms-playwright"
+        )
+    except (ImportError, KeyError, OSError):
+        pass
+
+    for candidate in candidates:
+        if any(candidate.glob("chromium-*")):
+            return candidate
+
+    raise AssertionError("Playwright browser cache was not found on this machine.")

--- a/tests/unit_tests/env/test_clawhub_auth.py
+++ b/tests/unit_tests/env/test_clawhub_auth.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+from relay_teams.env.clawhub_auth import (
+    build_clawhub_managed_subprocess_env,
+    clear_clawhub_runtime_home,
+    ensure_clawhub_cli_login,
+    get_clawhub_runtime_config_path,
+    get_clawhub_runtime_home,
+)
+
+
+def test_build_clawhub_managed_subprocess_env_sets_isolated_home(monkeypatch) -> None:
+    config_dir = Path("/tmp/.relay-teams")
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_auth.os.environ",
+        {"PATH": "/usr/bin"},
+    )
+
+    env = build_clawhub_managed_subprocess_env(
+        "ch_secret",
+        config_dir=config_dir,
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    runtime_home = get_clawhub_runtime_home(config_dir)
+    assert env["CLAWHUB_TOKEN"] == "ch_secret"
+    assert env["HOME"] == str(runtime_home)
+    assert env["USERPROFILE"] == str(runtime_home)
+    assert env["XDG_CONFIG_HOME"] == str(runtime_home / ".config")
+
+
+def test_ensure_clawhub_cli_login_uses_token_login_and_returns_runtime_env(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".relay-teams"
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_auth.resolve_existing_clawhub_path",
+        lambda: Path("/usr/bin/clawhub"),
+    )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_auth.os.environ",
+        {"PATH": "/usr/bin"},
+    )
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        command = args[0]
+        assert isinstance(command, list)
+        assert command == [
+            "/usr/bin/clawhub",
+            "login",
+            "--token",
+            "ch_secret",
+            "--no-browser",
+        ]
+        env = kwargs.get("env")
+        assert isinstance(env, dict)
+        assert env["CLAWHUB_TOKEN"] == "ch_secret"
+        assert env["HOME"] == str(get_clawhub_runtime_home(config_dir))
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="",
+            stderr="- Verifying token\n✔ OK. Logged in as @steven",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ensure_clawhub_cli_login(
+        "ch_secret",
+        config_dir=config_dir,
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert result.ok is True
+    assert result.endpoint_fallback_used is False
+    assert result.registry is None
+    assert result.env["HOME"] == str(get_clawhub_runtime_home(config_dir))
+
+
+def test_ensure_clawhub_cli_login_retries_without_endpoint_overrides(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".relay-teams"
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_auth.resolve_existing_clawhub_path",
+        lambda: Path("/usr/bin/clawhub"),
+    )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_auth.os.environ",
+        {"LANG": "zh_CN.UTF-8", "PATH": "/usr/bin"},
+    )
+    observed_envs: list[dict[str, str]] = []
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        command = args[0]
+        assert isinstance(command, list)
+        env = kwargs.get("env")
+        assert isinstance(env, dict)
+        observed_envs.append(dict(env))
+        if len(observed_envs) == 1:
+            assert env["CLAWHUB_REGISTRY"] == "https://mirror-cn.clawhub.com"
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=1,
+                stdout="",
+                stderr="- Verifying token\nValidation error\nuser: invalid value",
+            )
+        assert "CLAWHUB_REGISTRY" not in env
+        assert "CLAWHUB_SITE" not in env
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout="",
+            stderr="- Verifying token\n✔ OK. Logged in as @steven",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = ensure_clawhub_cli_login(
+        "ch_secret",
+        config_dir=config_dir,
+        base_env={"LANG": "zh_CN.UTF-8", "PATH": "/usr/bin"},
+    )
+
+    assert result.ok is True
+    assert result.registry == "https://mirror-cn.clawhub.com"
+    assert result.endpoint_fallback_used is True
+
+
+def test_ensure_clawhub_cli_login_reuses_existing_runtime_token(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_dir = tmp_path / ".relay-teams"
+    runtime_config = get_clawhub_runtime_config_path(config_dir)
+    runtime_config.parent.mkdir(parents=True, exist_ok=True)
+    runtime_config.write_text(
+        '{"token": "ch_secret"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_auth.resolve_existing_clawhub_path",
+        lambda: Path("/usr/bin/clawhub"),
+    )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_auth.os.environ",
+        {"PATH": "/usr/bin"},
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("login command should not run")
+        ),
+    )
+
+    result = ensure_clawhub_cli_login(
+        "ch_secret",
+        config_dir=config_dir,
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert result.ok is True
+    assert result.env["HOME"] == str(get_clawhub_runtime_home(config_dir))
+
+
+def test_clear_clawhub_runtime_home_removes_login_state(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".relay-teams"
+    runtime_config = get_clawhub_runtime_config_path(config_dir)
+    runtime_config.parent.mkdir(parents=True, exist_ok=True)
+    runtime_config.write_text('{"token":"ch_secret"}', encoding="utf-8")
+
+    clear_clawhub_runtime_home(config_dir)
+
+    assert not get_clawhub_runtime_home(config_dir).exists()

--- a/tests/unit_tests/env/test_clawhub_config_service.py
+++ b/tests/unit_tests/env/test_clawhub_config_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from relay_teams.env.clawhub_auth import get_clawhub_runtime_home
 from relay_teams.env.clawhub_config_models import ClawHubConfig
 from relay_teams.env.clawhub_config_service import ClawHubConfigService
 from relay_teams.env.clawhub_secret_store import ClawHubSecretStore
@@ -72,3 +73,21 @@ def test_save_clawhub_config_removes_plaintext_env_token(tmp_path: Path) -> None
     assert (config_dir / ".env").read_text(encoding="utf-8") == (
         "HTTP_PROXY=http://proxy.example:8080\n"
     )
+
+
+def test_save_clawhub_config_clears_runtime_home_when_token_removed(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".relay-teams"
+    config_dir.mkdir(parents=True)
+    runtime_home = get_clawhub_runtime_home(config_dir)
+    runtime_home.mkdir(parents=True, exist_ok=True)
+    (runtime_home / "marker.txt").write_text("present", encoding="utf-8")
+    service = ClawHubConfigService(
+        config_dir=config_dir,
+        secret_store=_FakeClawHubSecretStore(),
+    )
+
+    service.save_clawhub_config(ClawHubConfig(token=None))
+
+    assert not runtime_home.exists()

--- a/tests/unit_tests/env/test_clawhub_connectivity.py
+++ b/tests/unit_tests/env/test_clawhub_connectivity.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import subprocess
 
+from relay_teams.env.clawhub_auth import ClawHubCliLoginResult
 from relay_teams.env.clawhub_cli import ClawHubCliInstallResult
 from relay_teams.env.clawhub_config_models import ClawHubConfig
 from relay_teams.env.clawhub_connectivity import (
@@ -73,6 +74,20 @@ def test_clawhub_probe_validates_token_without_passing_it_on_cli(
         "relay_teams.env.clawhub_connectivity.os.environ",
         {"PATH": "/usr/bin"},
     )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_connectivity.ensure_clawhub_cli_login",
+        lambda *args, **kwargs: ClawHubCliLoginResult(
+            ok=True,
+            env={
+                "PATH": "/usr/bin",
+                "CLAWHUB_TOKEN": "ch_secret",
+                "HOME": "/tmp/.relay-teams/runtime/clawhub-home",
+                "USERPROFILE": "/tmp/.relay-teams/runtime/clawhub-home",
+                "XDG_CONFIG_HOME": "/tmp/.relay-teams/runtime/clawhub-home/.config",
+            },
+            registry=None,
+        ),
+    )
     observed_commands: list[list[str]] = []
 
     def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -135,6 +150,20 @@ def test_clawhub_probe_uses_remaining_timeout_budget_for_each_step(
         "relay_teams.env.clawhub_connectivity.perf_counter",
         lambda: next(perf_counter_values),
     )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_connectivity.ensure_clawhub_cli_login",
+        lambda *args, **kwargs: ClawHubCliLoginResult(
+            ok=True,
+            env={
+                "PATH": "/usr/bin",
+                "CLAWHUB_TOKEN": "ch_secret",
+                "HOME": "/tmp/.relay-teams/runtime/clawhub-home",
+                "USERPROFILE": "/tmp/.relay-teams/runtime/clawhub-home",
+                "XDG_CONFIG_HOME": "/tmp/.relay-teams/runtime/clawhub-home/.config",
+            },
+            registry=None,
+        ),
+    )
     observed_timeouts: list[float] = []
 
     def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -171,7 +200,7 @@ def test_clawhub_probe_uses_remaining_timeout_budget_for_each_step(
     )
 
     assert result.ok is True
-    assert observed_timeouts == [9.0, 6.0]
+    assert observed_timeouts == [9.0, 3.5]
 
 
 def test_clawhub_probe_rejects_invalid_token_when_auth_validation_fails(
@@ -185,31 +214,33 @@ def test_clawhub_probe_rejects_invalid_token_when_auth_validation_fails(
         "relay_teams.env.clawhub_connectivity.os.environ",
         {"PATH": "/usr/bin"},
     )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_connectivity.ensure_clawhub_cli_login",
+        lambda *args, **kwargs: ClawHubCliLoginResult(
+            ok=False,
+            env={
+                "PATH": "/usr/bin",
+                "CLAWHUB_TOKEN": "ch_secret",
+                "HOME": "/tmp/.relay-teams/runtime/clawhub-home",
+                "USERPROFILE": "/tmp/.relay-teams/runtime/clawhub-home",
+                "XDG_CONFIG_HOME": "/tmp/.relay-teams/runtime/clawhub-home/.config",
+            },
+            registry=None,
+            error_code="auth_failed",
+            error_message="Error: Invalid token",
+        ),
+    )
 
-    def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        command = kwargs.get("args")
-        if not isinstance(command, list):
-            command = _args[0]
-        assert isinstance(command, list)
-        env = kwargs.get("env")
-        assert isinstance(env, dict)
-        assert env["CLAWHUB_TOKEN"] == "ch_secret"
-        if command[1] == "--cli-version":
-            return subprocess.CompletedProcess(
-                args=command,
-                returncode=0,
-                stdout="0.4.2\n",
-                stderr="",
-            )
-        assert command[1] == "whoami"
-        return subprocess.CompletedProcess(
-            args=command,
-            returncode=1,
-            stdout="",
-            stderr="- Checking token\nError: Invalid token",
-        )
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="0.4.2\n",
+            stderr="",
+        ),
+    )
     service = ClawHubConnectivityProbeService(
         config_dir=Path("/tmp/.relay-teams"),
         get_clawhub_config=lambda: ClawHubConfig(token=None),
@@ -221,7 +252,7 @@ def test_clawhub_probe_rejects_invalid_token_when_auth_validation_fails(
     assert result.error_code == "auth_failed"
     assert result.error_message == "Error: Invalid token"
     assert result.clawhub_version == "clawhub 0.4.2"
-    assert result.exit_code == 1
+    assert result.exit_code is None
 
 
 def test_clawhub_probe_installs_missing_binary(monkeypatch) -> None:
@@ -243,6 +274,20 @@ def test_clawhub_probe_installs_missing_binary(monkeypatch) -> None:
     monkeypatch.setattr(
         "relay_teams.env.clawhub_connectivity.os.environ",
         {"PATH": "/usr/bin"},
+    )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_connectivity.ensure_clawhub_cli_login",
+        lambda *args, **kwargs: ClawHubCliLoginResult(
+            ok=True,
+            env={
+                "PATH": f"{installed_clawhub_path.parent}{os.pathsep}/usr/bin",
+                "CLAWHUB_TOKEN": "ch_secret",
+                "HOME": "/tmp/.relay-teams/runtime/clawhub-home",
+                "USERPROFILE": "/tmp/.relay-teams/runtime/clawhub-home",
+                "XDG_CONFIG_HOME": "/tmp/.relay-teams/runtime/clawhub-home/.config",
+            },
+            registry=None,
+        ),
     )
 
     def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -298,6 +343,25 @@ def test_clawhub_probe_retries_without_endpoint_overrides_for_invalid_user_paylo
     monkeypatch.setattr(
         "relay_teams.env.clawhub_connectivity.os.environ",
         {"LANG": "zh_CN.UTF-8", "PATH": "/usr/bin"},
+    )
+    monkeypatch.setattr(
+        "relay_teams.env.clawhub_connectivity.ensure_clawhub_cli_login",
+        lambda *args, **kwargs: ClawHubCliLoginResult(
+            ok=True,
+            env={
+                "LANG": "zh_CN.UTF-8",
+                "PATH": "/usr/bin",
+                "CLAWHUB_TOKEN": "ch_secret",
+                "CLAWHUB_SITE": "https://mirror-cn.clawhub.com",
+                "CLAWHUB_REGISTRY": "https://mirror-cn.clawhub.com",
+                "CLAWDHUB_SITE": "https://mirror-cn.clawhub.com",
+                "CLAWDHUB_REGISTRY": "https://mirror-cn.clawhub.com",
+                "HOME": "/tmp/.relay-teams/runtime/clawhub-home",
+                "USERPROFILE": "/tmp/.relay-teams/runtime/clawhub-home",
+                "XDG_CONFIG_HOME": "/tmp/.relay-teams/runtime/clawhub-home/.config",
+            },
+            registry="https://mirror-cn.clawhub.com",
+        ),
     )
     observed_envs: list[dict[str, str]] = []
 

--- a/tests/unit_tests/frontend/test_clawhub_settings_ui.py
+++ b/tests/unit_tests/frontend/test_clawhub_settings_ui.py
@@ -116,6 +116,40 @@ console.log(JSON.stringify({
     assert payload["probePayload"] == {"token": "ch_saved"}
 
 
+def test_clawhub_settings_panel_ignores_browser_autofill_when_saved_token_is_clean(
+    tmp_path: Path,
+) -> None:
+    payload = _run_clawhub_settings_script(
+        tmp_path=tmp_path,
+        fetch_config={"token": "ch_saved"},
+        runner_source="""
+import { bindClawHubSettingsHandlers, loadClawHubSettingsPanel } from "./clawhubSettings.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+
+bindClawHubSettingsHandlers();
+await loadClawHubSettingsPanel();
+
+document.getElementById("clawhub-token").value = "browser_password";
+
+await document.getElementById("test-clawhub-btn").onclick();
+await new Promise(resolve => setTimeout(resolve, 0));
+await document.getElementById("save-clawhub-token-btn").onclick();
+await new Promise(resolve => setTimeout(resolve, 0));
+
+console.log(JSON.stringify({
+    savePayload: globalThis.__saveClawHubPayload,
+    probePayload: globalThis.__probeClawHubPayload,
+}));
+""".strip(),
+    )
+
+    assert payload["savePayload"] == {"token": "ch_saved"}
+    assert payload["probePayload"] == {"token": "ch_saved"}
+
+
 def test_clawhub_settings_panel_shows_auto_install_success_message(
     tmp_path: Path,
 ) -> None:
@@ -229,6 +263,7 @@ def test_clawhub_settings_markup_lives_in_skills_feature_and_keeps_actions_inlin
     assert 'id="${escapeHtml(FEATURE_CLAWHUB_FIELD_IDS.statusId)}"' in source
     assert 'id="feature-clawhub-token-link"' in source
     assert 'href="https://clawhub.ai/settings"' in source
+    assert 'autocomplete="new-password"' in source
     assert 'target="_blank"' in source
     assert 'rel="noreferrer"' in source
     assert 'id="clawhub-token"' not in project_view_source

--- a/tests/unit_tests/frontend/test_clawhub_settings_ui.py
+++ b/tests/unit_tests/frontend/test_clawhub_settings_ui.py
@@ -150,6 +150,47 @@ console.log(JSON.stringify({
     assert payload["probePayload"] == {"token": "ch_saved"}
 
 
+def test_clawhub_settings_panel_allows_replacing_saved_token_after_focus(
+    tmp_path: Path,
+) -> None:
+    payload = _run_clawhub_settings_script(
+        tmp_path=tmp_path,
+        fetch_config={"token": "ch_saved"},
+        runner_source="""
+import { bindClawHubSettingsHandlers, loadClawHubSettingsPanel } from "./clawhubSettings.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+
+bindClawHubSettingsHandlers();
+await loadClawHubSettingsPanel();
+
+document.activeElement = null;
+document.getElementById("clawhub-token").onfocus();
+document.getElementById("clawhub-token").value = "ch_replacement";
+document.getElementById("clawhub-token").oninput();
+
+await document.getElementById("test-clawhub-btn").onclick();
+await new Promise(resolve => setTimeout(resolve, 0));
+await document.getElementById("save-clawhub-token-btn").onclick();
+await new Promise(resolve => setTimeout(resolve, 0));
+
+console.log(JSON.stringify({
+    tokenValue: document.getElementById("clawhub-token").value,
+    tokenPlaceholder: document.getElementById("clawhub-token").placeholder,
+    savePayload: globalThis.__saveClawHubPayload,
+    probePayload: globalThis.__probeClawHubPayload,
+}));
+""".strip(),
+    )
+
+    assert payload["tokenValue"] == ""
+    assert payload["tokenPlaceholder"] == "************"
+    assert payload["savePayload"] == {"token": "ch_replacement"}
+    assert payload["probePayload"] == {"token": "ch_replacement"}
+
+
 def test_clawhub_settings_panel_shows_auto_install_success_message(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_github_settings_ui.py
+++ b/tests/unit_tests/frontend/test_github_settings_ui.py
@@ -164,6 +164,49 @@ console.log(JSON.stringify({
     }
 
 
+def test_github_settings_panel_ignores_unfocused_autofilled_dom_value(
+    tmp_path: Path,
+) -> None:
+    payload = _run_github_settings_script(
+        tmp_path=tmp_path,
+        fetch_config={
+            "token": "ghp_saved",
+            "token_configured": True,
+            "webhook_base_url": None,
+        },
+        runner_source="""
+import { bindGitHubSettingsHandlers, loadGitHubSettingsPanel } from "./githubSettings.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+
+bindGitHubSettingsHandlers();
+await loadGitHubSettingsPanel();
+
+document.getElementById("github-token").value = "browser_password";
+document.getElementById("github-token").oninput();
+
+await document.getElementById("test-github-btn").onclick();
+await document.getElementById("save-github-btn").onclick();
+
+console.log(JSON.stringify({
+    tokenValue: document.getElementById("github-token").value,
+    tokenPlaceholder: document.getElementById("github-token").placeholder,
+    toggleDisplay: document.getElementById("toggle-github-token-btn").style.display,
+    savePayloads: globalThis.__saveGitHubPayloads,
+    probePayload: globalThis.__probeGitHubPayload,
+}));
+""".strip(),
+    )
+
+    assert payload["tokenValue"] == ""
+    assert payload["tokenPlaceholder"] == "************"
+    assert payload["toggleDisplay"] == "inline-flex"
+    assert payload["savePayloads"] == [{}]
+    assert payload["probePayload"] == {}
+
+
 def test_github_settings_panel_starts_and_stops_temporary_public_url(
     tmp_path: Path,
 ) -> None:
@@ -426,6 +469,10 @@ def test_github_settings_markup_includes_token_link_card() -> None:
     assert 'href="https://github.com/settings/tokens"' in github_source
     assert 'target="_blank"' in github_source
     assert 'rel="noreferrer"' in github_source
+    assert 'autocomplete="new-password"' in github_source
+    assert 'autocapitalize="off"' in github_source
+    assert 'autocorrect="off"' in github_source
+    assert 'spellcheck="false"' in github_source
     assert 'id="${escapeHtml(ids.webhookBaseUrlInputId)}"' in github_source
     assert 'id="${escapeHtml(ids.callbackPreviewId)}"' in github_source
     assert 'id="${escapeHtml(ids.tunnelStartButtonId)}"' in github_source

--- a/tests/unit_tests/frontend/test_github_settings_ui.py
+++ b/tests/unit_tests/frontend/test_github_settings_ui.py
@@ -207,6 +207,51 @@ console.log(JSON.stringify({
     assert payload["probePayload"] == {}
 
 
+def test_github_settings_panel_allows_replacing_saved_token_after_focus(
+    tmp_path: Path,
+) -> None:
+    payload = _run_github_settings_script(
+        tmp_path=tmp_path,
+        fetch_config={
+            "token": "ghp_saved",
+            "token_configured": True,
+            "webhook_base_url": None,
+        },
+        runner_source="""
+import { bindGitHubSettingsHandlers, loadGitHubSettingsPanel } from "./githubSettings.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+
+bindGitHubSettingsHandlers();
+await loadGitHubSettingsPanel();
+
+document.activeElement = null;
+document.getElementById("github-token").onfocus();
+document.getElementById("github-token").value = "ghp_replacement";
+document.getElementById("github-token").oninput();
+
+await document.getElementById("test-github-btn").onclick();
+await document.getElementById("save-github-btn").onclick();
+
+console.log(JSON.stringify({
+    tokenValue: document.getElementById("github-token").value,
+    tokenPlaceholder: document.getElementById("github-token").placeholder,
+    toggleDisplay: document.getElementById("toggle-github-token-btn").style.display,
+    savePayloads: globalThis.__saveGitHubPayloads,
+    probePayload: globalThis.__probeGitHubPayload,
+}));
+""".strip(),
+    )
+
+    assert payload["tokenValue"] == ""
+    assert payload["tokenPlaceholder"] == "************"
+    assert payload["toggleDisplay"] == "inline-flex"
+    assert payload["savePayloads"] == [{"token": "ghp_replacement"}]
+    assert payload["probePayload"] == {"token": "ghp_replacement"}
+
+
 def test_github_settings_panel_starts_and_stops_temporary_public_url(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -990,6 +990,42 @@ console.log(JSON.stringify({
     assert "api_key" not in saved_profile_body
 
 
+def test_edit_profile_allows_replacing_saved_api_key_after_focus(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+await loadModelProfilesPanel();
+
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn")[0].onclick();
+document.activeElement = null;
+document.getElementById("profile-api-key").onfocus();
+document.getElementById("profile-api-key").value = "replacement-secret-key";
+document.getElementById("profile-api-key").oninput();
+
+await document.getElementById("save-profile-btn").onclick();
+
+console.log(JSON.stringify({
+    toggleDisplay: document.getElementById("toggle-profile-api-key-btn").style.display,
+    savedProfile: globalThis.__savedProfile,
+}));
+""".strip(),
+    )
+
+    saved_profile = cast(dict[str, JsonValue], payload["savedProfile"])
+    saved_profile_body = cast(dict[str, JsonValue], saved_profile["profile"])
+    assert payload["toggleDisplay"] == "inline-flex"
+    assert saved_profile_body["api_key"] == "replacement-secret-key"
+
+
 def test_edit_profile_api_key_toggle_reveals_saved_value(tmp_path: Path) -> None:
     payload = _run_model_profiles_script(
         tmp_path=tmp_path,
@@ -1100,6 +1136,90 @@ export async function deleteModelProfile(name) {
     assert payload["toggleDisplay"] == "inline-flex"
     assert saved_maas_auth == {
         "username": "saved-user",
+    }
+
+
+def test_edit_maas_profile_allows_replacing_saved_password_after_focus(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+await loadModelProfilesPanel();
+
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "maas-profile").onclick();
+document.activeElement = null;
+document.getElementById("profile-maas-password").onfocus();
+document.getElementById("profile-maas-password").value = "replacement-maas-password";
+document.getElementById("profile-maas-password").oninput();
+
+await document.getElementById("save-profile-btn").onclick();
+
+console.log(JSON.stringify({
+    passwordValue: document.getElementById("profile-maas-password").value,
+    passwordPlaceholder: document.getElementById("profile-maas-password").placeholder,
+    toggleDisplay: document.getElementById("toggle-profile-maas-password-btn").style.display,
+    savedProfile: globalThis.__savedProfile,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "maas-profile": {
+            provider: "maas",
+            model: "maas-chat",
+            base_url: "http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/",
+            maas_auth: {
+                username: "saved-user",
+                password: "saved-password",
+                has_password: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function probeModelConnection(payload) {
+    globalThis.__probePayload = payload;
+    return { ok: true, latency_ms: 42, token_usage: { total_tokens: 9 } };
+}
+
+export async function discoverModelCatalog(payload) {
+    globalThis.__discoverPayload = payload;
+    return { ok: true, latency_ms: 37, models: ["maas-chat"] };
+}
+
+export async function saveModelProfile(name, profile) {
+    globalThis.__savedProfile = { name, profile };
+}
+
+export async function reloadModelConfig() {
+    globalThis.__reloadCalled = true;
+}
+
+export async function deleteModelProfile(name) {
+    globalThis.__deletedProfileName = name;
+}
+""".strip(),
+    )
+
+    saved_profile = cast(dict[str, JsonValue], payload["savedProfile"])
+    saved_profile_body = cast(dict[str, JsonValue], saved_profile["profile"])
+    saved_maas_auth = cast(dict[str, JsonValue], saved_profile_body["maas_auth"])
+    assert payload["toggleDisplay"] == "inline-flex"
+    assert saved_maas_auth == {
+        "username": "saved-user",
+        "password": "replacement-maas-password",
     }
 
 

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -916,6 +916,45 @@ console.log(JSON.stringify({
     assert saved_profile_body["top_p"] == 0.95
 
 
+def test_edit_profile_ignores_unfocused_autofilled_saved_api_key(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+await loadModelProfilesPanel();
+
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn")[0].onclick();
+document.activeElement = null;
+document.getElementById("profile-api-key").value = "browser_password";
+document.getElementById("profile-api-key").oninput();
+
+await document.getElementById("save-profile-btn").onclick();
+
+console.log(JSON.stringify({
+    apiKeyValue: document.getElementById("profile-api-key").value,
+    apiKeyPlaceholder: document.getElementById("profile-api-key").placeholder,
+    toggleDisplay: document.getElementById("toggle-profile-api-key-btn").style.display,
+    savedProfile: globalThis.__savedProfile,
+}));
+""".strip(),
+    )
+
+    saved_profile = cast(dict[str, JsonValue], payload["savedProfile"])
+    saved_profile_body = cast(dict[str, JsonValue], saved_profile["profile"])
+    assert payload["apiKeyValue"] == ""
+    assert payload["apiKeyPlaceholder"] == "************"
+    assert payload["toggleDisplay"] == "inline-flex"
+    assert "api_key" not in saved_profile_body
+
+
 def test_edit_profile_api_key_toggle_reveals_saved_value(tmp_path: Path) -> None:
     payload = _run_model_profiles_script(
         tmp_path=tmp_path,
@@ -943,6 +982,90 @@ console.log(JSON.stringify({
     assert payload["apiKeyValue"] == "saved-secret-key"
     assert payload["apiKeyType"] == "text"
     assert payload["toggleTitle"] == "Hide API key"
+
+
+def test_edit_maas_profile_ignores_unfocused_autofilled_saved_password(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+await loadModelProfilesPanel();
+
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "maas-profile").onclick();
+document.activeElement = null;
+document.getElementById("profile-maas-password").value = "browser_password";
+document.getElementById("profile-maas-password").oninput();
+
+await document.getElementById("save-profile-btn").onclick();
+
+console.log(JSON.stringify({
+    passwordValue: document.getElementById("profile-maas-password").value,
+    passwordPlaceholder: document.getElementById("profile-maas-password").placeholder,
+    toggleDisplay: document.getElementById("toggle-profile-maas-password-btn").style.display,
+    savedProfile: globalThis.__savedProfile,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "maas-profile": {
+            provider: "maas",
+            model: "maas-chat",
+            base_url: "http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/",
+            maas_auth: {
+                username: "saved-user",
+                password: "saved-password",
+                has_password: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function probeModelConnection(payload) {
+    globalThis.__probePayload = payload;
+    return { ok: true, latency_ms: 42, token_usage: { total_tokens: 9 } };
+}
+
+export async function discoverModelCatalog(payload) {
+    globalThis.__discoverPayload = payload;
+    return { ok: true, latency_ms: 37, models: ["maas-chat"] };
+}
+
+export async function saveModelProfile(name, profile) {
+    globalThis.__savedProfile = { name, profile };
+}
+
+export async function reloadModelConfig() {
+    globalThis.__reloadCalled = true;
+}
+
+export async function deleteModelProfile(name) {
+    globalThis.__deletedProfileName = name;
+}
+""".strip(),
+    )
+
+    saved_profile = cast(dict[str, JsonValue], payload["savedProfile"])
+    saved_profile_body = cast(dict[str, JsonValue], saved_profile["profile"])
+    saved_maas_auth = cast(dict[str, JsonValue], saved_profile_body["maas_auth"])
+    assert payload["passwordValue"] == ""
+    assert payload["passwordPlaceholder"] == "************"
+    assert payload["toggleDisplay"] == "inline-flex"
+    assert saved_maas_auth == {
+        "username": "saved-user",
+    }
 
 
 def test_maas_password_toggle_reveals_and_masks_draft_value(tmp_path: Path) -> None:

--- a/tests/unit_tests/frontend/test_proxy_settings_ui.py
+++ b/tests/unit_tests/frontend/test_proxy_settings_ui.py
@@ -215,6 +215,47 @@ console.log(JSON.stringify({
     ]
 
 
+def test_proxy_settings_ignore_unfocused_autofilled_saved_password(
+    tmp_path: Path,
+) -> None:
+    payload = _run_proxy_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindProxySettingsHandlers, loadProxyStatusPanel } from "./proxySettings.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+
+bindProxySettingsHandlers();
+await loadProxyStatusPanel();
+
+document.activeElement = null;
+document.getElementById("proxy-password").value = "browser_password";
+document.getElementById("proxy-password").oninput();
+document.getElementById("proxy-probe-url").value = "https://example.com";
+
+await document.getElementById("test-proxy-web-btn").onclick();
+await document.getElementById("save-proxy-btn").onclick();
+
+console.log(JSON.stringify({
+    proxyPasswordValue: document.getElementById("proxy-password").value,
+    proxyPasswordPlaceholder: document.getElementById("proxy-password").placeholder,
+    savePayload: globalThis.__saveProxyPayload,
+    probePayload: globalThis.__probePayload,
+}));
+""".strip(),
+    )
+
+    probe_payload = cast(dict[str, JsonValue], payload["probePayload"])
+    save_payload = cast(dict[str, JsonValue], payload["savePayload"])
+    proxy_override = cast(dict[str, JsonValue], probe_payload["proxy_override"])
+    assert payload["proxyPasswordValue"] == ""
+    assert payload["proxyPasswordPlaceholder"] == "************"
+    assert proxy_override["proxy_password"] == "secret"
+    assert save_payload["proxy_password"] == "secret"
+
+
 def test_proxy_settings_panel_allows_clearing_saved_password(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_proxy_settings_ui.py
+++ b/tests/unit_tests/frontend/test_proxy_settings_ui.py
@@ -256,6 +256,48 @@ console.log(JSON.stringify({
     assert save_payload["proxy_password"] == "secret"
 
 
+def test_proxy_settings_allow_replacing_saved_password_after_focus(
+    tmp_path: Path,
+) -> None:
+    payload = _run_proxy_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindProxySettingsHandlers, loadProxyStatusPanel } from "./proxySettings.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+
+bindProxySettingsHandlers();
+await loadProxyStatusPanel();
+
+document.activeElement = null;
+document.getElementById("proxy-password").onfocus();
+document.getElementById("proxy-password").value = "replacement-secret";
+document.getElementById("proxy-password").oninput();
+document.getElementById("proxy-probe-url").value = "https://example.com";
+
+await document.getElementById("test-proxy-web-btn").onclick();
+await document.getElementById("save-proxy-btn").onclick();
+
+console.log(JSON.stringify({
+    proxyPasswordValue: document.getElementById("proxy-password").value,
+    proxyPasswordPlaceholder: document.getElementById("proxy-password").placeholder,
+    savePayload: globalThis.__saveProxyPayload,
+    probePayload: globalThis.__probePayload,
+}));
+""".strip(),
+    )
+
+    probe_payload = cast(dict[str, JsonValue], payload["probePayload"])
+    save_payload = cast(dict[str, JsonValue], payload["savePayload"])
+    proxy_override = cast(dict[str, JsonValue], probe_payload["proxy_override"])
+    assert payload["proxyPasswordValue"] == ""
+    assert payload["proxyPasswordPlaceholder"] == "************"
+    assert proxy_override["proxy_password"] == "replacement-secret"
+    assert save_payload["proxy_password"] == "replacement-secret"
+
+
 def test_proxy_settings_panel_allows_clearing_saved_password(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -278,17 +278,33 @@ console.log(JSON.stringify({
     assert 'id="fetch-profile-models-btn"' in modal_html
     assert 'title="Fetch Models"' in modal_html
     assert 'id="toggle-profile-api-key-btn"' in modal_html
+    assert (
+        'id="profile-api-key" placeholder="sk-..." autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false"'
+        in modal_html
+    )
     assert 'id="profile-maas-auth-fields"' in modal_html
     assert 'id="profile-maas-username"' in modal_html
     assert 'id="profile-maas-password"' in modal_html
+    assert (
+        'id="profile-maas-password" placeholder="password" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false"'
+        in modal_html
+    )
     assert 'id="toggle-profile-maas-password-btn"' in modal_html
     assert 'id="toggle-web-api-key-btn"' in modal_html
     assert (
         'id="toggle-web-api-key-btn" type="button" title="Show API key" aria-label="Show API key"'
         in modal_html
     )
+    assert (
+        'id="web-api-key" placeholder="可选，用于更高频率限制" data-i18n-placeholder="settings.web.api_key_placeholder" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false"'
+        in modal_html
+    )
     assert 'id="toggle-github-token-btn"' not in modal_html
     assert 'id="toggle-proxy-password-btn"' in modal_html
+    assert (
+        'id="proxy-password" placeholder="Optional proxy password" data-i18n-placeholder="settings.proxy.password_placeholder" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false"'
+        in modal_html
+    )
     assert 'id="web-searxng-instance-url-field"' in modal_html
     assert 'id="web-searxng-builtins-field"' in modal_html
     assert 'id="web-searxng-builtins-list"' in modal_html

--- a/tests/unit_tests/frontend/test_web_settings_ui.py
+++ b/tests/unit_tests/frontend/test_web_settings_ui.py
@@ -137,6 +137,51 @@ console.log(JSON.stringify({
     }
 
 
+def test_web_settings_panel_ignores_unfocused_autofilled_saved_exa_key(
+    tmp_path: Path,
+) -> None:
+    payload = _run_web_settings_script(
+        tmp_path=tmp_path,
+        fetch_config={
+            "provider": "exa",
+            "exa_api_key": "saved-exa-key",
+            "fallback_provider": "searxng",
+            "searxng_instance_url": "https://search.example.test/",
+        },
+        runner_source="""
+import { bindWebSettingsHandlers, loadWebSettingsPanel } from "./webSettings.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+
+bindWebSettingsHandlers();
+await loadWebSettingsPanel();
+
+document.activeElement = null;
+document.getElementById("web-api-key").value = "browser_password";
+document.getElementById("web-api-key").oninput();
+
+await document.getElementById("save-web-btn").onclick();
+
+console.log(JSON.stringify({
+    apiKeyValue: document.getElementById("web-api-key").value,
+    apiKeyPlaceholder: document.getElementById("web-api-key").placeholder,
+    savePayload: globalThis.__saveWebPayload,
+}));
+""".strip(),
+    )
+
+    assert payload["apiKeyValue"] == ""
+    assert payload["apiKeyPlaceholder"] == "************"
+    assert payload["savePayload"] == {
+        "provider": "exa",
+        "exa_api_key": "saved-exa-key",
+        "fallback_provider": "searxng",
+        "searxng_instance_url": "https://search.example.test/",
+    }
+
+
 def test_web_settings_panel_reveals_and_clears_saved_exa_key(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_web_settings_ui.py
+++ b/tests/unit_tests/frontend/test_web_settings_ui.py
@@ -182,6 +182,52 @@ console.log(JSON.stringify({
     }
 
 
+def test_web_settings_panel_allows_replacing_saved_exa_key_after_focus(
+    tmp_path: Path,
+) -> None:
+    payload = _run_web_settings_script(
+        tmp_path=tmp_path,
+        fetch_config={
+            "provider": "exa",
+            "exa_api_key": "saved-exa-key",
+            "fallback_provider": "searxng",
+            "searxng_instance_url": "https://search.example.test/",
+        },
+        runner_source="""
+import { bindWebSettingsHandlers, loadWebSettingsPanel } from "./webSettings.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+
+bindWebSettingsHandlers();
+await loadWebSettingsPanel();
+
+document.activeElement = null;
+document.getElementById("web-api-key").onfocus();
+document.getElementById("web-api-key").value = "replacement-exa-key";
+document.getElementById("web-api-key").oninput();
+
+await document.getElementById("save-web-btn").onclick();
+
+console.log(JSON.stringify({
+    apiKeyValue: document.getElementById("web-api-key").value,
+    apiKeyPlaceholder: document.getElementById("web-api-key").placeholder,
+    savePayload: globalThis.__saveWebPayload,
+}));
+""".strip(),
+    )
+
+    assert payload["apiKeyValue"] == ""
+    assert payload["apiKeyPlaceholder"] == "************"
+    assert payload["savePayload"] == {
+        "provider": "exa",
+        "exa_api_key": "replacement-exa-key",
+        "fallback_provider": "searxng",
+        "searxng_instance_url": "https://search.example.test/",
+    }
+
+
 def test_web_settings_panel_reveals_and_clears_saved_exa_key(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- harden ClawHub settings so the probe performs a managed CLI login in an isolated runtime home before validating connectivity, and clear that runtime login state when the saved token is removed
- stop trusting browser-autofilled DOM values for persisted secrets across ClawHub, GitHub, model profile API key / MAAS password, proxy password, and web API key flows
- switch the remaining sensitive settings inputs away from `autocomplete="current-password"` and add regression coverage for masked save/probe flows

## Testing
- `uv run --extra dev pytest -q tests/unit_tests/env/test_clawhub_auth.py tests/unit_tests/env/test_clawhub_connectivity.py tests/unit_tests/env/test_clawhub_config_service.py tests/unit_tests/frontend/test_clawhub_settings_ui.py tests/unit_tests/frontend/test_github_settings_ui.py tests/unit_tests/frontend/test_model_profiles_ui.py tests/unit_tests/frontend/test_proxy_settings_ui.py tests/unit_tests/frontend/test_settings_shell_ui.py tests/unit_tests/frontend/test_web_settings_ui.py`
- `uv run --extra dev pytest -q tests/integration_tests/browser/test_clawhub_browser_flow.py`
- `uv run --extra dev pytest -q tests/integration_tests/browser/test_github_browser_flow.py`
- `uv run --extra dev ruff check tests/unit_tests/frontend/test_model_profiles_ui.py tests/unit_tests/frontend/test_proxy_settings_ui.py tests/unit_tests/frontend/test_web_settings_ui.py tests/unit_tests/frontend/test_settings_shell_ui.py tests/unit_tests/frontend/test_clawhub_settings_ui.py tests/unit_tests/frontend/test_github_settings_ui.py tests/integration_tests/browser/test_clawhub_browser_flow.py tests/integration_tests/browser/test_github_browser_flow.py`
- `uv run --extra dev basedpyright tests/unit_tests/frontend/test_model_profiles_ui.py tests/unit_tests/frontend/test_proxy_settings_ui.py tests/unit_tests/frontend/test_web_settings_ui.py tests/unit_tests/frontend/test_settings_shell_ui.py tests/unit_tests/frontend/test_clawhub_settings_ui.py tests/unit_tests/frontend/test_github_settings_ui.py tests/integration_tests/browser/test_clawhub_browser_flow.py tests/integration_tests/browser/test_github_browser_flow.py`

Closes #350