### PR TITLE
Fix delayed streaming tool result updates

### DIFF
--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -333,17 +333,43 @@ export function updateToolResult(
 ) {
     const runId = String(options.runId || '');
     const roleId = String(options.roleId || '');
+    const label = String(options.label || '');
     const container = options.container || null;
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
     const st = streamState.get(streamKey);
-    const toolBlock = resolveToolBlockTarget(st, container, toolName, toolCallId);
+    const resolvedRunId = (st && st.runId) || runId;
+    const resolvedInstanceId = (st && st.instanceId) || instanceId;
+    const resolvedRoleId = (st && st.roleId) || roleId;
+    updateOverlayToolResult(
+        resolvedRunId,
+        resolvedInstanceId,
+        resolvedRoleId,
+        label,
+        toolName,
+        toolCallId,
+        result,
+        isError,
+    );
+    let toolBlock = resolveToolBlockTarget(st, container, toolName, toolCallId);
+    let boundState = st;
     if (!toolBlock) {
-        updateOverlayToolResult(runId, instanceId, roleId, toolName, toolCallId, result, isError);
-        return;
+        const materialized = materializeToolBlockFromOverlay({
+            container,
+            runId: resolvedRunId,
+            instanceId: resolvedInstanceId,
+            roleId: resolvedRoleId,
+            label,
+            toolName,
+            toolCallId,
+        });
+        if (!materialized) {
+            return;
+        }
+        toolBlock = materialized.toolBlock;
+        boundState = materialized.streamState;
     }
     applyToolReturn(toolBlock, result);
-    updateOverlayToolResult(st.runId || runId, st.instanceId || instanceId, roleId || st.roleId, toolName, toolCallId, result, isError);
-    scrollBottom((st && st.container) || container);
+    scrollBottom((boundState && boundState.container) || container);
 }
 
 export function markToolInputValidationFailed(instanceId, payload, options = {}) {
@@ -574,6 +600,7 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
             runId,
             streamKey,
             roleId,
+            label,
             payload?.tool_name || '',
             payload?.tool_call_id || null,
             resultEnvelope,
@@ -984,6 +1011,63 @@ function resolveToolBlockTarget(st, container, toolName, toolCallId) {
     return findToolBlockInContainer(container, toolName, toolCallId);
 }
 
+function materializeToolBlockFromOverlay({
+    container,
+    runId,
+    instanceId,
+    roleId,
+    label,
+    toolName,
+    toolCallId,
+}) {
+    if (!container) {
+        return null;
+    }
+    const overlayEntry = resolveOverlayEntry(runId, instanceId, roleId, label);
+    const overlayPart = overlayEntry
+        ? findOverlayToolPart(overlayEntry, toolName, toolCallId)
+        : null;
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
+    let st = streamState.get(streamKey);
+    if (!st) {
+        st = createStreamState({
+            container,
+            instanceId,
+            roleId,
+            label: String(label || overlayEntry?.label || roleId || 'Agent'),
+            runId,
+        });
+        streamState.set(streamKey, st);
+    }
+    const existing = resolveToolBlockTarget(
+        st,
+        container,
+        toolName,
+        toolCallId,
+    );
+    if (existing) {
+        return { streamState: st, toolBlock: existing };
+    }
+    endActiveText(st);
+    const nextToolName = String(
+        toolName || overlayPart?.tool_name || 'unknown_tool',
+    );
+    const nextToolCallId = toolCallId || overlayPart?.tool_call_id || null;
+    const toolBlock = buildPendingToolBlock(
+        nextToolName,
+        overlayPart?.args || {},
+        nextToolCallId,
+    );
+    st.contentEl.appendChild(toolBlock);
+    indexPendingToolBlock(
+        st.pendingToolBlocks,
+        toolBlock,
+        nextToolName,
+        nextToolCallId,
+    );
+    return { streamState: st, toolBlock };
+}
+
 function clearOverlayEntry(runId, instanceId, roleId) {
     const safeRunId = String(runId || '').trim();
     if (!safeRunId) return;
@@ -1189,21 +1273,20 @@ function finishOverlayThinking(runId, instanceId, roleId, partIndex) {
 function updateOverlayToolCall(runId, instanceId, roleId, label, toolPart) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
     if (!entry) return;
-    const nextPart = {
-        kind: 'tool',
-        tool_call_id: String(toolPart.tool_call_id || ''),
-        tool_name: String(toolPart.tool_name || ''),
-        args: toolPart.args || {},
-        status: String(toolPart.status || 'pending'),
-    };
-    entry.parts.push(nextPart);
+    const part = upsertOverlayToolPart(
+        entry,
+        toolPart.tool_name,
+        toolPart.tool_call_id || null,
+        toolPart.args || {},
+    );
+    part.args = normalizeOverlayToolArgs(toolPart.args);
+    part.status = String(toolPart.status || 'pending');
 }
 
-function updateOverlayToolResult(runId, instanceId, roleId, toolName, toolCallId, result, isError) {
-    const entry = ensureOverlayEntry(runId, instanceId, roleId, '');
+function updateOverlayToolResult(runId, instanceId, roleId, label, toolName, toolCallId, result, isError) {
+    const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
     if (!entry) return;
-    const part = findOverlayToolPart(entry, toolName, toolCallId);
-    if (!part) return;
+    const part = upsertOverlayToolPart(entry, toolName, toolCallId);
     part.status = isError ? 'error' : 'completed';
     part.result = result;
 }
@@ -1223,9 +1306,47 @@ function updateOverlayToolValidation(runId, instanceId, roleId, payload) {
 function updateOverlayToolApproval(runId, instanceId, roleId, toolName, payload, approvalStatus) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, '');
     if (!entry) return;
-    const part = findOverlayToolPart(entry, toolName, payload?.tool_call_id || null);
-    if (!part) return;
+    const part = upsertOverlayToolPart(
+        entry,
+        toolName,
+        payload?.tool_call_id || null,
+    );
     part.approvalStatus = approvalStatus;
+}
+
+function upsertOverlayToolPart(entry, toolName, toolCallId, args = {}) {
+    let part = findOverlayToolPart(entry, toolName, toolCallId);
+    if (!part) {
+        part = {
+            kind: 'tool',
+            tool_call_id: String(toolCallId || ''),
+            tool_name: String(toolName || 'unknown_tool'),
+            args: normalizeOverlayToolArgs(args),
+            status: 'pending',
+        };
+        entry.parts.push(part);
+        return part;
+    }
+    if (!part.tool_name && toolName) {
+        part.tool_name = String(toolName);
+    }
+    if (!part.tool_call_id && toolCallId) {
+        part.tool_call_id = String(toolCallId);
+    }
+    const normalizedArgs = normalizeOverlayToolArgs(args);
+    if (Object.keys(normalizedArgs).length > 0) {
+        part.args = normalizedArgs;
+    } else if (!part.args || typeof part.args !== 'object') {
+        part.args = {};
+    }
+    return part;
+}
+
+function normalizeOverlayToolArgs(args) {
+    if (args && typeof args === 'object' && !Array.isArray(args)) {
+        return args;
+    }
+    return {};
 }
 
 function findOverlayThinkingPartByKey(entry, key) {

--- a/frontend/dist/js/core/eventRouter/toolEvents.js
+++ b/frontend/dist/js/core/eventRouter/toolEvents.js
@@ -105,8 +105,10 @@ export function handleToolResult(payload, instanceId, eventMeta = null, roleId =
     markLlmRetrySucceeded();
     const { container, isCoordinator } = resolveToolEventTarget(instanceId, roleId, eventMeta);
     const runId = eventMeta?.run_id || eventMeta?.trace_id || '';
+    const primaryRoleId = getRunPrimaryRoleId(runId);
     const isPrimary = !roleId || isRunPrimaryRoleId(roleId, runId);
     const streamKey = isPrimary ? 'primary' : (instanceId || roleId);
+    const label = isPrimary ? getRunPrimaryRoleLabel(runId) : (roleId || 'Agent');
     const resultEnvelope = payload.result || {};
     const isError = typeof resultEnvelope === 'object'
         ? resultEnvelope.ok === false
@@ -115,7 +117,8 @@ export function handleToolResult(payload, instanceId, eventMeta = null, roleId =
         applyStreamOverlayEvent('tool_result', payload, {
             runId,
             instanceId: isPrimary ? 'primary' : instanceId,
-            roleId,
+            roleId: isPrimary ? primaryRoleId : roleId,
+            label,
         });
         return;
     }
@@ -127,7 +130,8 @@ export function handleToolResult(payload, instanceId, eventMeta = null, roleId =
         payload.tool_call_id || null,
         {
             runId: eventMeta?.run_id || eventMeta?.trace_id || '',
-            roleId,
+            roleId: isPrimary ? primaryRoleId : roleId,
+            label,
             container,
         },
     );

--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -122,6 +122,10 @@ from relay_teams.tools.runtime import (
     ToolApprovalPolicy,
     ToolDeps,
 )
+from relay_teams.tools.runtime.persisted_state import (
+    ToolExecutionStatus,
+    load_tool_call_state,
+)
 from relay_teams.tools.workspace_tools.shell_approval_repo import (
     ShellApprovalRepository,
 )
@@ -3025,6 +3029,13 @@ class AgentLlmSession:
                 continue
             for part in msg.parts:
                 if isinstance(part, ToolReturnPart):
+                    tool_call_id = str(part.tool_call_id or "").strip()
+                    if self._tool_result_already_emitted_from_runtime(
+                        request=request,
+                        tool_name=str(part.tool_name),
+                        tool_call_id=tool_call_id,
+                    ):
+                        continue
                     result_payload = cast(
                         JsonValue,
                         sanitize_task_status_payload(
@@ -3051,11 +3062,7 @@ class AgentLlmSession:
                             payload_json=self._to_json(
                                 {
                                     "tool_name": str(part.tool_name),
-                                    "tool_call_id": (
-                                        str(part.tool_call_id)
-                                        if part.tool_call_id
-                                        else ""
-                                    ),
+                                    "tool_call_id": tool_call_id,
                                     "result": result_payload,
                                     "error": is_error,
                                     "role_id": request.role_id,
@@ -3086,6 +3093,35 @@ class AgentLlmSession:
                             ),
                         )
                     )
+
+    def _tool_result_already_emitted_from_runtime(
+        self,
+        *,
+        request: LLMRequest,
+        tool_name: str,
+        tool_call_id: str,
+    ) -> bool:
+        if not tool_call_id:
+            return False
+        state = load_tool_call_state(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            tool_call_id=tool_call_id,
+        )
+        if state is None or state.tool_name != tool_name:
+            return False
+        if state.execution_status not in (
+            ToolExecutionStatus.COMPLETED,
+            ToolExecutionStatus.FAILED,
+        ):
+            return False
+        result_envelope = state.result_envelope
+        if not isinstance(result_envelope, dict):
+            return False
+        runtime_meta = result_envelope.get("runtime_meta")
+        if not isinstance(runtime_meta, dict):
+            return False
+        return runtime_meta.get("tool_result_event_published") is True
 
     def _to_json_compatible(self, value: object) -> JsonValue:
         if isinstance(value, (str, int, float, bool)) or value is None:

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -18,6 +18,9 @@ from relay_teams.logger import get_logger, log_event, log_tool_error
 from relay_teams.metrics.adapters import record_tool_execution
 from relay_teams.notifications import NotificationContext, NotificationType
 from relay_teams.persistence import is_retryable_sqlite_error
+from relay_teams.agents.tasks.task_status_sanitizer import (
+    sanitize_task_status_payload,
+)
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_models import RunEvent
 
@@ -98,6 +101,7 @@ async def execute_tool(
         if approval_error is not None:
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             meta["duration_ms"] = elapsed_ms
+            meta["tool_result_event_published"] = True
             envelope = _visible_envelope(
                 ok=False,
                 error=approval_error,
@@ -118,6 +122,12 @@ async def execute_tool(
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=False,
+            )
+            _publish_tool_result_event(
+                ctx=ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                visible_envelope=envelope,
             )
             return envelope
 
@@ -163,6 +173,7 @@ async def execute_tool(
                 payload={"tool_name": tool_name},
             )
 
+            meta["tool_result_event_published"] = True
             envelope = _visible_envelope(
                 ok=True,
                 data=visible_data,
@@ -183,6 +194,12 @@ async def execute_tool(
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=True,
+            )
+            _publish_tool_result_event(
+                ctx=ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                visible_envelope=envelope,
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
                 ctx.deps.approval_ticket_repo.mark_completed(approval_ticket_id)
@@ -217,6 +234,7 @@ async def execute_tool(
                     "details": error.details,
                 },
             )
+            meta["tool_result_event_published"] = True
             envelope = _visible_envelope(
                 ok=False,
                 error=error,
@@ -237,6 +255,12 @@ async def execute_tool(
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=False,
+            )
+            _publish_tool_result_event(
+                ctx=ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                visible_envelope=envelope,
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
                 ctx.deps.approval_ticket_repo.mark_completed(approval_ticket_id)
@@ -265,6 +289,41 @@ def _record_tool_metrics(
         tool_name=tool_name,
         duration_ms=duration_ms,
         success=success,
+    )
+
+
+def _publish_tool_result_event(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_name: str,
+    visible_envelope: dict[str, JsonValue],
+) -> None:
+    result_payload = cast(
+        JsonValue,
+        sanitize_task_status_payload(visible_envelope),
+    )
+    is_error = bool(visible_envelope.get("ok") is False)
+    ctx.deps.run_event_hub.publish(
+        RunEvent(
+            session_id=ctx.deps.session_id,
+            run_id=ctx.deps.run_id,
+            trace_id=ctx.deps.trace_id,
+            task_id=ctx.deps.task_id,
+            instance_id=ctx.deps.instance_id,
+            role_id=ctx.deps.role_id,
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json=dumps(
+                {
+                    "tool_name": tool_name,
+                    "tool_call_id": tool_call_id,
+                    "result": result_payload,
+                    "error": is_error,
+                    "role_id": ctx.deps.role_id,
+                    "instance_id": ctx.deps.instance_id,
+                }
+            ),
+        )
     )
 
 

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -729,3 +729,408 @@ console.log(JSON.stringify({
         {"text": "50159495496", "streaming": False},
     ]
     assert payload["cursorStates"] == [True, False]
+
+
+def test_tool_result_materializes_overlay_tool_block_into_visible_container(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_tool_result_materialize"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() {
+    return "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+function toolMatches(block, toolName, toolCallId) {
+  const safeToolCallId = String(toolCallId || "");
+  if (safeToolCallId) {
+    return String(block?.dataset?.toolCallId || "") === safeToolCallId;
+  }
+  return String(block?.dataset?.toolName || "") === String(toolName || "");
+}
+
+function findInContent(contentEl, toolName, toolCallId) {
+  if (!contentEl || !Array.isArray(contentEl.children)) {
+    return null;
+  }
+  for (let index = contentEl.children.length - 1; index >= 0; index -= 1) {
+    const child = contentEl.children[index];
+    if (toolMatches(child, toolName, toolCallId)) {
+      return child;
+    }
+  }
+  return null;
+}
+
+export function applyToolReturn(toolBlock, content) {
+  toolBlock.__result = content;
+}
+
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+
+export function buildPendingToolBlock(toolName, args, toolCallId = null) {
+  const outputEl = { classList: { add() {}, remove() {} }, innerHTML: "", textContent: "" };
+  return {
+    dataset: {
+      toolName: String(toolName || ""),
+      toolCallId: String(toolCallId || ""),
+      status: "running",
+    },
+    __args: args || {},
+    __result: null,
+    querySelector(selector) {
+      if (selector === ".tool-output") {
+        return outputEl;
+      }
+      return null;
+    },
+    closest() { return null; },
+  };
+}
+
+export function findToolBlock(contentEl, toolName, toolCallId) {
+  return findInContent(contentEl, toolName, toolCallId);
+}
+
+export function findToolBlockInContainer(container, toolName, toolCallId) {
+  const messages = Array.isArray(container?.__messages) ? container.__messages : [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const found = findInContent(messages[index].contentEl, toolName, toolCallId);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+export function indexPendingToolBlock(pendingToolBlocks, toolBlock, toolName, toolCallId) {
+  const key = `${toolName || ""}::${toolCallId || ""}`;
+  pendingToolBlocks[key] = toolBlock;
+  if (toolName) {
+    pendingToolBlocks[`${toolName}::`] = toolBlock;
+  }
+}
+
+export function renderMessageBlock(container, _role, label, _parts = [], options = {}) {
+  const contentEl = {
+    children: [],
+    appendChild(child) {
+      this.children.push(child);
+    },
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  };
+  const wrapper = {
+    dataset: {
+      runId: String(options.runId || ""),
+      roleId: String(options.roleId || ""),
+      instanceId: String(options.instanceId || ""),
+      streamKey: String(options.streamKey || ""),
+    },
+    querySelector(selector) {
+      if (selector === ".msg-role") {
+        return { textContent: String(label || "").toUpperCase() };
+      }
+      if (selector === ".msg-content") {
+        return contentEl;
+      }
+      return null;
+    },
+    closest() { return null; },
+  };
+  container.__messages.push({ wrapper, contentEl });
+  return { wrapper, contentEl };
+}
+
+export function resolvePendingToolBlock(pendingToolBlocks, toolName, toolCallId) {
+  const byId = pendingToolBlocks[`${toolName || ""}::${toolCallId || ""}`];
+  if (byId) {
+    return byId;
+  }
+  return pendingToolBlocks[`${toolName || ""}::`] || null;
+}
+
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor() {}
+export function updateThinkingText() {}
+export function updateMessageText() {}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+  updateToolResult,
+} from "./stream.js";
+
+globalThis.document = {
+  createElement() {
+    return {
+      className: "",
+      dataset: {},
+      children: [],
+      appendChild(child) { this.children.push(child); },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      closest() { return null; },
+    };
+  },
+};
+
+const container = {
+  __messages: [],
+  querySelectorAll() {
+    return this.__messages.map(item => item.wrapper);
+  },
+};
+
+applyStreamOverlayEvent(
+  "tool_call",
+  {
+    tool_name: "shell",
+    tool_call_id: "call-1",
+    args: { command: "echo hi" },
+  },
+  {
+    runId: "run-1",
+    instanceId: "inst-1",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+
+updateToolResult(
+  "inst-1",
+  "shell",
+  {
+    ok: true,
+    data: { text: "done" },
+  },
+  false,
+  "call-1",
+  {
+    runId: "run-1",
+    roleId: "Writer",
+    label: "Writer",
+    container,
+  },
+);
+
+const snapshot = getRunStreamOverlaySnapshot("run-1");
+const block = container.__messages[0].contentEl.children[0];
+
+console.log(JSON.stringify({
+  messageCount: container.__messages.length,
+  blockArgs: block.__args,
+  blockResult: block.__result,
+  overlay: snapshot.byInstance["inst-1"],
+}));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["messageCount"] == 1
+    assert payload["blockArgs"] == {"command": "echo hi"}
+    assert payload["blockResult"] == {"ok": True, "data": {"text": "done"}}
+    assert payload["overlay"] == {
+        "instanceId": "inst-1",
+        "roleId": "Writer",
+        "label": "Writer",
+        "parts": [
+            {
+                "kind": "tool",
+                "tool_call_id": "call-1",
+                "tool_name": "shell",
+                "args": {"command": "echo hi"},
+                "status": "completed",
+                "result": {"ok": True, "data": {"text": "done"}},
+            }
+        ],
+        "textStreaming": False,
+    }
+
+
+def test_tool_result_event_synthesizes_overlay_part_without_prior_tool_call(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_tool_result_overlay_only"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() {
+    return "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+export function applyToolReturn() {}
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+export function buildPendingToolBlock() { return { querySelector() { return null; } }; }
+export function findToolBlock() { return null; }
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function renderMessageBlock() {
+  return {
+    wrapper: {
+      dataset: {},
+      querySelector() { return null; },
+      closest() { return null; },
+    },
+    contentEl: {
+      appendChild() {},
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+    },
+  };
+}
+export function resolvePendingToolBlock() { return null; }
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor() {}
+export function updateThinkingText() {}
+export function updateMessageText() {}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+} from "./stream.js";
+
+applyStreamOverlayEvent(
+  "tool_result",
+  {
+    tool_name: "read",
+    tool_call_id: "call-9",
+    result: {
+      ok: false,
+      error: { message: "boom" },
+    },
+  },
+  {
+    runId: "run-2",
+    instanceId: "inst-2",
+    roleId: "Researcher",
+    label: "Researcher",
+  },
+);
+
+console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-2")));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "coordinator": None,
+        "byInstance": {
+            "inst-2": {
+                "instanceId": "inst-2",
+                "roleId": "Researcher",
+                "label": "Researcher",
+                "parts": [
+                    {
+                        "kind": "tool",
+                        "tool_call_id": "call-9",
+                        "tool_name": "read",
+                        "args": {},
+                        "status": "error",
+                        "result": {
+                            "ok": False,
+                            "error": {"message": "boom"},
+                        },
+                    }
+                ],
+                "textStreaming": False,
+            }
+        },
+    }

--- a/tests/unit_tests/providers/test_llm_tool_events.py
+++ b/tests/unit_tests/providers/test_llm_tool_events.py
@@ -41,6 +41,10 @@ from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.tools.runtime import ToolApprovalPolicy
+from relay_teams.tools.runtime.persisted_state import (
+    ToolExecutionStatus,
+    merge_tool_call_state,
+)
 from relay_teams.tools.registry import ToolRegistry
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.roles.role_registry import RoleRegistry
@@ -379,6 +383,43 @@ def test_publish_tool_events_skips_retry_without_tool_name() -> None:
     provider._publish_committed_tool_outcome_events_from_messages(
         request=_request(),
         messages=[ModelRequest(parts=[RetryPromptPart(content="retry output")])],
+    )
+
+    assert hub.events == []
+
+
+def test_publish_tool_events_skips_tool_result_already_emitted_from_runtime() -> None:
+    hub = _FakeRunEventHub()
+    provider = _provider_with_hub(hub)
+    request = _request()
+    merge_tool_call_state(
+        shared_store=provider._session._shared_store,
+        task_id=request.task_id,
+        tool_call_id="dispatch_task:1",
+        tool_name="dispatch_task",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        execution_status=ToolExecutionStatus.COMPLETED,
+        result_envelope={
+            "runtime_meta": {"tool_result_event_published": True},
+        },
+    )
+
+    provider._publish_committed_tool_outcome_events_from_messages(
+        request=request,
+        messages=[
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="dispatch_task",
+                        tool_call_id="dispatch_task:1",
+                        content={"ok": True, "data": {"status": "queued"}},
+                    )
+                ]
+            )
+        ],
     )
 
     assert hub.events == []

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -159,6 +159,14 @@ def _build_notification_service(
     )
 
 
+def _tool_result_payloads(deps: _FakeDeps) -> list[dict[str, object]]:
+    return [
+        cast(dict[str, object], json.loads(event.payload_json))
+        for event in deps.run_event_hub.events
+        if event.event_type == RunEventType.TOOL_RESULT
+    ]
+
+
 def test_execute_tool_returns_standard_envelope() -> None:
     deps = _FakeDeps(
         manager=_FakeApprovalManager(wait_result=("approve", "")),
@@ -199,6 +207,12 @@ def test_execute_tool_returns_standard_envelope() -> None:
     assert runtime is not None
     assert runtime.status == RunRuntimeStatus.RUNNING
     assert runtime.phase == RunRuntimePhase.SUBAGENT_RUNNING
+    tool_result_payloads = _tool_result_payloads(deps)
+    assert len(tool_result_payloads) == 1
+    assert tool_result_payloads[0]["tool_name"] == "read"
+    assert tool_result_payloads[0]["tool_call_id"] == "call-read-1"
+    assert tool_result_payloads[0]["error"] is False
+    assert tool_result_payloads[0]["result"] == result
 
 
 def test_execute_tool_skips_approval_flow_when_yolo_enabled() -> None:
@@ -301,6 +315,12 @@ def test_execute_tool_returns_denied_error_when_approval_rejected() -> None:
     )
     assert ticket is not None
     assert ticket.status == ApprovalTicketStatus.DENIED
+    tool_result_payloads = _tool_result_payloads(deps)
+    assert len(tool_result_payloads) == 1
+    assert tool_result_payloads[0]["tool_name"] == "write"
+    assert tool_result_payloads[0]["tool_call_id"] == "call-model-deny"
+    assert tool_result_payloads[0]["error"] is True
+    assert tool_result_payloads[0]["result"] == result
 
 
 def test_execute_tool_returns_timeout_error_when_approval_times_out() -> None:
@@ -371,6 +391,58 @@ def test_execute_tool_preserves_custom_tool_error_details() -> None:
         "url_host": "example.com",
         "status_code": 403,
     }
+    tool_result_payloads = _tool_result_payloads(deps)
+    assert len(tool_result_payloads) == 1
+    assert tool_result_payloads[0]["tool_name"] == "webfetch"
+    assert tool_result_payloads[0]["tool_call_id"] == "call-webfetch-error"
+    assert tool_result_payloads[0]["error"] is True
+    assert tool_result_payloads[0]["result"] == result
+
+
+def test_execute_tool_publishes_sanitized_dispatch_task_result_immediately() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "dispatch-call-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="dispatch_task",
+            args_summary={"task_name": "ask_time"},
+            action=lambda: {
+                "task_status": {
+                    "ask_time": {
+                        "task_name": "ask_time",
+                        "task_id": "task-1",
+                        "role_id": "time",
+                        "instance_id": "inst-1",
+                        "status": "completed",
+                        "result": "Current time is 2026-03-07 00:41:29.",
+                        "error": "Task stopped by user",
+                    }
+                }
+            },
+        )
+    )
+
+    tool_result_payloads = _tool_result_payloads(deps)
+    assert len(tool_result_payloads) == 1
+    payload_result = cast(dict[str, object], tool_result_payloads[0]["result"])
+    task_status = cast(
+        dict[str, object],
+        cast(dict[str, object], payload_result["data"])["task_status"],
+    )["ask_time"]
+    task_status_payload = cast(dict[str, object], task_status)
+    assert tool_result_payloads[0]["tool_name"] == "dispatch_task"
+    assert tool_result_payloads[0]["tool_call_id"] == "dispatch-call-1"
+    assert tool_result_payloads[0]["error"] is False
+    assert task_status_payload["status"] == "completed"
+    assert task_status_payload["result"] == "Current time is 2026-03-07 00:41:29."
+    assert "error" not in task_status_payload
+    assert result["ok"] is True
 
 
 def test_execute_tool_marks_value_error_as_non_retryable() -> None:


### PR DESCRIPTION
## Summary
- patch live tool result rendering so completed results can materialize immediately from overlay state
- publish runtime tool results as soon as tool execution finishes and skip duplicate commit-time result events
- add frontend and backend regression coverage for dispatch_task-style timing

Closes #352