### PR TITLE
Propagate proxy settings to Node-based subprocesses

### DIFF
--- a/src/relay_teams/env/clawhub_env.py
+++ b/src/relay_teams/env/clawhub_env.py
@@ -5,7 +5,11 @@ from collections.abc import Mapping
 import os
 from pathlib import Path
 
-from relay_teams.env.proxy_env import build_subprocess_env, load_proxy_env_config
+from relay_teams.env.proxy_env import (
+    build_subprocess_env,
+    extract_proxy_env_vars,
+    load_proxy_env_config,
+)
 
 CLAWHUB_TOKEN_ENV_KEY = "CLAWHUB_TOKEN"
 CLAWHUB_SITE_ENV_KEY = "CLAWHUB_SITE"
@@ -150,7 +154,7 @@ def build_clawhub_subprocess_env(
         extra_env_files=_clawhub_proxy_env_files(config_dir),
         include_process_env=True,
     )
-    extra_env = proxy_config.normalized_env()
+    extra_env = extract_proxy_env_vars(proxy_config.normalized_env())
     extra_env.update(
         build_clawhub_cli_env(
             token,

--- a/src/relay_teams/env/proxy_env.py
+++ b/src/relay_teams/env/proxy_env.py
@@ -20,11 +20,22 @@ _PROXY_ENV_KEY_GROUPS: tuple[tuple[str, str], ...] = (
     ("ALL_PROXY", "all_proxy"),
     ("NO_PROXY", "no_proxy"),
 )
+_NODE_PROXY_ENV_KEY_GROUPS: tuple[tuple[str, str], ...] = (
+    ("NPM_CONFIG_PROXY", "npm_config_proxy"),
+    ("NPM_CONFIG_HTTPS_PROXY", "npm_config_https_proxy"),
+    ("NPM_CONFIG_NOPROXY", "npm_config_noproxy"),
+    ("NPM_CONFIG_STRICT_SSL", "npm_config_strict_ssl"),
+)
 _PROXY_ENV_KEYS: tuple[str, ...] = tuple(
     key for key_group in _PROXY_ENV_KEY_GROUPS for key in key_group
 )
 _SSL_VERIFY_ENV_KEYS: tuple[str, ...] = ("SSL_VERIFY",)
 _PROCESS_ENV_KEYS: tuple[str, ...] = _PROXY_ENV_KEYS + _SSL_VERIFY_ENV_KEYS
+_NODE_PROXY_ENV_KEYS: tuple[str, ...] = (
+    "NODE_USE_ENV_PROXY",
+    "NODE_TLS_REJECT_UNAUTHORIZED",
+) + tuple(key for key_group in _NODE_PROXY_ENV_KEY_GROUPS for key in key_group)
+_RUNTIME_ENV_KEYS: tuple[str, ...] = _PROCESS_ENV_KEYS + _NODE_PROXY_ENV_KEYS
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
 _DEFAULT_SSL_VERIFY = False
@@ -174,7 +185,7 @@ class NoProxyRule(BaseModel):
 
 
 def extract_proxy_env_vars(env_values: Mapping[str, str]) -> dict[str, str]:
-    return resolve_proxy_env_config(env_values).normalized_env()
+    return _build_runtime_proxy_env(resolve_proxy_env_config(env_values))
 
 
 def apply_proxy_env_to_process_env(env_values: Mapping[str, str]) -> dict[str, str]:
@@ -206,9 +217,15 @@ def load_proxy_env_config(
     )
 
 
+def _build_runtime_proxy_env(proxy_config: ProxyEnvConfig) -> dict[str, str]:
+    env_values = proxy_config.normalized_env()
+    env_values.update(_build_node_runtime_proxy_env(proxy_config))
+    return env_values
+
+
 def sync_proxy_env_to_process_env(proxy_config: ProxyEnvConfig) -> dict[str, str]:
-    normalized_env = proxy_config.normalized_env()
-    for key in _PROCESS_ENV_KEYS:
+    normalized_env = _build_runtime_proxy_env(proxy_config)
+    for key in _RUNTIME_ENV_KEYS:
         if key in normalized_env:
             os.environ[key] = normalized_env[key]
             continue
@@ -222,7 +239,7 @@ def build_subprocess_env(
     extra_env: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
     resolved_env = dict(os.environ if base_env is None else base_env)
-    for key in _PROCESS_ENV_KEYS:
+    for key in _RUNTIME_ENV_KEYS:
         resolved_env.pop(key, None)
     resolved_env.update(extract_proxy_env_vars(os.environ))
     if extra_env is not None:
@@ -326,6 +343,72 @@ def _normalize_no_proxy_for_export(value: str | None) -> str | None:
     if not tokens:
         return None
     return ",".join(tokens)
+
+
+def _build_node_runtime_proxy_env(proxy_config: ProxyEnvConfig) -> dict[str, str]:
+    env_values: dict[str, str] = {}
+    if not proxy_config.has_proxy:
+        return env_values
+
+    env_values["NODE_USE_ENV_PROXY"] = "1"
+
+    http_proxy = proxy_config.http_proxy or proxy_config.all_proxy
+    if http_proxy is not None:
+        _set_env_pair(
+            env_values,
+            uppercase_key="NPM_CONFIG_PROXY",
+            lowercase_key="npm_config_proxy",
+            value=http_proxy,
+        )
+
+    https_proxy = (
+        proxy_config.https_proxy or proxy_config.http_proxy or proxy_config.all_proxy
+    )
+    if https_proxy is not None:
+        _set_env_pair(
+            env_values,
+            uppercase_key="NPM_CONFIG_HTTPS_PROXY",
+            lowercase_key="npm_config_https_proxy",
+            value=https_proxy,
+        )
+
+    no_proxy = _normalize_no_proxy_for_export(proxy_config.no_proxy)
+    if no_proxy is not None:
+        _set_env_pair(
+            env_values,
+            uppercase_key="NPM_CONFIG_NOPROXY",
+            lowercase_key="npm_config_noproxy",
+            value=no_proxy,
+        )
+
+    if proxy_config.ssl_verify is False:
+        _set_env_pair(
+            env_values,
+            uppercase_key="NPM_CONFIG_STRICT_SSL",
+            lowercase_key="npm_config_strict_ssl",
+            value="false",
+        )
+        env_values["NODE_TLS_REJECT_UNAUTHORIZED"] = "0"
+    elif proxy_config.ssl_verify is True:
+        _set_env_pair(
+            env_values,
+            uppercase_key="NPM_CONFIG_STRICT_SSL",
+            lowercase_key="npm_config_strict_ssl",
+            value="true",
+        )
+
+    return env_values
+
+
+def _set_env_pair(
+    env_values: dict[str, str],
+    *,
+    uppercase_key: str,
+    lowercase_key: str,
+    value: str,
+) -> None:
+    env_values[uppercase_key] = value
+    env_values[lowercase_key] = value
 
 
 def host_matches_no_proxy(host: str, no_proxy: str | None) -> bool:

--- a/tests/unit_tests/env/test_clawhub_env.py
+++ b/tests/unit_tests/env/test_clawhub_env.py
@@ -72,3 +72,7 @@ def test_build_clawhub_subprocess_env_includes_hydrated_proxy_values(
     assert env[CLAWHUB_TOKEN_ENV_KEY] == "ch_secret"
     assert env["HTTP_PROXY"] == "http://alice:secret@proxy.example:8080"
     assert env["NO_PROXY"] == "localhost"
+    assert env["NODE_USE_ENV_PROXY"] == "1"
+    assert env["npm_config_proxy"] == "http://alice:secret@proxy.example:8080"
+    assert env["npm_config_https_proxy"] == "http://alice:secret@proxy.example:8080"
+    assert env["npm_config_noproxy"] == "localhost"

--- a/tests/unit_tests/env/test_proxy_env.py
+++ b/tests/unit_tests/env/test_proxy_env.py
@@ -31,6 +31,13 @@ def test_extract_proxy_env_vars_normalizes_upper_and_lowercase_keys() -> None:
         "http_proxy": "http://proxy.example:8080",
         "NO_PROXY": "localhost,127.0.0.1",
         "no_proxy": "localhost,127.0.0.1",
+        "NODE_USE_ENV_PROXY": "1",
+        "NPM_CONFIG_PROXY": "http://proxy.example:8080",
+        "npm_config_proxy": "http://proxy.example:8080",
+        "NPM_CONFIG_HTTPS_PROXY": "http://proxy.example:8080",
+        "npm_config_https_proxy": "http://proxy.example:8080",
+        "NPM_CONFIG_NOPROXY": "localhost,127.0.0.1",
+        "npm_config_noproxy": "localhost,127.0.0.1",
     }
 
 
@@ -64,6 +71,10 @@ def test_apply_proxy_env_to_process_env_updates_os_environ(monkeypatch) -> None:
     assert os.environ["http_proxy"] == "http://proxy.example:8080"
     assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
     assert os.environ["no_proxy"] == "localhost,127.0.0.1"
+    assert os.environ["NODE_USE_ENV_PROXY"] == "1"
+    assert os.environ["npm_config_proxy"] == "http://proxy.example:8080"
+    assert os.environ["npm_config_https_proxy"] == "http://proxy.example:8080"
+    assert os.environ["npm_config_noproxy"] == "localhost,127.0.0.1"
 
 
 def test_apply_proxy_env_to_process_env_clears_stale_proxy_keys(monkeypatch) -> None:
@@ -71,6 +82,8 @@ def test_apply_proxy_env_to_process_env_clears_stale_proxy_keys(monkeypatch) -> 
     monkeypatch.setenv("http_proxy", "http://stale.example:8080")
     monkeypatch.setenv("NO_PROXY", "localhost")
     monkeypatch.setenv("no_proxy", "localhost")
+    monkeypatch.setenv("NODE_USE_ENV_PROXY", "1")
+    monkeypatch.setenv("npm_config_proxy", "http://stale.example:8080")
 
     applied = apply_proxy_env_to_process_env({})
 
@@ -79,6 +92,8 @@ def test_apply_proxy_env_to_process_env_clears_stale_proxy_keys(monkeypatch) -> 
     assert "http_proxy" not in os.environ
     assert "NO_PROXY" not in os.environ
     assert "no_proxy" not in os.environ
+    assert "NODE_USE_ENV_PROXY" not in os.environ
+    assert "npm_config_proxy" not in os.environ
 
 
 def test_build_subprocess_env_uses_current_proxy_values(monkeypatch) -> None:
@@ -94,6 +109,51 @@ def test_build_subprocess_env_uses_current_proxy_values(monkeypatch) -> None:
     assert subprocess_env["CUSTOM"] == "1"
     assert subprocess_env["HTTP_PROXY"] == "http://proxy.example:8080"
     assert subprocess_env["NO_PROXY"] == "localhost,127.0.0.1"
+    assert subprocess_env["NODE_USE_ENV_PROXY"] == "1"
+    assert subprocess_env["npm_config_proxy"] == "http://proxy.example:8080"
+    assert subprocess_env["npm_config_https_proxy"] == "http://proxy.example:8080"
+    assert subprocess_env["npm_config_noproxy"] == "localhost,127.0.0.1"
+
+
+def test_build_subprocess_env_clears_stale_node_proxy_keys(monkeypatch) -> None:
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    monkeypatch.delenv("ALL_PROXY", raising=False)
+    monkeypatch.delenv("all_proxy", raising=False)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    monkeypatch.delenv("NODE_USE_ENV_PROXY", raising=False)
+    monkeypatch.delenv("npm_config_proxy", raising=False)
+
+    subprocess_env = build_subprocess_env(
+        base_env={
+            "PATH": "bin",
+            "NODE_USE_ENV_PROXY": "1",
+            "npm_config_proxy": "http://stale.example:8080",
+        }
+    )
+
+    assert subprocess_env["PATH"] == "bin"
+    assert "NODE_USE_ENV_PROXY" not in subprocess_env
+    assert "npm_config_proxy" not in subprocess_env
+
+
+def test_extract_proxy_env_vars_exports_node_ssl_proxy_controls() -> None:
+    proxy_env = extract_proxy_env_vars(
+        {
+            "HTTPS_PROXY": "http://proxy.example:8443",
+            "SSL_VERIFY": "false",
+        }
+    )
+
+    assert proxy_env["NODE_USE_ENV_PROXY"] == "1"
+    assert proxy_env["NPM_CONFIG_HTTPS_PROXY"] == "http://proxy.example:8443"
+    assert proxy_env["npm_config_https_proxy"] == "http://proxy.example:8443"
+    assert proxy_env["NPM_CONFIG_STRICT_SSL"] == "false"
+    assert proxy_env["npm_config_strict_ssl"] == "false"
+    assert proxy_env["NODE_TLS_REJECT_UNAUTHORIZED"] == "0"
 
 
 def test_resolve_ssl_verify_defaults_to_disabled() -> None:

--- a/tests/unit_tests/mcp/test_mcp_config_manager.py
+++ b/tests/unit_tests/mcp/test_mcp_config_manager.py
@@ -20,6 +20,16 @@ def _clear_proxy_env(monkeypatch) -> None:
         "NO_PROXY",
         "no_proxy",
         "SSL_VERIFY",
+        "NODE_USE_ENV_PROXY",
+        "NODE_TLS_REJECT_UNAUTHORIZED",
+        "NPM_CONFIG_PROXY",
+        "npm_config_proxy",
+        "NPM_CONFIG_HTTPS_PROXY",
+        "npm_config_https_proxy",
+        "NPM_CONFIG_NOPROXY",
+        "npm_config_noproxy",
+        "NPM_CONFIG_STRICT_SSL",
+        "npm_config_strict_ssl",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -103,6 +113,13 @@ def test_load_registry_applies_proxy_env_to_all_mcp_server_configs(
         "http_proxy": "http://proxy.internal:8080",
         "NO_PROXY": "localhost,127.0.0.1",
         "no_proxy": "localhost,127.0.0.1",
+        "NODE_USE_ENV_PROXY": "1",
+        "NPM_CONFIG_PROXY": "http://proxy.internal:8080",
+        "npm_config_proxy": "http://proxy.internal:8080",
+        "NPM_CONFIG_HTTPS_PROXY": "http://proxy.internal:8080",
+        "npm_config_https_proxy": "http://proxy.internal:8080",
+        "NPM_CONFIG_NOPROXY": "localhost,127.0.0.1",
+        "npm_config_noproxy": "localhost,127.0.0.1",
     }
     assert registry.get_spec("filesystem").server_config["env"] == expected_proxy_env
     assert registry.get_spec("events").server_config["env"] == expected_proxy_env
@@ -111,6 +128,10 @@ def test_load_registry_applies_proxy_env_to_all_mcp_server_configs(
     assert os.environ["http_proxy"] == "http://proxy.internal:8080"
     assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
     assert os.environ["no_proxy"] == "localhost,127.0.0.1"
+    assert os.environ["NODE_USE_ENV_PROXY"] == "1"
+    assert os.environ["npm_config_proxy"] == "http://proxy.internal:8080"
+    assert os.environ["npm_config_https_proxy"] == "http://proxy.internal:8080"
+    assert os.environ["npm_config_noproxy"] == "localhost,127.0.0.1"
 
 
 def test_load_registry_preserves_explicit_server_env_over_proxy_defaults(
@@ -150,6 +171,11 @@ def test_load_registry_preserves_explicit_server_env_over_proxy_defaults(
     assert registry.get_spec("remote").server_config["env"] == {
         "HTTP_PROXY": "http://custom-proxy.internal:9000",
         "http_proxy": "http://custom-proxy.internal:9000",
+        "NODE_USE_ENV_PROXY": "1",
+        "NPM_CONFIG_PROXY": "http://custom-proxy.internal:9000",
+        "npm_config_proxy": "http://custom-proxy.internal:9000",
+        "NPM_CONFIG_HTTPS_PROXY": "http://custom-proxy.internal:9000",
+        "npm_config_https_proxy": "http://custom-proxy.internal:9000",
         "CUSTOM_TOKEN": "secret",
     }
 

--- a/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
@@ -164,6 +164,51 @@ async def test_build_command_env_does_not_download_gh_when_missing(
 
 
 @pytest.mark.asyncio
+async def test_build_command_env_includes_node_proxy_runtime_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bash_runtime = ResolvedCommandRuntime(
+        kind=CommandRuntimeKind.BASH,
+        executable="/bin/bash",
+        display_name="Bash",
+    )
+
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_gh_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_clawhub_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(runtime_module, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(
+        runtime_module.os,
+        "environ",
+        {
+            "PATH": "/usr/bin",
+            "HTTP_PROXY": "http://proxy.example:8080",
+            "NO_PROXY": "localhost,127.0.0.1",
+        },
+    )
+
+    env = await build_command_env(
+        runtime=bash_runtime,
+        command="node script.js",
+    )
+
+    assert env["HTTP_PROXY"] == "http://proxy.example:8080"
+    assert env["NO_PROXY"] == "localhost,127.0.0.1"
+    assert env["NODE_USE_ENV_PROXY"] == "1"
+    assert env["npm_config_proxy"] == "http://proxy.example:8080"
+    assert env["npm_config_https_proxy"] == "http://proxy.example:8080"
+    assert env["npm_config_noproxy"] == "localhost,127.0.0.1"
+
+
+@pytest.mark.asyncio
 async def test_build_command_env_prepends_existing_gh_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,


### PR DESCRIPTION
## Summary
- extend runtime proxy env export so the `env` substrate also emits Node/npm-compatible proxy variables
- keep ClawHub and generic subprocess env assembly on the shared `env` path instead of adding a ClawHub-only workaround
- add regression coverage for proxy env export, generic Node command runtime envs, and MCP server env injection

## Testing
- `uv run --extra dev pytest -q tests/unit_tests/env/test_proxy_env.py tests/unit_tests/env/test_clawhub_env.py tests/unit_tests/env/test_clawhub_auth.py tests/unit_tests/env/test_clawhub_connectivity.py tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py`
- `uv run --extra dev pytest -q tests/unit_tests/env/test_proxy_env.py tests/unit_tests/env/test_clawhub_env.py tests/unit_tests/mcp/test_mcp_config_manager.py tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py`
- `uv run --extra dev ruff check --fix src/relay_teams/env/proxy_env.py src/relay_teams/env/clawhub_env.py tests/unit_tests/env/test_proxy_env.py tests/unit_tests/env/test_clawhub_env.py tests/unit_tests/mcp/test_mcp_config_manager.py tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py`
- `uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/env/proxy_env.py src/relay_teams/env/clawhub_env.py tests/unit_tests/env/test_proxy_env.py tests/unit_tests/env/test_clawhub_env.py`
- `uv run --extra dev basedpyright src/relay_teams/env/proxy_env.py src/relay_teams/env/clawhub_env.py tests/unit_tests/env/test_proxy_env.py tests/unit_tests/env/test_clawhub_env.py`

Closes #354
