### PR TITLE
Keep streaming loading cursor visible between segments

### DIFF
--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -116,6 +116,7 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
         && (
             (Array.isArray(streamOverlayEntry.parts) && streamOverlayEntry.parts.length > 0)
             || streamOverlayEntry.textStreaming === true
+            || streamOverlayEntry.idleCursor === true
         )
     ) {
         renderStreamOverlayEntry(
@@ -203,6 +204,7 @@ function renderStreamOverlayEntry(
     let renderedLiveTextTail = false;
     const overlayParts = Array.isArray(streamOverlayEntry.parts) ? streamOverlayEntry.parts : [];
     const hasLiveTextTail = streamOverlayEntry.textStreaming === true;
+    const hasIdleCursor = streamOverlayEntry.idleCursor === true;
     const trailingTextPart = [...overlayParts]
         .reverse()
         .find(part => part && typeof part === 'object' && part.kind === 'text');
@@ -249,8 +251,14 @@ function renderStreamOverlayEntry(
     });
 
     flushText(hasLiveTextTail && !!trailingTextPart);
-    if (hasLiveTextTail && !renderedLiveTextTail) {
-        appendMessageText(contentEl, '', { streaming: true });
+    if ((hasLiveTextTail || hasIdleCursor) && !renderedLiveTextTail) {
+        const liveTail = appendMessageText(contentEl, '', { streaming: true });
+        if (hasIdleCursor && liveTail) {
+            if (liveTail.dataset) {
+                liveTail.dataset.idleCursor = 'true';
+            }
+            liveTail.__idleCursor = true;
+        }
     }
 }
 
@@ -491,6 +499,9 @@ function shouldCollapseIntermediateMessages(streamOverlayEntry, options = {}) {
         return true;
     }
     if (streamOverlayEntry.textStreaming === true) {
+        return false;
+    }
+    if (streamOverlayEntry.idleCursor === true) {
         return false;
     }
     const parts = Array.isArray(streamOverlayEntry.parts) ? streamOverlayEntry.parts : [];

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -73,7 +73,9 @@ export function appendStreamChunk(instanceId, text, runId = '', roleId = '', lab
 
     st.raw += text;
     st.activeRaw += text;
+    st.activeTextIsIdle = false;
     updateMessageText(st.activeTextEl, st.activeRaw, { streaming: true });
+    markIdleCursorPlaceholder(st.activeTextEl, false);
     updateOverlayText(st.runId || runId, st.instanceId || instanceId, roleId || st.roleId, label || st.label, text);
     setOverlayTextStreaming(
         st.runId || runId,
@@ -81,6 +83,13 @@ export function appendStreamChunk(instanceId, text, runId = '', roleId = '', lab
         roleId || st.roleId,
         label || st.label,
         true,
+    );
+    setOverlayIdleCursor(
+        st.runId || runId,
+        st.instanceId || instanceId,
+        roleId || st.roleId,
+        label || st.label,
+        false,
     );
     scrollBottom(st.container);
 }
@@ -369,6 +378,9 @@ export function updateToolResult(
         boundState = materialized.streamState;
     }
     applyToolReturn(toolBlock, result);
+    if (boundState && !hasActiveThinking(boundState)) {
+        ensureIdleStreamingTail(boundState);
+    }
     scrollBottom((boundState && boundState.container) || container);
 }
 
@@ -462,6 +474,9 @@ export function finalizeThinking(instanceId, partIndex, options = {}) {
         st.thinkingActiveByPart.delete(String(partIndex));
     }
     finishOverlayThinking((st && st.runId) || runId, (st && st.instanceId) || instanceId, (st && st.roleId) || roleId, partIndex);
+    if (st && !hasActiveThinking(st)) {
+        ensureIdleStreamingTail(st);
+    }
     return true;
 }
 
@@ -554,11 +569,13 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
     if (evType === 'text_delta') {
         clearOverlayEntryCleanupTimer(runId, streamKey);
         updateOverlayText(runId, streamKey, roleId, label, payload?.text || '');
+        setOverlayIdleCursor(runId, streamKey, roleId, label, false);
         return;
     }
     if (evType === 'thinking_started') {
         clearOverlayEntryCleanupTimer(runId, streamKey);
         setOverlayTextStreaming(runId, streamKey, roleId, label, false);
+        setOverlayIdleCursor(runId, streamKey, roleId, label, false);
         startOverlayThinking(runId, streamKey, roleId, label, payload?.part_index ?? 0);
         return;
     }
@@ -577,11 +594,13 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
     }
     if (evType === 'thinking_finished') {
         finishOverlayThinking(runId, streamKey, roleId, payload?.part_index ?? 0);
+        setOverlayIdleCursor(runId, streamKey, roleId, label, true);
         return;
     }
     if (evType === 'tool_call') {
         clearOverlayEntryCleanupTimer(runId, streamKey);
         setOverlayTextStreaming(runId, streamKey, roleId, label, false);
+        setOverlayIdleCursor(runId, streamKey, roleId, label, false);
         updateOverlayToolCall(runId, streamKey, roleId, label, {
             tool_call_id: payload?.tool_call_id || '',
             tool_name: payload?.tool_name || '',
@@ -606,6 +625,7 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
             resultEnvelope,
             isError,
         );
+        setOverlayIdleCursor(runId, streamKey, roleId, label, true);
         return;
     }
     if (evType === 'tool_input_validation_failed') {
@@ -632,11 +652,13 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
     }
     if (evType === 'model_step_finished') {
         setOverlayTextStreaming(runId, streamKey, roleId, label, false);
+        setOverlayIdleCursor(runId, streamKey, roleId, label, false);
         scheduleOverlayEntryCleanup(runId, streamKey, roleId, cleanupDelayMs);
         return;
     }
     if (evType === 'run_completed' || evType === 'run_failed' || evType === 'run_stopped') {
         setOverlayTextStreaming(runId, streamKey, roleId, label, false);
+        setOverlayIdleCursor(runId, streamKey, roleId, label, false);
         scheduleRunOverlayCleanup(runId, cleanupDelayMs);
     }
 }
@@ -667,7 +689,16 @@ function finalizeStreamEntry(entry) {
         return;
     }
     if (entry.activeTextEl) {
-        updateMessageText(entry.activeTextEl, entry.activeRaw, { streaming: false });
+        if (entry.activeTextIsIdle === true && isIdleCursorPlaceholder(entry.activeTextEl)) {
+            syncStreamingCursor(entry.activeTextEl, false);
+            entry.activeTextEl.remove?.();
+        } else {
+            updateMessageText(entry.activeTextEl, entry.activeRaw, { streaming: false });
+            markIdleCursorPlaceholder(entry.activeTextEl, false);
+        }
+        entry.activeTextEl = null;
+        entry.activeRaw = '';
+        entry.activeTextIsIdle = false;
     }
     if (entry.thinkingParts instanceof Map) {
         entry.thinkingParts.forEach(thinkingEntry => {
@@ -750,6 +781,7 @@ function createStreamState({
         activeTextEl: null,
         raw: '',
         activeRaw: '',
+        activeTextIsIdle: false,
         thinkingParts: new Map(),
         thinkingActiveByPart: new Map(),
         thinkingSequence: 0,
@@ -779,10 +811,17 @@ function findReusableStreamState({
     if (!wrapper) return null;
     const contentEl = wrapper.querySelector('.msg-content');
     if (!contentEl) return null;
-    const activeTextEl = findLastReusableTextElement(contentEl);
-    const activeRaw = resolveReusableRawText(overlayEntry);
+    const idleRebind = overlayEntry?.idleCursor === true && overlayEntry?.textStreaming !== true;
+    const activeTextEl = idleRebind
+        ? findReusableIdleCursorElement(contentEl)
+        : findLastReusableTextElement(contentEl);
+    const activeRaw = idleRebind ? '' : resolveReusableRawText(overlayEntry);
     if (activeTextEl) {
         syncStreamingCursor(activeTextEl, overlayEntry?.textStreaming === true);
+        if (overlayEntry?.idleCursor === true && overlayEntry?.textStreaming !== true) {
+            markIdleCursorPlaceholder(activeTextEl, true);
+            syncStreamingCursor(activeTextEl, true);
+        }
     }
     const thinkingBinding = bindReusableThinkingState(contentEl, overlayEntry);
     const pendingToolBlocks = bindReusableToolBlocks(contentEl, overlayEntry);
@@ -794,6 +833,7 @@ function findReusableStreamState({
         activeTextEl,
         raw: activeRaw,
         activeRaw,
+        activeTextIsIdle: isIdleCursorPlaceholder(activeTextEl),
         thinkingParts: thinkingBinding.parts,
         thinkingActiveByPart: thinkingBinding.activeByPart,
         thinkingSequence: thinkingBinding.nextSequence,
@@ -877,7 +917,21 @@ function findLastReusableTextElement(contentEl) {
     for (let index = textBlocks.length - 1; index >= 0; index -= 1) {
         const textEl = textBlocks[index];
         if (textEl.closest('.thinking-block')) continue;
+        if (isIdleCursorPlaceholder(textEl)) continue;
         return textEl;
+    }
+    return null;
+}
+
+function findReusableIdleCursorElement(contentEl) {
+    if (!contentEl) return null;
+    const textBlocks = Array.from(contentEl.querySelectorAll('.msg-text'));
+    for (let index = textBlocks.length - 1; index >= 0; index -= 1) {
+        const textEl = textBlocks[index];
+        if (textEl.closest('.thinking-block')) continue;
+        if (isIdleCursorPlaceholder(textEl)) {
+            return textEl;
+        }
     }
     return null;
 }
@@ -989,11 +1043,19 @@ function escapeSelectorValue(value) {
 function endActiveText(st) {
     if (!st) return;
     if (st.activeTextEl) {
-        syncStreamingCursor(st.activeTextEl, false);
+        if (st.activeTextIsIdle === true && isIdleCursorPlaceholder(st.activeTextEl)) {
+            syncStreamingCursor(st.activeTextEl, false);
+            st.activeTextEl.remove?.();
+        } else {
+            syncStreamingCursor(st.activeTextEl, false);
+            markIdleCursorPlaceholder(st.activeTextEl, false);
+        }
     }
     setOverlayTextStreaming(st.runId, st.instanceId, st.roleId, st.label, false);
+    setOverlayIdleCursor(st.runId, st.instanceId, st.roleId, st.label, false);
     st.activeTextEl = null;
     st.activeRaw = '';
+    st.activeTextIsIdle = false;
 }
 
 function resolveToolBlockTarget(st, container, toolName, toolCallId) {
@@ -1100,6 +1162,7 @@ function ensureOverlayEntry(runId, instanceId, roleId, label) {
             thinkingActiveByPart: new Map(),
             thinkingSequence: 0,
             textStreaming: false,
+            idleCursor: false,
         };
         runOverlay.entries.set(key, entry);
     } else {
@@ -1109,6 +1172,7 @@ function ensureOverlayEntry(runId, instanceId, roleId, label) {
         if (!entry.thinkingActiveByPart) entry.thinkingActiveByPart = new Map();
         if (typeof entry.thinkingSequence !== 'number') entry.thinkingSequence = 0;
         if (typeof entry.textStreaming !== 'boolean') entry.textStreaming = false;
+        if (typeof entry.idleCursor !== 'boolean') entry.idleCursor = false;
     }
     return entry;
 }
@@ -1203,6 +1267,7 @@ function updateOverlayText(runId, instanceId, roleId, label, text) {
     if (!entry) return;
     const nextText = String(text || '');
     entry.textStreaming = true;
+    entry.idleCursor = false;
     if (!nextText) return;
     const lastPart = entry.parts[entry.parts.length - 1];
     if (lastPart && lastPart.kind === 'text') {
@@ -1216,6 +1281,12 @@ function setOverlayTextStreaming(runId, instanceId, roleId, label, isStreaming) 
     const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
     if (!entry) return;
     entry.textStreaming = isStreaming === true;
+}
+
+function setOverlayIdleCursor(runId, instanceId, roleId, label, isIdle) {
+    const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
+    if (!entry) return;
+    entry.idleCursor = isIdle === true;
 }
 
 function startOverlayThinking(runId, instanceId, roleId, label, partIndex) {
@@ -1406,6 +1477,49 @@ function findOverlayToolPart(entry, toolName, toolCallId) {
     return null;
 }
 
+function hasActiveThinking(st) {
+    return !!(st?.thinkingActiveByPart && st.thinkingActiveByPart.size > 0);
+}
+
+function ensureIdleStreamingTail(st) {
+    if (!st || hasActiveThinking(st)) {
+        return;
+    }
+    if (!st.activeTextEl || !isIdleCursorPlaceholder(st.activeTextEl)) {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'msg-text';
+        st.contentEl.appendChild(placeholder);
+        st.activeTextEl = placeholder;
+    }
+    st.activeRaw = '';
+    st.activeTextIsIdle = true;
+    updateMessageText(st.activeTextEl, '', { streaming: true });
+    markIdleCursorPlaceholder(st.activeTextEl, true);
+    setOverlayTextStreaming(st.runId, st.instanceId, st.roleId, st.label, false);
+    setOverlayIdleCursor(st.runId, st.instanceId, st.roleId, st.label, true);
+}
+
+function isIdleCursorPlaceholder(textEl) {
+    if (!textEl) {
+        return false;
+    }
+    return textEl?.dataset?.idleCursor === 'true' || textEl.__idleCursor === true;
+}
+
+function markIdleCursorPlaceholder(textEl, isIdle) {
+    if (!textEl) {
+        return;
+    }
+    if (textEl.dataset) {
+        if (isIdle === true) {
+            textEl.dataset.idleCursor = 'true';
+        } else if ('idleCursor' in textEl.dataset) {
+            delete textEl.dataset.idleCursor;
+        }
+    }
+    textEl.__idleCursor = isIdle === true;
+}
+
 function resolveThinkingEntry(st, partIndex, options = {}) {
     if (!st) return null;
     const safePartIndex = String(partIndex);
@@ -1458,5 +1572,6 @@ function cloneOverlayEntry(entry) {
         label: entry.label,
         parts: entry.parts.map(part => ({ ...part })),
         textStreaming: entry.textStreaming === true,
+        idleCursor: entry.idleCursor === true,
     };
 }

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -271,6 +271,160 @@ console.log(JSON.stringify(globalThis.__appendCalls));
     assert payload == [{"text": "", "streaming": True}]
 
 
+def test_history_overlay_renders_live_cursor_placeholder_for_idle_gap(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/history.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "history_overlay_idle_gap"
+    temp_dir.mkdir()
+
+    (temp_dir / "history.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function isRunPrimaryRoleId(roleId, runId) {
+    return roleId === "external-role" && runId === "run-1";
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(key, values = {}) {
+    return `${key}:${JSON.stringify(values)}`;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+function createContentEl() {
+  return {
+    children: [],
+    appendChild(child) {
+      this.children.push(child);
+    },
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  };
+}
+
+export function applyToolReturn() {}
+export function appendThinkingText() {}
+export function buildToolBlock() {
+  return { dataset: {}, querySelector() { return null; } };
+}
+export function decoratePendingApprovalBlock() {}
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function labelFromRole(_role, roleId, instanceId) {
+  return roleId || instanceId || "Agent";
+}
+export function parseApprovalArgsPreview() { return {}; }
+export function renderMessageBlock(container, _role, label, _parts = [], options = {}) {
+  const contentEl = createContentEl();
+  const wrapper = {
+    dataset: {
+      runId: String(options.runId || ""),
+      roleId: String(options.roleId || ""),
+      instanceId: String(options.instanceId || ""),
+      streamKey: String(options.streamKey || ""),
+    },
+    querySelector(selector) {
+      if (selector === ".msg-role") {
+        return { textContent: String(label || "").toUpperCase() };
+      }
+      if (selector === ".msg-content") {
+        return contentEl;
+      }
+      return null;
+    },
+  };
+  container.messages.push(wrapper);
+  return { wrapper, contentEl };
+}
+export function renderParts() {}
+export function resolvePendingToolBlock() { return null; }
+export function forceScrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+
+export function appendMessageText(contentEl, text, options = {}) {
+  globalThis.__appendCalls.push({
+    text,
+    streaming: options.streaming === true,
+  });
+  const block = {
+    type: "msg-text",
+    text,
+    streaming: options.streaming === true,
+  };
+  contentEl.appendChild(block);
+  return block;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+import { renderHistoricalMessageList } from "./history.js";
+
+globalThis.__appendCalls = [];
+
+const container = {
+  dataset: {},
+  messages: [],
+  appendChild(child) {
+    this.messages.push(child);
+  },
+  querySelectorAll() {
+    return [];
+  },
+  querySelector() {
+    return null;
+  },
+};
+
+renderHistoricalMessageList(container, [], {
+  runId: "run-1",
+  pendingToolApprovals: [],
+  streamOverlayEntry: {
+    roleId: "external-role",
+    instanceId: "external-instance",
+    label: "External ACP",
+    parts: [],
+    textStreaming: false,
+    idleCursor: true,
+  },
+});
+
+console.log(JSON.stringify(globalThis.__appendCalls));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == [{"text": "", "streaming": True}]
+
+
 def test_history_overlay_can_render_as_separate_live_message(
     tmp_path: Path,
 ) -> None:
@@ -577,6 +731,7 @@ console.log(JSON.stringify({ before, after }));
             "label": "Crafter",
             "parts": [{"kind": "text", "content": "stale overlay"}],
             "textStreaming": True,
+            "idleCursor": False,
         }
     }
     assert payload["after"] == {"coordinator": None, "byInstance": {}}
@@ -996,6 +1151,7 @@ console.log(JSON.stringify({
             }
         ],
         "textStreaming": False,
+        "idleCursor": True,
     }
 
 
@@ -1131,6 +1287,1269 @@ console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-2")));
                     }
                 ],
                 "textStreaming": False,
+                "idleCursor": True,
             }
         },
+    }
+
+
+def test_overlay_snapshot_preserves_idle_cursor_state(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_idle_cursor_snapshot"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() {
+    return "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+export function applyToolReturn() {}
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+export function buildPendingToolBlock() { return { querySelector() { return null; } }; }
+export function findToolBlock() { return null; }
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function renderMessageBlock() {
+  return {
+    wrapper: {
+      dataset: {},
+      querySelector() { return null; },
+      closest() { return null; },
+    },
+    contentEl: {
+      appendChild() {},
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+    },
+  };
+}
+export function resolvePendingToolBlock() { return null; }
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor() {}
+export function updateThinkingText() {}
+export function updateMessageText() {}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+} from "./stream.js";
+
+applyStreamOverlayEvent(
+  "thinking_finished",
+  { part_index: 0 },
+  {
+    runId: "run-3",
+    instanceId: "inst-3",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+
+console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-3")));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "coordinator": None,
+        "byInstance": {
+            "inst-3": {
+                "instanceId": "inst-3",
+                "roleId": "Writer",
+                "label": "Writer",
+                "parts": [],
+                "textStreaming": False,
+                "idleCursor": True,
+            }
+        },
+    }
+
+
+def test_finalize_thinking_restores_idle_streaming_cursor_until_finalize(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_idle_cursor_after_thinking"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() {
+    return "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+export function applyToolReturn() {}
+export function appendStructuredContentPart() {}
+export function buildPendingToolBlock() { return { querySelector() { return null; } }; }
+export function findToolBlock() { return null; }
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function renderMessageBlock() {
+  return {
+    wrapper: {
+      dataset: {},
+      querySelector() { return null; },
+      closest() { return null; },
+    },
+    contentEl: {
+      children: [],
+      appendChild(child) { this.children.push(child); },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+    },
+  };
+}
+export function resolvePendingToolBlock() { return null; }
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor(_textEl, active) {
+  globalThis.__cursorStates.push(active === true);
+}
+export function updateMessageText(_textEl, text, options = {}) {
+  globalThis.__messageUpdates.push({
+    text: String(text || ""),
+    streaming: options.streaming === true,
+  });
+  syncStreamingCursor(_textEl, options.streaming === true);
+}
+export function appendThinkingText(contentEl, _text, options = {}) {
+  const thinkingBlock = {
+    dataset: {},
+    open: true,
+    querySelector() {
+      return { style: {} };
+    },
+  };
+  const textEl = {
+    __partIndex: String(options.partIndex || ""),
+    closest() {
+      return thinkingBlock;
+    },
+  };
+  contentEl.appendChild(textEl);
+  return textEl;
+}
+export function updateThinkingText(_textEl, text, options = {}) {
+  globalThis.__thinkingUpdates.push({
+    text: String(text || ""),
+    streaming: options.streaming === true,
+  });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+globalThis.__cursorStates = [];
+globalThis.__messageUpdates = [];
+globalThis.__thinkingUpdates = [];
+globalThis.document = {
+  createElement() {
+    return {
+      className: "",
+      childNodes: [],
+      appendChild(child) { this.childNodes.push(child); },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      closest() { return null; },
+      remove() { this.__removed = true; },
+    };
+  },
+};
+
+import {
+  appendThinkingChunk,
+  finalizeStream,
+  finalizeThinking,
+  getOrCreateStreamBlock,
+  startThinkingBlock,
+} from "./stream.js";
+
+const container = {
+  appendChild() {},
+  querySelectorAll() { return []; },
+};
+
+getOrCreateStreamBlock(container, "inst-1", "Crafter", "Crafter", "run-1");
+startThinkingBlock("inst-1", 0, {
+  container,
+  runId: "run-1",
+  roleId: "Crafter",
+  label: "Crafter",
+});
+appendThinkingChunk("inst-1", 0, "working", {
+  container,
+  runId: "run-1",
+  roleId: "Crafter",
+  label: "Crafter",
+});
+finalizeThinking("inst-1", 0, { runId: "run-1", roleId: "Crafter" });
+const beforeFinalize = globalThis.__cursorStates.slice();
+finalizeStream("inst-1", "Crafter", { runId: "run-1" });
+
+console.log(JSON.stringify({
+  thinkingUpdates: globalThis.__thinkingUpdates,
+  messageUpdates: globalThis.__messageUpdates,
+  cursorStates: globalThis.__cursorStates,
+  beforeFinalize,
+}));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["thinkingUpdates"] == [
+        {"text": "working", "streaming": True},
+        {"text": "working", "streaming": False},
+        {"text": "working", "streaming": False},
+    ]
+    assert payload["messageUpdates"] == [{"text": "", "streaming": True}]
+    assert payload["beforeFinalize"] == [True]
+    assert payload["cursorStates"] == [True, False]
+
+
+def test_tool_result_restores_idle_streaming_cursor_until_next_segment(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_idle_cursor_after_tool"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() {
+    return "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function scrollBottom() {}
+
+export function buildPendingToolBlock(toolName, args, toolCallId = null) {
+  return {
+    dataset: {
+      toolName: String(toolName || ""),
+      toolCallId: String(toolCallId || ""),
+    },
+    __args: args || {},
+    __result: null,
+    querySelector() { return null; },
+    closest() { return null; },
+  };
+}
+
+export function applyToolReturn(toolBlock, content) {
+  toolBlock.__result = content;
+}
+
+export function findToolBlock(contentEl, toolName, toolCallId) {
+  return contentEl.children.find(child =>
+    String(child?.dataset?.toolName || "") === String(toolName || "")
+      && String(child?.dataset?.toolCallId || "") === String(toolCallId || "")
+  ) || null;
+}
+
+export function findToolBlockInContainer(container, toolName, toolCallId) {
+  return container.__messages
+    .flatMap(item => item.contentEl.children)
+    .find(child =>
+      String(child?.dataset?.toolName || "") === String(toolName || "")
+        && String(child?.dataset?.toolCallId || "") === String(toolCallId || "")
+    ) || null;
+}
+
+export function indexPendingToolBlock(pendingToolBlocks, toolBlock, toolName, toolCallId) {
+  pendingToolBlocks[`${toolName || ""}::${toolCallId || ""}`] = toolBlock;
+  pendingToolBlocks[`${toolName || ""}::`] = toolBlock;
+}
+
+export function renderMessageBlock(container, _role, label, _parts = [], options = {}) {
+  const contentEl = {
+    children: [],
+    appendChild(child) { this.children.push(child); },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+  const wrapper = {
+    dataset: {
+      runId: String(options.runId || ""),
+      roleId: String(options.roleId || ""),
+      instanceId: String(options.instanceId || ""),
+      streamKey: String(options.streamKey || ""),
+    },
+    querySelector(selector) {
+      if (selector === ".msg-role") return { textContent: String(label || "").toUpperCase() };
+      if (selector === ".msg-content") return contentEl;
+      return null;
+    },
+    closest() { return null; },
+  };
+  container.__messages.push({ wrapper, contentEl });
+  return { wrapper, contentEl };
+}
+
+export function resolvePendingToolBlock(pendingToolBlocks, toolName, toolCallId) {
+  return pendingToolBlocks[`${toolName || ""}::${toolCallId || ""}`]
+    || pendingToolBlocks[`${toolName || ""}::`]
+    || null;
+}
+
+export function syncStreamingCursor(_textEl, active) {
+  globalThis.__cursorStates.push(active === true);
+}
+
+export function updateMessageText(_textEl, text, options = {}) {
+  globalThis.__messageUpdates.push({
+    text: String(text || ""),
+    streaming: options.streaming === true,
+  });
+  syncStreamingCursor(_textEl, options.streaming === true);
+}
+
+export function updateThinkingText() {}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+globalThis.__cursorStates = [];
+globalThis.__messageUpdates = [];
+globalThis.document = {
+  createElement() {
+    return {
+      className: "",
+      childNodes: [],
+      appendChild(child) { this.childNodes.push(child); },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      closest() { return null; },
+      remove() { this.__removed = true; },
+    };
+  },
+};
+
+import {
+  appendToolCallBlock,
+  getOrCreateStreamBlock,
+  startThinkingBlock,
+  updateToolResult,
+} from "./stream.js";
+
+const container = {
+  __messages: [],
+  appendChild() {},
+  querySelectorAll() { return this.__messages.map(item => item.wrapper); },
+};
+
+getOrCreateStreamBlock(container, "inst-2", "Crafter", "Crafter", "run-2");
+appendToolCallBlock(container, "inst-2", "shell", { command: "echo ok" }, "call-1", {
+  runId: "run-2",
+  roleId: "Crafter",
+  label: "Crafter",
+});
+updateToolResult("inst-2", "shell", { ok: true, data: "ok" }, false, "call-1", {
+  runId: "run-2",
+  roleId: "Crafter",
+  label: "Crafter",
+  container,
+});
+const afterToolResult = globalThis.__cursorStates.slice();
+startThinkingBlock("inst-2", 1, {
+  container,
+  runId: "run-2",
+  roleId: "Crafter",
+  label: "Crafter",
+});
+
+console.log(JSON.stringify({
+  messageUpdates: globalThis.__messageUpdates,
+  cursorStates: globalThis.__cursorStates,
+  afterToolResult,
+}));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["messageUpdates"] == [{"text": "", "streaming": True}]
+    assert payload["afterToolResult"] == [True]
+    assert payload["cursorStates"] == [True, False]
+
+
+def test_rebind_then_tool_result_keeps_existing_text_and_appends_idle_placeholder(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_rebind_tool_result_idle_tail"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() {
+    return "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+function removeFromParent(node) {
+  const parent = node?.__parent || null;
+  if (!parent || !Array.isArray(parent.children)) {
+    return;
+  }
+  const index = parent.children.indexOf(node);
+  if (index >= 0) {
+    parent.children.splice(index, 1);
+  }
+}
+
+function createTextNode() {
+  return {
+    className: "msg-text",
+    dataset: {},
+    __text: "",
+    __streaming: false,
+    __parent: null,
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    closest() { return null; },
+    remove() { removeFromParent(this); },
+  };
+}
+
+function toolMatches(block, toolName, toolCallId) {
+  const safeToolCallId = String(toolCallId || "");
+  if (safeToolCallId) {
+    return String(block?.dataset?.toolCallId || "") === safeToolCallId;
+  }
+  return String(block?.dataset?.toolName || "") === String(toolName || "");
+}
+
+function findInContent(contentEl, toolName, toolCallId) {
+  if (!contentEl || !Array.isArray(contentEl.children)) {
+    return null;
+  }
+  for (let index = contentEl.children.length - 1; index >= 0; index -= 1) {
+    const child = contentEl.children[index];
+    if (toolMatches(child, toolName, toolCallId)) {
+      return child;
+    }
+  }
+  return null;
+}
+
+export function applyToolReturn(toolBlock, content) {
+  toolBlock.__result = content;
+}
+
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+
+export function buildPendingToolBlock(toolName, args, toolCallId = null) {
+  return {
+    dataset: {
+      toolName: String(toolName || ""),
+      toolCallId: String(toolCallId || ""),
+      status: "running",
+    },
+    __args: args || {},
+    __result: null,
+    __parent: null,
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    closest() { return null; },
+    remove() { removeFromParent(this); },
+  };
+}
+
+export function findToolBlock(contentEl, toolName, toolCallId) {
+  return findInContent(contentEl, toolName, toolCallId);
+}
+
+export function findToolBlockInContainer(container, toolName, toolCallId) {
+  const messages = Array.isArray(container?.__messages) ? container.__messages : [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const found = findInContent(messages[index].contentEl, toolName, toolCallId);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+export function indexPendingToolBlock(pendingToolBlocks, toolBlock, toolName, toolCallId) {
+  pendingToolBlocks[`${toolName || ""}::${toolCallId || ""}`] = toolBlock;
+  if (toolName) {
+    pendingToolBlocks[`${toolName}::`] = toolBlock;
+  }
+}
+
+export function renderMessageBlock(container, _role, label, _parts = [], options = {}) {
+  const contentEl = {
+    children: [],
+    appendChild(child) {
+      child.__parent = this;
+      this.children.push(child);
+    },
+    querySelector() {
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector === ".msg-text") {
+        return this.children.filter(child => child?.className === "msg-text");
+      }
+      return [];
+    },
+  };
+  const wrapper = {
+    dataset: {
+      runId: String(options.runId || ""),
+      roleId: String(options.roleId || ""),
+      instanceId: String(options.instanceId || ""),
+      streamKey: String(options.streamKey || ""),
+    },
+    querySelector(selector) {
+      if (selector === ".msg-role") {
+        return { textContent: String(label || "").toUpperCase() };
+      }
+      if (selector === ".msg-content") {
+        return contentEl;
+      }
+      return null;
+    },
+    closest() { return null; },
+  };
+  container.__messages.push({ wrapper, contentEl });
+  return { wrapper, contentEl };
+}
+
+export function resolvePendingToolBlock(pendingToolBlocks, toolName, toolCallId) {
+  return pendingToolBlocks[`${toolName || ""}::${toolCallId || ""}`]
+    || pendingToolBlocks[`${toolName || ""}::`]
+    || null;
+}
+
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor(_textEl, active) {
+  globalThis.__cursorStates.push(active === true);
+}
+export function updateThinkingText() {}
+export function updateMessageText(textEl, text, options = {}) {
+  textEl.__text = String(text || "");
+  textEl.__streaming = options.streaming === true;
+  syncStreamingCursor(textEl, options.streaming === true);
+}
+
+globalThis.__createTextNode = createTextNode;
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+globalThis.__cursorStates = [];
+globalThis.document = {
+  createElement() {
+    return globalThis.__createTextNode();
+  },
+};
+
+import {
+  appendStreamChunk,
+  appendToolCallBlock,
+  bindStreamOverlayToContainer,
+  clearRenderedStreamState,
+  getOrCreateStreamBlock,
+  updateToolResult,
+} from "./stream.js";
+
+const container = {
+  __messages: [],
+  appendChild() {},
+  querySelectorAll() {
+    return this.__messages.map(item => item.wrapper);
+  },
+};
+
+getOrCreateStreamBlock(container, "inst-1", "Writer", "Writer", "run-1");
+appendStreamChunk("inst-1", "hello", "run-1", "Writer", "Writer");
+appendToolCallBlock(container, "inst-1", "shell", { command: "echo hi" }, "call-1", {
+  runId: "run-1",
+  roleId: "Writer",
+  label: "Writer",
+});
+clearRenderedStreamState();
+bindStreamOverlayToContainer(container, {
+  instanceId: "inst-1",
+  roleId: "Writer",
+  label: "Writer",
+  runId: "run-1",
+});
+updateToolResult("inst-1", "shell", { ok: true, data: "done" }, false, "call-1", {
+  runId: "run-1",
+  roleId: "Writer",
+  label: "Writer",
+  container,
+});
+
+const children = container.__messages[0].contentEl.children.map(child => ({
+  className: String(child.className || ""),
+  text: String(child.__text || ""),
+  toolName: String(child?.dataset?.toolName || ""),
+  toolCallId: String(child?.dataset?.toolCallId || ""),
+  idleCursor: String(child?.dataset?.idleCursor || ""),
+}));
+
+console.log(JSON.stringify(children));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == [
+        {
+            "className": "msg-text",
+            "text": "hello",
+            "toolName": "",
+            "toolCallId": "",
+            "idleCursor": "",
+        },
+        {
+            "className": "",
+            "text": "",
+            "toolName": "shell",
+            "toolCallId": "call-1",
+            "idleCursor": "",
+        },
+        {
+            "className": "msg-text",
+            "text": "",
+            "toolName": "",
+            "toolCallId": "",
+            "idleCursor": "true",
+        },
+    ]
+
+
+def test_idle_cursor_rebind_resets_live_buffer_before_next_text_delta(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_idle_rebind_text_delta"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() {
+    return "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+function createTextNode(text = "", idle = false) {
+  return {
+    className: "msg-text",
+    dataset: idle ? { idleCursor: "true" } : {},
+    __idleCursor: idle,
+    __text: String(text || ""),
+    __streaming: false,
+    __parent: null,
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    closest() { return null; },
+    remove() {
+      const parent = this.__parent || null;
+      if (!parent || !Array.isArray(parent.children)) return;
+      const index = parent.children.indexOf(this);
+      if (index >= 0) parent.children.splice(index, 1);
+    },
+  };
+}
+
+export function applyToolReturn() {}
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+export function buildPendingToolBlock() { return { querySelector() { return null; } }; }
+export function findToolBlock() { return null; }
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function renderMessageBlock() {
+  return {
+    wrapper: {
+      dataset: {},
+      querySelector() { return null; },
+      closest() { return null; },
+    },
+    contentEl: {
+      children: [],
+      appendChild(child) {
+        child.__parent = this;
+        this.children.push(child);
+      },
+      querySelector() { return null; },
+      querySelectorAll(selector) {
+        if (selector === ".msg-text") {
+          return this.children.filter(child => child?.className === "msg-text");
+        }
+        return [];
+      },
+    },
+  };
+}
+export function resolvePendingToolBlock() { return null; }
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor() {}
+export function updateThinkingText() {}
+export function updateMessageText(textEl, text, options = {}) {
+  textEl.__text = String(text || "");
+  textEl.__streaming = options.streaming === true;
+}
+
+globalThis.__createTextNode = createTextNode;
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+globalThis.document = {
+  createElement() {
+    return globalThis.__createTextNode();
+  },
+};
+
+import {
+  applyStreamOverlayEvent,
+  appendStreamChunk,
+  bindStreamOverlayToContainer,
+} from "./stream.js";
+
+const contentEl = {
+  children: [
+    globalThis.__createTextNode("hello", false),
+    globalThis.__createTextNode("", true),
+  ],
+  appendChild(child) {
+    child.__parent = this;
+    this.children.push(child);
+  },
+  querySelector() { return null; },
+  querySelectorAll(selector) {
+    if (selector === ".msg-text") {
+      return this.children.filter(child => child?.className === "msg-text");
+    }
+    return [];
+  },
+};
+contentEl.children.forEach(child => {
+  child.__parent = contentEl;
+});
+
+const wrapper = {
+  dataset: {
+    runId: "run-2",
+    roleId: "Writer",
+    instanceId: "inst-2",
+    streamKey: "inst-2",
+  },
+  querySelector(selector) {
+    if (selector === ".msg-role") {
+      return { textContent: "WRITER" };
+    }
+    if (selector === ".msg-content") {
+      return contentEl;
+    }
+    return null;
+  },
+  closest() { return null; },
+};
+
+const container = {
+  __messages: [{ wrapper, contentEl }],
+  querySelectorAll() {
+    return this.__messages.map(item => item.wrapper);
+  },
+};
+
+applyStreamOverlayEvent(
+  "text_delta",
+  { text: "hello" },
+  {
+    runId: "run-2",
+    instanceId: "inst-2",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+applyStreamOverlayEvent(
+  "thinking_started",
+  { part_index: 0 },
+  {
+    runId: "run-2",
+    instanceId: "inst-2",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+applyStreamOverlayEvent(
+  "thinking_finished",
+  { part_index: 0 },
+  {
+    runId: "run-2",
+    instanceId: "inst-2",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+
+bindStreamOverlayToContainer(container, {
+  instanceId: "inst-2",
+  roleId: "Writer",
+  label: "Writer",
+  runId: "run-2",
+});
+appendStreamChunk("inst-2", " world", "run-2", "Writer", "Writer");
+
+console.log(JSON.stringify(contentEl.children.map(child => ({
+  text: String(child.__text || ""),
+  idleCursor: String(child?.dataset?.idleCursor || ""),
+  idleFlag: child.__idleCursor === true,
+}))));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == [
+        {
+            "text": "hello",
+            "idleCursor": "",
+            "idleFlag": False,
+        },
+        {
+            "text": " world",
+            "idleCursor": "",
+            "idleFlag": False,
+        },
+    ]
+
+
+def test_finalize_stream_keeps_real_text_tail_when_overlay_idle_cursor_drifts(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_finalize_real_text_tail"
+    temp_dir.mkdir()
+
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId() {
+    return "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+function createTextNode(text = "") {
+  return {
+    className: "msg-text",
+    dataset: {},
+    __text: String(text || ""),
+    __streaming: false,
+    __idleCursor: false,
+    __parent: null,
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    closest() { return null; },
+    remove() {
+      const parent = this.__parent || null;
+      if (!parent || !Array.isArray(parent.children)) return;
+      const index = parent.children.indexOf(this);
+      if (index >= 0) parent.children.splice(index, 1);
+    },
+  };
+}
+
+export function applyToolReturn() {}
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+export function buildPendingToolBlock() { return { querySelector() { return null; } }; }
+export function findToolBlock() { return null; }
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function renderMessageBlock() {
+  return {
+    wrapper: {
+      dataset: {},
+      querySelector() { return null; },
+      closest() { return null; },
+    },
+    contentEl: {
+      children: [],
+      appendChild(child) {
+        child.__parent = this;
+        this.children.push(child);
+      },
+      querySelector() { return null; },
+      querySelectorAll(selector) {
+        if (selector === ".msg-text") {
+          return this.children.filter(child => child?.className === "msg-text");
+        }
+        return [];
+      },
+    },
+  };
+}
+export function resolvePendingToolBlock() { return null; }
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor(_textEl, active) {
+  globalThis.__cursorStates.push(active === true);
+}
+export function updateThinkingText() {}
+export function updateMessageText(textEl, text, options = {}) {
+  textEl.__text = String(text || "");
+  textEl.__streaming = options.streaming === true;
+}
+
+globalThis.__createTextNode = createTextNode;
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+globalThis.__cursorStates = [];
+globalThis.document = {
+  createElement() {
+    return globalThis.__createTextNode();
+  },
+};
+
+import {
+  applyStreamOverlayEvent,
+  bindStreamOverlayToContainer,
+  finalizeStream,
+} from "./stream.js";
+
+const textNode = globalThis.__createTextNode("hello");
+const contentEl = {
+  children: [textNode],
+  appendChild(child) {
+    child.__parent = this;
+    this.children.push(child);
+  },
+  querySelector() { return null; },
+  querySelectorAll(selector) {
+    if (selector === ".msg-text") {
+      return this.children.filter(child => child?.className === "msg-text");
+    }
+    return [];
+  },
+};
+textNode.__parent = contentEl;
+
+const wrapper = {
+  dataset: {
+    runId: "run-3",
+    roleId: "Writer",
+    instanceId: "inst-3",
+    streamKey: "inst-3",
+  },
+  querySelector(selector) {
+    if (selector === ".msg-role") {
+      return { textContent: "WRITER" };
+    }
+    if (selector === ".msg-content") {
+      return contentEl;
+    }
+    return null;
+  },
+  closest() { return null; },
+};
+
+const container = {
+  __messages: [{ wrapper, contentEl }],
+  querySelectorAll() {
+    return this.__messages.map(item => item.wrapper);
+  },
+};
+
+applyStreamOverlayEvent(
+  "text_delta",
+  { text: "hello" },
+  {
+    runId: "run-3",
+    instanceId: "inst-3",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+applyStreamOverlayEvent(
+  "tool_result",
+  {
+    tool_name: "shell",
+    tool_call_id: "call-3",
+    result: { ok: true, data: "done" },
+  },
+  {
+    runId: "run-3",
+    instanceId: "inst-3",
+    roleId: "Writer",
+    label: "Writer",
+  },
+);
+
+bindStreamOverlayToContainer(container, {
+  instanceId: "inst-3",
+  roleId: "Writer",
+  label: "Writer",
+  runId: "run-3",
+});
+finalizeStream("inst-3", "Writer", { runId: "run-3" });
+
+console.log(JSON.stringify({
+  children: contentEl.children.map(child => ({
+    text: String(child.__text || ""),
+    idleCursor: String(child?.dataset?.idleCursor || ""),
+  })),
+  cursorStates: globalThis.__cursorStates,
+}));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "children": [
+            {
+                "text": "hello",
+                "idleCursor": "",
+            }
+        ],
+        "cursorStates": [True],
     }


### PR DESCRIPTION
## Summary
- keep a live loading cursor visible after tool results and thinking completion while the model step is still active
- preserve that idle cursor through overlay/history rebinds until the next segment or finalization
- add frontend regression coverage for idle cursor gaps after thinking and tool completion

## Verification
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_stream_session_overlay_ui.py tests/unit_tests/frontend/test_streaming_cursor_ui.py tests/unit_tests/frontend/test_streaming_tool_cursor_ui.py tests/unit_tests/frontend/test_streaming_tool_ui.py

Fixes #352