### PR TITLE
[codex] Add notebook read and edit tools

### DIFF
--- a/src/relay_teams/builtin/roles/crafter.md
+++ b/src/relay_teams/builtin/roles/crafter.md
@@ -10,6 +10,7 @@ tools:
   - glob
   - read
   - edit
+  - notebook_edit
   - write
   - shell
   - list_background_tasks

--- a/src/relay_teams/builtin/roles/daily-ai-report.md
+++ b/src/relay_teams/builtin/roles/daily-ai-report.md
@@ -10,6 +10,7 @@ tools:
 - glob
 - grep
 - read
+- notebook_edit
 - shell
 - list_background_tasks
 - wait_background_task

--- a/src/relay_teams/builtin/roles/main_agent.md
+++ b/src/relay_teams/builtin/roles/main_agent.md
@@ -14,6 +14,7 @@ tools:
   - glob
   - read
   - edit
+  - notebook_edit
   - write
   - shell
   - spawn_subagent

--- a/src/relay_teams/tools/workspace_tools/__init__.py
+++ b/src/relay_teams/tools/workspace_tools/__init__.py
@@ -27,6 +27,10 @@ def register_read(agent: Agent[ToolDeps, str]) -> None:
     _register_workspace_tools(agent, ("read",))
 
 
+def register_notebook_edit(agent: Agent[ToolDeps, str]) -> None:
+    _register_workspace_tools(agent, ("notebook_edit",))
+
+
 def register_shell(agent: Agent[ToolDeps, str]) -> None:
     _register_workspace_tools(agent, ("shell",))
 
@@ -109,6 +113,10 @@ def _register_single_tool(agent: Agent[ToolDeps, str], tool_name: str) -> None:
         from relay_teams.tools.workspace_tools.grep import register as register_impl
     elif tool_name == "read":
         from relay_teams.tools.workspace_tools.read import register as register_impl
+    elif tool_name == "notebook_edit":
+        from relay_teams.tools.workspace_tools.notebook_edit import (
+            register as register_impl,
+        )
     elif tool_name == "write":
         from relay_teams.tools.workspace_tools.write import register as register_impl
     elif tool_name == "write_tmp":
@@ -155,6 +163,7 @@ TOOLS = {
     "glob": register_glob,
     "grep": register_grep,
     "read": register_read,
+    "notebook_edit": register_notebook_edit,
     "write": register_write,
     "write_tmp": register_write_tmp,
     "shell": register_shell,
@@ -177,6 +186,7 @@ __all__ = [
     "register_list_background_tasks",
     "register_list_monitors",
     "register_monitors",
+    "register_notebook_edit",
     "register_read",
     "register_shell",
     "register_spawn_subagent",

--- a/src/relay_teams/tools/workspace_tools/edit.py
+++ b/src/relay_teams/tools/workspace_tools/edit.py
@@ -419,6 +419,10 @@ def apply_edit(
         raise ValueError(f"File not found: {file_path}")
     if path_is_dir(file_path):
         raise ValueError(f"Path is a directory: {file_path}")
+    if file_path.suffix.lower() == ".ipynb":
+        raise ValueError(
+            "File is a Jupyter notebook. Use notebook_edit to modify notebook cells."
+        )
 
     old_content = read_text_preserve_line_endings(file_path)
     ending = detect_line_ending(old_content)

--- a/src/relay_teams/tools/workspace_tools/notebook.py
+++ b/src/relay_teams/tools/workspace_tools/notebook.py
@@ -1,0 +1,474 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from pydantic import JsonValue
+
+from relay_teams.paths import open_text_file, path_exists, path_is_dir
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.tools.workspace_tools.edit_state import (
+    assert_file_unchanged_since_read,
+    record_file_read,
+)
+from relay_teams.tools.workspace_tools.write import (
+    atomic_write,
+    format_diff_summary,
+    generate_diff,
+)
+
+MAX_OUTPUT_TEXT_CHARS = 4_000
+MAX_NOTEBOOK_OUTPUT_CHARS = 80_000
+MAX_RAW_NOTEBOOK_PREVIEW_CHARS = 20_000
+EditMode = Literal["replace", "insert", "delete"]
+CellType = Literal["code", "markdown"]
+
+
+def parse_cell_index(cell_id: str) -> int | None:
+    if not cell_id.startswith("cell-"):
+        return None
+    raw_index = cell_id.removeprefix("cell-")
+    if not raw_index.isdigit():
+        return None
+    return int(raw_index)
+
+
+def read_notebook_text(file_path: Path) -> tuple[str, str]:
+    with open_text_file(file_path, encoding="utf-8-sig", newline="") as handle:
+        content = handle.read()
+    newline = "\r\n" if "\r\n" in content else "\n"
+    return content, newline
+
+
+def load_notebook(file_path: Path) -> tuple[dict[str, Any], str, str]:
+    if file_path.suffix.lower() != ".ipynb":
+        raise ValueError("File must be a Jupyter notebook (.ipynb).")
+    if not path_exists(file_path):
+        raise ValueError(f"Notebook file not found: {file_path}")
+    if path_is_dir(file_path):
+        raise ValueError(f"Path is a directory: {file_path}")
+
+    content, newline = read_notebook_text(file_path)
+    try:
+        notebook = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(_format_json_decode_error(content, exc)) from exc
+    if not isinstance(notebook, dict) or not isinstance(notebook.get("cells"), list):
+        raise ValueError("Notebook JSON must contain a cells array.")
+    return notebook, content, newline
+
+
+def _format_json_decode_error(content: str, exc: json.JSONDecodeError) -> str:
+    if not content.strip():
+        return "Notebook file is empty; expected Jupyter notebook JSON."
+    preview = content[:80].replace("\r", "\\r").replace("\n", "\\n")
+    return (
+        f"Notebook is not valid JSON: {exc.msg} "
+        f"at line {exc.lineno} column {exc.colno} (char {exc.pos}); "
+        f"first characters: {preview!r}"
+    )
+
+
+def notebook_language(notebook: dict[str, Any]) -> str:
+    metadata = notebook.get("metadata")
+    if isinstance(metadata, dict):
+        language_info = metadata.get("language_info")
+        if isinstance(language_info, dict) and isinstance(
+            language_info.get("name"),
+            str,
+        ):
+            return language_info["name"]
+    return "python"
+
+
+def normalize_source(source: object) -> str:
+    if isinstance(source, list):
+        return "".join(str(part) for part in source)
+    if isinstance(source, str):
+        return source
+    return ""
+
+
+def _truncate_text(text: str, max_chars: int = MAX_OUTPUT_TEXT_CHARS) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "\n... (output truncated)"
+
+
+def _output_text(value: object) -> str:
+    if isinstance(value, list):
+        return "".join(str(part) for part in value)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def summarize_output(output: object) -> dict[str, JsonValue]:
+    if not isinstance(output, dict):
+        return {"output_type": "unknown", "text": str(output)}
+
+    output_type = output.get("output_type")
+    summary: dict[str, JsonValue] = {
+        "output_type": output_type if isinstance(output_type, str) else "unknown"
+    }
+    if output_type == "stream":
+        summary["text"] = _truncate_text(_output_text(output.get("text")))
+        return summary
+
+    if output_type in {"execute_result", "display_data"}:
+        data = output.get("data")
+        if isinstance(data, dict):
+            summary["text"] = _truncate_text(_output_text(data.get("text/plain")))
+            media_types = sorted(
+                key
+                for key in data
+                if isinstance(key, str) and key not in {"text/plain"}
+            )
+            if media_types:
+                summary["media_types"] = cast(JsonValue, media_types)
+        return summary
+
+    if output_type == "error":
+        traceback = output.get("traceback")
+        trace_text = (
+            "\n".join(str(line) for line in traceback)
+            if isinstance(traceback, list)
+            else ""
+        )
+        ename = output.get("ename")
+        evalue = output.get("evalue")
+        header = ": ".join(str(part) for part in (ename, evalue) if part)
+        summary["text"] = _truncate_text(
+            "\n".join(part for part in (header, trace_text) if part)
+        )
+        return summary
+
+    if "text" in output:
+        summary["text"] = _truncate_text(_output_text(output.get("text")))
+    return summary
+
+
+def project_notebook_cell(
+    cell: object,
+    *,
+    index: int,
+    language: str,
+    include_outputs: bool,
+) -> dict[str, JsonValue]:
+    if not isinstance(cell, dict):
+        return {
+            "cell_id": f"cell-{index}",
+            "index": index,
+            "cell_type": "unknown",
+            "source": str(cell),
+        }
+
+    cell_type = cell.get("cell_type")
+    cell_id = cell.get("id")
+    projected: dict[str, JsonValue] = {
+        "cell_id": cell_id if isinstance(cell_id, str) else f"cell-{index}",
+        "index": index,
+        "cell_type": cell_type if isinstance(cell_type, str) else "unknown",
+        "source": normalize_source(cell.get("source")),
+    }
+    if cell_type == "code":
+        projected["language"] = language
+        execution_count = cell.get("execution_count")
+        if isinstance(execution_count, int) or execution_count is None:
+            projected["execution_count"] = execution_count
+        outputs = cell.get("outputs")
+        if include_outputs and isinstance(outputs, list) and outputs:
+            projected["outputs"] = [summarize_output(output) for output in outputs]
+        elif include_outputs:
+            projected["outputs"] = []
+    return projected
+
+
+def project_notebook(
+    notebook: dict[str, Any],
+    *,
+    cell_id: str | None = None,
+    include_outputs: bool = True,
+) -> list[dict[str, JsonValue]]:
+    cells = cast(list[object], notebook["cells"])
+    language = notebook_language(notebook)
+    if cell_id:
+        index = resolve_cell_index(notebook, cell_id)
+        return [
+            project_notebook_cell(
+                cells[index],
+                index=index,
+                language=language,
+                include_outputs=include_outputs,
+            )
+        ]
+    return [
+        project_notebook_cell(
+            cell,
+            index=index,
+            language=language,
+            include_outputs=include_outputs,
+        )
+        for index, cell in enumerate(cells)
+    ]
+
+
+def format_notebook_output(
+    *,
+    file_path: Path,
+    cells: list[dict[str, JsonValue]],
+    truncated: bool = False,
+) -> str:
+    output = [f"<path>{file_path}</path>", "<type>notebook</type>", "<cells>"]
+    content = json.dumps(cells, ensure_ascii=False, indent=2)
+    if len(content) > MAX_NOTEBOOK_OUTPUT_CHARS:
+        truncated = True
+        content = (
+            content[:MAX_NOTEBOOK_OUTPUT_CHARS] + "\n... (notebook output truncated)"
+        )
+    output.append(content)
+    output.append("</cells>")
+    if truncated:
+        output.append(
+            "Notebook output was truncated. "
+            "Use read with cell_id to inspect a single cell."
+        )
+    return "\n".join(output)
+
+
+def format_invalid_notebook_output(
+    *,
+    file_path: Path,
+    warning: str,
+    content: str,
+) -> tuple[str, bool]:
+    truncated = len(content) > MAX_RAW_NOTEBOOK_PREVIEW_CHARS
+    preview = content[:MAX_RAW_NOTEBOOK_PREVIEW_CHARS]
+    if truncated:
+        preview += "\n... (raw notebook preview truncated)"
+    output = [
+        f"<path>{file_path}</path>",
+        "<type>notebook</type>",
+        "<warning>",
+        "Notebook native parsing failed; showing raw text preview instead.",
+        warning,
+        "</warning>",
+        "<raw_content>",
+        preview,
+        "</raw_content>",
+    ]
+    return "\n".join(output), truncated
+
+
+def read_notebook_for_tool(
+    *,
+    file_path: Path,
+    cell_id: str | None = None,
+    include_outputs: bool = True,
+) -> tuple[str, list[dict[str, JsonValue]], bool, bool]:
+    try:
+        notebook, _original_content, _newline = load_notebook(file_path)
+    except ValueError as exc:
+        try:
+            raw_content, _newline = read_notebook_text(file_path)
+        except OSError as read_exc:
+            raise exc from read_exc
+        output, truncated = format_invalid_notebook_output(
+            file_path=file_path,
+            warning=str(exc),
+            content=raw_content,
+        )
+        return output, [], truncated, False
+
+    cells = project_notebook(
+        notebook,
+        cell_id=cell_id,
+        include_outputs=include_outputs,
+    )
+    output = format_notebook_output(file_path=file_path, cells=cells)
+    return output, cells, "... (notebook output truncated)" in output, True
+
+
+def resolve_cell_index(notebook: dict[str, Any], cell_id: str) -> int:
+    cells = cast(list[object], notebook["cells"])
+    for index, cell in enumerate(cells):
+        if isinstance(cell, dict) and cell.get("id") == cell_id:
+            return index
+
+    parsed_index = parse_cell_index(cell_id)
+    if parsed_index is not None and 0 <= parsed_index < len(cells):
+        return parsed_index
+    raise ValueError(f'Cell with ID "{cell_id}" not found in notebook.')
+
+
+def _should_write_cell_ids(notebook: dict[str, Any]) -> bool:
+    nbformat = notebook.get("nbformat")
+    minor = notebook.get("nbformat_minor")
+    return (
+        isinstance(nbformat, int)
+        and isinstance(minor, int)
+        and (nbformat > 4 or (nbformat == 4 and minor >= 5))
+    )
+
+
+def make_cell(*, cell_type: CellType, source: str, include_id: bool) -> dict[str, Any]:
+    cell: dict[str, Any] = {
+        "cell_type": cell_type,
+        "metadata": {},
+        "source": source,
+    }
+    if include_id:
+        cell["id"] = uuid.uuid4().hex
+    if cell_type == "code":
+        cell["execution_count"] = None
+        cell["outputs"] = []
+    return cell
+
+
+def apply_notebook_edit(
+    notebook: dict[str, Any],
+    *,
+    cell_id: str | None,
+    new_source: str,
+    cell_type: CellType | None,
+    edit_mode: EditMode,
+) -> dict[str, JsonValue]:
+    cells = cast(list[Any], notebook["cells"])
+    if edit_mode not in {"replace", "insert", "delete"}:
+        raise ValueError("edit_mode must be replace, insert, or delete.")
+    if edit_mode != "insert" and not cell_id:
+        raise ValueError("cell_id is required unless edit_mode is insert.")
+    if cell_type is not None and cell_type not in {"code", "markdown"}:
+        raise ValueError("cell_type must be code or markdown.")
+
+    target_index = 0
+    if cell_id:
+        target_index = resolve_cell_index(notebook, cell_id)
+        if edit_mode == "insert":
+            target_index += 1
+
+    if edit_mode == "insert":
+        new_cell = make_cell(
+            cell_type=cell_type or "code",
+            source=new_source,
+            include_id=_should_write_cell_ids(notebook),
+        )
+        cells.insert(target_index, new_cell)
+        new_cell_id = new_cell.get("id")
+        return {
+            "edit_mode": edit_mode,
+            "cell_index": target_index,
+            "cell_id": (
+                new_cell_id if isinstance(new_cell_id, str) else f"cell-{target_index}"
+            ),
+            "cell_type": cast(str, new_cell["cell_type"]),
+        }
+
+    target_cell = cells[target_index]
+    if not isinstance(target_cell, dict):
+        raise ValueError(f"Cell at index {target_index} is not a JSON object.")
+
+    resolved_cell_id = target_cell.get("id")
+    result_cell_id = (
+        resolved_cell_id
+        if isinstance(resolved_cell_id, str)
+        else f"cell-{target_index}"
+    )
+    original_cell_type = target_cell.get("cell_type")
+    if cell_type:
+        result_cell_type = cell_type
+    elif original_cell_type in {"code", "markdown"}:
+        result_cell_type = cast(str, original_cell_type)
+    else:
+        result_cell_type = "code"
+
+    if edit_mode == "delete":
+        del cells[target_index]
+        return {
+            "edit_mode": edit_mode,
+            "cell_index": target_index,
+            "cell_id": result_cell_id,
+            "cell_type": result_cell_type,
+        }
+
+    target_cell["source"] = new_source
+    if cell_type:
+        target_cell["cell_type"] = cell_type
+    if target_cell.get("cell_type") == "code":
+        target_cell["execution_count"] = None
+        target_cell["outputs"] = []
+    else:
+        target_cell.pop("execution_count", None)
+        target_cell.pop("outputs", None)
+    return {
+        "edit_mode": edit_mode,
+        "cell_index": target_index,
+        "cell_id": result_cell_id,
+        "cell_type": cast(str, target_cell.get("cell_type", result_cell_type)),
+    }
+
+
+def dump_notebook(
+    notebook: dict[str, Any],
+    *,
+    newline: str,
+    trailing_newline: bool,
+) -> str:
+    content = json.dumps(notebook, ensure_ascii=False, indent=1)
+    if newline != "\n":
+        content = content.replace("\n", newline)
+    if trailing_newline and not content.endswith(newline):
+        content += newline
+    return content
+
+
+def notebook_edit_file_with_guard(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    file_path: Path,
+    cell_id: str | None,
+    new_source: str,
+    cell_type: CellType | None = None,
+    edit_mode: EditMode = "replace",
+) -> dict[str, JsonValue]:
+    assert_file_unchanged_since_read(
+        shared_store=shared_store,
+        task_id=task_id,
+        path=file_path,
+    )
+    notebook, original_content, newline = load_notebook(file_path)
+    metadata = apply_notebook_edit(
+        notebook,
+        cell_id=cell_id,
+        new_source=new_source,
+        cell_type=cell_type,
+        edit_mode=edit_mode,
+    )
+    updated_content = dump_notebook(
+        notebook,
+        newline=newline,
+        trailing_newline=original_content.endswith(("\n", "\r\n")),
+    )
+    atomic_write(file_path, updated_content, encoding="utf-8", newline="")
+    record_file_read(shared_store=shared_store, task_id=task_id, path=file_path)
+    diff_summary = format_diff_summary(original_content, updated_content)
+    diff = generate_diff(str(file_path), original_content, updated_content)
+    output = (
+        f"Notebook edit applied successfully: {edit_mode} cell "
+        f"{metadata['cell_id']} at index {metadata['cell_index']}.\n\n"
+        f"Diff:\n{diff_summary}"
+    )
+    return {
+        "path": str(file_path),
+        "output": output,
+        "diff": diff,
+        "diff_summary": diff_summary,
+        "edit_mode": edit_mode,
+        "cell_id": metadata["cell_id"],
+        "cell_index": metadata["cell_index"],
+        "cell_type": metadata["cell_type"],
+    }

--- a/src/relay_teams/tools/workspace_tools/notebook_edit.py
+++ b/src/relay_teams/tools/workspace_tools/notebook_edit.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pydantic import JsonValue
+from pydantic_ai import Agent
+
+from relay_teams.tools._description_loader import load_tool_description
+from relay_teams.tools.runtime import (
+    ToolContext,
+    ToolDeps,
+    ToolResultProjection,
+    execute_tool,
+)
+from relay_teams.tools.workspace_tools.notebook import (
+    CellType,
+    EditMode,
+    notebook_edit_file_with_guard,
+)
+
+DESCRIPTION = load_tool_description(__file__)
+
+
+def _project_notebook_edit_result(
+    result: dict[str, JsonValue],
+) -> ToolResultProjection:
+    return ToolResultProjection(
+        visible_data={"output": result["output"]},
+        internal_data=result,
+    )
+
+
+def register(agent: Agent[ToolDeps, str]) -> None:
+    @agent.tool(description=DESCRIPTION)
+    async def notebook_edit(
+        ctx: ToolContext,
+        path: str,
+        new_source: str,
+        cell_id: str | None = None,
+        cell_type: CellType | None = None,
+        edit_mode: EditMode = "replace",
+    ) -> dict[str, JsonValue]:
+        """Edit a Jupyter notebook cell without editing raw JSON."""
+
+        async def _action() -> ToolResultProjection:
+            file_path = ctx.deps.workspace.resolve_path(path, write=True)
+            result = notebook_edit_file_with_guard(
+                shared_store=ctx.deps.shared_store,
+                task_id=ctx.deps.task_id,
+                file_path=file_path,
+                cell_id=cell_id,
+                new_source=new_source,
+                cell_type=cell_type,
+                edit_mode=edit_mode,
+            )
+            return _project_notebook_edit_result(result)
+
+        return await execute_tool(
+            ctx,
+            tool_name="notebook_edit",
+            args_summary={
+                "path": path,
+                "cell_id": cell_id,
+                "new_source_len": len(new_source),
+                "cell_type": cell_type,
+                "edit_mode": edit_mode,
+            },
+            action=_action,
+        )

--- a/src/relay_teams/tools/workspace_tools/notebook_edit.txt
+++ b/src/relay_teams/tools/workspace_tools/notebook_edit.txt
@@ -1,0 +1,2 @@
+Edit a Jupyter notebook (.ipynb) at the cell level. Supports edit_mode replace, insert, and delete.
+Use read first. Do not edit notebook JSON directly with the generic edit tool.

--- a/src/relay_teams/tools/workspace_tools/read.py
+++ b/src/relay_teams/tools/workspace_tools/read.py
@@ -28,6 +28,9 @@ from relay_teams.tools.runtime import (
     execute_tool,
 )
 from relay_teams.tools.workspace_tools.edit_state import record_file_read
+from relay_teams.tools.workspace_tools.notebook import (
+    read_notebook_for_tool,
+)
 
 DEFAULT_READ_LIMIT = 2000
 MAX_LINE_LENGTH = 2000
@@ -172,6 +175,23 @@ def read_directory(
     return sliced, len(entries), truncated
 
 
+def _inject_instruction_sections(
+    output: str,
+    instruction_sections: tuple[str, ...],
+) -> str:
+    if not instruction_sections:
+        return output
+    lines = output.splitlines()
+    instructions = [
+        "<instructions>",
+        "\n\n".join(instruction_sections),
+        "</instructions>",
+    ]
+    if len(lines) >= 2 and lines[1] == "<type>notebook</type>":
+        return "\n".join([*lines[:2], *instructions, *lines[2:]])
+    return "\n".join([*instructions, output])
+
+
 def _project_read_result(
     *,
     output: str,
@@ -222,6 +242,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         path: str,
         offset: int = 1,
         limit: int = DEFAULT_READ_LIMIT,
+        cell_id: str | None = None,
+        include_outputs: bool = True,
     ) -> dict[str, JsonValue]:
         """Read a file or directory content.
 
@@ -230,6 +252,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             path: Path to the file or directory, relative to the workspace root.
             offset: Line offset for files, or entry offset for directories (1-based).
             limit: Maximum number of lines or entries to return.
+            cell_id: Notebook cell id or cell-N fallback index for .ipynb files.
+            include_outputs: Whether notebook code cell outputs are included.
         """
 
         async def _action() -> ToolResultProjection:
@@ -265,6 +289,35 @@ def register(agent: Agent[ToolDeps, str]) -> None:
 
             if not path_is_file(file_path):
                 raise ValueError(f"Not a file: {path}")
+
+            if file_path.suffix.lower() == ".ipynb":
+                instruction_sections = await resolve_read_instruction_sections(
+                    deps=ctx.deps,
+                    file_path=file_path,
+                )
+                output, _cells, truncated, _parsed = read_notebook_for_tool(
+                    file_path=file_path,
+                    cell_id=cell_id,
+                    include_outputs=include_outputs,
+                )
+                output = _inject_instruction_sections(output, instruction_sections)
+                record_file_read(
+                    shared_store=ctx.deps.shared_store,
+                    task_id=ctx.deps.task_id,
+                    path=file_path,
+                )
+                return _project_read_result(
+                    output=output,
+                    truncated=truncated,
+                    next_offset=None,
+                )
+
+            if cell_id is not None:
+                raise ValueError("cell_id only applies to Jupyter notebooks (.ipynb).")
+            if not include_outputs:
+                raise ValueError(
+                    "include_outputs only applies to Jupyter notebooks (.ipynb)."
+                )
 
             if is_binary_file(file_path, path_stat(file_path).st_size):
                 raise ValueError(f"Cannot read binary file: {path}")
@@ -330,6 +383,12 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         return await execute_tool(
             ctx,
             tool_name="read",
-            args_summary={"path": path, "offset": offset, "limit": limit},
+            args_summary={
+                "path": path,
+                "offset": offset,
+                "limit": limit,
+                "cell_id": cell_id,
+                "include_outputs": include_outputs,
+            },
             action=_action,
         )

--- a/src/relay_teams/tools/workspace_tools/read.txt
+++ b/src/relay_teams/tools/workspace_tools/read.txt
@@ -7,6 +7,8 @@ Usage:
 - Files are returned with line numbers in the format `<line>: <content>`.
 - Directories are returned as one entry per line, with `/` appended for subdirectories.
 - Use `offset` and `limit` to page through large files or directories.
+- Jupyter notebooks (`.ipynb`) are returned as structured cells instead of raw JSON.
+- For notebooks, use optional `cell_id` and `include_outputs` to inspect a specific cell or omit outputs.
 - Text output is capped by line length, line count, and total bytes; the response tells you how to continue.
 - Binary files are rejected.
 - Use `glob` to find candidate file paths and `grep` to locate specific content before reading large files.

--- a/src/relay_teams/tools/workspace_tools/write.py
+++ b/src/relay_teams/tools/workspace_tools/write.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import difflib
+import json
 import tempfile
 from pathlib import Path
 
@@ -89,6 +90,17 @@ def atomic_write(
         raise
 
 
+def _is_notebook_editable_json(content: str) -> bool:
+    try:
+        notebook = json.loads(content.removeprefix("\ufeff"))
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(notebook, dict):
+        return False
+    cells = notebook.get("cells")
+    return isinstance(cells, list) and all(isinstance(cell, dict) for cell in cells)
+
+
 DESCRIPTION = load_tool_description(__file__)
 
 
@@ -134,6 +146,13 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 if path_is_dir(file_path):
                     raise ValueError(f"Path is a directory: {path}")
                 old_content = read_text_file(file_path)
+                if file_path.suffix.lower() == ".ipynb" and _is_notebook_editable_json(
+                    old_content
+                ):
+                    raise ValueError(
+                        "File is a Jupyter notebook. "
+                        "Use notebook_edit to modify notebook cells."
+                    )
 
             diff_summary = format_diff_summary(old_content, content)
             atomic_write(file_path, content, encoding="utf-8")

--- a/tests/unit_tests/roles/test_builtin_role_tools.py
+++ b/tests/unit_tests/roles/test_builtin_role_tools.py
@@ -27,6 +27,9 @@ def test_builtin_roles_mount_expected_write_tools() -> None:
 
     assert "write" in crafter.tools
     assert "edit" in crafter.tools
+    assert "read" in crafter.tools
+    assert "notebook_edit" in crafter.tools
+    assert "notebook_edit" in main_agent.tools
     assert "webfetch" in crafter.tools
     assert "websearch" in crafter.tools
     assert background_task_tools.issubset(set(crafter.tools))

--- a/tests/unit_tests/tools/registry/test_defaults.py
+++ b/tests/unit_tests/tools/registry/test_defaults.py
@@ -35,6 +35,7 @@ def test_registry_contains_registered_local_tools() -> None:
         "list_delegated_tasks",
         "list_monitors",
         "list_windows",
+        "notebook_edit",
         "read",
         "scroll_view",
         "shell",
@@ -72,6 +73,7 @@ def test_default_registry_rejects_unknown_tools_for_explicit_validation() -> Non
 
     registry.validate_known(("shell",))
     registry.validate_known(("list_background_tasks",))
+    registry.validate_known(("notebook_edit",))
     with pytest.raises(ValueError, match="Unknown tools"):
         registry.validate_known(("unknown_tool",))
     with pytest.raises(ValueError, match="Unknown tools"):

--- a/tests/unit_tests/tools/workspace_tools/test_edit.py
+++ b/tests/unit_tests/tools/workspace_tools/test_edit.py
@@ -184,3 +184,18 @@ def test_project_edit_result_keeps_only_output_visible() -> None:
         "diff": "@@ -1 +1 @@",
         "diff_summary": "  ~ 1: 1 line(s) changed",
     }
+
+
+def test_apply_edit_rejects_existing_notebook_file(tmp_path: Path) -> None:
+    file_path = tmp_path / "demo.ipynb"
+    file_path.write_text(
+        '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Use notebook_edit"):
+        apply_edit(
+            file_path=file_path,
+            old_string="[]",
+            new_string="[{}]",
+        )

--- a/tests/unit_tests/tools/workspace_tools/test_notebook.py
+++ b/tests/unit_tests/tools/workspace_tools/test_notebook.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.tools.workspace_tools.edit_state import record_file_read
+from relay_teams.tools.workspace_tools.notebook import (
+    apply_notebook_edit,
+    format_invalid_notebook_output,
+    load_notebook,
+    notebook_edit_file_with_guard,
+    project_notebook,
+)
+
+
+def _notebook() -> dict[str, object]:
+    return {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "id": "intro",
+                "metadata": {"keep": True},
+                "source": ["# Title\n", "Body"],
+            },
+            {
+                "cell_type": "code",
+                "id": "calc",
+                "metadata": {"tags": ["demo"]},
+                "source": "print(1)\n",
+                "execution_count": 7,
+                "outputs": [
+                    {
+                        "output_type": "stream",
+                        "name": "stdout",
+                        "text": ["1\n"],
+                    }
+                ],
+            },
+        ],
+        "metadata": {"language_info": {"name": "python"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _write_notebook(path: Path, notebook: dict[str, object] | None = None) -> None:
+    path.write_text(
+        json.dumps(_notebook() if notebook is None else notebook, indent=1),
+        encoding="utf-8",
+    )
+
+
+def test_project_notebook_projects_cells_and_outputs(tmp_path: Path) -> None:
+    file_path = tmp_path / "demo.ipynb"
+    _write_notebook(file_path)
+
+    notebook, _content, _newline = load_notebook(file_path)
+    cells = project_notebook(notebook)
+
+    assert cells[0]["cell_id"] == "intro"
+    assert cells[0]["cell_type"] == "markdown"
+    assert cells[0]["source"] == "# Title\nBody"
+    assert cells[1]["cell_id"] == "calc"
+    assert cells[1]["language"] == "python"
+    assert cells[1]["execution_count"] == 7
+    assert cells[1]["outputs"] == [{"output_type": "stream", "text": "1\n"}]
+
+
+def test_project_notebook_accepts_utf8_bom(tmp_path: Path) -> None:
+    file_path = tmp_path / "bom.ipynb"
+    file_path.write_text(
+        json.dumps(_notebook(), indent=1),
+        encoding="utf-8-sig",
+    )
+
+    notebook, content, _newline = load_notebook(file_path)
+    cells = project_notebook(notebook)
+
+    assert not content.startswith("\ufeff")
+    assert cells[0]["cell_id"] == "intro"
+
+
+def test_project_notebook_accepts_cell_n_fallback(tmp_path: Path) -> None:
+    file_path = tmp_path / "demo.ipynb"
+    _write_notebook(file_path)
+
+    notebook, _content, _newline = load_notebook(file_path)
+    cells = project_notebook(notebook, cell_id="cell-1", include_outputs=False)
+
+    assert len(cells) == 1
+    assert cells[0]["cell_id"] == "calc"
+    assert "outputs" not in cells[0]
+
+
+def test_apply_notebook_edit_replaces_code_cell_and_clears_outputs() -> None:
+    notebook = _notebook()
+
+    result = apply_notebook_edit(
+        notebook,
+        cell_id="calc",
+        new_source="print(2)\n",
+        cell_type=None,
+        edit_mode="replace",
+    )
+
+    cells = cast(list[Any], notebook["cells"])
+    cell = cells[1]
+    assert isinstance(cell, dict)
+    assert result["cell_id"] == "calc"
+    assert cell["source"] == "print(2)\n"
+    assert cell["execution_count"] is None
+    assert cell["outputs"] == []
+    assert cell["metadata"] == {"tags": ["demo"]}
+
+
+def test_apply_notebook_edit_converts_code_cell_to_markdown_cleanly() -> None:
+    notebook = _notebook()
+
+    result = apply_notebook_edit(
+        notebook,
+        cell_id="calc",
+        new_source="Notes only\n",
+        cell_type="markdown",
+        edit_mode="replace",
+    )
+
+    cells = cast(list[Any], notebook["cells"])
+    cell = cells[1]
+    assert isinstance(cell, dict)
+    assert result["cell_type"] == "markdown"
+    assert cell["cell_type"] == "markdown"
+    assert cell["source"] == "Notes only\n"
+    assert "execution_count" not in cell
+    assert "outputs" not in cell
+
+
+def test_apply_notebook_edit_inserts_cell_after_id_with_generated_id() -> None:
+    notebook = _notebook()
+
+    result = apply_notebook_edit(
+        notebook,
+        cell_id="intro",
+        new_source="Some notes",
+        cell_type="markdown",
+        edit_mode="insert",
+    )
+
+    cells = notebook["cells"]
+    assert isinstance(cells, list)
+    inserted = cells[1]
+    assert isinstance(inserted, dict)
+    assert result["cell_index"] == 1
+    assert isinstance(inserted["id"], str)
+    assert inserted["cell_type"] == "markdown"
+    assert inserted["source"] == "Some notes"
+
+
+def test_apply_notebook_edit_deletes_cell() -> None:
+    notebook = _notebook()
+
+    result = apply_notebook_edit(
+        notebook,
+        cell_id="cell-0",
+        new_source="",
+        cell_type=None,
+        edit_mode="delete",
+    )
+
+    cells = notebook["cells"]
+    assert isinstance(cells, list)
+    assert result["cell_id"] == "intro"
+    assert len(cells) == 1
+    assert cells[0]["id"] == "calc"
+
+
+def test_notebook_edit_file_requires_prior_read(tmp_path: Path) -> None:
+    file_path = tmp_path / "demo.ipynb"
+    _write_notebook(file_path)
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+
+    with pytest.raises(ValueError, match="read file before editing"):
+        notebook_edit_file_with_guard(
+            shared_store=shared_store,
+            task_id="task-1",
+            file_path=file_path,
+            cell_id="calc",
+            new_source="print(2)\n",
+        )
+
+
+def test_notebook_edit_file_rejects_external_change_after_read(tmp_path: Path) -> None:
+    file_path = tmp_path / "demo.ipynb"
+    _write_notebook(file_path)
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    record_file_read(shared_store=shared_store, task_id="task-1", path=file_path)
+    _write_notebook(file_path, {**_notebook(), "metadata": {"changed": True}})
+
+    with pytest.raises(ValueError, match="modified since it was last read"):
+        notebook_edit_file_with_guard(
+            shared_store=shared_store,
+            task_id="task-1",
+            file_path=file_path,
+            cell_id="calc",
+            new_source="print(2)\n",
+        )
+
+
+def test_notebook_edit_file_writes_cell_and_preserves_notebook_metadata(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "demo.ipynb"
+    _write_notebook(file_path)
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    record_file_read(shared_store=shared_store, task_id="task-1", path=file_path)
+
+    result = notebook_edit_file_with_guard(
+        shared_store=shared_store,
+        task_id="task-1",
+        file_path=file_path,
+        cell_id="calc",
+        new_source="print(2)\n",
+    )
+
+    updated = json.loads(file_path.read_text(encoding="utf-8"))
+    assert "Notebook edit applied successfully" in cast(str, result["output"])
+    assert updated["metadata"] == {"language_info": {"name": "python"}}
+    assert updated["cells"][1]["source"] == "print(2)\n"
+    assert updated["cells"][1]["outputs"] == []
+
+
+def test_load_notebook_empty_file_reports_empty_notebook(tmp_path: Path) -> None:
+    file_path = tmp_path / "empty.ipynb"
+    file_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Notebook file is empty"):
+        load_notebook(file_path)
+
+
+def test_format_invalid_notebook_output_includes_raw_preview(tmp_path: Path) -> None:
+    file_path = tmp_path / "bad.ipynb"
+    raw = "not notebook json"
+
+    output, truncated = format_invalid_notebook_output(
+        file_path=file_path,
+        warning="Notebook is not valid JSON: Expecting value",
+        content=raw,
+    )
+
+    assert truncated is False
+    assert "Notebook native parsing failed" in output
+    assert "Notebook is not valid JSON" in output
+    assert raw in output

--- a/tests/unit_tests/tools/workspace_tools/test_read.py
+++ b/tests/unit_tests/tools/workspace_tools/test_read.py
@@ -1,13 +1,45 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
 import pytest
+from pydantic_ai import Agent
 
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.tools.runtime import ToolResultProjection
 from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.workspace_tools import register_read
+from relay_teams.tools.workspace_tools.edit_state import load_file_read_state
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., object]] = {}
+
+    def tool(
+        self,
+        *,
+        description: str,
+    ) -> Callable[[Callable[..., object]], Callable[..., object]]:
+        del description
+
+        def decorator(func: Callable[..., object]) -> Callable[..., object]:
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+
+class _FakeWorkspace:
+    def __init__(self, root: Path) -> None:
+        self.scope_root = root
+
+    def resolve_read_path(self, relative_path: str) -> Path:
+        return (self.scope_root / relative_path).resolve()
 
 
 class TestIsBinaryFile:
@@ -171,6 +203,109 @@ def test_project_read_result_keeps_output_first_shape() -> None:
         "truncated": True,
         "next_offset": 2,
     }
+
+
+@pytest.mark.asyncio
+async def test_read_tool_reads_notebook_cell_without_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "id": "intro",
+                "metadata": {},
+                "source": "# Title\n",
+            },
+            {
+                "cell_type": "code",
+                "id": "calc",
+                "metadata": {},
+                "source": "print(1)\n",
+                "execution_count": 1,
+                "outputs": [
+                    {
+                        "output_type": "stream",
+                        "name": "stdout",
+                        "text": "1\n",
+                    }
+                ],
+            },
+        ],
+        "metadata": {"language_info": {"name": "python"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    instruction_path = source_dir / "AGENTS.md"
+    instruction_path.write_text("Notebook instructions.", encoding="utf-8")
+    file_path = source_dir / "demo.ipynb"
+    file_path.write_text(json.dumps(notebook, indent=1), encoding="utf-8")
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    fake_agent = _FakeAgent()
+    register_read(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["read"],
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            workspace=_FakeWorkspace(tmp_path),
+            shared_store=shared_store,
+            task_id="task-1",
+        )
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[[], Awaitable[ToolResultProjection]],
+        approval_request=None,
+    ) -> dict[str, object]:
+        del ctx, tool_name, args_summary, approval_request
+        return cast(dict[str, object], (await action()).internal_data)
+
+    monkeypatch.setattr(read_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(
+        ctx,
+        path="src/demo.ipynb",
+        cell_id="cell-1",
+        include_outputs=False,
+    )
+
+    output = cast(str, result["output"])
+    assert result["truncated"] is False
+    assert result["next_offset"] is None
+    assert "<type>notebook</type>" in output
+    assert "<instructions>" in output
+    assert "Notebook instructions." in output
+    assert '"cell_id": "calc"' in output
+    assert '"source": "print(1)\\n"' in output
+    assert '"outputs"' not in output
+    from relay_teams.agents.execution.prompt_instruction_state import (
+        is_prompt_instruction_loaded,
+    )
+
+    assert is_prompt_instruction_loaded(
+        shared_store=shared_store,
+        task_id="task-1",
+        path=instruction_path,
+    )
+    assert (
+        load_file_read_state(
+            shared_store=shared_store,
+            task_id="task-1",
+            path=file_path,
+        )
+        is not None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/tools/workspace_tools/test_write.py
+++ b/tests/unit_tests/tools/workspace_tools/test_write.py
@@ -384,3 +384,162 @@ async def test_write_tmp_tool_rejects_paths_outside_workspace_tmp_directory(
 
     with pytest.raises(ValueError, match="outside workspace tmp directory"):
         await tool(ctx, path="../outside.md", content="should fail\n")
+
+
+@pytest.mark.asyncio
+async def test_write_tool_rejects_existing_notebook_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import write as write_module
+
+    fake_agent = _FakeAgent()
+    register_write(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["write"],
+    )
+    file_path = tmp_path / "demo.ipynb"
+    file_path.write_text(
+        '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+        encoding="utf-8",
+    )
+    ctx = SimpleNamespace(deps=SimpleNamespace(workspace=_FakeWorkspace(tmp_path)))
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[[], Awaitable[ToolResultProjection]],
+        approval_request=None,
+    ) -> dict[str, object]:
+        del ctx, tool_name, args_summary, approval_request
+        return cast(dict[str, object], (await action()).internal_data)
+
+    monkeypatch.setattr(write_module, "execute_tool", _fake_execute_tool)
+
+    with pytest.raises(ValueError, match="Use notebook_edit"):
+        await tool(
+            ctx,
+            path="demo.ipynb",
+            content='{"cells": [{}], "metadata": {}, "nbformat": 4}',
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_tool_rejects_bom_prefixed_existing_notebook_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import write as write_module
+
+    fake_agent = _FakeAgent()
+    register_write(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["write"],
+    )
+    file_path = tmp_path / "demo.ipynb"
+    file_path.write_text(
+        '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+        encoding="utf-8-sig",
+    )
+    ctx = SimpleNamespace(deps=SimpleNamespace(workspace=_FakeWorkspace(tmp_path)))
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[[], Awaitable[ToolResultProjection]],
+        approval_request=None,
+    ) -> dict[str, object]:
+        del ctx, tool_name, args_summary, approval_request
+        return cast(dict[str, object], (await action()).internal_data)
+
+    monkeypatch.setattr(write_module, "execute_tool", _fake_execute_tool)
+
+    with pytest.raises(ValueError, match="Use notebook_edit"):
+        await tool(
+            ctx,
+            path="demo.ipynb",
+            content='{"cells": [{}], "metadata": {}, "nbformat": 4}',
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_tool_allows_repairing_invalid_notebook_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import write as write_module
+
+    fake_agent = _FakeAgent()
+    register_write(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["write"],
+    )
+    file_path = tmp_path / "demo.ipynb"
+    file_path.write_text("not notebook json", encoding="utf-8")
+    ctx = SimpleNamespace(deps=SimpleNamespace(workspace=_FakeWorkspace(tmp_path)))
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[[], Awaitable[ToolResultProjection]],
+        approval_request=None,
+    ) -> dict[str, object]:
+        del ctx, tool_name, args_summary, approval_request
+        return cast(dict[str, object], (await action()).internal_data)
+
+    monkeypatch.setattr(write_module, "execute_tool", _fake_execute_tool)
+
+    content = '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}'
+    result = await tool(ctx, path="demo.ipynb", content=content)
+
+    assert result["created"] is False
+    assert file_path.read_text(encoding="utf-8") == content
+
+
+@pytest.mark.asyncio
+async def test_write_tool_allows_repairing_notebook_with_non_object_cell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import write as write_module
+
+    fake_agent = _FakeAgent()
+    register_write(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["write"],
+    )
+    file_path = tmp_path / "demo.ipynb"
+    file_path.write_text(
+        '{"cells": [null], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+        encoding="utf-8",
+    )
+    ctx = SimpleNamespace(deps=SimpleNamespace(workspace=_FakeWorkspace(tmp_path)))
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[[], Awaitable[ToolResultProjection]],
+        approval_request=None,
+    ) -> dict[str, object]:
+        del ctx, tool_name, args_summary, approval_request
+        return cast(dict[str, object], (await action()).internal_data)
+
+    monkeypatch.setattr(write_module, "execute_tool", _fake_execute_tool)
+
+    content = '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}'
+    result = await tool(ctx, path="demo.ipynb", content=content)
+
+    assert result["created"] is False
+    assert file_path.read_text(encoding="utf-8") == content


### PR DESCRIPTION
## Summary

- Add notebook-aware read support for `.ipynb` files, including cell projection, output summaries, single-cell lookup, and raw preview fallback for invalid notebook JSON.
- Add a `notebook_edit` workspace tool for cell-level replace, insert, and delete operations while preserving notebook JSON structure and read-before-write guards.
- Prevent generic `edit` and `write` from modifying notebooks directly, and expose `notebook_edit` through the default tool registry and built-in roles.
- Expand unit coverage for notebook reading/editing, registry resolution, role tool wiring, and notebook guard behavior in generic edit/write tools.

## Validation

- `pytest tests/unit_tests/tools/workspace_tools/test_notebook.py tests/unit_tests/tools/workspace_tools/test_read.py tests/unit_tests/tools/workspace_tools/test_edit.py tests/unit_tests/tools/workspace_tools/test_write.py tests/unit_tests/tools/registry/test_defaults.py tests/unit_tests/roles/test_builtin_role_tools.py` (`67 passed`)
- pre-commit: `ruff-check`, `ruff-format`, `basedpyright-check`

Closes #199