### PR TITLE
Add model fallback policies and settings UI

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -103,7 +103,7 @@ The response body is a root object whose keys are profile ids and whose values u
 ### `GET /system/configs/model/profiles`
 
 Returns normalized model profiles.
-Each profile includes `has_api_key`, the currently stored `api_key` value so the web UI can mask it by default and reveal it on demand, `headers[]` for additional request headers, `is_default` to mark the runtime fallback profile, and optional `context_window` for next-send context preview UI.
+Each profile includes `has_api_key`, the currently stored `api_key` value so the web UI can mask it by default and reveal it on demand, `headers[]` for additional request headers, `is_default` to mark the runtime default profile, optional `context_window` for next-send context preview UI, optional `fallback_policy_id` to bind that profile to a fallback policy, and `fallback_priority` to rank it as a fallback candidate.
 `provider` currently supports `openai_compatible`, `bigmodel`, `minimax`, `maas`, and the internal/testing-only `echo`. MAAS profiles also return `maas_auth` with `username` and `has_password` so the web UI can preserve the stored password without echoing it back. The MAAS login endpoint and `app-id` are fixed by the backend.
 When no profile is explicitly marked default, the backend resolves the default in this order: a profile named `default`, the only configured profile, then the first profile by name.
 
@@ -116,9 +116,29 @@ If `source_name` does not exist, the backend returns `404`. Profile-level semant
 Profiles may also include optional `ssl_verify` to override the global outbound TLS verification default for that model only.
 Profiles may include `is_default` to promote that profile to the runtime default; saving one default clears the flag from all others.
 Profiles may include optional `context_window` to declare the total model context limit separately from `max_tokens`, which remains the output-token cap when explicitly set. If `max_tokens` is omitted, the backend preserves that unset state and lets the provider decide the default output cap for primary LLM requests.
+Profiles may include optional `fallback_policy_id` to enable quota/rate-limit fallback for that profile. The referenced policy id must exist in `model-fallback.json`. Profiles may also include `fallback_priority`; higher values are preferred when the profile is selected as a fallback candidate.
 Profiles may include `headers[]`, where each item has `name`, optional `value`, optional `secret`, and optional `configured`.
 Profiles must provide at least one auth source: `api_key`, one configured header, or `maas_auth` for `provider = "maas"`.
 When `provider = "maas"`, `maas_auth` must include `username`; `password` is accepted on write but persisted only in the unified secret store. The backend always authenticates against `http://rnd-idea-api.huawei.com/ideaclientservice/login/v4/secureLogin`, always sends `app-id: RelayTeams`, and always uses `http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/` as the MAAS inference base URL. When `context_window` is omitted and the backend recognizes the provider/model pair, it may auto-fill a known context limit during save and runtime load.
+
+### `GET /system/configs/model-fallback`
+
+Returns the model fallback policy config used after a profile exhausts its normal LLM retry budget because of a rate-limit or quota-style error.
+The response body contains `policies[]`. Each policy includes:
+- `policy_id`
+- `name`
+- `description`
+- `enabled`
+- `trigger`
+- `strategy`
+- `max_hops`
+- `cooldown_seconds`
+
+### `PUT /system/configs/model-fallback`
+
+Replaces the full model fallback policy config.
+The request body must match the same schema returned by `GET /system/configs/model-fallback`.
+Profile writes still validate `fallback_policy_id` strictly, but runtime loading tolerates stale saved references by ignoring the missing policy and logging a warning instead of failing startup.
 
 ### `DELETE /system/configs/model/profiles/{name}`
 

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -942,7 +942,7 @@ function renderRetryEventMarkup(event, nowMs) {
         <div class="round-retry-item${isActive ? ' round-retry-item-active' : ''}${phase === 'failed' ? ' round-retry-item-failed' : ''}">
             <div class="round-retry-main">
                 <span class="round-retry-label">${label}</span>
-                <span class="round-retry-copy">${copy}</span>
+                <span class="round-retry-copy">${esc(copy)}</span>
             </div>
             <div class="round-retry-meta">
                 ${errorCode ? `<span class="round-retry-code">${esc(errorCode)}</span>` : ''}

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -903,6 +903,7 @@ function renderRoundRetryEvents(section, retryEvents) {
 }
 
 function renderRetryEventMarkup(event, nowMs) {
+    const kind = String(event?.kind || 'retry').trim() || 'retry';
     const attemptNumber = Number(event?.attempt_number || 0);
     const totalAttempts = Number(event?.total_attempts || 0);
     const isActive = event?.is_active === true;
@@ -918,16 +919,25 @@ function renderRetryEventMarkup(event, nowMs) {
     const errorMessage = String(event?.error_message || '').trim();
     const occurredAt = String(event?.occurred_at || '').trim();
     const occurredLabel = occurredAt ? new Date(occurredAt).toLocaleTimeString() : '';
-    const copy = phase === 'retrying'
+    const fallbackTarget = String(event?.to_profile_id || event?.to_model || '').trim();
+    const fallbackCopy = phase === 'failed'
+        ? 'No fallback candidate succeeded'
+        : fallbackTarget
+            ? `Switched to ${fallbackTarget}`
+            : 'Fallback activated';
+    const retryCopy = phase === 'retrying'
         ? `Attempt ${attemptNumber}/${totalAttempts} in progress`
         : phase === 'failed'
             ? `Attempt ${attemptNumber}/${totalAttempts} failed`
             : `Attempt ${attemptNumber}/${totalAttempts} in ${retrySeconds}`;
-    const label = phase === 'retrying'
+    const copy = kind === 'fallback' ? fallbackCopy : retryCopy;
+    const fallbackLabel = phase === 'failed' ? 'Fallback failed' : 'Fallback';
+    const retryLabel = phase === 'retrying'
         ? 'Retrying'
         : phase === 'failed'
             ? 'Retry failed'
             : 'Retry scheduled';
+    const label = kind === 'fallback' ? fallbackLabel : retryLabel;
     return `
         <div class="round-retry-item${isActive ? ' round-retry-item-active' : ''}${phase === 'failed' ? ' round-retry-item-failed' : ''}">
             <div class="round-retry-main">

--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -319,6 +319,19 @@ function createModal() {
                                                 </div>
                                             </div>
                                         </div>
+                                        <div class="profile-editor-subsection">
+                                            <h5>Fallback</h5>
+                                            <div class="form-row">
+                                                <div class="form-group">
+                                                    <label for="profile-fallback-policy">Fallback Strategy</label>
+                                                    <select id="profile-fallback-policy"></select>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label for="profile-fallback-priority">Fallback Priority</label>
+                                                    <input type="number" id="profile-fallback-priority" value="0" min="0" max="1000000" autocomplete="off">
+                                                </div>
+                                            </div>
+                                        </div>
                                         <div class="profile-default-row">
                                             <input type="checkbox" id="profile-is-default">
                                             <label for="profile-is-default" data-i18n="settings.model.set_default">Set as default profile</label>

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -5,6 +5,7 @@
 import {
     deleteModelProfile,
     discoverModelCatalog,
+    fetchModelFallbackConfig,
     fetchModelProfiles,
     probeModelConnection,
     reloadModelConfig,
@@ -15,6 +16,7 @@ import { t } from '../../utils/i18n.js';
 import { errorToPayload, logError } from '../../utils/logger.js';
 
 let profiles = {};
+let fallbackConfig = { policies: [] };
 let editingProfile = null;
 let profileProbeStates = {};
 let draftProbeState = null;
@@ -135,7 +137,13 @@ export function bindModelProfileHandlers() {
 
 export async function loadModelProfilesPanel() {
     try {
-        profiles = await fetchModelProfiles();
+        const [loadedProfiles, loadedFallbackConfig] = await Promise.all([
+            fetchModelProfiles(),
+            fetchModelFallbackConfig(),
+        ]);
+        profiles = loadedProfiles;
+        fallbackConfig = loadedFallbackConfig || { policies: [] };
+        renderFallbackPolicyOptions();
         renderProfiles();
         renderDraftProbeState();
     } catch (e) {
@@ -190,6 +198,7 @@ function handleAddProfile() {
     editingProfile = null;
     resetDraftEditorState();
     renderProfileEditorTitle();
+    renderFallbackPolicyOptions();
     document.getElementById('profile-name').value = '';
     document.getElementById('profile-provider').value = 'openai_compatible';
     setDraftModelValue('');
@@ -209,6 +218,8 @@ function handleAddProfile() {
     delete document.getElementById('profile-context-window').dataset.autofilledModel;
     document.getElementById('profile-connect-timeout').value = '15';
     document.getElementById('profile-ssl-verify').value = '';
+    document.getElementById('profile-fallback-policy').value = '';
+    document.getElementById('profile-fallback-priority').value = '0';
 
     showProfileEditor();
     renderDraftApiKeyField();
@@ -227,6 +238,7 @@ function handleEditProfile(name) {
     editingProfile = name;
     resetDraftEditorState();
     renderProfileEditorTitle();
+    renderFallbackPolicyOptions();
     document.getElementById('profile-name').value = name;
     document.getElementById('profile-provider').value = profile.provider || 'openai_compatible';
     setDraftModelValue(profile.model || '');
@@ -260,6 +272,8 @@ function handleEditProfile(name) {
     delete document.getElementById('profile-context-window').dataset.autofilledModel;
     document.getElementById('profile-connect-timeout').value = profile.connect_timeout_seconds || 15;
     document.getElementById('profile-ssl-verify').value = serializeTriStateValue(profile.ssl_verify);
+    document.getElementById('profile-fallback-policy').value = profile.fallback_policy_id || '';
+    document.getElementById('profile-fallback-priority').value = String(profile.fallback_priority || 0);
 
     showProfileEditor();
     renderDraftApiKeyField();
@@ -298,6 +312,13 @@ async function handleSaveProfile() {
     const contextWindow = contextWindowValue ? parseInt(contextWindowValue) || null : null;
     const connectTimeoutSeconds = parseFloat(document.getElementById('profile-connect-timeout').value) || 15;
     const sslVerify = parseTriStateValue(document.getElementById('profile-ssl-verify').value);
+    const fallbackPolicyId = String(
+        document.getElementById('profile-fallback-policy').value || '',
+    ).trim();
+    const fallbackPriority = Math.max(
+        0,
+        parseInt(document.getElementById('profile-fallback-priority').value || '0', 10) || 0,
+    );
 
     if (!name) {
         showToast({ title: t('settings.model.profile_required_title'), message: t('settings.model.profile_required_message'), tone: 'warning' });
@@ -336,6 +357,8 @@ async function handleSaveProfile() {
         temperature: temperature,
         top_p: topP,
         context_window: contextWindow,
+        fallback_policy_id: fallbackPolicyId || null,
+        fallback_priority: fallbackPriority,
         connect_timeout_seconds: connectTimeoutSeconds,
     };
     if (maxTokens !== null) {
@@ -1370,6 +1393,10 @@ function renderProfileCard(name, profile, index) {
         : '';
     const modelLabel = profile.model || t('settings.model.no_model');
     const baseUrlLabel = profile.base_url || t('settings.model.no_endpoint');
+    const fallbackLabel = profile.fallback_policy_id
+        ? formatFallbackPolicyLabel(profile.fallback_policy_id)
+        : 'Fallback disabled';
+    const fallbackPriority = Number(profile.fallback_priority || 0);
 
     return `
         <div class="profile-record profile-card" data-profile-name="${escapeHtml(name)}" style="--profile-index:${index};">
@@ -1387,6 +1414,11 @@ function renderProfileCard(name, profile, index) {
                             <span class="profile-record-summary-primary">${escapeHtml(modelLabel)}</span>
                             <span class="profile-record-summary-separator">/</span>
                             <span class="profile-record-summary-secondary">${escapeHtml(baseUrlLabel)}</span>
+                        </div>
+                        <div class="profile-record-summary" title="${escapeHtml(fallbackLabel)}">
+                            <span class="profile-record-summary-primary">${escapeHtml(fallbackLabel)}</span>
+                            <span class="profile-record-summary-separator">/</span>
+                            <span class="profile-record-summary-secondary">Priority ${escapeHtml(String(fallbackPriority))}</span>
                         </div>
                     </div>
                 </div>
@@ -1439,6 +1471,30 @@ function formatProviderLabel(provider) {
         return 'Echo';
     }
     return provider || t('settings.model.unknown');
+}
+
+function renderFallbackPolicyOptions() {
+    const select = document.getElementById('profile-fallback-policy');
+    if (!select) {
+        return;
+    }
+    const policies = Array.isArray(fallbackConfig?.policies) ? fallbackConfig.policies : [];
+    const options = [
+        '<option value="">Disabled</option>',
+        ...policies.map(policy => (
+            `<option value="${escapeHtml(policy.policy_id)}">${escapeHtml(policy.name || policy.policy_id)}</option>`
+        )),
+    ];
+    select.innerHTML = options.join('');
+}
+
+function formatFallbackPolicyLabel(policyId) {
+    const policies = Array.isArray(fallbackConfig?.policies) ? fallbackConfig.policies : [];
+    const matched = policies.find(policy => policy?.policy_id === policyId);
+    if (matched?.name) {
+        return matched.name;
+    }
+    return policyId;
 }
 
 function escapeHtml(value) {

--- a/frontend/dist/js/core/api.js
+++ b/frontend/dist/js/core/api.js
@@ -50,6 +50,7 @@ export {
     deleteGitHubRepoSubscription,
     deleteGitHubTriggerRule,
     fetchModelConfig,
+    fetchModelFallbackConfig,
     fetchModelProfiles,
     fetchNotificationConfig,
     fetchOrchestrationConfig,

--- a/frontend/dist/js/core/api/index.js
+++ b/frontend/dist/js/core/api/index.js
@@ -56,6 +56,7 @@ export {
     fetchEnvironmentVariables,
     fetchMcpServerTools,
     fetchModelConfig,
+    fetchModelFallbackConfig,
     fetchModelProfiles,
     fetchNotificationConfig,
     fetchOrchestrationConfig,

--- a/frontend/dist/js/core/api/system.js
+++ b/frontend/dist/js/core/api/system.js
@@ -186,6 +186,14 @@ export async function fetchModelProfiles(options = {}) {
     );
 }
 
+export async function fetchModelFallbackConfig() {
+    return requestJson(
+        '/api/system/configs/model-fallback',
+        undefined,
+        'Failed to fetch model fallback config',
+    );
+}
+
 export async function probeModelConnection(payload) {
     return requestJson(
         '/api/system/configs/model:probe',

--- a/frontend/dist/js/core/eventRouter/index.js
+++ b/frontend/dist/js/core/eventRouter/index.js
@@ -7,6 +7,8 @@ import { scheduleSessionTokenUsageRefresh } from '../../components/sessionTokenU
 import { state } from '../state.js';
 import { sysLog } from '../../utils/logger.js';
 import {
+    handleLlmFallbackActivated,
+    handleLlmFallbackExhausted,
     handleLlmRetryExhausted,
     handleLlmRetryScheduled,
     handleModelStepFinished,
@@ -116,6 +118,10 @@ export function routeEvent(evType, payload, eventMeta) {
         handleLlmRetryScheduled(payload, eventMeta);
     } else if (evType === 'llm_retry_exhausted') {
         handleLlmRetryExhausted(payload, eventMeta);
+    } else if (evType === 'llm_fallback_activated') {
+        handleLlmFallbackActivated(payload, eventMeta);
+    } else if (evType === 'llm_fallback_exhausted') {
+        handleLlmFallbackExhausted(payload, eventMeta);
     } else if (evType === 'text_delta') {
         handleTextDelta(payload, eventMeta, instanceId, roleId);
     } else if (evType === 'output_delta') {
@@ -214,6 +220,8 @@ function scheduleContinuityRefreshForEvent(evType) {
     if (
         evType === 'llm_retry_scheduled'
         || evType === 'llm_retry_exhausted'
+        || evType === 'llm_fallback_activated'
+        || evType === 'llm_fallback_exhausted'
         || evType === 'tool_result'
         || evType === 'output_delta'
         || evType === 'generation_progress'

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -66,8 +66,8 @@ export function handleRunStarted(eventMeta) {
 }
 
 export function handleLlmFallbackActivated(payload) {
-    const fromProfile = String(payload?.from_profile_id || '').trim();
-    const toProfile = String(payload?.to_profile_id || '').trim();
+    const fromProfile = escapeLogLabel(payload?.from_profile_id);
+    const toProfile = escapeLogLabel(payload?.to_profile_id);
     if (fromProfile && toProfile) {
         sysLog(`Fallback activated: ${fromProfile} -> ${toProfile}`, 'log-info');
         return;
@@ -76,7 +76,7 @@ export function handleLlmFallbackActivated(payload) {
 }
 
 export function handleLlmFallbackExhausted(payload) {
-    const fromProfile = String(payload?.from_profile_id || '').trim();
+    const fromProfile = escapeLogLabel(payload?.from_profile_id);
     if (fromProfile) {
         sysLog(`Fallback exhausted for ${fromProfile}.`, 'log-error');
         return;
@@ -556,4 +556,14 @@ function isNormalModeSubagentRun(runId, roleId) {
         && safeRoleId
         && !isRunPrimaryRoleId(safeRoleId, safeRunId)
     );
+}
+
+function escapeLogLabel(value) {
+    return String(value || '')
+        .trim()
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
 }

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -65,6 +65,25 @@ export function handleRunStarted(eventMeta) {
     state.activeAgentInstanceId = null;
 }
 
+export function handleLlmFallbackActivated(payload) {
+    const fromProfile = String(payload?.from_profile_id || '').trim();
+    const toProfile = String(payload?.to_profile_id || '').trim();
+    if (fromProfile && toProfile) {
+        sysLog(`Fallback activated: ${fromProfile} -> ${toProfile}`, 'log-info');
+        return;
+    }
+    sysLog('Fallback activated.', 'log-info');
+}
+
+export function handleLlmFallbackExhausted(payload) {
+    const fromProfile = String(payload?.from_profile_id || '').trim();
+    if (fromProfile) {
+        sysLog(`Fallback exhausted for ${fromProfile}.`, 'log-error');
+        return;
+    }
+    sysLog('Fallback exhausted.', 'log-error');
+}
+
 export function handleModelStepStarted(eventMeta, instanceId, roleId) {
     beginLlmRetryAttempt();
     const runId = eventMeta?.run_id || eventMeta?.trace_id || state.activeRunId || '';

--- a/src/relay_teams/agents/execution/conversation_compaction.py
+++ b/src/relay_teams/agents/execution/conversation_compaction.py
@@ -28,8 +28,15 @@ from pydantic_ai.profiles.openai import OpenAIModelProfile
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.logger import get_logger, log_event
 from relay_teams.net.llm_client import build_llm_http_client
-from relay_teams.providers.llm_retry import run_with_llm_retry
+from relay_teams.providers.llm_retry import (
+    extract_retry_error_info,
+    run_with_llm_retry,
+)
 from relay_teams.providers.model_config import LlmRetryConfig, ModelEndpointConfig
+from relay_teams.providers.model_fallback import (
+    DisabledLlmFallbackMiddleware,
+    LlmFallbackMiddleware,
+)
 from relay_teams.providers.openai_model_profiles import (
     resolve_openai_chat_model_profile,
 )
@@ -280,13 +287,43 @@ class ConversationCompactionService:
         retry_config: LlmRetryConfig,
         message_repo: MessageRepository,
         session_history_marker_repo: SessionHistoryMarkerRepository,
+        fallback_middleware: LlmFallbackMiddleware
+        | DisabledLlmFallbackMiddleware
+        | None = None,
         strategy: ConversationCompactionStrategy | None = None,
+        profile_name: str | None = None,
     ) -> None:
         self._config = config
+        self._profile_name = (
+            profile_name.strip()
+            if profile_name is not None and profile_name.strip()
+            else None
+        )
         self._retry_config = retry_config
         self._message_repo = message_repo
         self._session_history_marker_repo = session_history_marker_repo
+        self._fallback_middleware = (
+            fallback_middleware
+            if fallback_middleware is not None
+            else DisabledLlmFallbackMiddleware()
+        )
         self._strategy = strategy or DefaultConversationCompactionStrategy()
+
+    def with_config(
+        self,
+        config: ModelEndpointConfig,
+        *,
+        profile_name: str | None = None,
+    ) -> "ConversationCompactionService":
+        return ConversationCompactionService(
+            config=config,
+            profile_name=self._profile_name if profile_name is None else profile_name,
+            retry_config=self._retry_config,
+            message_repo=self._message_repo,
+            session_history_marker_repo=self._session_history_marker_repo,
+            fallback_middleware=self._fallback_middleware,
+            strategy=self._strategy,
+        )
 
     async def maybe_compact(
         self,
@@ -452,6 +489,8 @@ class ConversationCompactionService:
         existing_summary: str,
         source_history: Sequence[ModelRequest | ModelResponse],
         source_char_budget: int,
+        fallback_hop: int = 0,
+        visited_profiles: tuple[str, ...] | None = None,
     ) -> str:
         transcript = _render_transcript(source_history, max_chars=source_char_budget)
         if not transcript.strip():
@@ -475,13 +514,50 @@ class ConversationCompactionService:
             f"Existing compacted summary:\n{existing_summary or '(empty)'}\n\n"
             f"Transcript to absorb:\n{transcript}"
         )
-        result = await run_with_llm_retry(
-            operation=lambda: self._run_streaming_summary(agent=agent, prompt=prompt),
-            config=self._retry_config,
-            is_retry_allowed=lambda: True,
-            on_retry_scheduled=lambda _schedule: None,
-        )
-        return result.strip()
+        try:
+            result = await run_with_llm_retry(
+                operation=lambda: self._run_streaming_summary(
+                    agent=agent, prompt=prompt
+                ),
+                config=self._retry_config,
+                is_retry_allowed=lambda: True,
+                on_retry_scheduled=lambda _schedule: None,
+            )
+            return result.strip()
+        except Exception as exc:
+            retry_error = extract_retry_error_info(exc)
+            if (
+                retry_error is None
+                or not retry_error.rate_limited
+                or self._profile_name is None
+                or not self._fallback_middleware.has_enabled_policy(self._config)
+            ):
+                raise
+            resolved_visited_profiles = visited_profiles or (
+                (self._profile_name,) if self._profile_name is not None else ()
+            )
+            decision = self._fallback_middleware.select_fallback(
+                current_profile_name=self._profile_name,
+                current_config=self._config,
+                error=retry_error,
+                visited_profiles=resolved_visited_profiles,
+                hop=fallback_hop,
+            )
+            if decision is None:
+                raise
+            next_service = self.with_config(
+                decision.target_config,
+                profile_name=decision.to_profile_name,
+            )
+            return await next_service._rewrite_summary(
+                role_id=role_id,
+                existing_summary=existing_summary,
+                source_history=source_history,
+                source_char_budget=source_char_budget,
+                fallback_hop=decision.hop,
+                visited_profiles=resolved_visited_profiles
+                + (decision.to_profile_name,),
+            )
 
     async def _run_streaming_summary(
         self,

--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -1725,11 +1725,14 @@ class AgentLlmSession:
         attempt_tool_outcome_event_emitted: bool,
         attempt_messages_committed: bool,
     ) -> bool:
+        retries_exhausted = (
+            not self._retry_config.enabled
+            or not retry_error.retryable
+            or retry_number >= self._retry_config.max_retries
+        )
         return (
-            retry_error.retryable
-            and retry_error.rate_limited
-            and self._retry_config.enabled
-            and retry_number >= self._retry_config.max_retries
+            retry_error.rate_limited
+            and retries_exhausted
             and not attempt_text_emitted
             and not attempt_tool_call_event_emitted
             and not attempt_tool_outcome_event_emitted

--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 import asyncio
 import json
@@ -43,6 +43,11 @@ from relay_teams.providers.llm_retry import (
     extract_retry_error_info,
 )
 from relay_teams.providers.model_config import LlmRetryConfig, ModelEndpointConfig
+from relay_teams.providers.model_fallback import (
+    DisabledLlmFallbackMiddleware,
+    LlmFallbackDecision,
+    LlmFallbackMiddleware,
+)
 from relay_teams.providers.openai_model_profiles import (
     resolve_openai_chat_model_profile,
 )
@@ -175,6 +180,31 @@ class _PreparedPromptContext(BaseModel):
     estimated_history_tokens_after_microcompact: int = 0
     microcompact_compacted_message_count: int = 0
     microcompact_compacted_part_count: int = 0
+
+
+class _FallbackAttemptState(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    hop: int = Field(default=0, ge=0)
+    visited_profiles: tuple[str, ...] = ()
+
+    @classmethod
+    def initial(cls, profile_name: str | None) -> "_FallbackAttemptState":
+        if profile_name is None or not profile_name.strip():
+            return cls()
+        return cls(visited_profiles=(profile_name.strip(),))
+
+    def with_profile(self, profile_name: str, *, hop: int) -> "_FallbackAttemptState":
+        normalized_name = profile_name.strip()
+        visited = list(self.visited_profiles)
+        if normalized_name and normalized_name not in visited:
+            visited.append(normalized_name)
+        return self.model_copy(
+            update={
+                "hop": hop,
+                "visited_profiles": tuple(visited),
+            }
+        )
 
 
 class _AgentRunResult(Protocol):
@@ -339,6 +369,7 @@ class AgentLlmSession:
         self,
         config: ModelEndpointConfig,
         *,
+        profile_name: str | None,
         task_repo: TaskRepository,
         shared_store: SharedStateRepository,
         event_bus: EventLog,
@@ -373,11 +404,19 @@ class AgentLlmSession:
         token_usage_repo: TokenUsageRepository | None = None,
         metric_recorder: MetricRecorder | None = None,
         retry_config: LlmRetryConfig | None = None,
+        fallback_middleware: LlmFallbackMiddleware
+        | DisabledLlmFallbackMiddleware
+        | None = None,
         im_tool_service: "ImToolService | None" = None,
         computer_runtime: "ComputerRuntime | None" = None,
         shell_approval_repo: ShellApprovalRepository | None = None,
     ) -> None:
         self._config = config
+        self._profile_name = (
+            profile_name.strip()
+            if profile_name is not None and profile_name.strip()
+            else None
+        )
         self._task_repo = task_repo
         self._shared_store = shared_store
         self._event_bus = event_bus
@@ -412,6 +451,11 @@ class AgentLlmSession:
         self._token_usage_repo = token_usage_repo
         self._metric_recorder = metric_recorder
         self._retry_config = retry_config or LlmRetryConfig()
+        self._fallback_middleware = (
+            fallback_middleware
+            if fallback_middleware is not None
+            else DisabledLlmFallbackMiddleware()
+        )
         self._im_tool_service = im_tool_service
         self._computer_runtime = computer_runtime
         self._shell_approval_repo = shell_approval_repo
@@ -427,7 +471,13 @@ class AgentLlmSession:
         retry_number: int = 0,
         total_attempts: int | None = None,
         skip_initial_user_prompt_persist: bool = False,
+        fallback_state: _FallbackAttemptState | None = None,
     ) -> str:
+        resolved_fallback_state = (
+            _FallbackAttemptState.initial(getattr(self, "_profile_name", None))
+            if fallback_state is None
+            else fallback_state
+        )
         resolved_workspace_id = request.workspace_id
         resolved_conversation_id = request.conversation_id or build_conversation_id(
             request.session_id,
@@ -979,8 +1029,22 @@ class AgentLlmSession:
                     request,
                     retry_number=next_retry_number,
                     total_attempts=total_attempts,
+                    fallback_state=resolved_fallback_state,
                 )
             if retry_error is not None and retry_error.retryable:
+                recovered_with_fallback = await self._maybe_fallback_after_retry_exhausted(
+                    request=request,
+                    retry_number=retry_number,
+                    total_attempts=total_attempts,
+                    retry_error=retry_error,
+                    fallback_state=resolved_fallback_state,
+                    attempt_text_emitted=attempt_text_emitted or printed_any,
+                    attempt_tool_event_emitted=attempt_tool_event_emitted,
+                    attempt_messages_committed=attempt_messages_committed,
+                    skip_initial_user_prompt_persist=skip_initial_user_prompt_persist,
+                )
+                if recovered_with_fallback is not None:
+                    return recovered_with_fallback
                 if (
                     self._retry_config.enabled
                     and retry_number >= self._retry_config.max_retries
@@ -1053,6 +1117,7 @@ class AgentLlmSession:
                     request,
                     retry_number=next_retry_number,
                     total_attempts=total_attempts,
+                    fallback_state=resolved_fallback_state,
                 )
             if retry_error is not None:
                 log_event(
@@ -1068,6 +1133,19 @@ class AgentLlmSession:
                     },
                     exc_info=exc,
                 )
+                recovered_with_fallback = await self._maybe_fallback_after_retry_exhausted(
+                    request=request,
+                    retry_number=retry_number,
+                    total_attempts=total_attempts,
+                    retry_error=retry_error,
+                    fallback_state=resolved_fallback_state,
+                    attempt_text_emitted=attempt_text_emitted or printed_any,
+                    attempt_tool_event_emitted=attempt_tool_event_emitted,
+                    attempt_messages_committed=attempt_messages_committed,
+                    skip_initial_user_prompt_persist=skip_initial_user_prompt_persist,
+                )
+                if recovered_with_fallback is not None:
+                    return recovered_with_fallback
                 if retry_error.retryable and (
                     self._retry_config.enabled
                     and retry_number >= self._retry_config.max_retries
@@ -1246,6 +1324,158 @@ class AgentLlmSession:
         status_code = retry_error.status_code
         return status_code is not None and status_code >= 500
 
+    def _can_attempt_fallback(
+        self,
+        *,
+        retry_error: LlmRetryErrorInfo,
+        retry_number: int,
+        attempt_text_emitted: bool,
+        attempt_tool_event_emitted: bool,
+        attempt_messages_committed: bool,
+    ) -> bool:
+        return (
+            retry_error.retryable
+            and retry_error.rate_limited
+            and self._retry_config.enabled
+            and retry_number >= self._retry_config.max_retries
+            and not attempt_text_emitted
+            and not attempt_tool_event_emitted
+            and not attempt_messages_committed
+        )
+
+    async def _maybe_fallback_after_retry_exhausted(
+        self,
+        *,
+        request: LLMRequest,
+        retry_number: int,
+        total_attempts: int,
+        retry_error: LlmRetryErrorInfo,
+        fallback_state: _FallbackAttemptState,
+        attempt_text_emitted: bool,
+        attempt_tool_event_emitted: bool,
+        attempt_messages_committed: bool,
+        skip_initial_user_prompt_persist: bool,
+    ) -> str | None:
+        if not self._can_attempt_fallback(
+            retry_error=retry_error,
+            retry_number=retry_number,
+            attempt_text_emitted=attempt_text_emitted,
+            attempt_tool_event_emitted=attempt_tool_event_emitted,
+            attempt_messages_committed=attempt_messages_committed,
+        ):
+            return None
+        fallback_middleware = getattr(
+            self,
+            "_fallback_middleware",
+            DisabledLlmFallbackMiddleware(),
+        )
+        if not fallback_middleware.has_enabled_policy(self._config):
+            return None
+        decision = fallback_middleware.select_fallback(
+            current_profile_name=self._profile_name,
+            current_config=self._config,
+            error=retry_error,
+            visited_profiles=fallback_state.visited_profiles,
+            hop=fallback_state.hop,
+        )
+        if decision is None:
+            self._handle_fallback_exhausted(
+                request=request,
+                retry_number=retry_number,
+                total_attempts=total_attempts,
+                error=retry_error,
+                fallback_state=fallback_state,
+            )
+            return None
+        self._handle_fallback_activated(
+            request=request,
+            retry_number=retry_number,
+            total_attempts=total_attempts,
+            decision=decision,
+        )
+        next_session = self._clone_with_config(
+            config=decision.target_config,
+            profile_name=decision.to_profile_name,
+        )
+        next_fallback_state = fallback_state.with_profile(
+            decision.to_profile_name,
+            hop=decision.hop,
+        )
+        return await next_session._generate_async(
+            request,
+            retry_number=0,
+            total_attempts=None,
+            skip_initial_user_prompt_persist=skip_initial_user_prompt_persist,
+            fallback_state=next_fallback_state,
+        )
+
+    def _clone_with_config(
+        self,
+        *,
+        config: ModelEndpointConfig,
+        profile_name: str | None,
+    ) -> "AgentLlmSession":
+        return AgentLlmSession(
+            config=config,
+            profile_name=profile_name,
+            task_repo=self._task_repo,
+            shared_store=self._shared_store,
+            event_bus=self._event_bus,
+            injection_manager=self._injection_manager,
+            run_event_hub=self._run_event_hub,
+            agent_repo=self._agent_repo,
+            approval_ticket_repo=self._approval_ticket_repo,
+            run_runtime_repo=self._run_runtime_repo,
+            run_intent_repo=self._run_intent_repo,
+            background_task_service=self._background_task_service,
+            monitor_service=self._monitor_service,
+            workspace_manager=self._workspace_manager,
+            media_asset_service=self._media_asset_service,
+            role_memory_service=self._role_memory_service,
+            subagent_reflection_service=(
+                self._subagent_reflection_service.with_config(
+                    config,
+                    profile_name=profile_name,
+                )
+                if self._subagent_reflection_service is not None
+                else None
+            ),
+            conversation_compaction_service=(
+                self._conversation_compaction_service.with_config(
+                    config,
+                    profile_name=profile_name,
+                )
+                if self._conversation_compaction_service is not None
+                else None
+            ),
+            conversation_microcompact_service=self._conversation_microcompact_service,
+            tool_registry=self._tool_registry,
+            mcp_registry=self._mcp_registry,
+            skill_registry=self._skill_registry,
+            allowed_tools=self._allowed_tools,
+            allowed_mcp_servers=self._allowed_mcp_servers,
+            allowed_skills=self._allowed_skills,
+            message_repo=self._message_repo,
+            role_registry=self._role_registry,
+            task_execution_service=self._task_execution_service,
+            task_service=self._task_service,
+            run_control_manager=self._run_control_manager,
+            tool_approval_manager=self._tool_approval_manager,
+            tool_approval_policy=self._tool_approval_policy,
+            notification_service=self._notification_service,
+            token_usage_repo=self._token_usage_repo,
+            metric_recorder=self._metric_recorder,
+            retry_config=self._retry_config,
+            fallback_middleware=getattr(
+                self,
+                "_fallback_middleware",
+                DisabledLlmFallbackMiddleware(),
+            ),
+            im_tool_service=self._im_tool_service,
+            computer_runtime=self._computer_runtime,
+            shell_approval_repo=self._shell_approval_repo,
+        )
+
     def _build_recoverable_pause_error(
         self,
         *,
@@ -1349,6 +1579,92 @@ class AgentLlmSession:
                 "status_code": error.status_code,
                 "error_code": error.error_code,
             },
+        )
+
+    def _handle_fallback_activated(
+        self,
+        *,
+        request: LLMRequest,
+        retry_number: int,
+        total_attempts: int,
+        decision: LlmFallbackDecision,
+    ) -> None:
+        payload = {
+            "role_id": request.role_id,
+            "instance_id": request.instance_id,
+            "attempt_number": retry_number + 1,
+            "total_attempts": total_attempts,
+            "strategy_id": decision.policy_id,
+            "from_profile_id": decision.from_profile_name,
+            "to_profile_id": decision.to_profile_name,
+            "from_provider": decision.from_provider.value,
+            "to_provider": decision.to_provider.value,
+            "from_model": decision.from_model,
+            "to_model": decision.to_model,
+            "hop": decision.hop,
+            "reason": decision.reason,
+        }
+        self._run_event_hub.publish(
+            RunEvent(
+                session_id=request.session_id,
+                run_id=request.run_id,
+                trace_id=request.trace_id,
+                task_id=request.task_id,
+                instance_id=request.instance_id,
+                role_id=request.role_id,
+                event_type=RunEventType.LLM_FALLBACK_ACTIVATED,
+                payload_json=dumps(payload),
+            )
+        )
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="llm.request.fallback_activated",
+            message="LLM request fallback activated after rate limit exhaustion",
+            payload=payload,
+        )
+
+    def _handle_fallback_exhausted(
+        self,
+        *,
+        request: LLMRequest,
+        retry_number: int,
+        total_attempts: int,
+        error: LlmRetryErrorInfo,
+        fallback_state: _FallbackAttemptState,
+    ) -> None:
+        payload = {
+            "role_id": request.role_id,
+            "instance_id": request.instance_id,
+            "attempt_number": retry_number + 1,
+            "total_attempts": total_attempts,
+            "from_profile_id": self._profile_name or "",
+            "from_provider": self._config.provider.value,
+            "from_model": self._config.model,
+            "hop": fallback_state.hop,
+            "visited_profiles": list(fallback_state.visited_profiles),
+            "error_code": error.error_code or "",
+            "error_message": error.message,
+            "status_code": error.status_code,
+        }
+        self._run_event_hub.publish(
+            RunEvent(
+                session_id=request.session_id,
+                run_id=request.run_id,
+                trace_id=request.trace_id,
+                task_id=request.task_id,
+                instance_id=request.instance_id,
+                role_id=request.role_id,
+                event_type=RunEventType.LLM_FALLBACK_EXHAUSTED,
+                payload_json=dumps(payload),
+            )
+        )
+        log_event(
+            LOGGER,
+            logging.ERROR,
+            event="llm.request.fallback_exhausted",
+            message="No fallback candidate succeeded after LLM rate limit exhaustion",
+            payload=payload,
         )
 
     def _usage_field_int(self, usage_obj: object, field_name: str) -> int:

--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -9,6 +9,7 @@ import logging
 from copy import deepcopy
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import replace
+from enum import StrEnum
 from json import dumps
 from typing import TYPE_CHECKING, Protocol, cast
 
@@ -204,6 +205,34 @@ class _FallbackAttemptState(BaseModel):
                 "hop": hop,
                 "visited_profiles": tuple(visited),
             }
+        )
+
+
+class _FallbackAttemptStatus(StrEnum):
+    SKIPPED = "skipped"
+    RECOVERED = "recovered"
+    EXHAUSTED = "exhausted"
+
+
+class _FallbackAttemptOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: _FallbackAttemptStatus
+    response: str | None = None
+
+    @classmethod
+    def skipped(cls) -> "_FallbackAttemptOutcome":
+        return cls(status=_FallbackAttemptStatus.SKIPPED)
+
+    @classmethod
+    def exhausted(cls) -> "_FallbackAttemptOutcome":
+        return cls(status=_FallbackAttemptStatus.EXHAUSTED)
+
+    @classmethod
+    def recovered(cls, response: str) -> "_FallbackAttemptOutcome":
+        return cls(
+            status=_FallbackAttemptStatus.RECOVERED,
+            response=response,
         )
 
 
@@ -1032,7 +1061,7 @@ class AgentLlmSession:
                     fallback_state=resolved_fallback_state,
                 )
             if retry_error is not None and retry_error.retryable:
-                recovered_with_fallback = await self._maybe_fallback_after_retry_exhausted(
+                fallback_outcome = await self._maybe_fallback_after_retry_exhausted(
                     request=request,
                     retry_number=retry_number,
                     total_attempts=total_attempts,
@@ -1043,10 +1072,11 @@ class AgentLlmSession:
                     attempt_messages_committed=attempt_messages_committed,
                     skip_initial_user_prompt_persist=skip_initial_user_prompt_persist,
                 )
-                if recovered_with_fallback is not None:
-                    return recovered_with_fallback
+                if fallback_outcome.response is not None:
+                    return fallback_outcome.response
                 if (
-                    self._retry_config.enabled
+                    fallback_outcome.status != _FallbackAttemptStatus.EXHAUSTED
+                    and self._retry_config.enabled
                     and retry_number >= self._retry_config.max_retries
                 ):
                     self._handle_retry_exhausted(
@@ -1133,7 +1163,7 @@ class AgentLlmSession:
                     },
                     exc_info=exc,
                 )
-                recovered_with_fallback = await self._maybe_fallback_after_retry_exhausted(
+                fallback_outcome = await self._maybe_fallback_after_retry_exhausted(
                     request=request,
                     retry_number=retry_number,
                     total_attempts=total_attempts,
@@ -1144,10 +1174,11 @@ class AgentLlmSession:
                     attempt_messages_committed=attempt_messages_committed,
                     skip_initial_user_prompt_persist=skip_initial_user_prompt_persist,
                 )
-                if recovered_with_fallback is not None:
-                    return recovered_with_fallback
+                if fallback_outcome.response is not None:
+                    return fallback_outcome.response
                 if retry_error.retryable and (
-                    self._retry_config.enabled
+                    fallback_outcome.status != _FallbackAttemptStatus.EXHAUSTED
+                    and self._retry_config.enabled
                     and retry_number >= self._retry_config.max_retries
                 ):
                     self._handle_retry_exhausted(
@@ -1355,7 +1386,7 @@ class AgentLlmSession:
         attempt_tool_event_emitted: bool,
         attempt_messages_committed: bool,
         skip_initial_user_prompt_persist: bool,
-    ) -> str | None:
+    ) -> _FallbackAttemptOutcome:
         if not self._can_attempt_fallback(
             retry_error=retry_error,
             retry_number=retry_number,
@@ -1363,14 +1394,14 @@ class AgentLlmSession:
             attempt_tool_event_emitted=attempt_tool_event_emitted,
             attempt_messages_committed=attempt_messages_committed,
         ):
-            return None
+            return _FallbackAttemptOutcome.skipped()
         fallback_middleware = getattr(
             self,
             "_fallback_middleware",
             DisabledLlmFallbackMiddleware(),
         )
         if not fallback_middleware.has_enabled_policy(self._config):
-            return None
+            return _FallbackAttemptOutcome.skipped()
         decision = fallback_middleware.select_fallback(
             current_profile_name=self._profile_name,
             current_config=self._config,
@@ -1386,7 +1417,7 @@ class AgentLlmSession:
                 error=retry_error,
                 fallback_state=fallback_state,
             )
-            return None
+            return _FallbackAttemptOutcome.exhausted()
         self._handle_fallback_activated(
             request=request,
             retry_number=retry_number,
@@ -1401,12 +1432,14 @@ class AgentLlmSession:
             decision.to_profile_name,
             hop=decision.hop,
         )
-        return await next_session._generate_async(
-            request,
-            retry_number=0,
-            total_attempts=None,
-            skip_initial_user_prompt_persist=skip_initial_user_prompt_persist,
-            fallback_state=next_fallback_state,
+        return _FallbackAttemptOutcome.recovered(
+            await next_session._generate_async(
+                request,
+                retry_number=0,
+                total_attempts=None,
+                skip_initial_user_prompt_persist=skip_initial_user_prompt_persist,
+                fallback_state=next_fallback_state,
+            )
         )
 
     def _clone_with_config(

--- a/src/relay_teams/agents/execution/subagent_reflection.py
+++ b/src/relay_teams/agents/execution/subagent_reflection.py
@@ -23,8 +23,15 @@ from pydantic_ai.profiles.openai import OpenAIModelProfile
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.logger import get_logger, log_event
 from relay_teams.net.llm_client import build_llm_http_client
-from relay_teams.providers.llm_retry import run_with_llm_retry
+from relay_teams.providers.llm_retry import (
+    extract_retry_error_info,
+    run_with_llm_retry,
+)
 from relay_teams.providers.model_config import LlmRetryConfig, ModelEndpointConfig
+from relay_teams.providers.model_fallback import (
+    DisabledLlmFallbackMiddleware,
+    LlmFallbackMiddleware,
+)
 from relay_teams.providers.openai_model_profiles import (
     resolve_openai_chat_model_profile,
 )
@@ -83,13 +90,43 @@ class SubagentReflectionService:
         retry_config: LlmRetryConfig,
         message_repo: MessageRepository,
         role_memory_service: RoleMemoryService,
+        fallback_middleware: LlmFallbackMiddleware
+        | DisabledLlmFallbackMiddleware
+        | None = None,
         strategy: SubagentCompactionStrategy | None = None,
+        profile_name: str | None = None,
     ) -> None:
         self._config = config
+        self._profile_name = (
+            profile_name.strip()
+            if profile_name is not None and profile_name.strip()
+            else None
+        )
         self._retry_config = retry_config
         self._message_repo = message_repo
         self._role_memory_service = role_memory_service
+        self._fallback_middleware = (
+            fallback_middleware
+            if fallback_middleware is not None
+            else DisabledLlmFallbackMiddleware()
+        )
         self._strategy = strategy or DefaultSubagentCompactionStrategy()
+
+    def with_config(
+        self,
+        config: ModelEndpointConfig,
+        *,
+        profile_name: str | None = None,
+    ) -> "SubagentReflectionService":
+        return SubagentReflectionService(
+            config=config,
+            profile_name=self._profile_name if profile_name is None else profile_name,
+            retry_config=self._retry_config,
+            message_repo=self._message_repo,
+            role_memory_service=self._role_memory_service,
+            fallback_middleware=self._fallback_middleware,
+            strategy=self._strategy,
+        )
 
     async def maybe_compact(
         self,
@@ -189,6 +226,8 @@ class SubagentReflectionService:
         workspace_id: str,
         source_history: Sequence[ModelRequest | ModelResponse],
         source_char_budget: int,
+        fallback_hop: int = 0,
+        visited_profiles: tuple[str, ...] | None = None,
     ) -> str:
         existing_summary = self._role_memory_service.build_injected_memory(
             role_id=role.role_id,
@@ -216,15 +255,50 @@ class SubagentReflectionService:
             f"Existing reflection memory:\n{existing_summary or '(empty)'}\n\n"
             f"Transcript to absorb:\n{transcript}"
         )
-        result = await run_with_llm_retry(
-            operation=lambda: self._run_streaming_reflection(
-                agent=agent, prompt=prompt
-            ),
-            config=self._retry_config,
-            is_retry_allowed=lambda: True,
-            on_retry_scheduled=lambda _schedule: None,
-        )
-        return result.strip()
+        try:
+            result = await run_with_llm_retry(
+                operation=lambda: self._run_streaming_reflection(
+                    agent=agent, prompt=prompt
+                ),
+                config=self._retry_config,
+                is_retry_allowed=lambda: True,
+                on_retry_scheduled=lambda _schedule: None,
+            )
+            return result.strip()
+        except Exception as exc:
+            retry_error = extract_retry_error_info(exc)
+            if (
+                retry_error is None
+                or not retry_error.rate_limited
+                or self._profile_name is None
+                or not self._fallback_middleware.has_enabled_policy(self._config)
+            ):
+                raise
+            resolved_visited_profiles = visited_profiles or (
+                (self._profile_name,) if self._profile_name is not None else ()
+            )
+            decision = self._fallback_middleware.select_fallback(
+                current_profile_name=self._profile_name,
+                current_config=self._config,
+                error=retry_error,
+                visited_profiles=resolved_visited_profiles,
+                hop=fallback_hop,
+            )
+            if decision is None:
+                raise
+            next_service = self.with_config(
+                decision.target_config,
+                profile_name=decision.to_profile_name,
+            )
+            return await next_service._rewrite_reflection_summary(
+                role=role,
+                workspace_id=workspace_id,
+                source_history=source_history,
+                source_char_budget=source_char_budget,
+                fallback_hop=decision.hop,
+                visited_profiles=resolved_visited_profiles
+                + (decision.to_profile_name,),
+            )
 
     async def _run_streaming_reflection(
         self,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -100,6 +100,9 @@ from relay_teams.providers.provider_contracts import LLMProvider, LLMRequest
 from relay_teams.providers.model_config_manager import ModelConfigManager
 from relay_teams.providers.model_config_service import ModelConfigService
 from relay_teams.providers.model_config import ModelEndpointConfig
+from relay_teams.providers.model_fallback_config_manager import (
+    ModelFallbackConfigManager,
+)
 from relay_teams.net.llm_client import clear_llm_http_client_cache
 from relay_teams.providers.provider_factory import (
     apply_default_model_profile_override,
@@ -215,6 +218,9 @@ class ServerContainer:
         self._session_model_profile_lookup = session_model_profile_lookup
 
         self.model_config_manager: ModelConfigManager = ModelConfigManager(
+            config_dir=app_config_dir
+        )
+        self.model_fallback_config_manager = ModelFallbackConfigManager(
             config_dir=app_config_dir
         )
         self.notification_config_manager: NotificationConfigManager = (
@@ -771,6 +777,7 @@ class ServerContainer:
             roles_dir=self.runtime.paths.roles_dir,
             db_path=self.runtime.paths.db_path,
             model_config_manager=self.model_config_manager,
+            model_fallback_config_manager=self.model_fallback_config_manager,
             get_runtime=lambda: self.runtime,
             on_runtime_reloaded=self._on_runtime_reloaded,
         )
@@ -893,6 +900,13 @@ class ServerContainer:
             return profile
         return None
 
+    def _resolve_reflection_model_profile_name(self) -> str | None:
+        if self.runtime.default_model_profile is not None:
+            return self.runtime.default_model_profile
+        for profile_name in self.runtime.llm_profiles.keys():
+            return profile_name
+        return None
+
     def _resolve_external_agent_model_config(
         self,
         role: RoleDefinition,
@@ -921,6 +935,7 @@ class ServerContainer:
             return None
         return SubagentReflectionService(
             config=reflection_config,
+            profile_name=self._resolve_reflection_model_profile_name(),
             retry_config=self.runtime.llm_retry,
             message_repo=self.message_repo,
             role_memory_service=self.role_memory_service,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -103,6 +103,7 @@ from relay_teams.providers.model_config import ModelEndpointConfig
 from relay_teams.providers.model_fallback_config_manager import (
     ModelFallbackConfigManager,
 )
+from relay_teams.providers.model_fallback import LlmFallbackMiddleware
 from relay_teams.net.llm_client import clear_llm_http_client_cache
 from relay_teams.providers.provider_factory import (
     apply_default_model_profile_override,
@@ -939,6 +940,10 @@ class ServerContainer:
             retry_config=self.runtime.llm_retry,
             message_repo=self.message_repo,
             role_memory_service=self.role_memory_service,
+            fallback_middleware=LlmFallbackMiddleware(
+                get_fallback_config=lambda: self.runtime.model_fallback,
+                get_profiles=lambda: self.runtime.llm_profiles,
+            ),
         )
 
     async def start(self) -> None:

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -247,10 +247,12 @@ def save_model_profile(
             "temperature": req.temperature,
             "top_p": req.top_p,
             "context_window": req.context_window,
-            "fallback_policy_id": req.fallback_policy_id,
-            "fallback_priority": req.fallback_priority,
             "connect_timeout_seconds": req.connect_timeout_seconds,
         }
+        if "fallback_policy_id" in req.model_fields_set:
+            profile["fallback_policy_id"] = req.fallback_policy_id
+        if "fallback_priority" in req.model_fields_set:
+            profile["fallback_priority"] = req.fallback_priority
         if "max_tokens" in req.model_fields_set:
             profile["max_tokens"] = req.max_tokens
         if req.is_default is not None:

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -89,6 +89,7 @@ from relay_teams.notifications.notification_settings_service import (
 from relay_teams.providers.model_config import (
     DEFAULT_MAAS_BASE_URL,
     ModelConfigPayload,
+    ModelFallbackConfig,
     ModelProfileConfigPayload,
     ProviderType,
 )
@@ -122,6 +123,12 @@ class ModelConfigRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     config: ModelConfigPayload
+
+
+class ModelFallbackConfigRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    config: ModelFallbackConfig
 
 
 class OrchestrationConfigRequest(BaseModel):
@@ -209,6 +216,13 @@ def get_model_profiles(
     return service.get_model_profiles()
 
 
+@router.get("/configs/model-fallback")
+def get_model_fallback_config(
+    service: ModelConfigService = Depends(get_model_config_service),
+) -> ModelFallbackConfig:
+    return service.get_model_fallback_config()
+
+
 class ModelProfileRequest(ModelProfileConfigPayload):
     model_config = ConfigDict(extra="forbid")
 
@@ -233,6 +247,8 @@ def save_model_profile(
             "temperature": req.temperature,
             "top_p": req.top_p,
             "context_window": req.context_window,
+            "fallback_policy_id": req.fallback_policy_id,
+            "fallback_priority": req.fallback_priority,
             "connect_timeout_seconds": req.connect_timeout_seconds,
         }
         if "max_tokens" in req.model_fields_set:
@@ -294,6 +310,19 @@ def save_model_config(
     try:
         config = req.config if isinstance(req, ModelConfigRequest) else req
         service.save_model_config(config)
+        return {"status": "ok"}
+    except Exception as exc:
+        _raise_system_http_error(exc, value_error_status=400)
+
+
+@router.put("/configs/model-fallback")
+def save_model_fallback_config(
+    req: ModelFallbackConfig | ModelFallbackConfigRequest,
+    service: ModelConfigService = Depends(get_model_config_service),
+) -> dict[str, str]:
+    try:
+        config = req.config if isinstance(req, ModelFallbackConfigRequest) else req
+        service.save_model_fallback_config(config)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(exc, value_error_status=400)

--- a/src/relay_teams/providers/__init__.py
+++ b/src/relay_teams/providers/__init__.py
@@ -11,11 +11,16 @@ if TYPE_CHECKING:
         MaaSAuthConfig,
         ModelConfigPayload,
         ModelEndpointConfig,
+        ModelFallbackConfig,
+        ModelFallbackPolicy,
+        ModelFallbackStrategy,
+        ModelFallbackTrigger,
         ModelProfileConfigPayload,
         ModelRequestHeader,
         ProviderModelInfo,
         ProviderType,
         SamplingConfig,
+        default_model_fallback_config,
     )
     from relay_teams.providers.llm_retry import (
         LlmRetryErrorInfo,
@@ -27,6 +32,16 @@ if TYPE_CHECKING:
     from relay_teams.providers.openai_compatible import OpenAICompatibleProvider
     from relay_teams.providers.model_config_manager import ModelConfigManager
     from relay_teams.providers.model_config_service import ModelConfigService
+    from relay_teams.providers.model_fallback import (
+        DisabledLlmFallbackMiddleware,
+        LlmFallbackDecision,
+        LlmFallbackMiddleware,
+        ProfileCooldownRecord,
+        ProfileCooldownRegistry,
+    )
+    from relay_teams.providers.model_fallback_config_manager import (
+        ModelFallbackConfigManager,
+    )
     from relay_teams.providers.model_connectivity import (
         ModelDiscoveryEntry,
         ModelConnectivityDiagnostics,
@@ -60,8 +75,15 @@ __all__ = [
     "LlmRetryConfig",
     "MaaSAuthConfig",
     "ModelConfigPayload",
+    "ModelFallbackConfig",
+    "ModelFallbackConfigManager",
+    "ModelFallbackPolicy",
+    "ModelFallbackStrategy",
+    "ModelFallbackTrigger",
     "LlmRetryErrorInfo",
     "LlmRetrySchedule",
+    "LlmFallbackDecision",
+    "LlmFallbackMiddleware",
     "ModelEndpointConfig",
     "ModelProfileConfigPayload",
     "ModelRequestHeader",
@@ -77,6 +99,8 @@ __all__ = [
     "ModelConnectivityTokenUsage",
     "OpenAICompatibleProvider",
     "ProviderModelInfo",
+    "ProfileCooldownRecord",
+    "ProfileCooldownRegistry",
     "ProviderRegistry",
     "ProviderType",
     "RunTokenUsage",
@@ -86,6 +110,8 @@ __all__ = [
     "TokenUsageRepository",
     "compute_retry_delay_ms",
     "create_default_provider_registry",
+    "default_model_fallback_config",
+    "DisabledLlmFallbackMiddleware",
     "extract_retry_error_info",
     "infer_known_context_window",
     "list_provider_models",
@@ -102,11 +128,35 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LlmRetryConfig": ("relay_teams.providers.model_config", "LlmRetryConfig"),
     "MaaSAuthConfig": ("relay_teams.providers.model_config", "MaaSAuthConfig"),
     "ModelConfigPayload": ("relay_teams.providers.model_config", "ModelConfigPayload"),
+    "ModelFallbackConfig": (
+        "relay_teams.providers.model_config",
+        "ModelFallbackConfig",
+    ),
+    "ModelFallbackPolicy": (
+        "relay_teams.providers.model_config",
+        "ModelFallbackPolicy",
+    ),
+    "ModelFallbackStrategy": (
+        "relay_teams.providers.model_config",
+        "ModelFallbackStrategy",
+    ),
+    "ModelFallbackTrigger": (
+        "relay_teams.providers.model_config",
+        "ModelFallbackTrigger",
+    ),
     "LlmRetryErrorInfo": (
         "relay_teams.providers.llm_retry",
         "LlmRetryErrorInfo",
     ),
     "LlmRetrySchedule": ("relay_teams.providers.llm_retry", "LlmRetrySchedule"),
+    "LlmFallbackDecision": (
+        "relay_teams.providers.model_fallback",
+        "LlmFallbackDecision",
+    ),
+    "LlmFallbackMiddleware": (
+        "relay_teams.providers.model_fallback",
+        "LlmFallbackMiddleware",
+    ),
     "ModelEndpointConfig": (
         "relay_teams.providers.model_config",
         "ModelEndpointConfig",
@@ -122,6 +172,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ModelConfigManager": (
         "relay_teams.providers.model_config_manager",
         "ModelConfigManager",
+    ),
+    "ModelFallbackConfigManager": (
+        "relay_teams.providers.model_fallback_config_manager",
+        "ModelFallbackConfigManager",
     ),
     "ModelConfigService": (
         "relay_teams.providers.model_config_service",
@@ -167,6 +221,14 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
         "relay_teams.providers.model_config",
         "ProviderModelInfo",
     ),
+    "ProfileCooldownRecord": (
+        "relay_teams.providers.model_fallback",
+        "ProfileCooldownRecord",
+    ),
+    "ProfileCooldownRegistry": (
+        "relay_teams.providers.model_fallback",
+        "ProfileCooldownRegistry",
+    ),
     "ProviderRegistry": ("relay_teams.providers.provider_registry", "ProviderRegistry"),
     "ProviderType": ("relay_teams.providers.model_config", "ProviderType"),
     "RunTokenUsage": (
@@ -193,6 +255,14 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "create_default_provider_registry": (
         "relay_teams.providers.provider_registry",
         "create_default_provider_registry",
+    ),
+    "default_model_fallback_config": (
+        "relay_teams.providers.model_config",
+        "default_model_fallback_config",
+    ),
+    "DisabledLlmFallbackMiddleware": (
+        "relay_teams.providers.model_fallback",
+        "DisabledLlmFallbackMiddleware",
     ),
     "extract_retry_error_info": (
         "relay_teams.providers.llm_retry",

--- a/src/relay_teams/providers/llm_retry.py
+++ b/src/relay_teams/providers/llm_retry.py
@@ -36,6 +36,7 @@ class LlmRetryErrorInfo(BaseModel):
     error_type: str | None = None
     retry_after_ms: int | None = Field(default=None, ge=0)
     retryable: bool = False
+    rate_limited: bool = False
     transport_error: bool = False
     timeout_error: bool = False
 
@@ -156,6 +157,12 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
             status_code=exc.status_code,
             error_code=_status_code_error_code(exc.status_code),
             retryable=retryable,
+            rate_limited=_is_rate_limited_error(
+                status_code=exc.status_code,
+                error_code=_status_code_error_code(exc.status_code),
+                error_type=None,
+                message=str(exc),
+            ),
         )
     if isinstance(exc, ModelAPIError):
         parsed = _parse_message_metadata(str(exc))
@@ -166,12 +173,19 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
             status_code=parsed.status_code,
             error_code=parsed.error_code,
             retryable=_is_retryable_status_code(parsed.status_code),
+            rate_limited=_is_rate_limited_error(
+                status_code=parsed.status_code,
+                error_code=parsed.error_code,
+                error_type=None,
+                message=str(exc),
+            ),
         )
     if isinstance(exc, httpx.TimeoutException):
         return LlmRetryErrorInfo(
             message=str(exc) or "Connection timed out.",
             error_code="network_timeout",
             retryable=True,
+            rate_limited=False,
             transport_error=True,
             timeout_error=True,
         )
@@ -180,6 +194,7 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
             message=str(exc) or "Stream transport was interrupted.",
             error_code="network_stream_interrupted",
             retryable=True,
+            rate_limited=False,
             transport_error=True,
         )
     if isinstance(exc, httpx.RequestError):
@@ -187,6 +202,7 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
             message=str(exc) or "Network request failed.",
             error_code="network_error",
             retryable=True,
+            rate_limited=False,
             transport_error=True,
         )
 
@@ -195,6 +211,7 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
             message=str(exc) or "Connection timed out.",
             error_code="network_timeout",
             retryable=True,
+            rate_limited=False,
             transport_error=True,
             timeout_error=True,
         )
@@ -203,6 +220,7 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
             message=str(exc) or "Network request failed.",
             error_code="network_error",
             retryable=True,
+            rate_limited=False,
             transport_error=True,
         )
     if APIStatusError is not None and isinstance(exc, APIStatusError):
@@ -225,6 +243,13 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
                 if retry_override is not None
                 else _is_retryable_status_code(status_code)
             ),
+            rate_limited=_is_rate_limited_error(
+                status_code=status_code,
+                error_code=error_payload.error_code
+                or _status_code_error_code(status_code),
+                error_type=error_payload.error_type,
+                message=error_payload.message or str(exc),
+            ),
         )
     if APIError is not None and isinstance(exc, APIError):
         body = getattr(exc, "body", None)
@@ -244,6 +269,14 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
                 if retry_override is not None
                 else _is_retryable_status_code(status_code)
             ),
+            rate_limited=_is_rate_limited_error(
+                status_code=status_code,
+                error_code=error_payload.error_code
+                or _optional_str(getattr(exc, "code", None))
+                or (fallback.error_code if fallback is not None else None),
+                error_type=error_payload.error_type,
+                message=error_payload.message or str(exc),
+            ),
         )
 
     return None
@@ -258,6 +291,7 @@ def _extract_invalid_json_error_info(
         message=str(exc),
         error_code="model_tool_args_invalid_json",
         retryable=False,
+        rate_limited=False,
         transport_error=False,
         timeout_error=False,
     )
@@ -365,6 +399,43 @@ def _explicit_retry_override(headers: object) -> bool | None:
     if lowered == "false":
         return False
     return None
+
+
+def _is_rate_limited_error(
+    *,
+    status_code: int | None,
+    error_code: str | None,
+    error_type: str | None,
+    message: str,
+) -> bool:
+    if status_code == 429:
+        return True
+    normalized_code = (error_code or "").strip().casefold()
+    normalized_type = (error_type or "").strip().casefold()
+    normalized_message = message.strip().casefold()
+    if normalized_code in {
+        "rate_limited",
+        "rate_limit_exceeded",
+        "insufficient_quota",
+        "quota_exceeded",
+    }:
+        return True
+    if normalized_type in {
+        "rate_limit_error",
+        "insufficient_quota",
+        "quota_exceeded",
+    }:
+        return True
+    return any(
+        hint in normalized_message
+        for hint in (
+            "rate limit",
+            "rate-limit",
+            "too many requests",
+            "insufficient quota",
+            "quota exceeded",
+        )
+    )
 
 
 def _parse_retry_after_ms(raw_value: str | None) -> int | None:

--- a/src/relay_teams/providers/model_config.py
+++ b/src/relay_teams/providers/model_config.py
@@ -29,6 +29,15 @@ class ProviderType(StrEnum):
     ECHO = "echo"
 
 
+class ModelFallbackTrigger(StrEnum):
+    RATE_LIMIT_AFTER_RETRIES = "rate_limit_after_retries"
+
+
+class ModelFallbackStrategy(StrEnum):
+    SAME_PROVIDER_THEN_OTHER_PROVIDER = "same_provider_then_other_provider"
+    OTHER_PROVIDER_ONLY = "other_provider_only"
+
+
 DEFAULT_MAAS_LOGIN_URL = (
     "http://rnd-idea-api.huawei.com/ideaclientservice/login/v4/secureLogin"
 )
@@ -112,6 +121,8 @@ class ModelEndpointConfig(BaseModel):
     maas_auth: MaaSAuthConfig | None = None
     ssl_verify: bool | None = None
     context_window: int | None = Field(default=None, ge=1)
+    fallback_policy_id: str | None = Field(default=None, min_length=1)
+    fallback_priority: int = Field(default=0, ge=0, le=1_000_000)
     connect_timeout_seconds: float = Field(
         default=DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
         gt=0.0,
@@ -180,6 +191,8 @@ class ModelProfileConfigPayload(BaseModel):
     top_p: float = Field(default=1.0, ge=0.0, le=1.0)
     max_tokens: int | None = Field(default=None, ge=1)
     context_window: int | None = Field(default=None, ge=1)
+    fallback_policy_id: str | None = Field(default=None, min_length=1)
+    fallback_priority: int = Field(default=0, ge=0, le=1_000_000)
     connect_timeout_seconds: float = Field(
         default=DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
         gt=0.0,
@@ -226,3 +239,74 @@ class LlmRetryConfig(BaseModel):
         le=10.0,
     )
     jitter: bool = False
+
+
+class ModelFallbackPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    policy_id: RequiredIdentifierStr
+    name: str = Field(min_length=1)
+    description: str = ""
+    enabled: bool = True
+    trigger: ModelFallbackTrigger = ModelFallbackTrigger.RATE_LIMIT_AFTER_RETRIES
+    strategy: ModelFallbackStrategy
+    max_hops: int = Field(default=3, ge=1, le=10)
+    cooldown_seconds: int = Field(default=60, ge=0, le=3600)
+
+
+class ModelFallbackConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    policies: tuple[ModelFallbackPolicy, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_unique_policy_ids(self) -> "ModelFallbackConfig":
+        seen_ids: set[str] = set()
+        for policy in self.policies:
+            normalized_id = policy.policy_id.casefold()
+            if normalized_id in seen_ids:
+                raise ValueError(
+                    f"Duplicate model fallback policy id: {policy.policy_id}"
+                )
+            seen_ids.add(normalized_id)
+        return self
+
+    def get_policy(self, policy_id: str | None) -> ModelFallbackPolicy | None:
+        if policy_id is None:
+            return None
+        normalized_id = policy_id.strip().casefold()
+        if not normalized_id:
+            return None
+        for policy in self.policies:
+            if policy.policy_id.casefold() == normalized_id:
+                return policy
+        return None
+
+
+def default_model_fallback_config() -> ModelFallbackConfig:
+    return ModelFallbackConfig(
+        policies=(
+            ModelFallbackPolicy(
+                policy_id="same_provider_then_other_provider",
+                name="Same Provider Then Other Provider",
+                description=(
+                    "Retry the same provider with higher-priority fallback profiles "
+                    "before switching to other providers."
+                ),
+                strategy=(ModelFallbackStrategy.SAME_PROVIDER_THEN_OTHER_PROVIDER),
+                max_hops=3,
+                cooldown_seconds=60,
+            ),
+            ModelFallbackPolicy(
+                policy_id="other_provider_only",
+                name="Other Provider Only",
+                description=(
+                    "Skip same-provider alternatives and fail over directly to "
+                    "profiles from other providers."
+                ),
+                strategy=ModelFallbackStrategy.OTHER_PROVIDER_ONLY,
+                max_hops=3,
+                cooldown_seconds=60,
+            ),
+        )
+    )

--- a/src/relay_teams/providers/model_config_manager.py
+++ b/src/relay_teams/providers/model_config_manager.py
@@ -832,10 +832,21 @@ def _prepare_profile_api_key_for_storage(
     current_secret: str | None,
 ) -> tuple[dict[str, JsonValue], str | None, bool]:
     merged_profile = dict(next_profile)
-    if isinstance(existing_profile, dict) and "is_default" not in merged_profile:
-        existing_is_default = existing_profile.get("is_default")
-        if isinstance(existing_is_default, bool):
-            merged_profile["is_default"] = existing_is_default
+    if isinstance(existing_profile, dict):
+        if "is_default" not in merged_profile:
+            existing_is_default = existing_profile.get("is_default")
+            if isinstance(existing_is_default, bool):
+                merged_profile["is_default"] = existing_is_default
+        if "fallback_policy_id" not in merged_profile:
+            existing_fallback_policy_id = existing_profile.get("fallback_policy_id")
+            if isinstance(existing_fallback_policy_id, str):
+                merged_profile["fallback_policy_id"] = existing_fallback_policy_id
+        if "fallback_priority" not in merged_profile:
+            existing_fallback_priority = existing_profile.get("fallback_priority")
+            if isinstance(existing_fallback_priority, int) and not isinstance(
+                existing_fallback_priority, bool
+            ):
+                merged_profile["fallback_priority"] = existing_fallback_priority
     next_api_key = merged_profile.get("api_key")
     if isinstance(next_api_key, str) and next_api_key.strip():
         normalized_api_key = next_api_key.strip()

--- a/src/relay_teams/providers/model_config_manager.py
+++ b/src/relay_teams/providers/model_config_manager.py
@@ -83,6 +83,8 @@ class ModelConfigManager:
                 "top_p": normalized_profile.get("top_p", 1.0),
                 "max_tokens": normalized_profile.get("max_tokens"),
                 "context_window": normalized_profile.get("context_window"),
+                "fallback_policy_id": normalized_profile.get("fallback_policy_id"),
+                "fallback_priority": normalized_profile.get("fallback_priority", 0),
                 "is_default": name == default_profile_name,
                 "connect_timeout_seconds": normalized_profile.get(
                     "connect_timeout_seconds",

--- a/src/relay_teams/providers/model_config_service.py
+++ b/src/relay_teams/providers/model_config_service.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from relay_teams.providers.model_config import (
     ModelConfigPayload,
+    ModelFallbackConfig,
     ProviderModelInfo,
     ProviderType,
 )
@@ -19,6 +20,9 @@ from relay_teams.providers.model_connectivity import (
     ModelDiscoveryResult,
 )
 from relay_teams.providers.model_config_manager import ModelConfigManager
+from relay_teams.providers.model_fallback_config_manager import (
+    ModelFallbackConfigManager,
+)
 from relay_teams.providers.provider_registry import list_provider_models
 from relay_teams.sessions.runs.runtime_config import RuntimeConfig, load_runtime_config
 
@@ -31,6 +35,7 @@ class ModelConfigService:
         roles_dir: Path,
         db_path: Path,
         model_config_manager: ModelConfigManager,
+        model_fallback_config_manager: ModelFallbackConfigManager,
         get_runtime: Callable[[], RuntimeConfig],
         on_runtime_reloaded: Callable[[RuntimeConfig], None],
     ) -> None:
@@ -38,6 +43,7 @@ class ModelConfigService:
         self._roles_dir: Path = roles_dir
         self._db_path: Path = db_path
         self._model_config_manager: ModelConfigManager = model_config_manager
+        self._model_fallback_config_manager = model_fallback_config_manager
         self._get_runtime: Callable[[], RuntimeConfig] = get_runtime
         self._on_runtime_reloaded: Callable[[RuntimeConfig], None] = on_runtime_reloaded
         self._model_connectivity_probe_service = ModelConnectivityProbeService(
@@ -54,6 +60,9 @@ class ModelConfigService:
     def get_model_profiles(self) -> dict[str, dict[str, JsonValue]]:
         return self._model_config_manager.get_model_profiles()
 
+    def get_model_fallback_config(self) -> ModelFallbackConfig:
+        return self._model_fallback_config_manager.get_model_fallback_config()
+
     def get_provider_models(
         self,
         *,
@@ -68,6 +77,7 @@ class ModelConfigService:
         *,
         source_name: str | None = None,
     ) -> None:
+        self._validate_profile_fallback_policy(profile)
         self._model_config_manager.save_model_profile(
             name,
             profile,
@@ -80,9 +90,15 @@ class ModelConfigService:
         self.reload_model_config()
 
     def save_model_config(self, config: ModelConfigPayload) -> None:
-        self._model_config_manager.save_model_config(
-            config.model_dump(mode="json", exclude_unset=True)
-        )
+        normalized_config = config.model_dump(mode="json", exclude_unset=True)
+        for profile in normalized_config.values():
+            if isinstance(profile, dict):
+                self._validate_profile_fallback_policy(profile)
+        self._model_config_manager.save_model_config(normalized_config)
+        self.reload_model_config()
+
+    def save_model_fallback_config(self, config: ModelFallbackConfig) -> None:
+        self._model_fallback_config_manager.save_model_fallback_config(config)
         self.reload_model_config()
 
     def probe_connectivity(
@@ -104,3 +120,16 @@ class ModelConfigService:
             db_path=self._db_path,
         )
         self._on_runtime_reloaded(runtime)
+
+    def _validate_profile_fallback_policy(
+        self,
+        profile: dict[str, JsonValue],
+    ) -> None:
+        raw_policy_id = profile.get("fallback_policy_id")
+        if raw_policy_id is None:
+            return
+        if not isinstance(raw_policy_id, str) or not raw_policy_id.strip():
+            raise ValueError("fallback_policy_id must be a non-empty string.")
+        fallback_config = self.get_model_fallback_config()
+        if fallback_config.get_policy(raw_policy_id) is None:
+            raise ValueError(f"Unknown fallback policy: {raw_policy_id}")

--- a/src/relay_teams/providers/model_fallback.py
+++ b/src/relay_teams/providers/model_fallback.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from datetime import datetime, timedelta, timezone
+import logging
+from threading import Lock
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.providers.llm_retry import LlmRetryErrorInfo
+from relay_teams.providers.model_config import (
+    ModelEndpointConfig,
+    ModelFallbackConfig,
+    ModelFallbackPolicy,
+    ModelFallbackStrategy,
+    ProviderType,
+)
+
+LOGGER = get_logger(__name__)
+
+
+class ProfileCooldownRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    profile_name: str = Field(min_length=1)
+    cooldown_until: datetime
+    reason: str = ""
+
+
+class LlmFallbackDecision(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        arbitrary_types_allowed=True,
+    )
+
+    policy_id: str = Field(min_length=1)
+    from_profile_name: str = Field(min_length=1)
+    to_profile_name: str = Field(min_length=1)
+    from_provider: ProviderType
+    to_provider: ProviderType
+    from_model: str = Field(min_length=1)
+    to_model: str = Field(min_length=1)
+    hop: int = Field(ge=1)
+    reason: str = ""
+    cooldown_until: datetime
+    target_config: ModelEndpointConfig
+
+
+class DisabledLlmFallbackMiddleware:
+    def has_enabled_policy(self, config: ModelEndpointConfig) -> bool:
+        _ = config
+        return False
+
+    def select_fallback(
+        self,
+        *,
+        current_profile_name: str | None,
+        current_config: ModelEndpointConfig,
+        error: LlmRetryErrorInfo,
+        visited_profiles: Sequence[str],
+        hop: int,
+    ) -> LlmFallbackDecision | None:
+        _ = (
+            current_profile_name,
+            current_config,
+            error,
+            visited_profiles,
+            hop,
+        )
+        return None
+
+
+class ProfileCooldownRegistry:
+    def __init__(self) -> None:
+        self._records: dict[str, ProfileCooldownRecord] = {}
+        self._lock = Lock()
+
+    def get(self, profile_name: str) -> ProfileCooldownRecord | None:
+        normalized_name = profile_name.strip()
+        if not normalized_name:
+            return None
+        now = datetime.now(tz=timezone.utc)
+        with self._lock:
+            record = self._records.get(normalized_name)
+            if record is None:
+                return None
+            if record.cooldown_until <= now:
+                self._records.pop(normalized_name, None)
+                return None
+            return record
+
+    def is_cooling(self, profile_name: str) -> bool:
+        return self.get(profile_name) is not None
+
+    def set_cooldown(
+        self,
+        *,
+        profile_name: str,
+        delay_ms: int,
+        reason: str,
+    ) -> ProfileCooldownRecord:
+        normalized_name = profile_name.strip()
+        cooldown_until = datetime.now(tz=timezone.utc) + timedelta(
+            milliseconds=max(0, delay_ms)
+        )
+        record = ProfileCooldownRecord(
+            profile_name=normalized_name,
+            cooldown_until=cooldown_until,
+            reason=reason,
+        )
+        with self._lock:
+            self._records[normalized_name] = record
+        return record
+
+
+class LlmFallbackMiddleware:
+    def __init__(
+        self,
+        *,
+        get_fallback_config: Callable[[], ModelFallbackConfig],
+        get_profiles: Callable[[], dict[str, ModelEndpointConfig]],
+        cooldown_registry: ProfileCooldownRegistry | None = None,
+    ) -> None:
+        self._get_fallback_config = get_fallback_config
+        self._get_profiles = get_profiles
+        self._cooldown_registry = cooldown_registry or ProfileCooldownRegistry()
+
+    def has_enabled_policy(self, config: ModelEndpointConfig) -> bool:
+        policy = self._get_fallback_config().get_policy(config.fallback_policy_id)
+        return policy is not None and policy.enabled
+
+    def select_fallback(
+        self,
+        *,
+        current_profile_name: str | None,
+        current_config: ModelEndpointConfig,
+        error: LlmRetryErrorInfo,
+        visited_profiles: Sequence[str],
+        hop: int,
+    ) -> LlmFallbackDecision | None:
+        if current_profile_name is None:
+            return None
+        normalized_current_profile = current_profile_name.strip()
+        if not normalized_current_profile:
+            return None
+        if not error.rate_limited:
+            return None
+        fallback_config = self._get_fallback_config()
+        policy = fallback_config.get_policy(current_config.fallback_policy_id)
+        if policy is None or not policy.enabled:
+            return None
+        if hop >= policy.max_hops:
+            return None
+        cooldown_record = self._cooldown_registry.set_cooldown(
+            profile_name=normalized_current_profile,
+            delay_ms=_resolve_cooldown_ms(error=error, policy=policy),
+            reason=error.error_code or error.error_type or "rate_limited",
+        )
+        candidate = self._select_candidate(
+            current_profile_name=normalized_current_profile,
+            current_config=current_config,
+            policy=policy,
+            visited_profiles=visited_profiles,
+        )
+        if candidate is None:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="llm.fallback.no_candidate",
+                message="No fallback candidate available after LLM rate limit.",
+                payload={
+                    "profile_name": normalized_current_profile,
+                    "policy_id": policy.policy_id,
+                    "provider": current_config.provider,
+                    "model": current_config.model,
+                    "visited_profiles": list(visited_profiles),
+                    "cooldown_until": cooldown_record.cooldown_until.isoformat(),
+                },
+            )
+            return None
+        target_profile_name, target_config = candidate
+        return LlmFallbackDecision(
+            policy_id=policy.policy_id,
+            from_profile_name=normalized_current_profile,
+            to_profile_name=target_profile_name,
+            from_provider=current_config.provider,
+            to_provider=target_config.provider,
+            from_model=current_config.model,
+            to_model=target_config.model,
+            hop=hop + 1,
+            reason=error.error_code or error.error_type or "rate_limited",
+            cooldown_until=cooldown_record.cooldown_until,
+            target_config=target_config,
+        )
+
+    def _select_candidate(
+        self,
+        *,
+        current_profile_name: str,
+        current_config: ModelEndpointConfig,
+        policy: ModelFallbackPolicy,
+        visited_profiles: Sequence[str],
+    ) -> tuple[str, ModelEndpointConfig] | None:
+        visited = {
+            profile_name.strip() for profile_name in visited_profiles if profile_name
+        }
+        current_provider = current_config.provider
+        same_provider_candidates: list[tuple[str, ModelEndpointConfig]] = []
+        other_provider_candidates: list[tuple[str, ModelEndpointConfig]] = []
+        for profile_name, profile_config in self._get_profiles().items():
+            if profile_name == current_profile_name:
+                continue
+            if profile_name in visited:
+                continue
+            if profile_config.provider == ProviderType.ECHO:
+                continue
+            if profile_config.fallback_priority <= 0:
+                continue
+            if self._cooldown_registry.is_cooling(profile_name):
+                continue
+            candidate = (profile_name, profile_config)
+            if profile_config.provider == current_provider:
+                same_provider_candidates.append(candidate)
+            else:
+                other_provider_candidates.append(candidate)
+        same_provider_candidates.sort(key=_sort_candidates)
+        other_provider_candidates.sort(key=_sort_candidates)
+        ordered_candidates = _merge_candidates_by_policy(
+            policy=policy,
+            same_provider_candidates=same_provider_candidates,
+            other_provider_candidates=other_provider_candidates,
+        )
+        if not ordered_candidates:
+            return None
+        return ordered_candidates[0]
+
+
+def _sort_candidates(candidate: tuple[str, ModelEndpointConfig]) -> tuple[int, str]:
+    profile_name, config = candidate
+    return (-config.fallback_priority, profile_name.casefold())
+
+
+def _merge_candidates_by_policy(
+    *,
+    policy: ModelFallbackPolicy,
+    same_provider_candidates: Sequence[tuple[str, ModelEndpointConfig]],
+    other_provider_candidates: Sequence[tuple[str, ModelEndpointConfig]],
+) -> tuple[tuple[str, ModelEndpointConfig], ...]:
+    if policy.strategy == ModelFallbackStrategy.OTHER_PROVIDER_ONLY:
+        return tuple(other_provider_candidates)
+    return tuple(same_provider_candidates) + tuple(other_provider_candidates)
+
+
+def _resolve_cooldown_ms(
+    *,
+    error: LlmRetryErrorInfo,
+    policy: ModelFallbackPolicy,
+) -> int:
+    if error.retry_after_ms is not None:
+        return error.retry_after_ms
+    return policy.cooldown_seconds * 1000

--- a/src/relay_teams/providers/model_fallback_config_manager.py
+++ b/src/relay_teams/providers/model_fallback_config_manager.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from json import dumps, loads
+from pathlib import Path
+from typing import cast
+
+from pydantic import JsonValue
+
+from relay_teams.providers.model_config import (
+    ModelFallbackConfig,
+    default_model_fallback_config,
+)
+
+
+class ModelFallbackConfigManager:
+    def __init__(self, *, config_dir: Path) -> None:
+        self._config_dir: Path = config_dir
+
+    def get_model_fallback_config(self) -> ModelFallbackConfig:
+        fallback_file = self._config_dir / "model-fallback.json"
+        if not fallback_file.exists():
+            return default_model_fallback_config()
+        try:
+            payload = _load_json_object(fallback_file)
+            return ModelFallbackConfig.model_validate(payload)
+        except Exception:
+            return default_model_fallback_config()
+
+    def save_model_fallback_config(self, config: ModelFallbackConfig) -> None:
+        fallback_file = self._config_dir / "model-fallback.json"
+        _ = fallback_file.write_text(
+            dumps(config.model_dump(mode="json"), indent=2),
+            encoding="utf-8",
+        )
+
+
+def _load_json_object(file_path: Path) -> dict[str, JsonValue]:
+    raw = cast(object, loads(file_path.read_text("utf-8")))
+    if isinstance(raw, dict):
+        return cast(dict[str, JsonValue], raw)
+    return {}

--- a/src/relay_teams/providers/openai_compatible.py
+++ b/src/relay_teams/providers/openai_compatible.py
@@ -24,6 +24,10 @@ from relay_teams.metrics import MetricRecorder
 from relay_teams.monitors import MonitorService
 from relay_teams.net.llm_client import build_llm_http_client
 from relay_teams.providers.model_config import LlmRetryConfig, ProviderType
+from relay_teams.providers.model_fallback import (
+    DisabledLlmFallbackMiddleware,
+    LlmFallbackMiddleware,
+)
 from relay_teams.providers.openai_support import build_model_request_headers
 from relay_teams.providers.provider_contracts import (
     LLMProvider,
@@ -86,6 +90,7 @@ class OpenAICompatibleProvider(LLMProvider):
         self,
         config: ModelEndpointConfig,
         *,
+        profile_name: str | None,
         task_repo: TaskRepository,
         shared_store: SharedStateRepository,
         event_bus: EventLog,
@@ -120,6 +125,9 @@ class OpenAICompatibleProvider(LLMProvider):
         token_usage_repo: TokenUsageRepository | None = None,
         metric_recorder: MetricRecorder | None = None,
         retry_config: LlmRetryConfig | None = None,
+        fallback_middleware: LlmFallbackMiddleware
+        | DisabledLlmFallbackMiddleware
+        | None = None,
         im_tool_service: ImToolService | None = None,
         computer_runtime: ComputerRuntime | None = None,
     ) -> None:
@@ -127,6 +135,7 @@ class OpenAICompatibleProvider(LLMProvider):
         self._media_asset_service = media_asset_service
         self._session = AgentLlmSession(
             config=config,
+            profile_name=profile_name,
             task_repo=task_repo,
             shared_store=shared_store,
             event_bus=event_bus,
@@ -144,9 +153,11 @@ class OpenAICompatibleProvider(LLMProvider):
             subagent_reflection_service=subagent_reflection_service,
             conversation_compaction_service=ConversationCompactionService(
                 config=config,
+                profile_name=profile_name,
                 retry_config=retry_config or LlmRetryConfig(),
                 message_repo=message_repo,
                 session_history_marker_repo=session_history_marker_repo,
+                fallback_middleware=fallback_middleware,
             ),
             conversation_microcompact_service=ConversationMicrocompactService(),
             tool_registry=tool_registry,
@@ -167,6 +178,7 @@ class OpenAICompatibleProvider(LLMProvider):
             token_usage_repo=token_usage_repo,
             metric_recorder=metric_recorder,
             retry_config=retry_config,
+            fallback_middleware=fallback_middleware,
             im_tool_service=im_tool_service,
             computer_runtime=computer_runtime,
         )

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -147,16 +147,7 @@ def create_provider_factory(
             )
         profile_fallback_middleware: (
             LlmFallbackMiddleware | DisabledLlmFallbackMiddleware
-        )
-        if (
-            session_id is not None
-            and session_model_profile_lookup is not None
-            and session_override is not None
-        ):
-            profile_name_to_use = None
-            profile_fallback_middleware = DisabledLlmFallbackMiddleware()
-        else:
-            profile_fallback_middleware = fallback_middleware
+        ) = fallback_middleware
 
         provider_registry = create_default_provider_registry(
             openai_compatible_builder=lambda config: OpenAICompatibleProvider(

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from hashlib import sha256
+import json
+from threading import Lock
 from typing import TYPE_CHECKING
 
 from relay_teams.external_agents.provider import (
@@ -103,7 +106,19 @@ def create_provider_factory(
     session_model_profile_lookup: Callable[[str], ModelEndpointConfig | None]
     | None = None,
 ) -> Callable[[RoleDefinition, str | None], LLMProvider]:
-    fallback_cooldown_registry = ProfileCooldownRegistry()
+    fallback_cooldown_registries: dict[tuple[str, ...], ProfileCooldownRegistry] = {}
+    fallback_cooldown_registry_lock = Lock()
+
+    def resolve_fallback_cooldown_registry(
+        runtime_to_use: RuntimeConfig,
+    ) -> ProfileCooldownRegistry:
+        profile_set_key = _build_fallback_profile_set_key(runtime_to_use)
+        with fallback_cooldown_registry_lock:
+            registry = fallback_cooldown_registries.get(profile_set_key)
+            if registry is None:
+                registry = ProfileCooldownRegistry()
+                fallback_cooldown_registries[profile_set_key] = registry
+            return registry
 
     def build_fallback_middleware(
         runtime_to_use: RuntimeConfig,
@@ -115,7 +130,7 @@ def create_provider_factory(
             get_profiles=lambda runtime_to_use=runtime_to_use: (
                 runtime_to_use.llm_profiles
             ),
-            cooldown_registry=fallback_cooldown_registry,
+            cooldown_registry=resolve_fallback_cooldown_registry(runtime_to_use),
         )
 
     def provider_factory(
@@ -219,6 +234,19 @@ def create_provider_factory(
         return provider_registry.create(config_to_use)
 
     return provider_factory
+
+
+def _build_fallback_profile_set_key(runtime: RuntimeConfig) -> tuple[str, ...]:
+    entries: list[str] = []
+    for profile_name, config in sorted(runtime.llm_profiles.items()):
+        serialized_config = json.dumps(
+            config.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        fingerprint = sha256(serialized_config.encode("utf-8")).hexdigest()
+        entries.append(f"{profile_name}:{fingerprint}")
+    return tuple(entries)
 
 
 def apply_default_model_profile_override(

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -26,6 +26,7 @@ from relay_teams.providers.model_config import ModelEndpointConfig
 from relay_teams.providers.model_fallback import (
     DisabledLlmFallbackMiddleware,
     LlmFallbackMiddleware,
+    ProfileCooldownRegistry,
 )
 from relay_teams.providers.openai_compatible import OpenAICompatibleProvider
 from relay_teams.providers.provider_registry import create_default_provider_registry
@@ -102,10 +103,20 @@ def create_provider_factory(
     session_model_profile_lookup: Callable[[str], ModelEndpointConfig | None]
     | None = None,
 ) -> Callable[[RoleDefinition, str | None], LLMProvider]:
-    fallback_middleware = LlmFallbackMiddleware(
-        get_fallback_config=lambda: runtime.model_fallback,
-        get_profiles=lambda: runtime.llm_profiles,
-    )
+    fallback_cooldown_registry = ProfileCooldownRegistry()
+
+    def build_fallback_middleware(
+        runtime_to_use: RuntimeConfig,
+    ) -> LlmFallbackMiddleware:
+        return LlmFallbackMiddleware(
+            get_fallback_config=lambda runtime_to_use=runtime_to_use: (
+                runtime_to_use.model_fallback
+            ),
+            get_profiles=lambda runtime_to_use=runtime_to_use: (
+                runtime_to_use.llm_profiles
+            ),
+            cooldown_registry=fallback_cooldown_registry,
+        )
 
     def provider_factory(
         role: RoleDefinition, session_id: str | None = None
@@ -147,7 +158,7 @@ def create_provider_factory(
             )
         profile_fallback_middleware: (
             LlmFallbackMiddleware | DisabledLlmFallbackMiddleware
-        ) = fallback_middleware
+        ) = build_fallback_middleware(runtime_to_use)
 
         provider_registry = create_default_provider_registry(
             openai_compatible_builder=lambda config: OpenAICompatibleProvider(

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -23,6 +23,10 @@ from relay_teams.providers.provider_contracts import (
     MisconfiguredProvider,
 )
 from relay_teams.providers.model_config import ModelEndpointConfig
+from relay_teams.providers.model_fallback import (
+    DisabledLlmFallbackMiddleware,
+    LlmFallbackMiddleware,
+)
 from relay_teams.providers.openai_compatible import OpenAICompatibleProvider
 from relay_teams.providers.provider_registry import create_default_provider_registry
 from relay_teams.roles.memory_service import RoleMemoryService
@@ -98,6 +102,11 @@ def create_provider_factory(
     session_model_profile_lookup: Callable[[str], ModelEndpointConfig | None]
     | None = None,
 ) -> Callable[[RoleDefinition, str | None], LLMProvider]:
+    fallback_middleware = LlmFallbackMiddleware(
+        get_fallback_config=lambda: runtime.model_fallback,
+        get_profiles=lambda: runtime.llm_profiles,
+    )
+
     def provider_factory(
         role: RoleDefinition, session_id: str | None = None
     ) -> LLMProvider:
@@ -112,15 +121,21 @@ def create_provider_factory(
                 session_manager=external_agent_session_manager,
             )
         runtime_to_use = runtime
+        session_override: ModelEndpointConfig | None = None
         if (
             session_id is not None
             and session_model_profile_lookup is not None
-            and (override := session_model_profile_lookup(session_id)) is not None
+            and (session_override := session_model_profile_lookup(session_id))
+            is not None
         ):
             runtime_to_use = apply_default_model_profile_override(
-                runtime=runtime, override=override
+                runtime=runtime, override=session_override
             )
         config_to_use = resolve_model_profile_config(
+            runtime=runtime_to_use,
+            profile_name=role.model_profile,
+        )
+        profile_name_to_use = resolve_model_profile_name(
             runtime=runtime_to_use,
             profile_name=role.model_profile,
         )
@@ -130,10 +145,23 @@ def create_provider_factory(
                 "Configure at least one profile in "
                 f"{format_app_config_file_reference('model.json', config_dir=runtime_to_use.paths.config_dir)}."
             )
+        profile_fallback_middleware: (
+            LlmFallbackMiddleware | DisabledLlmFallbackMiddleware
+        )
+        if (
+            session_id is not None
+            and session_model_profile_lookup is not None
+            and session_override is not None
+        ):
+            profile_name_to_use = None
+            profile_fallback_middleware = DisabledLlmFallbackMiddleware()
+        else:
+            profile_fallback_middleware = fallback_middleware
 
         provider_registry = create_default_provider_registry(
             openai_compatible_builder=lambda config: OpenAICompatibleProvider(
                 config,
+                profile_name=profile_name_to_use,
                 task_repo=task_repo,
                 shared_store=shared_store,
                 event_bus=event_log,
@@ -182,6 +210,7 @@ def create_provider_factory(
                 token_usage_repo=token_usage_repo,
                 metric_recorder=metric_recorder,
                 retry_config=runtime_to_use.llm_retry,
+                fallback_middleware=profile_fallback_middleware,
                 im_tool_service=im_tool_service,
             ),
         )
@@ -229,3 +258,16 @@ def resolve_model_profile_config(
     if runtime.default_model_profile is None:
         return None
     return runtime.llm_profiles.get(runtime.default_model_profile)
+
+
+def resolve_model_profile_name(
+    *,
+    runtime: RuntimeConfig,
+    profile_name: str,
+) -> str | None:
+    normalized_name = profile_name.strip()
+    if normalized_name == "default":
+        return runtime.default_model_profile
+    if normalized_name in runtime.llm_profiles:
+        return normalized_name
+    return runtime.default_model_profile

--- a/src/relay_teams/sessions/runs/enums.py
+++ b/src/relay_teams/sessions/runs/enums.py
@@ -27,6 +27,8 @@ class RunEventType(str, Enum):
     MONITOR_STOPPED = "monitor_stopped"
     LLM_RETRY_SCHEDULED = "llm_retry_scheduled"
     LLM_RETRY_EXHAUSTED = "llm_retry_exhausted"
+    LLM_FALLBACK_ACTIVATED = "llm_fallback_activated"
+    LLM_FALLBACK_EXHAUSTED = "llm_fallback_exhausted"
     MODEL_STEP_STARTED = "model_step_started"
     MODEL_STEP_FINISHED = "model_step_finished"
     TEXT_DELTA = "text_delta"

--- a/src/relay_teams/sessions/runs/runtime_config.py
+++ b/src/relay_teams/sessions/runs/runtime_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from json import loads
+import logging
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -12,6 +13,7 @@ from relay_teams.agents.execution.prompt_instructions import (
     load_prompt_instructions_config,
 )
 from relay_teams.env import load_merged_env_vars
+from relay_teams.logger import get_logger, log_event
 from relay_teams.paths import (
     format_app_config_file_reference,
     get_app_config_dir,
@@ -23,9 +25,14 @@ from relay_teams.providers.model_config import (
     LlmRetryConfig,
     MaaSAuthConfig,
     ModelEndpointConfig,
+    ModelFallbackConfig,
     ModelRequestHeader,
     ProviderType,
     SamplingConfig,
+    default_model_fallback_config,
+)
+from relay_teams.providers.model_fallback_config_manager import (
+    ModelFallbackConfigManager,
 )
 from relay_teams.providers.model_header_utils import (
     model_header_secret_field_name,
@@ -39,6 +46,7 @@ from relay_teams.secrets import get_secret_store
 _MODEL_PROFILE_SECRET_NAMESPACE = "model_profile"
 _MODEL_PROFILE_SECRET_FIELD = "api_key"
 _MODEL_PROFILE_MAAS_PASSWORD_FIELD = maas_password_secret_field_name()
+LOGGER = get_logger(__name__)
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
@@ -74,6 +82,9 @@ class RuntimeConfig(BaseModel):
     paths: RuntimePaths
     llm_profiles: dict[str, ModelEndpointConfig]
     llm_retry: LlmRetryConfig = Field(default_factory=LlmRetryConfig)
+    model_fallback: ModelFallbackConfig = Field(
+        default_factory=default_model_fallback_config
+    )
     default_model_profile: str | None = None
     model_status: ModelConfigStatus = ModelConfigStatus(loaded=True)
     prompt_instructions: PromptInstructionsConfig = Field(
@@ -114,8 +125,15 @@ def load_runtime_config(
         if db_path is not None
         else resolved_config_dir / "relay_teams.db"
     )
+    model_fallback = ModelFallbackConfigManager(
+        config_dir=resolved_config_dir
+    ).get_model_fallback_config()
     try:
-        loaded_profiles = load_llm_profile_state(resolved_config_dir, merged_env)
+        loaded_profiles = load_llm_profile_state(
+            resolved_config_dir,
+            merged_env,
+            model_fallback=model_fallback,
+        )
         llm_profiles = loaded_profiles.profiles
         model_status = ModelConfigStatus(
             loaded=True,
@@ -142,6 +160,7 @@ def load_runtime_config(
         ),
         llm_profiles=llm_profiles,
         llm_retry=LlmRetryConfig(),
+        model_fallback=model_fallback,
         default_model_profile=default_model_profile,
         model_status=model_status,
         prompt_instructions=prompt_instructions,
@@ -152,12 +171,21 @@ def load_llm_configs(
     config_dir: Path,
     env_values: Mapping[str, str],
 ) -> dict[str, ModelEndpointConfig]:
-    return load_llm_profile_state(config_dir, env_values).profiles
+    fallback_config = ModelFallbackConfigManager(
+        config_dir=config_dir
+    ).get_model_fallback_config()
+    return load_llm_profile_state(
+        config_dir,
+        env_values,
+        model_fallback=fallback_config,
+    ).profiles
 
 
 def load_llm_profile_state(
     config_dir: Path,
     env_values: Mapping[str, str],
+    *,
+    model_fallback: ModelFallbackConfig | None = None,
 ) -> LoadedLlmProfiles:
     model_file = config_dir / "model.json"
     if not model_file.exists():
@@ -168,6 +196,7 @@ def load_llm_profile_state(
         )
 
     data = _load_model_payload(model_file)
+    fallback_config = model_fallback or default_model_fallback_config()
     default_profile_name = _resolve_default_profile_name(data)
 
     profiles: dict[str, ModelEndpointConfig] = {}
@@ -227,6 +256,14 @@ def load_llm_profile_state(
             "connect_timeout_seconds",
             DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
         )
+        fallback_policy_id = _resolve_profile_fallback_policy_id(
+            raw_value=cfg.get("fallback_policy_id"),
+            fallback_config=fallback_config,
+            profile_name=name,
+        )
+        fallback_priority = _resolve_profile_fallback_priority(
+            cfg.get("fallback_priority")
+        )
 
         profiles[name] = ModelEndpointConfig(
             provider=provider,
@@ -244,6 +281,8 @@ def load_llm_profile_state(
                     model=model,
                 )
             ),
+            fallback_policy_id=fallback_policy_id,
+            fallback_priority=fallback_priority,
             connect_timeout_seconds=connect_timeout_seconds,
             sampling=SamplingConfig(
                 temperature=temperature,
@@ -257,6 +296,40 @@ def load_llm_profile_state(
         profiles=profiles,
         default_profile_name=default_profile_name,
     )
+
+
+def _resolve_profile_fallback_policy_id(
+    *,
+    raw_value: object,
+    fallback_config: ModelFallbackConfig,
+    profile_name: str,
+) -> str | None:
+    if not isinstance(raw_value, str):
+        return None
+    normalized_value = raw_value.strip()
+    if not normalized_value:
+        return None
+    if fallback_config.get_policy(normalized_value) is None:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="runtime_config.model_fallback_policy_missing",
+            message="Ignoring unknown fallback policy reference in model profile.",
+            payload={
+                "profile_name": profile_name,
+                "fallback_policy_id": normalized_value,
+            },
+        )
+        return None
+    return normalized_value
+
+
+def _resolve_profile_fallback_priority(raw_value: object) -> int:
+    if isinstance(raw_value, bool):
+        return 0
+    if isinstance(raw_value, int):
+        return max(0, raw_value)
+    return 0
 
 
 def _load_model_payload(model_file: Path) -> dict[str, object]:

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -121,6 +121,7 @@ def build_session_rounds(
         if event_type == RunEventType.LLM_RETRY_SCHEDULED.value:
             payload = _parse_event_payload(event.get("payload_json"))
             active_retry_by_run[run_id] = {
+                "kind": "retry",
                 "occurred_at": str(event.get("occurred_at") or ""),
                 "instance_id": payload.get("instance_id", ""),
                 "role_id": payload.get("role_id", ""),
@@ -136,6 +137,7 @@ def build_session_rounds(
         if event_type == RunEventType.LLM_RETRY_EXHAUSTED.value:
             payload = _parse_event_payload(event.get("payload_json"))
             active_retry_by_run[run_id] = {
+                "kind": "retry",
                 "occurred_at": str(event.get("occurred_at") or ""),
                 "instance_id": payload.get("instance_id", ""),
                 "role_id": payload.get("role_id", ""),
@@ -146,6 +148,50 @@ def build_session_rounds(
                 "is_active": False,
                 "error_code": payload.get("error_code", ""),
                 "error_message": payload.get("error_message", ""),
+            }
+            continue
+        if event_type == RunEventType.LLM_FALLBACK_ACTIVATED.value:
+            payload = _parse_event_payload(event.get("payload_json"))
+            active_retry_by_run[run_id] = {
+                "kind": "fallback",
+                "occurred_at": str(event.get("occurred_at") or ""),
+                "instance_id": payload.get("instance_id", ""),
+                "role_id": payload.get("role_id", ""),
+                "attempt_number": payload.get("attempt_number", 0),
+                "total_attempts": payload.get("total_attempts", 0),
+                "retry_in_ms": 0,
+                "phase": "activated",
+                "is_active": False,
+                "error_code": payload.get("reason", ""),
+                "error_message": "",
+                "from_profile_id": payload.get("from_profile_id", ""),
+                "to_profile_id": payload.get("to_profile_id", ""),
+                "from_provider": payload.get("from_provider", ""),
+                "to_provider": payload.get("to_provider", ""),
+                "from_model": payload.get("from_model", ""),
+                "to_model": payload.get("to_model", ""),
+                "hop": payload.get("hop", 0),
+                "strategy_id": payload.get("strategy_id", ""),
+            }
+            continue
+        if event_type == RunEventType.LLM_FALLBACK_EXHAUSTED.value:
+            payload = _parse_event_payload(event.get("payload_json"))
+            active_retry_by_run[run_id] = {
+                "kind": "fallback",
+                "occurred_at": str(event.get("occurred_at") or ""),
+                "instance_id": payload.get("instance_id", ""),
+                "role_id": payload.get("role_id", ""),
+                "attempt_number": payload.get("attempt_number", 0),
+                "total_attempts": payload.get("total_attempts", 0),
+                "retry_in_ms": 0,
+                "phase": "failed",
+                "is_active": False,
+                "error_code": payload.get("error_code", ""),
+                "error_message": payload.get("error_message", ""),
+                "from_profile_id": payload.get("from_profile_id", ""),
+                "from_provider": payload.get("from_provider", ""),
+                "from_model": payload.get("from_model", ""),
+                "hop": payload.get("hop", 0),
             }
             continue
         if event_type == RunEventType.RUN_COMPLETED.value:
@@ -166,8 +212,14 @@ def build_session_rounds(
                 microcompact_by_run[run_id] = projected_microcompact
             elif _payload_reports_microcompact_state(payload):
                 microcompact_by_run.pop(run_id, None)
-        if event_type in retry_clear_events:
+        active_event = active_retry_by_run.get(run_id)
+        if (
+            active_event is not None
+            and active_event.get("kind") == "retry"
+            and event_type in retry_clear_events
+        ):
             active_retry_by_run.pop(run_id, None)
+            continue
     for run_id, retry_event in active_retry_by_run.items():
         retry_events_by_run[run_id] = [retry_event]
 

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -100,6 +100,7 @@ def build_session_rounds(
         messages_by_run[run_id].append(message)
 
     retry_events_by_run: dict[str, list[dict[str, object]]] = defaultdict(list)
+    fallback_events_by_run: dict[str, list[dict[str, object]]] = defaultdict(list)
     completed_output_by_run: dict[str, dict[str, str]] = {}
     microcompact_by_run: dict[str, dict[str, object]] = {}
     retry_clear_events = {
@@ -152,47 +153,51 @@ def build_session_rounds(
             continue
         if event_type == RunEventType.LLM_FALLBACK_ACTIVATED.value:
             payload = _parse_event_payload(event.get("payload_json"))
-            active_retry_by_run[run_id] = {
-                "kind": "fallback",
-                "occurred_at": str(event.get("occurred_at") or ""),
-                "instance_id": payload.get("instance_id", ""),
-                "role_id": payload.get("role_id", ""),
-                "attempt_number": payload.get("attempt_number", 0),
-                "total_attempts": payload.get("total_attempts", 0),
-                "retry_in_ms": 0,
-                "phase": "activated",
-                "is_active": False,
-                "error_code": payload.get("reason", ""),
-                "error_message": "",
-                "from_profile_id": payload.get("from_profile_id", ""),
-                "to_profile_id": payload.get("to_profile_id", ""),
-                "from_provider": payload.get("from_provider", ""),
-                "to_provider": payload.get("to_provider", ""),
-                "from_model": payload.get("from_model", ""),
-                "to_model": payload.get("to_model", ""),
-                "hop": payload.get("hop", 0),
-                "strategy_id": payload.get("strategy_id", ""),
-            }
+            fallback_events_by_run[run_id].append(
+                {
+                    "kind": "fallback",
+                    "occurred_at": str(event.get("occurred_at") or ""),
+                    "instance_id": payload.get("instance_id", ""),
+                    "role_id": payload.get("role_id", ""),
+                    "attempt_number": payload.get("attempt_number", 0),
+                    "total_attempts": payload.get("total_attempts", 0),
+                    "retry_in_ms": 0,
+                    "phase": "activated",
+                    "is_active": False,
+                    "error_code": payload.get("reason", ""),
+                    "error_message": "",
+                    "from_profile_id": payload.get("from_profile_id", ""),
+                    "to_profile_id": payload.get("to_profile_id", ""),
+                    "from_provider": payload.get("from_provider", ""),
+                    "to_provider": payload.get("to_provider", ""),
+                    "from_model": payload.get("from_model", ""),
+                    "to_model": payload.get("to_model", ""),
+                    "hop": payload.get("hop", 0),
+                    "strategy_id": payload.get("strategy_id", ""),
+                }
+            )
             continue
         if event_type == RunEventType.LLM_FALLBACK_EXHAUSTED.value:
             payload = _parse_event_payload(event.get("payload_json"))
-            active_retry_by_run[run_id] = {
-                "kind": "fallback",
-                "occurred_at": str(event.get("occurred_at") or ""),
-                "instance_id": payload.get("instance_id", ""),
-                "role_id": payload.get("role_id", ""),
-                "attempt_number": payload.get("attempt_number", 0),
-                "total_attempts": payload.get("total_attempts", 0),
-                "retry_in_ms": 0,
-                "phase": "failed",
-                "is_active": False,
-                "error_code": payload.get("error_code", ""),
-                "error_message": payload.get("error_message", ""),
-                "from_profile_id": payload.get("from_profile_id", ""),
-                "from_provider": payload.get("from_provider", ""),
-                "from_model": payload.get("from_model", ""),
-                "hop": payload.get("hop", 0),
-            }
+            fallback_events_by_run[run_id].append(
+                {
+                    "kind": "fallback",
+                    "occurred_at": str(event.get("occurred_at") or ""),
+                    "instance_id": payload.get("instance_id", ""),
+                    "role_id": payload.get("role_id", ""),
+                    "attempt_number": payload.get("attempt_number", 0),
+                    "total_attempts": payload.get("total_attempts", 0),
+                    "retry_in_ms": 0,
+                    "phase": "failed",
+                    "is_active": False,
+                    "error_code": payload.get("error_code", ""),
+                    "error_message": payload.get("error_message", ""),
+                    "from_profile_id": payload.get("from_profile_id", ""),
+                    "from_provider": payload.get("from_provider", ""),
+                    "from_model": payload.get("from_model", ""),
+                    "hop": payload.get("hop", 0),
+                }
+            )
             continue
         if event_type == RunEventType.RUN_COMPLETED.value:
             payload = _parse_event_payload(event.get("payload_json"))
@@ -220,8 +225,10 @@ def build_session_rounds(
         ):
             active_retry_by_run.pop(run_id, None)
             continue
+    for run_id, fallback_events in fallback_events_by_run.items():
+        retry_events_by_run[run_id].extend(fallback_events)
     for run_id, retry_event in active_retry_by_run.items():
-        retry_events_by_run[run_id] = [retry_event]
+        retry_events_by_run[run_id].append(retry_event)
 
     run_ids = set(root_task_by_run.keys())
     run_ids.update(messages_by_run.keys())

--- a/tests/unit_tests/agents/execution/test_llm_session.py
+++ b/tests/unit_tests/agents/execution/test_llm_session.py
@@ -818,6 +818,86 @@ async def test_maybe_fallback_after_retry_exhausted_switches_profile() -> None:
 
 
 @pytest.mark.asyncio
+async def test_maybe_fallback_after_non_retryable_quota_error_switches_profile() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    primary_config = ModelEndpointConfig(
+        model="primary-model",
+        base_url="https://example.test/v1",
+        api_key="primary-key",
+        fallback_policy_id="same_provider_then_other_provider",
+    )
+    fallback_config = ModelEndpointConfig(
+        model="fallback-model",
+        base_url="https://fallback.test/v1",
+        api_key="fallback-key",
+        fallback_priority=10,
+    )
+    session.__dict__["_config"] = primary_config
+    session.__dict__["_profile_name"] = "primary"
+    session.__dict__["_retry_config"] = LlmRetryConfig(max_retries=3)
+
+    class _FallbackMiddleware:
+        def has_enabled_policy(self, config: ModelEndpointConfig) -> bool:
+            return config.fallback_policy_id == "same_provider_then_other_provider"
+
+        def select_fallback(self, **kwargs: object) -> LlmFallbackDecision:
+            _ = kwargs
+            return LlmFallbackDecision(
+                policy_id="same_provider_then_other_provider",
+                from_profile_name="primary",
+                to_profile_name="secondary",
+                from_provider=primary_config.provider,
+                to_provider=fallback_config.provider,
+                from_model=primary_config.model,
+                to_model=fallback_config.model,
+                hop=1,
+                reason="insufficient_quota",
+                cooldown_until=datetime.now(UTC),
+                target_config=fallback_config,
+            )
+
+    session.__dict__["_fallback_middleware"] = _FallbackMiddleware()
+    session.__dict__["_handle_fallback_activated"] = lambda **kwargs: None
+    session.__dict__["_handle_fallback_exhausted"] = lambda **kwargs: None
+
+    class _FallbackSession:
+        async def _generate_async(
+            self,
+            request: LLMRequest,
+            **kwargs: object,
+        ) -> str:
+            _ = (request, kwargs)
+            return "fallback-response"
+
+    session.__dict__["_clone_with_config"] = lambda **kwargs: _FallbackSession()
+
+    result = await AgentLlmSession._maybe_fallback_after_retry_exhausted(
+        session,
+        request=_build_request(),
+        retry_number=0,
+        total_attempts=4,
+        retry_error=LlmRetryErrorInfo(
+            message="quota exceeded",
+            status_code=400,
+            error_code="insufficient_quota",
+            retryable=False,
+            rate_limited=True,
+        ),
+        fallback_state=_FallbackAttemptState.initial("primary"),
+        attempt_text_emitted=False,
+        attempt_tool_call_event_emitted=False,
+        attempt_tool_outcome_event_emitted=False,
+        attempt_messages_committed=False,
+        skip_initial_user_prompt_persist=False,
+    )
+
+    assert result.response == "fallback-response"
+    assert result.status == _FallbackAttemptStatus.RECOVERED
+
+
+@pytest.mark.asyncio
 async def test_generate_async_does_not_emit_retry_exhausted_after_fallback_exhausted() -> (
     None
 ):

--- a/tests/unit_tests/agents/execution/test_llm_session.py
+++ b/tests/unit_tests/agents/execution/test_llm_session.py
@@ -13,6 +13,7 @@ from openai import APIStatusError
 from relay_teams.agents.execution.llm_session import (
     AgentLlmSession,
     _FallbackAttemptState,
+    _FallbackAttemptStatus,
 )
 from relay_teams.agents.execution.conversation_compaction import (
     ConversationCompactionService,
@@ -642,6 +643,8 @@ async def test_generate_async_passes_retry_after_to_retry_schedule() -> None:
     session.__dict__["_computer_runtime"] = None
     session.__dict__["_background_task_service"] = None
     session.__dict__["_monitor_service"] = None
+    session.__dict__["_metric_recorder"] = None
+    session.__dict__["_token_usage_repo"] = None
     session.__dict__["_role_registry"] = cast(object, None)
     session.__dict__["_mcp_registry"] = McpRegistry()
     session.__dict__["_task_service"] = cast(object, None)
@@ -804,9 +807,158 @@ async def test_maybe_fallback_after_retry_exhausted_switches_profile() -> None:
         skip_initial_user_prompt_persist=False,
     )
 
-    assert result == "fallback-response"
+    assert result.response == "fallback-response"
+    assert result.status == _FallbackAttemptStatus.RECOVERED
     assert len(activated) == 1
     assert activated[0].to_profile_name == "secondary"
     assert captured_generate_kwargs[0]["retry_number"] == 0
     next_fallback_state = captured_generate_kwargs[0]["fallback_state"]
     assert getattr(next_fallback_state, "hop") == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_async_does_not_emit_retry_exhausted_after_fallback_exhausted() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_config"] = ModelEndpointConfig(
+        model="primary-model",
+        base_url="https://example.test/v1",
+        api_key="primary-key",
+        fallback_policy_id="same_provider_then_other_provider",
+    )
+    session.__dict__["_profile_name"] = "primary"
+    session.__dict__["_retry_config"] = LlmRetryConfig(max_retries=0)
+    session.__dict__["_tool_registry"] = cast(object, None)
+    session.__dict__["_skill_registry"] = cast(object, None)
+    session.__dict__["_allowed_tools"] = ()
+    session.__dict__["_allowed_mcp_servers"] = ()
+    session.__dict__["_allowed_skills"] = ()
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_shared_store"] = cast(object, None)
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_message_repo"] = cast(
+        MessageRepository, _FakeMessageRepo(history=[])
+    )
+    session.__dict__["_approval_ticket_repo"] = cast(object, None)
+    session.__dict__["_run_runtime_repo"] = cast(object, None)
+    session.__dict__["_injection_manager"] = type(
+        "_InjectionManager",
+        (),
+        {"drain_at_boundary": lambda self, run_id, instance_id: []},
+    )()
+    session.__dict__["_run_event_hub"] = type(
+        "_RunEventHub", (), {"publish": lambda self, event: None}
+    )()
+    session.__dict__["_agent_repo"] = cast(object, None)
+    session.__dict__["_workspace_manager"] = type(
+        "_WorkspaceManager",
+        (),
+        {"resolve": lambda self, **kwargs: cast(object, None)},
+    )()
+    session.__dict__["_role_memory_service"] = None
+    session.__dict__["_media_asset_service"] = None
+    session.__dict__["_computer_runtime"] = None
+    session.__dict__["_background_task_service"] = None
+    session.__dict__["_monitor_service"] = None
+    session.__dict__["_metric_recorder"] = None
+    session.__dict__["_token_usage_repo"] = None
+    session.__dict__["_role_registry"] = cast(object, None)
+    session.__dict__["_mcp_registry"] = McpRegistry()
+    session.__dict__["_task_service"] = cast(object, None)
+    session.__dict__["_task_execution_service"] = cast(object, object())
+    session.__dict__["_tool_approval_manager"] = cast(object, None)
+    session.__dict__["_shell_approval_repo"] = None
+    session.__dict__["_notification_service"] = None
+    session.__dict__["_im_tool_service"] = None
+    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
+        object, None
+    )
+    session.__dict__["_build_model_api_error_message"] = lambda error: "rate limited"
+    session.__dict__["_persist_user_prompt_if_needed"] = lambda **kwargs: kwargs[
+        "history"
+    ]
+    session.__dict__["_run_control_manager"] = type(
+        "_RunControlManager",
+        (),
+        {
+            "context": lambda self, run_id, instance_id: type(
+                "_ControlContext",
+                (),
+                {"raise_if_cancelled": lambda self: None},
+            )()
+        },
+    )()
+
+    async def _no_recovery(**kwargs: object) -> None:
+        _ = kwargs
+        return None
+
+    session.__dict__["_maybe_recover_from_tool_args_parse_failure"] = _no_recovery
+    session.__dict__["_should_retry_request"] = lambda **kwargs: False
+    session.__dict__["_fallback_middleware"] = type(
+        "_FallbackMiddleware",
+        (),
+        {
+            "has_enabled_policy": lambda self, config: True,
+            "select_fallback": lambda self, **kwargs: None,
+        },
+    )()
+
+    retry_exhausted_calls: list[dict[str, object]] = []
+    fallback_exhausted_calls: list[dict[str, object]] = []
+    retry_scheduled_calls: list[dict[str, object]] = []
+
+    async def _capture_retry_scheduled(**kwargs: object) -> None:
+        retry_scheduled_calls.append(kwargs)
+
+    session.__dict__["_handle_retry_scheduled"] = _capture_retry_scheduled
+    session.__dict__["_handle_retry_exhausted"] = lambda **kwargs: (
+        retry_exhausted_calls.append(kwargs)
+    )
+    session.__dict__["_handle_fallback_exhausted"] = lambda **kwargs: (
+        fallback_exhausted_calls.append(kwargs)
+    )
+    session.__dict__["_raise_assistant_run_error"] = lambda **kwargs: (
+        _ for _ in ()
+    ).throw(RuntimeError("stop after fallback exhaustion"))
+
+    class _FailingAgentContext:
+        async def __aenter__(self) -> object:
+            request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+            response = httpx.Response(
+                429,
+                headers={"Retry-After": "1"},
+                request=request,
+            )
+            raise APIStatusError(
+                "rate limited",
+                response=response,
+                body={"error": {"code": "rate_limit_exceeded", "message": "slow down"}},
+            )
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            _ = (exc_type, exc, tb)
+            return False
+
+    class _FailingAgent:
+        def iter(self, *_args: object, **_kwargs: object) -> _FailingAgentContext:
+            return _FailingAgentContext()
+
+    async def _build_agent_iteration_context(
+        **kwargs: object,
+    ) -> tuple[str, list[object], str, object]:
+        _ = kwargs
+        return "", [], "System prompt", _FailingAgent()
+
+    session.__dict__["_build_agent_iteration_context"] = _build_agent_iteration_context
+
+    with pytest.raises(RuntimeError, match="stop after fallback exhaustion"):
+        await AgentLlmSession._generate_async(
+            session,
+            _build_request(),
+        )
+
+    assert len(fallback_exhausted_calls) == 1
+    assert retry_scheduled_calls == []
+    assert retry_exhausted_calls == []

--- a/tests/unit_tests/agents/execution/test_llm_session.py
+++ b/tests/unit_tests/agents/execution/test_llm_session.py
@@ -10,7 +10,10 @@ from typing import cast
 import pytest
 from openai import APIStatusError
 
-from relay_teams.agents.execution.llm_session import AgentLlmSession
+from relay_teams.agents.execution.llm_session import (
+    AgentLlmSession,
+    _FallbackAttemptState,
+)
 from relay_teams.agents.execution.conversation_compaction import (
     ConversationCompactionService,
 )
@@ -21,8 +24,9 @@ from relay_teams.agents.execution.conversation_microcompact import (
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
 from relay_teams.mcp.mcp_registry import McpRegistry
-from relay_teams.providers.llm_retry import LlmRetrySchedule
+from relay_teams.providers.llm_retry import LlmRetryErrorInfo, LlmRetrySchedule
 from relay_teams.providers.model_config import LlmRetryConfig, ModelEndpointConfig
+from relay_teams.providers.model_fallback import LlmFallbackDecision
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from pydantic_ai.messages import (
@@ -719,3 +723,90 @@ async def test_generate_async_passes_retry_after_to_retry_schedule() -> None:
     assert len(captured_schedules) == 1
     schedule = captured_schedules[0]
     assert schedule.delay_ms == 7000
+
+
+@pytest.mark.asyncio
+async def test_maybe_fallback_after_retry_exhausted_switches_profile() -> None:
+    session = object.__new__(AgentLlmSession)
+    primary_config = ModelEndpointConfig(
+        model="primary-model",
+        base_url="https://example.test/v1",
+        api_key="primary-key",
+        fallback_policy_id="same_provider_then_other_provider",
+    )
+    fallback_config = ModelEndpointConfig(
+        model="fallback-model",
+        base_url="https://fallback.test/v1",
+        api_key="fallback-key",
+        fallback_priority=10,
+    )
+    session.__dict__["_config"] = primary_config
+    session.__dict__["_profile_name"] = "primary"
+    session.__dict__["_retry_config"] = LlmRetryConfig(max_retries=1)
+
+    class _FallbackMiddleware:
+        def has_enabled_policy(self, config: ModelEndpointConfig) -> bool:
+            return config.fallback_policy_id == "same_provider_then_other_provider"
+
+        def select_fallback(self, **kwargs: object) -> LlmFallbackDecision:
+            _ = kwargs
+            return LlmFallbackDecision(
+                policy_id="same_provider_then_other_provider",
+                from_profile_name="primary",
+                to_profile_name="secondary",
+                from_provider=primary_config.provider,
+                to_provider=fallback_config.provider,
+                from_model=primary_config.model,
+                to_model=fallback_config.model,
+                hop=1,
+                reason="rate_limited",
+                cooldown_until=datetime.now(UTC),
+                target_config=fallback_config,
+            )
+
+    activated: list[LlmFallbackDecision] = []
+    session.__dict__["_fallback_middleware"] = _FallbackMiddleware()
+    session.__dict__["_handle_fallback_activated"] = lambda **kwargs: activated.append(
+        cast(LlmFallbackDecision, kwargs["decision"])
+    )
+    session.__dict__["_handle_fallback_exhausted"] = lambda **kwargs: None
+
+    captured_generate_kwargs: list[dict[str, object]] = []
+
+    class _FallbackSession:
+        async def _generate_async(
+            self,
+            request: LLMRequest,
+            **kwargs: object,
+        ) -> str:
+            _ = request
+            captured_generate_kwargs.append(kwargs)
+            return "fallback-response"
+
+    session.__dict__["_clone_with_config"] = lambda **kwargs: _FallbackSession()
+
+    result = await AgentLlmSession._maybe_fallback_after_retry_exhausted(
+        session,
+        request=_build_request(),
+        retry_number=1,
+        total_attempts=2,
+        retry_error=LlmRetryErrorInfo(
+            message="slow down",
+            status_code=429,
+            error_code="rate_limited",
+            retryable=True,
+            rate_limited=True,
+        ),
+        fallback_state=_FallbackAttemptState.initial("primary"),
+        attempt_text_emitted=False,
+        attempt_tool_event_emitted=False,
+        attempt_messages_committed=False,
+        skip_initial_user_prompt_persist=False,
+    )
+
+    assert result == "fallback-response"
+    assert len(activated) == 1
+    assert activated[0].to_profile_name == "secondary"
+    assert captured_generate_kwargs[0]["retry_number"] == 0
+    next_fallback_state = captured_generate_kwargs[0]["fallback_state"]
+    assert getattr(next_fallback_state, "hop") == 1

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -40,6 +40,23 @@ export async function fetchModelProfiles() {
     };
 }
 
+export async function fetchModelFallbackConfig() {
+    return {
+        policies: [
+            {
+                policy_id: "same_provider_then_other_provider",
+                name: "Same Provider Then Other Provider",
+                enabled: true,
+            },
+            {
+                policy_id: "other_provider_only",
+                name: "Other Provider Only",
+                enabled: true,
+            },
+        ],
+    };
+}
+
 export async function probeModelConnection(payload) {
     globalThis.__probePayload = payload;
     return {
@@ -131,6 +148,44 @@ console.log(JSON.stringify({
     assert saved_profile_body["provider"] == "openai_compatible"
     assert saved_profile_body["is_default"] is True
     assert saved_profile_body["context_window"] == 128000
+    assert saved_profile_body["fallback_policy_id"] is None
+    assert saved_profile_body["fallback_priority"] == 0
+
+
+def test_saving_model_profile_includes_fallback_settings(tmp_path: Path) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+await loadModelProfilesPanel();
+
+document.getElementById("add-profile-btn").onclick();
+document.getElementById("profile-name").value = "fallback-profile";
+document.getElementById("profile-provider").value = "openai_compatible";
+document.getElementById("profile-model").value = "reasoning-model";
+document.getElementById("profile-base-url").value = "http://127.0.0.1:8001/v1";
+document.getElementById("profile-api-key").value = "test-api-key";
+document.getElementById("profile-fallback-policy").value = "other_provider_only";
+document.getElementById("profile-fallback-priority").value = "9";
+
+await document.getElementById("save-profile-btn").onclick();
+
+console.log(JSON.stringify({
+    savedProfile: globalThis.__savedProfile,
+}));
+""".strip(),
+    )
+
+    saved_profile = cast(dict[str, JsonValue], payload["savedProfile"])
+    saved_profile_body = cast(dict[str, JsonValue], saved_profile["profile"])
+    assert saved_profile_body["fallback_policy_id"] == "other_provider_only"
+    assert saved_profile_body["fallback_priority"] == 9
 
 
 def test_draft_probe_updates_inline_status_and_payload(tmp_path: Path) -> None:
@@ -1805,7 +1860,15 @@ def _run_model_profiles_script(
     module_under_test_path = tmp_path / "modelProfiles.mjs"
     runner_path = tmp_path / "runner.mjs"
 
-    mock_api_path.write_text(mock_api_source, encoding="utf-8")
+    resolved_mock_api_source = mock_api_source
+    if "fetchModelFallbackConfig" not in resolved_mock_api_source:
+        resolved_mock_api_source = (
+            f"{resolved_mock_api_source}\n\n"
+            "export async function fetchModelFallbackConfig() {\n"
+            "    return { policies: [] };\n"
+            "}\n"
+        )
+    mock_api_path.write_text(resolved_mock_api_source, encoding="utf-8")
     mock_logger_path.write_text(
         """
 export function errorToPayload(error, extra = {}) {
@@ -2008,6 +2071,8 @@ function createElements() {{
             ["profile-context-window", createElement("block", "profile-context-window")],
             ["profile-connect-timeout", createElement("block", "profile-connect-timeout")],
             ["profile-ssl-verify", createElement("block", "profile-ssl-verify")],
+            ["profile-fallback-policy", createElement("block", "profile-fallback-policy")],
+            ["profile-fallback-priority", createElement("block", "profile-fallback-priority")],
         ];
         const elements = new Map(entries);
         elements.get("profile-primary-credentials-row")?.appendChild(elements.get("profile-api-key-group"));

--- a/tests/unit_tests/frontend/test_round_retry_timeline_ui.py
+++ b/tests/unit_tests/frontend/test_round_retry_timeline_ui.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+def test_retry_timeline_escapes_fallback_target_markup(tmp_path: Path) -> None:
+    payload = _run_round_timeline_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { renderRetryEventMarkup } = await import('./timeline.mjs');
+
+const html = renderRetryEventMarkup(
+    {
+        kind: 'fallback',
+        phase: 'scheduled',
+        to_profile_id: '<img src=x onerror=alert(1)>',
+    },
+    Date.now(),
+);
+
+console.log(JSON.stringify({ html }));
+""".strip(),
+    )
+
+    html = str(payload["html"])
+    assert "<img src=x onerror=alert(1)>" not in html
+    assert (
+        '<span class="round-retry-copy">Switched to &lt;img src=x onerror=alert(1)&gt;</span>'
+        in html
+    )
+
+
+def _run_round_timeline_script(tmp_path: Path, runner_source: str) -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "rounds" / "timeline.js"
+    )
+
+    module_under_test_path = tmp_path / "timeline.mjs"
+    runner_path = tmp_path / "runner-timeline.mjs"
+
+    replacements = {
+        "../../utils/dom.js": "./mockDom.mjs",
+        "../../core/state.js": "./mockState.mjs",
+        "../../core/api.js": "./mockApi.mjs",
+        "../agentPanel.js": "./mockAgentPanel.mjs",
+        "../messageRenderer.js": "./mockMessageRenderer.mjs",
+        "./navigator.js": "./mockNavigator.mjs",
+        "./paging.js": "./mockPaging.mjs",
+        "./state.js": "./mockRoundsState.mjs",
+        "./utils.js": "./mockRoundUtils.mjs",
+        "../../utils/logger.js": "./mockLogger.mjs",
+        "../../utils/i18n.js": "./mockI18n.mjs",
+    }
+    source_text = source_path.read_text(encoding="utf-8")
+    for original, replacement in replacements.items():
+        source_text = source_text.replace(original, replacement)
+    source_text = source_text.replace(
+        "function renderRetryEventMarkup(event, nowMs) {",
+        "export function renderRetryEventMarkup(event, nowMs) {",
+        1,
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+
+    (tmp_path / "mockDom.mjs").write_text(
+        """
+export const els = {
+    chatMessages: {
+        scrollHeight: 0,
+        scrollTop: 0,
+    },
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    activeSubagentSession: null,
+    currentSessionId: 'session-1',
+};
+
+export function getRunPrimaryRoleId() {
+    return null;
+}
+
+export function getRunPrimaryRoleLabel() {
+    return 'Main Agent';
+}
+
+export function isRunPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockApi.mjs").write_text(
+        """
+export async function fetchRunTokenUsage() {
+    return {};
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockAgentPanel.mjs").write_text(
+        """
+export function setRoundPendingApprovals() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockMessageRenderer.mjs").write_text(
+        """
+export function clearAllStreamState() {
+    return undefined;
+}
+
+export function getCoordinatorStreamOverlay() {
+    return null;
+}
+
+export function renderHistoricalMessageList() {
+    return undefined;
+}
+
+export function getOrCreateStreamBlock() {
+    return undefined;
+}
+
+export function appendStreamChunk() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockNavigator.mjs").write_text(
+        """
+export function renderRoundNavigator() {
+    return undefined;
+}
+
+export function setActiveRoundNav() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockPaging.mjs").write_text(
+        """
+export function applyRoundPage() {
+    return undefined;
+}
+
+export async function fetchInitialRoundsPage() {
+    return { rounds: [] };
+}
+
+export async function fetchOlderRoundsPage() {
+    return { rounds: [] };
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockRoundsState.mjs").write_text(
+        """
+export const roundsState = {
+    currentRound: null,
+    currentRounds: [],
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockRoundUtils.mjs").write_text(
+        """
+export function roundSectionId(runId) {
+    return String(runId || '');
+}
+
+export function esc(value) {
+    return String(value || '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
+export function roundStateLabel() {
+    return '';
+}
+
+export function roundStateTone() {
+    return 'idle';
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockLogger.mjs").write_text(
+        """
+export function errorToPayload() {
+    return {};
+}
+
+export function logError() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(message, values = {}) {
+    return Object.entries(values).reduce(
+        (result, [key, value]) => result.replaceAll(`{${key}}`, String(value)),
+        String(message || ''),
+    );
+}
+
+export function t(key) {
+    return String(key || '');
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner_path.write_text(runner_source, encoding="utf-8")
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        timeout=3,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    return json.loads(completed.stdout)

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -139,6 +139,58 @@ console.log(JSON.stringify({
     ]
 
 
+def test_route_event_routes_fallback_events(tmp_path: Path) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+routeEvent('llm_fallback_activated', { from_profile_id: 'default', to_profile_id: 'secondary' }, { run_id: 'run-1', trace_id: 'run-1' });
+routeEvent('llm_fallback_exhausted', { from_profile_id: 'default' }, { run_id: 'run-1', trace_id: 'run-1' });
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    recoveryCalls: globalThis.__scheduleRecoveryContinuityRefreshCalls,
+    runEventCalls: globalThis.__runEventCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["recoveryCalls"] == [
+        {
+            "sessionId": "session-1",
+            "delayMs": 0,
+            "includeRounds": False,
+            "quiet": True,
+            "reason": "llm_fallback_activated",
+        },
+        {
+            "sessionId": "session-1",
+            "delayMs": 0,
+            "includeRounds": False,
+            "quiet": True,
+            "reason": "llm_fallback_exhausted",
+        },
+    ]
+    assert payload["runEventCalls"] == [
+        {
+            "name": "handleLlmFallbackActivated",
+            "args": [
+                {"from_profile_id": "default", "to_profile_id": "secondary"},
+                {"run_id": "run-1", "trace_id": "run-1"},
+            ],
+        },
+        {
+            "name": "handleLlmFallbackExhausted",
+            "args": [
+                {"from_profile_id": "default"},
+                {"run_id": "run-1", "trace_id": "run-1"},
+            ],
+        },
+    ]
+
+
 def test_handle_subagent_run_terminal_finalizes_with_run_id(
     tmp_path: Path,
 ) -> None:
@@ -611,6 +663,8 @@ function pushCall(name, args) {
 
 export function handleLlmRetryExhausted(...args) { pushCall('handleLlmRetryExhausted', args); }
 export function handleLlmRetryScheduled(...args) { pushCall('handleLlmRetryScheduled', args); }
+export function handleLlmFallbackActivated(...args) { pushCall('handleLlmFallbackActivated', args); }
+export function handleLlmFallbackExhausted(...args) { pushCall('handleLlmFallbackExhausted', args); }
 export function handleModelStepFinished(...args) { pushCall('handleModelStepFinished', args); }
 export function handleModelStepStarted(...args) { pushCall('handleModelStepStarted', args); }
 export function handleOutputDelta(...args) { pushCall('handleOutputDelta', args); }

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -275,6 +275,38 @@ console.log(JSON.stringify({
     assert payload["settleCalls"] == ["writer-1"]
 
 
+def test_handle_fallback_logs_escape_profile_labels(tmp_path: Path) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleLlmFallbackActivated, handleLlmFallbackExhausted } = await import('./runEvents.mjs');
+
+handleLlmFallbackActivated({
+    from_profile_id: '<img src=x onerror=1>',
+    to_profile_id: '<svg onload=1>',
+});
+handleLlmFallbackExhausted({
+    from_profile_id: '<script>alert(1)</script>',
+});
+
+console.log(JSON.stringify({
+    sysLogCalls: globalThis.__sysLogCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["sysLogCalls"] == [
+        [
+            "Fallback activated: &lt;img src=x onerror=1&gt; -> &lt;svg onload=1&gt;",
+            "log-info",
+        ],
+        [
+            "Fallback exhausted for &lt;script&gt;alert(1)&lt;/script&gt;.",
+            "log-error",
+        ],
+    ]
+
+
 def test_handle_model_step_finished_passes_run_id_for_normal_mode_subagent(
     tmp_path: Path,
 ) -> None:
@@ -491,8 +523,8 @@ export const els = {
     )
     (tmp_path / "mockLogger.mjs").write_text(
         """
-export function sysLog() {
-    return undefined;
+export function sysLog(...args) {
+    globalThis.__sysLogCalls.push(args);
 }
 """.strip(),
         encoding="utf-8",
@@ -568,6 +600,7 @@ globalThis.__renderActiveSubagentSessionCalls = [];
 globalThis.__updateNormalModeSubagentSessionStatusCalls = [];
 globalThis.__finalizeStreamCalls = [];
 globalThis.__settleActiveSubagentSessionAfterTerminalCalls = [];
+globalThis.__sysLogCalls = [];
 globalThis.__activeSubagentSession = null;
 globalThis.__activeSubagentSessionStreamContainer = null;
 

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -12,6 +12,7 @@ from relay_teams.env.environment_variable_models import (
     EnvironmentVariableScope,
 )
 from relay_teams.interfaces.server.container import ServerContainer
+from relay_teams.providers.model_fallback import LlmFallbackMiddleware
 from relay_teams.roles import RoleLoader
 from relay_teams.sessions.runs.background_tasks.models import (
     BackgroundTaskRecord,
@@ -86,6 +87,21 @@ def test_runtime_reload_updates_run_manager_provider_factory(
 
     assert container.run_service._provider_factory is container._provider_factory
     assert container.run_service._provider_factory is not previous_provider_factory
+
+
+def test_container_injects_fallback_middleware_into_reflection_service(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = ServerContainer(config_dir=config_dir)
+
+    reflection_service = container._build_subagent_reflection_service()
+
+    assert reflection_service is not None
+    assert isinstance(reflection_service._fallback_middleware, LlmFallbackMiddleware)
 
 
 def test_roles_reload_updates_long_lived_role_registry_references(

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -743,6 +743,31 @@ def test_save_model_profile_includes_connect_timeout_seconds() -> None:
     assert source_name is None
 
 
+def test_save_model_profile_omits_fallback_settings_when_not_provided() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model/profiles/default",
+        json={
+            "provider": "openai_compatible",
+            "model": "gpt-4o-mini",
+            "base_url": "https://example.test/v1",
+            "api_key": "secret",
+            "temperature": 0.2,
+            "top_p": 1.0,
+            "context_window": 128000,
+            "connect_timeout_seconds": 25.0,
+        },
+    )
+
+    assert response.status_code == 200
+    assert service.saved_model_profile is not None
+    _, saved_profile, _ = service.saved_model_profile
+    assert "fallback_policy_id" not in saved_profile
+    assert "fallback_priority" not in saved_profile
+
+
 def test_get_model_fallback_config() -> None:
     client = _create_test_client(_FakeSystemService())
 

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -73,6 +73,9 @@ from relay_teams.providers.model_connectivity import (
 from relay_teams.providers.model_config import (
     DEFAULT_MAAS_BASE_URL,
     ModelConfigPayload,
+    ModelFallbackConfig,
+    ModelFallbackPolicy,
+    ModelFallbackStrategy,
     ProviderModelInfo,
     ProviderType,
 )
@@ -91,6 +94,7 @@ class _FakeSystemService:
         self.saved_notification_config: dict[str, object] | None = None
         self.saved_orchestration_config: dict[str, object] | None = None
         self.saved_model_config: dict[str, object] | None = None
+        self.saved_model_fallback_config: dict[str, object] | None = None
         self.saved_model_profile: tuple[str, dict[str, object], str | None] | None = (
             None
         )
@@ -181,8 +185,21 @@ class _FakeSystemService:
                 "headers": [],
                 "is_default": True,
                 "context_window": 128000,
+                "fallback_policy_id": "same_provider_then_other_provider",
+                "fallback_priority": 3,
             }
         }
+
+    def get_model_fallback_config(self) -> ModelFallbackConfig:
+        return ModelFallbackConfig(
+            policies=(
+                ModelFallbackPolicy(
+                    policy_id="same_provider_then_other_provider",
+                    name="Same Provider Then Other Provider",
+                    strategy=(ModelFallbackStrategy.SAME_PROVIDER_THEN_OTHER_PROVIDER),
+                ),
+            )
+        )
 
     def save_model_profile(
         self,
@@ -204,6 +221,9 @@ class _FakeSystemService:
         if self.model_config_error is not None:
             raise self.model_config_error
         self.saved_model_config = config.model_dump(mode="json")
+
+    def save_model_fallback_config(self, config: ModelFallbackConfig) -> None:
+        self.saved_model_fallback_config = config.model_dump(mode="json")
 
     def reload_model_config(self) -> None:
         if self.model_reload_error is not None:
@@ -706,6 +726,8 @@ def test_save_model_profile_includes_connect_timeout_seconds() -> None:
             "top_p": 1.0,
             "max_tokens": 2048,
             "context_window": 128000,
+            "fallback_policy_id": "same_provider_then_other_provider",
+            "fallback_priority": 5,
             "connect_timeout_seconds": 25.0,
         },
     )
@@ -716,7 +738,51 @@ def test_save_model_profile_includes_connect_timeout_seconds() -> None:
     _, saved_profile, source_name = service.saved_model_profile
     assert saved_profile["connect_timeout_seconds"] == 25.0
     assert saved_profile["context_window"] == 128000
+    assert saved_profile["fallback_policy_id"] == ("same_provider_then_other_provider")
+    assert saved_profile["fallback_priority"] == 5
     assert source_name is None
+
+
+def test_get_model_fallback_config() -> None:
+    client = _create_test_client(_FakeSystemService())
+
+    response = client.get("/api/system/configs/model-fallback")
+
+    assert response.status_code == 200
+    payload = response.json()
+    policies = cast(list[dict[str, object]], payload["policies"])
+    assert policies[0]["policy_id"] == "same_provider_then_other_provider"
+
+
+def test_save_model_fallback_config() -> None:
+    service = _FakeSystemService()
+    client = _create_test_client(service)
+
+    response = client.put(
+        "/api/system/configs/model-fallback",
+        json={
+            "policies": [
+                {
+                    "policy_id": "same_provider_then_other_provider",
+                    "name": "Same Provider Then Other Provider",
+                    "enabled": True,
+                    "trigger": "rate_limit_after_retries",
+                    "strategy": "same_provider_then_other_provider",
+                    "max_hops": 4,
+                    "cooldown_seconds": 90,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert service.saved_model_fallback_config is not None
+    saved_policies = cast(
+        list[dict[str, object]],
+        service.saved_model_fallback_config["policies"],
+    )
+    assert saved_policies[0]["max_hops"] == 4
 
 
 def test_save_notification_config() -> None:
@@ -1144,23 +1210,23 @@ def test_save_model_config() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
-    assert service.saved_model_config == {
-        "default": {
-            "provider": "openai_compatible",
-            "model": "gpt-4o-mini",
-            "base_url": "https://example.test/v1",
-            "api_key": "secret",
-            "headers": [],
-            "temperature": 0.2,
-            "top_p": 1.0,
-            "max_tokens": 2048,
-            "context_window": 128000,
-            "connect_timeout_seconds": 25.0,
-            "is_default": True,
-            "maas_auth": None,
-            "ssl_verify": None,
-        }
-    }
+    assert service.saved_model_config is not None
+    saved_default = cast(dict[str, object], service.saved_model_config["default"])
+    assert saved_default["provider"] == "openai_compatible"
+    assert saved_default["model"] == "gpt-4o-mini"
+    assert saved_default["base_url"] == "https://example.test/v1"
+    assert saved_default["api_key"] == "secret"
+    assert saved_default["headers"] == []
+    assert saved_default["temperature"] == 0.2
+    assert saved_default["top_p"] == 1.0
+    assert saved_default["max_tokens"] == 2048
+    assert saved_default["context_window"] == 128000
+    assert saved_default["connect_timeout_seconds"] == 25.0
+    assert saved_default["is_default"] is True
+    assert saved_default["fallback_policy_id"] is None
+    assert saved_default["fallback_priority"] == 0
+    assert saved_default["maas_auth"] is None
+    assert saved_default["ssl_verify"] is None
 
 
 def test_save_model_config_accepts_legacy_wrapper_payload() -> None:
@@ -1219,6 +1285,10 @@ def test_get_model_profiles_returns_api_key() -> None:
     assert payload["default"]["has_api_key"] is True
     assert payload["default"]["is_default"] is True
     assert payload["default"]["context_window"] == 128000
+    assert payload["default"]["fallback_policy_id"] == (
+        "same_provider_then_other_provider"
+    )
+    assert payload["default"]["fallback_priority"] == 3
 
 
 def test_get_model_profiles_returns_maas_password() -> None:

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -729,6 +729,7 @@ def _build_provider(
     session_history_marker_repo = SessionHistoryMarkerRepository(db_path)
     provider = OpenAICompatibleProvider(
         config,
+        profile_name=None,
         task_repo=TaskRepository(db_path),
         shared_store=shared_store,
         event_bus=EventLog(db_path),

--- a/tests/unit_tests/providers/test_llm_retry.py
+++ b/tests/unit_tests/providers/test_llm_retry.py
@@ -48,6 +48,7 @@ def test_extract_retry_error_info_reads_status_code_and_retry_after() -> None:
     assert info.status_code == 429
     assert info.error_code == "rate_limited"
     assert info.retry_after_ms == 7000
+    assert info.rate_limited is True
 
 
 def test_extract_retry_error_info_reads_provider_code_without_status() -> None:
@@ -65,6 +66,7 @@ def test_extract_retry_error_info_reads_provider_code_without_status() -> None:
     assert info.error_code == "2062"
     assert info.message == "busy"
     assert info.retryable is False
+    assert info.rate_limited is False
 
 
 def test_extract_retry_error_info_marks_408_and_409_as_retryable() -> None:

--- a/tests/unit_tests/providers/test_llm_tool_events.py
+++ b/tests/unit_tests/providers/test_llm_tool_events.py
@@ -140,6 +140,7 @@ def _provider_with_hub(hub: _FakeRunEventHub) -> OpenAICompatibleProvider:
     session_history_marker_repo = SessionHistoryMarkerRepository(db_path)
     return OpenAICompatibleProvider(
         config,
+        profile_name=None,
         task_repo=cast(TaskRepository, cast(object, _FakeTaskRepository())),
         shared_store=shared_store,
         event_bus=cast(EventLog, cast(object, _FakeEventLog())),

--- a/tests/unit_tests/providers/test_model_config_manager.py
+++ b/tests/unit_tests/providers/test_model_config_manager.py
@@ -57,6 +57,8 @@ def test_save_model_profile_and_get_model_profiles(tmp_path: Path) -> None:
     assert profiles["default"]["temperature"] == 0.25
     assert profiles["default"]["max_tokens"] == 2000
     assert profiles["default"]["context_window"] == 128000
+    assert profiles["default"]["fallback_policy_id"] is None
+    assert profiles["default"]["fallback_priority"] == 0
     assert profiles["default"]["connect_timeout_seconds"] == 45.0
     model_payload = json.loads((tmp_path / "model.json").read_text(encoding="utf-8"))
     assert "api_key" not in model_payload["default"]
@@ -187,6 +189,33 @@ def test_get_model_profiles_uses_default_connect_timeout_when_missing(
         == DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS
     )
     assert profiles["default"]["max_tokens"] is None
+
+
+def test_get_model_profiles_returns_fallback_settings(tmp_path: Path) -> None:
+    manager = ModelConfigManager(config_dir=tmp_path)
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "default": {
+                    "provider": "openai_compatible",
+                    "model": "gpt-4o-mini",
+                    "base_url": "https://example.test/v1",
+                    "api_key": "secret-key",
+                    "fallback_policy_id": "same_provider_then_other_provider",
+                    "fallback_priority": 7,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    profiles = manager.get_model_profiles()
+
+    assert profiles["default"]["fallback_policy_id"] == (
+        "same_provider_then_other_provider"
+    )
+    assert profiles["default"]["fallback_priority"] == 7
 
 
 def test_get_model_profiles_infers_known_context_window_when_missing(

--- a/tests/unit_tests/providers/test_model_config_manager.py
+++ b/tests/unit_tests/providers/test_model_config_manager.py
@@ -218,6 +218,50 @@ def test_get_model_profiles_returns_fallback_settings(tmp_path: Path) -> None:
     assert profiles["default"]["fallback_priority"] == 7
 
 
+def test_save_model_profile_preserves_existing_fallback_settings_when_omitted(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(config_dir=tmp_path)
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "default": {
+                    "provider": "openai_compatible",
+                    "model": "gpt-4o-mini",
+                    "base_url": "https://example.test/v1",
+                    "fallback_policy_id": "same_provider_then_other_provider",
+                    "fallback_priority": 7,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager.save_model_profile(
+        "default",
+        {
+            "provider": "openai_compatible",
+            "model": "gpt-4.1",
+            "base_url": "https://example.test/v1",
+            "temperature": 0.2,
+            "top_p": 1.0,
+        },
+    )
+
+    profiles = manager.get_model_profiles()
+    saved_payload = json.loads(model_file.read_text(encoding="utf-8"))
+
+    assert profiles["default"]["fallback_policy_id"] == (
+        "same_provider_then_other_provider"
+    )
+    assert profiles["default"]["fallback_priority"] == 7
+    assert saved_payload["default"]["fallback_policy_id"] == (
+        "same_provider_then_other_provider"
+    )
+    assert saved_payload["default"]["fallback_priority"] == 7
+
+
 def test_get_model_profiles_infers_known_context_window_when_missing(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/providers/test_model_config_service.py
+++ b/tests/unit_tests/providers/test_model_config_service.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
-from relay_teams.providers.model_config import ModelConfigPayload
+from relay_teams.providers.model_config import (
+    ModelConfigPayload,
+    default_model_fallback_config,
+)
 from relay_teams.providers.model_config_manager import ModelConfigManager
 from relay_teams.providers.model_config_service import ModelConfigService
+from relay_teams.providers.model_fallback_config_manager import (
+    ModelFallbackConfigManager,
+)
 from relay_teams.sessions.runs.runtime_config import RuntimeConfig
 
 
@@ -36,6 +42,15 @@ class _RecordingModelConfigManager:
         self.saved_config = config
 
 
+class _RecordingModelFallbackConfigManager:
+    def get_model_fallback_config(self) -> object:
+        return default_model_fallback_config()
+
+    def save_model_fallback_config(self, config: object) -> None:
+        _ = config
+        return None
+
+
 def test_save_model_config_preserves_omitted_optional_fields() -> None:
     manager = _RecordingModelConfigManager()
     service = ModelConfigService(
@@ -43,6 +58,10 @@ def test_save_model_config_preserves_omitted_optional_fields() -> None:
         roles_dir=Path("."),
         db_path=Path("relay-teams.db"),
         model_config_manager=cast(ModelConfigManager, manager),
+        model_fallback_config_manager=cast(
+            ModelFallbackConfigManager,
+            _RecordingModelFallbackConfigManager(),
+        ),
         get_runtime=lambda: RuntimeConfig.model_construct(),
         on_runtime_reloaded=lambda runtime: None,
     )

--- a/tests/unit_tests/providers/test_provider_factory.py
+++ b/tests/unit_tests/providers/test_provider_factory.py
@@ -384,6 +384,108 @@ def test_create_provider_factory_keeps_fallback_middleware_for_session_override(
     assert fallback_middleware._get_profiles()["default"] is override_config
 
 
+def test_create_provider_factory_scopes_cooldown_registry_to_effective_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_config = ModelEndpointConfig(
+        provider=ProviderType.OPENAI_COMPATIBLE,
+        model="default-model",
+        base_url="https://default.example/v1",
+        api_key="default-key",
+        fallback_policy_id="same_provider_then_other_provider",
+    )
+    override_alpha = ModelEndpointConfig(
+        provider=ProviderType.OPENAI_COMPATIBLE,
+        model="override-alpha",
+        base_url="https://override-alpha.example/v1",
+        api_key="override-alpha-key",
+        fallback_policy_id="same_provider_then_other_provider",
+    )
+    override_beta = ModelEndpointConfig(
+        provider=ProviderType.OPENAI_COMPATIBLE,
+        model="override-beta",
+        base_url="https://override-beta.example/v1",
+        api_key="override-beta-key",
+        fallback_policy_id="same_provider_then_other_provider",
+    )
+    monkeypatch.setattr(
+        runtime_factory_module,
+        "OpenAICompatibleProvider",
+        _CapturingOpenAICompatibleProvider,
+    )
+    monkeypatch.setattr(
+        runtime_factory_module,
+        "create_default_provider_registry",
+        lambda **kwargs: _BuilderCallingProviderRegistry(
+            kwargs["openai_compatible_builder"]
+        ),
+    )
+    factory = create_provider_factory(
+        runtime=_build_runtime(
+            profiles={"default": default_config},
+            default_model_profile="default",
+        ),
+        task_repo=cast(TaskRepository, object()),
+        shared_store=cast(SharedStateRepository, object()),
+        event_log=cast(EventLog, object()),
+        injection_manager=cast(RunInjectionManager, object()),
+        run_event_hub=cast(RunEventHub, object()),
+        agent_repo=cast(AgentInstanceRepository, object()),
+        approval_ticket_repo=cast(ApprovalTicketRepository, object()),
+        run_runtime_repo=cast(RunRuntimeRepository, object()),
+        run_intent_repo=cast(RunIntentRepository, object()),
+        background_task_service=None,
+        workspace_manager=cast(WorkspaceManager, object()),
+        media_asset_service=cast(MediaAssetService, object()),
+        tool_registry=ToolRegistry({}),
+        mcp_registry=McpRegistry(),
+        skill_registry=SkillRegistry(
+            directory=SkillsDirectory(base_dir=Path.cwd() / ".missing-skills")
+        ),
+        message_repo=cast(MessageRepository, object()),
+        session_history_marker_repo=cast(SessionHistoryMarkerRepository, object()),
+        role_registry=cast(RoleRegistry, object()),
+        get_task_service=lambda: cast(TaskOrchestrationService, object()),
+        run_control_manager=cast(RunControlManager, object()),
+        tool_approval_manager=cast(ToolApprovalManager, object()),
+        tool_approval_policy=cast(ToolApprovalPolicy, object()),
+        notification_service=cast(NotificationService | None, None),
+        get_task_execution_service=lambda: cast(TaskExecutionService, object()),
+        token_usage_repo=cast(TokenUsageRepository | None, None),
+        external_agent_session_manager=None,
+        session_model_profile_lookup=lambda session_id: {
+            "session-alpha": override_alpha,
+            "session-alpha-copy": override_alpha.model_copy(),
+            "session-beta": override_beta,
+        }.get(session_id),
+    )
+
+    provider_alpha = cast(
+        _CapturingOpenAICompatibleProvider,
+        factory(_build_role(model_profile="default"), "session-alpha"),
+    )
+    provider_alpha_copy = cast(
+        _CapturingOpenAICompatibleProvider,
+        factory(_build_role(model_profile="default"), "session-alpha-copy"),
+    )
+    provider_beta = cast(
+        _CapturingOpenAICompatibleProvider,
+        factory(_build_role(model_profile="default"), "session-beta"),
+    )
+
+    fallback_alpha = cast(
+        LlmFallbackMiddleware, provider_alpha.kwargs["fallback_middleware"]
+    )
+    fallback_alpha_copy = cast(
+        LlmFallbackMiddleware, provider_alpha_copy.kwargs["fallback_middleware"]
+    )
+    fallback_beta = cast(
+        LlmFallbackMiddleware, provider_beta.kwargs["fallback_middleware"]
+    )
+    assert fallback_alpha._cooldown_registry is fallback_alpha_copy._cooldown_registry
+    assert fallback_alpha._cooldown_registry is not fallback_beta._cooldown_registry
+
+
 @pytest.mark.asyncio
 async def test_create_provider_factory_returns_misconfigured_provider_when_no_profiles(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/providers/test_provider_factory.py
+++ b/tests/unit_tests/providers/test_provider_factory.py
@@ -21,6 +21,7 @@ from relay_teams.providers.provider_contracts import (
     MisconfiguredProvider,
 )
 from relay_teams.providers.model_config import ModelEndpointConfig, ProviderType
+from relay_teams.providers.model_fallback import LlmFallbackMiddleware
 from relay_teams.providers.provider_factory import create_provider_factory
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
@@ -129,9 +130,11 @@ def _build_factory(
         background_task_service=None,
         workspace_manager=cast(WorkspaceManager, object()),
         media_asset_service=cast(MediaAssetService, object()),
-        tool_registry=cast(ToolRegistry, object()),
-        mcp_registry=cast(McpRegistry, object()),
-        skill_registry=cast(SkillRegistry, object()),
+        tool_registry=ToolRegistry({}),
+        mcp_registry=McpRegistry(),
+        skill_registry=SkillRegistry(
+            directory=SkillsDirectory(base_dir=Path.cwd() / ".missing-skills")
+        ),
         message_repo=cast(MessageRepository, object()),
         session_history_marker_repo=cast(SessionHistoryMarkerRepository, object()),
         role_registry=cast(RoleRegistry, object()),
@@ -277,9 +280,11 @@ def test_create_provider_factory_uses_session_override_for_default_profile(
         background_task_service=None,
         workspace_manager=cast(WorkspaceManager, object()),
         media_asset_service=cast(MediaAssetService, object()),
-        tool_registry=cast(ToolRegistry, object()),
-        mcp_registry=cast(McpRegistry, object()),
-        skill_registry=cast(SkillRegistry, object()),
+        tool_registry=ToolRegistry({}),
+        mcp_registry=McpRegistry(),
+        skill_registry=SkillRegistry(
+            directory=SkillsDirectory(base_dir=Path.cwd() / ".missing-skills")
+        ),
         message_repo=cast(MessageRepository, object()),
         session_history_marker_repo=cast(SessionHistoryMarkerRepository, object()),
         role_registry=cast(RoleRegistry, object()),
@@ -299,6 +304,80 @@ def test_create_provider_factory_uses_session_override_for_default_profile(
 
     assert isinstance(provider, EchoProvider)
     assert provider_registry.created_config is override_config
+
+
+def test_create_provider_factory_keeps_fallback_middleware_for_session_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_config = ModelEndpointConfig(
+        provider=ProviderType.OPENAI_COMPATIBLE,
+        model="default-model",
+        base_url="https://default.example/v1",
+        api_key="default-key",
+        fallback_policy_id="same_provider_then_other_provider",
+    )
+    override_config = ModelEndpointConfig(
+        provider=ProviderType.OPENAI_COMPATIBLE,
+        model="override-model",
+        base_url="https://override.example/v1",
+        api_key="override-key",
+        fallback_policy_id="same_provider_then_other_provider",
+    )
+    monkeypatch.setattr(
+        runtime_factory_module,
+        "OpenAICompatibleProvider",
+        _CapturingOpenAICompatibleProvider,
+    )
+    monkeypatch.setattr(
+        runtime_factory_module,
+        "create_default_provider_registry",
+        lambda **kwargs: _BuilderCallingProviderRegistry(
+            kwargs["openai_compatible_builder"]
+        ),
+    )
+    factory = create_provider_factory(
+        runtime=_build_runtime(
+            profiles={"default": default_config},
+            default_model_profile="default",
+        ),
+        task_repo=cast(TaskRepository, object()),
+        shared_store=cast(SharedStateRepository, object()),
+        event_log=cast(EventLog, object()),
+        injection_manager=cast(RunInjectionManager, object()),
+        run_event_hub=cast(RunEventHub, object()),
+        agent_repo=cast(AgentInstanceRepository, object()),
+        approval_ticket_repo=cast(ApprovalTicketRepository, object()),
+        run_runtime_repo=cast(RunRuntimeRepository, object()),
+        run_intent_repo=cast(RunIntentRepository, object()),
+        background_task_service=None,
+        workspace_manager=cast(WorkspaceManager, object()),
+        media_asset_service=cast(MediaAssetService, object()),
+        tool_registry=ToolRegistry({}),
+        mcp_registry=McpRegistry(),
+        skill_registry=SkillRegistry(
+            directory=SkillsDirectory(base_dir=Path.cwd() / ".missing-skills")
+        ),
+        message_repo=cast(MessageRepository, object()),
+        session_history_marker_repo=cast(SessionHistoryMarkerRepository, object()),
+        role_registry=cast(RoleRegistry, object()),
+        get_task_service=lambda: cast(TaskOrchestrationService, object()),
+        run_control_manager=cast(RunControlManager, object()),
+        tool_approval_manager=cast(ToolApprovalManager, object()),
+        tool_approval_policy=cast(ToolApprovalPolicy, object()),
+        notification_service=cast(NotificationService | None, None),
+        get_task_execution_service=lambda: cast(TaskExecutionService, object()),
+        token_usage_repo=cast(TokenUsageRepository | None, None),
+        external_agent_session_manager=None,
+        session_model_profile_lookup=lambda session_id: (
+            override_config if session_id == "session-1" else None
+        ),
+    )
+
+    provider = factory(_build_role(model_profile="default"), "session-1")
+
+    assert isinstance(provider, _CapturingOpenAICompatibleProvider)
+    assert provider.kwargs["profile_name"] == "default"
+    assert isinstance(provider.kwargs["fallback_middleware"], LlmFallbackMiddleware)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_provider_factory.py
+++ b/tests/unit_tests/providers/test_provider_factory.py
@@ -378,6 +378,10 @@ def test_create_provider_factory_keeps_fallback_middleware_for_session_override(
     assert isinstance(provider, _CapturingOpenAICompatibleProvider)
     assert provider.kwargs["profile_name"] == "default"
     assert isinstance(provider.kwargs["fallback_middleware"], LlmFallbackMiddleware)
+    fallback_middleware = cast(
+        LlmFallbackMiddleware, provider.kwargs["fallback_middleware"]
+    )
+    assert fallback_middleware._get_profiles()["default"] is override_config
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/test_rounds_projection_role_instance_map.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_role_instance_map.py
@@ -449,6 +449,71 @@ def test_build_session_rounds_keeps_fallback_event_after_run_completed() -> None
     assert retry_events[0]["phase"] == "activated"
 
 
+def test_build_session_rounds_keeps_fallback_history_when_retry_follows() -> None:
+    session_id = "session-1"
+    run_id = "run-1"
+    root_task = TaskRecord(
+        envelope=TaskEnvelope(
+            task_id="task-root",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            objective="root",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        ),
+    )
+    runtime = RunRuntimeRecord(
+        run_id=run_id,
+        session_id=session_id,
+        status=RunRuntimeStatus.COMPLETED,
+        phase=RunRuntimePhase.TERMINAL,
+    )
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=cast(AgentInstanceRepository, cast(object, _FakeAgentRepo())),
+        task_repo=cast(TaskRepository, cast(object, _FakeTaskRepo((root_task,)))),
+        approval_tickets_by_run={},
+        run_runtime_repo=cast(
+            RunRuntimeRepository,
+            cast(object, _FakeRunRuntimeRepo((runtime,))),
+        ),
+        get_session_messages=lambda _: [],
+        get_session_events=lambda _: [
+            {
+                "trace_id": run_id,
+                "event_type": RunEventType.LLM_FALLBACK_ACTIVATED.value,
+                "occurred_at": "2026-03-19T12:00:05Z",
+                "payload_json": (
+                    '{"from_profile_id":"primary","to_profile_id":"secondary",'
+                    '"strategy_id":"same_provider_then_other_provider","hop":1}'
+                ),
+            },
+            {
+                "trace_id": run_id,
+                "event_type": RunEventType.LLM_RETRY_SCHEDULED.value,
+                "occurred_at": "2026-03-19T12:00:06Z",
+                "payload_json": (
+                    '{"attempt_number":2,"total_attempts":6,"retry_in_ms":2000,'
+                    '"error_code":"network_error"}'
+                ),
+            },
+            {
+                "trace_id": run_id,
+                "event_type": RunEventType.RUN_COMPLETED.value,
+                "occurred_at": "2026-03-19T12:00:08Z",
+                "payload_json": '{"completion_reason":"assistant_response"}',
+            },
+        ],
+    )
+
+    retry_events = cast(list[dict[str, object]], rounds[0]["retry_events"])
+    assert len(retry_events) == 1
+    assert retry_events[0]["kind"] == "fallback"
+    assert retry_events[0]["to_profile_id"] == "secondary"
+    assert retry_events[0]["phase"] == "activated"
+
+
 def test_build_session_rounds_excludes_background_subagent_runs() -> None:
     session_id = "session-1"
     main_run_id = "run-1"

--- a/tests/unit_tests/sessions/test_rounds_projection_role_instance_map.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_role_instance_map.py
@@ -343,6 +343,112 @@ def test_build_session_rounds_keeps_exhausted_retry_card_after_run_failed() -> N
     assert retry_events[0]["is_active"] is False
 
 
+def test_build_session_rounds_projects_fallback_event() -> None:
+    session_id = "session-1"
+    run_id = "run-1"
+    root_task = TaskRecord(
+        envelope=TaskEnvelope(
+            task_id="task-root",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            objective="root",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        ),
+    )
+    runtime = RunRuntimeRecord(
+        run_id=run_id,
+        session_id=session_id,
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=cast(AgentInstanceRepository, cast(object, _FakeAgentRepo())),
+        task_repo=cast(TaskRepository, cast(object, _FakeTaskRepo((root_task,)))),
+        approval_tickets_by_run={},
+        run_runtime_repo=cast(
+            RunRuntimeRepository,
+            cast(object, _FakeRunRuntimeRepo((runtime,))),
+        ),
+        get_session_messages=lambda _: [],
+        get_session_events=lambda _: [
+            {
+                "trace_id": run_id,
+                "event_type": RunEventType.LLM_FALLBACK_ACTIVATED.value,
+                "occurred_at": "2026-03-19T12:00:05Z",
+                "payload_json": (
+                    '{"from_profile_id":"primary","to_profile_id":"secondary",'
+                    '"strategy_id":"same_provider_then_other_provider","hop":1}'
+                ),
+            },
+        ],
+    )
+
+    retry_events = cast(list[dict[str, object]], rounds[0]["retry_events"])
+    assert len(retry_events) == 1
+    assert retry_events[0]["kind"] == "fallback"
+    assert retry_events[0]["to_profile_id"] == "secondary"
+    assert retry_events[0]["phase"] == "activated"
+
+
+def test_build_session_rounds_keeps_fallback_event_after_run_completed() -> None:
+    session_id = "session-1"
+    run_id = "run-1"
+    root_task = TaskRecord(
+        envelope=TaskEnvelope(
+            task_id="task-root",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            objective="root",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        ),
+    )
+    runtime = RunRuntimeRecord(
+        run_id=run_id,
+        session_id=session_id,
+        status=RunRuntimeStatus.COMPLETED,
+        phase=RunRuntimePhase.TERMINAL,
+    )
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=cast(AgentInstanceRepository, cast(object, _FakeAgentRepo())),
+        task_repo=cast(TaskRepository, cast(object, _FakeTaskRepo((root_task,)))),
+        approval_tickets_by_run={},
+        run_runtime_repo=cast(
+            RunRuntimeRepository,
+            cast(object, _FakeRunRuntimeRepo((runtime,))),
+        ),
+        get_session_messages=lambda _: [],
+        get_session_events=lambda _: [
+            {
+                "trace_id": run_id,
+                "event_type": RunEventType.LLM_FALLBACK_ACTIVATED.value,
+                "occurred_at": "2026-03-19T12:00:05Z",
+                "payload_json": (
+                    '{"from_profile_id":"primary","to_profile_id":"secondary",'
+                    '"strategy_id":"same_provider_then_other_provider","hop":1}'
+                ),
+            },
+            {
+                "trace_id": run_id,
+                "event_type": RunEventType.RUN_COMPLETED.value,
+                "occurred_at": "2026-03-19T12:00:08Z",
+                "payload_json": '{"completion_reason":"assistant_response"}',
+            },
+        ],
+    )
+
+    retry_events = cast(list[dict[str, object]], rounds[0]["retry_events"])
+    assert len(retry_events) == 1
+    assert retry_events[0]["kind"] == "fallback"
+    assert retry_events[0]["to_profile_id"] == "secondary"
+    assert retry_events[0]["phase"] == "activated"
+
+
 def test_build_session_rounds_excludes_background_subagent_runs() -> None:
     session_id = "session-1"
     main_run_id = "run-1"


### PR DESCRIPTION
## Summary
- add configurable model fallback policies that switch to same-provider or cross-provider profiles after rate-limit retries are exhausted
- expose fallback policy APIs and settings UI so each model profile can choose a fallback strategy and priority
- project fallback events into rounds history and timeline so historical runs show the provider/model switch

## Testing
- uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_conversation_compaction.py tests/unit_tests/agents/execution/test_subagent_reflection.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py tests/unit_tests/providers/test_llm_tool_events.py tests/unit_tests/providers/test_llm_retry.py tests/unit_tests/providers/test_model_config_manager.py tests/unit_tests/providers/test_model_config_service.py tests/unit_tests/interfaces/server/test_system_router.py tests/unit_tests/agents/execution/test_llm_session.py tests/unit_tests/sessions/test_rounds_projection_role_instance_map.py tests/unit_tests/frontend/test_model_profiles_ui.py
- uv run --extra dev ruff check src/relay_teams/agents/execution/conversation_compaction.py src/relay_teams/agents/execution/llm_session.py src/relay_teams/agents/execution/subagent_reflection.py src/relay_teams/interfaces/server/container.py src/relay_teams/interfaces/server/routers/system.py src/relay_teams/providers/__init__.py src/relay_teams/providers/llm_retry.py src/relay_teams/providers/model_config.py src/relay_teams/providers/model_config_manager.py src/relay_teams/providers/model_config_service.py src/relay_teams/providers/model_fallback.py src/relay_teams/providers/model_fallback_config_manager.py src/relay_teams/providers/openai_compatible.py src/relay_teams/providers/provider_factory.py src/relay_teams/sessions/runs/enums.py src/relay_teams/sessions/runs/runtime_config.py src/relay_teams/sessions/session_rounds_projection.py tests/unit_tests/agents/execution/test_llm_session.py tests/unit_tests/frontend/test_model_profiles_ui.py tests/unit_tests/interfaces/server/test_system_router.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py tests/unit_tests/providers/test_llm_retry.py tests/unit_tests/providers/test_llm_tool_events.py tests/unit_tests/providers/test_model_config_manager.py tests/unit_tests/providers/test_model_config_service.py tests/unit_tests/sessions/test_rounds_projection_role_instance_map.py
- uv run --extra dev basedpyright src/relay_teams/agents/execution/conversation_compaction.py src/relay_teams/agents/execution/llm_session.py src/relay_teams/agents/execution/subagent_reflection.py src/relay_teams/interfaces/server/container.py src/relay_teams/interfaces/server/routers/system.py src/relay_teams/providers/__init__.py src/relay_teams/providers/llm_retry.py src/relay_teams/providers/model_config.py src/relay_teams/providers/model_config_manager.py src/relay_teams/providers/model_config_service.py src/relay_teams/providers/model_fallback.py src/relay_teams/providers/model_fallback_config_manager.py src/relay_teams/providers/openai_compatible.py src/relay_teams/providers/provider_factory.py src/relay_teams/sessions/runs/enums.py src/relay_teams/sessions/runs/runtime_config.py src/relay_teams/sessions/session_rounds_projection.py
- browser smoke against a fake rate-limited primary model and successful secondary fallback model

Closes #363