### PR TITLE
[codex] fix subagent yolo approval inheritance

### DIFF
--- a/src/relay_teams/sessions/runs/run_manager.py
+++ b/src/relay_teams/sessions/runs/run_manager.py
@@ -535,6 +535,11 @@ class RunManager:
                 active_run_id in self._running_run_ids
                 or self._injection_manager.is_active(active_run_id)
             ):
+                self._update_run_yolo(
+                    run_id=active_run_id,
+                    session_id=session_id,
+                    yolo=intent.yolo,
+                )
                 self._append_followup_to_coordinator(
                     active_run_id,
                     intent.intent,

--- a/tests/unit_tests/sessions/runs/test_run_manager_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_manager_recovery.py
@@ -264,6 +264,52 @@ def test_create_run_injects_into_active_run(tmp_path: Path) -> None:
     assert queued[0].content == "follow up"
 
 
+def test_create_run_updates_active_run_yolo(tmp_path: Path) -> None:
+    db_path = tmp_path / "run_active_yolo.db"
+    manager = _build_manager(db_path)
+    _upsert_coordinator(AgentInstanceRepository(db_path))
+    _create_root_task(TaskRepository(db_path))
+    existing_intent = IntentInput(
+        session_id="session-1",
+        input=content_parts_from_text("initial"),
+        yolo=False,
+    )
+    RunRuntimeRepository(db_path).ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    RunIntentRepository(db_path).upsert(
+        run_id="run-existing",
+        session_id="session-1",
+        intent=existing_intent,
+    )
+    manager._active_run_registry.remember_active_run(
+        session_id="session-1",
+        run_id="run-existing",
+    )
+    manager._running_run_ids.add("run-existing")
+    manager._injection_manager.activate("run-existing")
+
+    run_id, session_id = manager.create_run(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("follow up"),
+            yolo=True,
+        )
+    )
+
+    persisted = RunIntentRepository(db_path).get("run-existing")
+    assert run_id == "run-existing"
+    assert session_id == "session-1"
+    assert persisted.yolo is True
+    queued = manager._injection_manager.drain_at_boundary("run-existing", "inst-1")
+    assert len(queued) == 1
+    assert queued[0].content == "follow up"
+
+
 def test_background_task_completion_enqueues_to_running_origin_instance(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
﻿## Summary
- propagate updated `yolo` state when new follow-up input is attached to an already-running normal-mode run
- keep subagent tool approval policy aligned with the latest run intent instead of stale approval settings
- add a regression test covering active-run follow-up input switching the persisted run intent to `yolo=true`

## Root Cause
When a session already had an active running run, `create_run()` enqueued the follow-up input but did not persist the new `yolo` value back into `run_intent_repo`. Subagents launched later in that same run still resolved tool approval policy from the stale intent record, so they could incorrectly require manual approval.

## Impact
Normal-mode runs that switch to `yolo` while already running now propagate that policy consistently to later subagent tool calls.

## Validation
- `uv run --frozen --no-default-groups --extra dev pytest -q tests\unit_tests\sessions\runs\test_run_manager_recovery.py -k "active_run_yolo or injects_into_active_run"`
- `uv run --frozen --no-default-groups --extra dev ruff check src\relay_teams\sessions\runs\run_manager.py tests\unit_tests\sessions\runs\test_run_manager_recovery.py`

## Issue
Fixes #367
