### PR TITLE
[codex] Refine LLM retry and recovery handling

### DIFF
--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import replace
 from json import dumps
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Literal, Protocol, cast
 
 from pydantic_ai._agent_graph import ModelRequestNode
 from pydantic_ai.exceptions import ModelAPIError
@@ -540,6 +540,7 @@ class AgentLlmSession:
 
         printed_any = False
         emitted_text_chunks: list[str] = []
+        active_retry_number = retry_number
         attempt_text_emitted = False
         attempt_tool_call_event_emitted = False
         attempt_tool_outcome_event_emitted = False
@@ -627,6 +628,8 @@ class AgentLlmSession:
                                         if text_emitted:
                                             printed_any = True
                                             attempt_text_emitted = True
+                                            if active_retry_number > 0:
+                                                active_retry_number = 0
                                 else:
                                     async for text_delta in stream.stream_text(
                                         delta=True
@@ -638,6 +641,8 @@ class AgentLlmSession:
                                             )
                                             printed_any = True
                                             attempt_text_emitted = True
+                                            if active_retry_number > 0:
+                                                active_retry_number = 0
                                             emitted_text_chunks.append(text_delta)
                                             self._publish_text_delta_event(
                                                 request=request,
@@ -692,6 +697,8 @@ class AgentLlmSession:
                             streamed_text=streamed_node_text,
                         )
                         if new_to_process:
+                            if active_retry_number > 0:
+                                active_retry_number = 0
                             tool_call_events_emitted = (
                                 self._publish_tool_call_events_from_messages(
                                     request=request,
@@ -930,290 +937,70 @@ class AgentLlmSession:
                     )
                     break  # done
         except ModelAPIError as exc:
-            log_event(
-                LOGGER,
-                logging.ERROR,
-                event="llm.request.failed",
-                message="LLM provider request failed",
-                payload={
-                    "model": self._config.model,
-                    "base_url": self._config.base_url,
-                    "role_id": request.role_id,
-                    "instance_id": request.instance_id,
-                },
-                exc_info=exc,
-            )
-            recovered = await self._maybe_recover_from_tool_args_parse_failure(
+            self._log_provider_request_failed(request=request, error=exc)
+            retry_error = extract_retry_error_info(exc)
+            error_message = self._build_model_api_error_message(exc)
+            recovered = await self._handle_generate_attempt_failure(
                 request=request,
-                retry_number=retry_number,
+                error=exc,
+                retry_error=retry_error,
+                error_message=error_message,
+                diagnostics_kind="model_api_error",
+                retry_number=active_retry_number,
                 total_attempts=total_attempts,
+                history=history,
+                pending_messages=buffered_messages,
                 emitted_text_chunks=emitted_text_chunks,
                 published_tool_call_ids=published_tool_call_ids,
                 streamed_tool_calls=streamed_tool_calls,
-                error_message=self._build_model_api_error_message(exc),
+                attempt_text_emitted=attempt_text_emitted or printed_any,
+                attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+                attempt_messages_committed=attempt_messages_committed,
             )
             if recovered is not None:
                 return recovered
-            retry_error = extract_retry_error_info(exc)
-            should_retry = self._should_retry_request(
-                retry_error=retry_error,
-                retry_number=retry_number,
-                attempt_text_emitted=attempt_text_emitted or printed_any,
-                attempt_tool_outcome_event_emitted=attempt_tool_outcome_event_emitted,
-                attempt_messages_committed=attempt_messages_committed,
-            )
-            should_resume_after_tool_outcomes = self._should_resume_after_tool_outcomes(
-                retry_error=retry_error,
-                retry_number=retry_number,
-                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
-            )
-            closed_pending_tool_call_count = 0
-            if should_retry:
-                closed_pending_tool_call_count = (
-                    self._close_pending_tool_calls_for_retry(
-                        request=request,
-                        pending_messages=buffered_messages,
-                        attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
-                        attempt_tool_outcome_event_emitted=(
-                            attempt_tool_outcome_event_emitted
-                        ),
-                        attempt_messages_committed=attempt_messages_committed,
-                    )
-                )
-            log_event(
-                LOGGER,
-                logging.ERROR,
-                event="llm.request.model_api_error.diagnostics",
-                message="ModelAPIError retry diagnostics",
-                payload=cast(
-                    dict[str, JsonValue],
-                    self._to_json_compatible(
-                        self._model_api_error_diagnostics_payload(
-                            error=exc,
-                            retry_error=retry_error,
-                            retry_number=retry_number,
-                            attempt_text_emitted=attempt_text_emitted or printed_any,
-                            attempt_tool_call_event_emitted=(
-                                attempt_tool_call_event_emitted
-                            ),
-                            attempt_tool_outcome_event_emitted=(
-                                attempt_tool_outcome_event_emitted
-                            ),
-                            attempt_messages_committed=attempt_messages_committed,
-                            should_retry=should_retry,
-                            should_resume_after_tool_outcomes=(
-                                should_resume_after_tool_outcomes
-                            ),
-                            closed_pending_tool_call_count=(
-                                closed_pending_tool_call_count
-                            ),
-                        )
-                    ),
-                ),
-            )
-            if should_retry:
-                resolved_retry_error = retry_error
-                assert resolved_retry_error is not None
-                next_retry_number = retry_number + 1
-                delay_ms = compute_retry_delay_ms(
-                    config=self._retry_config,
-                    retry_number=next_retry_number,
-                    retry_after_ms=resolved_retry_error.retry_after_ms,
-                )
-                await self._handle_retry_scheduled(
-                    request=request,
-                    schedule=LlmRetrySchedule(
-                        retry_number=next_retry_number,
-                        next_attempt_number=next_retry_number + 1,
-                        total_attempts=total_attempts,
-                        delay_ms=delay_ms,
-                        error=resolved_retry_error,
-                    ),
-                )
-                await asyncio.sleep(delay_ms / 1000)
-                return await self._generate_async(
-                    request,
-                    retry_number=next_retry_number,
-                    total_attempts=total_attempts,
-                )
-            if should_resume_after_tool_outcomes:
-                return await self._resume_after_tool_outcomes(
-                    request=request,
-                    retry_number=retry_number,
-                    total_attempts=total_attempts,
-                    history=history,
-                    pending_messages=buffered_messages,
-                )
-            if retry_error is not None and retry_error.retryable:
-                if (
-                    self._retry_config.enabled
-                    and retry_number >= self._retry_config.max_retries
-                ):
-                    self._handle_retry_exhausted(
-                        request=request,
-                        retry_number=retry_number,
-                        total_attempts=total_attempts,
-                        error=retry_error,
-                    )
-                self._raise_assistant_run_error(
-                    request=request,
-                    error_code=retry_error.error_code,
-                    error_message=self._build_model_api_error_message(exc),
-                )
-            self._raise_assistant_run_error(
+            self._raise_terminal_model_api_failure(
                 request=request,
-                error_code=(
-                    retry_error.error_code
-                    if retry_error is not None
-                    else getattr(exc, "model_name", None)
-                ),
-                error_message=self._build_model_api_error_message(exc),
+                error=exc,
+                retry_error=retry_error,
+                retry_number=active_retry_number,
+                total_attempts=total_attempts,
+                error_message=error_message,
             )
         except Exception as exc:
             retry_error = extract_retry_error_info(exc)
-            recovered = await self._maybe_recover_from_tool_args_parse_failure(
+            error_message = (
+                retry_error.message
+                if retry_error is not None
+                else (str(exc) or exc.__class__.__name__)
+            )
+            recovered = await self._handle_generate_attempt_failure(
                 request=request,
-                retry_number=retry_number,
+                error=exc,
+                retry_error=retry_error,
+                error_message=error_message,
+                diagnostics_kind="generic_exception",
+                retry_number=active_retry_number,
                 total_attempts=total_attempts,
+                history=history,
+                pending_messages=buffered_messages,
                 emitted_text_chunks=emitted_text_chunks,
                 published_tool_call_ids=published_tool_call_ids,
                 streamed_tool_calls=streamed_tool_calls,
-                error_message=(
-                    retry_error.message
-                    if retry_error is not None
-                    else (str(exc) or exc.__class__.__name__)
-                ),
+                attempt_text_emitted=attempt_text_emitted or printed_any,
+                attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+                attempt_messages_committed=attempt_messages_committed,
             )
             if recovered is not None:
                 return recovered
-            should_retry = self._should_retry_request(
-                retry_error=retry_error,
-                retry_number=retry_number,
-                attempt_text_emitted=attempt_text_emitted or printed_any,
-                attempt_tool_outcome_event_emitted=attempt_tool_outcome_event_emitted,
-                attempt_messages_committed=attempt_messages_committed,
-            )
-            should_resume_after_tool_outcomes = self._should_resume_after_tool_outcomes(
-                retry_error=retry_error,
-                retry_number=retry_number,
-                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
-            )
-            closed_pending_tool_call_count = 0
-            if should_retry:
-                closed_pending_tool_call_count = (
-                    self._close_pending_tool_calls_for_retry(
-                        request=request,
-                        pending_messages=buffered_messages,
-                        attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
-                        attempt_tool_outcome_event_emitted=(
-                            attempt_tool_outcome_event_emitted
-                        ),
-                        attempt_messages_committed=attempt_messages_committed,
-                    )
-                )
-            log_event(
-                LOGGER,
-                logging.ERROR,
-                event="llm.request.exception.diagnostics",
-                message="Unhandled exception retry diagnostics",
-                payload=cast(
-                    dict[str, JsonValue],
-                    self._to_json_compatible(
-                        self._exception_retry_diagnostics_payload(
-                            error=exc,
-                            retry_error=retry_error,
-                            retry_number=retry_number,
-                            attempt_text_emitted=attempt_text_emitted or printed_any,
-                            attempt_tool_call_event_emitted=(
-                                attempt_tool_call_event_emitted
-                            ),
-                            attempt_tool_outcome_event_emitted=(
-                                attempt_tool_outcome_event_emitted
-                            ),
-                            attempt_messages_committed=attempt_messages_committed,
-                            should_retry=should_retry,
-                            should_resume_after_tool_outcomes=(
-                                should_resume_after_tool_outcomes
-                            ),
-                            closed_pending_tool_call_count=(
-                                closed_pending_tool_call_count
-                            ),
-                        )
-                    ),
-                ),
-            )
-            if should_retry:
-                resolved_retry_error = retry_error
-                assert resolved_retry_error is not None
-                next_retry_number = retry_number + 1
-                delay_ms = compute_retry_delay_ms(
-                    config=self._retry_config,
-                    retry_number=next_retry_number,
-                    retry_after_ms=resolved_retry_error.retry_after_ms,
-                )
-                await self._handle_retry_scheduled(
-                    request=request,
-                    schedule=LlmRetrySchedule(
-                        retry_number=next_retry_number,
-                        next_attempt_number=next_retry_number + 1,
-                        total_attempts=total_attempts,
-                        delay_ms=delay_ms,
-                        error=resolved_retry_error,
-                    ),
-                )
-                await asyncio.sleep(delay_ms / 1000)
-                return await self._generate_async(
-                    request,
-                    retry_number=next_retry_number,
-                    total_attempts=total_attempts,
-                )
-            if should_resume_after_tool_outcomes:
-                return await self._resume_after_tool_outcomes(
-                    request=request,
-                    retry_number=retry_number,
-                    total_attempts=total_attempts,
-                    history=history,
-                    pending_messages=buffered_messages,
-                )
-            if retry_error is not None:
-                log_event(
-                    LOGGER,
-                    logging.ERROR,
-                    event="llm.request.failed",
-                    message="LLM provider request failed",
-                    payload={
-                        "model": self._config.model,
-                        "base_url": self._config.base_url,
-                        "role_id": request.role_id,
-                        "instance_id": request.instance_id,
-                    },
-                    exc_info=exc,
-                )
-                if retry_error.retryable and (
-                    self._retry_config.enabled
-                    and retry_number >= self._retry_config.max_retries
-                ):
-                    self._handle_retry_exhausted(
-                        request=request,
-                        retry_number=retry_number,
-                        total_attempts=total_attempts,
-                        error=retry_error,
-                    )
-                if retry_error.retryable:
-                    self._raise_assistant_run_error(
-                        request=request,
-                        error_code=retry_error.error_code,
-                        error_message=retry_error.message,
-                    )
-                self._raise_assistant_run_error(
-                    request=request,
-                    error_code=retry_error.error_code,
-                    error_message=retry_error.message,
-                )
-            self._raise_assistant_run_error(
+            self._raise_terminal_generic_failure(
                 request=request,
-                error_code="internal_execution_error",
-                error_message=str(exc) or exc.__class__.__name__,
+                error=exc,
+                retry_error=retry_error,
+                retry_number=active_retry_number,
+                total_attempts=total_attempts,
             )
 
         assert result is not None
@@ -1331,6 +1118,219 @@ class AgentLlmSession:
                 "transport_error": schedule.error.transport_error,
                 "timeout_error": schedule.error.timeout_error,
             },
+        )
+
+    def _log_provider_request_failed(
+        self,
+        *,
+        request: LLMRequest,
+        error: BaseException,
+    ) -> None:
+        log_event(
+            LOGGER,
+            logging.ERROR,
+            event="llm.request.failed",
+            message="LLM provider request failed",
+            payload={
+                "model": self._config.model,
+                "base_url": self._config.base_url,
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+            exc_info=error,
+        )
+
+    async def _handle_generate_attempt_failure(
+        self,
+        *,
+        request: LLMRequest,
+        error: BaseException,
+        retry_error: LlmRetryErrorInfo | None,
+        error_message: str,
+        diagnostics_kind: Literal["model_api_error", "generic_exception"],
+        retry_number: int,
+        total_attempts: int,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+        emitted_text_chunks: list[str],
+        published_tool_call_ids: set[str],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+        attempt_text_emitted: bool,
+        attempt_tool_call_event_emitted: bool,
+        attempt_tool_outcome_event_emitted: bool,
+        attempt_messages_committed: bool,
+    ) -> str | None:
+        """Handle recovery paths for a failed `_generate_async()` attempt.
+
+        This method centralizes the shared failure flow used by both
+        `ModelAPIError` and generic exception branches. It tries, in order, to:
+        recover from tool-args parse failures, emit diagnostics, and execute
+        request-retry or resume-from-outcomes when those paths are allowed.
+
+        Returns:
+            The final assistant text when the failed attempt was fully recovered
+            inside this method, otherwise `None`.
+        """
+        recovered = await self._maybe_recover_from_tool_args_parse_failure(
+            request=request,
+            retry_number=retry_number,
+            total_attempts=total_attempts,
+            emitted_text_chunks=emitted_text_chunks,
+            published_tool_call_ids=published_tool_call_ids,
+            streamed_tool_calls=streamed_tool_calls,
+            error_message=error_message,
+        )
+        if recovered is not None:
+            return recovered
+        should_retry = self._should_retry_request(
+            retry_error=retry_error,
+            retry_number=retry_number,
+            attempt_text_emitted=attempt_text_emitted,
+            attempt_tool_outcome_event_emitted=attempt_tool_outcome_event_emitted,
+            attempt_messages_committed=attempt_messages_committed,
+        )
+        should_resume_after_tool_outcomes = self._should_resume_after_tool_outcomes(
+            retry_error=retry_error,
+            retry_number=retry_number,
+            attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+        )
+        closed_pending_tool_call_count = 0
+        if should_retry:
+            closed_pending_tool_call_count = self._close_pending_tool_calls_for_retry(
+                request=request,
+                pending_messages=pending_messages,
+                attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+                attempt_messages_committed=attempt_messages_committed,
+            )
+        self._log_generate_failure_diagnostics(
+            request=request,
+            error=error,
+            retry_error=retry_error,
+            diagnostics_kind=diagnostics_kind,
+            retry_number=retry_number,
+            attempt_text_emitted=attempt_text_emitted,
+            attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
+            attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+            attempt_messages_committed=attempt_messages_committed,
+            should_retry=should_retry,
+            should_resume_after_tool_outcomes=(should_resume_after_tool_outcomes),
+            closed_pending_tool_call_count=closed_pending_tool_call_count,
+        )
+        return await self._execute_attempt_recovery(
+            request=request,
+            retry_error=retry_error,
+            retry_number=retry_number,
+            total_attempts=total_attempts,
+            history=history,
+            pending_messages=pending_messages,
+            should_retry=should_retry,
+            should_resume_after_tool_outcomes=(should_resume_after_tool_outcomes),
+        )
+
+    async def _execute_attempt_recovery(
+        self,
+        *,
+        request: LLMRequest,
+        retry_error: LlmRetryErrorInfo | None,
+        retry_number: int,
+        total_attempts: int,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+        should_retry: bool,
+        should_resume_after_tool_outcomes: bool,
+    ) -> str | None:
+        if should_retry:
+            resolved_retry_error = retry_error
+            assert resolved_retry_error is not None
+            next_retry_number = retry_number + 1
+            delay_ms = compute_retry_delay_ms(
+                config=self._retry_config,
+                retry_number=next_retry_number,
+                retry_after_ms=resolved_retry_error.retry_after_ms,
+            )
+            await self._handle_retry_scheduled(
+                request=request,
+                schedule=LlmRetrySchedule(
+                    retry_number=next_retry_number,
+                    next_attempt_number=next_retry_number + 1,
+                    total_attempts=total_attempts,
+                    delay_ms=delay_ms,
+                    error=resolved_retry_error,
+                ),
+            )
+            await asyncio.sleep(delay_ms / 1000)
+            return await self._generate_async(
+                request,
+                retry_number=next_retry_number,
+                total_attempts=total_attempts,
+            )
+        if should_resume_after_tool_outcomes:
+            return await self._resume_after_tool_outcomes(
+                request=request,
+                retry_number=retry_number,
+                total_attempts=total_attempts,
+                history=history,
+                pending_messages=pending_messages,
+            )
+        return None
+
+    def _log_generate_failure_diagnostics(
+        self,
+        *,
+        request: LLMRequest,
+        error: BaseException,
+        retry_error: LlmRetryErrorInfo | None,
+        diagnostics_kind: Literal["model_api_error", "generic_exception"],
+        retry_number: int,
+        attempt_text_emitted: bool,
+        attempt_tool_call_event_emitted: bool,
+        attempt_tool_outcome_event_emitted: bool,
+        attempt_messages_committed: bool,
+        should_retry: bool,
+        should_resume_after_tool_outcomes: bool,
+        closed_pending_tool_call_count: int,
+    ) -> None:
+        if diagnostics_kind == "model_api_error":
+            assert isinstance(error, ModelAPIError)
+            event = "llm.request.model_api_error.diagnostics"
+            message = "ModelAPIError retry diagnostics"
+            payload = self._model_api_error_diagnostics_payload(
+                error=error,
+                retry_error=retry_error,
+                retry_number=retry_number,
+                attempt_text_emitted=attempt_text_emitted,
+                attempt_tool_call_event_emitted=(attempt_tool_call_event_emitted),
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+                attempt_messages_committed=attempt_messages_committed,
+                should_retry=should_retry,
+                should_resume_after_tool_outcomes=(should_resume_after_tool_outcomes),
+                closed_pending_tool_call_count=closed_pending_tool_call_count,
+            )
+        else:
+            event = "llm.request.exception.diagnostics"
+            message = "Unhandled exception retry diagnostics"
+            payload = self._exception_retry_diagnostics_payload(
+                error=error,
+                retry_error=retry_error,
+                retry_number=retry_number,
+                attempt_text_emitted=attempt_text_emitted,
+                attempt_tool_call_event_emitted=(attempt_tool_call_event_emitted),
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+                attempt_messages_committed=attempt_messages_committed,
+                should_retry=should_retry,
+                should_resume_after_tool_outcomes=(should_resume_after_tool_outcomes),
+                closed_pending_tool_call_count=closed_pending_tool_call_count,
+            )
+        log_event(
+            LOGGER,
+            logging.ERROR,
+            event=event,
+            message=message,
+            payload=cast(
+                dict[str, JsonValue],
+                self._to_json_compatible(payload),
+            ),
         )
 
     def _publish_synthetic_tool_results_for_pending_calls(
@@ -1477,6 +1477,74 @@ class AgentLlmSession:
             skip_initial_user_prompt_persist=True,
         )
 
+    def _raise_terminal_model_api_failure(
+        self,
+        *,
+        request: LLMRequest,
+        error: ModelAPIError,
+        retry_error: LlmRetryErrorInfo | None,
+        retry_number: int,
+        total_attempts: int,
+        error_message: str,
+    ) -> None:
+        if retry_error is not None and retry_error.retryable:
+            if (
+                self._retry_config.enabled
+                and retry_number >= self._retry_config.max_retries
+            ):
+                self._handle_retry_exhausted(
+                    request=request,
+                    retry_number=retry_number,
+                    total_attempts=total_attempts,
+                    error=retry_error,
+                )
+            self._raise_assistant_run_error(
+                request=request,
+                error_code=retry_error.error_code,
+                error_message=error_message,
+            )
+        self._raise_assistant_run_error(
+            request=request,
+            error_code=(
+                retry_error.error_code
+                if retry_error is not None
+                else getattr(error, "model_name", None)
+            ),
+            error_message=error_message,
+        )
+
+    def _raise_terminal_generic_failure(
+        self,
+        *,
+        request: LLMRequest,
+        error: BaseException,
+        retry_error: LlmRetryErrorInfo | None,
+        retry_number: int,
+        total_attempts: int,
+    ) -> None:
+        if retry_error is not None:
+            self._log_provider_request_failed(request=request, error=error)
+            if retry_error.retryable and (
+                self._retry_config.enabled
+                and retry_number >= self._retry_config.max_retries
+            ):
+                self._handle_retry_exhausted(
+                    request=request,
+                    retry_number=retry_number,
+                    total_attempts=total_attempts,
+                    error=retry_error,
+                )
+            self._raise_assistant_run_error(
+                request=request,
+                error_code=retry_error.error_code,
+                error_message=retry_error.message,
+            )
+        self._raise_assistant_run_error(
+            request=request,
+            error_code="internal_execution_error",
+            error_message=str(error) or error.__class__.__name__,
+        )
+
     def _should_retry_after_text_side_effect(
         self,
         *,
@@ -1487,7 +1555,7 @@ class AgentLlmSession:
         if retry_error.transport_error:
             return True
         status_code = retry_error.status_code
-        return status_code is not None and status_code >= 500
+        return status_code is not None and (status_code == 429 or status_code >= 500)
 
     def _build_recoverable_pause_error(
         self,

--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -159,6 +159,12 @@ _BUILTIN_TOOL_CONTEXT_CHARS = 200
 _EXTERNAL_TOOL_CONTEXT_CHARS = 600
 _SKILL_CONTEXT_CHARS = 800
 _MCP_SERVER_CONTEXT_FALLBACK_CHARS = 1_200
+_RETRY_SUPERSEDED_TOOL_CALL_ERROR_CODE = "tool_call_superseded_by_retry"
+_RETRY_SUPERSEDED_TOOL_CALL_MESSAGE = "This tool call was superseded by an automatic model retry before tool execution started."
+_RESUME_SUPERSEDED_TOOL_CALL_ERROR_CODE = "tool_call_superseded_by_resume"
+_RESUME_SUPERSEDED_TOOL_CALL_MESSAGE = (
+    "This tool call was superseded by automatic recovery after a model request failure."
+)
 
 
 class _PreparedPromptContext(BaseModel):
@@ -535,7 +541,8 @@ class AgentLlmSession:
         printed_any = False
         emitted_text_chunks: list[str] = []
         attempt_text_emitted = False
-        attempt_tool_event_emitted = False
+        attempt_tool_call_event_emitted = False
+        attempt_tool_outcome_event_emitted = False
         attempt_messages_committed = False
         published_tool_call_ids: set[str] = set()
         log_event(
@@ -693,7 +700,7 @@ class AgentLlmSession:
                                 )
                             )
                             if tool_call_events_emitted:
-                                attempt_tool_event_emitted = True
+                                attempt_tool_call_event_emitted = True
                             self._normalize_tool_call_args_for_replay(new_to_process)
                             buffered_messages.extend(new_to_process)
                             previous_history_size = len(history)
@@ -708,7 +715,7 @@ class AgentLlmSession:
                                 pending_messages=buffered_messages,
                             )
                             if committed_tool_events_published:
-                                attempt_tool_event_emitted = True
+                                attempt_tool_outcome_event_emitted = True
                             if len(history) > previous_history_size:
                                 attempt_messages_committed = True
                             if committed_tool_validation_failures:
@@ -820,7 +827,7 @@ class AgentLlmSession:
                             )
                         )
                         if tool_call_events_emitted:
-                            attempt_tool_event_emitted = True
+                            attempt_tool_call_event_emitted = True
                         self._normalize_tool_call_args_for_replay(to_save)
                         buffered_messages.extend(to_save)
                     previous_history_size = len(history)
@@ -835,7 +842,7 @@ class AgentLlmSession:
                         pending_messages=buffered_messages,
                     )
                     if committed_tool_events_published:
-                        attempt_tool_event_emitted = True
+                        attempt_tool_outcome_event_emitted = True
                     if len(history) > previous_history_size:
                         attempt_messages_committed = True
                     # Record and publish token usage
@@ -952,8 +959,57 @@ class AgentLlmSession:
                 retry_error=retry_error,
                 retry_number=retry_number,
                 attempt_text_emitted=attempt_text_emitted or printed_any,
-                attempt_tool_event_emitted=attempt_tool_event_emitted,
+                attempt_tool_outcome_event_emitted=attempt_tool_outcome_event_emitted,
                 attempt_messages_committed=attempt_messages_committed,
+            )
+            should_resume_after_tool_outcomes = self._should_resume_after_tool_outcomes(
+                retry_error=retry_error,
+                retry_number=retry_number,
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+            )
+            closed_pending_tool_call_count = 0
+            if should_retry:
+                closed_pending_tool_call_count = (
+                    self._close_pending_tool_calls_for_retry(
+                        request=request,
+                        pending_messages=buffered_messages,
+                        attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
+                        attempt_tool_outcome_event_emitted=(
+                            attempt_tool_outcome_event_emitted
+                        ),
+                        attempt_messages_committed=attempt_messages_committed,
+                    )
+                )
+            log_event(
+                LOGGER,
+                logging.ERROR,
+                event="llm.request.model_api_error.diagnostics",
+                message="ModelAPIError retry diagnostics",
+                payload=cast(
+                    dict[str, JsonValue],
+                    self._to_json_compatible(
+                        self._model_api_error_diagnostics_payload(
+                            error=exc,
+                            retry_error=retry_error,
+                            retry_number=retry_number,
+                            attempt_text_emitted=attempt_text_emitted or printed_any,
+                            attempt_tool_call_event_emitted=(
+                                attempt_tool_call_event_emitted
+                            ),
+                            attempt_tool_outcome_event_emitted=(
+                                attempt_tool_outcome_event_emitted
+                            ),
+                            attempt_messages_committed=attempt_messages_committed,
+                            should_retry=should_retry,
+                            should_resume_after_tool_outcomes=(
+                                should_resume_after_tool_outcomes
+                            ),
+                            closed_pending_tool_call_count=(
+                                closed_pending_tool_call_count
+                            ),
+                        )
+                    ),
+                ),
             )
             if should_retry:
                 resolved_retry_error = retry_error
@@ -979,6 +1035,14 @@ class AgentLlmSession:
                     request,
                     retry_number=next_retry_number,
                     total_attempts=total_attempts,
+                )
+            if should_resume_after_tool_outcomes:
+                return await self._resume_after_tool_outcomes(
+                    request=request,
+                    retry_number=retry_number,
+                    total_attempts=total_attempts,
+                    history=history,
+                    pending_messages=buffered_messages,
                 )
             if retry_error is not None and retry_error.retryable:
                 if (
@@ -1026,8 +1090,57 @@ class AgentLlmSession:
                 retry_error=retry_error,
                 retry_number=retry_number,
                 attempt_text_emitted=attempt_text_emitted or printed_any,
-                attempt_tool_event_emitted=attempt_tool_event_emitted,
+                attempt_tool_outcome_event_emitted=attempt_tool_outcome_event_emitted,
                 attempt_messages_committed=attempt_messages_committed,
+            )
+            should_resume_after_tool_outcomes = self._should_resume_after_tool_outcomes(
+                retry_error=retry_error,
+                retry_number=retry_number,
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+            )
+            closed_pending_tool_call_count = 0
+            if should_retry:
+                closed_pending_tool_call_count = (
+                    self._close_pending_tool_calls_for_retry(
+                        request=request,
+                        pending_messages=buffered_messages,
+                        attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
+                        attempt_tool_outcome_event_emitted=(
+                            attempt_tool_outcome_event_emitted
+                        ),
+                        attempt_messages_committed=attempt_messages_committed,
+                    )
+                )
+            log_event(
+                LOGGER,
+                logging.ERROR,
+                event="llm.request.exception.diagnostics",
+                message="Unhandled exception retry diagnostics",
+                payload=cast(
+                    dict[str, JsonValue],
+                    self._to_json_compatible(
+                        self._exception_retry_diagnostics_payload(
+                            error=exc,
+                            retry_error=retry_error,
+                            retry_number=retry_number,
+                            attempt_text_emitted=attempt_text_emitted or printed_any,
+                            attempt_tool_call_event_emitted=(
+                                attempt_tool_call_event_emitted
+                            ),
+                            attempt_tool_outcome_event_emitted=(
+                                attempt_tool_outcome_event_emitted
+                            ),
+                            attempt_messages_committed=attempt_messages_committed,
+                            should_retry=should_retry,
+                            should_resume_after_tool_outcomes=(
+                                should_resume_after_tool_outcomes
+                            ),
+                            closed_pending_tool_call_count=(
+                                closed_pending_tool_call_count
+                            ),
+                        )
+                    ),
+                ),
             )
             if should_retry:
                 resolved_retry_error = retry_error
@@ -1053,6 +1166,14 @@ class AgentLlmSession:
                     request,
                     retry_number=next_retry_number,
                     total_attempts=total_attempts,
+                )
+            if should_resume_after_tool_outcomes:
+                return await self._resume_after_tool_outcomes(
+                    request=request,
+                    retry_number=retry_number,
+                    total_attempts=total_attempts,
+                    history=history,
+                    pending_messages=buffered_messages,
                 )
             if retry_error is not None:
                 log_event(
@@ -1212,13 +1333,65 @@ class AgentLlmSession:
             },
         )
 
+    def _publish_synthetic_tool_results_for_pending_calls(
+        self,
+        *,
+        request: LLMRequest,
+        pending_messages: Sequence[ModelRequest | ModelResponse],
+        error_code: str,
+        message: str,
+    ) -> int:
+        pending_tool_calls = self._collect_pending_tool_calls(pending_messages)
+        if not pending_tool_calls:
+            return 0
+        synthetic_request = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name=tool_name,
+                    tool_call_id=tool_call_id,
+                    content=build_tool_error_result(
+                        error_code=error_code,
+                        message=message,
+                    ),
+                )
+                for tool_call_id, tool_name in pending_tool_calls
+            ]
+        )
+        self._publish_committed_tool_outcome_events_from_messages(
+            request=request,
+            messages=[synthetic_request],
+        )
+        return len(pending_tool_calls)
+
+    def _close_pending_tool_calls_for_retry(
+        self,
+        *,
+        request: LLMRequest,
+        pending_messages: Sequence[ModelRequest | ModelResponse],
+        attempt_tool_call_event_emitted: bool,
+        attempt_tool_outcome_event_emitted: bool,
+        attempt_messages_committed: bool,
+    ) -> int:
+        if (
+            not attempt_tool_call_event_emitted
+            or attempt_tool_outcome_event_emitted
+            or attempt_messages_committed
+        ):
+            return 0
+        return self._publish_synthetic_tool_results_for_pending_calls(
+            request=request,
+            pending_messages=pending_messages,
+            error_code=_RETRY_SUPERSEDED_TOOL_CALL_ERROR_CODE,
+            message=_RETRY_SUPERSEDED_TOOL_CALL_MESSAGE,
+        )
+
     def _should_retry_request(
         self,
         *,
         retry_error: LlmRetryErrorInfo | None,
         retry_number: int,
         attempt_text_emitted: bool,
-        attempt_tool_event_emitted: bool,
+        attempt_tool_outcome_event_emitted: bool,
         attempt_messages_committed: bool,
     ) -> bool:
         allow_after_text = self._should_retry_after_text_side_effect(
@@ -1230,8 +1403,78 @@ class AgentLlmSession:
             and self._retry_config.enabled
             and retry_number < self._retry_config.max_retries
             and (not attempt_text_emitted or allow_after_text)
-            and not attempt_tool_event_emitted
+            and not attempt_tool_outcome_event_emitted
             and not attempt_messages_committed
+        )
+
+    def _should_resume_after_tool_outcomes(
+        self,
+        *,
+        retry_error: LlmRetryErrorInfo | None,
+        retry_number: int,
+        attempt_tool_outcome_event_emitted: bool,
+    ) -> bool:
+        return (
+            retry_error is not None
+            and retry_error.retryable
+            and self._retry_config.enabled
+            and retry_number < self._retry_config.max_retries
+            and attempt_tool_outcome_event_emitted
+        )
+
+    async def _resume_after_tool_outcomes(
+        self,
+        *,
+        request: LLMRequest,
+        retry_number: int,
+        total_attempts: int,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> str:
+        next_retry_number = retry_number + 1
+        (
+            next_history,
+            remaining_pending_messages,
+            _committed_tool_events_published,
+            _committed_tool_validation_failures,
+        ) = self._commit_all_safe_messages(
+            request=request,
+            history=history,
+            pending_messages=pending_messages,
+        )
+        closed_pending_tool_call_count = (
+            self._publish_synthetic_tool_results_for_pending_calls(
+                request=request,
+                pending_messages=remaining_pending_messages,
+                error_code=_RESUME_SUPERSEDED_TOOL_CALL_ERROR_CODE,
+                message=_RESUME_SUPERSEDED_TOOL_CALL_MESSAGE,
+            )
+        )
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="llm.request.resuming_after_tool_outcomes",
+            message=(
+                "Resuming LLM request from the latest committed tool outcomes "
+                "after a retryable provider failure"
+            ),
+            payload={
+                "run_id": request.run_id,
+                "task_id": request.task_id,
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+                "retry_number": retry_number,
+                "next_attempt_number": next_retry_number + 1,
+                "history_message_count": len(next_history),
+                "dropped_pending_message_count": len(remaining_pending_messages),
+                "closed_pending_tool_call_count": closed_pending_tool_call_count,
+            },
+        )
+        return await self._generate_async(
+            request,
+            retry_number=next_retry_number,
+            total_attempts=total_attempts,
+            skip_initial_user_prompt_persist=True,
         )
 
     def _should_retry_after_text_side_effect(
@@ -1412,6 +1655,111 @@ class AgentLlmSession:
             return error.message
         return f"{error.message} Root cause: {root_message}"
 
+    def _model_api_error_diagnostics_payload(
+        self,
+        *,
+        error: ModelAPIError,
+        retry_error: LlmRetryErrorInfo | None,
+        retry_number: int,
+        attempt_text_emitted: bool,
+        attempt_tool_call_event_emitted: bool,
+        attempt_tool_outcome_event_emitted: bool,
+        attempt_messages_committed: bool,
+        should_retry: bool,
+        should_resume_after_tool_outcomes: bool,
+        closed_pending_tool_call_count: int,
+    ) -> dict[str, object]:
+        chain = self._exception_chain(error)
+        response = getattr(error, "response", None)
+        response_headers = getattr(response, "headers", None)
+        direct_headers = getattr(error, "headers", None)
+        return {
+            "error_type": error.__class__.__name__,
+            "message": str(error),
+            "error_message": getattr(error, "message", str(error)),
+            "model_name": getattr(error, "model_name", None),
+            "status_code": getattr(error, "status_code", None),
+            "code": getattr(error, "code", None),
+            "body": self._diagnostic_value(getattr(error, "body", None)),
+            "headers": self._diagnostic_headers(direct_headers),
+            "response_headers": self._diagnostic_headers(response_headers),
+            "exception_chain": [
+                self._exception_diagnostic_item(item) for item in chain
+            ],
+            "retry_error": (
+                retry_error.model_dump(mode="json") if retry_error is not None else None
+            ),
+            "retry_number": retry_number,
+            "max_retries": self._retry_config.max_retries,
+            "retry_enabled": self._retry_config.enabled,
+            "attempt_text_emitted": attempt_text_emitted,
+            "attempt_tool_call_event_emitted": attempt_tool_call_event_emitted,
+            "attempt_tool_outcome_event_emitted": attempt_tool_outcome_event_emitted,
+            "tool_event_state": self._tool_event_state(
+                attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
+                attempt_tool_outcome_event_emitted=attempt_tool_outcome_event_emitted,
+            ),
+            "attempt_messages_committed": attempt_messages_committed,
+            "should_retry": should_retry,
+            "should_resume_after_tool_outcomes": should_resume_after_tool_outcomes,
+            "closed_pending_tool_call_count": closed_pending_tool_call_count,
+            "retry_blockers": self._retry_blockers(
+                retry_error=retry_error,
+                retry_number=retry_number,
+                attempt_text_emitted=attempt_text_emitted,
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+                attempt_messages_committed=attempt_messages_committed,
+            ),
+        }
+
+    def _exception_retry_diagnostics_payload(
+        self,
+        *,
+        error: BaseException,
+        retry_error: LlmRetryErrorInfo | None,
+        retry_number: int,
+        attempt_text_emitted: bool,
+        attempt_tool_call_event_emitted: bool,
+        attempt_tool_outcome_event_emitted: bool,
+        attempt_messages_committed: bool,
+        should_retry: bool,
+        should_resume_after_tool_outcomes: bool,
+        closed_pending_tool_call_count: int,
+    ) -> dict[str, object]:
+        chain = self._exception_chain(error)
+        return {
+            "error_type": error.__class__.__name__,
+            "message": str(error),
+            "args": [self._diagnostic_value(item) for item in error.args],
+            "exception_chain": [
+                self._exception_diagnostic_item(item) for item in chain
+            ],
+            "retry_error": (
+                retry_error.model_dump(mode="json") if retry_error is not None else None
+            ),
+            "retry_number": retry_number,
+            "max_retries": self._retry_config.max_retries,
+            "retry_enabled": self._retry_config.enabled,
+            "attempt_text_emitted": attempt_text_emitted,
+            "attempt_tool_call_event_emitted": attempt_tool_call_event_emitted,
+            "attempt_tool_outcome_event_emitted": attempt_tool_outcome_event_emitted,
+            "tool_event_state": self._tool_event_state(
+                attempt_tool_call_event_emitted=attempt_tool_call_event_emitted,
+                attempt_tool_outcome_event_emitted=attempt_tool_outcome_event_emitted,
+            ),
+            "attempt_messages_committed": attempt_messages_committed,
+            "should_retry": should_retry,
+            "should_resume_after_tool_outcomes": should_resume_after_tool_outcomes,
+            "closed_pending_tool_call_count": closed_pending_tool_call_count,
+            "retry_blockers": self._retry_blockers(
+                retry_error=retry_error,
+                retry_number=retry_number,
+                attempt_text_emitted=attempt_text_emitted,
+                attempt_tool_outcome_event_emitted=(attempt_tool_outcome_event_emitted),
+                attempt_messages_committed=attempt_messages_committed,
+            ),
+        }
+
     def _exception_chain(self, error: BaseException) -> tuple[BaseException, ...]:
         chain: list[BaseException] = []
         seen_ids: set[int] = set()
@@ -1459,6 +1807,98 @@ class AgentLlmSession:
                 continue
             return message
         return None
+
+    def _exception_diagnostic_item(self, error: BaseException) -> dict[str, object]:
+        response = getattr(error, "response", None)
+        return {
+            "type": error.__class__.__name__,
+            "message": str(error),
+            "status_code": getattr(error, "status_code", None),
+            "code": getattr(error, "code", None),
+            "body": self._diagnostic_value(getattr(error, "body", None)),
+            "response_headers": self._diagnostic_headers(
+                getattr(response, "headers", None)
+            ),
+        }
+
+    def _diagnostic_value(self, value: object) -> object:
+        compatible = self._to_json_compatible(value)
+        serialized = json.dumps(compatible, ensure_ascii=False, default=str)
+        if len(serialized) <= 1_500:
+            return compatible
+        return f"{serialized[:1500]}...<truncated>"
+
+    def _diagnostic_headers(self, headers: object) -> dict[str, str]:
+        header_names = (
+            "retry-after",
+            "x-should-retry",
+            "x-request-id",
+            "request-id",
+            "content-type",
+        )
+        values: dict[str, str] = {}
+        for name in header_names:
+            value = self._header_value(headers, name)
+            if value:
+                values[name] = value
+        return values
+
+    def _header_value(self, headers: object, name: str) -> str:
+        raw_value: object | None = None
+        if isinstance(headers, dict):
+            raw_value = headers.get(name)
+            if raw_value is None:
+                raw_value = headers.get(name.title())
+        else:
+            getter = getattr(headers, "get", None)
+            if getter is None:
+                return ""
+            raw_value = getter(name)
+            if raw_value is None:
+                raw_value = getter(name.title())
+        if not isinstance(raw_value, str):
+            return ""
+        return raw_value.strip()
+
+    def _tool_event_state(
+        self,
+        *,
+        attempt_tool_call_event_emitted: bool,
+        attempt_tool_outcome_event_emitted: bool,
+    ) -> str:
+        if attempt_tool_outcome_event_emitted:
+            return "tool_outcomes_emitted"
+        if attempt_tool_call_event_emitted:
+            return "tool_call_events_only"
+        return "none"
+
+    def _retry_blockers(
+        self,
+        *,
+        retry_error: LlmRetryErrorInfo | None,
+        retry_number: int,
+        attempt_text_emitted: bool,
+        attempt_tool_outcome_event_emitted: bool,
+        attempt_messages_committed: bool,
+    ) -> tuple[str, ...]:
+        blockers: list[str] = []
+        if retry_error is None:
+            blockers.append("retry_error_unclassified")
+        elif not retry_error.retryable:
+            blockers.append("retry_error_marked_non_retryable")
+        if not self._retry_config.enabled:
+            blockers.append("retry_disabled")
+        if retry_number >= self._retry_config.max_retries:
+            blockers.append("max_retries_exhausted")
+        if attempt_text_emitted and not self._should_retry_after_text_side_effect(
+            retry_error=retry_error
+        ):
+            blockers.append("text_already_emitted")
+        if attempt_tool_outcome_event_emitted:
+            blockers.append("tool_outcomes_emitted")
+        if attempt_messages_committed:
+            blockers.append("messages_already_committed")
+        return tuple(blockers)
 
     def _extract_text(self, response: object) -> str:
         parts = getattr(response, "parts", None)

--- a/src/relay_teams/providers/llm_retry.py
+++ b/src/relay_teams/providers/llm_retry.py
@@ -230,19 +230,27 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
         body = getattr(exc, "body", None)
         error_payload = _extract_error_payload(body)
         fallback = _parse_message_metadata(str(exc))
+        resolved_error_code = (
+            error_payload.error_code
+            or _optional_str(getattr(exc, "code", None))
+            or (fallback.error_code if fallback is not None else None)
+        )
         status_code = fallback.status_code if fallback is not None else None
+        if status_code is None:
+            status_code = _status_code_from_error_code(resolved_error_code)
         retry_override = _explicit_retry_override(getattr(exc, "headers", None))
         return LlmRetryErrorInfo(
             message=error_payload.message or str(exc),
             status_code=status_code,
-            error_code=error_payload.error_code
-            or _optional_str(getattr(exc, "code", None))
-            or (fallback.error_code if fallback is not None else None),
+            error_code=resolved_error_code,
             error_type=error_payload.error_type,
             retryable=(
                 retry_override
                 if retry_override is not None
-                else _is_retryable_status_code(status_code)
+                else (
+                    _is_retryable_status_code(status_code)
+                    or _is_retryable_error_code(resolved_error_code)
+                )
             ),
         )
 
@@ -284,15 +292,44 @@ def _extract_error_payload(body: object) -> _ParsedErrorPayload:
     error_payload = body.get("error")
     if isinstance(error_payload, dict):
         return _ParsedErrorPayload(
-            message=_optional_str(error_payload.get("message")),
-            error_code=_optional_str(error_payload.get("code")),
+            message=_optional_str(error_payload.get("message"))
+            or _optional_str(error_payload.get("error_msg")),
+            error_code=_optional_str(error_payload.get("code"))
+            or _optional_str(error_payload.get("error_code")),
             error_type=_optional_str(error_payload.get("type")),
         )
     return _ParsedErrorPayload(
-        message=_optional_str(body.get("message")) or _optional_str(body.get("detail")),
-        error_code=_optional_str(body.get("code")),
+        message=_optional_str(body.get("message"))
+        or _optional_str(body.get("detail"))
+        or _optional_str(body.get("error_msg")),
+        error_code=_optional_str(body.get("code"))
+        or _optional_str(body.get("error_code")),
         error_type=_optional_str(body.get("type")),
     )
+
+
+def _status_code_from_error_code(error_code: str | None) -> int | None:
+    normalized = _optional_str(error_code)
+    if normalized is None:
+        return None
+    matched = re.search(r"(?<!\d)(\d{3})(?!\d)$", normalized)
+    if matched is None:
+        return None
+    status_code = int(matched.group(1))
+    if 400 <= status_code <= 599:
+        return status_code
+    return None
+
+
+def _is_retryable_error_code(error_code: str | None) -> bool:
+    normalized = _optional_str(error_code)
+    if normalized is None:
+        return False
+    lowered = normalized.lower()
+    if lowered in {"rate_limited", "rate_limit_exceeded"}:
+        return True
+    derived_status_code = _status_code_from_error_code(normalized)
+    return _is_retryable_status_code(derived_status_code)
 
 
 def _parse_message_metadata(message: str) -> _ParsedMessageMetadata | None:

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -1029,7 +1029,7 @@ async def test_generate_recomputes_budget_after_injection_restart(
         ]
     )
 
-    monkeypatch.setattr(llm_module, "ModelRequestNode", _FakeModelRequestNode)
+    monkeypatch.setattr(llm_module, "ModelRequestNode", _StreamingTextNode)
     monkeypatch.setattr(
         llm_module,
         "build_coordination_agent",
@@ -2734,6 +2734,119 @@ async def test_generate_retries_retryable_api_error_after_live_tool_call_event(
 
 
 @pytest.mark.asyncio
+async def test_generate_resets_retry_budget_after_successful_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "retry_budget_reset.db", fake_hub
+    )
+    provider._session._retry_config.jitter = False
+    provider._session._retry_config.initial_delay_ms = 1
+    provider._session._retry_config.max_retries = 1
+
+    async def _fast_sleep(delay: float) -> None:
+        _ = delay
+
+    monkeypatch.setattr(llm_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(llm_retry_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(llm_module, "compute_retry_delay_ms", lambda **_: 0)
+    monkeypatch.setattr(llm_module, "ModelRequestNode", _FakeModelRequestNode)
+    request_error = APIError(
+        "An error occurred during streaming",
+        request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+        body={
+            "error_msg": "Too many requests, the rate limit is 8000000 tokens per minute.",
+            "error_code": "InferHub.ModelArts.81101.429",
+        },
+    )
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=request_error,
+            ),
+            _ScriptedAgentRun(
+                nodes=[_StreamingTextNode([""])],
+                messages_by_step=[
+                    [
+                        ModelResponse(
+                            parts=[
+                                ToolCallPart(
+                                    tool_name="write",
+                                    args={"path": "notes.txt", "content": "hello"},
+                                    tool_call_id="call-reset-budget",
+                                )
+                            ]
+                        )
+                    ]
+                ],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=request_error,
+            ),
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(
+                        parts=[TextPart(content="after second retry")]
+                    ),
+                    messages=[
+                        ModelResponse(parts=[TextPart(content="after second retry")])
+                    ],
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+    request = LLMRequest(
+        run_id="run-retry-budget-reset",
+        trace_id="run-retry-budget-reset",
+        task_id="task-retry-budget-reset",
+        session_id="session-retry-budget-reset",
+        workspace_id="default",
+        instance_id="inst-retry-budget-reset",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="retry me",
+    )
+
+    result = await provider.generate(request)
+
+    assert result == "after second retry"
+    retry_events = [
+        event
+        for event in fake_hub.events
+        if event.event_type == RunEventType.LLM_RETRY_SCHEDULED
+    ]
+    assert len(retry_events) == 2
+    first_payload = json.loads(retry_events[0].payload_json)
+    second_payload = json.loads(retry_events[1].payload_json)
+    assert first_payload["attempt_number"] == 2
+    assert second_payload["attempt_number"] == 2
+    tool_result_event = next(
+        event
+        for event in fake_hub.events
+        if event.event_type == RunEventType.TOOL_RESULT
+    )
+    tool_result_payload = json.loads(tool_result_event.payload_json)
+    assert tool_result_payload["tool_call_id"] == "call-reset-budget"
+    assert (
+        tool_result_payload["result"]["error"]["code"]
+        == "tool_call_superseded_by_retry"
+    )
+    history = message_repo.get_history("inst-retry-budget-reset")
+    assert len(history) == 2
+
+
+@pytest.mark.asyncio
 async def test_generate_rebuilds_prompt_context_after_tool_validation_restart(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -3053,6 +3166,79 @@ async def test_generate_retries_midstream_provider_500_after_streamed_text(
     event_types = [event.event_type for event in fake_hub.events]
     assert RunEventType.LLM_RETRY_SCHEDULED in event_types
     history = message_repo.get_history("inst-midstream-500")
+    assert len(history) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_retries_midstream_provider_429_after_streamed_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "retry_midstream_429.db", fake_hub
+    )
+    provider._session._retry_config.jitter = False
+    provider._session._retry_config.initial_delay_ms = 1
+
+    async def _fast_sleep(delay: float) -> None:
+        _ = delay
+
+    monkeypatch.setattr(llm_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(llm_retry_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(llm_module, "compute_retry_delay_ms", lambda **_: 0)
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[_StreamingTextNode(["partial "])],
+                messages_by_step=[[]],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=APIStatusError(
+                    "rate limited",
+                    response=httpx.Response(
+                        429,
+                        request=httpx.Request(
+                            "POST",
+                            "https://example.test/v1/chat/completions",
+                        ),
+                    ),
+                    body={"error": {"code": "rate_limited", "message": "retry me"}},
+                ),
+            ),
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(parts=[TextPart(content="after retry")]),
+                    messages=[ModelResponse(parts=[TextPart(content="after retry")])],
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(llm_module, "ModelRequestNode", _StreamingTextNode)
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+    request = LLMRequest(
+        run_id="run-midstream-429",
+        trace_id="run-midstream-429",
+        task_id="task-midstream-429",
+        session_id="session-midstream-429",
+        workspace_id="default",
+        instance_id="inst-midstream-429",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="retry me",
+    )
+
+    result = await provider.generate(request)
+
+    assert result == "after retry"
+    event_types = [event.event_type for event in fake_hub.events]
+    assert RunEventType.LLM_RETRY_SCHEDULED in event_types
+    history = message_repo.get_history("inst-midstream-429")
     assert len(history) == 2
 
 

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -2638,6 +2638,102 @@ async def test_generate_retries_retryable_status_error_before_side_effects(
 
 
 @pytest.mark.asyncio
+async def test_generate_retries_retryable_api_error_after_live_tool_call_event(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "retry_live_tool_call_event.db", fake_hub
+    )
+    provider._session._retry_config.jitter = False
+    provider._session._retry_config.initial_delay_ms = 1
+
+    async def _fast_sleep(delay: float) -> None:
+        _ = delay
+
+    monkeypatch.setattr(llm_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(llm_retry_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(llm_module, "compute_retry_delay_ms", lambda **_: 0)
+    request_error = APIError(
+        "An error occurred during streaming",
+        request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+        body={
+            "error_msg": "Too many requests, the rate limit is 8000000 tokens per minute.",
+            "error_code": "InferHub.ModelArts.81101.429",
+        },
+    )
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[object()],
+                messages_by_step=[
+                    [
+                        ModelResponse(
+                            parts=[
+                                ToolCallPart(
+                                    tool_name="write",
+                                    args={"path": "notes.txt", "content": "hello"},
+                                    tool_call_id="call-live-retry",
+                                )
+                            ]
+                        )
+                    ]
+                ],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=request_error,
+            ),
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(parts=[TextPart(content="after retry")]),
+                    messages=[ModelResponse(parts=[TextPart(content="after retry")])],
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+    request = LLMRequest(
+        run_id="run-live-tool-retry",
+        trace_id="run-live-tool-retry",
+        task_id="task-live-tool-retry",
+        session_id="session-live-tool-retry",
+        workspace_id="default",
+        instance_id="inst-live-tool-retry",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="retry me",
+    )
+
+    result = await provider.generate(request)
+
+    assert result == "after retry"
+    event_types = [event.event_type for event in fake_hub.events]
+    assert RunEventType.TOOL_CALL in event_types
+    assert RunEventType.TOOL_RESULT in event_types
+    assert RunEventType.LLM_RETRY_SCHEDULED in event_types
+    tool_result_event = next(
+        event
+        for event in fake_hub.events
+        if event.event_type == RunEventType.TOOL_RESULT
+    )
+    tool_result_payload = json.loads(tool_result_event.payload_json)
+    assert tool_result_payload["tool_call_id"] == "call-live-retry"
+    assert tool_result_payload["error"] is True
+    assert (
+        tool_result_payload["result"]["error"]["code"]
+        == "tool_call_superseded_by_retry"
+    )
+    history = message_repo.get_history("inst-live-tool-retry")
+    assert len(history) == 2
+
+
+@pytest.mark.asyncio
 async def test_generate_rebuilds_prompt_context_after_tool_validation_restart(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -2958,6 +3054,261 @@ async def test_generate_retries_midstream_provider_500_after_streamed_text(
     assert RunEventType.LLM_RETRY_SCHEDULED in event_types
     history = message_repo.get_history("inst-midstream-500")
     assert len(history) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_resumes_after_committed_tool_result_for_retryable_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "resume_after_tool_result.db", fake_hub
+    )
+    provider._session._retry_config.jitter = False
+    request_error = APIError(
+        "An error occurred during streaming",
+        request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+        body={
+            "error_msg": "Too many requests, the rate limit is 8000000 tokens per minute.",
+            "error_code": "InferHub.ModelArts.81101.429",
+        },
+    )
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[object()],
+                messages_by_step=[
+                    [
+                        ModelResponse(
+                            parts=[
+                                ToolCallPart(
+                                    tool_name="write",
+                                    args={"path": "notes.txt", "content": "hello"},
+                                    tool_call_id="call-real-result",
+                                )
+                            ]
+                        ),
+                        ModelRequest(
+                            parts=[
+                                ToolReturnPart(
+                                    tool_name="write",
+                                    tool_call_id="call-real-result",
+                                    content={"ok": True, "data": {"saved": True}},
+                                )
+                            ]
+                        ),
+                    ]
+                ],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=request_error,
+            ),
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(
+                        parts=[TextPart(content="continued after tool result")]
+                    ),
+                    messages=[
+                        ModelResponse(
+                            parts=[TextPart(content="continued after tool result")]
+                        )
+                    ],
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+    request = LLMRequest(
+        run_id="run-tool-result-resume",
+        trace_id="run-tool-result-resume",
+        task_id="task-tool-result-resume",
+        session_id="session-tool-result-resume",
+        workspace_id="default",
+        instance_id="inst-tool-result-resume",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="retry me",
+    )
+
+    result = await provider.generate(request)
+
+    assert result == "continued after tool result"
+    event_types = [event.event_type for event in fake_hub.events]
+    assert RunEventType.LLM_RETRY_SCHEDULED not in event_types
+    assert event_types.count(RunEventType.TOOL_RESULT) == 1
+    assert len(scripted_agent.histories) == 2
+    resumed_history = scripted_agent.histories[1]
+    assert isinstance(resumed_history[-1], ModelRequest)
+    resumed_result_message = resumed_history[-1]
+    assert isinstance(resumed_result_message.parts[0], ToolReturnPart)
+    assert resumed_result_message.parts[0].tool_call_id == "call-real-result"
+    history = message_repo.get_history("inst-tool-result-resume")
+    assert len(history) == 4
+
+
+@pytest.mark.asyncio
+async def test_generate_resumes_after_failed_tool_result_for_retryable_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "resume_after_failed_tool_result.db", fake_hub
+    )
+    provider._session._retry_config.jitter = False
+    request_error = APIError(
+        "An error occurred during streaming",
+        request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+        body={
+            "error_msg": "Too many requests, the rate limit is 8000000 tokens per minute.",
+            "error_code": "InferHub.ModelArts.81101.429",
+        },
+    )
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[object()],
+                messages_by_step=[
+                    [
+                        ModelResponse(
+                            parts=[
+                                ToolCallPart(
+                                    tool_name="write",
+                                    args={"path": "notes.txt", "content": "hello"},
+                                    tool_call_id="call-failed-result",
+                                )
+                            ]
+                        ),
+                        ModelRequest(
+                            parts=[
+                                ToolReturnPart(
+                                    tool_name="write",
+                                    tool_call_id="call-failed-result",
+                                    content={
+                                        "ok": False,
+                                        "error": {
+                                            "code": "write_failed",
+                                            "message": "disk full",
+                                        },
+                                    },
+                                )
+                            ]
+                        ),
+                    ]
+                ],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=request_error,
+            ),
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(
+                        parts=[TextPart(content="continued after tool failure")]
+                    ),
+                    messages=[
+                        ModelResponse(
+                            parts=[TextPart(content="continued after tool failure")]
+                        )
+                    ],
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+    request = LLMRequest(
+        run_id="run-failed-tool-result-resume",
+        trace_id="run-failed-tool-result-resume",
+        task_id="task-failed-tool-result-resume",
+        session_id="session-failed-tool-result-resume",
+        workspace_id="default",
+        instance_id="inst-failed-tool-result-resume",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="retry me",
+    )
+
+    result = await provider.generate(request)
+
+    assert result == "continued after tool failure"
+    event_types = [event.event_type for event in fake_hub.events]
+    assert RunEventType.LLM_RETRY_SCHEDULED not in event_types
+    assert event_types.count(RunEventType.TOOL_RESULT) == 1
+    assert len(scripted_agent.histories) == 2
+    resumed_history = scripted_agent.histories[1]
+    assert isinstance(resumed_history[-1], ModelRequest)
+    resumed_result_message = resumed_history[-1]
+    assert isinstance(resumed_result_message.parts[0], ToolReturnPart)
+    assert resumed_result_message.parts[0].tool_call_id == "call-failed-result"
+    history = message_repo.get_history("inst-failed-tool-result-resume")
+    assert len(history) == 4
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_retry_after_committed_messages_for_retryable_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "retry_blocked_committed_message.db", fake_hub
+    )
+    provider._session._retry_config.jitter = False
+    request_error = APIError(
+        "An error occurred during streaming",
+        request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+        body={
+            "error_msg": "Too many requests, the rate limit is 8000000 tokens per minute.",
+            "error_code": "InferHub.ModelArts.81101.429",
+        },
+    )
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[object()],
+                messages_by_step=[
+                    [ModelResponse(parts=[TextPart(content="committed before error")])]
+                ],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=request_error,
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+    request = LLMRequest(
+        run_id="run-committed-message-blocked",
+        trace_id="run-committed-message-blocked",
+        task_id="task-committed-message-blocked",
+        session_id="session-committed-message-blocked",
+        workspace_id="default",
+        instance_id="inst-committed-message-blocked",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="retry me",
+    )
+
+    with pytest.raises(AssistantRunError):
+        await provider.generate(request)
+
+    event_types = [event.event_type for event in fake_hub.events]
+    assert RunEventType.LLM_RETRY_SCHEDULED not in event_types
+    assert len(scripted_agent.histories) == 1
+    history = message_repo.get_history("inst-committed-message-blocked")
+    assert len(history) == 3
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_llm_retry.py
+++ b/tests/unit_tests/providers/test_llm_retry.py
@@ -67,6 +67,29 @@ def test_extract_retry_error_info_reads_provider_code_without_status() -> None:
     assert info.retryable is False
 
 
+def test_extract_retry_error_info_marks_maas_stream_rate_limit_as_retryable() -> None:
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    exc = APIError(
+        "An error occurred during streaming",
+        request=request,
+        body={
+            "error_msg": "Too many requests, the rate limit is 8000000 tokens per minute.",
+            "error_code": "InferHub.ModelArts.81101.429",
+        },
+    )
+
+    info = extract_retry_error_info(exc)
+
+    assert info is not None
+    assert info.status_code == 429
+    assert info.error_code == "InferHub.ModelArts.81101.429"
+    assert (
+        info.message
+        == "Too many requests, the rate limit is 8000000 tokens per minute."
+    )
+    assert info.retryable is True
+
+
 def test_extract_retry_error_info_marks_408_and_409_as_retryable() -> None:
     request = httpx.Request("POST", "https://example.test/v1/chat/completions")
     response_408 = httpx.Response(408, request=request)


### PR DESCRIPTION
## Summary
- harden LLM request retry classification for streamed provider rate-limit errors
- split request retry from tool-outcome resume and close superseded pending tool calls explicitly
- dedupe `_generate_async()` failure handling and refine retry budget reset semantics after successful retry progress
- allow retry after streamed text for `429` responses and add regression coverage

## Root Cause
Issue #362 exposed two separate problems in the LLM recovery path:
1. streamed MaaS rate-limit failures surfaced as `APIError` payloads that were not parsed into retryable `429` errors
2. retry/resume handling in `llm_session` coupled request replay decisions too tightly to coarse attempt side-effect flags, which blocked valid recovery paths and made failure handling harder to reason about

## What Changed
- extend `llm_retry` payload parsing to understand vendor-style streamed error bodies and recover retryable `429` metadata
- rework `llm_session` recovery so plain request retry and resume-after-tool-outcomes are distinct paths
- emit synthetic tool results when pending tool calls are superseded by retry or resume, so UI and run state do not keep hanging tool calls
- refactor `_generate_async()` exception recovery into shared helpers while preserving terminal error semantics per exception type
- reset retry budget only after a retry has made real forward progress, instead of carrying stale retry counts into later failures
- add unit coverage for streamed tool-call recovery, resume behavior, retry budget reset, and mid-stream `429` handling after text output

## Impact
- streamed provider throttling now retries correctly when recovery is still safe
- runs that already produced tool outcomes can resume from committed history instead of failing or replaying the wrong work
- retry status and tool lifecycle events stay consistent with what the runtime actually did

## Validation
- `uv run --extra dev pytest -q tests/unit_tests/providers/test_llm_retry.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py`
- `uv run --extra dev ruff check src/relay_teams/providers/llm_retry.py src/relay_teams/agents/execution/llm_session.py tests/unit_tests/providers/test_llm_retry.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py`
- `uv run --extra dev basedpyright src/relay_teams/providers/llm_retry.py src/relay_teams/agents/execution/llm_session.py tests/unit_tests/providers/test_llm_retry.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py`
- `python -m py_compile src/relay_teams/agents/execution/llm_session.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py`

Closes #362
