### PR TITLE
[codex] add windows computer runtime support

### DIFF
--- a/docs/computer-use-real-smoke.md
+++ b/docs/computer-use-real-smoke.md
@@ -79,4 +79,5 @@ Keep the existing fake model server setup if you want a deterministic tool seque
 
 - The OS really launches Calculator instead of only appending a fake window entry.
 - The run timeline contains a real screenshot from the desktop session.
+- Windows screenshot observations include the virtual-screen origin so multi-monitor coordinate picks stay aligned with pointer actions.
 - The `launch_app` tool result includes `data.launched_command`, which shows the resolved executable used by the OS backend, such as `calc.exe` on Windows or `gnome-calculator` on Linux.

--- a/docs/computer-use-real-smoke.md
+++ b/docs/computer-use-real-smoke.md
@@ -1,8 +1,16 @@
 # Computer Use Real Smoke
 
-This feature already has CI coverage through the scripted desktop runtime. Use this runbook when you need to verify that the built-in computer tools are operating a real Linux desktop session.
+This feature already has CI coverage through the scripted desktop runtime. Use this runbook when you need to verify that the built-in computer tools are operating a real desktop session on Linux or Windows.
 
 ## Prerequisites
+
+### Windows
+
+- Windows desktop session with an interactive user session
+- PowerShell available on `PATH`
+- Calculator available through `calc.exe`
+
+### Linux
 
 - Linux desktop session with `DISPLAY` or `WAYLAND_DISPLAY` available
 - Window discovery/activation:
@@ -15,7 +23,7 @@ This feature already has CI coverage through the scripted desktop runtime. Use t
   - `grim`, or
   - `scrot`, or
   - ImageMagick `import`, or
-  - `flameshot`
+- `flameshot`
 - A calculator app available through one of these launch paths:
   - `gtk-launch org.gnome.Calculator`
   - `gnome-calculator`
@@ -23,6 +31,8 @@ This feature already has CI coverage through the scripted desktop runtime. Use t
   - `mate-calc`
   - `galculator`
   - `xcalc`
+
+The Windows backend uses PowerShell for screenshot and window discovery, plus Win32 input injection for mouse and keyboard control. It expects a normal interactive desktop session.
 
 The Linux backend is intended for X11 or XWayland-style desktop control. Scripted CI validation remains the default because many headless or pure Wayland environments do not expose window/input automation consistently.
 
@@ -32,7 +42,7 @@ When Agent Teams launches apps through the Linux backend, it now prefers X11-com
 
 ## Start The Backend
 
-Agent Teams now auto-detects the host OS backend. On Linux, the real desktop runtime is selected automatically unless you explicitly force scripted validation.
+Agent Teams now auto-detects the host OS backend. On Linux and Windows, the real desktop runtime is selected automatically unless you explicitly force scripted validation.
 
 ```bash
 uv run --extra dev python -m uvicorn relay_teams.interfaces.server.app:app --host 127.0.0.1 --port 8000
@@ -69,4 +79,4 @@ Keep the existing fake model server setup if you want a deterministic tool seque
 
 - The OS really launches Calculator instead of only appending a fake window entry.
 - The run timeline contains a real screenshot from the desktop session.
-- The `launch_app` tool result includes `data.launched_command`, which shows the resolved executable used by the Linux backend.
+- The `launch_app` tool result includes `data.launched_command`, which shows the resolved executable used by the OS backend, such as `calc.exe` on Windows or `gnome-calculator` on Linux.

--- a/src/relay_teams/computer/__init__.py
+++ b/src/relay_teams/computer/__init__.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         ScriptedComputerRuntime,
         build_default_computer_runtime,
     )
+    from relay_teams.computer.windows_runtime import WindowsDesktopRuntime
 
 __all__ = [
     "BUILTIN_COMPUTER_TOOL_NAMES",
@@ -48,6 +49,7 @@ __all__ = [
     "ExecutionSurface",
     "LinuxDesktopRuntime",
     "ScriptedComputerRuntime",
+    "WindowsDesktopRuntime",
     "build_computer_tool_payload",
     "build_default_computer_runtime",
     "describe_builtin_tool",
@@ -88,6 +90,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ScriptedComputerRuntime": (
         "relay_teams.computer.runtime",
         "ScriptedComputerRuntime",
+    ),
+    "WindowsDesktopRuntime": (
+        "relay_teams.computer.windows_runtime",
+        "WindowsDesktopRuntime",
     ),
     "build_computer_tool_payload": (
         "relay_teams.computer.mapping",

--- a/src/relay_teams/computer/models.py
+++ b/src/relay_teams/computer/models.py
@@ -100,6 +100,8 @@ class ComputerObservation(BaseModel):
     screenshot_bytes: bytes | None = None
     screenshot_mime_type: str | None = None
     screenshot_name: str = ""
+    screenshot_origin_x: int | None = None
+    screenshot_origin_y: int | None = None
     screenshot_width: int | None = Field(default=None, ge=0)
     screenshot_height: int | None = Field(default=None, ge=0)
 

--- a/src/relay_teams/computer/runtime.py
+++ b/src/relay_teams/computer/runtime.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Protocol
 
 from relay_teams.computer.linux_runtime import LinuxDesktopRuntime
+from relay_teams.computer.windows_runtime import WindowsDesktopRuntime
 from relay_teams.computer.models import (
     ComputerActionDescriptor,
     ComputerActionResult,
@@ -370,6 +371,8 @@ def build_default_computer_runtime(*, project_root: Path) -> ComputerRuntime:
     system_name = _platform_system()
     if system_name == "linux":
         return LinuxDesktopRuntime(project_root=project_root)
+    if system_name == "windows":
+        return WindowsDesktopRuntime(project_root=project_root)
     if system_name == "darwin":
         return DisabledComputerRuntime(
             reason="macOS desktop control has not been implemented yet."

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -230,6 +230,8 @@ class WindowsDesktopRuntime:
             data={
                 "window_count": len(observation.windows),
                 "runtime_mode": "windows",
+                "virtual_screen_origin_x": observation.screenshot_origin_x,
+                "virtual_screen_origin_y": observation.screenshot_origin_y,
             },
         )
 
@@ -509,6 +511,8 @@ class WindowsDesktopRuntime:
         screenshot_bytes: bytes | None = None
         screenshot_name = ""
         screenshot_mime_type: str | None = None
+        screenshot_origin_x: int | None = None
+        screenshot_origin_y: int | None = None
         screenshot_width: int | None = None
         screenshot_height: int | None = None
         if require_screenshot:
@@ -516,6 +520,8 @@ class WindowsDesktopRuntime:
                 screenshot_bytes,
                 screenshot_name,
                 screenshot_mime_type,
+                screenshot_origin_x,
+                screenshot_origin_y,
                 screenshot_width,
                 screenshot_height,
             ) = self._capture_screenshot_bytes(required=True)
@@ -534,6 +540,8 @@ class WindowsDesktopRuntime:
             screenshot_bytes=screenshot_bytes,
             screenshot_mime_type=screenshot_mime_type,
             screenshot_name=screenshot_name,
+            screenshot_origin_x=screenshot_origin_x,
+            screenshot_origin_y=screenshot_origin_y,
             screenshot_width=screenshot_width,
             screenshot_height=screenshot_height,
         )
@@ -542,7 +550,15 @@ class WindowsDesktopRuntime:
         self,
         *,
         required: bool,
-    ) -> tuple[bytes | None, str, str | None, int | None, int | None]:
+    ) -> tuple[
+        bytes | None,
+        str,
+        str | None,
+        int | None,
+        int | None,
+        int | None,
+        int | None,
+    ]:
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as handle:
             screenshot_path = Path(handle.name)
 
@@ -551,12 +567,16 @@ class WindowsDesktopRuntime:
                 self._build_capture_screenshot_script(screenshot_path)
             )
             if screenshot_path.exists() and screenshot_path.stat().st_size > 0:
+                origin_x = self._read_json_int(payload, "left")
+                origin_y = self._read_json_int(payload, "top")
                 width = self._read_json_int(payload, "width")
                 height = self._read_json_int(payload, "height")
                 return (
                     screenshot_path.read_bytes(),
                     screenshot_path.name,
                     "image/png",
+                    origin_x,
+                    origin_y,
                     width,
                     height,
                 )
@@ -568,7 +588,7 @@ class WindowsDesktopRuntime:
                 "Skipping Windows desktop screenshot because no screenshot was "
                 "produced."
             )
-            return None, "", None, None, None
+            return None, "", None, None, None, None, None
         except RuntimeError:
             if required:
                 raise
@@ -576,7 +596,7 @@ class WindowsDesktopRuntime:
                 "Skipping Windows desktop screenshot because screenshot capture "
                 "failed.",
             )
-            return None, "", None, None, None
+            return None, "", None, None, None, None, None
         finally:
             screenshot_path.unlink(missing_ok=True)
 
@@ -601,7 +621,12 @@ class WindowsDesktopRuntime:
                 "$graphics.Dispose()",
                 "$bitmap.Dispose()",
                 (
-                    "[pscustomobject]@{ width = $bounds.Width; height = $bounds.Height } "
+                    "[pscustomobject]@{ "
+                    "left = $bounds.Left; "
+                    "top = $bounds.Top; "
+                    "width = $bounds.Width; "
+                    "height = $bounds.Height "
+                    "} "
                     "| ConvertTo-Json -Compress"
                 ),
             ]

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -377,8 +377,12 @@ class WindowsDesktopRuntime:
         )
         command = self._resolve_launch_command(app_name)
         self._spawn_process(command)
+        window_queries = self._build_launch_window_queries(
+            app_name=app_name,
+            command=command,
+        )
         matched_window = self._wait_for_window_match(
-            query=app_name,
+            queries=window_queries,
             before_windows=before_windows,
         )
         if matched_window is None:
@@ -410,7 +414,7 @@ class WindowsDesktopRuntime:
         )
 
     def _wait_for_window_sync(self, window_title: str) -> ComputerActionResult:
-        matched_window = self._wait_for_window_match(query=window_title)
+        matched_window = self._wait_for_window_match(queries=(window_title,))
         if matched_window is None:
             raise RuntimeError(f"Window not found within timeout: {window_title}")
         observation = self._build_observation(
@@ -487,13 +491,19 @@ class WindowsDesktopRuntime:
         require_input: bool,
         require_screenshot: bool,
     ) -> ComputerObservation:
-        (
-            screenshot_bytes,
-            screenshot_name,
-            screenshot_mime_type,
-            screenshot_width,
-            screenshot_height,
-        ) = self._capture_screenshot_bytes(required=require_screenshot)
+        screenshot_bytes: bytes | None = None
+        screenshot_name = ""
+        screenshot_mime_type: str | None = None
+        screenshot_width: int | None = None
+        screenshot_height: int | None = None
+        if require_screenshot:
+            (
+                screenshot_bytes,
+                screenshot_name,
+                screenshot_mime_type,
+                screenshot_width,
+                screenshot_height,
+            ) = self._capture_screenshot_bytes(required=True)
         windows = self._list_windows_snapshot(
             require_windows=require_windows,
             require_input=require_input,
@@ -668,10 +678,10 @@ class WindowsDesktopRuntime:
     def _wait_for_window_match(
         self,
         *,
-        query: str,
+        queries: tuple[str, ...] = (),
         before_windows: tuple[ComputerWindow, ...] = (),
     ) -> ComputerWindow | None:
-        normalized_query = query.strip()
+        normalized_queries = self._normalize_match_queries(*queries)
         before_ids = {window.window_id for window in before_windows}
         deadline = self._time_monotonic() + _WAIT_TIMEOUT_SECONDS
         while self._time_monotonic() < deadline:
@@ -682,14 +692,74 @@ class WindowsDesktopRuntime:
             for window in windows:
                 is_new_window = window.window_id not in before_ids
                 if is_new_window and (
-                    not normalized_query
-                    or self._window_matches(window, normalized_query)
+                    not normalized_queries
+                    or self._window_matches_any(window, normalized_queries)
                 ):
                     return window
-                if normalized_query and self._window_matches(window, normalized_query):
+                if normalized_queries and self._window_matches_any(
+                    window,
+                    normalized_queries,
+                ):
                     return window
             self._sleep(_POLL_INTERVAL_SECONDS)
         return None
+
+    def _build_launch_window_queries(
+        self,
+        *,
+        app_name: str,
+        command: list[str],
+    ) -> tuple[str, ...]:
+        raw_query = app_name.strip()
+        parsed_command = shlex.split(raw_query, posix=False)
+        first_input_token = parsed_command[0] if parsed_command else raw_query
+        command_token = self._launch_match_token(command)
+        candidate_queries: list[str] = [raw_query]
+        for token in (first_input_token, command_token):
+            if token is None:
+                continue
+            normalized_token = token.strip().strip('"').strip("'")
+            if not normalized_token:
+                continue
+            token_path = Path(normalized_token)
+            candidate_queries.append(normalized_token)
+            candidate_queries.append(token_path.name)
+            if token_path.suffix:
+                candidate_queries.append(token_path.stem)
+        return self._normalize_match_queries(*candidate_queries)
+
+    def _launch_match_token(self, command: list[str]) -> str | None:
+        if not command:
+            return None
+        if (
+            len(command) >= 5
+            and command[0].casefold() == "cmd"
+            and command[1].casefold() == "/c"
+            and command[2].casefold() == "start"
+        ):
+            return command[4]
+        return command[0]
+
+    def _normalize_match_queries(self, *queries: str) -> tuple[str, ...]:
+        normalized_queries: list[str] = []
+        seen_queries: set[str] = set()
+        for query in queries:
+            normalized_query = query.strip()
+            if not normalized_query:
+                continue
+            dedupe_key = normalized_query.casefold()
+            if dedupe_key in seen_queries:
+                continue
+            normalized_queries.append(normalized_query)
+            seen_queries.add(dedupe_key)
+        return tuple(normalized_queries)
+
+    def _window_matches_any(
+        self,
+        window: ComputerWindow,
+        queries: tuple[str, ...],
+    ) -> bool:
+        return any(self._window_matches(window, query) for query in queries)
 
     def _window_matches(self, window: ComputerWindow, query: str) -> bool:
         normalized_query = query.casefold()

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -64,6 +64,7 @@ _VK_BACK = 0x08
 _VK_LWIN = 0x5B
 _SM_XVIRTUALSCREEN = 76
 _SM_YVIRTUALSCREEN = 77
+_SW_RESTORE = 9
 
 _PROCESS_CREATION_FLAGS = getattr(
     subprocess,
@@ -257,7 +258,7 @@ class WindowsDesktopRuntime:
 
     def _focus_window_sync(self, window_title: str) -> ComputerActionResult:
         matched_window = self._find_window(window_title)
-        self._activate_window(matched_window.title)
+        self._activate_window(matched_window.window_id)
         self._sleep(_WINDOW_ACTIVATE_DELAY_SECONDS)
         observation = self._build_observation(
             require_windows=True,
@@ -402,7 +403,7 @@ class WindowsDesktopRuntime:
         )
         if matched_window is None:
             raise RuntimeError(f"App window did not appear within timeout: {app_name}")
-        self._activate_window(matched_window.title)
+        self._activate_window(matched_window.window_id)
         self._sleep(_WINDOW_ACTIVATE_DELAY_SECONDS)
         observation = self._build_observation(
             require_windows=True,
@@ -683,25 +684,62 @@ class WindowsDesktopRuntime:
             [
                 "Add-Type @'",
                 "using System;",
+                "using System.Collections.Generic;",
                 "using System.Runtime.InteropServices;",
+                "using System.Text;",
                 "public static class RelayTeamsWin32 {",
+                "    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);",
+                '    [DllImport("user32.dll")]',
+                "    public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);",
                 '    [DllImport("user32.dll")]',
                 "    public static extern IntPtr GetForegroundWindow();",
+                '    [DllImport("user32.dll")]',
+                "    public static extern bool IsWindowVisible(IntPtr hWnd);",
+                '    [DllImport("user32.dll", CharSet = CharSet.Unicode)]',
+                "    public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);",
+                '    [DllImport("user32.dll", CharSet = CharSet.Unicode)]',
+                "    public static extern int GetWindowTextLength(IntPtr hWnd);",
+                '    [DllImport("user32.dll")]',
+                "    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);",
                 "}",
                 "'@",
                 "$foreground = [int64][RelayTeamsWin32]::GetForegroundWindow()",
-                (
-                    "$windows = Get-Process | Where-Object { "
-                    "$_.MainWindowHandle -ne 0 -and $_.MainWindowTitle "
-                    "} | Sort-Object Id | ForEach-Object {"
-                ),
-                "    [pscustomobject]@{",
-                "        window_id = ('0x{0:x}' -f [int64]$_.MainWindowHandle)",
-                "        app_name = $_.ProcessName",
-                "        title = $_.MainWindowTitle",
-                "        focused = ([int64]$_.MainWindowHandle -eq $foreground)",
+                "$windows = New-Object 'System.Collections.Generic.List[object]'",
+                "$callback = [RelayTeamsWin32+EnumWindowsProc] {",
+                "    param([IntPtr]$hWnd, [IntPtr]$lParam)",
+                "    if (-not [RelayTeamsWin32]::IsWindowVisible($hWnd)) {",
+                "        return $true",
                 "    }",
+                "    $length = [RelayTeamsWin32]::GetWindowTextLength($hWnd)",
+                "    if ($length -le 0) {",
+                "        return $true",
+                "    }",
+                "    $builder = New-Object System.Text.StringBuilder ($length + 1)",
+                "    [void][RelayTeamsWin32]::GetWindowText($hWnd, $builder, $builder.Capacity)",
+                "    $title = $builder.ToString()",
+                "    if ([string]::IsNullOrWhiteSpace($title)) {",
+                "        return $true",
+                "    }",
+                "    $processId = [uint32]0",
+                "    [void][RelayTeamsWin32]::GetWindowThreadProcessId($hWnd, [ref]$processId)",
+                "    $processName = ''",
+                "    if ($processId -ne 0) {",
+                "        try {",
+                "            $processName = (Get-Process -Id $processId -ErrorAction Stop).ProcessName",
+                "        } catch {",
+                "            $processName = ''",
+                "        }",
+                "    }",
+                "    $windows.Add([pscustomobject]@{",
+                "        window_id = ('0x{0:x}' -f [int64]$hWnd)",
+                "        app_name = $processName",
+                "        title = $title",
+                "        focused = ([int64]$hWnd -eq $foreground)",
+                "    })",
+                "    return $true",
                 "}",
+                "[void][RelayTeamsWin32]::EnumWindows($callback, [IntPtr]::Zero)",
+                "$windows = $windows | Sort-Object window_id",
                 "$windows | ConvertTo-Json -Depth 3 -Compress",
             ]
         )
@@ -814,18 +852,30 @@ class WindowsDesktopRuntime:
             or normalized_query in window.app_name.casefold()
         )
 
-    def _activate_window(self, window_title: str) -> None:
-        literal_title = self._powershell_literal(window_title)
-        self._run_powershell(
-            "\n".join(
-                [
-                    "$wshell = New-Object -ComObject WScript.Shell",
-                    f"if (-not $wshell.AppActivate({literal_title})) {{",
-                    f"    throw {self._powershell_literal(f'Window not found: {window_title}')}",
-                    "}",
-                ]
-            )
-        )
+    def _activate_window(self, window_id: str) -> None:
+        handle = self._parse_window_id(window_id)
+        user32 = self._load_user32()
+        user32.IsWindow.argtypes = (wintypes.HWND,)
+        user32.IsWindow.restype = wintypes.BOOL
+        user32.ShowWindow.argtypes = (wintypes.HWND, ctypes.c_int)
+        user32.ShowWindow.restype = wintypes.BOOL
+        user32.SetForegroundWindow.argtypes = (wintypes.HWND,)
+        user32.SetForegroundWindow.restype = wintypes.BOOL
+        if not user32.IsWindow(handle):
+            raise RuntimeError(f"Window not found: {window_id}")
+        user32.ShowWindow(handle, _SW_RESTORE)
+        if not user32.SetForegroundWindow(handle):
+            raise RuntimeError(f"Windows desktop activation failed: {window_id}")
+
+    def _parse_window_id(self, window_id: str) -> wintypes.HWND:
+        normalized = window_id.strip()
+        if not normalized:
+            raise ValueError("window_id is required")
+        try:
+            handle_value = int(normalized, 16)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported window_id: {window_id}") from exc
+        return wintypes.HWND(handle_value)
 
     def _resolve_launch_command(self, app_name: str) -> list[str]:
         normalized = app_name.strip()

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -816,11 +816,13 @@ class WindowsDesktopRuntime:
         if not command:
             return None
         if (
-            len(command) >= 5
+            len(command) >= 4
             and command[0].casefold() == "cmd"
             and command[1].casefold() == "/c"
             and command[2].casefold() == "start"
         ):
+            if len(command) == 4:
+                return command[3]
             return command[4]
         return command[0]
 

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -62,6 +62,8 @@ _VK_NEXT = 0x22
 _VK_INSERT = 0x2D
 _VK_BACK = 0x08
 _VK_LWIN = 0x5B
+_SM_XVIRTUALSCREEN = 76
+_SM_YVIRTUALSCREEN = 77
 
 _PROCESS_CREATION_FLAGS = getattr(
     subprocess,
@@ -276,7 +278,8 @@ class WindowsDesktopRuntime:
         )
 
     def _click_at_sync(self, x: int, y: int) -> ComputerActionResult:
-        self._set_cursor_position(x, y)
+        translated_x, translated_y = self._translate_screenshot_coordinates(x, y)
+        self._set_cursor_position(translated_x, translated_y)
         self._mouse_click(repeat=1)
         self._sleep(_POINTER_SETTLE_SECONDS)
         return self._action_result(
@@ -288,7 +291,8 @@ class WindowsDesktopRuntime:
         )
 
     def _double_click_at_sync(self, x: int, y: int) -> ComputerActionResult:
-        self._set_cursor_position(x, y)
+        translated_x, translated_y = self._translate_screenshot_coordinates(x, y)
+        self._set_cursor_position(translated_x, translated_y)
         self._mouse_click(repeat=2)
         self._sleep(_POINTER_SETTLE_SECONDS)
         return self._action_result(
@@ -306,10 +310,18 @@ class WindowsDesktopRuntime:
         end_x: int,
         end_y: int,
     ) -> ComputerActionResult:
-        self._set_cursor_position(start_x, start_y)
+        translated_start_x, translated_start_y = self._translate_screenshot_coordinates(
+            start_x,
+            start_y,
+        )
+        translated_end_x, translated_end_y = self._translate_screenshot_coordinates(
+            end_x,
+            end_y,
+        )
+        self._set_cursor_position(translated_start_x, translated_start_y)
         self._send_mouse_event(_MOUSEEVENTF_LEFTDOWN)
         self._sleep(_POINTER_SETTLE_SECONDS)
-        self._set_cursor_position(end_x, end_y)
+        self._set_cursor_position(translated_end_x, translated_end_y)
         self._sleep(_POINTER_SETTLE_SECONDS)
         self._send_mouse_event(_MOUSEEVENTF_LEFTUP)
         self._sleep(_POINTER_SETTLE_SECONDS)
@@ -414,7 +426,10 @@ class WindowsDesktopRuntime:
         )
 
     def _wait_for_window_sync(self, window_title: str) -> ComputerActionResult:
-        matched_window = self._wait_for_window_match(queries=(window_title,))
+        normalized_title = window_title.strip()
+        if not normalized_title:
+            raise ValueError("window_title is required")
+        matched_window = self._wait_for_window_match(queries=(normalized_title,))
         if matched_window is None:
             raise RuntimeError(f"Window not found within timeout: {window_title}")
         observation = self._build_observation(
@@ -914,6 +929,19 @@ class WindowsDesktopRuntime:
                 flags=_KEYEVENTF_KEYUP,
             ),
         ]
+
+    def _translate_screenshot_coordinates(self, x: int, y: int) -> tuple[int, int]:
+        origin_x, origin_y = self._get_virtual_screen_origin()
+        return x + origin_x, y + origin_y
+
+    def _get_virtual_screen_origin(self) -> tuple[int, int]:
+        user32 = self._load_user32()
+        user32.GetSystemMetrics.argtypes = (ctypes.c_int,)
+        user32.GetSystemMetrics.restype = ctypes.c_int
+        return (
+            int(user32.GetSystemMetrics(_SM_XVIRTUALSCREEN)),
+            int(user32.GetSystemMetrics(_SM_YVIRTUALSCREEN)),
+        )
 
     def _keyboard_input(
         self,

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -1,0 +1,1003 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import json
+import shlex
+import shutil
+import subprocess
+import tempfile
+import time
+from ctypes import wintypes
+from pathlib import Path
+
+from relay_teams.computer.models import (
+    ComputerActionDescriptor,
+    ComputerActionResult,
+    ComputerActionRisk,
+    ComputerActionTarget,
+    ComputerActionType,
+    ComputerObservation,
+    ComputerPermissionScope,
+    ComputerRuntimeKind,
+    ComputerWindow,
+    ExecutionSurface,
+)
+from relay_teams.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+_WAIT_TIMEOUT_SECONDS = 10.0
+_POLL_INTERVAL_SECONDS = 0.25
+_COMMAND_TIMEOUT_SECONDS = 10.0
+_POINTER_SETTLE_SECONDS = 0.05
+_WINDOW_ACTIVATE_DELAY_SECONDS = 0.2
+
+_INPUT_MOUSE = 0
+_INPUT_KEYBOARD = 1
+_KEYEVENTF_KEYUP = 0x0002
+_KEYEVENTF_UNICODE = 0x0004
+_MOUSEEVENTF_LEFTDOWN = 0x0002
+_MOUSEEVENTF_LEFTUP = 0x0004
+_MOUSEEVENTF_WHEEL = 0x0800
+_WHEEL_DELTA = 120
+
+_VK_SHIFT = 0x10
+_VK_CONTROL = 0x11
+_VK_MENU = 0x12
+_VK_RETURN = 0x0D
+_VK_ESCAPE = 0x1B
+_VK_TAB = 0x09
+_VK_SPACE = 0x20
+_VK_LEFT = 0x25
+_VK_UP = 0x26
+_VK_RIGHT = 0x27
+_VK_DOWN = 0x28
+_VK_DELETE = 0x2E
+_VK_HOME = 0x24
+_VK_END = 0x23
+_VK_PRIOR = 0x21
+_VK_NEXT = 0x22
+_VK_INSERT = 0x2D
+_VK_BACK = 0x08
+_VK_LWIN = 0x5B
+
+_PROCESS_CREATION_FLAGS = getattr(
+    subprocess,
+    "CREATE_NEW_PROCESS_GROUP",
+    0,
+) | getattr(
+    subprocess,
+    "DETACHED_PROCESS",
+    0,
+)
+
+_MODIFIER_VKEYS: dict[str, int] = {
+    "alt": _VK_MENU,
+    "cmd": _VK_LWIN,
+    "command": _VK_LWIN,
+    "control": _VK_CONTROL,
+    "ctrl": _VK_CONTROL,
+    "meta": _VK_LWIN,
+    "shift": _VK_SHIFT,
+    "super": _VK_LWIN,
+    "win": _VK_LWIN,
+    "windows": _VK_LWIN,
+}
+
+_NAMED_VKEYS: dict[str, int] = {
+    "backspace": _VK_BACK,
+    "delete": _VK_DELETE,
+    "del": _VK_DELETE,
+    "down": _VK_DOWN,
+    "end": _VK_END,
+    "enter": _VK_RETURN,
+    "esc": _VK_ESCAPE,
+    "escape": _VK_ESCAPE,
+    "home": _VK_HOME,
+    "insert": _VK_INSERT,
+    "ins": _VK_INSERT,
+    "left": _VK_LEFT,
+    "minus": 0xBD,
+    "pagedown": _VK_NEXT,
+    "pageup": _VK_PRIOR,
+    "period": 0xBE,
+    "plus": 0xBB,
+    "quote": 0xDE,
+    "right": _VK_RIGHT,
+    "semicolon": 0xBA,
+    "slash": 0xBF,
+    "space": _VK_SPACE,
+    "tab": _VK_TAB,
+    "up": _VK_UP,
+}
+
+_ULONG_PTR = ctypes.c_size_t
+
+
+class _MouseInput(ctypes.Structure):
+    _fields_ = [
+        ("dx", wintypes.LONG),
+        ("dy", wintypes.LONG),
+        ("mouseData", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("time", wintypes.DWORD),
+        ("dwExtraInfo", _ULONG_PTR),
+    ]
+
+
+class _KeyboardInput(ctypes.Structure):
+    _fields_ = [
+        ("wVk", wintypes.WORD),
+        ("wScan", wintypes.WORD),
+        ("dwFlags", wintypes.DWORD),
+        ("time", wintypes.DWORD),
+        ("dwExtraInfo", _ULONG_PTR),
+    ]
+
+
+class _HardwareInput(ctypes.Structure):
+    _fields_ = [
+        ("uMsg", wintypes.DWORD),
+        ("wParamL", wintypes.WORD),
+        ("wParamH", wintypes.WORD),
+    ]
+
+
+class _InputUnion(ctypes.Union):
+    _fields_ = [
+        ("mi", _MouseInput),
+        ("ki", _KeyboardInput),
+        ("hi", _HardwareInput),
+    ]
+
+
+class _Input(ctypes.Structure):
+    _anonymous_ = ("payload",)
+    _fields_ = [
+        ("type", wintypes.DWORD),
+        ("payload", _InputUnion),
+    ]
+
+
+class WindowsDesktopRuntime:
+    def __init__(self, *, project_root: Path) -> None:
+        self._project_root = Path(project_root)
+
+    async def capture_screen(self) -> ComputerActionResult:
+        return await asyncio.to_thread(self._capture_screen_sync)
+
+    async def list_windows(self) -> ComputerActionResult:
+        return await asyncio.to_thread(self._list_windows_sync)
+
+    async def focus_window(self, *, window_title: str) -> ComputerActionResult:
+        return await asyncio.to_thread(self._focus_window_sync, window_title)
+
+    async def click_at(self, *, x: int, y: int) -> ComputerActionResult:
+        return await asyncio.to_thread(self._click_at_sync, x, y)
+
+    async def double_click_at(self, *, x: int, y: int) -> ComputerActionResult:
+        return await asyncio.to_thread(self._double_click_at_sync, x, y)
+
+    async def drag_between(
+        self,
+        *,
+        start_x: int,
+        start_y: int,
+        end_x: int,
+        end_y: int,
+    ) -> ComputerActionResult:
+        return await asyncio.to_thread(
+            self._drag_between_sync,
+            start_x,
+            start_y,
+            end_x,
+            end_y,
+        )
+
+    async def type_text(self, *, text: str) -> ComputerActionResult:
+        return await asyncio.to_thread(self._type_text_sync, text)
+
+    async def scroll_view(self, *, amount: int) -> ComputerActionResult:
+        return await asyncio.to_thread(self._scroll_view_sync, amount)
+
+    async def hotkey(self, *, shortcut: str) -> ComputerActionResult:
+        return await asyncio.to_thread(self._hotkey_sync, shortcut)
+
+    async def launch_app(self, *, app_name: str) -> ComputerActionResult:
+        return await asyncio.to_thread(self._launch_app_sync, app_name)
+
+    async def wait_for_window(self, *, window_title: str) -> ComputerActionResult:
+        return await asyncio.to_thread(self._wait_for_window_sync, window_title)
+
+    def _capture_screen_sync(self) -> ComputerActionResult:
+        observation = self._build_observation(
+            require_windows=False,
+            require_input=False,
+            require_screenshot=True,
+        )
+        return ComputerActionResult(
+            action=self._descriptor(
+                action=ComputerActionType.CAPTURE_SCREEN,
+                permission_scope=ComputerPermissionScope.OBSERVE,
+                risk_level=ComputerActionRisk.SAFE,
+            ),
+            message="Captured the current Windows desktop screenshot.",
+            observation=observation,
+            data={
+                "window_count": len(observation.windows),
+                "runtime_mode": "windows",
+            },
+        )
+
+    def _list_windows_sync(self) -> ComputerActionResult:
+        observation = self._build_observation(
+            require_windows=True,
+            require_input=False,
+            require_screenshot=False,
+        )
+        return ComputerActionResult(
+            action=self._descriptor(
+                action=ComputerActionType.LIST_WINDOWS,
+                permission_scope=ComputerPermissionScope.OBSERVE,
+                risk_level=ComputerActionRisk.SAFE,
+            ),
+            message="Listed visible windows in the Windows desktop runtime.",
+            observation=observation,
+            data={
+                "window_count": len(observation.windows),
+                "runtime_mode": "windows",
+            },
+        )
+
+    def _focus_window_sync(self, window_title: str) -> ComputerActionResult:
+        matched_window = self._find_window(window_title)
+        self._activate_window(matched_window.title)
+        self._sleep(_WINDOW_ACTIVATE_DELAY_SECONDS)
+        observation = self._build_observation(
+            require_windows=True,
+            require_input=True,
+            require_screenshot=False,
+        )
+        return ComputerActionResult(
+            action=self._descriptor(
+                action=ComputerActionType.FOCUS_WINDOW,
+                permission_scope=ComputerPermissionScope.WINDOW_MANAGEMENT,
+                risk_level=ComputerActionRisk.GUARDED,
+                target=ComputerActionTarget(window_title=matched_window.title),
+            ),
+            message=f"Focused Windows desktop window: {matched_window.title}.",
+            observation=observation,
+            data={
+                "window_count": len(observation.windows),
+                "runtime_mode": "windows",
+            },
+        )
+
+    def _click_at_sync(self, x: int, y: int) -> ComputerActionResult:
+        self._set_cursor_position(x, y)
+        self._mouse_click(repeat=1)
+        self._sleep(_POINTER_SETTLE_SECONDS)
+        return self._action_result(
+            action=ComputerActionType.CLICK,
+            permission_scope=ComputerPermissionScope.POINTER,
+            risk_level=ComputerActionRisk.GUARDED,
+            target=ComputerActionTarget(x=x, y=y),
+            message=f"Clicked Windows desktop coordinates ({x}, {y}).",
+        )
+
+    def _double_click_at_sync(self, x: int, y: int) -> ComputerActionResult:
+        self._set_cursor_position(x, y)
+        self._mouse_click(repeat=2)
+        self._sleep(_POINTER_SETTLE_SECONDS)
+        return self._action_result(
+            action=ComputerActionType.DOUBLE_CLICK,
+            permission_scope=ComputerPermissionScope.POINTER,
+            risk_level=ComputerActionRisk.GUARDED,
+            target=ComputerActionTarget(x=x, y=y),
+            message=f"Double-clicked Windows desktop coordinates ({x}, {y}).",
+        )
+
+    def _drag_between_sync(
+        self,
+        start_x: int,
+        start_y: int,
+        end_x: int,
+        end_y: int,
+    ) -> ComputerActionResult:
+        self._set_cursor_position(start_x, start_y)
+        self._send_mouse_event(_MOUSEEVENTF_LEFTDOWN)
+        self._sleep(_POINTER_SETTLE_SECONDS)
+        self._set_cursor_position(end_x, end_y)
+        self._sleep(_POINTER_SETTLE_SECONDS)
+        self._send_mouse_event(_MOUSEEVENTF_LEFTUP)
+        self._sleep(_POINTER_SETTLE_SECONDS)
+        return self._action_result(
+            action=ComputerActionType.DRAG,
+            permission_scope=ComputerPermissionScope.DESTRUCTIVE,
+            risk_level=ComputerActionRisk.DESTRUCTIVE,
+            target=ComputerActionTarget(
+                x=start_x,
+                y=start_y,
+                end_x=end_x,
+                end_y=end_y,
+            ),
+            message=(
+                "Dragged between Windows desktop coordinates "
+                f"({start_x}, {start_y}) -> ({end_x}, {end_y})."
+            ),
+        )
+
+    def _type_text_sync(self, text: str) -> ComputerActionResult:
+        if not text.strip():
+            raise ValueError("text is required")
+        self._send_unicode_text(text)
+        self._sleep(_POINTER_SETTLE_SECONDS)
+        return self._action_result(
+            action=ComputerActionType.TYPE_TEXT,
+            permission_scope=ComputerPermissionScope.INPUT_TEXT,
+            risk_level=ComputerActionRisk.GUARDED,
+            target=ComputerActionTarget(text=text),
+            message=f"Typed text into the Windows desktop: {text}",
+        )
+
+    def _scroll_view_sync(self, amount: int) -> ComputerActionResult:
+        if amount == 0:
+            raise ValueError("amount must not be zero")
+        self._send_mouse_event(
+            _MOUSEEVENTF_WHEEL,
+            data=amount * _WHEEL_DELTA,
+        )
+        self._sleep(_POINTER_SETTLE_SECONDS)
+        return self._action_result(
+            action=ComputerActionType.SCROLL,
+            permission_scope=ComputerPermissionScope.POINTER,
+            risk_level=ComputerActionRisk.GUARDED,
+            target=ComputerActionTarget(amount=amount),
+            message=f"Scrolled the Windows desktop by {amount}.",
+        )
+
+    def _hotkey_sync(self, shortcut: str) -> ComputerActionResult:
+        modifier_keys, normal_keys = self._normalize_shortcut(shortcut)
+        self._send_hotkey_inputs(modifier_keys, normal_keys)
+        self._sleep(_POINTER_SETTLE_SECONDS)
+        return self._action_result(
+            action=ComputerActionType.HOTKEY,
+            permission_scope=ComputerPermissionScope.KEYBOARD_SHORTCUT,
+            risk_level=ComputerActionRisk.GUARDED,
+            target=ComputerActionTarget(shortcut=shortcut),
+            message=f"Sent Windows desktop shortcut: {shortcut}",
+        )
+
+    def _launch_app_sync(self, app_name: str) -> ComputerActionResult:
+        before_windows = self._list_windows_snapshot(
+            require_windows=False,
+            require_input=False,
+        )
+        command = self._resolve_launch_command(app_name)
+        self._spawn_process(command)
+        matched_window = self._wait_for_window_match(
+            query=app_name,
+            before_windows=before_windows,
+        )
+        if matched_window is None:
+            raise RuntimeError(f"App window did not appear within timeout: {app_name}")
+        self._activate_window(matched_window.title)
+        self._sleep(_WINDOW_ACTIVATE_DELAY_SECONDS)
+        observation = self._build_observation(
+            require_windows=True,
+            require_input=True,
+            require_screenshot=False,
+        )
+        return ComputerActionResult(
+            action=self._descriptor(
+                action=ComputerActionType.LAUNCH_APP,
+                permission_scope=ComputerPermissionScope.APP_LAUNCH,
+                risk_level=ComputerActionRisk.DESTRUCTIVE,
+                target=ComputerActionTarget(
+                    app_name=app_name,
+                    window_title=matched_window.title,
+                ),
+            ),
+            message=f"Launched Windows desktop app: {app_name}.",
+            observation=observation,
+            data={
+                "window_count": len(observation.windows),
+                "runtime_mode": "windows",
+                "launched_command": " ".join(command),
+            },
+        )
+
+    def _wait_for_window_sync(self, window_title: str) -> ComputerActionResult:
+        matched_window = self._wait_for_window_match(query=window_title)
+        if matched_window is None:
+            raise RuntimeError(f"Window not found within timeout: {window_title}")
+        observation = self._build_observation(
+            require_windows=True,
+            require_input=True,
+            require_screenshot=False,
+        )
+        return ComputerActionResult(
+            action=self._descriptor(
+                action=ComputerActionType.WAIT_FOR_WINDOW,
+                permission_scope=ComputerPermissionScope.OBSERVE,
+                risk_level=ComputerActionRisk.SAFE,
+                target=ComputerActionTarget(window_title=matched_window.title),
+            ),
+            message=f"Observed Windows desktop window: {matched_window.title}.",
+            observation=observation,
+            data={
+                "window_count": len(observation.windows),
+                "runtime_mode": "windows",
+            },
+        )
+
+    def _action_result(
+        self,
+        *,
+        action: ComputerActionType,
+        permission_scope: ComputerPermissionScope,
+        risk_level: ComputerActionRisk,
+        target: ComputerActionTarget,
+        message: str,
+    ) -> ComputerActionResult:
+        observation = self._build_observation(
+            require_windows=True,
+            require_input=True,
+            require_screenshot=False,
+        )
+        return ComputerActionResult(
+            action=self._descriptor(
+                action=action,
+                permission_scope=permission_scope,
+                risk_level=risk_level,
+                target=target,
+            ),
+            message=message,
+            observation=observation,
+            data={
+                "window_count": len(observation.windows),
+                "runtime_mode": "windows",
+            },
+        )
+
+    def _descriptor(
+        self,
+        *,
+        action: ComputerActionType,
+        permission_scope: ComputerPermissionScope,
+        risk_level: ComputerActionRisk,
+        target: ComputerActionTarget | None = None,
+    ) -> ComputerActionDescriptor:
+        return ComputerActionDescriptor(
+            action=action,
+            runtime_kind=ComputerRuntimeKind.BUILTIN_TOOL,
+            execution_surface=ExecutionSurface.DESKTOP,
+            permission_scope=permission_scope,
+            risk_level=risk_level,
+            source="tool",
+            target=target or ComputerActionTarget(),
+        )
+
+    def _build_observation(
+        self,
+        *,
+        require_windows: bool,
+        require_input: bool,
+        require_screenshot: bool,
+    ) -> ComputerObservation:
+        (
+            screenshot_bytes,
+            screenshot_name,
+            screenshot_mime_type,
+            screenshot_width,
+            screenshot_height,
+        ) = self._capture_screenshot_bytes(required=require_screenshot)
+        windows = self._list_windows_snapshot(
+            require_windows=require_windows,
+            require_input=require_input,
+        )
+        focused_window = next(
+            (window.title for window in windows if window.focused),
+            "",
+        )
+        return ComputerObservation(
+            text="Windows desktop runtime snapshot.",
+            windows=windows,
+            focused_window=focused_window,
+            screenshot_bytes=screenshot_bytes,
+            screenshot_mime_type=screenshot_mime_type,
+            screenshot_name=screenshot_name,
+            screenshot_width=screenshot_width,
+            screenshot_height=screenshot_height,
+        )
+
+    def _capture_screenshot_bytes(
+        self,
+        *,
+        required: bool,
+    ) -> tuple[bytes | None, str, str | None, int | None, int | None]:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as handle:
+            screenshot_path = Path(handle.name)
+
+        try:
+            payload = self._run_powershell_json(
+                self._build_capture_screenshot_script(screenshot_path)
+            )
+            if screenshot_path.exists() and screenshot_path.stat().st_size > 0:
+                width = self._read_json_int(payload, "width")
+                height = self._read_json_int(payload, "height")
+                return (
+                    screenshot_path.read_bytes(),
+                    screenshot_path.name,
+                    "image/png",
+                    width,
+                    height,
+                )
+            if required:
+                raise RuntimeError(
+                    "Windows desktop command produced no screenshot file."
+                )
+            LOGGER.warning(
+                "Skipping Windows desktop screenshot because no screenshot was "
+                "produced."
+            )
+            return None, "", None, None, None
+        except RuntimeError:
+            if required:
+                raise
+            LOGGER.warning(
+                "Skipping Windows desktop screenshot because screenshot capture "
+                "failed.",
+            )
+            return None, "", None, None, None
+        finally:
+            screenshot_path.unlink(missing_ok=True)
+
+    def _build_capture_screenshot_script(self, screenshot_path: Path) -> str:
+        literal_path = self._powershell_literal(str(screenshot_path))
+        return "\n".join(
+            [
+                "Add-Type -AssemblyName System.Windows.Forms",
+                "Add-Type -AssemblyName System.Drawing",
+                "$bounds = [System.Windows.Forms.SystemInformation]::VirtualScreen",
+                "if ($bounds.Width -le 0 -or $bounds.Height -le 0) {",
+                '    throw "Windows desktop screenshot requires an active desktop session."',
+                "}",
+                "$bitmap = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height",
+                "$graphics = [System.Drawing.Graphics]::FromImage($bitmap)",
+                "$graphics.CopyFromScreen($bounds.Left, $bounds.Top, 0, 0, $bitmap.Size)",
+                (
+                    "$bitmap.Save("
+                    f"{literal_path}, "
+                    "[System.Drawing.Imaging.ImageFormat]::Png)"
+                ),
+                "$graphics.Dispose()",
+                "$bitmap.Dispose()",
+                (
+                    "[pscustomobject]@{ width = $bounds.Width; height = $bounds.Height } "
+                    "| ConvertTo-Json -Compress"
+                ),
+            ]
+        )
+
+    def _list_windows_snapshot(
+        self,
+        *,
+        require_windows: bool,
+        require_input: bool,
+    ) -> tuple[ComputerWindow, ...]:
+        try:
+            payload = self._run_powershell_json(self._build_list_windows_script())
+        except RuntimeError:
+            if require_windows or require_input:
+                raise
+            LOGGER.warning(
+                "Skipping Windows desktop window discovery because PowerShell "
+                "window enumeration failed."
+            )
+            return ()
+
+        raw_windows: list[object]
+        if isinstance(payload, list):
+            raw_windows = payload
+        elif isinstance(payload, dict):
+            raw_windows = [payload]
+        else:
+            raw_windows = []
+
+        windows: list[ComputerWindow] = []
+        for item in raw_windows:
+            if not isinstance(item, dict):
+                continue
+            window_id = self._read_json_text(item, "window_id")
+            title = self._read_json_text(item, "title")
+            if not window_id or not title:
+                continue
+            app_name = self._read_json_text(item, "app_name") or title
+            focused = self._read_json_bool(item, "focused")
+            windows.append(
+                ComputerWindow(
+                    window_id=window_id,
+                    app_name=app_name,
+                    title=title,
+                    focused=focused,
+                )
+            )
+        return tuple(windows)
+
+    def _build_list_windows_script(self) -> str:
+        return "\n".join(
+            [
+                "Add-Type @'",
+                "using System;",
+                "using System.Runtime.InteropServices;",
+                "public static class RelayTeamsWin32 {",
+                '    [DllImport("user32.dll")]',
+                "    public static extern IntPtr GetForegroundWindow();",
+                "}",
+                "'@",
+                "$foreground = [int64][RelayTeamsWin32]::GetForegroundWindow()",
+                (
+                    "$windows = Get-Process | Where-Object { "
+                    "$_.MainWindowHandle -ne 0 -and $_.MainWindowTitle "
+                    "} | Sort-Object Id | ForEach-Object {"
+                ),
+                "    [pscustomobject]@{",
+                "        window_id = ('0x{0:x}' -f [int64]$_.MainWindowHandle)",
+                "        app_name = $_.ProcessName",
+                "        title = $_.MainWindowTitle",
+                "        focused = ([int64]$_.MainWindowHandle -eq $foreground)",
+                "    }",
+                "}",
+                "$windows | ConvertTo-Json -Depth 3 -Compress",
+            ]
+        )
+
+    def _find_window(self, query: str) -> ComputerWindow:
+        normalized = query.strip()
+        if not normalized:
+            raise ValueError("window_title is required")
+        windows = self._list_windows_snapshot(require_windows=True, require_input=False)
+        for window in windows:
+            if self._window_matches(window, normalized):
+                return window
+        raise RuntimeError(f"Window not found: {query}")
+
+    def _wait_for_window_match(
+        self,
+        *,
+        query: str,
+        before_windows: tuple[ComputerWindow, ...] = (),
+    ) -> ComputerWindow | None:
+        normalized_query = query.strip()
+        before_ids = {window.window_id for window in before_windows}
+        deadline = self._time_monotonic() + _WAIT_TIMEOUT_SECONDS
+        while self._time_monotonic() < deadline:
+            windows = self._list_windows_snapshot(
+                require_windows=True,
+                require_input=False,
+            )
+            for window in windows:
+                is_new_window = window.window_id not in before_ids
+                if is_new_window and (
+                    not normalized_query
+                    or self._window_matches(window, normalized_query)
+                ):
+                    return window
+                if normalized_query and self._window_matches(window, normalized_query):
+                    return window
+            self._sleep(_POLL_INTERVAL_SECONDS)
+        return None
+
+    def _window_matches(self, window: ComputerWindow, query: str) -> bool:
+        normalized_query = query.casefold()
+        return (
+            normalized_query in window.title.casefold()
+            or normalized_query in window.app_name.casefold()
+        )
+
+    def _activate_window(self, window_title: str) -> None:
+        literal_title = self._powershell_literal(window_title)
+        self._run_powershell(
+            "\n".join(
+                [
+                    "$wshell = New-Object -ComObject WScript.Shell",
+                    f"if (-not $wshell.AppActivate({literal_title})) {{",
+                    f"    throw {self._powershell_literal(f'Window not found: {window_title}')}",
+                    "}",
+                ]
+            )
+        )
+
+    def _resolve_launch_command(self, app_name: str) -> list[str]:
+        normalized = app_name.strip()
+        if not normalized:
+            raise ValueError("app_name is required")
+
+        lowered = normalized.casefold()
+        if lowered in {"calc", "calculator"}:
+            return ["calc.exe"]
+
+        parsed_command = shlex.split(normalized, posix=False)
+        if parsed_command:
+            first_token = parsed_command[0]
+            if Path(first_token).exists() or shutil.which(first_token) is not None:
+                return parsed_command
+
+        if Path(normalized).exists() or shutil.which(normalized) is not None:
+            return [normalized]
+
+        return ["cmd", "/c", "start", "", normalized]
+
+    def _spawn_process(self, command: list[str]) -> None:
+        LOGGER.info("Launching Windows desktop app", extra={"command": command})
+        subprocess.Popen(
+            command,
+            cwd=self._project_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=_PROCESS_CREATION_FLAGS,
+        )
+
+    def _send_unicode_text(self, text: str) -> None:
+        normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+        inputs: list[_Input] = []
+        for character in normalized:
+            if character == "\n":
+                inputs.extend(self._keyboard_inputs_for_virtual_key(_VK_RETURN))
+                continue
+            if character == "\t":
+                inputs.extend(self._keyboard_inputs_for_virtual_key(_VK_TAB))
+                continue
+            codepoint = ord(character)
+            inputs.append(
+                self._keyboard_input(
+                    virtual_key=0,
+                    scan_code=codepoint,
+                    flags=_KEYEVENTF_UNICODE,
+                )
+            )
+            inputs.append(
+                self._keyboard_input(
+                    virtual_key=0,
+                    scan_code=codepoint,
+                    flags=_KEYEVENTF_UNICODE | _KEYEVENTF_KEYUP,
+                )
+            )
+        self._send_inputs(inputs)
+
+    def _send_hotkey_inputs(
+        self,
+        modifier_keys: tuple[int, ...],
+        normal_keys: tuple[int, ...],
+    ) -> None:
+        inputs: list[_Input] = []
+        for key in modifier_keys:
+            inputs.append(self._keyboard_input(virtual_key=key))
+        for key in normal_keys:
+            inputs.append(self._keyboard_input(virtual_key=key))
+        for key in reversed(normal_keys):
+            inputs.append(
+                self._keyboard_input(
+                    virtual_key=key,
+                    flags=_KEYEVENTF_KEYUP,
+                )
+            )
+        for key in reversed(modifier_keys):
+            inputs.append(
+                self._keyboard_input(
+                    virtual_key=key,
+                    flags=_KEYEVENTF_KEYUP,
+                )
+            )
+        self._send_inputs(inputs)
+
+    def _normalize_shortcut(
+        self, shortcut: str
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        normalized = shortcut.strip()
+        if not normalized:
+            raise ValueError("shortcut is required")
+
+        modifier_keys: list[int] = []
+        normal_keys: list[int] = []
+        for part in normalized.split("+"):
+            token = part.strip()
+            if not token:
+                continue
+            lowered = token.casefold()
+            modifier_key = _MODIFIER_VKEYS.get(lowered)
+            if modifier_key is not None:
+                modifier_keys.append(modifier_key)
+                continue
+            normal_keys.append(self._resolve_virtual_key(token))
+
+        if not normal_keys:
+            raise ValueError("shortcut must include a non-modifier key")
+        return tuple(modifier_keys), tuple(normal_keys)
+
+    def _resolve_virtual_key(self, token: str) -> int:
+        lowered = token.casefold()
+        named_key = _NAMED_VKEYS.get(lowered)
+        if named_key is not None:
+            return named_key
+
+        if len(token) == 1:
+            character = token.upper()
+            if character.isalpha() or character.isdigit():
+                return ord(character)
+
+        if lowered.startswith("f") and lowered[1:].isdigit():
+            function_number = int(lowered[1:])
+            if 1 <= function_number <= 24:
+                return 0x6F + function_number
+
+        raise ValueError(f"Unsupported shortcut key: {token}")
+
+    def _keyboard_inputs_for_virtual_key(self, virtual_key: int) -> list[_Input]:
+        return [
+            self._keyboard_input(virtual_key=virtual_key),
+            self._keyboard_input(
+                virtual_key=virtual_key,
+                flags=_KEYEVENTF_KEYUP,
+            ),
+        ]
+
+    def _keyboard_input(
+        self,
+        *,
+        virtual_key: int,
+        scan_code: int = 0,
+        flags: int = 0,
+    ) -> _Input:
+        return _Input(
+            type=_INPUT_KEYBOARD,
+            ki=_KeyboardInput(
+                wVk=virtual_key,
+                wScan=scan_code,
+                dwFlags=flags,
+                time=0,
+                dwExtraInfo=0,
+            ),
+        )
+
+    def _send_inputs(self, inputs: list[_Input]) -> None:
+        if not inputs:
+            return
+        user32 = self._load_user32()
+        user32.SendInput.argtypes = (
+            wintypes.UINT,
+            ctypes.POINTER(_Input),
+            ctypes.c_int,
+        )
+        user32.SendInput.restype = wintypes.UINT
+        array_type = _Input * len(inputs)
+        sent = user32.SendInput(
+            len(inputs),
+            array_type(*inputs),
+            ctypes.sizeof(_Input),
+        )
+        if sent != len(inputs):
+            raise RuntimeError("Windows desktop input injection failed.")
+
+    def _set_cursor_position(self, x: int, y: int) -> None:
+        user32 = self._load_user32()
+        user32.SetCursorPos.argtypes = (ctypes.c_int, ctypes.c_int)
+        user32.SetCursorPos.restype = wintypes.BOOL
+        if not user32.SetCursorPos(x, y):
+            raise RuntimeError(
+                f"Windows desktop pointer movement failed at ({x}, {y})."
+            )
+
+    def _mouse_click(self, *, repeat: int) -> None:
+        for index in range(repeat):
+            self._send_mouse_event(_MOUSEEVENTF_LEFTDOWN)
+            self._send_mouse_event(_MOUSEEVENTF_LEFTUP)
+            if index + 1 < repeat:
+                self._sleep(_POINTER_SETTLE_SECONDS)
+
+    def _send_mouse_event(self, flags: int, *, data: int = 0) -> None:
+        user32 = self._load_user32()
+        user32.mouse_event.argtypes = (
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            _ULONG_PTR,
+        )
+        user32.mouse_event.restype = None
+        user32.mouse_event(flags, 0, 0, data, 0)
+
+    def _load_user32(self) -> ctypes.WinDLL:
+        try:
+            return ctypes.WinDLL("user32", use_last_error=True)
+        except OSError as exc:
+            raise RuntimeError(
+                "Windows desktop runtime requires an active Windows host."
+            ) from exc
+
+    def _run_powershell_json(self, script: str) -> object:
+        output = self._run_powershell(script).strip()
+        if not output:
+            return []
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                "Windows desktop PowerShell command returned invalid JSON."
+            ) from exc
+
+    def _run_powershell(self, script: str) -> str:
+        executable = self._resolve_powershell_executable()
+        wrapped_script = "\n".join(
+            [
+                "$OutputEncoding = [System.Text.Encoding]::UTF8",
+                "[Console]::InputEncoding = [System.Text.Encoding]::UTF8",
+                "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+                script,
+            ]
+        )
+        try:
+            completed = subprocess.run(
+                [
+                    executable,
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    wrapped_script,
+                ],
+                cwd=self._project_root,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+                timeout=_COMMAND_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                "Windows desktop PowerShell command timed out after "
+                f"{_COMMAND_TIMEOUT_SECONDS:.0f}s."
+            ) from exc
+
+        if completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            stdout = (completed.stdout or "").strip()
+            details = stderr or stdout or f"exit code {completed.returncode}"
+            raise RuntimeError(f"Windows desktop PowerShell command failed: {details}")
+        return completed.stdout or ""
+
+    def _resolve_powershell_executable(self) -> str:
+        powershell = shutil.which("powershell")
+        if powershell is not None:
+            return powershell
+        pwsh = shutil.which("pwsh")
+        if pwsh is not None:
+            return pwsh
+        raise RuntimeError("Windows desktop runtime requires PowerShell.")
+
+    def _powershell_literal(self, value: str) -> str:
+        return "'" + value.replace("'", "''") + "'"
+
+    def _read_json_text(self, payload: dict[object, object], key: str) -> str:
+        value = payload.get(key)
+        return value.strip() if isinstance(value, str) else ""
+
+    def _read_json_bool(self, payload: dict[object, object], key: str) -> bool:
+        value = payload.get(key)
+        return value is True
+
+    def _read_json_int(self, payload: object, key: str) -> int | None:
+        if not isinstance(payload, dict):
+            return None
+        value = payload.get(key)
+        return value if isinstance(value, int) else None
+
+    def _sleep(self, seconds: float) -> None:
+        time.sleep(seconds)
+
+    def _time_monotonic(self) -> float:
+        return time.monotonic()

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -10,7 +10,7 @@ import subprocess
 import tempfile
 import time
 from ctypes import wintypes
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from relay_teams.computer.models import (
     ComputerActionDescriptor,
@@ -736,7 +736,7 @@ class WindowsDesktopRuntime:
             normalized_token = token.strip().strip('"').strip("'")
             if not normalized_token:
                 continue
-            token_path = Path(normalized_token)
+            token_path = PureWindowsPath(normalized_token)
             candidate_queries.append(normalized_token)
             candidate_queries.append(token_path.name)
             if token_path.suffix:

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -398,6 +398,7 @@ class WindowsDesktopRuntime:
         matched_window = self._wait_for_window_match(
             queries=window_queries,
             before_windows=before_windows,
+            allow_existing_matches=False,
         )
         if matched_window is None:
             raise RuntimeError(f"App window did not appear within timeout: {app_name}")
@@ -720,6 +721,7 @@ class WindowsDesktopRuntime:
         *,
         queries: tuple[str, ...] = (),
         before_windows: tuple[ComputerWindow, ...] = (),
+        allow_existing_matches: bool = True,
     ) -> ComputerWindow | None:
         normalized_queries = self._normalize_match_queries(*queries)
         before_ids = {window.window_id for window in before_windows}
@@ -736,9 +738,13 @@ class WindowsDesktopRuntime:
                     or self._window_matches_any(window, normalized_queries)
                 ):
                     return window
-                if normalized_queries and self._window_matches_any(
-                    window,
-                    normalized_queries,
+                if (
+                    allow_existing_matches
+                    and normalized_queries
+                    and self._window_matches_any(
+                        window,
+                        normalized_queries,
+                    )
                 ):
                     return window
             self._sleep(_POLL_INTERVAL_SECONDS)
@@ -861,22 +867,31 @@ class WindowsDesktopRuntime:
             if character == "\t":
                 inputs.extend(self._keyboard_inputs_for_virtual_key(_VK_TAB))
                 continue
-            codepoint = ord(character)
-            inputs.append(
-                self._keyboard_input(
-                    virtual_key=0,
-                    scan_code=codepoint,
-                    flags=_KEYEVENTF_UNICODE,
+            for scan_code in self._unicode_scan_codes(character):
+                inputs.append(
+                    self._keyboard_input(
+                        virtual_key=0,
+                        scan_code=scan_code,
+                        flags=_KEYEVENTF_UNICODE,
+                    )
                 )
-            )
-            inputs.append(
-                self._keyboard_input(
-                    virtual_key=0,
-                    scan_code=codepoint,
-                    flags=_KEYEVENTF_UNICODE | _KEYEVENTF_KEYUP,
+                inputs.append(
+                    self._keyboard_input(
+                        virtual_key=0,
+                        scan_code=scan_code,
+                        flags=_KEYEVENTF_UNICODE | _KEYEVENTF_KEYUP,
+                    )
                 )
-            )
         self._send_inputs(inputs)
+
+    def _unicode_scan_codes(self, text: str) -> tuple[int, ...]:
+        encoded = text.encode("utf-16-le")
+        scan_codes: list[int] = []
+        for index in range(0, len(encoded), 2):
+            scan_codes.append(
+                int.from_bytes(encoded[index : index + 2], byteorder="little")
+            )
+        return tuple(scan_codes)
 
     def _send_hotkey_inputs(
         self,

--- a/tests/unit_tests/computer/test_runtime.py
+++ b/tests/unit_tests/computer/test_runtime.py
@@ -7,6 +7,7 @@ from relay_teams.computer import (
     DisabledComputerRuntime,
     LinuxDesktopRuntime,
     ScriptedComputerRuntime,
+    WindowsDesktopRuntime,
     build_default_computer_runtime,
 )
 
@@ -28,7 +29,7 @@ def test_build_default_computer_runtime_returns_scripted_runtime_in_fake_mode(
     assert result.observation.screenshot_bytes == b"\x89PNG\r\n\x1a\nfake"
 
 
-def test_build_default_computer_runtime_returns_disabled_runtime_by_default(
+def test_build_default_computer_runtime_auto_detects_windows_runtime(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -40,7 +41,7 @@ def test_build_default_computer_runtime_returns_disabled_runtime_by_default(
 
     runtime = build_default_computer_runtime(project_root=tmp_path)
 
-    assert isinstance(runtime, DisabledComputerRuntime)
+    assert isinstance(runtime, WindowsDesktopRuntime)
 
 
 def test_build_default_computer_runtime_auto_detects_linux_runtime(

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -144,7 +144,7 @@ def test_windows_runtime_launch_app_records_real_command(
 ) -> None:
     runtime = WindowsDesktopRuntime(project_root=tmp_path)
     spawned_commands: list[list[str]] = []
-    activated_titles: list[str] = []
+    activated_window_ids: list[str] = []
     matched_window = ComputerWindow(
         window_id="0x20",
         app_name="Calculator",
@@ -183,8 +183,8 @@ def test_windows_runtime_launch_app_records_real_command(
         assert allow_existing_matches is False
         return matched_window
 
-    def fake_activate_window(window_title: str) -> None:
-        activated_titles.append(window_title)
+    def fake_activate_window(window_id: str) -> None:
+        activated_window_ids.append(window_id)
 
     def fake_build_observation(
         *,
@@ -206,7 +206,7 @@ def test_windows_runtime_launch_app_records_real_command(
     result = asyncio.run(runtime.launch_app(app_name="Calculator"))
 
     assert spawned_commands == [["calc.exe"]]
-    assert activated_titles == ["Calculator"]
+    assert activated_window_ids == ["0x20"]
     assert result.observation is not None
     assert result.observation.focused_window == "Calculator"
     assert result.action.target.app_name == "Calculator"
@@ -306,6 +306,19 @@ def test_windows_runtime_build_launch_window_queries_normalizes_path_command(
         "app.exe",
         "app",
     )
+
+
+def test_windows_runtime_build_list_windows_script_uses_hwnd_enumeration(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    script = runtime._build_list_windows_script()
+
+    assert "EnumWindows" in script
+    assert "GetWindowThreadProcessId" in script
+    assert "GetWindowTextLength" in script
+    assert "MainWindowHandle" not in script
 
 
 def test_windows_runtime_wait_for_window_match_ignores_existing_launch_match(

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from relay_teams.computer import (
+    ComputerObservation,
+    ComputerWindow,
+    WindowsDesktopRuntime,
+)
+
+
+def test_windows_runtime_capture_screen_reads_generated_png(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    focused_window = ComputerWindow(
+        window_id="0x10",
+        app_name="Calculator",
+        title="Calculator",
+        focused=True,
+    )
+
+    def fake_capture_screenshot_bytes(
+        *,
+        required: bool,
+    ) -> tuple[bytes | None, str, str | None, int | None, int | None]:
+        assert required is True
+        return (b"\x89PNG\r\n\x1a\nwindows", "desktop.png", "image/png", 1440, 900)
+
+    def fake_list_windows_snapshot(
+        *,
+        require_windows: bool,
+        require_input: bool,
+    ) -> tuple[ComputerWindow, ...]:
+        _ = (require_windows, require_input)
+        return (focused_window,)
+
+    monkeypatch.setattr(
+        runtime,
+        "_capture_screenshot_bytes",
+        fake_capture_screenshot_bytes,
+    )
+    monkeypatch.setattr(runtime, "_list_windows_snapshot", fake_list_windows_snapshot)
+
+    result = asyncio.run(runtime.capture_screen())
+
+    assert result.observation is not None
+    assert result.observation.screenshot_bytes == b"\x89PNG\r\n\x1a\nwindows"
+    assert result.observation.screenshot_mime_type == "image/png"
+    assert result.observation.screenshot_width == 1440
+    assert result.observation.screenshot_height == 900
+    assert result.data["runtime_mode"] == "windows"
+
+
+def test_windows_runtime_list_windows_marks_active_window(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    windows = (
+        ComputerWindow(
+            window_id="0x10",
+            app_name="Calculator",
+            title="Calculator",
+            focused=True,
+        ),
+        ComputerWindow(
+            window_id="0x11",
+            app_name="Code",
+            title="relay-teams - Visual Studio Code",
+            focused=False,
+        ),
+    )
+
+    def fake_list_windows_snapshot(
+        *,
+        require_windows: bool,
+        require_input: bool,
+    ) -> tuple[ComputerWindow, ...]:
+        assert require_windows is True
+        assert require_input is False
+        return windows
+
+    monkeypatch.setattr(runtime, "_list_windows_snapshot", fake_list_windows_snapshot)
+
+    result = asyncio.run(runtime.list_windows())
+
+    assert result.observation is not None
+    assert result.observation.focused_window == "Calculator"
+    assert [window.title for window in result.observation.windows] == [
+        "Calculator",
+        "relay-teams - Visual Studio Code",
+    ]
+
+
+def test_windows_runtime_launch_app_records_real_command(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    spawned_commands: list[list[str]] = []
+    activated_titles: list[str] = []
+    matched_window = ComputerWindow(
+        window_id="0x20",
+        app_name="Calculator",
+        title="Calculator",
+        focused=True,
+    )
+    observation = ComputerObservation(
+        text="Windows desktop runtime snapshot.",
+        windows=(matched_window,),
+        focused_window="Calculator",
+    )
+
+    def fake_list_windows_snapshot(
+        *,
+        require_windows: bool,
+        require_input: bool,
+    ) -> tuple[ComputerWindow, ...]:
+        _ = (require_windows, require_input)
+        return ()
+
+    def fake_resolve_launch_command(app_name: str) -> list[str]:
+        assert app_name == "Calculator"
+        return ["calc.exe"]
+
+    def fake_spawn_process(command: list[str]) -> None:
+        spawned_commands.append(command)
+
+    def fake_wait_for_window_match(
+        *,
+        query: str,
+        before_windows: tuple[ComputerWindow, ...] = (),
+    ) -> ComputerWindow:
+        assert query == "Calculator"
+        assert before_windows == ()
+        return matched_window
+
+    def fake_activate_window(window_title: str) -> None:
+        activated_titles.append(window_title)
+
+    def fake_build_observation(
+        *,
+        require_windows: bool,
+        require_input: bool,
+        require_screenshot: bool,
+    ) -> ComputerObservation:
+        _ = (require_windows, require_input, require_screenshot)
+        return observation
+
+    monkeypatch.setattr(runtime, "_list_windows_snapshot", fake_list_windows_snapshot)
+    monkeypatch.setattr(runtime, "_resolve_launch_command", fake_resolve_launch_command)
+    monkeypatch.setattr(runtime, "_spawn_process", fake_spawn_process)
+    monkeypatch.setattr(runtime, "_wait_for_window_match", fake_wait_for_window_match)
+    monkeypatch.setattr(runtime, "_activate_window", fake_activate_window)
+    monkeypatch.setattr(runtime, "_build_observation", fake_build_observation)
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+
+    result = asyncio.run(runtime.launch_app(app_name="Calculator"))
+
+    assert spawned_commands == [["calc.exe"]]
+    assert activated_titles == ["Calculator"]
+    assert result.observation is not None
+    assert result.observation.focused_window == "Calculator"
+    assert result.action.target.app_name == "Calculator"
+    assert result.action.target.window_title == "Calculator"
+    assert result.data["launched_command"] == "calc.exe"
+
+
+def test_windows_runtime_resolves_calculator_candidates(tmp_path: Path) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    command = runtime._resolve_launch_command("Calculator")
+
+    assert command == ["calc.exe"]

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -5,6 +5,7 @@ import asyncio
 from pathlib import Path
 
 import pytest
+import relay_teams.computer.windows_runtime as windows_runtime_module
 
 from relay_teams.computer import (
     ComputerObservation,
@@ -175,9 +176,11 @@ def test_windows_runtime_launch_app_records_real_command(
         *,
         queries: tuple[str, ...],
         before_windows: tuple[ComputerWindow, ...] = (),
+        allow_existing_matches: bool = True,
     ) -> ComputerWindow:
         assert queries == ("Calculator", "calc.exe", "calc")
         assert before_windows == ()
+        assert allow_existing_matches is False
         return matched_window
 
     def fake_activate_window(window_title: str) -> None:
@@ -303,6 +306,62 @@ def test_windows_runtime_build_launch_window_queries_normalizes_path_command(
         "app.exe",
         "app",
     )
+
+
+def test_windows_runtime_wait_for_window_match_ignores_existing_launch_match(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    existing_window = ComputerWindow(
+        window_id="0x10",
+        app_name="notepad",
+        title="notes.txt - Notepad",
+        focused=True,
+    )
+    times = iter((0.0, 0.0, 11.0))
+
+    monkeypatch.setattr(
+        runtime,
+        "_list_windows_snapshot",
+        lambda **kwargs: (existing_window,),
+    )
+    monkeypatch.setattr(runtime, "_time_monotonic", lambda: next(times))
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+
+    matched_window = runtime._wait_for_window_match(
+        queries=("notepad.exe", "notepad"),
+        before_windows=(existing_window,),
+        allow_existing_matches=False,
+    )
+
+    assert matched_window is None
+
+
+def test_windows_runtime_send_unicode_text_uses_utf16_surrogate_pairs(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    captured_inputs: list[tuple[int, int]] = []
+
+    def fake_send_inputs(
+        inputs: list[windows_runtime_module._Input],
+    ) -> None:
+        captured_inputs.extend(
+            (int(item.ki.wScan), int(item.ki.dwFlags)) for item in inputs
+        )
+
+    monkeypatch.setattr(runtime, "_send_inputs", fake_send_inputs)
+
+    runtime._send_unicode_text("🙂")
+
+    assert captured_inputs == [
+        (0xD83D, 0x0004),
+        (0xD83D, 0x0006),
+        (0xDE42, 0x0004),
+        (0xDE42, 0x0006),
+    ]
 
 
 def test_windows_runtime_wait_for_window_requires_title(

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -28,9 +28,25 @@ def test_windows_runtime_capture_screen_reads_generated_png(
     def fake_capture_screenshot_bytes(
         *,
         required: bool,
-    ) -> tuple[bytes | None, str, str | None, int | None, int | None]:
+    ) -> tuple[
+        bytes | None,
+        str,
+        str | None,
+        int | None,
+        int | None,
+        int | None,
+        int | None,
+    ]:
         assert required is True
-        return (b"\x89PNG\r\n\x1a\nwindows", "desktop.png", "image/png", 1440, 900)
+        return (
+            b"\x89PNG\r\n\x1a\nwindows",
+            "desktop.png",
+            "image/png",
+            -1920,
+            -40,
+            1440,
+            900,
+        )
 
     def fake_list_windows_snapshot(
         *,
@@ -52,9 +68,13 @@ def test_windows_runtime_capture_screen_reads_generated_png(
     assert result.observation is not None
     assert result.observation.screenshot_bytes == b"\x89PNG\r\n\x1a\nwindows"
     assert result.observation.screenshot_mime_type == "image/png"
+    assert result.observation.screenshot_origin_x == -1920
+    assert result.observation.screenshot_origin_y == -40
     assert result.observation.screenshot_width == 1440
     assert result.observation.screenshot_height == 900
     assert result.data["runtime_mode"] == "windows"
+    assert result.data["virtual_screen_origin_x"] == -1920
+    assert result.data["virtual_screen_origin_y"] == -40
 
 
 def test_windows_runtime_list_windows_marks_active_window(
@@ -89,7 +109,15 @@ def test_windows_runtime_list_windows_marks_active_window(
     def fail_capture_screenshot_bytes(
         *,
         required: bool,
-    ) -> tuple[bytes | None, str, str | None, int | None, int | None]:
+    ) -> tuple[
+        bytes | None,
+        str,
+        str | None,
+        int | None,
+        int | None,
+        int | None,
+        int | None,
+    ]:
         raise AssertionError(f"unexpected screenshot capture: {required}")
 
     monkeypatch.setattr(

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -308,6 +308,24 @@ def test_windows_runtime_build_launch_window_queries_normalizes_path_command(
     )
 
 
+def test_windows_runtime_build_launch_window_queries_handles_cmd_start_without_title(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    queries = runtime._build_launch_window_queries(
+        app_name="cmd /c start notepad.exe",
+        command=["cmd", "/c", "start", "notepad.exe"],
+    )
+
+    assert queries == (
+        "cmd /c start notepad.exe",
+        "cmd",
+        "notepad.exe",
+        "notepad",
+    )
+
+
 def test_windows_runtime_build_list_windows_script_uses_hwnd_enumeration(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+
 from relay_teams.computer import (
     ComputerObservation,
     ComputerWindow,
@@ -189,6 +191,74 @@ def test_windows_runtime_resolves_calculator_candidates(tmp_path: Path) -> None:
     assert command == ["calc.exe"]
 
 
+def test_windows_runtime_click_translates_virtual_screen_origin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    cursor_positions: list[tuple[int, int]] = []
+    observation = ComputerObservation(text="Windows desktop runtime snapshot.")
+
+    monkeypatch.setattr(runtime, "_get_virtual_screen_origin", lambda: (-1920, -40))
+    monkeypatch.setattr(
+        runtime,
+        "_set_cursor_position",
+        lambda x, y: cursor_positions.append((x, y)),
+    )
+    monkeypatch.setattr(runtime, "_mouse_click", lambda *, repeat: None)
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.click_at(x=125, y=250))
+
+    assert cursor_positions == [(-1795, 210)]
+    assert result.action.target.x == 125
+    assert result.action.target.y == 250
+
+
+def test_windows_runtime_drag_translates_virtual_screen_origin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    cursor_positions: list[tuple[int, int]] = []
+    mouse_events: list[int] = []
+    observation = ComputerObservation(text="Windows desktop runtime snapshot.")
+
+    monkeypatch.setattr(runtime, "_get_virtual_screen_origin", lambda: (-1600, -120))
+    monkeypatch.setattr(
+        runtime,
+        "_set_cursor_position",
+        lambda x, y: cursor_positions.append((x, y)),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_send_mouse_event",
+        lambda flags, *, data=0: mouse_events.append(flags),
+    )
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(
+        runtime.drag_between(start_x=10, start_y=20, end_x=400, end_y=500)
+    )
+
+    assert cursor_positions == [(-1590, -100), (-1200, 380)]
+    assert mouse_events == [0x0002, 0x0004]
+    assert result.action.target.x == 10
+    assert result.action.target.y == 20
+    assert result.action.target.end_x == 400
+    assert result.action.target.end_y == 500
+
+
 def test_windows_runtime_build_launch_window_queries_normalizes_path_command(
     tmp_path: Path,
 ) -> None:
@@ -205,3 +275,12 @@ def test_windows_runtime_build_launch_window_queries_normalizes_path_command(
         "app.exe",
         "app",
     )
+
+
+def test_windows_runtime_wait_for_window_requires_title(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    with pytest.raises(ValueError, match="window_title is required"):
+        asyncio.run(runtime.wait_for_window(window_title="   "))

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -84,6 +84,17 @@ def test_windows_runtime_list_windows_marks_active_window(
         assert require_input is False
         return windows
 
+    def fail_capture_screenshot_bytes(
+        *,
+        required: bool,
+    ) -> tuple[bytes | None, str, str | None, int | None, int | None]:
+        raise AssertionError(f"unexpected screenshot capture: {required}")
+
+    monkeypatch.setattr(
+        runtime,
+        "_capture_screenshot_bytes",
+        fail_capture_screenshot_bytes,
+    )
     monkeypatch.setattr(runtime, "_list_windows_snapshot", fake_list_windows_snapshot)
 
     result = asyncio.run(runtime.list_windows())
@@ -132,10 +143,10 @@ def test_windows_runtime_launch_app_records_real_command(
 
     def fake_wait_for_window_match(
         *,
-        query: str,
+        queries: tuple[str, ...],
         before_windows: tuple[ComputerWindow, ...] = (),
     ) -> ComputerWindow:
-        assert query == "Calculator"
+        assert queries == ("Calculator", "calc.exe", "calc")
         assert before_windows == ()
         return matched_window
 
@@ -176,3 +187,21 @@ def test_windows_runtime_resolves_calculator_candidates(tmp_path: Path) -> None:
     command = runtime._resolve_launch_command("Calculator")
 
     assert command == ["calc.exe"]
+
+
+def test_windows_runtime_build_launch_window_queries_normalizes_path_command(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    queries = runtime._build_launch_window_queries(
+        app_name='"C:\\Program Files\\App\\app.exe" --flag',
+        command=["C:\\Program Files\\App\\app.exe", "--flag"],
+    )
+
+    assert queries == (
+        '"C:\\Program Files\\App\\app.exe" --flag',
+        "C:\\Program Files\\App\\app.exe",
+        "app.exe",
+        "app",
+    )


### PR DESCRIPTION
## Summary

Fixes #372.

Add a real Windows desktop runtime for the built-in computer tools so Windows no longer falls back to the disabled runtime path.

## Root Cause

`build_default_computer_runtime()` only auto-selected the Linux backend or the scripted fake runtime. On Windows it always returned `DisabledComputerRuntime`, which caused built-in computer tools such as `capture_screen` to fail with `Unsupported host platform: Windows`.

## Changes

- add `WindowsDesktopRuntime` with real screenshot, window enumeration, focus, pointer, keyboard, and app-launch support
- auto-select the Windows runtime in the default runtime builder and export it from the package API
- add Windows-focused unit coverage for runtime selection, screenshot capture, and launch command wiring
- update the real computer smoke doc to cover both Linux and Windows
- force PowerShell subprocess output to UTF-8 so window discovery does not break on localized Windows sessions

## Impact

- Windows users can now use built-in computer tools like `capture_screen` without forcing `AGENT_TEAMS_COMPUTER_RUNTIME=fake`
- API/UI runs on Windows can attach real desktop screenshots to the run timeline
- the runtime still has a follow-up gap for Calculator launch/window discovery on this machine, but the issue-reported screenshot path is now working end-to-end

## Validation

- `uv run --extra dev ruff check --fix src\relay_teams\computer\runtime.py src\relay_teams\computer\windows_runtime.py src\relay_teams\computer\__init__.py tests\unit_tests\computer\test_runtime.py tests\unit_tests\computer\test_windows_runtime.py docs\computer-use-real-smoke.md`
- `uv run --extra dev basedpyright src\relay_teams\computer src\relay_teams\tools\computer_tools tests\unit_tests\computer`
- `uv run --extra dev pytest -q tests\unit_tests\computer\test_runtime.py tests\unit_tests\computer\test_windows_runtime.py tests\unit_tests\computer\test_linux_runtime.py`
- manual browser validation on Windows: `capture_screen` succeeded end-to-end and rendered the screenshot in the session UI
