### PR TITLE
[codex] Add code context mode to websearch

### DIFF
--- a/src/relay_teams/tools/web_tools/websearch.py
+++ b/src/relay_teams/tools/web_tools/websearch.py
@@ -6,7 +6,7 @@ import re
 import time
 from collections.abc import Sequence
 from urllib.parse import urlencode, urlparse
-from typing import Literal
+from typing import Final, Literal, TypeAlias
 
 import httpx
 from pydantic import (
@@ -40,6 +40,7 @@ from relay_teams.tools.web_tools.common import load_runtime_web_config
 EXA_BASE_URL = "https://mcp.exa.ai"
 EXA_PATH = "/mcp"
 EXA_TOOL_NAME = "web_search_advanced_exa"
+EXA_CODE_CONTEXT_TOOL_NAME = "get_code_context_exa"
 SEARXNG_SEARCH_PATH = "/search"
 SEARXNG_SEARCH_TOOL_NAME = "search"
 SEARXNG_PUBLIC_INSTANCES_URL = "https://searx.space/data/instances.json"
@@ -52,10 +53,24 @@ DEFAULT_TIMEOUT_SECONDS = 25.0
 DEFAULT_TEXT_MAX_CHARACTERS = 300
 DEFAULT_HIGHLIGHTS_PER_URL = 3
 DEFAULT_HIGHLIGHT_SENTENCES = 2
+DEFAULT_CODE_TOKENS_NUM = 5000
+MIN_CODE_TOKENS_NUM = 1000
+MAX_CODE_TOKENS_NUM = 50000
+SEARCH_MODE_AUTO: Final = "auto"
+SEARCH_MODE_WEB: Final = "web"
+SEARCH_MODE_CODE: Final = "code"
+EMPTY_CODE_CONTEXT_MESSAGE = (
+    "No code snippets or documentation found. Please try a different query, "
+    "be more specific about the library or programming concept, or check the "
+    "spelling of framework names."
+)
 DESCRIPTION = load_tool_description(__file__)
 
 _SEARXNG_INSTANCE_CACHE: SearxngInstanceCache | None = None
 _SEARXNG_INSTANCE_COOLDOWNS: dict[str, float] = {}
+
+WebSearchRequestMode: TypeAlias = Literal["auto", "web", "code"]
+WebSearchResolvedMode: TypeAlias = Literal["web", "code"]
 
 
 class WebSearchRequest(BaseModel):
@@ -65,6 +80,12 @@ class WebSearchRequest(BaseModel):
     num_results: int = Field(default=DEFAULT_NUM_RESULTS, ge=1)
     allowed_domains: tuple[str, ...] | None = None
     blocked_domains: tuple[str, ...] | None = None
+    search_mode: WebSearchRequestMode = SEARCH_MODE_AUTO
+    tokens_num: int = Field(
+        default=DEFAULT_CODE_TOKENS_NUM,
+        ge=MIN_CODE_TOKENS_NUM,
+        le=MAX_CODE_TOKENS_NUM,
+    )
 
     @field_validator("query")
     @classmethod
@@ -107,6 +128,10 @@ class WebSearchRequest(BaseModel):
             raise ValueError(
                 "Cannot specify both allowed_domains and blocked_domains in the same request"
             )
+        if self.search_mode == SEARCH_MODE_CODE and (
+            self.allowed_domains is not None or self.blocked_domains is not None
+        ):
+            raise ValueError("Domain filters are not supported for code context search")
         return self
 
 
@@ -127,7 +152,14 @@ class WebSearchResponse(BaseModel):
 
     query: str = Field(min_length=1)
     provider: WebProvider
+    search_mode: WebSearchResolvedMode = SEARCH_MODE_WEB
     hits: tuple[WebSearchHit, ...] = ()
+    context: str | None = None
+    tokens_num: int | None = Field(
+        default=None,
+        ge=MIN_CODE_TOKENS_NUM,
+        le=MAX_CODE_TOKENS_NUM,
+    )
     duration_ms: int = Field(ge=0)
 
 
@@ -137,7 +169,14 @@ class SearchExecutionResult(BaseModel):
     provider: WebProvider
     endpoint_host: str
     upstream_tool: str
+    search_mode: WebSearchResolvedMode = SEARCH_MODE_WEB
     hits: tuple[WebSearchHit, ...] = ()
+    context: str | None = None
+    tokens_num: int | None = Field(
+        default=None,
+        ge=MIN_CODE_TOKENS_NUM,
+        le=MAX_CODE_TOKENS_NUM,
+    )
     upstream_search_time: float | None = None
     internal_data: dict[str, JsonValue] = Field(default_factory=dict)
 
@@ -155,6 +194,13 @@ class ExaSearchArguments(BaseModel):
     highlightsNumSentences: int = DEFAULT_HIGHLIGHT_SENTENCES
     highlightsPerUrl: int = DEFAULT_HIGHLIGHTS_PER_URL
     highlightsQuery: str
+
+
+class ExaCodeContextArguments(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    query: str
+    tokensNum: int
 
 
 class ExaSearchRequest(BaseModel):
@@ -296,21 +342,31 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         num_results: int | None = None,
         allowed_domains: list[str] | None = None,
         blocked_domains: list[str] | None = None,
+        search_mode: WebSearchRequestMode | None = None,
+        tokens_num: int | None = None,
     ) -> dict[str, JsonValue]:
-        """Search the web and return structured search hits."""
+        """Search the web and return structured search hits, or retrieve code-oriented context."""
 
         async def _action() -> ToolResultProjection:
             config = load_runtime_web_config()
             started = time.perf_counter()
             request = WebSearchRequest(
                 query=query,
-                num_results=num_results or DEFAULT_NUM_RESULTS,
+                num_results=num_results
+                if num_results is not None
+                else DEFAULT_NUM_RESULTS,
                 allowed_domains=(
                     tuple(allowed_domains) if allowed_domains is not None else None
                 ),
                 blocked_domains=(
                     tuple(blocked_domains) if blocked_domains is not None else None
                 ),
+                search_mode=search_mode
+                if search_mode is not None
+                else SEARCH_MODE_AUTO,
+                tokens_num=tokens_num
+                if tokens_num is not None
+                else DEFAULT_CODE_TOKENS_NUM,
             )
             async with create_async_http_client(
                 timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
@@ -337,6 +393,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 "num_results": num_results,
                 "allowed_domains": _normalize_domain_summary(allowed_domains),
                 "blocked_domains": _normalize_domain_summary(blocked_domains),
+                "search_mode": search_mode,
+                "tokens_num": tokens_num,
             },
             action=_action,
         )
@@ -348,6 +406,14 @@ async def execute_search(
     config: WebConfig,
     request: WebSearchRequest,
 ) -> SearchExecutionResult:
+    resolved_mode = resolve_search_mode(request)
+    if resolved_mode == SEARCH_MODE_CODE:
+        return await execute_code_context_search(
+            client=client,
+            config=config,
+            request=request,
+        )
+
     try:
         return await execute_provider_search(
             client=client,
@@ -381,6 +447,51 @@ async def execute_search(
         )
 
 
+def resolve_search_mode(request: WebSearchRequest) -> WebSearchResolvedMode:
+    if request.search_mode == SEARCH_MODE_CODE:
+        return SEARCH_MODE_CODE
+    return SEARCH_MODE_WEB
+
+
+async def execute_code_context_search(
+    *,
+    client: httpx.AsyncClient,
+    config: WebConfig,
+    request: WebSearchRequest,
+) -> SearchExecutionResult:
+    if config.provider != WebProvider.EXA:
+        raise ToolExecutionError(
+            error_type="unsupported_provider",
+            message="Code context search requires the Exa web provider",
+            retryable=False,
+            details={
+                "provider": config.provider.value,
+                "search_mode": SEARCH_MODE_CODE,
+            },
+        )
+
+    prepared_request = build_provider_code_context_request(
+        config=config,
+        request=request,
+    )
+    response_text = await fetch_exa_search_response(
+        client=client,
+        endpoint=prepared_request.endpoint,
+        payload=prepared_request.payload,
+    )
+    context = extract_code_context_response(response_text)
+    if not context:
+        context = EMPTY_CODE_CONTEXT_MESSAGE
+    return SearchExecutionResult(
+        provider=prepared_request.provider,
+        endpoint_host=prepared_request.endpoint_host,
+        upstream_tool=prepared_request.upstream_tool,
+        search_mode=SEARCH_MODE_CODE,
+        context=context,
+        tokens_num=request.tokens_num,
+    )
+
+
 def should_fallback_from_exa(
     *,
     config: WebConfig,
@@ -395,7 +506,7 @@ def should_fallback_from_exa(
 
 def is_exa_fallback_error(primary_error: ToolExecutionError) -> bool:
     status_code = primary_error.details.get("status_code")
-    if primary_error.error_type == "rate_limited":
+    if primary_error.error_type in {"network_error", "network_timeout", "rate_limited"}:
         return True
     if status_code == 402:
         return True
@@ -877,6 +988,29 @@ def build_provider_search_request(
     raise ValueError(f"Unsupported web provider: {config.provider.value}")
 
 
+def build_provider_code_context_request(
+    *,
+    config: WebConfig,
+    request: WebSearchRequest,
+) -> PreparedSearchRequest:
+    if config.provider == WebProvider.EXA:
+        endpoint = build_exa_search_url(
+            api_key=config.get_api_key_for_provider(WebProvider.EXA),
+            enabled_tools=(EXA_CODE_CONTEXT_TOOL_NAME,),
+        )
+        return PreparedSearchRequest(
+            provider=config.provider,
+            endpoint=endpoint,
+            endpoint_host=httpx.URL(endpoint).host or "",
+            payload=build_exa_code_context_request(
+                query=request.query,
+                tokens_num=request.tokens_num,
+            ),
+            upstream_tool=EXA_CODE_CONTEXT_TOOL_NAME,
+        )
+    raise ValueError(f"Unsupported web provider: {config.provider.value}")
+
+
 def build_search_result_projection(
     *,
     query: str,
@@ -886,7 +1020,10 @@ def build_search_result_projection(
     response = WebSearchResponse(
         query=query,
         provider=result.provider,
+        search_mode=result.search_mode,
         hits=result.hits,
+        context=result.context,
+        tokens_num=result.tokens_num,
         duration_ms=duration_ms,
     )
     internal_data: dict[str, JsonValue] = {
@@ -896,8 +1033,13 @@ def build_search_result_projection(
     if result.upstream_search_time is not None:
         internal_data["upstream_search_time"] = result.upstream_search_time
     internal_data.update(result.internal_data)
+    visible_data = response.model_dump(mode="json")
+    if result.context is None:
+        visible_data.pop("context", None)
+    if result.tokens_num is None:
+        visible_data.pop("tokens_num", None)
     return ToolResultProjection(
-        visible_data=response.model_dump(mode="json"),
+        visible_data=visible_data,
         internal_data=internal_data,
     )
 
@@ -921,6 +1063,24 @@ def build_exa_search_request(
         params={
             "name": EXA_TOOL_NAME,
             "arguments": arguments.model_dump(mode="json", exclude_none=True),
+        }
+    )
+    return request.model_dump(mode="json")
+
+
+def build_exa_code_context_request(
+    *,
+    query: str,
+    tokens_num: int,
+) -> dict[str, JsonValue]:
+    arguments = ExaCodeContextArguments(
+        query=query,
+        tokensNum=tokens_num,
+    )
+    request = ExaSearchRequest(
+        params={
+            "name": EXA_CODE_CONTEXT_TOOL_NAME,
+            "arguments": arguments.model_dump(mode="json"),
         }
     )
     return request.model_dump(mode="json")
@@ -1012,25 +1172,29 @@ def _search_status_error_type(status_code: int) -> str:
 
 
 def _parse_exa_rpc_error_response(response_text: str) -> ToolExecutionError | None:
-    try:
-        payload = ExaRpcResponsePayload.model_validate_json(response_text)
-    except Exception:
-        return None
-    if payload.error is None:
-        return None
-    message = _normalize_optional_text(payload.error.message) or "Exa web search failed"
-    error_type = (
-        "rate_limited" if _contains_exa_quota_hint(message) else "upstream_error"
-    )
-    return ToolExecutionError(
-        error_type=error_type,
-        message=f"Exa web search returned JSON-RPC error: {message}",
-        retryable=error_type == "rate_limited",
-        details={
-            "provider": WebProvider.EXA.value,
-            "rpc_error_code": payload.error.code,
-        },
-    )
+    for payload in _iter_exa_response_payloads(response_text):
+        try:
+            rpc_payload = ExaRpcResponsePayload.model_validate(payload)
+        except Exception:
+            continue
+        if rpc_payload.error is None:
+            continue
+        message = _normalize_optional_text(rpc_payload.error.message) or (
+            "Exa web search failed"
+        )
+        error_type = (
+            "rate_limited" if _contains_exa_quota_hint(message) else "upstream_error"
+        )
+        return ToolExecutionError(
+            error_type=error_type,
+            message=f"Exa web search returned JSON-RPC error: {message}",
+            retryable=error_type == "rate_limited",
+            details={
+                "provider": WebProvider.EXA.value,
+                "rpc_error_code": rpc_payload.error.code,
+            },
+        )
+    return None
 
 
 def _search_status_error_message(
@@ -1043,6 +1207,45 @@ def _search_status_error_message(
     if detail:
         return f"{base}: {detail}"
     return base
+
+
+def extract_code_context_response(response_text: str) -> str:
+    contexts: list[str] = []
+    for payload in _iter_exa_response_payloads(response_text):
+        result = payload.get("result")
+        if not isinstance(result, dict):
+            continue
+        content = result.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            normalized = _normalize_optional_text(item.get("text"))
+            if normalized is not None:
+                contexts.append(normalized)
+    return "\n\n".join(contexts).strip()
+
+
+def _iter_exa_response_payloads(response_text: str) -> tuple[dict[str, JsonValue], ...]:
+    payloads: list[dict[str, JsonValue]] = []
+    for raw_line in response_text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload_text = line[5:].strip()
+        if not payload_text:
+            continue
+        try:
+            payloads.append(_parse_search_event(payload_text))
+        except Exception:
+            continue
+    if payloads:
+        return tuple(payloads)
+    try:
+        return (_parse_search_event(response_text),)
+    except Exception:
+        return ()
 
 
 def extract_search_response(response_text: str) -> ExtractedSearchResponse:

--- a/src/relay_teams/tools/web_tools/websearch.txt
+++ b/src/relay_teams/tools/web_tools/websearch.txt
@@ -1,6 +1,8 @@
-Search the web with the configured provider and return structured search hits for the query.
+Search the web and return structured search hits with the configured provider, or retrieve code-oriented context for the query.
 
-Use this when you need fresh external information that is not available in the workspace.
+Use this when you need fresh external information that is not available in the workspace, including SDK, API, library, framework, documentation, usage pattern, or code example context.
 Keep arguments minimal: provide the query and optionally the number of results.
-You may also pass `allowed_domains` or `blocked_domains` to constrain sources, but never both in the same call.
+For programming questions about SDK/API/library/framework usage, configuration, documentation, or code examples, explicitly pass `search_mode="code"` to retrieve concentrated Exa code context; optionally pass `tokens_num` from 1000 to 50000 to control context size.
+Use `search_mode="web"`, or leave `search_mode` unset, for normal web search such as release notes, news, changelogs, pricing, status pages, current events, and source-constrained searches.
+You may also pass `allowed_domains` or `blocked_domains` to constrain normal web search sources, but never both in the same call; domain filters are not supported with `search_mode="code"`.
 Provider-specific search knobs are handled internally.

--- a/tests/unit_tests/tools/web_tools/test_websearch.py
+++ b/tests/unit_tests/tools/web_tools/test_websearch.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+import json
 from typing import cast
 
 import httpx
 import pytest
+from pydantic import JsonValue
+from pydantic_ai import Agent
 
 from relay_teams.env.web_config_models import (
     DEFAULT_SEARXNG_INSTANCE_URL,
@@ -12,8 +16,26 @@ from relay_teams.env.web_config_models import (
     WebFallbackProvider,
     WebProvider,
 )
-from relay_teams.tools.runtime import ToolExecutionError
+from relay_teams.tools.runtime import ToolContext, ToolDeps, ToolExecutionError
 from relay_teams.tools.web_tools import websearch
+
+RegisteredWebSearch = Callable[..., Awaitable[dict[str, JsonValue]]]
+
+
+class _ToolCaptureAgent:
+    def __init__(self) -> None:
+        self.registered: RegisteredWebSearch | None = None
+
+    def tool(
+        self, *, description: str
+    ) -> Callable[[RegisteredWebSearch], RegisteredWebSearch]:
+        assert description
+
+        def _decorator(func: RegisteredWebSearch) -> RegisteredWebSearch:
+            self.registered = func
+            return func
+
+        return _decorator
 
 
 def test_web_search_request_normalizes_domain_filters() -> None:
@@ -32,6 +54,97 @@ def test_web_search_request_rejects_mixed_domain_filters() -> None:
             query="latest ai news",
             allowed_domains=("docs.python.org",),
             blocked_domains=("example.com",),
+        )
+
+
+def test_web_search_description_covers_code_context_queries() -> None:
+    description = websearch.DESCRIPTION.lower()
+
+    assert "sdk" in description
+    assert "api" in description
+    assert "library" in description
+    assert "framework" in description
+    assert "code example" in description
+    assert 'search_mode="code"' in description
+
+
+def test_web_search_auto_mode_defaults_to_web_until_code_mode_is_explicit() -> None:
+    assert (
+        websearch.resolve_search_mode(
+            websearch.WebSearchRequest(query="React useState hook examples")
+        )
+        == "web"
+    )
+    assert (
+        websearch.resolve_search_mode(
+            websearch.WebSearchRequest(
+                query="React useState hook examples",
+                search_mode="code",
+            )
+        )
+        == "code"
+    )
+
+
+def test_web_search_request_accepts_code_mode_and_tokens() -> None:
+    request = websearch.WebSearchRequest(
+        query=" React useState examples ",
+        search_mode="code",
+        tokens_num=8000,
+    )
+
+    assert request.query == "React useState examples"
+    assert request.search_mode == "code"
+    assert request.tokens_num == 8000
+
+
+def test_web_search_request_rejects_invalid_code_context_options() -> None:
+    with pytest.raises(ValueError):
+        websearch.WebSearchRequest(query="python", search_mode="code", tokens_num=0)
+
+    with pytest.raises(ValueError):
+        websearch.WebSearchRequest(query="python", search_mode="code", tokens_num=999)
+
+    with pytest.raises(ValueError):
+        websearch.WebSearchRequest(
+            query="python",
+            search_mode="code",
+            tokens_num=50001,
+        )
+
+    with pytest.raises(ValueError, match="Domain filters"):
+        websearch.WebSearchRequest(
+            query="python docs",
+            search_mode="code",
+            allowed_domains=("docs.python.org",),
+        )
+
+
+@pytest.mark.asyncio
+async def test_registered_websearch_preserves_explicit_invalid_search_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _execute_tool(_ctx: object, **kwargs: object) -> dict[str, JsonValue]:
+        action = cast(Callable[[], Awaitable[object]], kwargs["action"])
+        await action()
+        raise AssertionError("expected invalid search_mode to fail validation")
+
+    monkeypatch.setattr(websearch, "execute_tool", _execute_tool)
+    monkeypatch.setattr(
+        websearch,
+        "load_runtime_web_config",
+        lambda: WebConfig(provider=WebProvider.EXA, exa_api_key="secret"),
+    )
+    agent = _ToolCaptureAgent()
+    websearch.register(cast(Agent[ToolDeps, str], agent))
+    registered = agent.registered
+    assert registered is not None
+
+    with pytest.raises(ValueError):
+        await registered(
+            cast(ToolContext, cast(object, object())),
+            query="python",
+            search_mode=cast(websearch.WebSearchRequestMode, ""),
         )
 
 
@@ -76,6 +189,45 @@ def test_build_provider_search_request_uses_exa_provider_adapter() -> None:
     assert "excludeDomains" not in arguments
 
 
+def test_build_exa_code_context_request_uses_exa_code_tool() -> None:
+    payload = websearch.build_exa_code_context_request(
+        query="Next.js partial prerendering config",
+        tokens_num=8000,
+    )
+
+    params = cast(dict[str, object], payload["params"])
+    assert params["name"] == "get_code_context_exa"
+    arguments = cast(dict[str, object], params["arguments"])
+    assert arguments == {
+        "query": "Next.js partial prerendering config",
+        "tokensNum": 8000,
+    }
+
+
+def test_build_provider_code_context_request_uses_exa_provider_config() -> None:
+    prepared = websearch.build_provider_code_context_request(
+        config=WebConfig(provider=WebProvider.EXA, exa_api_key="secret"),
+        request=websearch.WebSearchRequest(
+            query="React useState examples",
+            search_mode="code",
+        ),
+    )
+
+    assert prepared.provider == WebProvider.EXA
+    assert (
+        prepared.endpoint
+        == "https://mcp.exa.ai/mcp?exaApiKey=secret&tools=get_code_context_exa"
+    )
+    assert prepared.endpoint_host == "mcp.exa.ai"
+    assert prepared.upstream_tool == "get_code_context_exa"
+    params = cast(dict[str, object], prepared.payload["params"])
+    arguments = cast(dict[str, object], params["arguments"])
+    assert arguments == {
+        "query": "React useState examples",
+        "tokensNum": 5000,
+    }
+
+
 def test_build_search_result_projection_keeps_sanitized_internal_metadata() -> None:
     projection = websearch.build_search_result_projection(
         query="latest ai news",
@@ -101,6 +253,7 @@ def test_build_search_result_projection_keeps_sanitized_internal_metadata() -> N
     assert projection.visible_data == {
         "query": "latest ai news",
         "provider": "searxng",
+        "search_mode": "web",
         "hits": [
             {
                 "title": "Python Docs",
@@ -398,6 +551,191 @@ async def test_fetch_exa_search_response_classifies_http_errors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_search_auto_mode_uses_web_path_for_code_like_query() -> None:
+    requests: list[dict[str, object]] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            request=request,
+            text=(
+                "event: message\n"
+                'data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"results\\":[{\\"title\\":\\"React Docs\\",\\"url\\":\\"https://react.dev/reference/react/useState\\",\\"summary\\":\\"useState reference\\"}]}"}]}}\n'
+            ),
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        result = await websearch.execute_search(
+            client=client,
+            config=WebConfig(provider=WebProvider.EXA),
+            request=websearch.WebSearchRequest(query="React useState hook examples"),
+        )
+    finally:
+        await client.aclose()
+
+    params = cast(dict[str, object], requests[0]["params"])
+    assert params["name"] == "web_search_advanced_exa"
+    assert result.search_mode == "web"
+    assert result.upstream_tool == "web_search_advanced_exa"
+    assert result.hits == (
+        websearch.WebSearchHit(
+            title="React Docs",
+            url="https://react.dev/reference/react/useState",
+            summary="useState reference",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_search_code_mode_returns_exa_code_context() -> None:
+    requests: list[dict[str, object]] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            request=request,
+            text=(
+                "event: message\n"
+                'data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"Use useState for local state."}]}}\n'
+            ),
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        result = await websearch.execute_search(
+            client=client,
+            config=WebConfig(provider=WebProvider.EXA, exa_api_key="secret"),
+            request=websearch.WebSearchRequest(
+                query="React useState examples",
+                search_mode="code",
+                tokens_num=3000,
+            ),
+        )
+    finally:
+        await client.aclose()
+
+    assert result.provider == WebProvider.EXA
+    assert result.search_mode == "code"
+    assert result.endpoint_host == "mcp.exa.ai"
+    assert result.upstream_tool == "get_code_context_exa"
+    assert result.context == "Use useState for local state."
+    assert result.tokens_num == 3000
+    params = cast(dict[str, object], requests[0]["params"])
+    arguments = cast(dict[str, object], params["arguments"])
+    assert arguments == {
+        "query": "React useState examples",
+        "tokensNum": 3000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_search_falls_back_after_exa_sse_json_rpc_rate_limit_error() -> (
+    None
+):
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        if "mcp.exa.ai" in str(request.url):
+            return httpx.Response(
+                200,
+                request=request,
+                text=(
+                    "event: message\n"
+                    'data: {"jsonrpc":"2.0","error":{"code":-32000,"message":"free MCP rate limit reached"},"id":null}\n'
+                ),
+            )
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "results": [
+                    {
+                        "title": "Python Docs",
+                        "url": "https://docs.python.org/3/",
+                        "content": "Reference",
+                    }
+                ]
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        result = await websearch.execute_search(
+            client=client,
+            config=WebConfig(
+                provider=WebProvider.EXA,
+                fallback_provider=WebFallbackProvider.SEARXNG,
+                searxng_instance_url="https://search.example.test/",
+            ),
+            request=websearch.WebSearchRequest(query="python"),
+        )
+    finally:
+        await client.aclose()
+
+    assert result.provider == WebProvider.SEARXNG
+    assert result.internal_data == {
+        "searxng_instance_url": "https://search.example.test/",
+        "instance_source": "configured",
+        "fallback_from": "exa",
+        "primary_error_type": "rate_limited",
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_search_falls_back_after_exa_network_error() -> None:
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        if "mcp.exa.ai" in str(request.url):
+            raise httpx.ConnectError("connection refused", request=request)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "results": [
+                    {
+                        "title": "Python Release Notes",
+                        "url": "https://docs.python.org/3/whatsnew/",
+                        "content": "Latest release notes",
+                    }
+                ]
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        result = await websearch.execute_search(
+            client=client,
+            config=WebConfig(
+                provider=WebProvider.EXA,
+                fallback_provider=WebFallbackProvider.SEARXNG,
+                searxng_instance_url="https://search.example.test/",
+            ),
+            request=websearch.WebSearchRequest(
+                query="latest Python release notes",
+                search_mode="web",
+            ),
+        )
+    finally:
+        await client.aclose()
+
+    assert result.provider == WebProvider.SEARXNG
+    assert result.endpoint_host == "search.example.test"
+    assert result.internal_data == {
+        "searxng_instance_url": "https://search.example.test/",
+        "instance_source": "configured",
+        "fallback_from": "exa",
+        "primary_error_type": "network_error",
+    }
+    assert result.hits == (
+        websearch.WebSearchHit(
+            title="Python Release Notes",
+            url="https://docs.python.org/3/whatsnew/",
+            text="Latest release notes",
+        ),
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute_search_falls_back_to_searxng_after_exa_rate_limit() -> None:
     async def _handler(request: httpx.Request) -> httpx.Response:
         if "mcp.exa.ai" in str(request.url):
@@ -646,6 +984,25 @@ async def test_execute_search_does_not_fallback_when_explicitly_disabled() -> No
         "status_code": 429,
     }
     assert request_hosts == ["mcp.exa.ai"]
+
+
+def test_is_exa_fallback_error_accepts_network_failures() -> None:
+    assert websearch.is_exa_fallback_error(
+        ToolExecutionError(
+            error_type="network_error",
+            message="Exa web search request failed",
+            retryable=True,
+            details={},
+        )
+    )
+    assert websearch.is_exa_fallback_error(
+        ToolExecutionError(
+            error_type="network_timeout",
+            message="Exa web search timed out",
+            retryable=True,
+            details={},
+        )
+    )
 
 
 def test_is_exa_fallback_error_accepts_quota_style_403_errors() -> None:


### PR DESCRIPTION
## Summary

Adds code-oriented context retrieval to the existing `websearch` tool instead of exposing a separate `codesearch` tool.

Programming queries can opt into Exa code context by calling `websearch` with `search_mode="code"` and optional `tokens_num`. When `search_mode` is omitted or set to `web`, `websearch` continues to use the normal web search path.

## Changes

- Keeps code retrieval behind the existing `websearch` tool instead of exposing a standalone `codesearch` tool.
- Extends `websearch` with `search_mode` (`auto`/`web`/`code`) and `tokens_num` for code-context retrieval.
- Routes only explicit `search_mode="code"` calls to Exa `get_code_context_exa`; unset/auto mode defaults to normal web search.
- Reuses the existing websearch runtime, projection, approval, and UI surfaces for both normal search and code context.
- Improves Exa JSON-RPC error parsing for direct JSON and SSE `data:` payloads.
- Falls back from Exa to SearXNG for normal web search when Exa fails with network errors, timeouts, rate limits, payment/quota errors, or quota-style 403s.
- Updates `websearch.txt` to guide models to pass `search_mode="code"` for SDK/API/library/framework usage, docs, configuration, and code examples.

## Impact

Agents keep a single web search tool surface while still being able to retrieve code-oriented SDK/API/library context. Existing roles, approval policy, registry output, and frontend rendering no longer expose a separate `codesearch` tool.

Normal web searches continue to work through `websearch`; code context is opt-in through `search_mode="code"`.

## Validation

- `.venv\Scripts\python.exe -m pytest tests/unit_tests/tools/web_tools/test_websearch.py tests/unit_tests/tools/registry/test_defaults.py tests/unit_tests/tools/runtime/test_policy.py tests/unit_tests/roles/test_builtin_role_tools.py tests/unit_tests/frontend/test_streaming_tool_ui.py`
- `.venv\Scripts\python.exe -m ruff check src/relay_teams/tools/web_tools/websearch.py tests/unit_tests/tools/web_tools/test_websearch.py`
- `.venv\Scripts\basedpyright.exe src/relay_teams/tools/web_tools/websearch.py tests/unit_tests/tools/web_tools/test_websearch.py`
- `git diff --check HEAD^ HEAD`

Closes #364