### PR TITLE
Fix missing openWorkspace API export

### DIFF
--- a/frontend/dist/js/core/api.js
+++ b/frontend/dist/js/core/api.js
@@ -126,6 +126,7 @@ export {
     fetchWorkspaceTree,
     fetchWorkspaces,
     forkWorkspace,
+    openWorkspace,
     pickWorkspace,
     deleteExternalAgent,
     createAutomationProject,

--- a/frontend/dist/js/core/api/index.js
+++ b/frontend/dist/js/core/api/index.js
@@ -150,6 +150,7 @@ export {
     fetchWorkspaceTree,
     fetchWorkspaces,
     forkWorkspace,
+    openWorkspace,
     pickWorkspace,
 } from './workspaces.js';
 

--- a/frontend/dist/js/core/api/workspaces.js
+++ b/frontend/dist/js/core/api/workspaces.js
@@ -67,6 +67,9 @@ export async function pickWorkspace(rootPath = null) {
     );
 }
 
+// Keep the legacy workspace picker name available for stale frontend imports.
+export const openWorkspace = pickWorkspace;
+
 export async function forkWorkspace(workspaceId, name) {
     return requestJson(
         `/api/workspaces/${encodeURIComponent(workspaceId)}:fork`,

--- a/tests/unit_tests/frontend/test_api_facade_ui.py
+++ b/tests/unit_tests/frontend/test_api_facade_ui.py
@@ -245,6 +245,43 @@ def test_core_api_facade_exports_wechat_gateway_helpers() -> None:
     )
 
 
+def test_core_api_facade_exports_legacy_open_workspace_alias() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    api_module_path = repo_root / "frontend" / "dist" / "js" / "core" / "api.js"
+
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                "globalThis.document = {"
+                "querySelector() { return null; },"
+                "querySelectorAll() { return []; },"
+                "getElementById() { return null; },"
+                "body: null"
+                "}; "
+                f"const mod = await import({api_module_path.as_uri()!r}); "
+                "console.log([typeof mod.openWorkspace, typeof mod.pickWorkspace, mod.openWorkspace === mod.pickWorkspace].join(','));"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node import failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    assert completed.stdout.strip() == "function,function,true"
+
+
 def test_request_json_disables_browser_cache_for_get_requests(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- restore the legacy `openWorkspace` workspace picker export as an alias of `pickWorkspace`
- re-export the alias through both frontend API facade layers so stale imports keep working
- add a frontend unit test that verifies `openWorkspace` and `pickWorkspace` resolve to the same function

## Testing
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_api_facade_ui.py tests/unit_tests/frontend/test_project_view_ui.py

Closes #378