### PR TITLE
Reset cached LLM transport before transport retries

### DIFF
--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -49,6 +49,7 @@ from relay_teams.providers.model_fallback import (
     LlmFallbackDecision,
     LlmFallbackMiddleware,
 )
+from relay_teams.net.llm_client import clear_llm_http_client_cache
 from relay_teams.providers.openai_model_profiles import (
     resolve_openai_chat_model_profile,
 )
@@ -1367,6 +1368,7 @@ class AgentLlmSession:
         skip_initial_user_prompt_persist: bool,
     ) -> _AttemptRecoveryOutcome:
         if should_retry:
+            self._reset_cached_transport_for_retry(retry_error=retry_error)
             resolved_retry_error = retry_error
             assert resolved_retry_error is not None
             next_retry_number = retry_number + 1
@@ -1395,6 +1397,7 @@ class AgentLlmSession:
                 )
             )
         if should_resume_after_tool_outcomes:
+            self._reset_cached_transport_for_retry(retry_error=retry_error)
             return _AttemptRecoveryOutcome.recovered(
                 await self._resume_after_tool_outcomes(
                     request=request,
@@ -1426,6 +1429,15 @@ class AgentLlmSession:
             if fallback_outcome.status == _FallbackAttemptStatus.EXHAUSTED:
                 return _AttemptRecoveryOutcome.fallback_exhausted()
         return _AttemptRecoveryOutcome.no_recovery()
+
+    def _reset_cached_transport_for_retry(
+        self,
+        *,
+        retry_error: LlmRetryErrorInfo | None,
+    ) -> None:
+        if retry_error is None or not retry_error.transport_error:
+            return
+        clear_llm_http_client_cache()
 
     def _log_generate_failure_diagnostics(
         self,

--- a/tests/unit_tests/agents/execution/test_llm_session.py
+++ b/tests/unit_tests/agents/execution/test_llm_session.py
@@ -10,6 +10,7 @@ from typing import cast
 import pytest
 from openai import APIStatusError
 
+import relay_teams.agents.execution.llm_session as llm_module
 from relay_teams.agents.execution.llm_session import (
     AgentLlmSession,
     _FallbackAttemptState,
@@ -726,6 +727,192 @@ async def test_generate_async_passes_retry_after_to_retry_schedule() -> None:
     assert len(captured_schedules) == 1
     schedule = captured_schedules[0]
     assert schedule.delay_ms == 7000
+
+
+@pytest.mark.asyncio
+async def test_execute_attempt_recovery_clears_cached_transport_before_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_retry_config"] = LlmRetryConfig(
+        jitter=False,
+        max_retries=1,
+        initial_delay_ms=1,
+    )
+
+    cleared: list[str] = []
+    monkeypatch.setattr(
+        llm_module,
+        "clear_llm_http_client_cache",
+        lambda: cleared.append("cleared"),
+    )
+    monkeypatch.setattr(llm_module, "compute_retry_delay_ms", lambda **_: 0)
+
+    async def _fast_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(llm_module.asyncio, "sleep", _fast_sleep)
+
+    scheduled: list[LlmRetrySchedule] = []
+
+    async def _capture_retry_scheduled(**kwargs: object) -> None:
+        scheduled.append(cast(LlmRetrySchedule, kwargs["schedule"]))
+
+    session.__dict__["_handle_retry_scheduled"] = _capture_retry_scheduled
+
+    async def _generate_async(
+        request: LLMRequest,
+        **kwargs: object,
+    ) -> str:
+        _ = (request, kwargs)
+        assert cleared == ["cleared"]
+        return "after retry"
+
+    session.__dict__["_generate_async"] = _generate_async
+
+    result = await AgentLlmSession._execute_attempt_recovery(
+        session,
+        request=_build_request(),
+        retry_error=LlmRetryErrorInfo(
+            message="TLS handshake failed",
+            error_code="network_error",
+            retryable=True,
+            transport_error=True,
+        ),
+        retry_number=0,
+        total_attempts=2,
+        history=[],
+        pending_messages=[],
+        should_retry=True,
+        should_resume_after_tool_outcomes=False,
+        attempt_text_emitted=False,
+        attempt_tool_call_event_emitted=False,
+        attempt_tool_outcome_event_emitted=False,
+        attempt_messages_committed=False,
+        fallback_state=_FallbackAttemptState.initial("default"),
+        skip_initial_user_prompt_persist=False,
+    )
+
+    assert result.response == "after retry"
+    assert scheduled[0].delay_ms == 0
+    assert cleared == ["cleared"]
+
+
+@pytest.mark.asyncio
+async def test_execute_attempt_recovery_keeps_cached_transport_for_non_transport_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_retry_config"] = LlmRetryConfig(
+        jitter=False,
+        max_retries=1,
+        initial_delay_ms=1,
+    )
+
+    cleared: list[str] = []
+    monkeypatch.setattr(
+        llm_module,
+        "clear_llm_http_client_cache",
+        lambda: cleared.append("cleared"),
+    )
+    monkeypatch.setattr(llm_module, "compute_retry_delay_ms", lambda **_: 0)
+
+    async def _fast_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(llm_module.asyncio, "sleep", _fast_sleep)
+
+    async def _ignore_retry_schedule(**kwargs: object) -> None:
+        _ = kwargs
+        return None
+
+    session.__dict__["_handle_retry_scheduled"] = _ignore_retry_schedule
+
+    async def _generate_async(
+        request: LLMRequest,
+        **kwargs: object,
+    ) -> str:
+        _ = (request, kwargs)
+        assert cleared == []
+        return "after retry"
+
+    session.__dict__["_generate_async"] = _generate_async
+
+    result = await AgentLlmSession._execute_attempt_recovery(
+        session,
+        request=_build_request(),
+        retry_error=LlmRetryErrorInfo(
+            message="slow down",
+            status_code=429,
+            error_code="rate_limited",
+            retryable=True,
+            rate_limited=True,
+            transport_error=False,
+        ),
+        retry_number=0,
+        total_attempts=2,
+        history=[],
+        pending_messages=[],
+        should_retry=True,
+        should_resume_after_tool_outcomes=False,
+        attempt_text_emitted=False,
+        attempt_tool_call_event_emitted=False,
+        attempt_tool_outcome_event_emitted=False,
+        attempt_messages_committed=False,
+        fallback_state=_FallbackAttemptState.initial("default"),
+        skip_initial_user_prompt_persist=False,
+    )
+
+    assert result.response == "after retry"
+    assert cleared == []
+
+
+@pytest.mark.asyncio
+async def test_execute_attempt_recovery_clears_cached_transport_before_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_retry_config"] = LlmRetryConfig(max_retries=1)
+
+    cleared: list[str] = []
+    monkeypatch.setattr(
+        llm_module,
+        "clear_llm_http_client_cache",
+        lambda: cleared.append("cleared"),
+    )
+
+    async def _resume_after_tool_outcomes(**kwargs: object) -> str:
+        _ = kwargs
+        assert cleared == ["cleared"]
+        return "resumed"
+
+    session.__dict__["_resume_after_tool_outcomes"] = _resume_after_tool_outcomes
+
+    result = await AgentLlmSession._execute_attempt_recovery(
+        session,
+        request=_build_request(),
+        retry_error=LlmRetryErrorInfo(
+            message="TLS handshake failed",
+            error_code="network_error",
+            retryable=True,
+            transport_error=True,
+        ),
+        retry_number=0,
+        total_attempts=2,
+        history=[],
+        pending_messages=[],
+        should_retry=False,
+        should_resume_after_tool_outcomes=True,
+        attempt_text_emitted=False,
+        attempt_tool_call_event_emitted=False,
+        attempt_tool_outcome_event_emitted=False,
+        attempt_messages_committed=False,
+        fallback_state=_FallbackAttemptState.initial("default"),
+        skip_initial_user_prompt_persist=False,
+    )
+
+    assert result.response == "resumed"
+    assert cleared == ["cleared"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- clear the cached LLM HTTP client before retrying a transport-level model failure
- also clear the cached transport before resuming after tool outcomes when the triggering error was transport-related
- add regression tests covering transport retries, resume-after-tool-outcomes, and non-transport retries

## Testing
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`

Fixes #368