### PR TITLE
[codex] fix workspace root open on Windows

### DIFF
--- a/src/relay_teams/workspace/directory_opener.py
+++ b/src/relay_teams/workspace/directory_opener.py
@@ -93,7 +93,7 @@ def _start_detached_process(command: list[str], *, platform_name: str) -> None:
                 | int(getattr(subprocess, "DETACHED_PROCESS", 0))
                 | int(getattr(subprocess, "CREATE_NO_WINDOW", 0))
             )
-            process = subprocess.Popen(
+            _ = subprocess.Popen(
                 command,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -101,7 +101,8 @@ def _start_detached_process(command: list[str], *, platform_name: str) -> None:
                 creationflags=creationflags,
                 startupinfo=startupinfo,
             )
-            _ensure_process_started(process)
+            # Explorer can hand the directory off to the shell and exit immediately
+            # with a non-zero code even when the folder opens successfully.
             return
 
         process = subprocess.Popen(

--- a/src/relay_teams/workspace/directory_opener.py
+++ b/src/relay_teams/workspace/directory_opener.py
@@ -37,7 +37,11 @@ def _open_directory_windows(target_path: Path) -> None:
     if explorer is None:
         explorer = shutil.which("explorer.exe")
     if explorer is not None:
-        _start_detached_process([explorer, str(target_path)], platform_name="Windows")
+        _start_detached_process(
+            [explorer, str(target_path)],
+            platform_name="Windows",
+            skip_startup_check=True,
+        )
         return
 
     shell = shutil.which("powershell")
@@ -82,7 +86,12 @@ def _build_linux_open_command(target_path: Path) -> list[str]:
     raise RuntimeError(_OPEN_DIRECTORY_ERROR_MESSAGE)
 
 
-def _start_detached_process(command: list[str], *, platform_name: str) -> None:
+def _start_detached_process(
+    command: list[str],
+    *,
+    platform_name: str,
+    skip_startup_check: bool = False,
+) -> None:
     try:
         if platform_name == "Windows":
             startupinfo = subprocess.STARTUPINFO()
@@ -93,7 +102,7 @@ def _start_detached_process(command: list[str], *, platform_name: str) -> None:
                 | int(getattr(subprocess, "DETACHED_PROCESS", 0))
                 | int(getattr(subprocess, "CREATE_NO_WINDOW", 0))
             )
-            _ = subprocess.Popen(
+            process = subprocess.Popen(
                 command,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -101,8 +110,8 @@ def _start_detached_process(command: list[str], *, platform_name: str) -> None:
                 creationflags=creationflags,
                 startupinfo=startupinfo,
             )
-            # Explorer can hand the directory off to the shell and exit immediately
-            # with a non-zero code even when the folder opens successfully.
+            if not skip_startup_check:
+                _ensure_process_started(process)
             return
 
         process = subprocess.Popen(

--- a/tests/unit_tests/workspace/test_directory_opener.py
+++ b/tests/unit_tests/workspace/test_directory_opener.py
@@ -151,6 +151,67 @@ def test_open_workspace_directory_tolerates_explorer_exiting_immediately_on_wind
     directory_opener.open_workspace_directory(target_path)
 
 
+def test_open_workspace_directory_raises_when_powershell_fallback_exits_immediately(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_path = tmp_path / "workspace-root"
+    target_path.mkdir()
+
+    def fake_popen(command: list[str], **kwargs: object) -> object:
+        _ = (command, kwargs)
+        return _FakeProcess(returncode=1)
+
+    monkeypatch.setattr(directory_opener.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        directory_opener.shutil,
+        "which",
+        lambda name: (
+            "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+            if name == "powershell"
+            else None
+        ),
+    )
+    monkeypatch.setattr(directory_opener.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "STARTUPINFO",
+        lambda: types.SimpleNamespace(dwFlags=0, wShowWindow=0),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "STARTF_USESHOWWINDOW",
+        1,
+        raising=False,
+    )
+    monkeypatch.setattr(directory_opener.subprocess, "SW_HIDE", 0, raising=False)
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "CREATE_NEW_PROCESS_GROUP",
+        2,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "DETACHED_PROCESS",
+        4,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "CREATE_NO_WINDOW",
+        8,
+        raising=False,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to launch native file manager: opener exited before startup completed",
+    ):
+        directory_opener.open_workspace_directory(target_path)
+
+
 def test_open_workspace_directory_falls_back_to_gio_on_linux(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/workspace/test_directory_opener.py
+++ b/tests/unit_tests/workspace/test_directory_opener.py
@@ -98,6 +98,59 @@ def test_open_workspace_directory_uses_explorer_on_windows(
     }
 
 
+def test_open_workspace_directory_tolerates_explorer_exiting_immediately_on_windows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_path = tmp_path / "workspace-root"
+    target_path.mkdir()
+
+    def fake_popen(command: list[str], **kwargs: object) -> object:
+        _ = (command, kwargs)
+        return _FakeProcess(returncode=1)
+
+    monkeypatch.setattr(directory_opener.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        directory_opener.shutil,
+        "which",
+        lambda name: "C:/Windows/explorer.exe" if name == "explorer" else None,
+    )
+    monkeypatch.setattr(directory_opener.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "STARTUPINFO",
+        lambda: types.SimpleNamespace(dwFlags=0, wShowWindow=0),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "STARTF_USESHOWWINDOW",
+        1,
+        raising=False,
+    )
+    monkeypatch.setattr(directory_opener.subprocess, "SW_HIDE", 0, raising=False)
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "CREATE_NEW_PROCESS_GROUP",
+        2,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "DETACHED_PROCESS",
+        4,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        directory_opener.subprocess,
+        "CREATE_NO_WINDOW",
+        8,
+        raising=False,
+    )
+
+    directory_opener.open_workspace_directory(target_path)
+
+
 def test_open_workspace_directory_falls_back_to_gio_on_linux(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
﻿## Summary
- stop treating explorer.exe immediate exit as a failed launch on Windows
- keep the detached-launch startup check for non-Windows platforms
- add a Windows regression test for the case where Explorer exits immediately after handing off the folder to the shell

## Root Cause
The Windows workspace directory opener waited for explorer.exe to stay alive long enough to count as started. On Windows, Explorer can successfully hand the target folder off to the shell and then exit immediately with a non-zero status. The backend treated that normal handoff as a launch failure and returned 503.

## Impact
Opening the workspace root from the workspace details view no longer returns a false 503 on Windows when the native file manager launch succeeds.

## Validation
- uv run --extra dev python -m pytest -q tests/unit_tests/workspace/test_directory_opener.py
- uv run --extra dev python -m pytest -q tests/unit_tests/interfaces/server/test_workspaces_router.py
- uv run --extra dev ruff check src/relay_teams/workspace/directory_opener.py tests/unit_tests/workspace/test_directory_opener.py
- uv run --extra dev basedpyright src/relay_teams/workspace/directory_opener.py tests/unit_tests/workspace/test_directory_opener.py tests/unit_tests/interfaces/server/test_workspaces_router.py
- real Windows route verification: POST /api/workspaces/{id}:open-root returned 200 for both a temp workspace and D:\openworkspace\relay-teams

Closes #385
