### PR TITLE
[codex] harden Windows computer use validation

### DIFF
--- a/docs/computer-use-real-smoke.md
+++ b/docs/computer-use-real-smoke.md
@@ -8,7 +8,7 @@ This feature already has CI coverage through the scripted desktop runtime. Use t
 
 - Windows desktop session with an interactive user session
 - PowerShell available on `PATH`
-- Calculator available through `calc.exe`
+- Notepad available through `notepad.exe`
 
 ### Linux
 
@@ -33,6 +33,8 @@ This feature already has CI coverage through the scripted desktop runtime. Use t
   - `xcalc`
 
 The Windows backend uses PowerShell for screenshot and window discovery, plus Win32 input injection for mouse and keyboard control. It expects a normal interactive desktop session.
+
+Windows launch resolution now includes built-in aliases for common apps such as `Notepad` / `记事本` and `Calculator` / `计算器`. Use Notepad for smoke validation because it is consistently present on Windows desktop and server images, while Calculator can still depend on AppX availability.
 
 The Linux backend is intended for X11 or XWayland-style desktop control. Scripted CI validation remains the default because many headless or pure Wayland environments do not expose window/input automation consistently.
 
@@ -65,19 +67,19 @@ Keep the existing fake model server setup if you want a deterministic tool seque
 5. Start a run with a prompt such as:
 
 ```text
-[computer-real-validation] 打开计算器，等待窗口出现，然后截图确认。
+[computer-real-validation] 打开记事本，等待窗口出现，然后截图确认。
 ```
 
 6. Approve the `launch_app` action when the approval card appears.
-7. Confirm that a real calculator window appears on the desktop.
+7. Confirm that a real Notepad window appears on the desktop.
 8. Confirm that the completed run includes:
    - a successful `launch_app`
    - a successful `wait_for_window`
-   - a screenshot showing the calculator window
+   - a screenshot showing the Notepad window
 
 ## Expected Result
 
-- The OS really launches Calculator instead of only appending a fake window entry.
+- The OS really launches Notepad instead of only appending a fake window entry.
 - The run timeline contains a real screenshot from the desktop session.
 - Windows screenshot observations include the virtual-screen origin so multi-monitor coordinate picks stay aligned with pointer actions.
-- The `launch_app` tool result includes `data.launched_command`, which shows the resolved executable used by the OS backend, such as `calc.exe` on Windows or `gnome-calculator` on Linux.
+- The `launch_app` tool result includes `data.launched_command`, which shows the resolved executable used by the OS backend, such as `notepad.exe` or `calc.exe` on Windows, or `gnome-calculator` on Linux.

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -470,10 +470,24 @@ class WindowsDesktopRuntime:
         launched_command: tuple[str, ...] | None = None
         matched_window: ComputerWindow | None = None
         attempted_commands: list[str] = []
+        failed_commands: list[str] = []
         for candidate in self._resolve_launch_candidates(app_name):
             command = list(candidate.command)
-            attempted_commands.append(" ".join(command))
-            self._spawn_process(command)
+            command_text = " ".join(command)
+            attempted_commands.append(command_text)
+            try:
+                self._spawn_process(command)
+            except OSError as exc:
+                failed_commands.append(f"{command_text} ({exc})")
+                LOGGER.warning(
+                    "Windows desktop launch candidate failed before window wait.",
+                    extra={
+                        "app_name": app_name,
+                        "command": command,
+                        "error": str(exc),
+                    },
+                )
+                continue
             matched_window = self._wait_for_window_match(
                 queries=candidate.match_queries,
                 before_windows=before_windows,
@@ -487,6 +501,7 @@ class WindowsDesktopRuntime:
                 self._launch_failure_message(
                     app_name=app_name,
                     attempted_commands=attempted_commands,
+                    failed_commands=failed_commands,
                 )
             )
         self._activate_window(matched_window.window_id)
@@ -1060,10 +1075,13 @@ class WindowsDesktopRuntime:
         *,
         app_name: str,
         attempted_commands: list[str],
+        failed_commands: list[str],
     ) -> str:
         details = [f"App window did not appear within timeout: {app_name}."]
         if attempted_commands:
             details.append("Attempted commands: " + ", ".join(attempted_commands) + ".")
+        if failed_commands:
+            details.append("Spawn failures: " + ", ".join(failed_commands) + ".")
         visible_titles = self._visible_window_titles()
         if visible_titles:
             details.append("Visible windows: " + visible_titles + ".")

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 from ctypes import wintypes
 from pathlib import Path, PureWindowsPath
+from typing import NamedTuple
 
 from relay_teams.computer.models import (
     ComputerActionDescriptor,
@@ -116,7 +117,83 @@ _NAMED_VKEYS: dict[str, int] = {
     "up": _VK_UP,
 }
 
+_WINDOWS_APP_QUERY_ALIASES: dict[str, tuple[str, ...]] = {
+    "calc": (
+        "Calculator",
+        "calc",
+        "calc.exe",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+    "calc.exe": (
+        "Calculator",
+        "calc",
+        "calc.exe",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+    "calculator": (
+        "Calculator",
+        "calc",
+        "calc.exe",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+    "microsoft.windowscalculator": (
+        "Calculator",
+        "calc",
+        "calc.exe",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+    "notepad": (
+        "Notepad",
+        "notepad",
+        "notepad.exe",
+        "记事本",
+    ),
+    "notepad.exe": (
+        "Notepad",
+        "notepad",
+        "notepad.exe",
+        "记事本",
+    ),
+    "记事本": (
+        "Notepad",
+        "notepad",
+        "notepad.exe",
+        "记事本",
+    ),
+    "计算器": (
+        "Calculator",
+        "calc",
+        "calc.exe",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+}
+
+_WINDOWS_KNOWN_LAUNCH_COMMANDS: dict[str, tuple[str, ...]] = {
+    "calc": ("calc.exe",),
+    "calc.exe": ("calc.exe",),
+    "calculator": ("calc.exe",),
+    "notepad": ("notepad.exe",),
+    "notepad.exe": ("notepad.exe",),
+    "记事本": ("notepad.exe",),
+    "计算器": ("calc.exe",),
+}
+
+_WINDOWS_CALCULATOR_SHELL_COMMAND = (
+    "explorer.exe",
+    r"shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App",
+)
+
 _ULONG_PTR = ctypes.c_size_t
+
+
+class _LaunchCandidate(NamedTuple):
+    command: tuple[str, ...]
+    match_queries: tuple[str, ...]
 
 
 class _MouseInput(ctypes.Structure):
@@ -390,19 +467,28 @@ class WindowsDesktopRuntime:
             require_windows=False,
             require_input=False,
         )
-        command = self._resolve_launch_command(app_name)
-        self._spawn_process(command)
-        window_queries = self._build_launch_window_queries(
-            app_name=app_name,
-            command=command,
-        )
-        matched_window = self._wait_for_window_match(
-            queries=window_queries,
-            before_windows=before_windows,
-            allow_existing_matches=False,
-        )
+        launched_command: tuple[str, ...] | None = None
+        matched_window: ComputerWindow | None = None
+        attempted_commands: list[str] = []
+        for candidate in self._resolve_launch_candidates(app_name):
+            command = list(candidate.command)
+            attempted_commands.append(" ".join(command))
+            self._spawn_process(command)
+            matched_window = self._wait_for_window_match(
+                queries=candidate.match_queries,
+                before_windows=before_windows,
+                allow_existing_matches=False,
+            )
+            if matched_window is not None:
+                launched_command = candidate.command
+                break
         if matched_window is None:
-            raise RuntimeError(f"App window did not appear within timeout: {app_name}")
+            raise RuntimeError(
+                self._launch_failure_message(
+                    app_name=app_name,
+                    attempted_commands=attempted_commands,
+                )
+            )
         self._activate_window(matched_window.window_id)
         self._sleep(_WINDOW_ACTIVATE_DELAY_SECONDS)
         observation = self._build_observation(
@@ -425,7 +511,7 @@ class WindowsDesktopRuntime:
             data={
                 "window_count": len(observation.windows),
                 "runtime_mode": "windows",
-                "launched_command": " ".join(command),
+                "launched_command": " ".join(launched_command or ()),
             },
         )
 
@@ -748,9 +834,10 @@ class WindowsDesktopRuntime:
         normalized = query.strip()
         if not normalized:
             raise ValueError("window_title is required")
+        match_queries = self._expand_match_queries(normalized)
         windows = self._list_windows_snapshot(require_windows=True, require_input=False)
         for window in windows:
-            if self._window_matches(window, normalized):
+            if self._window_matches_any(window, match_queries):
                 return window
         raise RuntimeError(f"Window not found: {query}")
 
@@ -761,7 +848,7 @@ class WindowsDesktopRuntime:
         before_windows: tuple[ComputerWindow, ...] = (),
         allow_existing_matches: bool = True,
     ) -> ComputerWindow | None:
-        normalized_queries = self._normalize_match_queries(*queries)
+        normalized_queries = self._expand_match_queries(*queries)
         before_ids = {window.window_id for window in before_windows}
         deadline = self._time_monotonic() + _WAIT_TIMEOUT_SECONDS
         while self._time_monotonic() < deadline:
@@ -840,6 +927,15 @@ class WindowsDesktopRuntime:
             seen_queries.add(dedupe_key)
         return tuple(normalized_queries)
 
+    def _expand_match_queries(self, *queries: str) -> tuple[str, ...]:
+        expanded_queries: list[str] = []
+        for query in self._normalize_match_queries(*queries):
+            expanded_queries.append(query)
+            expanded_queries.extend(
+                _WINDOWS_APP_QUERY_ALIASES.get(query.casefold(), ())
+            )
+        return self._normalize_match_queries(*expanded_queries)
+
     def _window_matches_any(
         self,
         window: ComputerWindow,
@@ -859,15 +955,32 @@ class WindowsDesktopRuntime:
         user32 = self._load_user32()
         user32.IsWindow.argtypes = (wintypes.HWND,)
         user32.IsWindow.restype = wintypes.BOOL
+        user32.GetForegroundWindow.argtypes = ()
+        user32.GetForegroundWindow.restype = wintypes.HWND
         user32.ShowWindow.argtypes = (wintypes.HWND, ctypes.c_int)
         user32.ShowWindow.restype = wintypes.BOOL
         user32.SetForegroundWindow.argtypes = (wintypes.HWND,)
         user32.SetForegroundWindow.restype = wintypes.BOOL
+        user32.BringWindowToTop.argtypes = (wintypes.HWND,)
+        user32.BringWindowToTop.restype = wintypes.BOOL
         if not user32.IsWindow(handle):
             raise RuntimeError(f"Window not found: {window_id}")
+        if self._handle_value(user32.GetForegroundWindow()) == self._handle_value(
+            handle
+        ):
+            return
         user32.ShowWindow(handle, _SW_RESTORE)
-        if not user32.SetForegroundWindow(handle):
-            raise RuntimeError(f"Windows desktop activation failed: {window_id}")
+        if user32.SetForegroundWindow(handle):
+            return
+        user32.BringWindowToTop(handle)
+        if self._handle_value(user32.GetForegroundWindow()) == self._handle_value(
+            handle
+        ):
+            return
+        LOGGER.warning(
+            "Windows desktop activation could not be confirmed.",
+            extra={"window_id": window_id},
+        )
 
     def _parse_window_id(self, window_id: str) -> wintypes.HWND:
         normalized = window_id.strip()
@@ -879,14 +992,21 @@ class WindowsDesktopRuntime:
             raise ValueError(f"Unsupported window_id: {window_id}") from exc
         return wintypes.HWND(handle_value)
 
+    def _handle_value(self, handle: wintypes.HWND | int | None) -> int:
+        raw_value = getattr(handle, "value", handle)
+        if raw_value is None:
+            return 0
+        return int(raw_value)
+
     def _resolve_launch_command(self, app_name: str) -> list[str]:
         normalized = app_name.strip()
         if not normalized:
             raise ValueError("app_name is required")
 
         lowered = normalized.casefold()
-        if lowered in {"calc", "calculator"}:
-            return ["calc.exe"]
+        known_command = _WINDOWS_KNOWN_LAUNCH_COMMANDS.get(lowered)
+        if known_command is not None:
+            return list(known_command)
 
         parsed_command = shlex.split(normalized, posix=False)
         if parsed_command:
@@ -898,6 +1018,67 @@ class WindowsDesktopRuntime:
             return [normalized]
 
         return ["cmd", "/c", "start", "", normalized]
+
+    def _resolve_launch_candidates(self, app_name: str) -> tuple[_LaunchCandidate, ...]:
+        command = tuple(self._resolve_launch_command(app_name))
+        match_queries = self._expand_match_queries(
+            *self._build_launch_window_queries(
+                app_name=app_name,
+                command=list(command),
+            )
+        )
+        candidates: list[_LaunchCandidate] = [
+            _LaunchCandidate(
+                command=command,
+                match_queries=match_queries,
+            )
+        ]
+        if (
+            app_name.strip().casefold()
+            in {
+                "calc",
+                "calc.exe",
+                "calculator",
+                "microsoft.windowscalculator",
+                "计算器",
+            }
+            and command != _WINDOWS_CALCULATOR_SHELL_COMMAND
+        ):
+            candidates.append(
+                _LaunchCandidate(
+                    command=_WINDOWS_CALCULATOR_SHELL_COMMAND,
+                    match_queries=self._expand_match_queries(
+                        *match_queries,
+                        "Microsoft.WindowsCalculator",
+                    ),
+                )
+            )
+        return tuple(candidates)
+
+    def _launch_failure_message(
+        self,
+        *,
+        app_name: str,
+        attempted_commands: list[str],
+    ) -> str:
+        details = [f"App window did not appear within timeout: {app_name}."]
+        if attempted_commands:
+            details.append("Attempted commands: " + ", ".join(attempted_commands) + ".")
+        visible_titles = self._visible_window_titles()
+        if visible_titles:
+            details.append("Visible windows: " + visible_titles + ".")
+        return " ".join(details)
+
+    def _visible_window_titles(self) -> str:
+        try:
+            windows = self._list_windows_snapshot(
+                require_windows=False,
+                require_input=False,
+            )
+        except RuntimeError:
+            return ""
+        titles = [window.title for window in windows[:5] if window.title]
+        return "; ".join(titles)
 
     def _spawn_process(self, command: list[str]) -> None:
         LOGGER.info("Launching Windows desktop app", extra={"command": command})

--- a/src/relay_teams/computer/windows_runtime.py
+++ b/src/relay_teams/computer/windows_runtime.py
@@ -173,6 +173,46 @@ _WINDOWS_APP_QUERY_ALIASES: dict[str, tuple[str, ...]] = {
     ),
 }
 
+_WINDOWS_WINDOW_TITLE_QUERY_ALIASES: dict[str, tuple[str, ...]] = {
+    "calc": (
+        "Calculator",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+    "calc.exe": (
+        "Calculator",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+    "calculator": (
+        "Calculator",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+    "microsoft.windowscalculator": (
+        "Calculator",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+    "notepad": (
+        "Notepad",
+        "记事本",
+    ),
+    "notepad.exe": (
+        "Notepad",
+        "记事本",
+    ),
+    "记事本": (
+        "Notepad",
+        "记事本",
+    ),
+    "计算器": (
+        "Calculator",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    ),
+}
+
 _WINDOWS_KNOWN_LAUNCH_COMMANDS: dict[str, tuple[str, ...]] = {
     "calc": ("calc.exe",),
     "calc.exe": ("calc.exe",),
@@ -534,7 +574,9 @@ class WindowsDesktopRuntime:
         normalized_title = window_title.strip()
         if not normalized_title:
             raise ValueError("window_title is required")
-        matched_window = self._wait_for_window_match(queries=(normalized_title,))
+        matched_window = self._wait_for_window_match(
+            queries=self._expand_window_title_queries(normalized_title)
+        )
         if matched_window is None:
             raise RuntimeError(f"Window not found within timeout: {window_title}")
         observation = self._build_observation(
@@ -849,7 +891,7 @@ class WindowsDesktopRuntime:
         normalized = query.strip()
         if not normalized:
             raise ValueError("window_title is required")
-        match_queries = self._expand_match_queries(normalized)
+        match_queries = self._expand_window_title_queries(normalized)
         windows = self._list_windows_snapshot(require_windows=True, require_input=False)
         for window in windows:
             if self._window_matches_any(window, match_queries):
@@ -863,7 +905,7 @@ class WindowsDesktopRuntime:
         before_windows: tuple[ComputerWindow, ...] = (),
         allow_existing_matches: bool = True,
     ) -> ComputerWindow | None:
-        normalized_queries = self._expand_match_queries(*queries)
+        normalized_queries = self._normalize_match_queries(*queries)
         before_ids = {window.window_id for window in before_windows}
         deadline = self._time_monotonic() + _WAIT_TIMEOUT_SECONDS
         while self._time_monotonic() < deadline:
@@ -948,6 +990,15 @@ class WindowsDesktopRuntime:
             expanded_queries.append(query)
             expanded_queries.extend(
                 _WINDOWS_APP_QUERY_ALIASES.get(query.casefold(), ())
+            )
+        return self._normalize_match_queries(*expanded_queries)
+
+    def _expand_window_title_queries(self, *queries: str) -> tuple[str, ...]:
+        expanded_queries: list[str] = []
+        for query in self._normalize_match_queries(*queries):
+            expanded_queries.append(query)
+            expanded_queries.extend(
+                _WINDOWS_WINDOW_TITLE_QUERY_ALIASES.get(query.casefold(), ())
             )
         return self._normalize_match_queries(*expanded_queries)
 

--- a/tests/integration_tests/api/test_http_run_flows.py
+++ b/tests/integration_tests/api/test_http_run_flows.py
@@ -4,7 +4,6 @@ import json
 import time
 
 import httpx
-import pytest
 
 from integration_tests.support.environment import IntegrationEnvironment
 from integration_tests.support.api_helpers import (
@@ -349,11 +348,227 @@ def test_ai_run_executes_builtin_computer_tools_with_fake_runtime(
     assert launch_result["ok"] is True
     assert launch_result["data"]["computer"]["source"] == "tool"
     assert launch_result["data"]["computer"]["risk_level"] == "destructive"
-    assert launch_result["data"]["observation"]["focused_window"] == "Calculator Window"
+    assert launch_result["data"]["observation"]["focused_window"] == "Notepad Window"
 
 
-@pytest.mark.skip(reason="Flaky on CI - LLM tool call generation is non-deterministic")
-def test_ai_run_executes_real_computer_smoke_sequence_with_fake_runtime(
+def test_ai_run_executes_builtin_mouse_computer_tools_with_fake_runtime(
+    api_client: httpx.Client,
+) -> None:
+    original_response = api_client.get("/api/roles/configs/MainAgent")
+    original_response.raise_for_status()
+    original_record = original_response.json()
+    assert isinstance(original_record, dict)
+
+    updated_record = dict(original_record)
+    updated_tools = {
+        str(tool)
+        for tool in updated_record.get("tools", [])
+        if isinstance(tool, str) and tool
+    }
+    updated_tools.update({"click_at", "double_click_at", "drag_between", "scroll_view"})
+    updated_record["tools"] = sorted(updated_tools)
+    updated_record["execution_surface"] = "desktop"
+
+    save_response = api_client.put(
+        "/api/roles/configs/MainAgent",
+        json=_role_draft_payload(updated_record),
+    )
+    save_response.raise_for_status()
+    _wait_for_role_tools(
+        api_client,
+        "MainAgent",
+        {"click_at", "double_click_at", "drag_between", "scroll_view"},
+    )
+
+    try:
+        session_id = create_session(
+            api_client,
+            session_id=new_session_id("session-computer-mouse"),
+        )
+        run_id = create_run(
+            api_client,
+            session_id=session_id,
+            intent="[computer-mouse-validation] 通过内建鼠标工具完成一次验证。",
+            execution_mode="ai",
+            yolo=True,
+        )
+        _ = stream_run_until_terminal(api_client, run_id=run_id)
+    finally:
+        restore_response = api_client.put(
+            "/api/roles/configs/MainAgent",
+            json=_role_draft_payload(original_record),
+        )
+        restore_response.raise_for_status()
+
+    events = _session_run_events(
+        api_client,
+        session_id=session_id,
+        run_id=run_id,
+    )
+    tool_calls = [
+        json.loads(str(event["payload_json"]))
+        for event in events
+        if str(event.get("event_type") or "") == "tool_call"
+    ]
+    tool_results = [
+        json.loads(str(event["payload_json"]))
+        for event in events
+        if str(event.get("event_type") or "") == "tool_result"
+    ]
+
+    assert [payload["tool_name"] for payload in tool_calls] == [
+        "click_at",
+        "double_click_at",
+        "drag_between",
+        "scroll_view",
+    ]
+    assert [payload["tool_name"] for payload in tool_results] == [
+        "click_at",
+        "double_click_at",
+        "drag_between",
+        "scroll_view",
+    ]
+
+    click_result = tool_results[0]["result"]
+    assert click_result["ok"] is True
+    assert click_result["data"]["computer"]["action"] == "click"
+    assert click_result["data"]["computer"]["risk_level"] == "guarded"
+    assert click_result["data"]["computer"]["target"]["x"] == 120
+    assert click_result["data"]["computer"]["target"]["y"] == 240
+
+    double_click_result = tool_results[1]["result"]
+    assert double_click_result["ok"] is True
+    assert double_click_result["data"]["computer"]["action"] == "double_click"
+    assert double_click_result["data"]["computer"]["target"]["x"] == 120
+    assert double_click_result["data"]["computer"]["target"]["y"] == 240
+
+    drag_result = tool_results[2]["result"]
+    assert drag_result["ok"] is True
+    assert drag_result["data"]["computer"]["action"] == "drag"
+    assert drag_result["data"]["computer"]["risk_level"] == "destructive"
+    assert drag_result["data"]["computer"]["target"]["x"] == 120
+    assert drag_result["data"]["computer"]["target"]["y"] == 240
+    assert drag_result["data"]["computer"]["target"]["end_x"] == 360
+    assert drag_result["data"]["computer"]["target"]["end_y"] == 420
+
+    scroll_result = tool_results[3]["result"]
+    assert scroll_result["ok"] is True
+    assert scroll_result["data"]["computer"]["action"] == "scroll"
+    assert scroll_result["data"]["computer"]["risk_level"] == "guarded"
+    assert scroll_result["data"]["computer"]["target"]["amount"] == -3
+
+
+def test_ai_run_executes_builtin_input_computer_tools_with_fake_runtime(
+    api_client: httpx.Client,
+) -> None:
+    original_response = api_client.get("/api/roles/configs/MainAgent")
+    original_response.raise_for_status()
+    original_record = original_response.json()
+    assert isinstance(original_record, dict)
+
+    updated_record = dict(original_record)
+    updated_tools = {
+        str(tool)
+        for tool in updated_record.get("tools", [])
+        if isinstance(tool, str) and tool
+    }
+    updated_tools.update({"list_windows", "focus_window", "type_text", "hotkey"})
+    updated_record["tools"] = sorted(updated_tools)
+    updated_record["execution_surface"] = "desktop"
+
+    save_response = api_client.put(
+        "/api/roles/configs/MainAgent",
+        json=_role_draft_payload(updated_record),
+    )
+    save_response.raise_for_status()
+    _wait_for_role_tools(
+        api_client,
+        "MainAgent",
+        {"list_windows", "focus_window", "type_text", "hotkey"},
+    )
+
+    try:
+        session_id = create_session(
+            api_client,
+            session_id=new_session_id("session-computer-input"),
+        )
+        run_id = create_run(
+            api_client,
+            session_id=session_id,
+            intent="[computer-input-validation] 通过内建窗口和输入工具完成一次验证。",
+            execution_mode="ai",
+            yolo=True,
+        )
+        _ = stream_run_until_terminal(api_client, run_id=run_id)
+    finally:
+        restore_response = api_client.put(
+            "/api/roles/configs/MainAgent",
+            json=_role_draft_payload(original_record),
+        )
+        restore_response.raise_for_status()
+
+    events = _session_run_events(
+        api_client,
+        session_id=session_id,
+        run_id=run_id,
+    )
+    tool_calls = [
+        json.loads(str(event["payload_json"]))
+        for event in events
+        if str(event.get("event_type") or "") == "tool_call"
+    ]
+    tool_results = [
+        json.loads(str(event["payload_json"]))
+        for event in events
+        if str(event.get("event_type") or "") == "tool_result"
+    ]
+
+    assert [payload["tool_name"] for payload in tool_calls] == [
+        "focus_window",
+        "list_windows",
+        "type_text",
+        "hotkey",
+    ]
+    assert [payload["tool_name"] for payload in tool_results] == [
+        "focus_window",
+        "list_windows",
+        "type_text",
+        "hotkey",
+    ]
+
+    focus_result = tool_results[0]["result"]
+    assert focus_result["ok"] is True
+    assert focus_result["data"]["computer"]["action"] == "focus_window"
+    assert focus_result["data"]["computer"]["risk_level"] == "guarded"
+    assert (
+        focus_result["data"]["computer"]["target"]["window_title"] == "Agent Teams Demo"
+    )
+    assert focus_result["data"]["observation"]["focused_window"] == "Agent Teams Demo"
+
+    list_result = tool_results[1]["result"]
+    assert list_result["ok"] is True
+    assert list_result["data"]["computer"]["action"] == "list_windows"
+    assert list_result["data"]["computer"]["risk_level"] == "safe"
+    assert list_result["data"]["observation"]["focused_window"] == "Agent Teams Demo"
+    window_titles = [
+        window["title"] for window in list_result["data"]["observation"]["windows"]
+    ]
+    assert "Agent Teams Demo" in window_titles
+
+    type_result = tool_results[2]["result"]
+    assert type_result["ok"] is True
+    assert type_result["data"]["computer"]["action"] == "type_text"
+    assert type_result["data"]["computer"]["risk_level"] == "guarded"
+    assert type_result["data"]["computer"]["target"]["text"] == "hello from fake llm"
+
+    hotkey_result = tool_results[3]["result"]
+    assert hotkey_result["ok"] is True
+    assert hotkey_result["data"]["computer"]["action"] == "hotkey"
+    assert hotkey_result["data"]["computer"]["risk_level"] == "guarded"
+    assert hotkey_result["data"]["computer"]["target"]["shortcut"] == "Ctrl+A"
+
+
+def test_ai_run_executes_builtin_wait_for_window_computer_tools_with_fake_runtime(
     api_client: httpx.Client,
 ) -> None:
     original_response = api_client.get("/api/roles/configs/MainAgent")
@@ -390,7 +605,7 @@ def test_ai_run_executes_real_computer_smoke_sequence_with_fake_runtime(
         run_id = create_run(
             api_client,
             session_id=session_id,
-            intent="[computer-real-validation] 打开计算器，等待窗口出现，然后截图确认。",
+            intent="[computer-real-validation] 打开记事本，等待窗口出现，然后截图确认。",
             execution_mode="ai",
             yolo=True,
         )
@@ -437,7 +652,7 @@ def test_ai_run_executes_real_computer_smoke_sequence_with_fake_runtime(
     wait_result = tool_results[1]["result"]
     assert wait_result["ok"] is True
     assert wait_result["data"]["computer"]["action"] == "wait_for_window"
-    assert wait_result["data"]["observation"]["focused_window"] == "Calculator Window"
+    assert wait_result["data"]["observation"]["focused_window"] == "Notepad Window"
 
     capture_result = tool_results[2]["result"]
     assert capture_result["ok"] is True

--- a/tests/integration_tests/support/fake_llm_server.py
+++ b/tests/integration_tests/support/fake_llm_server.py
@@ -531,6 +531,10 @@ def build_fake_response_text(payload: object) -> str:
 
 def _computer_validation_mode(messages: list[object]) -> str | None:
     last_user_text = _extract_last_user_text(messages)
+    if "[computer-input-validation]" in last_user_text:
+        return "input"
+    if "[computer-mouse-validation]" in last_user_text:
+        return "mouse"
     if "[computer-real-validation]" in last_user_text:
         return "real"
     if "[computer-validation]" in last_user_text:
@@ -546,6 +550,18 @@ def _plan_computer_validation_response(
 ) -> dict[str, object] | None:
     available_tools = _extract_available_tools(payload)
     last_tool_call_id = _extract_last_tool_call_id(messages)
+
+    if mode == "input":
+        return _plan_input_computer_validation_response(
+            available_tools=available_tools,
+            last_tool_call_id=last_tool_call_id,
+        )
+
+    if mode == "mouse":
+        return _plan_mouse_computer_validation_response(
+            available_tools=available_tools,
+            last_tool_call_id=last_tool_call_id,
+        )
 
     if mode == "real":
         return _plan_real_computer_validation_response(
@@ -576,7 +592,7 @@ def _plan_computer_validation_response(
             "kind": "tool_call",
             "tool_name": "launch_app",
             "tool_call_id": "call-launch-app-1",
-            "arguments": {"app_name": "Calculator"},
+            "arguments": {"app_name": "Notepad"},
         }
 
     if last_tool_call_id == "call-launch-app-1":
@@ -588,6 +604,155 @@ def _plan_computer_validation_response(
     return {
         "kind": "text",
         "content": "[fake-llm] Computer validation reached an unknown step.",
+    }
+
+
+def _plan_input_computer_validation_response(
+    *,
+    available_tools: set[str],
+    last_tool_call_id: str | None,
+) -> dict[str, object]:
+    if last_tool_call_id is None:
+        if "focus_window" not in available_tools:
+            return {
+                "kind": "text",
+                "content": "[fake-llm] focus_window is not available for this role.",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "focus_window",
+            "tool_call_id": "call-input-focus-window-1",
+            "arguments": {"window_title": "Agent Teams"},
+        }
+
+    if last_tool_call_id == "call-input-focus-window-1":
+        if "list_windows" not in available_tools:
+            return {
+                "kind": "text",
+                "content": "[fake-llm] list_windows is not available for this role.",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "list_windows",
+            "tool_call_id": "call-input-list-windows-1",
+            "arguments": {},
+        }
+
+    if last_tool_call_id == "call-input-list-windows-1":
+        if "type_text" not in available_tools:
+            return {
+                "kind": "text",
+                "content": "[fake-llm] type_text is not available for this role.",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "type_text",
+            "tool_call_id": "call-input-type-text-1",
+            "arguments": {"text": "hello from fake llm"},
+        }
+
+    if last_tool_call_id == "call-input-type-text-1":
+        if "hotkey" not in available_tools:
+            return {
+                "kind": "text",
+                "content": "[fake-llm] hotkey is not available for this role.",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "hotkey",
+            "tool_call_id": "call-input-hotkey-1",
+            "arguments": {"shortcut": "Ctrl+A"},
+        }
+
+    if last_tool_call_id == "call-input-hotkey-1":
+        return {
+            "kind": "text",
+            "content": (
+                "[fake-llm] Input computer validation finished after focus_window, "
+                "list_windows, type_text, and hotkey."
+            ),
+        }
+
+    return {
+        "kind": "text",
+        "content": "[fake-llm] Input computer validation reached an unknown step.",
+    }
+
+
+def _plan_mouse_computer_validation_response(
+    *,
+    available_tools: set[str],
+    last_tool_call_id: str | None,
+) -> dict[str, object]:
+    if last_tool_call_id is None:
+        if "click_at" not in available_tools:
+            return {
+                "kind": "text",
+                "content": "[fake-llm] click_at is not available for this role.",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "click_at",
+            "tool_call_id": "call-mouse-click-1",
+            "arguments": {"x": 120, "y": 240},
+        }
+
+    if last_tool_call_id == "call-mouse-click-1":
+        if "double_click_at" not in available_tools:
+            return {
+                "kind": "text",
+                "content": "[fake-llm] double_click_at is not available for this role.",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "double_click_at",
+            "tool_call_id": "call-mouse-double-click-1",
+            "arguments": {"x": 120, "y": 240},
+        }
+
+    if last_tool_call_id == "call-mouse-double-click-1":
+        if "drag_between" not in available_tools:
+            return {
+                "kind": "text",
+                "content": "[fake-llm] drag_between is not available for this role.",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "drag_between",
+            "tool_call_id": "call-mouse-drag-1",
+            "arguments": {
+                "start_x": 120,
+                "start_y": 240,
+                "end_x": 360,
+                "end_y": 420,
+            },
+        }
+
+    if last_tool_call_id == "call-mouse-drag-1":
+        if "scroll_view" not in available_tools:
+            return {
+                "kind": "text",
+                "content": "[fake-llm] scroll_view is not available for this role.",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "scroll_view",
+            "tool_call_id": "call-mouse-scroll-1",
+            "arguments": {"amount": -3},
+        }
+
+    if last_tool_call_id == "call-mouse-scroll-1":
+        return {
+            "kind": "text",
+            "content": (
+                "[fake-llm] Mouse computer validation finished after click_at, "
+                "double_click_at, drag_between, and scroll_view."
+            ),
+        }
+
+    return {
+        "kind": "text",
+        "content": "[fake-llm] Mouse computer validation reached an unknown step.",
     }
 
 
@@ -606,7 +771,7 @@ def _plan_real_computer_validation_response(
             "kind": "tool_call",
             "tool_name": "launch_app",
             "tool_call_id": "call-real-launch-app-1",
-            "arguments": {"app_name": "Calculator"},
+            "arguments": {"app_name": "Notepad"},
         }
 
     if last_tool_call_id == "call-real-launch-app-1":
@@ -619,7 +784,7 @@ def _plan_real_computer_validation_response(
             "kind": "tool_call",
             "tool_name": "wait_for_window",
             "tool_call_id": "call-real-wait-window-1",
-            "arguments": {"window_title": "Calculator"},
+            "arguments": {"window_title": "Notepad"},
         }
 
     if last_tool_call_id == "call-real-wait-window-1":

--- a/tests/unit_tests/computer/test_linux_runtime.py
+++ b/tests/unit_tests/computer/test_linux_runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+
 from relay_teams.computer import (
     ComputerObservation,
     ComputerWindow,
@@ -80,6 +82,46 @@ def test_linux_runtime_list_windows_marks_active_window(
     ]
     assert result.observation.windows[0].focused is True
     assert result.observation.windows[1].focused is False
+
+
+def test_linux_runtime_focus_window_activates_matched_window(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+    matched_window = ComputerWindow(
+        window_id="0x00000003",
+        app_name="notepad",
+        title="Untitled - Notepad",
+        focused=True,
+    )
+    activated_window_ids: list[str] = []
+    observation = ComputerObservation(
+        text="Linux desktop runtime snapshot.",
+        windows=(matched_window,),
+        focused_window="Untitled - Notepad",
+    )
+
+    monkeypatch.setattr(runtime, "_find_window", lambda query: matched_window)
+    monkeypatch.setattr(
+        runtime,
+        "_activate_window",
+        lambda window_id: activated_window_ids.append(window_id),
+    )
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.focus_window(window_title="Notepad"))
+
+    assert activated_window_ids == ["0x00000003"]
+    assert result.observation is not None
+    assert result.observation.focused_window == "Untitled - Notepad"
+    assert result.action.target.window_title == "Untitled - Notepad"
+    assert result.data["runtime_mode"] == "linux"
 
 
 def test_linux_runtime_launch_app_records_real_command(
@@ -167,6 +209,208 @@ def test_linux_runtime_resolves_calculator_candidates(
     assert command == ["gnome-calculator"]
 
 
+def test_linux_runtime_click_runs_xdotool_mousemove_and_click(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+    commands: list[list[str]] = []
+    observation = ComputerObservation(text="Linux desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime, "_run_input_command", lambda command: commands.append(command)
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.click_at(x=125, y=250))
+
+    assert commands == [["xdotool", "mousemove", "--sync", "125", "250", "click", "1"]]
+    assert result.action.target.x == 125
+    assert result.action.target.y == 250
+
+
+def test_linux_runtime_double_click_runs_xdotool_repeat_click(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+    commands: list[list[str]] = []
+    observation = ComputerObservation(text="Linux desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime, "_run_input_command", lambda command: commands.append(command)
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.double_click_at(x=125, y=250))
+
+    assert commands == [
+        [
+            "xdotool",
+            "mousemove",
+            "--sync",
+            "125",
+            "250",
+            "click",
+            "--repeat",
+            "2",
+            "1",
+        ]
+    ]
+    assert result.action.target.x == 125
+    assert result.action.target.y == 250
+
+
+def test_linux_runtime_drag_runs_xdotool_drag_sequence(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+    commands: list[list[str]] = []
+    observation = ComputerObservation(text="Linux desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime, "_run_input_command", lambda command: commands.append(command)
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(
+        runtime.drag_between(start_x=10, start_y=20, end_x=400, end_y=500)
+    )
+
+    assert commands == [
+        [
+            "xdotool",
+            "mousemove",
+            "--sync",
+            "10",
+            "20",
+            "mousedown",
+            "1",
+            "mousemove",
+            "--sync",
+            "400",
+            "500",
+            "mouseup",
+            "1",
+        ]
+    ]
+    assert result.action.target.x == 10
+    assert result.action.target.y == 20
+    assert result.action.target.end_x == 400
+    assert result.action.target.end_y == 500
+
+
+def test_linux_runtime_type_text_runs_xdotool_type_command(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+    commands: list[list[str]] = []
+    observation = ComputerObservation(text="Linux desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime, "_run_input_command", lambda command: commands.append(command)
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.type_text(text="hello from linux"))
+
+    assert commands == [["xdotool", "type", "--delay", "1", "--", "hello from linux"]]
+    assert result.action.target.text == "hello from linux"
+    assert result.data["runtime_mode"] == "linux"
+
+
+def test_linux_runtime_type_text_requires_non_blank_text(
+    tmp_path: Path,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+
+    with pytest.raises(ValueError, match="text is required"):
+        asyncio.run(runtime.type_text(text="   "))
+
+
+def test_linux_runtime_scroll_view_uses_button_direction_and_repeat(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+    commands: list[list[str]] = []
+    observation = ComputerObservation(text="Linux desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime, "_run_input_command", lambda command: commands.append(command)
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.scroll_view(amount=-3))
+
+    assert commands == [["xdotool", "click", "--repeat", "3", "5"]]
+    assert result.action.target.amount == -3
+
+
+def test_linux_runtime_hotkey_runs_normalized_xdotool_key_command(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+    commands: list[list[str]] = []
+    observation = ComputerObservation(text="Linux desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime, "_run_input_command", lambda command: commands.append(command)
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.hotkey(shortcut="Control+A"))
+
+    assert commands == [["xdotool", "key", "ctrl+A"]]
+    assert result.action.target.shortcut == "Control+A"
+    assert result.data["runtime_mode"] == "linux"
+
+
+def test_linux_runtime_hotkey_requires_non_blank_shortcut(
+    tmp_path: Path,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+
+    with pytest.raises(ValueError, match="shortcut is required"):
+        asyncio.run(runtime.hotkey(shortcut="   "))
+
+
+def test_linux_runtime_scroll_view_requires_non_zero_amount(
+    tmp_path: Path,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+
+    with pytest.raises(ValueError, match="amount must not be zero"):
+        asyncio.run(runtime.scroll_view(amount=0))
+
+
 def test_linux_runtime_lists_windows_with_xdotool_fallback(
     tmp_path: Path,
     monkeypatch,
@@ -208,6 +452,42 @@ def test_linux_runtime_lists_windows_with_xdotool_fallback(
         "Gnome calculator",
         "Google chrome",
     ]
+
+
+def test_linux_runtime_wait_for_window_returns_observation_for_match(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = LinuxDesktopRuntime(project_root=tmp_path)
+    matched_window = ComputerWindow(
+        window_id="0x00000003",
+        app_name="notepad",
+        title="Untitled - Notepad",
+        focused=True,
+    )
+    observation = ComputerObservation(
+        text="Linux desktop runtime snapshot.",
+        windows=(matched_window,),
+        focused_window="Untitled - Notepad",
+    )
+
+    monkeypatch.setattr(
+        runtime,
+        "_wait_for_window_match",
+        lambda **kwargs: matched_window,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.wait_for_window(window_title="Notepad"))
+
+    assert result.observation is not None
+    assert result.observation.focused_window == "Untitled - Notepad"
+    assert result.action.target.window_title == "Untitled - Notepad"
+    assert result.data["runtime_mode"] == "linux"
 
 
 def test_linux_runtime_launch_environment_prefers_x11_compatible_backends(

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -277,6 +277,93 @@ def test_windows_runtime_launch_app_records_real_command(
     assert result.data["launched_command"] == "calc.exe"
 
 
+def test_windows_runtime_launch_app_tries_next_candidate_after_spawn_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    spawned_commands: list[list[str]] = []
+    waited_queries: list[tuple[str, ...]] = []
+    activated_window_ids: list[str] = []
+    matched_window = ComputerWindow(
+        window_id="0x20",
+        app_name="Calculator",
+        title="Calculator",
+        focused=True,
+    )
+    observation = ComputerObservation(
+        text="Windows desktop runtime snapshot.",
+        windows=(matched_window,),
+        focused_window="Calculator",
+    )
+
+    def fake_resolve_launch_candidates(
+        app_name: str,
+    ) -> tuple[windows_runtime_module._LaunchCandidate, ...]:
+        assert app_name == "Calculator"
+        return (
+            windows_runtime_module._LaunchCandidate(
+                command=("calc.exe",),
+                match_queries=("Calculator",),
+            ),
+            windows_runtime_module._LaunchCandidate(
+                command=(
+                    "explorer.exe",
+                    r"shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App",
+                ),
+                match_queries=("Calculator", "Microsoft.WindowsCalculator"),
+            ),
+        )
+
+    def fake_spawn_process(command: list[str]) -> None:
+        spawned_commands.append(command)
+        if command == ["calc.exe"]:
+            raise FileNotFoundError("calc.exe")
+
+    def fake_wait_for_window_match(
+        *,
+        queries: tuple[str, ...],
+        before_windows: tuple[ComputerWindow, ...] = (),
+        allow_existing_matches: bool = True,
+    ) -> ComputerWindow:
+        assert before_windows == ()
+        assert allow_existing_matches is False
+        waited_queries.append(queries)
+        return matched_window
+
+    monkeypatch.setattr(runtime, "_list_windows_snapshot", lambda **kwargs: ())
+    monkeypatch.setattr(
+        runtime,
+        "_resolve_launch_candidates",
+        fake_resolve_launch_candidates,
+    )
+    monkeypatch.setattr(runtime, "_spawn_process", fake_spawn_process)
+    monkeypatch.setattr(runtime, "_wait_for_window_match", fake_wait_for_window_match)
+    monkeypatch.setattr(
+        runtime,
+        "_activate_window",
+        lambda window_id: activated_window_ids.append(window_id),
+    )
+    monkeypatch.setattr(runtime, "_build_observation", lambda **kwargs: observation)
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+
+    result = asyncio.run(runtime.launch_app(app_name="Calculator"))
+
+    assert spawned_commands == [
+        ["calc.exe"],
+        [
+            "explorer.exe",
+            r"shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App",
+        ],
+    ]
+    assert waited_queries == [("Calculator", "Microsoft.WindowsCalculator")]
+    assert activated_window_ids == ["0x20"]
+    assert result.data["launched_command"] == (
+        "explorer.exe "
+        r"shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"
+    )
+
+
 def test_windows_runtime_resolves_calculator_candidates(tmp_path: Path) -> None:
     runtime = WindowsDesktopRuntime(project_root=tmp_path)
 

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -138,6 +138,46 @@ def test_windows_runtime_list_windows_marks_active_window(
     ]
 
 
+def test_windows_runtime_focus_window_activates_matched_window(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    matched_window = ComputerWindow(
+        window_id="0x20",
+        app_name="notepad",
+        title="Untitled - Notepad",
+        focused=True,
+    )
+    activated_window_ids: list[str] = []
+    observation = ComputerObservation(
+        text="Windows desktop runtime snapshot.",
+        windows=(matched_window,),
+        focused_window="Untitled - Notepad",
+    )
+
+    monkeypatch.setattr(runtime, "_find_window", lambda query: matched_window)
+    monkeypatch.setattr(
+        runtime,
+        "_activate_window",
+        lambda window_id: activated_window_ids.append(window_id),
+    )
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.focus_window(window_title="Notepad"))
+
+    assert activated_window_ids == ["0x20"]
+    assert result.observation is not None
+    assert result.observation.focused_window == "Untitled - Notepad"
+    assert result.action.target.window_title == "Untitled - Notepad"
+    assert result.data["runtime_mode"] == "windows"
+
+
 def test_windows_runtime_launch_app_records_real_command(
     tmp_path: Path,
     monkeypatch,
@@ -165,9 +205,22 @@ def test_windows_runtime_launch_app_records_real_command(
         _ = (require_windows, require_input)
         return ()
 
-    def fake_resolve_launch_command(app_name: str) -> list[str]:
+    def fake_resolve_launch_candidates(
+        app_name: str,
+    ) -> tuple[windows_runtime_module._LaunchCandidate, ...]:
         assert app_name == "Calculator"
-        return ["calc.exe"]
+        return (
+            windows_runtime_module._LaunchCandidate(
+                command=("calc.exe",),
+                match_queries=(
+                    "Calculator",
+                    "calc",
+                    "calc.exe",
+                    "Microsoft.WindowsCalculator",
+                    "计算器",
+                ),
+            ),
+        )
 
     def fake_spawn_process(command: list[str]) -> None:
         spawned_commands.append(command)
@@ -178,7 +231,13 @@ def test_windows_runtime_launch_app_records_real_command(
         before_windows: tuple[ComputerWindow, ...] = (),
         allow_existing_matches: bool = True,
     ) -> ComputerWindow:
-        assert queries == ("Calculator", "calc.exe", "calc")
+        assert queries == (
+            "Calculator",
+            "calc",
+            "calc.exe",
+            "Microsoft.WindowsCalculator",
+            "计算器",
+        )
         assert before_windows == ()
         assert allow_existing_matches is False
         return matched_window
@@ -196,7 +255,11 @@ def test_windows_runtime_launch_app_records_real_command(
         return observation
 
     monkeypatch.setattr(runtime, "_list_windows_snapshot", fake_list_windows_snapshot)
-    monkeypatch.setattr(runtime, "_resolve_launch_command", fake_resolve_launch_command)
+    monkeypatch.setattr(
+        runtime,
+        "_resolve_launch_candidates",
+        fake_resolve_launch_candidates,
+    )
     monkeypatch.setattr(runtime, "_spawn_process", fake_spawn_process)
     monkeypatch.setattr(runtime, "_wait_for_window_match", fake_wait_for_window_match)
     monkeypatch.setattr(runtime, "_activate_window", fake_activate_window)
@@ -220,6 +283,54 @@ def test_windows_runtime_resolves_calculator_candidates(tmp_path: Path) -> None:
     command = runtime._resolve_launch_command("Calculator")
 
     assert command == ["calc.exe"]
+
+
+def test_windows_runtime_resolves_localized_notepad_command(tmp_path: Path) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    command = runtime._resolve_launch_command("记事本")
+
+    assert command == ["notepad.exe"]
+
+
+def test_windows_runtime_resolve_launch_candidates_adds_calculator_shell_fallback(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    candidates = runtime._resolve_launch_candidates("Calculator")
+
+    assert candidates[0].command == ("calc.exe",)
+    assert candidates[0].match_queries == (
+        "Calculator",
+        "calc",
+        "calc.exe",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+    )
+    assert candidates[1].command == (
+        "explorer.exe",
+        r"shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App",
+    )
+
+
+def test_windows_runtime_expand_match_queries_adds_localized_aliases(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    queries = runtime._expand_match_queries("Calculator", "Notepad")
+
+    assert queries == (
+        "Calculator",
+        "calc",
+        "calc.exe",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+        "Notepad",
+        "notepad.exe",
+        "记事本",
+    )
 
 
 def test_windows_runtime_click_translates_virtual_screen_origin(
@@ -247,6 +358,77 @@ def test_windows_runtime_click_translates_virtual_screen_origin(
     result = asyncio.run(runtime.click_at(x=125, y=250))
 
     assert cursor_positions == [(-1795, 210)]
+    assert result.action.target.x == 125
+    assert result.action.target.y == 250
+
+
+def test_windows_runtime_type_text_sends_unicode_input(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    typed_texts: list[str] = []
+    observation = ComputerObservation(text="Windows desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime,
+        "_send_unicode_text",
+        lambda text: typed_texts.append(text),
+    )
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.type_text(text="hello from windows"))
+
+    assert typed_texts == ["hello from windows"]
+    assert result.action.target.text == "hello from windows"
+    assert result.data["runtime_mode"] == "windows"
+
+
+def test_windows_runtime_type_text_requires_non_blank_text(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    with pytest.raises(ValueError, match="text is required"):
+        asyncio.run(runtime.type_text(text="   "))
+
+
+def test_windows_runtime_double_click_translates_virtual_screen_origin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    cursor_positions: list[tuple[int, int]] = []
+    click_repeats: list[int] = []
+    observation = ComputerObservation(text="Windows desktop runtime snapshot.")
+
+    monkeypatch.setattr(runtime, "_get_virtual_screen_origin", lambda: (-100, 50))
+    monkeypatch.setattr(
+        runtime,
+        "_set_cursor_position",
+        lambda x, y: cursor_positions.append((x, y)),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_mouse_click",
+        lambda *, repeat: click_repeats.append(repeat),
+    )
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.double_click_at(x=125, y=250))
+
+    assert cursor_positions == [(25, 300)]
+    assert click_repeats == [2]
     assert result.action.target.x == 125
     assert result.action.target.y == 250
 
@@ -288,6 +470,77 @@ def test_windows_runtime_drag_translates_virtual_screen_origin(
     assert result.action.target.y == 20
     assert result.action.target.end_x == 400
     assert result.action.target.end_y == 500
+
+
+def test_windows_runtime_scroll_view_uses_signed_wheel_delta(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    mouse_events: list[tuple[int, int]] = []
+    observation = ComputerObservation(text="Windows desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime,
+        "_send_mouse_event",
+        lambda flags, *, data=0: mouse_events.append((flags, data)),
+    )
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.scroll_view(amount=-3))
+
+    assert mouse_events == [(0x0800, -360)]
+    assert result.action.target.amount == -3
+
+
+def test_windows_runtime_hotkey_sends_normalized_shortcut(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    sent_shortcuts: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    observation = ComputerObservation(text="Windows desktop runtime snapshot.")
+
+    monkeypatch.setattr(
+        runtime,
+        "_send_hotkey_inputs",
+        lambda modifiers, normal: sent_shortcuts.append((modifiers, normal)),
+    )
+    monkeypatch.setattr(runtime, "_sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.hotkey(shortcut="Ctrl+A"))
+
+    assert sent_shortcuts == [((0x11,), (0x41,))]
+    assert result.action.target.shortcut == "Ctrl+A"
+    assert result.data["runtime_mode"] == "windows"
+
+
+def test_windows_runtime_hotkey_requires_non_blank_shortcut(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    with pytest.raises(ValueError, match="shortcut is required"):
+        asyncio.run(runtime.hotkey(shortcut="   "))
+
+
+def test_windows_runtime_scroll_view_requires_non_zero_amount(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    with pytest.raises(ValueError, match="amount must not be zero"):
+        asyncio.run(runtime.scroll_view(amount=0))
 
 
 def test_windows_runtime_build_launch_window_queries_normalizes_path_command(
@@ -337,6 +590,76 @@ def test_windows_runtime_build_list_windows_script_uses_hwnd_enumeration(
     assert "GetWindowThreadProcessId" in script
     assert "GetWindowTextLength" in script
     assert "MainWindowHandle" not in script
+
+
+def test_windows_runtime_activate_window_tolerates_focus_stealing_guard(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    class _FakeCallable:
+        def __init__(self, result: object) -> None:
+            self._result = result
+            self.calls: list[tuple[object, ...]] = []
+
+        def __call__(self, *args: object) -> object:
+            self.calls.append(args)
+            return self._result
+
+    class _FakeUser32:
+        def __init__(self) -> None:
+            self.IsWindow = _FakeCallable(True)
+            self.GetForegroundWindow = _FakeCallable(0)
+            self.ShowWindow = _FakeCallable(True)
+            self.SetForegroundWindow = _FakeCallable(False)
+            self.BringWindowToTop = _FakeCallable(False)
+
+    fake_user32 = _FakeUser32()
+    monkeypatch.setattr(runtime, "_load_user32", lambda: fake_user32)
+
+    runtime._activate_window("0x20")
+
+    assert len(fake_user32.IsWindow.calls) == 1
+    assert len(fake_user32.ShowWindow.calls) == 1
+    assert len(fake_user32.SetForegroundWindow.calls) == 1
+    assert len(fake_user32.BringWindowToTop.calls) == 1
+
+
+def test_windows_runtime_wait_for_window_returns_observation_for_match(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    matched_window = ComputerWindow(
+        window_id="0x20",
+        app_name="notepad",
+        title="Untitled - Notepad",
+        focused=True,
+    )
+    observation = ComputerObservation(
+        text="Windows desktop runtime snapshot.",
+        windows=(matched_window,),
+        focused_window="Untitled - Notepad",
+    )
+
+    monkeypatch.setattr(
+        runtime,
+        "_wait_for_window_match",
+        lambda **kwargs: matched_window,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_observation",
+        lambda **kwargs: observation,
+    )
+
+    result = asyncio.run(runtime.wait_for_window(window_title="Notepad"))
+
+    assert result.observation is not None
+    assert result.observation.focused_window == "Untitled - Notepad"
+    assert result.action.target.window_title == "Untitled - Notepad"
+    assert result.data["runtime_mode"] == "windows"
 
 
 def test_windows_runtime_wait_for_window_match_ignores_existing_launch_match(

--- a/tests/unit_tests/computer/test_windows_runtime.py
+++ b/tests/unit_tests/computer/test_windows_runtime.py
@@ -420,6 +420,23 @@ def test_windows_runtime_expand_match_queries_adds_localized_aliases(
     )
 
 
+def test_windows_runtime_expand_window_title_queries_avoids_calc_shorthand(
+    tmp_path: Path,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+
+    queries = runtime._expand_window_title_queries("Calculator", "notepad.exe")
+
+    assert queries == (
+        "Calculator",
+        "Microsoft.WindowsCalculator",
+        "计算器",
+        "notepad.exe",
+        "Notepad",
+        "记事本",
+    )
+
+
 def test_windows_runtime_click_translates_virtual_screen_origin(
     tmp_path: Path,
     monkeypatch,
@@ -729,11 +746,23 @@ def test_windows_runtime_wait_for_window_returns_observation_for_match(
         windows=(matched_window,),
         focused_window="Untitled - Notepad",
     )
+    waited_queries: list[tuple[str, ...]] = []
+
+    def fake_wait_for_window_match(
+        *,
+        queries: tuple[str, ...] = (),
+        before_windows: tuple[ComputerWindow, ...] = (),
+        allow_existing_matches: bool = True,
+    ) -> ComputerWindow:
+        _ = before_windows
+        assert allow_existing_matches is True
+        waited_queries.append(queries)
+        return matched_window
 
     monkeypatch.setattr(
         runtime,
         "_wait_for_window_match",
-        lambda **kwargs: matched_window,
+        fake_wait_for_window_match,
     )
     monkeypatch.setattr(
         runtime,
@@ -747,6 +776,39 @@ def test_windows_runtime_wait_for_window_returns_observation_for_match(
     assert result.observation.focused_window == "Untitled - Notepad"
     assert result.action.target.window_title == "Untitled - Notepad"
     assert result.data["runtime_mode"] == "windows"
+    assert waited_queries == [("Notepad", "记事本")]
+
+
+def test_windows_runtime_find_window_avoids_calc_alias_false_positive(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = WindowsDesktopRuntime(project_root=tmp_path)
+    windows = (
+        ComputerWindow(
+            window_id="0x10",
+            app_name="spreadsheet",
+            title="Calculation Draft",
+            focused=False,
+        ),
+        ComputerWindow(
+            window_id="0x20",
+            app_name="ApplicationFrameHost",
+            title="计算器",
+            focused=True,
+        ),
+    )
+
+    monkeypatch.setattr(
+        runtime,
+        "_list_windows_snapshot",
+        lambda **kwargs: windows,
+    )
+
+    matched_window = runtime._find_window("Calculator")
+
+    assert matched_window.window_id == "0x20"
+    assert matched_window.title == "计算器"
 
 
 def test_windows_runtime_wait_for_window_match_ignores_existing_launch_match(


### PR DESCRIPTION
## Summary
- harden Windows desktop runtime launch and window matching for localized built-in apps
- switch Windows smoke coverage to Notepad and add stable API validation for mouse, input, and wait-for-window flows
- expand Windows and Linux runtime unit coverage for the remaining computer-use interfaces

## Why
Windows computer use was previously too fragile in real sessions and still had validation gaps after the runtime fix. Calculator availability varied across hosts, localized window titles could fail to match English queries, and several public desktop actions were not covered by stable tests.

## Impact
The built-in computer-use tools now behave more reliably on Windows hosts, and the remaining public interfaces have explicit runtime and API validation coverage.

## Root Cause
The Windows runtime assumed a narrow set of launch commands and title matches, while the test suite still relied on a flaky smoke path and did not exercise the full public desktop action surface.

## Validation
- `uv run --extra dev pytest -q tests/unit_tests/computer/test_windows_runtime.py tests/unit_tests/computer/test_linux_runtime.py tests/integration_tests/api/test_http_run_flows.py -k computer --tb=no`
- `uv run --extra dev ruff check tests/unit_tests/computer/test_windows_runtime.py tests/unit_tests/computer/test_linux_runtime.py tests/integration_tests/support/fake_llm_server.py tests/integration_tests/api/test_http_run_flows.py`
- `uv run --extra dev basedpyright src/relay_teams/computer/windows_runtime.py tests/unit_tests/computer/test_windows_runtime.py tests/unit_tests/computer/test_linux_runtime.py tests/integration_tests/support/fake_llm_server.py tests/integration_tests/api/test_http_run_flows.py`

Fixes #372
