### PR TITLE
fix: rehydrate tool call models from postponed annotations

### DIFF
--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -12,7 +12,7 @@ import time
 from collections.abc import Awaitable, Callable, Mapping
 from enum import Enum
 from json import dumps
-from typing import Protocol, cast, get_args, get_origin
+from typing import Protocol, cast, get_args, get_origin, get_type_hints
 from uuid import uuid4
 
 from relay_teams.logger import get_logger, log_event, log_tool_error
@@ -549,7 +549,11 @@ def _invoke_tool_action(
             action,
         )
         return input_action(tool_input)
-    kwargs = _bind_tool_action_kwargs(parameters=parameters, tool_input=tool_input)
+    kwargs = _bind_tool_action_kwargs(
+        parameters=parameters,
+        tool_input=tool_input,
+        resolved_annotations=_resolve_tool_action_annotations(action),
+    )
     named_action = cast(Callable[..., object | Awaitable[object]], action)
     return named_action(**kwargs)
 
@@ -604,6 +608,7 @@ def _bind_tool_action_kwargs(
     *,
     parameters: list[inspect.Parameter],
     tool_input: dict[str, JsonValue],
+    resolved_annotations: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     kwargs: dict[str, object] = {}
     for parameter in parameters:
@@ -622,6 +627,10 @@ def _bind_tool_action_kwargs(
         kwargs[parameter.name] = _coerce_tool_argument_for_parameter(
             value=tool_input[parameter.name],
             parameter=parameter,
+            annotation=_resolved_parameter_annotation(
+                parameter=parameter,
+                resolved_annotations=resolved_annotations,
+            ),
         )
     return kwargs
 
@@ -630,38 +639,52 @@ def _coerce_tool_argument_for_parameter(
     *,
     value: JsonValue,
     parameter: inspect.Parameter,
+    annotation: object,
 ) -> object:
     if value is None:
         return None
-    model_list_type = _resolve_pydantic_model_list_type(parameter)
+    model_list_type = _resolve_pydantic_model_list_type(annotation)
     if model_list_type is not None and isinstance(value, list):
         return [model_list_type.model_validate(item) for item in value]
-    model_type = _resolve_pydantic_model_type(parameter)
+    model_type = _resolve_pydantic_model_type(annotation)
     if model_type is not None and isinstance(value, dict):
         return model_type.model_validate(value)
-    enum_type = _resolve_enum_type(parameter)
+    enum_type = _resolve_enum_type(annotation=annotation, parameter=parameter)
     if enum_type is not None and isinstance(value, str):
         return enum_type(value)
-    if _parameter_accepts_type(parameter, bool):
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=bool
+    ):
         return _coerce_bool(value)
-    if _parameter_accepts_type(parameter, int):
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=int
+    ):
         return _coerce_int(value)
-    if _parameter_accepts_type(parameter, float):
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=float
+    ):
         return _coerce_float(value)
-    if _parameter_accepts_type(parameter, str):
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=str
+    ):
         return str(value)
-    if _parameter_accepts_type(parameter, tuple) and isinstance(value, list):
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=tuple
+    ) and isinstance(value, list):
         return tuple(value)
-    if _parameter_accepts_type(parameter, list) and isinstance(value, tuple):
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=list
+    ) and isinstance(value, tuple):
         return list(value)
     return value
 
 
 def _parameter_accepts_type(
+    *,
+    annotation: object,
     parameter: inspect.Parameter,
     expected_type: type[object],
 ) -> bool:
-    annotation = parameter.annotation
     if annotation is not inspect._empty and _annotation_contains_type(
         annotation=annotation,
         expected_type=expected_type,
@@ -689,9 +712,8 @@ def _annotation_contains_type(
 
 
 def _resolve_pydantic_model_list_type(
-    parameter: inspect.Parameter,
+    annotation: object,
 ) -> type[BaseModel] | None:
-    annotation = parameter.annotation
     origin = get_origin(annotation)
     if origin not in {list, tuple}:
         return None
@@ -702,9 +724,8 @@ def _resolve_pydantic_model_list_type(
 
 
 def _resolve_pydantic_model_type(
-    parameter: inspect.Parameter,
+    annotation: object,
 ) -> type[BaseModel] | None:
-    annotation = parameter.annotation
     if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
         return cast(type[BaseModel], annotation)
     origin = get_origin(annotation)
@@ -719,9 +740,10 @@ def _resolve_pydantic_model_type(
 
 
 def _resolve_enum_type(
+    *,
+    annotation: object,
     parameter: inspect.Parameter,
 ) -> type[Enum] | None:
-    annotation = parameter.annotation
     if annotation is not inspect._empty:
         candidate = _enum_type_from_annotation(annotation)
         if candidate is not None:
@@ -744,6 +766,27 @@ def _enum_type_from_annotation(annotation: object) -> type[Enum] | None:
         if inspect.isclass(item) and issubclass(item, Enum):
             return cast(type[Enum], item)
     return None
+
+
+def _resolve_tool_action_annotations(
+    action: Callable[..., object | Awaitable[object]] | object,
+) -> dict[str, object]:
+    if not callable(action):
+        return {}
+    try:
+        return get_type_hints(action)
+    except (AttributeError, NameError, TypeError):
+        return {}
+
+
+def _resolved_parameter_annotation(
+    *,
+    parameter: inspect.Parameter,
+    resolved_annotations: Mapping[str, object] | None,
+) -> object:
+    if resolved_annotations is None:
+        return parameter.annotation
+    return resolved_annotations.get(parameter.name, parameter.annotation)
 
 
 def _coerce_bool(value: JsonValue) -> bool:

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from pydantic import JsonValue
+from pydantic import BaseModel, JsonValue
 
 import asyncio
 import sqlite3
@@ -37,9 +37,15 @@ from relay_teams.tools.runtime import (
     ToolExecutionError,
     ToolResultProjection,
     execute_tool,
+    execute_tool_call,
 )
 from relay_teams.tools.runtime.persisted_state import load_tool_call_state
 from relay_teams.tools.runtime.persisted_state import ToolApprovalMode
+
+
+class _TaskDraftPayload(BaseModel):
+    objective: str
+    title: str | None = None
 
 
 class _FakeRunEventHub:
@@ -501,6 +507,82 @@ def test_execute_tool_marks_value_error_as_non_retryable() -> None:
     assert result["ok"] is False
     assert error["type"] == "validation_error"
     assert error["retryable"] is False
+
+
+def test_execute_tool_call_rehydrates_pydantic_model_lists_from_future_annotations() -> (
+    None
+):
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    captured_types: list[type[object]] = []
+
+    async def _action(tasks: list[_TaskDraftPayload]) -> dict[str, JsonValue]:
+        captured_types.extend(type(task) for task in tasks)
+        return {
+            "titles": [task.title for task in tasks],
+        }
+
+    result = asyncio.run(
+        execute_tool_call(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="create_tasks",
+            args_summary={"task_count": 1},
+            action=_action,
+            raw_args={
+                "ctx": ctx,
+                "tasks": [
+                    _TaskDraftPayload(
+                        objective="Implement the endpoint",
+                        title="Endpoint implementation",
+                    )
+                ],
+            },
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["data"] == {"titles": ["Endpoint implementation"]}
+    assert captured_types == [_TaskDraftPayload]
+
+
+def test_execute_tool_call_rehydrates_optional_pydantic_models_from_future_annotations() -> (
+    None
+):
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    captured_type: list[type[object]] = []
+
+    async def _action(task: _TaskDraftPayload | None = None) -> dict[str, JsonValue]:
+        if task is None:
+            return {"title": None}
+        captured_type.append(type(task))
+        return {"title": task.title}
+
+    result = asyncio.run(
+        execute_tool_call(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="create_task",
+            args_summary={"has_task": True},
+            action=_action,
+            raw_args={
+                "ctx": ctx,
+                "task": _TaskDraftPayload(
+                    objective="Implement the endpoint",
+                    title="Endpoint implementation",
+                ),
+            },
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["data"] == {"title": "Endpoint implementation"}
+    assert captured_type == [_TaskDraftPayload]
 
 
 def _raise_tool_execution_error() -> object:


### PR DESCRIPTION
## Summary
- resolve postponed annotations in shared tool runtime before rebinding tool action kwargs
- rehydrate `list[BaseModel]` and optional `BaseModel` arguments correctly for `execute_tool_call`
- add regression coverage for the `create_tasks`-style tool path

## Testing
- uv run --extra dev ruff check --fix src/relay_teams/tools/runtime/execution.py tests/unit_tests/tools/runtime/test_execution.py
- uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/tools/runtime/execution.py tests/unit_tests/tools/runtime/test_execution.py
- uv run --extra dev basedpyright src/relay_teams/tools/runtime/execution.py tests/unit_tests/tools/runtime/test_execution.py
- uv run --extra dev pytest -q tests/unit_tests/tools/runtime/test_execution.py
- uv run --extra dev pytest -q tests/unit_tests/agents/orchestration/test_task_orchestration_service.py

Closes #394
