### PR TITLE
fix: make app env updates visible to MCP

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -479,6 +479,7 @@ This updates process-level proxy variables for future HTTP requests and shell/MC
 ### `POST /system/configs/mcp:reload`
 
 Reloads MCP config into runtime.
+For stdio MCP servers launched through `uvx` or `uv tool run`, the backend clears the relevant `uv` package cache before rebuilding runtime state so newly added MCP tools are visible on the next load.
 If persisted MCP config is semantically invalid, the backend returns `400`.
 
 ### `POST /system/configs/skills:reload`
@@ -545,12 +546,14 @@ Request body fields:
 Sensitive app keys are written to the secret store instead of `.env`, and any managed plaintext copy is removed from `.env`.
 The backend preserves the existing value kind on edit or rename when possible, otherwise it infers `expandable` when the value contains `%NAME%` placeholders.
 Saving an app variable also reloads runtime model config immediately, so `model.json` placeholders such as `${OPENAI_API_KEY}` take effect without a restart.
+Saving an app variable also refreshes MCP runtime state and skills runtime state for future tool and skill use, so newly spawned stdio MCP subprocesses observe the updated environment without a server restart.
 Changes to `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, or `SSL_VERIFY` also trigger the same proxy runtime refresh side effects as the dedicated proxy settings API.
 `system` scope is read-only and returns a user-facing validation error on mutation.
 
 ### `DELETE /system/configs/environment-variables/{scope}/{key}`
 
 Deletes one app environment variable from the target scope.
+Deleting an app variable also refreshes MCP runtime state and skills runtime state for future tool and skill use.
 Deleting a missing key returns a user-facing validation error.
 
 ### `POST /system/configs/web:probe`

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -1088,6 +1088,24 @@ class ServerContainer:
         self.feishu_subscription_service.reload()
         self.wechat_gateway_service.reload()
 
+    def _reload_mcp_runtime_after_app_env_change(self) -> None:
+        try:
+            self._on_mcp_reloaded(self.mcp_config_manager.load_registry())
+        except Exception as exc:
+            LOGGER.warning(
+                "Failed to reload MCP runtime after app environment change: %s",
+                exc,
+            )
+
+    def _reload_skills_runtime_after_app_env_change(self) -> None:
+        try:
+            self.skills_config_reload_service.reload_skills_config()
+        except Exception as exc:
+            LOGGER.warning(
+                "Failed to reload skills runtime after app environment change: %s",
+                exc,
+            )
+
     def _on_app_environment_changed(self, changed_keys: frozenset[str]) -> None:
         self.model_config_service.reload_model_config()
         proxy_related_keys = {
@@ -1099,8 +1117,10 @@ class ServerContainer:
         }
         normalized_keys = {key.upper() for key in changed_keys}
         if normalized_keys.isdisjoint(proxy_related_keys):
-            return
-        self.proxy_config_service.reload_proxy_config()
+            self._reload_mcp_runtime_after_app_env_change()
+        else:
+            self.proxy_config_service.reload_proxy_config()
+        self._reload_skills_runtime_after_app_env_change()
 
     def _ensure_default_workspace(self) -> None:
         if self.workspace_repo.exists("default"):

--- a/src/relay_teams/mcp/config_reload_service.py
+++ b/src/relay_teams/mcp/config_reload_service.py
@@ -58,25 +58,58 @@ class McpConfigReloadService:
 
 
 def _resolve_uv_cache_clean_argv(spec: McpServerSpec) -> tuple[str, ...] | None:
-    command_name = _normalize_command_name(
-        _required_server_config_string(spec.server_config, "command")
+    configured_command = _required_server_config_string(spec.server_config, "command")
+    command_name = _normalize_command_name(configured_command)
+    uv_cache_clean_command = _resolve_uv_cache_clean_command(
+        configured_command=configured_command,
+        command_name=command_name,
     )
+    if uv_cache_clean_command is None:
+        return None
     args = _server_config_args(spec.server_config)
     if command_name == "uvx":
-        return _build_uv_cache_clean_argv(_resolve_uv_tool_package(args))
-    if command_name != "uv":
-        return None
-    if len(args) >= 2 and args[:2] == ("tool", "run"):
-        return _build_uv_cache_clean_argv(_resolve_uv_tool_package(args[2:]))
-    if args and args[0] == "x":
-        return _build_uv_cache_clean_argv(_resolve_uv_tool_package(args[1:]))
+        return _build_uv_cache_clean_argv(
+            command=uv_cache_clean_command,
+            package_name=_resolve_uv_tool_package(args),
+        )
+    subcommand_args = _strip_uv_global_args(args)
+    if len(subcommand_args) >= 2 and subcommand_args[:2] == ("tool", "run"):
+        return _build_uv_cache_clean_argv(
+            command=uv_cache_clean_command,
+            package_name=_resolve_uv_tool_package(subcommand_args[2:]),
+        )
+    if subcommand_args and subcommand_args[0] == "x":
+        return _build_uv_cache_clean_argv(
+            command=uv_cache_clean_command,
+            package_name=_resolve_uv_tool_package(subcommand_args[1:]),
+        )
     return None
 
 
-def _build_uv_cache_clean_argv(package_name: str | None) -> tuple[str, ...]:
+def _resolve_uv_cache_clean_command(
+    *,
+    configured_command: str,
+    command_name: str,
+) -> str | None:
+    stripped_command = configured_command.strip()
+    if command_name == "uv":
+        return stripped_command or "uv"
+    if command_name != "uvx":
+        return None
+    return _replace_command_basename(
+        command=stripped_command or "uvx",
+        replacement_name="uv",
+    )
+
+
+def _build_uv_cache_clean_argv(
+    *,
+    command: str,
+    package_name: str | None,
+) -> tuple[str, ...]:
     if package_name is None:
-        return ("uv", "cache", "clean", "--force")
-    return ("uv", "cache", "clean", "--force", package_name)
+        return (command, "cache", "clean", "--force")
+    return (command, "cache", "clean", "--force", package_name)
 
 
 def _resolve_uv_tool_package(args: tuple[str, ...]) -> str | None:
@@ -117,9 +150,58 @@ def _server_config_args(server_config: dict[str, JsonValue]) -> tuple[str, ...]:
     return tuple(str(item).strip() for item in raw_args if str(item).strip())
 
 
+def _strip_uv_global_args(args: tuple[str, ...]) -> tuple[str, ...]:
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if not arg.startswith("-"):
+            break
+        if arg == "--":
+            index += 1
+            break
+        if _uv_option_requires_value(arg):
+            next_index = index + 1
+            if next_index >= len(args):
+                return ()
+            index += 2
+            continue
+        index += 1
+    return args[index:]
+
+
+def _uv_option_requires_value(arg: str) -> bool:
+    if "=" in arg:
+        return False
+    return arg in _UV_OPTIONS_WITH_VALUE
+
+
+_UV_OPTIONS_WITH_VALUE: frozenset[str] = frozenset(
+    {
+        "--allow-insecure-host",
+        "--color",
+        "--config-file",
+        "--directory",
+        "--project",
+    }
+)
+
+
 def _normalize_command_name(command: str) -> str:
     resolved_name = Path(command.strip()).name.lower()
     return resolved_name.removesuffix(".exe")
+
+
+def _replace_command_basename(command: str, replacement_name: str) -> str:
+    stripped_command = command.strip()
+    if not stripped_command:
+        return replacement_name
+    separator_index = max(stripped_command.rfind("/"), stripped_command.rfind("\\"))
+    if separator_index < 0:
+        suffix = ".exe" if stripped_command.lower().endswith(".exe") else ""
+        return replacement_name + suffix
+    prefix = stripped_command[: separator_index + 1]
+    suffix = ".exe" if stripped_command.lower().endswith(".exe") else ""
+    return prefix + replacement_name + suffix
 
 
 def _run_uv_cache_clean_command(

--- a/src/relay_teams/mcp/config_reload_service.py
+++ b/src/relay_teams/mcp/config_reload_service.py
@@ -2,9 +2,15 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
+import logging
+import subprocess
 
-from relay_teams.logger import get_logger
+from pydantic import JsonValue
+
+from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_config_manager import McpConfigManager
+from relay_teams.mcp.mcp_models import McpServerSpec
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.trace import trace_span
@@ -31,6 +37,7 @@ class McpConfigReloadService:
             operation="reload",
         ):
             mcp_registry = self._mcp_config_manager.load_registry()
+            self._clean_uv_tool_cache(mcp_registry.list_specs())
             for role in self._role_registry.list_roles():
                 mcp_registry.resolve_server_names(
                     role.mcp_servers,
@@ -38,3 +45,143 @@ class McpConfigReloadService:
                     consumer=f"mcp.config_reload.role:{role.role_id}",
                 )
             self._on_mcp_reloaded(mcp_registry)
+
+    def _clean_uv_tool_cache(self, specs: tuple[McpServerSpec, ...]) -> None:
+        grouped_commands: dict[tuple[str, ...], list[str]] = {}
+        for spec in specs:
+            argv = _resolve_uv_cache_clean_argv(spec)
+            if argv is None:
+                continue
+            grouped_commands.setdefault(argv, []).append(spec.name)
+        for argv, server_names in grouped_commands.items():
+            _run_uv_cache_clean_command(argv=argv, server_names=tuple(server_names))
+
+
+def _resolve_uv_cache_clean_argv(spec: McpServerSpec) -> tuple[str, ...] | None:
+    command_name = _normalize_command_name(
+        _required_server_config_string(spec.server_config, "command")
+    )
+    args = _server_config_args(spec.server_config)
+    if command_name == "uvx":
+        return _build_uv_cache_clean_argv(_resolve_uv_tool_package(args))
+    if command_name != "uv":
+        return None
+    if len(args) >= 2 and args[:2] == ("tool", "run"):
+        return _build_uv_cache_clean_argv(_resolve_uv_tool_package(args[2:]))
+    if args and args[0] == "x":
+        return _build_uv_cache_clean_argv(_resolve_uv_tool_package(args[1:]))
+    return None
+
+
+def _build_uv_cache_clean_argv(package_name: str | None) -> tuple[str, ...]:
+    if package_name is None:
+        return ("uv", "cache", "clean", "--force")
+    return ("uv", "cache", "clean", "--force", package_name)
+
+
+def _resolve_uv_tool_package(args: tuple[str, ...]) -> str | None:
+    for arg in args:
+        if arg.startswith("--from="):
+            resolved = arg.partition("=")[2].strip()
+            return resolved or None
+    for index, arg in enumerate(args):
+        if arg != "--from":
+            continue
+        next_index = index + 1
+        if next_index >= len(args):
+            return None
+        resolved = args[next_index].strip()
+        return resolved or None
+    if not args:
+        return None
+    first_arg = args[0].strip()
+    if not first_arg or first_arg.startswith("-"):
+        return None
+    return first_arg
+
+
+def _required_server_config_string(
+    server_config: dict[str, JsonValue],
+    key: str,
+) -> str:
+    value = server_config.get(key)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _server_config_args(server_config: dict[str, JsonValue]) -> tuple[str, ...]:
+    raw_args = server_config.get("args")
+    if not isinstance(raw_args, list):
+        return ()
+    return tuple(str(item).strip() for item in raw_args if str(item).strip())
+
+
+def _normalize_command_name(command: str) -> str:
+    resolved_name = Path(command.strip()).name.lower()
+    return resolved_name.removesuffix(".exe")
+
+
+def _run_uv_cache_clean_command(
+    *,
+    argv: tuple[str, ...],
+    server_names: tuple[str, ...],
+) -> None:
+    cache_target = argv[4] if len(argv) > 4 else "all"
+    payload: dict[str, JsonValue] = {
+        "server_names": list(server_names),
+        "command": list(argv),
+        "cache_target": cache_target,
+    }
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=60,
+        )
+    except FileNotFoundError as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="mcp.config.uv_cache_clean_missing",
+            message="Skipping uv cache clean because uv is unavailable",
+            payload=payload,
+            exc_info=exc,
+        )
+        return
+    except subprocess.TimeoutExpired as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="mcp.config.uv_cache_clean_timeout",
+            message="Timed out while clearing uv cache for MCP reload",
+            payload=payload,
+            exc_info=exc,
+        )
+        return
+
+    payload["returncode"] = result.returncode
+    stdout = result.stdout.strip()
+    stderr = result.stderr.strip()
+    if stdout:
+        payload["stdout"] = stdout
+    if stderr:
+        payload["stderr"] = stderr
+    if result.returncode != 0:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="mcp.config.uv_cache_clean_failed",
+            message="uv cache clean failed during MCP reload",
+            payload=payload,
+        )
+        return
+    log_event(
+        LOGGER,
+        logging.INFO,
+        event="mcp.config.uv_cache_cleaned",
+        message="Cleared uv cache before MCP reload",
+        payload=payload,
+    )

--- a/src/relay_teams/mcp/config_reload_service.py
+++ b/src/relay_teams/mcp/config_reload_service.py
@@ -127,14 +127,72 @@ def _run_uv_cache_clean_command(
     argv: tuple[str, ...],
     server_names: tuple[str, ...],
 ) -> None:
-    cache_target = argv[4] if len(argv) > 4 else "all"
-    payload: dict[str, JsonValue] = {
+    payload_base: dict[str, JsonValue] = {
         "server_names": list(server_names),
-        "command": list(argv),
-        "cache_target": cache_target,
+        "cache_target": _uv_cache_target(argv),
     }
+    result = _run_uv_cache_clean_subprocess(
+        argv=argv,
+        payload={**payload_base, "command": list(argv)},
+    )
+    if result is None:
+        return
+
+    if result.returncode != 0 and _is_unsupported_uv_force_error(result.stderr):
+        legacy_argv = _build_legacy_uv_cache_clean_argv(argv)
+        if legacy_argv is not None:
+            legacy_payload: dict[str, JsonValue] = {
+                **payload_base,
+                "command": list(legacy_argv),
+                "fallback_from_command": list(argv),
+            }
+            initial_stderr = result.stderr.strip()
+            if initial_stderr:
+                legacy_payload["initial_stderr"] = initial_stderr
+            legacy_result = _run_uv_cache_clean_subprocess(
+                argv=legacy_argv,
+                payload=legacy_payload,
+            )
+            if legacy_result is None:
+                return
+            _log_uv_cache_clean_result(result=legacy_result, payload=legacy_payload)
+            return
+
+    _log_uv_cache_clean_result(
+        result=result,
+        payload={**payload_base, "command": list(argv)},
+    )
+
+
+def _uv_cache_target(argv: tuple[str, ...]) -> str:
+    trailing_args = argv[3:]
+    if trailing_args and trailing_args[0] == "--force":
+        trailing_args = trailing_args[1:]
+    if not trailing_args:
+        return "all"
+    return trailing_args[0]
+
+
+def _build_legacy_uv_cache_clean_argv(argv: tuple[str, ...]) -> tuple[str, ...] | None:
+    if len(argv) < 4 or argv[3] != "--force":
+        return None
+    return argv[:3] + argv[4:]
+
+
+def _is_unsupported_uv_force_error(stderr: str) -> bool:
+    normalized = stderr.casefold()
+    if "--force" not in normalized:
+        return False
+    return "unexpected argument" in normalized or "unexpected option" in normalized
+
+
+def _run_uv_cache_clean_subprocess(
+    *,
+    argv: tuple[str, ...],
+    payload: dict[str, JsonValue],
+) -> subprocess.CompletedProcess[str] | None:
     try:
-        result = subprocess.run(
+        return subprocess.run(
             argv,
             capture_output=True,
             check=False,
@@ -150,7 +208,7 @@ def _run_uv_cache_clean_command(
             payload=payload,
             exc_info=exc,
         )
-        return
+        return None
     except subprocess.TimeoutExpired as exc:
         log_event(
             LOGGER,
@@ -160,8 +218,14 @@ def _run_uv_cache_clean_command(
             payload=payload,
             exc_info=exc,
         )
-        return
+        return None
 
+
+def _log_uv_cache_clean_result(
+    *,
+    result: subprocess.CompletedProcess[str],
+    payload: dict[str, JsonValue],
+) -> None:
     payload["returncode"] = result.returncode
     stdout = result.stdout.strip()
     stderr = result.stderr.strip()

--- a/src/relay_teams/mcp/config_reload_service.py
+++ b/src/relay_teams/mcp/config_reload_service.py
@@ -178,6 +178,7 @@ def _uv_option_requires_value(arg: str) -> bool:
 _UV_OPTIONS_WITH_VALUE: frozenset[str] = frozenset(
     {
         "--allow-insecure-host",
+        "--cache-dir",
         "--color",
         "--config-file",
         "--directory",

--- a/src/relay_teams/mcp/mcp_config_manager.py
+++ b/src/relay_teams/mcp/mcp_config_manager.py
@@ -12,6 +12,7 @@ from relay_teams.env import (
     apply_proxy_env_to_process_env,
     extract_proxy_env_vars,
     load_merged_env_vars,
+    sync_app_env_to_process_env,
 )
 from relay_teams.logger import get_logger
 from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
@@ -46,6 +47,7 @@ class McpConfigManager:
 
     def load_registry(self) -> McpRegistry:
         ensure_app_config_bootstrap(self._app_config_dir)
+        sync_app_env_to_process_env(self._app_config_dir / _ENV_FILE_NAME)
         with trace_span(
             logger,
             component="mcp.config",

--- a/src/relay_teams/mcp/mcp_registry.py
+++ b/src/relay_teams/mcp/mcp_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import logging
+import os
 from typing import Protocol, cast
 
 from pydantic import JsonValue
@@ -171,7 +172,7 @@ def build_mcp_server(spec: McpServerSpec) -> MCPServer:
         return MCPServerStdio(
             command=command,
             args=_string_list(server_config.get("args")),
-            env=_string_dict(server_config.get("env")),
+            env=_build_stdio_env(server_config),
             cwd=_optional_string(server_config.get("cwd")),
             tool_prefix=get_mcp_tool_prefix(spec.name),
             timeout=(
@@ -246,3 +247,10 @@ def _string_dict(value: JsonValue) -> dict[str, str] | None:
     if not isinstance(value, dict):
         return None
     return {str(key): str(item) for key, item in value.items() if isinstance(key, str)}
+
+
+def _build_stdio_env(server_config: Mapping[str, JsonValue]) -> dict[str, str]:
+    merged_env = dict(os.environ)
+    explicit_env = _string_dict(server_config.get("env")) or {}
+    merged_env.update(explicit_env)
+    return merged_env

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -182,6 +182,40 @@ def test_saving_environment_variable_reloads_model_runtime(
     assert container.runtime.llm_profiles["default"].api_key == "secret-key"
 
 
+def test_saving_app_environment_variable_reloads_mcp_and_skills_runtime(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    env_key = "AGENT_TEAMS_RUNTIME_RELOAD_TEST_ENV"
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.delenv(env_key, raising=False)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = ServerContainer(config_dir=config_dir)
+    mcp_reload_calls: list[str] = []
+    skill_reload_calls: list[str] = []
+
+    monkeypatch.setattr(
+        container.mcp_config_manager,
+        "load_registry",
+        lambda: (mcp_reload_calls.append("mcp"), container.mcp_registry)[1],
+    )
+    monkeypatch.setattr(
+        container.skills_config_reload_service,
+        "reload_skills_config",
+        lambda: skill_reload_calls.append("skills"),
+    )
+
+    container.environment_variable_service.save_environment_variable(
+        scope=EnvironmentVariableScope.APP,
+        key=env_key,
+        request=EnvironmentVariableSaveRequest(value="enabled"),
+    )
+
+    assert mcp_reload_calls == ["mcp"]
+    assert skill_reload_calls == ["skills"]
+
+
 def test_proxy_environment_variable_change_triggers_proxy_runtime_refresh(
     monkeypatch,
     tmp_path: Path,
@@ -193,6 +227,7 @@ def test_proxy_environment_variable_change_triggers_proxy_runtime_refresh(
     feishu_reload_calls: list[str] = []
     wechat_reload_calls: list[str] = []
     mcp_reload_calls: list[str] = []
+    skill_reload_calls: list[str] = []
 
     monkeypatch.setattr(
         container.feishu_subscription_service,
@@ -209,6 +244,11 @@ def test_proxy_environment_variable_change_triggers_proxy_runtime_refresh(
         "load_registry",
         lambda: (mcp_reload_calls.append("mcp"), container.mcp_registry)[1],
     )
+    monkeypatch.setattr(
+        container.skills_config_reload_service,
+        "reload_skills_config",
+        lambda: skill_reload_calls.append("skills"),
+    )
 
     container.environment_variable_service.save_environment_variable(
         scope=EnvironmentVariableScope.APP,
@@ -223,6 +263,7 @@ def test_proxy_environment_variable_change_triggers_proxy_runtime_refresh(
     assert feishu_reload_calls == ["feishu"]
     assert wechat_reload_calls == ["wechat"]
     assert mcp_reload_calls == ["mcp"]
+    assert skill_reload_calls == ["skills"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/mcp/test_config_reload_service.py
+++ b/tests/unit_tests/mcp/test_config_reload_service.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
 
 from relay_teams.mcp import (
     McpConfigManager,
     McpConfigReloadService,
 )
+from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
+from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 
@@ -41,3 +44,178 @@ def test_reload_mcp_config_ignores_unknown_servers_on_existing_roles(
 
     assert len(reloaded_registries) == 1
     assert reloaded_registries[0].list_names() == ()
+
+
+def test_reload_mcp_config_cleans_uvx_package_cache_before_reload(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": ["mcp-server-filesystem"],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [
+        ("uv", "cache", "clean", "--force", "mcp-server-filesystem")
+    ]
+
+
+def test_reload_mcp_config_cleans_uv_tool_run_package_from_from_flag(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "uv"}}},
+                server_config={
+                    "command": "uv",
+                    "args": [
+                        "tool",
+                        "run",
+                        "--from=context7-mcp",
+                        "context7",
+                    ],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [("uv", "cache", "clean", "--force", "context7-mcp")]
+
+
+def test_reload_mcp_config_falls_back_to_global_uv_cache_clean_when_package_unknown(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": ["--isolated", "--env-file", ".env"],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [("uv", "cache", "clean", "--force")]
+
+
+def test_reload_mcp_config_skips_uv_cache_clean_for_uv_run_projects(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "uv"}}},
+                server_config={
+                    "command": "uv",
+                    "args": ["run", "python", "-m", "my_mcp_server"],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == []

--- a/tests/unit_tests/mcp/test_config_reload_service.py
+++ b/tests/unit_tests/mcp/test_config_reload_service.py
@@ -219,3 +219,56 @@ def test_reload_mcp_config_skips_uv_cache_clean_for_uv_run_projects(
     service.reload_mcp_config()
 
     assert recorded_commands == []
+
+
+def test_reload_mcp_config_retries_without_force_for_legacy_uv(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": ["mcp-server-filesystem"],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        argv = tuple(args[0])
+        recorded_commands.append(argv)
+        if argv == ("uv", "cache", "clean", "--force", "mcp-server-filesystem"):
+            return subprocess.CompletedProcess(
+                args[0],
+                2,
+                stdout="",
+                stderr="error: unexpected argument '--force' found",
+            )
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [
+        ("uv", "cache", "clean", "--force", "mcp-server-filesystem"),
+        ("uv", "cache", "clean", "mcp-server-filesystem"),
+    ]

--- a/tests/unit_tests/mcp/test_config_reload_service.py
+++ b/tests/unit_tests/mcp/test_config_reload_service.py
@@ -272,3 +272,99 @@ def test_reload_mcp_config_retries_without_force_for_legacy_uv(
         ("uv", "cache", "clean", "--force", "mcp-server-filesystem"),
         ("uv", "cache", "clean", "mcp-server-filesystem"),
     ]
+
+
+def test_reload_mcp_config_reuses_configured_uv_path_for_uvx_servers(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "/custom/bin/uvx"}}},
+                server_config={
+                    "command": "/custom/bin/uvx",
+                    "args": ["mcp-server-filesystem"],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [
+        ("/custom/bin/uv", "cache", "clean", "--force", "mcp-server-filesystem")
+    ]
+
+
+def test_reload_mcp_config_parses_uv_global_options_before_tool_run(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "/custom/bin/uv"}}},
+                server_config={
+                    "command": "/custom/bin/uv",
+                    "args": [
+                        "--project",
+                        "/repo",
+                        "--color=always",
+                        "tool",
+                        "run",
+                        "--from=context7-mcp",
+                        "context7",
+                    ],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [
+        ("/custom/bin/uv", "cache", "clean", "--force", "context7-mcp")
+    ]

--- a/tests/unit_tests/mcp/test_config_reload_service.py
+++ b/tests/unit_tests/mcp/test_config_reload_service.py
@@ -368,3 +368,52 @@ def test_reload_mcp_config_parses_uv_global_options_before_tool_run(
     assert recorded_commands == [
         ("/custom/bin/uv", "cache", "clean", "--force", "context7-mcp")
     ]
+
+
+def test_reload_mcp_config_parses_uv_cache_dir_before_tool_run(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "uv"}}},
+                server_config={
+                    "command": "uv",
+                    "args": [
+                        "--cache-dir",
+                        "/tmp/uv-cache",
+                        "tool",
+                        "run",
+                        "--from=context7-mcp",
+                        "context7",
+                    ],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [("uv", "cache", "clean", "--force", "context7-mcp")]

--- a/tests/unit_tests/mcp/test_mcp_config_manager.py
+++ b/tests/unit_tests/mcp/test_mcp_config_manager.py
@@ -5,8 +5,11 @@ import json
 import os
 from pathlib import Path
 
+from pydantic_ai.mcp import MCPServerStdio
+
 from relay_teams.mcp import mcp_config_manager as config_manager
 from relay_teams.mcp.mcp_models import McpConfigScope
+from relay_teams.mcp.mcp_registry import build_mcp_server
 
 
 def _clear_proxy_env(monkeypatch) -> None:
@@ -167,17 +170,17 @@ def test_load_registry_preserves_explicit_server_env_over_proxy_defaults(
     manager = config_manager.McpConfigManager(app_config_dir=app_config_dir)
 
     registry = manager.load_registry()
+    server_env = registry.get_spec("remote").server_config["env"]
 
-    assert registry.get_spec("remote").server_config["env"] == {
-        "HTTP_PROXY": "http://custom-proxy.internal:9000",
-        "http_proxy": "http://custom-proxy.internal:9000",
-        "NODE_USE_ENV_PROXY": "1",
-        "NPM_CONFIG_PROXY": "http://custom-proxy.internal:9000",
-        "npm_config_proxy": "http://custom-proxy.internal:9000",
-        "NPM_CONFIG_HTTPS_PROXY": "http://custom-proxy.internal:9000",
-        "npm_config_https_proxy": "http://custom-proxy.internal:9000",
-        "CUSTOM_TOKEN": "secret",
-    }
+    assert isinstance(server_env, dict)
+    assert server_env["HTTP_PROXY"] == "http://custom-proxy.internal:9000"
+    assert server_env["http_proxy"] == "http://custom-proxy.internal:9000"
+    assert server_env["NODE_USE_ENV_PROXY"] == "1"
+    assert server_env["NPM_CONFIG_PROXY"] == "http://custom-proxy.internal:9000"
+    assert server_env["npm_config_proxy"] == "http://custom-proxy.internal:9000"
+    assert server_env["NPM_CONFIG_HTTPS_PROXY"] == "http://custom-proxy.internal:9000"
+    assert server_env["npm_config_https_proxy"] == "http://custom-proxy.internal:9000"
+    assert server_env["CUSTOM_TOKEN"] == "secret"
 
 
 def test_load_registry_accepts_utf8_bom(tmp_path: Path) -> None:
@@ -201,6 +204,35 @@ def test_load_registry_accepts_utf8_bom(tmp_path: Path) -> None:
     registry = manager.load_registry()
 
     assert registry.list_names() == ("time-mcp",)
+
+
+def test_load_registry_syncs_app_environment_for_stdio_mcp(tmp_path: Path) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir(parents=True)
+    env_key = "MCP_SYNCED_APP_ENV"
+    (app_config_dir / ".env").write_text(f"{env_key}=from-app\n", encoding="utf-8")
+    (app_config_dir / "mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "time-mcp": {
+                        "command": "npx",
+                        "args": ["-y", "@upstash/context7-mcp"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    manager = config_manager.McpConfigManager(app_config_dir=app_config_dir)
+
+    registry = manager.load_registry()
+    server = build_mcp_server(registry.get_spec("time-mcp"))
+
+    assert isinstance(server, MCPServerStdio)
+    assert os.environ[env_key] == "from-app"
+    assert server.env is not None
+    assert server.env[env_key] == "from-app"
 
 
 def test_get_mcp_file_paths_follow_scope_conventions(

--- a/tests/unit_tests/mcp/test_mcp_service.py
+++ b/tests/unit_tests/mcp/test_mcp_service.py
@@ -197,6 +197,35 @@ def test_build_mcp_server_allows_stdio_timeout_override() -> None:
     assert server.read_timeout == 123.0
 
 
+def test_build_mcp_server_stdio_inherits_process_env_and_prefers_explicit_env(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MCP_PROCESS_ONLY", "from-process")
+    monkeypatch.setenv("MCP_SHARED_ENV", "from-process")
+
+    server = build_mcp_server(
+        McpServerSpec(
+            name="context7",
+            config={"mcpServers": {"context7": {"command": "npx"}}},
+            server_config={
+                "command": "npx",
+                "args": ["-y", "@upstash/context7-mcp"],
+                "env": {
+                    "MCP_SHARED_ENV": "from-spec",
+                    "MCP_SPEC_ONLY": "from-spec",
+                },
+            },
+            source=McpConfigScope.SESSION,
+        )
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert server.env["MCP_PROCESS_ONLY"] == "from-process"
+    assert server.env["MCP_SHARED_ENV"] == "from-spec"
+    assert server.env["MCP_SPEC_ONLY"] == "from-spec"
+
+
 def test_registry_resolve_server_names_ignores_unknown_servers_when_not_strict() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- inherit the effective runtime environment for stdio MCP servers and sync app env before registry loads
- auto-refresh MCP and skills runtime after app environment changes
- clear uv package cache during MCP reload with --force so uv-managed tool updates take effect

## Testing
- uv run --extra dev pytest -q tests/unit_tests/mcp/test_mcp_service.py tests/unit_tests/mcp/test_mcp_config_manager.py tests/unit_tests/mcp/test_config_reload_service.py tests/unit_tests/interfaces/server/test_container.py
- uv run --extra dev basedpyright src/relay_teams/mcp/config_reload_service.py src/relay_teams/mcp/mcp_config_manager.py src/relay_teams/mcp/mcp_registry.py src/relay_teams/interfaces/server/container.py tests/unit_tests/mcp/test_mcp_service.py tests/unit_tests/mcp/test_mcp_config_manager.py tests/unit_tests/mcp/test_config_reload_service.py tests/unit_tests/interfaces/server/test_container.py
- manual end-to-end verification against a real FastMCP stdio server and live /api/system/configs/mcp:reload

Closes #397