### PR TITLE
feat: add project-level custom commands module (discovery, registry, resolution, routing)

### DIFF
--- a/src/relay_teams/commands/__init__.py
+++ b/src/relay_teams/commands/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from relay_teams.commands.command_models import (
+    CommandEntry,
+    CommandScope,
+    CommandSummary,
+)
+from relay_teams.commands.discovery import CommandsDirectory
+from relay_teams.commands.registry import CommandRegistry
+from relay_teams.commands.resolver import CommandResolver, ResolveResult
+
+__all__ = [
+    "CommandEntry",
+    "CommandResolver",
+    "CommandRegistry",
+    "CommandScope",
+    "CommandSummary",
+    "CommandsDirectory",
+    "ResolveResult",
+]

--- a/src/relay_teams/commands/command_cli.py
+++ b/src/relay_teams/commands/command_cli.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from enum import Enum
+import json
+from pathlib import Path
+from typing import TypedDict
+
+import typer
+
+from relay_teams.commands.command_models import CommandEntry, CommandScope
+from relay_teams.commands.registry import CommandRegistry
+
+commands_app = typer.Typer(
+    no_args_is_help=True,
+    pretty_exceptions_enable=False,
+    help=(
+        "Inspect project-level and app-level custom commands.\n\n"
+        "Load order:\n"
+        "1. <workspace>/.relay-teams/commands or .codex/commands (project scope)\n"
+        "2. ~/.relay-teams/commands (app scope)\n\n"
+        "Project scope takes priority over app scope for same-name commands.\n\n"
+        "Common usage:\n"
+        "- relay-teams commands list\n"
+        "- relay-teams commands list --source project --format json\n"
+        "- relay-teams commands show my-cmd"
+    ),
+)
+
+
+class CommandOutputFormat(str, Enum):
+    TABLE = "table"
+    JSON = "json"
+
+
+class CommandSourceFilter(str, Enum):
+    ALL = "all"
+    APP = "app"
+    PROJECT = "project"
+
+
+class CommandListEntry(TypedDict):
+    name: str
+    source: str
+    description: str
+    argument_hint: str
+
+
+@commands_app.command(
+    "list",
+    help=(
+        "List all discovered commands across project and app scopes.\n\n"
+        "If the same command exists in both scopes, only the project version is shown.\n\n"
+        "Examples:\n"
+        "- relay-teams commands list\n"
+        "- relay-teams commands list --source project\n"
+        "- relay-teams commands list --format json"
+    ),
+)
+def commands_list(
+    output_format: CommandOutputFormat = typer.Option(
+        CommandOutputFormat.TABLE,
+        "--format",
+        help="Render as an ASCII table or JSON.",
+        case_sensitive=False,
+    ),
+    source: CommandSourceFilter = typer.Option(
+        CommandSourceFilter.ALL,
+        "--source",
+        help="Filter by resolved scope: all, app, or project.",
+        case_sensitive=False,
+    ),
+) -> None:
+    registry = load_command_registry()
+    commands = _filter_commands(registry.list_commands(), source)
+    if output_format == CommandOutputFormat.JSON:
+        typer.echo(
+            json.dumps(
+                [_to_command_list_entry(cmd) for cmd in commands], ensure_ascii=False
+            )
+        )
+        return
+    render_command_list_table(commands)
+
+
+@commands_app.command(
+    "show",
+    help=(
+        "Show a single command definition.\n\n"
+        "The argument is the command name.\n\n"
+        "Examples:\n"
+        "- relay-teams commands show my-cmd\n"
+        "- relay-teams commands show my-cmd --format json"
+    ),
+)
+def commands_show(
+    name: str = typer.Argument(..., help="Command name to inspect."),
+    output_format: CommandOutputFormat = typer.Option(
+        CommandOutputFormat.TABLE,
+        "--format",
+        help="Render as an ASCII table or JSON.",
+        case_sensitive=False,
+    ),
+) -> None:
+    registry = load_command_registry()
+    command = registry.get_command(name)
+    if command is None:
+        raise typer.BadParameter(f"Unknown command: {name}")
+    if output_format == CommandOutputFormat.JSON:
+        typer.echo(json.dumps(_to_command_json(command), ensure_ascii=False))
+        return
+    render_command_detail_table(command)
+
+
+def load_command_registry() -> CommandRegistry:
+    return CommandRegistry.from_default_scopes()
+
+
+def render_command_list_table(commands: tuple[CommandEntry, ...]) -> None:
+    if not commands:
+        typer.echo("No commands discovered.")
+        return
+
+    rows = [_to_command_list_entry(cmd) for cmd in commands]
+    typer.echo(f"Commands ({len(rows)} total)")
+    name_width = max(len("Name"), *(len(row["name"]) for row in rows))
+    source_width = max(len("Source"), *(len(row["source"]) for row in rows))
+    description_width = max(
+        len("Description"), *(len(row["description"]) for row in rows)
+    )
+
+    border = (
+        f"+-{'-' * name_width}-+-{'-' * source_width}-+-{'-' * description_width}-+"
+    )
+    typer.echo(border)
+    typer.echo(
+        f"| {'Name'.ljust(name_width)} | "
+        f"{'Source'.ljust(source_width)} | "
+        f"{'Description'.ljust(description_width)} |"
+    )
+    typer.echo(border)
+    for row in rows:
+        typer.echo(
+            f"| {row['name'].ljust(name_width)} | "
+            f"{row['source'].ljust(source_width)} | "
+            f"{row['description'].ljust(description_width)} |"
+        )
+    typer.echo(border)
+
+
+def render_command_detail_table(command: CommandEntry) -> None:
+    summary_rows = [
+        ("Name", command.name),
+        ("Source", command.scope.value),
+        ("Path", _to_path_text(command.path)),
+        ("Description", command.description),
+        ("Argument Hint", command.argument_hint),
+        ("Allowed Modes", ", ".join(command.allowed_modes)),
+    ]
+    _render_key_value_table(title="Command", rows=summary_rows)
+    typer.echo("Body")
+    typer.echo(command.body or "<empty>")
+
+
+def _render_key_value_table(title: str, rows: list[tuple[str, str]]) -> None:
+    typer.echo(title)
+    field_width = max(len("Field"), *(len(field) for field, _ in rows))
+    value_width = max(len("Value"), *(len(value) for _, value in rows))
+    border = f"+-{'-' * field_width}-+-{'-' * value_width}-+"
+    typer.echo(border)
+    typer.echo(f"| {'Field'.ljust(field_width)} | {'Value'.ljust(value_width)} |")
+    typer.echo(border)
+    for field, value in rows:
+        typer.echo(f"| {field.ljust(field_width)} | {value.ljust(value_width)} |")
+    typer.echo(border)
+
+
+def _filter_commands(
+    commands: tuple[CommandEntry, ...], source: CommandSourceFilter
+) -> tuple[CommandEntry, ...]:
+    if source == CommandSourceFilter.ALL:
+        return commands
+    requested_scope = CommandScope(source.value)
+    return tuple(cmd for cmd in commands if cmd.scope == requested_scope)
+
+
+def _to_command_list_entry(command: CommandEntry) -> CommandListEntry:
+    return CommandListEntry(
+        name=command.name,
+        source=command.scope.value,
+        description=command.description,
+        argument_hint=command.argument_hint,
+    )
+
+
+def _to_command_json(command: CommandEntry) -> dict[str, object]:
+    return {
+        "name": command.name,
+        "description": command.description,
+        "argument_hint": command.argument_hint,
+        "allowed_modes": command.allowed_modes,
+        "body": command.body,
+        "source": command.scope.value,
+        "path": _to_path_text(command.path),
+    }
+
+
+def _to_path_text(path: Path) -> str:
+    return path.resolve().as_posix()

--- a/src/relay_teams/commands/command_models.py
+++ b/src/relay_teams/commands/command_models.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CommandScope(str, Enum):
+    APP = "app"
+    PROJECT = "project"
+
+
+class CommandFrontMatter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = ""
+    description: str = ""
+    argument_hint: str = ""
+    allowed_modes: list[str] = Field(default_factory=lambda: ["normal"])
+
+
+class CommandEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    description: str = ""
+    argument_hint: str = ""
+    allowed_modes: list[str] = Field(default_factory=lambda: ["normal"])
+    body: str = ""
+    scope: CommandScope
+    path: Path
+
+
+class CommandSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    description: str = ""
+    scope: CommandScope
+    argument_hint: str = ""
+
+
+class ResolveResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    command_name: str = Field(min_length=1)
+    scope: CommandScope
+    raw_text: str = Field(min_length=1)
+    expanded_prompt: str = Field(min_length=1)
+    args: str = ""
+    prompt_length: int = 0

--- a/src/relay_teams/commands/discovery.py
+++ b/src/relay_teams/commands/discovery.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from threading import RLock
+
+import yaml
+
+from relay_teams.commands.command_models import (
+    CommandEntry,
+    CommandScope,
+)
+from relay_teams.logger import get_logger
+from relay_teams.paths import get_app_config_dir, get_project_root_or_none
+from relay_teams.trace import trace_span
+
+logger = get_logger(__name__)
+
+_COMMAND_FILE_PATTERN = re.compile(r"^(.+)\.md$", re.IGNORECASE)
+
+
+def get_app_commands_dir(user_home_dir: Path | None = None) -> Path:
+    return get_app_config_dir(user_home_dir=user_home_dir) / "commands"
+
+
+def get_project_commands_dir(project_root: Path | None = None) -> Path:
+    effective_root = project_root or get_project_root_or_none() or Path.cwd()
+    relay_teams_dir = effective_root / ".relay-teams" / "commands"
+    codex_dir = effective_root / ".codex" / "commands"
+    if codex_dir.exists():
+        return codex_dir
+    return relay_teams_dir
+
+
+class CommandsDirectory:
+    def __init__(
+        self,
+        *,
+        app_commands_dir: Path,
+        project_commands_dir: Path | None = None,
+    ) -> None:
+        self.app_commands_dir = app_commands_dir.expanduser().resolve()
+        self.project_commands_dir = (
+            project_commands_dir.expanduser().resolve()
+            if project_commands_dir is not None
+            else None
+        )
+        self._commands: dict[str, CommandEntry] = {}
+        self._lock = RLock()
+
+    @classmethod
+    def from_default_scopes(
+        cls,
+        *,
+        user_home_dir: Path | None = None,
+        project_root: Path | None = None,
+    ) -> CommandsDirectory:
+        return cls(
+            app_commands_dir=get_app_commands_dir(user_home_dir=user_home_dir),
+            project_commands_dir=get_project_commands_dir(project_root=project_root),
+        )
+
+    def discover(self) -> None:
+        with trace_span(
+            logger,
+            component="commands.discovery",
+            operation="discover",
+            attributes={
+                "app_commands_dir": str(self.app_commands_dir),
+                "project_commands_dir": (
+                    str(self.project_commands_dir)
+                    if self.project_commands_dir is not None
+                    else None
+                ),
+            },
+        ):
+            discovered: dict[str, CommandEntry] = {}
+            for scope, base_dir in self._iter_sources():
+                if not base_dir.exists():
+                    continue
+                for path in sorted(base_dir.iterdir()):
+                    if not path.is_file():
+                        continue
+                    match = _COMMAND_FILE_PATTERN.match(path.name)
+                    if match is None:
+                        continue
+                    try:
+                        command = self._load_command(path=path, scope=scope)
+                        if command is not None:
+                            discovered[command.name] = command
+                    except Exception as exc:
+                        logger.warning("Failed to load command at %s: %s", path, exc)
+            with self._lock:
+                self._commands = discovered
+
+    def list_commands(self) -> list[CommandEntry]:
+        with self._lock:
+            return list(self._commands.values())
+
+    def get_command(self, name: str) -> CommandEntry | None:
+        with self._lock:
+            return self._commands.get(name)
+
+    def _iter_sources(self) -> tuple[tuple[CommandScope, Path], ...]:
+        sources: list[tuple[CommandScope, Path]] = []
+        sources.append((CommandScope.APP, self.app_commands_dir))
+        if self.project_commands_dir is not None:
+            sources.append((CommandScope.PROJECT, self.project_commands_dir))
+        return tuple(sources)
+
+    def _load_command(self, *, path: Path, scope: CommandScope) -> CommandEntry | None:
+        with trace_span(
+            logger,
+            component="commands.discovery",
+            operation="load_command",
+            attributes={"path": str(path), "scope": scope.value},
+        ):
+            raw = path.read_text(encoding="utf-8")
+            front_matter, body = _split_front_matter(raw)
+            data = _as_object_mapping(yaml.safe_load(front_matter))
+            if data is None:
+                data = {}
+
+            name = _coerce_string(data.get("name")) or path.stem
+            description = _coerce_string(data.get("description"))
+            argument_hint = _coerce_string(data.get("argument_hint"))
+            allowed_modes_raw = data.get("allowed_modes")
+            if isinstance(allowed_modes_raw, list):
+                allowed_modes = [str(m) for m in allowed_modes_raw]
+            else:
+                allowed_modes = ["normal"]
+
+            return CommandEntry(
+                name=name,
+                description=description,
+                argument_hint=argument_hint,
+                allowed_modes=allowed_modes,
+                body=body.strip(),
+                scope=scope,
+                path=path,
+            )
+
+
+def _split_front_matter(content: str) -> tuple[str, str]:
+    if not content.startswith("---"):
+        return "", content
+
+    lines = content.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return "", content
+
+    end_index = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            end_index = idx
+            break
+
+    if end_index is None:
+        return "", content
+
+    front_matter = "".join(lines[1:end_index])
+    body = "".join(lines[end_index + 1 :])
+    return front_matter, body
+
+
+def _as_object_mapping(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): item for key, item in value.items()}
+
+
+def _coerce_string(value: object) -> str:
+    return value if isinstance(value, str) else ""

--- a/src/relay_teams/commands/registry.py
+++ b/src/relay_teams/commands/registry.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from relay_teams.commands.command_models import (
+    CommandEntry,
+    CommandSummary,
+)
+from relay_teams.commands.discovery import CommandsDirectory
+from relay_teams.logger import get_logger
+from relay_teams.trace import trace_span
+
+LOGGER = get_logger(__name__)
+
+
+class CommandRegistry(BaseModel):
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    directory: CommandsDirectory
+
+    @classmethod
+    def from_default_scopes(
+        cls,
+        *,
+        user_home_dir: Path | None = None,
+        project_root: Path | None = None,
+    ) -> CommandRegistry:
+        return cls(
+            directory=CommandsDirectory.from_default_scopes(
+                user_home_dir=user_home_dir,
+                project_root=project_root,
+            )
+        )
+
+    def list_commands(self) -> tuple[CommandEntry, ...]:
+        with trace_span(
+            LOGGER,
+            component="commands.registry",
+            operation="list_commands",
+        ):
+            self.directory.discover()
+            return tuple(self.directory.list_commands())
+
+    def get_command(self, name: str) -> CommandEntry | None:
+        with trace_span(
+            LOGGER,
+            component="commands.registry",
+            operation="get_command",
+            attributes={"command_name": name},
+        ):
+            self.directory.discover()
+            return self.directory.get_command(name)
+
+    def list_summaries(self) -> tuple[CommandSummary, ...]:
+        return tuple(
+            CommandSummary(
+                name=cmd.name,
+                description=cmd.description,
+                scope=cmd.scope,
+                argument_hint=cmd.argument_hint,
+            )
+            for cmd in self.list_commands()
+        )
+
+    def resolve(self, name: str) -> CommandEntry | None:
+        self.directory.discover()
+        return self.directory.get_command(name)

--- a/src/relay_teams/commands/resolver.py
+++ b/src/relay_teams/commands/resolver.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from relay_teams.commands.command_models import ResolveResult
+from relay_teams.commands.registry import CommandRegistry
+from relay_teams.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+_TEMPLATE_VAR_PATTERN = re.compile(r"\{\{(\w+)\}\}")
+
+
+class CommandResolver:
+    def __init__(
+        self,
+        *,
+        registry: CommandRegistry,
+        workspace_root: Path | None = None,
+    ) -> None:
+        self._registry = registry
+        self._workspace_root = workspace_root or Path.cwd()
+
+    def try_resolve(
+        self,
+        raw_text: str,
+        *,
+        mode: str = "normal",
+    ) -> ResolveResult | None:
+        if not raw_text.startswith("/"):
+            return None
+
+        parts = raw_text[1:].split(maxsplit=1)
+        command_name = parts[0]
+        args = parts[1] if len(parts) > 1 else ""
+
+        command = self._registry.get_command(command_name)
+        if command is None:
+            return None
+
+        if mode not in command.allowed_modes:
+            raise ValueError(
+                f"Command '{command_name}' is not allowed in mode '{mode}'"
+            )
+
+        expanded = _expand_template(
+            command.body,
+            args=args,
+            workspace_root=self._workspace_root,
+        )
+
+        return ResolveResult(
+            command_name=command.name,
+            scope=command.scope,
+            raw_text=raw_text,
+            expanded_prompt=expanded,
+            args=args,
+            prompt_length=len(expanded),
+        )
+
+    def resolve(
+        self,
+        raw_text: str,
+        *,
+        mode: str = "normal",
+    ) -> ResolveResult:
+        result = self.try_resolve(raw_text, mode=mode)
+        if result is None:
+            raise KeyError(f"No command found for: {raw_text}")
+        return result
+
+
+def _expand_template(
+    template: str,
+    *,
+    args: str,
+    workspace_root: Path,
+) -> str:
+    replacements: dict[str, str] = {
+        "args": args,
+        "workspace_root": str(workspace_root),
+        "cwd": str(Path.cwd()),
+    }
+
+    def _replacer(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        return replacements.get(var_name, match.group(0))
+
+    return _TEMPLATE_VAR_PATTERN.sub(_replacer, template)

--- a/src/relay_teams/interfaces/cli/app.py
+++ b/src/relay_teams/interfaces/cli/app.py
@@ -35,6 +35,7 @@ from relay_teams.mcp.mcp_cli import mcp_app
 from relay_teams.paths import get_project_config_dir
 from relay_teams.roles.role_cli import build_roles_app
 from relay_teams.sessions.session_models import SessionMode
+from relay_teams.commands.command_cli import commands_app
 from relay_teams.skills.clawhub_cli import build_clawhub_app
 from relay_teams.skills.skill_cli import skills_app
 
@@ -356,6 +357,7 @@ def _execute_prompt(
     )
 
 
+app.add_typer(commands_app, name="commands")
 app.add_typer(server_app, name="server")
 app.add_typer(roles_app, name="roles")
 app.add_typer(agents_app, name="agents")

--- a/src/relay_teams/interfaces/cli/run_prompt_cli.py
+++ b/src/relay_teams/interfaces/cli/run_prompt_cli.py
@@ -164,13 +164,20 @@ def execute_prompt(
             request_json=request_json,
         )
 
+    effective_message = _resolve_command_if_needed(
+        base_url=base_url,
+        message=message,
+        session_mode=session_mode,
+        request_json=request_json,
+    )
+
     run_response = request_json(
         base_url,
         "POST",
         "/api/runs",
         {
             "session_id": resolved_session_id,
-            "input": [{"kind": "text", "text": message}],
+            "input": [{"kind": "text", "text": effective_message}],
             "execution_mode": execution_mode,
             "yolo": yolo,
         },
@@ -424,3 +431,33 @@ def _available_normal_role_ids_hint(
     if not role_ids:
         return "No normal mode roles are currently configured."
     return "Available normal mode roles: " + ", ".join(role_ids) + "."
+
+
+def _resolve_command_if_needed(
+    *,
+    base_url: str,
+    message: str,
+    session_mode: SessionMode,
+    request_json: RequestJsonCallable,
+) -> str:
+    if not message.startswith("/"):
+        return message
+
+    mode = session_mode.value
+    try:
+        response = request_json(
+            base_url,
+            "POST",
+            "/api/system/commands:resolve",
+            {"text": message, "mode": mode},
+        )
+    except RuntimeError:
+        return message
+
+    if not isinstance(response, dict):
+        return message
+
+    expanded = response.get("expanded_prompt")
+    if isinstance(expanded, str) and expanded:
+        return expanded
+    return message

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -933,6 +933,18 @@ class CommandResolveRequest(BaseModel):
     mode: str = "normal"
 
 
+class CommandDetailResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str
+    argument_hint: str
+    allowed_modes: list[str]
+    body: str
+    scope: str
+    path: str
+
+
 def _get_command_registry() -> CommandRegistry:
     return CommandRegistry.from_default_scopes()
 
@@ -946,21 +958,21 @@ def list_commands() -> list[CommandSummary]:
     return list(registry.list_summaries())
 
 
-@router.get("/commands/{name}")
-def get_command(name: str) -> dict[str, JsonValue]:
+@router.get("/commands/{name}", response_model=CommandDetailResponse)
+def get_command(name: str) -> CommandDetailResponse:
     registry = _get_command_registry()
     command = registry.get_command(name)
     if command is None:
         raise HTTPException(status_code=404, detail=f"Command not found: {name}")
-    return {
-        "name": command.name,
-        "description": command.description,
-        "argument_hint": command.argument_hint,
-        "allowed_modes": command.allowed_modes,
-        "body": command.body,
-        "scope": command.scope.value,
-        "path": command.path.resolve().as_posix(),
-    }
+    return CommandDetailResponse(
+        name=command.name,
+        description=command.description,
+        argument_hint=command.argument_hint,
+        allowed_modes=command.allowed_modes,
+        body=command.body,
+        scope=command.scope.value,
+        path=command.path.resolve().as_posix(),
+    )
 
 
 @router.post("/commands:resolve")

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 from typing import NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, ConfigDict, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
+from relay_teams.commands.command_models import CommandSummary
+from relay_teams.commands.registry import CommandRegistry
+from relay_teams.commands.resolver import CommandResolver
 from relay_teams.env.clawhub_config_models import ClawHubConfig
 from relay_teams.env.clawhub_config_service import ClawHubConfigService
 from relay_teams.env.clawhub_connectivity import (
@@ -921,3 +924,60 @@ def validate_hooks_config(
         return {"status": "ok"}
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+class CommandResolveRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    text: str = Field(min_length=1)
+    mode: str = "normal"
+
+
+def _get_command_registry() -> CommandRegistry:
+    return CommandRegistry.from_default_scopes()
+
+
+@router.get(
+    "/commands",
+    response_model=list[CommandSummary],
+)
+def list_commands() -> list[CommandSummary]:
+    registry = _get_command_registry()
+    return list(registry.list_summaries())
+
+
+@router.get("/commands/{name}")
+def get_command(name: str) -> dict[str, JsonValue]:
+    registry = _get_command_registry()
+    command = registry.get_command(name)
+    if command is None:
+        raise HTTPException(status_code=404, detail=f"Command not found: {name}")
+    return {
+        "name": command.name,
+        "description": command.description,
+        "argument_hint": command.argument_hint,
+        "allowed_modes": command.allowed_modes,
+        "body": command.body,
+        "scope": command.scope.value,
+        "path": command.path.resolve().as_posix(),
+    }
+
+
+@router.post("/commands:resolve")
+def resolve_command(req: CommandResolveRequest) -> dict[str, JsonValue]:
+    registry = _get_command_registry()
+    resolver = CommandResolver(registry=registry)
+    try:
+        result = resolver.resolve(req.text, mode=req.mode)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "command_name": result.command_name,
+        "scope": result.scope.value,
+        "raw_text": result.raw_text,
+        "expanded_prompt": result.expanded_prompt,
+        "args": result.args,
+        "prompt_length": result.prompt_length,
+    }

--- a/tests/unit_tests/commands/__init__.py
+++ b/tests/unit_tests/commands/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/tests/unit_tests/commands/test_commands.py
+++ b/tests/unit_tests/commands/test_commands.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from relay_teams.commands.command_models import CommandScope
+from relay_teams.commands.discovery import CommandsDirectory
+from relay_teams.commands.registry import CommandRegistry
+from relay_teams.commands.resolver import CommandResolver
+
+
+@pytest.fixture()
+def tmp_command_dirs(tmp_path: Path) -> tuple[Path, Path]:
+    app_dir = tmp_path / "app_commands"
+    project_dir = tmp_path / "project_commands"
+    app_dir.mkdir()
+    project_dir.mkdir()
+    return app_dir, project_dir
+
+
+def _write_command(directory: Path, name: str, content: str) -> Path:
+    path = directory / f"{name}.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestDiscovery:
+    def test_discovers_command_without_front_matter(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, project_dir = tmp_command_dirs
+        _write_command(app_dir, "hello", "Say hello to the user.")
+
+        directory = CommandsDirectory(app_commands_dir=app_dir)
+        directory.discover()
+        commands = directory.list_commands()
+
+        assert len(commands) == 1
+        cmd = commands[0]
+        assert cmd.name == "hello"
+        assert cmd.body == "Say hello to the user."
+        assert cmd.scope == CommandScope.APP
+
+    def test_discovers_command_with_front_matter(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        _write_command(
+            app_dir,
+            "review",
+            "---\nname: review\ndescription: Review PR\nargument_hint: <pr_number>\nallowed_modes: [normal]\n---\nReview PR {{args}}.",
+        )
+
+        directory = CommandsDirectory(app_commands_dir=app_dir)
+        directory.discover()
+        commands = directory.list_commands()
+
+        assert len(commands) == 1
+        cmd = commands[0]
+        assert cmd.name == "review"
+        assert cmd.description == "Review PR"
+        assert cmd.argument_hint == "<pr_number>"
+        assert cmd.allowed_modes == ["normal"]
+        assert cmd.body == "Review PR {{args}}."
+
+    def test_project_takes_priority_over_app(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, project_dir = tmp_command_dirs
+        _write_command(app_dir, "deploy", "---\nname: deploy\n---\nApp deploy.")
+        _write_command(project_dir, "deploy", "---\nname: deploy\n---\nProject deploy.")
+
+        directory = CommandsDirectory(
+            app_commands_dir=app_dir,
+            project_commands_dir=project_dir,
+        )
+        directory.discover()
+        cmd = directory.get_command("deploy")
+
+        assert cmd is not None
+        assert cmd.scope == CommandScope.PROJECT
+        assert cmd.body == "Project deploy."
+
+    def test_ignores_non_markdown_files(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        (app_dir / "notes.txt").write_text("not a command", encoding="utf-8")
+        (app_dir / "readme").write_text("also not", encoding="utf-8")
+
+        directory = CommandsDirectory(app_commands_dir=app_dir)
+        directory.discover()
+        assert directory.list_commands() == []
+
+    def test_empty_directory(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        directory = CommandsDirectory(app_commands_dir=app_dir)
+        directory.discover()
+        assert directory.list_commands() == []
+
+
+class TestRegistry:
+    def test_list_summaries(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        _write_command(
+            app_dir,
+            "test",
+            "---\nname: test\ndescription: Run tests\n---\nRun tests.",
+        )
+
+        registry = CommandRegistry(
+            directory=CommandsDirectory(app_commands_dir=app_dir)
+        )
+        summaries = registry.list_summaries()
+
+        assert len(summaries) == 1
+        assert summaries[0].name == "test"
+        assert summaries[0].description == "Run tests"
+
+
+class TestResolver:
+    def test_resolves_command_with_args(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        _write_command(
+            app_dir,
+            "review",
+            "---\nname: review\n---\nPlease review PR #{{args}} in {{workspace_root}}.",
+        )
+
+        registry = CommandRegistry(
+            directory=CommandsDirectory(app_commands_dir=app_dir)
+        )
+        resolver = CommandResolver(registry=registry, workspace_root=Path("/workspace"))
+
+        result = resolver.resolve("/review 42")
+
+        assert result.command_name == "review"
+        assert result.args == "42"
+        assert "PR #42" in result.expanded_prompt
+        assert "/workspace" in result.expanded_prompt
+        assert result.prompt_length > 0
+
+    def test_resolves_command_without_args(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        _write_command(app_dir, "status", "---\nname: status\n---\nShow current status.")
+
+        registry = CommandRegistry(
+            directory=CommandsDirectory(app_commands_dir=app_dir)
+        )
+        resolver = CommandResolver(registry=registry)
+
+        result = resolver.resolve("/status")
+
+        assert result.command_name == "status"
+        assert result.args == ""
+        assert result.expanded_prompt == "Show current status."
+
+    def test_raises_for_unknown_command(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        registry = CommandRegistry(
+            directory=CommandsDirectory(app_commands_dir=app_dir)
+        )
+        resolver = CommandResolver(registry=registry)
+
+        with pytest.raises(KeyError):
+            resolver.resolve("/nonexistent")
+
+    def test_raises_for_wrong_mode(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        _write_command(
+            app_dir,
+            "orch",
+            "---\nname: orch\nallowed_modes: [orchestration]\n---\nOrchestrate.",
+        )
+
+        registry = CommandRegistry(
+            directory=CommandsDirectory(app_commands_dir=app_dir)
+        )
+        resolver = CommandResolver(registry=registry)
+
+        with pytest.raises(ValueError):
+            resolver.resolve("/orch", mode="normal")
+
+    def test_non_slash_text_returns_none(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        _write_command(app_dir, "test", "---\nname: test\n---\nTest.")
+
+        registry = CommandRegistry(
+            directory=CommandsDirectory(app_commands_dir=app_dir)
+        )
+        resolver = CommandResolver(registry=registry)
+
+        assert resolver.try_resolve("hello world") is None
+
+    def test_template_variables(self, tmp_command_dirs: tuple[Path, Path]) -> None:
+        app_dir, _ = tmp_command_dirs
+        _write_command(
+            app_dir,
+            "cwd-cmd",
+            "---\nname: cwd-cmd\n---\nWorkspace: {{workspace_root}}, cwd: {{cwd}}, args: {{args}}.",
+        )
+
+        registry = CommandRegistry(
+            directory=CommandsDirectory(app_commands_dir=app_dir)
+        )
+        resolver = CommandResolver(registry=registry, workspace_root=Path("/ws"))
+
+        result = resolver.resolve("/cwd-cmd foo bar")
+
+        assert "/ws" in result.expanded_prompt
+        assert "foo bar" in result.expanded_prompt


### PR DESCRIPTION
## Summary
- New module `src/relay_teams/commands/` with command_models, discovery, registry, resolver, and CLI.
- Command scope supports `app` and `project`; project takes priority over app for same-name commands.
- Project roots: `<workspace>/.relay-teams/commands` and `.codex/commands`.
- Markdown command files with optional YAML front matter (`name`, `description`, `argument_hint`, `allowed_modes`).
- Template variables: `{{args}}`, `{{workspace_root}}`, `{{cwd}}`.
- New APIs: `GET /api/system/commands`, `GET /api/system/commands/{name}`, `POST /api/system/commands:resolve`.
- New CLI: `relay-teams commands list`, `relay-teams commands show`.
- `run_prompt_cli` resolves slash commands server-side before creating runs.
- 12 unit tests covering discovery, registry, resolver, priority, mode restriction, and template expansion.

## Testing
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright src/relay_teams/commands/`
- `uv run --extra dev pytest -q tests/unit_tests/commands/` (12 passed)
- `uv run --extra dev pytest -q tests/unit_tests` (2381 passed, 5 skipped)
- CLI validation: `relay-teams commands list`, `relay-teams commands show review --format json`
- Direct module tests: discovery, registry, resolver, API router endpoints

Closes #401