### PR TITLE
fix(frontend): restore legacy dispatchHumanTask export

### DIFF
--- a/frontend/dist/js/core/api.js
+++ b/frontend/dist/js/core/api.js
@@ -19,6 +19,7 @@ export {
     deleteAgentReflection,
     updateSession,
     sendUserPrompt,
+    dispatchHumanTask,
     resolveGate,
     resolveToolApproval,
     injectMessage,

--- a/frontend/dist/js/core/api/index.js
+++ b/frontend/dist/js/core/api/index.js
@@ -23,6 +23,7 @@ export {
 } from './sessions.js';
 
 export {
+    dispatchHumanTask,
     fetchRunBackgroundTask,
     fetchRunBackgroundTasks,
     injectMessage,

--- a/frontend/dist/js/core/api/runs.js
+++ b/frontend/dist/js/core/api/runs.js
@@ -54,6 +54,12 @@ export async function resolveToolApproval(runId, toolCallId, action, feedback = 
     );
 }
 
+export async function dispatchHumanTask(_sessionId, _runId, _taskId) {
+    throw new Error(
+        'dispatchHumanTask is deprecated. Reload the page to fetch the current frontend assets.',
+    );
+}
+
 export async function injectMessage(runId, content) {
     return requestJson(
         `/api/runs/${runId}/inject`,

--- a/tests/unit_tests/frontend/test_api_facade_ui.py
+++ b/tests/unit_tests/frontend/test_api_facade_ui.py
@@ -43,6 +43,43 @@ def test_core_api_facade_exports_update_session() -> None:
     assert completed.stdout.strip() == "function"
 
 
+def test_core_api_facade_exports_legacy_dispatch_human_task_alias() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    api_module_path = repo_root / "frontend" / "dist" / "js" / "core" / "api.js"
+
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                "globalThis.document = {"
+                "querySelector() { return null; },"
+                "querySelectorAll() { return []; },"
+                "getElementById() { return null; },"
+                "body: null"
+                "}; "
+                f"const mod = await import({api_module_path.as_uri()!r}); "
+                "console.log(typeof mod.dispatchHumanTask);"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node import failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    assert completed.stdout.strip() == "function"
+
+
 def test_core_api_facade_exports_ui_language_helpers() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     api_module_path = repo_root / "frontend" / "dist" / "js" / "core" / "api.js"


### PR DESCRIPTION
## Summary
- restore `dispatchHumanTask` as a legacy export in the frontend API facade
- add a deprecated compatibility implementation so stale cached modules fail gracefully instead of breaking ESM initialization
- cover the legacy export with a frontend unit test

## Root cause
Browsers can temporarily load a mixed frontend module graph during cache transitions. Older cached modules still import `dispatchHumanTask` from `js/core/api.js`, but the current facade stopped exporting that symbol, which causes module loading to abort with a syntax error.

Fixes #412

## Verification
- `uv run --extra dev ruff check tests/unit_tests/frontend/test_api_facade_ui.py`
- `uv run --extra dev ruff format --check tests/unit_tests/frontend/test_api_facade_ui.py`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`
- `uv run --extra dev pytest -q tests/unit_tests/frontend/test_api_facade_ui.py tests/unit_tests/frontend/test_core_api_facade_exports.py`
- browser reload against `http://127.0.0.1:8000/` with no missing-export console error
