### PR TITLE
test(frontend): cover dispatchHumanTask facade export

### DIFF
--- a/tests/unit_tests/frontend/test_api_facade_ui.py
+++ b/tests/unit_tests/frontend/test_api_facade_ui.py
@@ -43,6 +43,43 @@ def test_core_api_facade_exports_update_session() -> None:
     assert completed.stdout.strip() == "function"
 
 
+def test_core_api_facade_exports_legacy_dispatch_human_task_alias() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    api_module_path = repo_root / "frontend" / "dist" / "js" / "core" / "api.js"
+
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                "globalThis.document = {"
+                "querySelector() { return null; },"
+                "querySelectorAll() { return []; },"
+                "getElementById() { return null; },"
+                "body: null"
+                "}; "
+                f"const mod = await import({api_module_path.as_uri()!r}); "
+                "console.log(typeof mod.dispatchHumanTask);"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node import failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    assert completed.stdout.strip() == "function"
+
+
 def test_core_api_facade_exports_ui_language_helpers() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     api_module_path = repo_root / "frontend" / "dist" / "js" / "core" / "api.js"


### PR DESCRIPTION
## Summary
- resolve the merge conflicts against the latest `main`
- keep the current `main` runtime implementation for `dispatchHumanTask`
- add regression coverage that asserts `js/core/api.js` still exports `dispatchHumanTask`

## Context
`origin/main` now already contains the live `dispatchHumanTask` implementation and related run APIs. After rebasing onto the newer API surface, the meaningful remaining change in this branch is regression coverage for the facade export so the symbol does not disappear again.

Fixes #415

## Verification
- pre-commit hooks on cherry-pick continue: `ruff`, `ruff format`, `basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/frontend/test_api_facade_ui.py tests/unit_tests/frontend/test_core_api_facade_exports.py`
