### PR TITLE
fix(sidebar): lazy load session subagent details

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -748,6 +748,7 @@ Response fields also include:
 - `orchestration_preset_id`
 - `started_at`
 - `can_switch_mode`
+- `subagent_session_count`: summary count of normal-mode child-session subagents so the UI can render expand affordances without fetching `GET /sessions/{session_id}/subagents` for every listed session
 
 ### `PATCH /sessions/{session_id}`
 

--- a/frontend/dist/js/components/sidebar.js
+++ b/frontend/dist/js/components/sidebar.js
@@ -41,10 +41,10 @@ import {
 } from './projectView.js';
 import {
     buildSubagentSessionLabel,
-    ensureSessionSubagents,
     getActiveSubagentSession,
     removeSessionSubagent,
     getSessionSubagentSessions,
+    hasLoadedSessionSubagents,
     isSubagentSessionListExpanded,
     isSubagentSessionListLoading,
     toggleSubagentSessionList,
@@ -235,7 +235,13 @@ function renderSubagentToggle(session) {
         return '';
     }
     const children = getSessionSubagentSessions(sessionId);
-    if (children.length === 0) {
+    const loading = isSubagentSessionListLoading(sessionId);
+    const loaded = hasLoadedSessionSubagents(sessionId);
+    const summaryCount = normalizeSubagentSessionCount(
+        session?.subagent_session_count,
+    );
+    const childCount = loaded ? children.length : summaryCount;
+    if (!loading && childCount === 0) {
         return '';
     }
     const expanded = isSubagentSessionListExpanded(sessionId);
@@ -250,7 +256,7 @@ function renderSubagentToggle(session) {
             aria-label="${escapeHtml(t('sidebar.subagent_sessions_toggle'))}"
         >
             <span class="session-subagents-toggle-icon" aria-hidden="true">${icon}</span>
-            <span class="session-subagents-toggle-count">${escapeHtml(String(children.length))}</span>
+            <span class="session-subagents-toggle-count">${escapeHtml(String(childCount))}</span>
         </button>
     `;
 }
@@ -347,6 +353,14 @@ function formatRelativeTime(value) {
     const diffMonths = Math.round(diffDays / 30);
     if (diffMonths < 12) return `${diffMonths}${t('time.month_short')}`;
     return `${Math.round(diffDays / 365)}${t('time.year_short')}`;
+}
+
+function normalizeSubagentSessionCount(value) {
+    const parsed = Number(value || 0);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return 0;
+    }
+    return Math.floor(parsed);
 }
 
 function formatWorkspaceLabel(workspace) {
@@ -1041,39 +1055,6 @@ function renderProjectCard(group) {
     return card;
 }
 
-function prefetchVisibleSubagentSessions(groups) {
-    const sessionIds = new Set();
-    const currentSessionId = String(state.currentSessionId || '').trim();
-    groups.forEach(group => {
-        const sessionsExpanded = expandedProjectSessionIds.has(group.key);
-        const visibleSessions = visibleSessionsForGroup(group, {
-            sessionsExpanded,
-        });
-        visibleSessions.forEach(session => {
-            const sessionId = String(session?.session_id || '').trim();
-            if (sessionId && shouldRenderSubagentChildren(session)) {
-                sessionIds.add(sessionId);
-            }
-        });
-        if (!currentSessionId) {
-            return;
-        }
-        const currentSession = group.sessions.find(session => String(session?.session_id || '').trim() === currentSessionId);
-        if (currentSession && shouldRenderSubagentChildren(currentSession)) {
-            sessionIds.add(currentSessionId);
-        }
-    });
-    sessionIds.forEach(sessionId => {
-        if (isSubagentSessionListLoading(sessionId)) {
-            return;
-        }
-        void ensureSessionSubagents(sessionId, {
-            force: false,
-            emitLoadingEvents: false,
-        });
-    });
-}
-
 function visibleSessionsForGroup(group, { sessionsExpanded = false } = {}) {
     if (sessionsExpanded) {
         return group.sessions;
@@ -1149,14 +1130,12 @@ export async function loadProjects() {
         groups.forEach(group => nextNodes.push(renderProjectCard(group)));
         const nextSignature = nextNodes.map(renderNodeSignature).join('\n');
         if (nextSignature === lastProjectsRenderSignature) {
-            prefetchVisibleSubagentSessions(groups);
             return;
         }
         lastProjectsRenderSignature = nextSignature;
         els.projectsList.innerHTML = '';
         nextNodes.forEach(node => els.projectsList.appendChild(node));
         syncProjectSortButton();
-        prefetchVisibleSubagentSessions(groups);
         playPendingSessionAnimation();
     } catch (error) {
         if (requestId !== loadProjectsRequestId) {

--- a/frontend/dist/js/components/subagentSessions.js
+++ b/frontend/dist/js/components/subagentSessions.js
@@ -23,6 +23,10 @@ export function getSessionSubagentSessions(sessionId) {
     return [...(subagentSessionsBySessionId.get(String(sessionId || '').trim()) || [])];
 }
 
+export function hasLoadedSessionSubagents(sessionId) {
+    return subagentSessionsBySessionId.has(String(sessionId || '').trim());
+}
+
 export function isSubagentSessionListExpanded(sessionId) {
     return expandedParentSessionIds.has(String(sessionId || '').trim());
 }

--- a/src/relay_teams/agents/instances/instance_repository.py
+++ b/src/relay_teams/agents/instances/instance_repository.py
@@ -11,6 +11,8 @@ from relay_teams.agents.instances.models import AgentRuntimeRecord
 from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
 from relay_teams.workspace import build_conversation_id
 
+_SQLITE_SAFE_VARIABLE_LIMIT = 900
+
 
 class AgentInstanceRepository:
     def __init__(self, db_path: Path) -> None:
@@ -240,6 +242,33 @@ class AgentInstanceRepository:
                 (session_id,),
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    def count_normal_mode_subagents_by_session_ids(
+        self,
+        session_ids: tuple[str, ...],
+    ) -> dict[str, int]:
+        if len(session_ids) == 0:
+            return {}
+        subagent_counts: dict[str, int] = {}
+        with self._lock:
+            for index in range(0, len(session_ids), _SQLITE_SAFE_VARIABLE_LIMIT):
+                session_id_chunk = session_ids[
+                    index : index + _SQLITE_SAFE_VARIABLE_LIMIT
+                ]
+                placeholders = ", ".join("?" for _ in session_id_chunk)
+                rows = self._conn.execute(
+                    f"""
+                    SELECT session_id, COUNT(*) AS subagent_count
+                    FROM agent_instances
+                    WHERE session_id IN ({placeholders})
+                      AND run_id GLOB 'subagent_run_*'
+                    GROUP BY session_id
+                    """,
+                    session_id_chunk,
+                ).fetchall()
+                for row in rows:
+                    subagent_counts[str(row["session_id"])] = int(row["subagent_count"])
+        return subagent_counts
 
     def list_session_role_instances(
         self, session_id: str

--- a/src/relay_teams/sessions/session_models.py
+++ b/src/relay_teams/sessions/session_models.py
@@ -253,6 +253,7 @@ class SessionRecord(BaseModel):
     active_run_status: str | None = None
     active_run_phase: str | None = None
     pending_tool_approval_count: int = 0
+    subagent_session_count: int = 0
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
 

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -701,11 +701,26 @@ class SessionService:
 
     def list_sessions(self) -> tuple[SessionRecord, ...]:
         sessions = self._session_repo.list_all()
+        normal_session_ids = tuple(
+            record.session_id
+            for record in sessions
+            if record.session_mode == SessionMode.NORMAL
+        )
+        subagent_counts = self._agent_repo.count_normal_mode_subagents_by_session_ids(
+            normal_session_ids
+        )
         enriched: list[SessionRecord] = []
         for record in sessions:
             selected = self._select_active_run(record.session_id)
+            subagent_session_count = subagent_counts.get(record.session_id, 0)
             if selected is None:
-                enriched.append(record)
+                enriched.append(
+                    record.model_copy(
+                        update={
+                            "subagent_session_count": subagent_session_count,
+                        }
+                    )
+                )
                 continue
             run_id, runtime = selected
             approval_count = len(self._approval_ticket_repo.list_open_by_run(run_id))
@@ -722,6 +737,7 @@ class SessionService:
                             question_count,
                         ),
                         "pending_tool_approval_count": approval_count,
+                        "subagent_session_count": subagent_session_count,
                     }
                 )
             )

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -1845,6 +1845,64 @@ def test_browser_workspace_and_automation_project_views(
     )
 
 
+def test_browser_sidebar_lazy_loads_subagent_sessions_on_initial_open(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+    api_client: httpx.Client,
+    tmp_path: Path,
+) -> None:
+    workspace_count = 4
+    sessions_per_workspace = 12
+    for index in range(workspace_count):
+        workspace_id = f"perf-workspace-{index}-{uuid4().hex[:6]}"
+        workspace_root = tmp_path / workspace_id
+        workspace_root.mkdir(parents=True, exist_ok=True)
+        (workspace_root / "README.md").write_text(
+            f"Workspace {index}.\n",
+            encoding="utf-8",
+        )
+        workspace_response = api_client.post(
+            "/api/workspaces",
+            json={
+                "workspace_id": workspace_id,
+                "root_path": str(workspace_root),
+            },
+        )
+        workspace_response.raise_for_status()
+        for _ in range(sessions_per_workspace):
+            session_response = api_client.post(
+                "/api/sessions",
+                json={"workspace_id": workspace_id},
+            )
+            session_response.raise_for_status()
+
+    page = browser_page
+    subagent_request_urls: list[str] = []
+    page.on(
+        "request",
+        lambda request: (
+            subagent_request_urls.append(request.url)
+            if (
+                request.method == "GET"
+                and request.url.startswith(
+                    f"{integration_env.api_base_url}/api/sessions/"
+                )
+                and request.url.endswith("/subagents")
+            )
+            else None
+        ),
+    )
+
+    _open_app(page, integration_env)
+    expect(page.locator(".session-item.active")).to_have_count(
+        1,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    page.wait_for_timeout(2500)
+
+    assert len(subagent_request_urls) == 1
+
+
 def _open_app(page: Page, integration_env: IntegrationEnvironment) -> None:
     page.goto(integration_env.api_base_url, wait_until="domcontentloaded")
     expect(page.locator("#backend-status-label")).to_contain_text(

--- a/tests/unit_tests/frontend/test_projects_sidebar_ui.py
+++ b/tests/unit_tests/frontend/test_projects_sidebar_ui.py
@@ -348,7 +348,7 @@ export async function runAutomationProject() {
     }
 
 
-def test_projects_sidebar_prefetches_visible_normal_session_subagent_counts_and_hides_zero_toggle(
+def test_projects_sidebar_uses_session_summary_for_subagent_toggle_without_prefetch(
     tmp_path: Path,
 ) -> None:
     payload = _run_sidebar_script(
@@ -372,8 +372,6 @@ globalThis.__sessionSubagentFetchResults = {
     "session-2": [],
 };
 
-await loadProjects();
-await flushTasks();
 await loadProjects();
 
 const projectsList = document.getElementById("projects-list");
@@ -407,6 +405,7 @@ const sessions = [
         session_mode: "normal",
         updated_at: "2026-03-14T10:11:00Z",
         pending_tool_approval_count: 0,
+        subagent_session_count: 1,
         metadata: { title: "Root session 1" },
     },
     {
@@ -415,6 +414,7 @@ const sessions = [
         session_mode: "normal",
         updated_at: "2026-03-14T10:10:00Z",
         pending_tool_approval_count: 0,
+        subagent_session_count: 0,
         metadata: { title: "Root session 2" },
     },
     {
@@ -495,13 +495,129 @@ export async function runAutomationProject() {
     ).read_text(encoding="utf-8")
 
     ensure_calls = cast(list[str], payload["ensureCalls"])
-    assert sorted(set(ensure_calls)) == ["session-1", "session-2"]
+    assert ensure_calls == []
     assert payload["toggleCount"] == 1
     assert payload["firstToggleSessionId"] == "session-1"
     assert (
         "${renderSubagentToggle(session)}\n"
         '                                            <span class="session-id">'
     ) in sidebar_script
+
+
+def test_projects_sidebar_hides_stale_summary_toggle_after_empty_subagent_list_load(
+    tmp_path: Path,
+) -> None:
+    payload = _run_sidebar_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import {
+    loadProjects,
+} from "./sidebar.mjs";
+
+globalThis.__sessionSubagentSessionsMap = {
+    "session-1": [],
+};
+globalThis.__expandedSubagentSessionIds.add("session-1");
+
+await loadProjects();
+
+const projectsList = document.getElementById("projects-list");
+const firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
+const toggles = firstProject.querySelectorAll(".session-subagents-toggle");
+
+console.log(JSON.stringify({
+    toggleCount: toggles.length,
+}));
+""".strip(),
+        mock_api_source="""
+const workspaces = [
+    {
+        workspace_id: "alpha-project",
+        root_path: "/work/Alpha Project",
+        updated_at: "2026-03-14T10:00:00Z",
+        profile: {
+            file_scope: {
+                backend: "project",
+            },
+        },
+    },
+];
+
+const sessions = [
+    {
+        session_id: "session-1",
+        workspace_id: "alpha-project",
+        session_mode: "normal",
+        updated_at: "2026-03-14T10:11:00Z",
+        pending_tool_approval_count: 0,
+        subagent_session_count: 1,
+        metadata: { title: "Root session 1" },
+    },
+];
+
+export async function fetchWorkspaces() {
+    return workspaces;
+}
+
+export async function fetchSessions() {
+    return sessions;
+}
+
+export async function fetchAutomationProjects() {
+    return [];
+}
+
+export async function fetchAutomationFeishuBindings() {
+    return [];
+}
+
+export async function startNewSession() {
+    throw new Error("not used");
+}
+
+export async function updateSession() {
+    return { status: "ok" };
+}
+
+export async function pickWorkspace() {
+    throw new Error("not used");
+}
+
+export async function forkWorkspace() {
+    throw new Error("not used");
+}
+
+export async function deleteSession() {
+    return undefined;
+}
+
+export async function deleteWorkspace() {
+    return { status: "ok" };
+}
+
+export async function createAutomationProject() {
+    throw new Error("not used");
+}
+
+export async function deleteAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function disableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function enableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function runAutomationProject() {
+    throw new Error("not used");
+}
+""".strip(),
+    )
+
+    assert payload["toggleCount"] == 0
 
 
 def test_projects_sidebar_deletes_subagent_child_session_and_returns_to_parent(
@@ -2737,6 +2853,14 @@ export function getActiveSubagentSession() {
 
 export function getSessionSubagentSessions(sessionId) {
     return readRows(String(sessionId || "").trim());
+}
+
+export function hasLoadedSessionSubagents(sessionId) {
+    const safeSessionId = String(sessionId || "").trim();
+    return Object.prototype.hasOwnProperty.call(
+        globalThis.__sessionSubagentSessionsMap || {},
+        safeSessionId,
+    );
 }
 
 export async function ensureSessionSubagents(sessionId) {

--- a/tests/unit_tests/sessions/test_session_list_status.py
+++ b/tests/unit_tests/sessions/test_session_list_status.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 import sqlite3
 
+from relay_teams.agents.instances import instance_repository as instance_repo_module
 from relay_teams.sessions.session_service import SessionService
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
@@ -126,6 +127,122 @@ def test_list_sessions_uses_runtime_overlay_for_running_subagent(
     assert active.active_run_status == "paused"
     assert active.active_run_phase == "awaiting_subagent_followup"
     assert active.pending_tool_approval_count == 0
+
+
+def test_list_sessions_includes_normal_mode_subagent_count(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_list_subagent_count.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-main", workspace_id="default")
+    _ = service.create_session(session_id="session-empty", workspace_id="default")
+
+    from relay_teams.agents.instances.enums import InstanceStatus
+
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="subagent_run_one",
+        trace_id="subagent_run_one",
+        session_id="session-main",
+        instance_id="inst-sub-1",
+        role_id="Explorer",
+        workspace_id="default",
+        conversation_id="conv_session_main_explorer_inst_sub_1",
+        status=InstanceStatus.COMPLETED,
+    )
+    agent_repo.upsert_instance(
+        run_id="subagent_run_two",
+        trace_id="subagent_run_two",
+        session_id="session-main",
+        instance_id="inst-sub-2",
+        role_id="Crafter",
+        workspace_id="default",
+        conversation_id="conv_session_main_crafter_inst_sub_2",
+        status=InstanceStatus.COMPLETED,
+    )
+    agent_repo.upsert_instance(
+        run_id="run-root-main",
+        trace_id="run-root-main",
+        session_id="session-main",
+        instance_id="inst-main",
+        role_id="MainAgent",
+        workspace_id="default",
+        conversation_id="conv_session_main_mainagent",
+        status=InstanceStatus.COMPLETED,
+    )
+
+    sessions = {record.session_id: record for record in service.list_sessions()}
+
+    assert sessions["session-main"].subagent_session_count == 2
+    assert sessions["session-empty"].subagent_session_count == 0
+
+
+def test_list_sessions_ignores_legacy_hyphenated_subagent_run_ids_in_summary(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_list_subagent_count_legacy.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-main", workspace_id="default")
+
+    from relay_teams.agents.instances.enums import InstanceStatus
+
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="subagent-run-legacy",
+        trace_id="subagent-run-legacy",
+        session_id="session-main",
+        instance_id="inst-sub-legacy",
+        role_id="Explorer",
+        workspace_id="default",
+        conversation_id="conv_session_main_explorer_inst_sub_legacy",
+        status=InstanceStatus.COMPLETED,
+    )
+
+    sessions = {record.session_id: record for record in service.list_sessions()}
+
+    assert sessions["session-main"].subagent_session_count == 0
+
+
+def test_list_sessions_chunks_subagent_summary_queries(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "session_list_subagent_count_chunked.db"
+    monkeypatch.setattr(instance_repo_module, "_SQLITE_SAFE_VARIABLE_LIMIT", 2)
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-first", workspace_id="default")
+    _ = service.create_session(session_id="session-middle", workspace_id="default")
+    _ = service.create_session(session_id="session-last", workspace_id="default")
+
+    from relay_teams.agents.instances.enums import InstanceStatus
+
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="subagent_run_first",
+        trace_id="subagent_run_first",
+        session_id="session-first",
+        instance_id="inst-sub-first",
+        role_id="Explorer",
+        workspace_id="default",
+        conversation_id="conv_session_first_explorer_inst_sub_first",
+        status=InstanceStatus.COMPLETED,
+    )
+    agent_repo.upsert_instance(
+        run_id="subagent_run_last",
+        trace_id="subagent_run_last",
+        session_id="session-last",
+        instance_id="inst-sub-last",
+        role_id="Crafter",
+        workspace_id="default",
+        conversation_id="conv_session_last_crafter_inst_sub_last",
+        status=InstanceStatus.COMPLETED,
+    )
+
+    sessions = {record.session_id: record for record in service.list_sessions()}
+
+    assert sessions["session-first"].subagent_session_count == 1
+    assert sessions["session-middle"].subagent_session_count == 0
+    assert sessions["session-last"].subagent_session_count == 1
 
 
 def test_list_sessions_skips_invalid_persisted_run_runtime_rows(


### PR DESCRIPTION
## Summary

  - stop eagerly fetching subagent session details for visible normal-mode sessions in the sidebar
  - add `subagent_session_count` to session list responses so the sidebar can render the expand toggle and count from summary data
  - only load full subagent session details when the user expands a session
  - preserve existing empty/loading behavior for expanded subagent lists

  ## Why

  The sidebar was prefetching subagent details during project/session list rendering, which adds unnecessary work and extra requests even when users never expand those session rows.

  This change keeps the sidebar responsive by using lightweight summary counts first, then fetching the detailed subagent list on demand.

  ## Changes

  - backend:
    - include normal-mode subagent counts in `SessionService.list_sessions()`
    - ignore legacy non-normal-mode style subagent identifiers in the summary count
    - document the new session summary field in `docs/api-design.md`

  - frontend:
    - remove sidebar prefetch of visible subagent sessions
    - render subagent toggle/count from `subagent_session_count` when cached children are not loaded yet
    - keep detail fetch tied to explicit expand actions

  - tests:
    - add unit coverage for session summary subagent counts
    - update sidebar UI coverage for count-driven rendering
    - add browser coverage for the lazy-load sidebar flow

  ## Validation

  - unit tests updated under:
    - `tests/unit_tests/sessions/test_session_list_status.py`
    - `tests/unit_tests/frontend/test_projects_sidebar_ui.py`
  - integration/browser coverage updated under:
    - `tests/integration_tests/browser/test_browser_smoke.py`

Fixes #437