### PR TITLE
[codex] Add tool_search discovery tool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pyright: reportMissingModuleSource=false
 from __future__ import annotations
 
 import importlib.util

--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -4247,7 +4247,10 @@ class AgentLlmSession:
         committed_tool_validation_failures = self._has_tool_input_validation_failures(
             raw_ready
         )
-        ready = self._normalize_committable_messages(raw_ready)
+        ready = self._normalize_committable_messages(
+            raw_ready,
+            instance_id=request.instance_id,
+        )
         self._message_repo.append(
             session_id=request.session_id,
             workspace_id=self._workspace_id(request),
@@ -4336,6 +4339,8 @@ class AgentLlmSession:
     def _normalize_committable_messages(
         self,
         messages: Sequence[ModelRequest | ModelResponse],
+        *,
+        instance_id: str = "",
     ) -> list[ModelRequest | ModelResponse]:
         normalized: list[ModelRequest | ModelResponse] = []
         for message in messages:
@@ -4353,6 +4358,7 @@ class AgentLlmSession:
                             content=build_tool_error_result(
                                 error_code="tool_input_validation_failed",
                                 message=self._normalize_tool_retry_prompt_message(
+                                    instance_id=instance_id,
                                     tool_name=str(part.tool_name or ""),
                                     message=str(part.content or "").strip(),
                                 ),
@@ -4371,6 +4377,7 @@ class AgentLlmSession:
     def _normalize_tool_retry_prompt_message(
         self,
         *,
+        instance_id: str,
         tool_name: str,
         message: str,
     ) -> str:
@@ -4385,13 +4392,45 @@ class AgentLlmSession:
                 "not a valid tool",
                 "tool is not available",
             )
-        ):
+        ) and self._runtime_has_deferred_tool_discovery(instance_id):
             return (
                 f"{normalized_message} If `{tool_name}` is an authorized local tool "
                 "that is currently deferred, use `tool_search` to inspect it and "
                 "`activate_tools` before retrying."
             )
         return normalized_message
+
+    def _runtime_has_deferred_tool_discovery(self, instance_id: str) -> bool:
+        if not instance_id:
+            return False
+        agent_repo = getattr(self, "_agent_repo", None)
+        if agent_repo is None or not hasattr(agent_repo, "get_instance"):
+            return False
+        try:
+            runtime_record = agent_repo.get_instance(instance_id)
+        except KeyError:
+            return False
+        raw_snapshot = str(getattr(runtime_record, "runtime_tools_json", "")).strip()
+        if not raw_snapshot:
+            return False
+        try:
+            parsed = json.loads(raw_snapshot)
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(parsed, dict):
+            return False
+        local_tools = parsed.get("local_tools")
+        if not isinstance(local_tools, list):
+            return False
+        local_tool_names = {
+            str(entry.get("name", "")).strip()
+            for entry in local_tools
+            if isinstance(entry, dict)
+        }
+        return {
+            "tool_search",
+            "activate_tools",
+        }.issubset(local_tool_names)
 
     @staticmethod
     def _normalize_tool_call_args_for_replay(

--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -4352,8 +4352,10 @@ class AgentLlmSession:
                             tool_call_id=part.tool_call_id,
                             content=build_tool_error_result(
                                 error_code="tool_input_validation_failed",
-                                message=str(part.content or "").strip()
-                                or "Tool input validation failed.",
+                                message=self._normalize_tool_retry_prompt_message(
+                                    tool_name=str(part.tool_name or ""),
+                                    message=str(part.content or "").strip(),
+                                ),
                             ),
                         )
                     )
@@ -4365,6 +4367,31 @@ class AgentLlmSession:
                 continue
             normalized.append(message)
         return normalized
+
+    def _normalize_tool_retry_prompt_message(
+        self,
+        *,
+        tool_name: str,
+        message: str,
+    ) -> str:
+        normalized_message = message.strip() or "Tool input validation failed."
+        lowered_message = normalized_message.casefold()
+        if any(
+            phrase in lowered_message
+            for phrase in (
+                "unknown tool",
+                "tool not found",
+                "not in the tool list",
+                "not a valid tool",
+                "tool is not available",
+            )
+        ):
+            return (
+                f"{normalized_message} If `{tool_name}` is an authorized local tool "
+                "that is currently deferred, use `tool_search` to inspect it and "
+                "`activate_tools` before retrying."
+            )
+        return normalized_message
 
     @staticmethod
     def _normalize_tool_call_args_for_replay(

--- a/src/relay_teams/agents/execution/system_prompts.py
+++ b/src/relay_teams/agents/execution/system_prompts.py
@@ -132,6 +132,7 @@ class RuntimePromptBuildInput(BaseModel):
     ssh_profile_metadata: tuple[WorkspaceSshProfilePromptMetadata, ...] = ()
     conversation_context: RuntimePromptConversationContext | None = None
     runtime_tools: RuntimeToolsSnapshot | None = None
+    runtime_active_local_tools: tuple[str, ...] = ()
 
 
 class PromptSkillInstruction(BaseModel):
@@ -584,7 +585,10 @@ async def build_runtime_system_prompt_result(
     workspace_context_sections.extend(loaded_instructions.sections)
     if _is_feishu_group_conversation(data.conversation_context):
         workspace_context_sections.append(FEISHU_GROUP_CONTEXT_PROMPT)
-    runtime_tools_prompt = build_runtime_tools_prompt(data.runtime_tools)
+    runtime_tools_prompt = build_runtime_tools_prompt(
+        data.runtime_tools,
+        runtime_active_local_tools=data.runtime_active_local_tools,
+    )
     if runtime_tools_prompt:
         workspace_context_sections.append(runtime_tools_prompt)
 
@@ -718,7 +722,11 @@ def build_skill_instructions_prompt(
     )
 
 
-def build_runtime_tools_prompt(runtime_tools: RuntimeToolsSnapshot | None) -> str:
+def build_runtime_tools_prompt(
+    runtime_tools: RuntimeToolsSnapshot | None,
+    *,
+    runtime_active_local_tools: tuple[str, ...] = (),
+) -> str:
     if runtime_tools is None:
         return ""
     total_tools = (
@@ -726,13 +734,33 @@ def build_runtime_tools_prompt(runtime_tools: RuntimeToolsSnapshot | None) -> st
         + len(runtime_tools.skill_tools)
         + len(runtime_tools.mcp_tools)
     )
-    discovery_authorized = "tool_search" in set(_tool_names(runtime_tools.local_tools))
+    local_tool_names = _tool_names(runtime_tools.local_tools)
+    local_tool_name_set = set(local_tool_names)
+    active_local_tool_names = tuple(
+        tool_name
+        for tool_name in runtime_active_local_tools
+        if tool_name in local_tool_name_set
+    )
+    discovery_authorized = "tool_search" in local_tool_name_set
     lines = [AUTHORIZED_RUNTIME_TOOLS_HEADING]
     lines.append("- Only call tools that are authorized for this runtime.")
-    if discovery_authorized:
-        lines.append(
-            "- Use `tool_search` to discover authorized tools and inspect parameter schemas before calling unfamiliar tools."
+    lines.append(
+        "- Active Local Tools: "
+        + (
+            _format_names(active_local_tool_names)
+            if active_local_tool_names
+            else NONE_LABEL
         )
+    )
+    if discovery_authorized:
+        activation_authorized = "activate_tools" in local_tool_name_set
+        lines.append(
+            "- Use `tool_search` to discover authorized tools, inspect parameter schemas, and check whether local tools are currently active or deferred."
+        )
+        if activation_authorized:
+            lines.append(
+                "- If `tool_search` marks a local tool as `deferred`, call `activate_tools` before trying to use it."
+            )
         lines.append(
             "- Tool names and descriptions are intentionally summarized here to keep the prompt compact."
         )
@@ -740,9 +768,7 @@ def build_runtime_tools_prompt(runtime_tools: RuntimeToolsSnapshot | None) -> st
         lines.append(
             "- Discovery tooling is unavailable in this runtime, so explicit authorized tool names are listed below."
         )
-        lines.append(
-            "- Local Tools: " + _format_names(_tool_names(runtime_tools.local_tools))
-        )
+        lines.append("- Local Tools: " + _format_names(local_tool_names))
         lines.append(
             "- Skill Tools: " + _format_names(_tool_names(runtime_tools.skill_tools))
         )

--- a/src/relay_teams/agents/execution/system_prompts.py
+++ b/src/relay_teams/agents/execution/system_prompts.py
@@ -726,15 +726,26 @@ def build_runtime_tools_prompt(runtime_tools: RuntimeToolsSnapshot | None) -> st
         + len(runtime_tools.skill_tools)
         + len(runtime_tools.mcp_tools)
     )
+    discovery_authorized = "tool_search" in set(_tool_names(runtime_tools.local_tools))
     lines = [AUTHORIZED_RUNTIME_TOOLS_HEADING]
     lines.append("- Only call tools that are authorized for this runtime.")
-    if "tool_search" in set(_tool_names(runtime_tools.local_tools)):
+    if discovery_authorized:
         lines.append(
             "- Use `tool_search` to discover authorized tools and inspect parameter schemas before calling unfamiliar tools."
         )
-    lines.append(
-        "- Tool names and descriptions are intentionally summarized here to keep the prompt compact."
-    )
+        lines.append(
+            "- Tool names and descriptions are intentionally summarized here to keep the prompt compact."
+        )
+    else:
+        lines.append(
+            "- Discovery tooling is unavailable in this runtime, so explicit authorized tool names are listed below."
+        )
+        lines.append(
+            "- Local Tools: " + _format_names(_tool_names(runtime_tools.local_tools))
+        )
+        lines.append(
+            "- Skill Tools: " + _format_names(_tool_names(runtime_tools.skill_tools))
+        )
     lines.extend(_build_todo_guidance(runtime_tools))
     lines.append(f"- Total Authorized Tools: {total_tools}")
     lines.append(f"- Local Tools: {len(runtime_tools.local_tools)} authorized")
@@ -888,6 +899,7 @@ def _append_available_subagents_prompt(
 def _format_mcp_tool_lines(runtime_tools: RuntimeToolsSnapshot) -> list[str]:
     if not runtime_tools.mcp_tools:
         return ["- MCP Tools: 0 authorized"]
+    discovery_authorized = "tool_search" in set(_tool_names(runtime_tools.local_tools))
     grouped: dict[str, list[str]] = {}
     for entry in runtime_tools.mcp_tools:
         server_name = entry.server_name or "unknown"
@@ -895,8 +907,16 @@ def _format_mcp_tool_lines(runtime_tools: RuntimeToolsSnapshot) -> list[str]:
     lines: list[str] = [
         f"- MCP Tools: {len(runtime_tools.mcp_tools)} authorized across {len(grouped)} server(s)"
     ]
+    if discovery_authorized:
+        for server_name in sorted(grouped.keys()):
+            lines.append(
+                f"- MCP Tool Server: {server_name} ({len(grouped[server_name])})"
+            )
+        return lines
     for server_name in sorted(grouped.keys()):
-        lines.append(f"- MCP Tool Server: {server_name} ({len(grouped[server_name])})")
+        lines.append(
+            f"- MCP Tools {server_name}: {', '.join(sorted(grouped[server_name]))}"
+        )
     return lines
 
 

--- a/src/relay_teams/agents/execution/system_prompts.py
+++ b/src/relay_teams/agents/execution/system_prompts.py
@@ -721,15 +721,24 @@ def build_skill_instructions_prompt(
 def build_runtime_tools_prompt(runtime_tools: RuntimeToolsSnapshot | None) -> str:
     if runtime_tools is None:
         return ""
-    lines = [AUTHORIZED_RUNTIME_TOOLS_HEADING]
-    lines.append("- Only call tools that appear in this runtime-authorized list.")
-    lines.append(
-        "- Local Tools: " + _format_names(_tool_names(runtime_tools.local_tools))
+    total_tools = (
+        len(runtime_tools.local_tools)
+        + len(runtime_tools.skill_tools)
+        + len(runtime_tools.mcp_tools)
     )
+    lines = [AUTHORIZED_RUNTIME_TOOLS_HEADING]
+    lines.append("- Only call tools that are authorized for this runtime.")
+    if "tool_search" in set(_tool_names(runtime_tools.local_tools)):
+        lines.append(
+            "- Use `tool_search` to discover authorized tools and inspect parameter schemas before calling unfamiliar tools."
+        )
     lines.append(
-        "- Skill Tools: " + _format_names(_tool_names(runtime_tools.skill_tools))
+        "- Tool names and descriptions are intentionally summarized here to keep the prompt compact."
     )
     lines.extend(_build_todo_guidance(runtime_tools))
+    lines.append(f"- Total Authorized Tools: {total_tools}")
+    lines.append(f"- Local Tools: {len(runtime_tools.local_tools)} authorized")
+    lines.append(f"- Skill Tools: {len(runtime_tools.skill_tools)} authorized")
     lines.extend(_format_mcp_tool_lines(runtime_tools))
     return "\n".join(lines)
 
@@ -878,17 +887,16 @@ def _append_available_subagents_prompt(
 
 def _format_mcp_tool_lines(runtime_tools: RuntimeToolsSnapshot) -> list[str]:
     if not runtime_tools.mcp_tools:
-        return ["- MCP Tools: none"]
+        return ["- MCP Tools: 0 authorized"]
     grouped: dict[str, list[str]] = {}
     for entry in runtime_tools.mcp_tools:
         server_name = entry.server_name or "unknown"
         grouped.setdefault(server_name, []).append(entry.name)
-    lines: list[str] = []
-    for index, server_name in enumerate(sorted(grouped.keys())):
-        prefix = "- MCP Tools: " if index == 0 else "- MCP Tools "
-        lines.append(
-            f"{prefix}{server_name}: {', '.join(sorted(grouped[server_name]))}"
-        )
+    lines: list[str] = [
+        f"- MCP Tools: {len(runtime_tools.mcp_tools)} authorized across {len(grouped)} server(s)"
+    ]
+    for server_name in sorted(grouped.keys()):
+        lines.append(f"- MCP Tool Server: {server_name} ({len(grouped[server_name])})")
     return lines
 
 

--- a/src/relay_teams/agents/instances/instance_repository.py
+++ b/src/relay_teams/agents/instances/instance_repository.py
@@ -37,6 +37,7 @@ class AgentInstanceRepository:
                     status TEXT NOT NULL,
                     runtime_system_prompt TEXT NOT NULL DEFAULT '',
                     runtime_tools_json TEXT NOT NULL DEFAULT '',
+                    runtime_active_tools_json TEXT NOT NULL DEFAULT '',
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 )
@@ -63,6 +64,10 @@ class AgentInstanceRepository:
             if "runtime_tools_json" not in columns:
                 self._conn.execute(
                     "ALTER TABLE agent_instances ADD COLUMN runtime_tools_json TEXT NOT NULL DEFAULT ''"
+                )
+            if "runtime_active_tools_json" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE agent_instances ADD COLUMN runtime_active_tools_json TEXT NOT NULL DEFAULT ''"
                 )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_agent_instances_run_status ON agent_instances(run_id, status)"
@@ -102,8 +107,8 @@ class AgentInstanceRepository:
             db_path=self._db_path,
             operation=lambda: self._conn.execute(
                 """
-                INSERT INTO agent_instances(run_id, trace_id, session_id, instance_id, role_id, workspace_id, conversation_id, status, runtime_system_prompt, runtime_tools_json, created_at, updated_at)
-                VALUES(?, ?, ?, ?, ?, ?, ?, ?, '', '', ?, ?)
+                INSERT INTO agent_instances(run_id, trace_id, session_id, instance_id, role_id, workspace_id, conversation_id, status, runtime_system_prompt, runtime_tools_json, runtime_active_tools_json, created_at, updated_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, '', '', '', ?, ?)
                 ON CONFLICT(instance_id)
                 DO UPDATE SET
                     run_id=excluded.run_id,
@@ -139,6 +144,7 @@ class AgentInstanceRepository:
         *,
         runtime_system_prompt: str,
         runtime_tools_json: str,
+        runtime_active_tools_json: str = "",
     ) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
         run_sqlite_write_with_retry(
@@ -147,10 +153,16 @@ class AgentInstanceRepository:
             operation=lambda: self._conn.execute(
                 """
                 UPDATE agent_instances
-                SET runtime_system_prompt=?, runtime_tools_json=?, updated_at=?
+                SET runtime_system_prompt=?, runtime_tools_json=?, runtime_active_tools_json=?, updated_at=?
                 WHERE instance_id=?
                 """,
-                (runtime_system_prompt, runtime_tools_json, now, instance_id),
+                (
+                    runtime_system_prompt,
+                    runtime_tools_json,
+                    runtime_active_tools_json,
+                    now,
+                    instance_id,
+                ),
             ),
             lock=self._lock,
             repository_name="AgentInstanceRepository",
@@ -366,6 +378,7 @@ class AgentInstanceRepository:
             status=InstanceStatus(str(row["status"])),
             runtime_system_prompt=str(row["runtime_system_prompt"] or ""),
             runtime_tools_json=str(row["runtime_tools_json"] or ""),
+            runtime_active_tools_json=str(row["runtime_active_tools_json"] or ""),
             created_at=datetime.fromisoformat(str(row["created_at"])),
             updated_at=datetime.fromisoformat(str(row["updated_at"])),
         )

--- a/src/relay_teams/agents/instances/models.py
+++ b/src/relay_teams/agents/instances/models.py
@@ -65,6 +65,7 @@ class AgentRuntimeRecord(BaseModel):
     status: InstanceStatus
     runtime_system_prompt: str = ""
     runtime_tools_json: str = ""
+    runtime_active_tools_json: str = ""
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
 

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -70,6 +70,10 @@ from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeStatus,
 )
 from relay_teams.tools.registry.registry import ToolResolutionContext
+from relay_teams.tools.registry.runtime_activation import (
+    build_initial_active_tools,
+    validate_activation_request,
+)
 
 if TYPE_CHECKING:
     from relay_teams.skills.skill_registry import SkillRegistry
@@ -230,10 +234,15 @@ class TaskExecutionService(BaseModel):
             role_id=role_id,
             workspace_id=workspace.ref.workspace_id,
         )
-        runner = SubAgentRunner(
+        role_for_execution = self._role_with_active_local_tools(
             role=role_for_run,
+            session_id=task.session_id,
+            runtime_active_tools_json=instance_record.runtime_active_tools_json,
+        )
+        runner = SubAgentRunner(
+            role=role_for_execution,
             prompt_builder=self.prompt_builder,
-            provider=self.provider_factory(role_for_run, task.session_id),
+            provider=self.provider_factory(role_for_execution, task.session_id),
         )
         snapshot = self._shared_state_snapshot(
             session_id=task.session_id,
@@ -251,6 +260,9 @@ class TaskExecutionService(BaseModel):
                 objective=self._resolve_turn_objective(
                     task=task,
                     user_prompt_override=user_prompt_override,
+                ),
+                existing_runtime_active_tools_json=(
+                    instance_record.runtime_active_tools_json
                 ),
             )
             self._ensure_committed_task_prompt(
@@ -273,6 +285,9 @@ class TaskExecutionService(BaseModel):
                 instance_id,
                 runtime_system_prompt=runtime_system_prompt,
                 runtime_tools_json=runtime_tools_json,
+                runtime_active_tools_json=(
+                    prepared_runtime_snapshot.runtime_active_tools_json
+                ),
             )
             provider_system_prompt = self._compose_provider_system_prompt(
                 role=role_for_run,
@@ -615,6 +630,7 @@ class TaskExecutionService(BaseModel):
         workspace: WorkspaceHandle | None,
         shared_state_snapshot: tuple[tuple[str, str], ...],
         objective: str,
+        existing_runtime_active_tools_json: str = "",
     ) -> PreparedRuntimeSnapshot:
         topology = self._topology_for_run(task.trace_id)
         conversation_context = self._conversation_context_for_run(task.trace_id)
@@ -644,6 +660,12 @@ class TaskExecutionService(BaseModel):
                 ),
                 conversation_context=conversation_context,
                 runtime_tools=runtime_tools,
+                runtime_active_local_tools=self._resolve_active_local_tools(
+                    authorized_local_tools=tuple(
+                        tool.name for tool in runtime_tools.local_tools
+                    ),
+                    runtime_active_tools_json=existing_runtime_active_tools_json,
+                ),
             )
         )
         record_prompt_instruction_paths_loaded(
@@ -660,6 +682,10 @@ class TaskExecutionService(BaseModel):
                 "" if topology is None else topology.orchestration_prompt
             ),
         )
+        runtime_active_tools_json = self._build_runtime_active_tools_json(
+            runtime_tools=runtime_tools,
+            existing_runtime_active_tools_json=existing_runtime_active_tools_json,
+        )
         return PreparedRuntimeSnapshot(
             prompt_sections=prompt_sections,
             runtime_tools_json=json.dumps(
@@ -667,6 +693,7 @@ class TaskExecutionService(BaseModel):
                 ensure_ascii=False,
                 indent=2,
             ),
+            runtime_active_tools_json=runtime_active_tools_json,
             user_prompt=user_prompt,
             skill_instructions=skill_instructions,
         )
@@ -820,6 +847,97 @@ class TaskExecutionService(BaseModel):
                 kind,
             )
         return "function"
+
+    def _build_runtime_active_tools_json(
+        self,
+        *,
+        runtime_tools: RuntimeToolsSnapshot,
+        existing_runtime_active_tools_json: str,
+    ) -> str:
+        authorized_local_tools = tuple(tool.name for tool in runtime_tools.local_tools)
+        initial_active_tools = build_initial_active_tools(authorized_local_tools)
+        existing_active_tools = self._parse_runtime_active_tools_json(
+            existing_runtime_active_tools_json
+        )
+        if existing_active_tools:
+            normalized_existing_active_tools = validate_activation_request(
+                authorized_tools=authorized_local_tools,
+                active_tools=existing_active_tools,
+                requested_tool_names=(),
+            ).active
+        else:
+            normalized_existing_active_tools = ()
+        active_tools = (
+            normalized_existing_active_tools
+            if normalized_existing_active_tools
+            else initial_active_tools
+        )
+        return json.dumps(list(active_tools), ensure_ascii=False, indent=2)
+
+    def _parse_runtime_active_tools_json(
+        self,
+        runtime_active_tools_json: str,
+    ) -> tuple[str, ...]:
+        raw_payload = runtime_active_tools_json.strip()
+        if not raw_payload:
+            return ()
+        try:
+            parsed = json.loads(raw_payload)
+        except json.JSONDecodeError:
+            return ()
+        if not isinstance(parsed, list):
+            return ()
+        parsed_names: list[str] = []
+        for item in parsed:
+            if isinstance(item, str):
+                parsed_names.append(item)
+        return tuple(parsed_names)
+
+    def _role_with_active_local_tools(
+        self,
+        *,
+        role: RoleDefinition,
+        session_id: str,
+        runtime_active_tools_json: str,
+    ) -> RoleDefinition:
+        tool_registry = cast("ToolRegistry", self.tool_registry)
+        authorized_local_tools = tool_registry.resolve_names(
+            role.tools,
+            context=ToolResolutionContext(session_id=session_id),
+        )
+        active_local_tools = self._resolve_active_local_tools(
+            authorized_local_tools=authorized_local_tools,
+            runtime_active_tools_json=runtime_active_tools_json,
+        )
+        active_local_tool_set = set(active_local_tools)
+        return role.model_copy(
+            update={
+                "tools": tuple(
+                    tool_name
+                    for tool_name in role.tools
+                    if tool_name in active_local_tool_set
+                )
+            }
+        )
+
+    def _resolve_active_local_tools(
+        self,
+        *,
+        authorized_local_tools: tuple[str, ...],
+        runtime_active_tools_json: str,
+    ) -> tuple[str, ...]:
+        existing_active_tools = self._parse_runtime_active_tools_json(
+            runtime_active_tools_json
+        )
+        if existing_active_tools:
+            normalized_existing_active_tools = validate_activation_request(
+                authorized_tools=authorized_local_tools,
+                active_tools=existing_active_tools,
+                requested_tool_names=(),
+            ).active
+            if normalized_existing_active_tools:
+                return normalized_existing_active_tools
+        return build_initial_active_tools(authorized_local_tools)
 
     def _record_memory_if_needed(
         self,
@@ -1017,5 +1135,6 @@ class PreparedRuntimeSnapshot(BaseModel):
 
     prompt_sections: RuntimePromptSections
     runtime_tools_json: str
+    runtime_active_tools_json: str
     user_prompt: str
     skill_instructions: tuple[PromptSkillInstruction, ...] = ()

--- a/src/relay_teams/tools/discovery_tools/__init__.py
+++ b/src/relay_teams/tools/discovery_tools/__init__.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+from relay_teams.tools.discovery_tools.activate_tools import (
+    register as register_activate_tools,
+)
 from relay_teams.tools.discovery_tools.tool_search import (
     register as register_tool_search,
 )
 from relay_teams.tools.registry import ToolImplicitResolver, ToolResolutionContext
 
-ALWAYS_AVAILABLE_DISCOVERY_TOOLS: tuple[str, ...] = ("tool_search",)
+ALWAYS_AVAILABLE_DISCOVERY_TOOLS: tuple[str, ...] = (
+    "tool_search",
+    "activate_tools",
+)
 
 
 class DiscoveryToolResolver(ToolImplicitResolver):
@@ -18,6 +24,7 @@ class DiscoveryToolResolver(ToolImplicitResolver):
 
 
 TOOLS = {
+    "activate_tools": register_activate_tools,
     "tool_search": register_tool_search,
 }
 
@@ -25,5 +32,6 @@ __all__ = [
     "ALWAYS_AVAILABLE_DISCOVERY_TOOLS",
     "DiscoveryToolResolver",
     "TOOLS",
+    "register_activate_tools",
     "register_tool_search",
 ]

--- a/src/relay_teams/tools/discovery_tools/__init__.py
+++ b/src/relay_teams/tools/discovery_tools/__init__.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from relay_teams.tools.discovery_tools.tool_search import (
+    register as register_tool_search,
+)
+from relay_teams.tools.registry import ToolImplicitResolver, ToolResolutionContext
+
+ALWAYS_AVAILABLE_DISCOVERY_TOOLS: tuple[str, ...] = ("tool_search",)
+
+
+class DiscoveryToolResolver(ToolImplicitResolver):
+    def resolve_implicit_tools(
+        self,
+        context: ToolResolutionContext,
+    ) -> tuple[str, ...]:
+        del context
+        return ALWAYS_AVAILABLE_DISCOVERY_TOOLS
+
+
+TOOLS = {
+    "tool_search": register_tool_search,
+}
+
+__all__ = [
+    "ALWAYS_AVAILABLE_DISCOVERY_TOOLS",
+    "DiscoveryToolResolver",
+    "TOOLS",
+    "register_tool_search",
+]

--- a/src/relay_teams/tools/discovery_tools/activate_tools.py
+++ b/src/relay_teams/tools/discovery_tools/activate_tools.py
@@ -50,18 +50,6 @@ def _activate_runtime_tools(
     tool_names: list[str] | str,
 ) -> dict[str, JsonValue]:
     requested_tool_names = _normalize_requested_tool_names(tool_names)
-    if not requested_tool_names:
-        return {
-            "activated": [],
-            "already_active": [],
-            "unknown_or_unauthorized": [],
-            "rejected_due_to_limit": [],
-            "active_tools": [],
-            "active_tools_count": 0,
-            "deferred_tools_count": 0,
-            "warning": "tool_names must contain at least one non-empty tool name.",
-        }
-
     try:
         runtime_record = ctx.deps.agent_repo.get_instance(ctx.deps.instance_id)
     except KeyError:
@@ -86,6 +74,17 @@ def _activate_runtime_tools(
         requested_tool_names=requested_tool_names,
         max_active_tools=_MAX_ACTIVE_TOOLS,
     )
+    if not requested_tool_names:
+        return {
+            "activated": [],
+            "already_active": [],
+            "unknown_or_unauthorized": [],
+            "rejected_due_to_limit": [],
+            "active_tools": list(activation_result.active_tools),
+            "active_tools_count": len(activation_result.active_tools),
+            "deferred_tools_count": len(activation_result.deferred_tools),
+            "warning": "tool_names must contain at least one non-empty tool name.",
+        }
 
     next_runtime_active_tools_json = json.dumps(
         list(activation_result.active_tools),

--- a/src/relay_teams/tools/discovery_tools/activate_tools.py
+++ b/src/relay_teams/tools/discovery_tools/activate_tools.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+
+from pydantic import JsonValue
+from pydantic_ai import Agent
+
+from relay_teams.agents.instances.models import RuntimeToolsSnapshot
+from relay_teams.tools._description_loader import load_tool_description
+from relay_teams.tools.registry.runtime_activation import apply_tool_activation
+from relay_teams.tools.runtime import ToolContext, ToolDeps, execute_tool_call
+
+DESCRIPTION = load_tool_description(__file__)
+_MAX_ACTIVE_TOOLS = 20
+
+
+def register(agent: Agent[ToolDeps, str]) -> None:
+    @agent.tool(description=DESCRIPTION)
+    async def activate_tools(
+        ctx: ToolContext,
+        tool_names: list[str] | str,
+    ) -> dict[str, JsonValue]:
+        """Activate runtime-authorized local tools for future model turns."""
+
+        def _action(tool_names: list[str] | str) -> dict[str, JsonValue]:
+            return _activate_runtime_tools(
+                ctx=ctx,
+                tool_names=tool_names,
+            )
+
+        summary_tool_names: JsonValue = (
+            tool_names
+            if isinstance(tool_names, str)
+            else [str(name) for name in tool_names]
+        )
+
+        return await execute_tool_call(
+            ctx,
+            tool_name="activate_tools",
+            args_summary={"tool_names": summary_tool_names},
+            action=_action,
+            raw_args=locals(),
+        )
+
+
+def _activate_runtime_tools(
+    *,
+    ctx: ToolContext,
+    tool_names: list[str] | str,
+) -> dict[str, JsonValue]:
+    requested_tool_names = _normalize_requested_tool_names(tool_names)
+    if not requested_tool_names:
+        return {
+            "activated": [],
+            "already_active": [],
+            "unknown_or_unauthorized": [],
+            "rejected_due_to_limit": [],
+            "active_tools": [],
+            "active_tools_count": 0,
+            "deferred_tools_count": 0,
+            "warning": "tool_names must contain at least one non-empty tool name.",
+        }
+
+    try:
+        runtime_record = ctx.deps.agent_repo.get_instance(ctx.deps.instance_id)
+    except KeyError:
+        return {
+            "activated": [],
+            "already_active": [],
+            "unknown_or_unauthorized": list(requested_tool_names),
+            "rejected_due_to_limit": [],
+            "active_tools": [],
+            "active_tools_count": 0,
+            "deferred_tools_count": 0,
+            "warning": "Runtime tool snapshot is unavailable for the current instance.",
+        }
+
+    snapshot = _parse_runtime_tools_snapshot(runtime_record.runtime_tools_json)
+    authorized_local_tools = tuple(entry.name for entry in snapshot.local_tools)
+    activation_result = apply_tool_activation(
+        authorized_tools=authorized_local_tools,
+        active_tools=_parse_runtime_active_tools_json(
+            runtime_record.runtime_active_tools_json
+        ),
+        requested_tool_names=requested_tool_names,
+        max_active_tools=_MAX_ACTIVE_TOOLS,
+    )
+
+    next_runtime_active_tools_json = json.dumps(
+        list(activation_result.active_tools),
+        ensure_ascii=False,
+        indent=2,
+    )
+    ctx.deps.agent_repo.update_runtime_snapshot(
+        ctx.deps.instance_id,
+        runtime_system_prompt=runtime_record.runtime_system_prompt,
+        runtime_tools_json=runtime_record.runtime_tools_json,
+        runtime_active_tools_json=next_runtime_active_tools_json,
+    )
+    warning = _build_warning_message(activation_result)
+    return {
+        "activated": list(activation_result.activated),
+        "already_active": list(activation_result.already_active),
+        "unknown_or_unauthorized": list(activation_result.unknown_or_unauthorized),
+        "rejected_due_to_limit": list(activation_result.rejected_due_to_limit),
+        "active_tools": list(activation_result.active_tools),
+        "active_tools_count": len(activation_result.active_tools),
+        "deferred_tools_count": len(activation_result.deferred_tools),
+        "warning": warning,
+    }
+
+
+def _normalize_requested_tool_names(
+    tool_names: list[str] | str,
+) -> tuple[str, ...]:
+    if isinstance(tool_names, str):
+        normalized_name = tool_names.strip()
+        return (normalized_name,) if normalized_name else ()
+    return tuple(str(name).strip() for name in tool_names if str(name).strip())
+
+
+def _parse_runtime_tools_snapshot(raw_snapshot: str) -> RuntimeToolsSnapshot:
+    normalized_snapshot = raw_snapshot.strip()
+    if not normalized_snapshot:
+        return RuntimeToolsSnapshot()
+    try:
+        return RuntimeToolsSnapshot.model_validate_json(normalized_snapshot)
+    except (ValueError, TypeError):
+        return RuntimeToolsSnapshot()
+
+
+def _parse_runtime_active_tools_json(raw_active_tools: str) -> tuple[str, ...]:
+    normalized_active_tools = raw_active_tools.strip()
+    if not normalized_active_tools:
+        return ()
+    try:
+        parsed = json.loads(normalized_active_tools)
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    return tuple(item for item in parsed if isinstance(item, str))
+
+
+def _build_warning_message(activation_result: object) -> str | None:
+    result = activation_result
+    warning_parts: list[str] = []
+    unknown_or_unauthorized = getattr(result, "unknown_or_unauthorized", ())
+    rejected_due_to_limit = getattr(result, "rejected_due_to_limit", ())
+    if unknown_or_unauthorized:
+        warning_parts.append(
+            "Some requested tools were not authorized local tools for this runtime: "
+            + ", ".join(str(name) for name in unknown_or_unauthorized)
+        )
+    if rejected_due_to_limit:
+        warning_parts.append(
+            "Some requested tools could not be activated because the active-tool "
+            f"limit ({_MAX_ACTIVE_TOOLS}) was reached: "
+            + ", ".join(str(name) for name in rejected_due_to_limit)
+        )
+    return " ".join(warning_parts) if warning_parts else None

--- a/src/relay_teams/tools/discovery_tools/activate_tools.txt
+++ b/src/relay_teams/tools/discovery_tools/activate_tools.txt
@@ -1,0 +1,9 @@
+Activate runtime-authorized local tools so they become directly callable in subsequent model turns.
+
+Use this tool after `tool_search` when you discover a local tool that is authorized for the current runtime but not yet active.
+
+Behavior:
+- Activates only local runtime tools for the current instance.
+- Keeps already-active tools active.
+- Ignores unauthorized or unknown tool names and reports them in the response.
+- Updates the runtime active-tool set persisted for the current agent instance.

--- a/src/relay_teams/tools/discovery_tools/tool_search.py
+++ b/src/relay_teams/tools/discovery_tools/tool_search.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
+import json
 import math
 import re
 from collections.abc import Iterable, Mapping
@@ -109,13 +110,18 @@ def _search_runtime_tools(
     query: str,
     max_results: int,
 ) -> dict[str, JsonValue]:
-    authorized_tools, total_authorized_tools = _load_authorized_tools(ctx)
+    (
+        authorized_tools,
+        total_authorized_tools,
+        active_local_tools,
+    ) = _load_authorized_tools(ctx)
     if authorized_tools is None:
         return _build_search_response(
             query=query,
             mode="keyword",
             matches=(),
             total_authorized_tools=0,
+            active_local_tools=(),
             warning="Runtime tool snapshot is unavailable for the current instance.",
         )
 
@@ -125,6 +131,7 @@ def _search_runtime_tools(
             mode="keyword",
             matches=(),
             total_authorized_tools=total_authorized_tools,
+            active_local_tools=active_local_tools,
             warning="Query must not be empty.",
         )
 
@@ -157,6 +164,7 @@ def _search_runtime_tools(
             mode="select",
             matches=matches,
             total_authorized_tools=total_authorized_tools,
+            active_local_tools=active_local_tools,
             include_schema=True,
             warning=warning,
         )
@@ -178,6 +186,7 @@ def _search_runtime_tools(
             mode="exact",
             matches=matches,
             total_authorized_tools=total_authorized_tools,
+            active_local_tools=active_local_tools,
             include_schema=True,
         )
 
@@ -191,19 +200,27 @@ def _search_runtime_tools(
         mode="keyword",
         matches=matches,
         total_authorized_tools=total_authorized_tools,
+        active_local_tools=active_local_tools,
     )
 
 
 def _load_authorized_tools(
     ctx: ToolContext,
-) -> tuple[tuple[RuntimeToolSnapshotEntry, ...], int] | tuple[None, int]:
+) -> (
+    tuple[tuple[RuntimeToolSnapshotEntry, ...], int, tuple[str, ...]]
+    | tuple[None, int, tuple[str, ...]]
+):
     try:
         runtime_record = ctx.deps.agent_repo.get_instance(ctx.deps.instance_id)
     except KeyError:
-        return None, 0
+        return None, 0, ()
     snapshot = _parse_runtime_tools_snapshot(runtime_record.runtime_tools_json)
     authorized_tools = _flatten_runtime_tools(snapshot)
-    return authorized_tools, len(authorized_tools)
+    return (
+        authorized_tools,
+        len(authorized_tools),
+        _parse_runtime_active_tools_json(runtime_record.runtime_active_tools_json),
+    )
 
 
 def _parse_runtime_tools_snapshot(raw_snapshot: str) -> RuntimeToolsSnapshot:
@@ -214,6 +231,19 @@ def _parse_runtime_tools_snapshot(raw_snapshot: str) -> RuntimeToolsSnapshot:
         return RuntimeToolsSnapshot.model_validate_json(normalized_snapshot)
     except (ValueError, TypeError):
         return RuntimeToolsSnapshot()
+
+
+def _parse_runtime_active_tools_json(raw_active_tools: str) -> tuple[str, ...]:
+    normalized_active_tools = raw_active_tools.strip()
+    if not normalized_active_tools:
+        return ()
+    try:
+        parsed = json.loads(normalized_active_tools)
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    return tuple(item for item in parsed if isinstance(item, str))
 
 
 def _flatten_runtime_tools(
@@ -487,6 +517,7 @@ def _build_search_response(
     mode: str,
     matches: tuple[RuntimeToolSnapshotEntry, ...],
     total_authorized_tools: int,
+    active_local_tools: tuple[str, ...],
     include_schema: bool = False,
     warning: str | None = None,
 ) -> dict[str, JsonValue]:
@@ -495,7 +526,12 @@ def _build_search_response(
         "mode": mode,
         "total_authorized_tools": total_authorized_tools,
         "matches": [
-            _serialize_match(entry, include_schema=include_schema) for entry in matches
+            _serialize_match(
+                entry,
+                include_schema=include_schema,
+                active_local_tools=active_local_tools,
+            )
+            for entry in matches
         ],
     }
     if warning:
@@ -507,6 +543,7 @@ def _serialize_match(
     entry: RuntimeToolSnapshotEntry,
     *,
     include_schema: bool,
+    active_local_tools: tuple[str, ...],
 ) -> dict[str, JsonValue]:
     payload: dict[str, JsonValue] = {
         "name": entry.name,
@@ -514,6 +551,11 @@ def _serialize_match(
         "description": entry.description,
         "kind": entry.kind,
         "sequential": entry.sequential,
+        "activation_state": (
+            "deferred"
+            if entry.source == "local" and entry.name not in set(active_local_tools)
+            else "active"
+        ),
     }
     if entry.server_name:
         payload["server_name"] = entry.server_name

--- a/src/relay_teams/tools/discovery_tools/tool_search.py
+++ b/src/relay_teams/tools/discovery_tools/tool_search.py
@@ -16,7 +16,7 @@ from relay_teams.agents.instances.models import (
     RuntimeToolsSnapshot,
 )
 from relay_teams.tools._description_loader import load_tool_description
-from relay_teams.tools.runtime import ToolContext, ToolDeps, execute_tool
+from relay_teams.tools.runtime import ToolContext, ToolDeps, execute_tool_call
 
 DESCRIPTION = load_tool_description(__file__)
 _DEFAULT_MAX_RESULTS = 5
@@ -81,24 +81,25 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     ) -> dict[str, JsonValue]:
         """Discover runtime-authorized tools and inspect their contracts."""
 
-        normalized_query = query.strip()
-        resolved_max_results = _clamp_max_results(max_results)
-
-        def _action() -> dict[str, JsonValue]:
+        def _action(
+            query: str,
+            max_results: int = _DEFAULT_MAX_RESULTS,
+        ) -> dict[str, JsonValue]:
             return _search_runtime_tools(
                 ctx=ctx,
-                query=normalized_query,
-                max_results=resolved_max_results,
+                query=query.strip(),
+                max_results=_clamp_max_results(max_results),
             )
 
-        return await execute_tool(
+        return await execute_tool_call(
             ctx,
             tool_name="tool_search",
             args_summary={
-                "query": normalized_query,
-                "max_results": resolved_max_results,
+                "query": query,
+                "max_results": max_results,
             },
             action=_action,
+            raw_args=locals(),
         )
 
 

--- a/src/relay_teams/tools/discovery_tools/tool_search.py
+++ b/src/relay_teams/tools/discovery_tools/tool_search.py
@@ -1,0 +1,514 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import math
+import re
+from collections.abc import Iterable, Mapping
+from typing import cast
+
+from pydantic import JsonValue
+from pydantic_ai import Agent
+
+from relay_teams.agents.instances.models import (
+    RuntimeToolSnapshotEntry,
+    RuntimeToolsSnapshot,
+)
+from relay_teams.tools._description_loader import load_tool_description
+from relay_teams.tools.runtime import ToolContext, ToolDeps, execute_tool
+
+DESCRIPTION = load_tool_description(__file__)
+_DEFAULT_MAX_RESULTS = 5
+_MAX_RESULTS_LIMIT = 20
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+_SELECT_PREFIX = "select:"
+_MIN_TOKEN_LENGTH = 2
+_NAME_WEIGHT = 4.0
+_SERVER_WEIGHT = 2.5
+_KEYWORD_WEIGHT = 2.0
+_DESCRIPTION_WEIGHT = 1.0
+_SOURCE_WEIGHT = 0.5
+_BM25_K1 = 1.2
+_BM25_B = 0.75
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "authorized",
+        "by",
+        "current",
+        "for",
+        "from",
+        "function",
+        "functions",
+        "in",
+        "local",
+        "mcp",
+        "of",
+        "on",
+        "or",
+        "runtime",
+        "server",
+        "skill",
+        "the",
+        "to",
+        "tool",
+        "tools",
+        "with",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _SearchableTool:
+    entry: RuntimeToolSnapshotEntry
+    weighted_terms: Counter[str]
+    matched_terms: frozenset[str]
+    weighted_length: float
+    name_text: str
+    server_text: str
+    description_text: str
+
+
+def register(agent: Agent[ToolDeps, str]) -> None:
+    @agent.tool(description=DESCRIPTION)
+    async def tool_search(
+        ctx: ToolContext,
+        query: str,
+        max_results: int = _DEFAULT_MAX_RESULTS,
+    ) -> dict[str, JsonValue]:
+        """Discover runtime-authorized tools and inspect their contracts."""
+
+        normalized_query = query.strip()
+        resolved_max_results = _clamp_max_results(max_results)
+
+        def _action() -> dict[str, JsonValue]:
+            return _search_runtime_tools(
+                ctx=ctx,
+                query=normalized_query,
+                max_results=resolved_max_results,
+            )
+
+        return await execute_tool(
+            ctx,
+            tool_name="tool_search",
+            args_summary={
+                "query": normalized_query,
+                "max_results": resolved_max_results,
+            },
+            action=_action,
+        )
+
+
+def _search_runtime_tools(
+    *,
+    ctx: ToolContext,
+    query: str,
+    max_results: int,
+) -> dict[str, JsonValue]:
+    if not query:
+        return _build_search_response(
+            query=query,
+            mode="keyword",
+            matches=(),
+            total_authorized_tools=0,
+            warning="Query must not be empty.",
+        )
+
+    try:
+        runtime_record = ctx.deps.agent_repo.get_instance(ctx.deps.instance_id)
+    except KeyError:
+        return _build_search_response(
+            query=query,
+            mode="keyword",
+            matches=(),
+            total_authorized_tools=0,
+            warning="Runtime tool snapshot is unavailable for the current instance.",
+        )
+
+    snapshot = _parse_runtime_tools_snapshot(runtime_record.runtime_tools_json)
+    authorized_tools = _flatten_runtime_tools(snapshot)
+    total_authorized_tools = len(authorized_tools)
+
+    if query.casefold().startswith(_SELECT_PREFIX):
+        requested_names = _parse_select_query(query)
+        matches = tuple(
+            entry
+            for name in requested_names
+            if (entry := _find_tool_by_name(authorized_tools, name)) is not None
+        )
+        missing_names = tuple(
+            name
+            for name in requested_names
+            if _find_tool_by_name(authorized_tools, name) is None
+        )
+        warning = (
+            "Some requested tools were not authorized for this runtime: "
+            + ", ".join(missing_names)
+            if missing_names
+            else None
+        )
+        return _build_search_response(
+            query=query,
+            mode="select",
+            matches=matches,
+            total_authorized_tools=total_authorized_tools,
+            include_schema=True,
+            warning=warning,
+        )
+
+    exact_match = _find_tool_by_name(authorized_tools, query)
+    if exact_match is not None:
+        keyword_matches = _search_by_keywords(
+            authorized_tools=authorized_tools,
+            query=query,
+            max_results=max_results,
+        )
+        matches = _prepend_exact_match(
+            exact_match=exact_match,
+            keyword_matches=keyword_matches,
+            max_results=max_results,
+        )
+        return _build_search_response(
+            query=query,
+            mode="exact",
+            matches=matches,
+            total_authorized_tools=total_authorized_tools,
+            include_schema=True,
+        )
+
+    matches = _search_by_keywords(
+        authorized_tools=authorized_tools,
+        query=query,
+        max_results=max_results,
+    )
+    return _build_search_response(
+        query=query,
+        mode="keyword",
+        matches=matches,
+        total_authorized_tools=total_authorized_tools,
+    )
+
+
+def _parse_runtime_tools_snapshot(raw_snapshot: str) -> RuntimeToolsSnapshot:
+    normalized_snapshot = raw_snapshot.strip()
+    if not normalized_snapshot:
+        return RuntimeToolsSnapshot()
+    try:
+        return RuntimeToolsSnapshot.model_validate_json(normalized_snapshot)
+    except (ValueError, TypeError):
+        return RuntimeToolsSnapshot()
+
+
+def _flatten_runtime_tools(
+    snapshot: RuntimeToolsSnapshot,
+) -> tuple[RuntimeToolSnapshotEntry, ...]:
+    return (
+        tuple(snapshot.local_tools)
+        + tuple(snapshot.skill_tools)
+        + tuple(snapshot.mcp_tools)
+    )
+
+
+def _parse_select_query(query: str) -> tuple[str, ...]:
+    raw_selection = query[len(_SELECT_PREFIX) :]
+    names: list[str] = []
+    seen: set[str] = set()
+    for item in raw_selection.split(","):
+        normalized_name = item.strip()
+        if not normalized_name:
+            continue
+        folded_name = normalized_name.casefold()
+        if folded_name in seen:
+            continue
+        seen.add(folded_name)
+        names.append(normalized_name)
+    return tuple(names)
+
+
+def _find_tool_by_name(
+    entries: Iterable[RuntimeToolSnapshotEntry],
+    tool_name: str,
+) -> RuntimeToolSnapshotEntry | None:
+    normalized_name = tool_name.strip().casefold()
+    if not normalized_name:
+        return None
+    for entry in entries:
+        if entry.name.casefold() == normalized_name:
+            return entry
+    return None
+
+
+def _prepend_exact_match(
+    *,
+    exact_match: RuntimeToolSnapshotEntry,
+    keyword_matches: tuple[RuntimeToolSnapshotEntry, ...],
+    max_results: int,
+) -> tuple[RuntimeToolSnapshotEntry, ...]:
+    matches: list[RuntimeToolSnapshotEntry] = [exact_match]
+    seen = {exact_match.name.casefold()}
+    for entry in keyword_matches:
+        folded_name = entry.name.casefold()
+        if folded_name in seen:
+            continue
+        seen.add(folded_name)
+        matches.append(entry)
+        if len(matches) >= max_results:
+            break
+    return tuple(matches)
+
+
+def _search_by_keywords(
+    *,
+    authorized_tools: tuple[RuntimeToolSnapshotEntry, ...],
+    query: str,
+    max_results: int,
+) -> tuple[RuntimeToolSnapshotEntry, ...]:
+    normalized_query = query.strip().casefold()
+    query_terms = _query_terms(normalized_query)
+    if not query_terms:
+        return ()
+    searchable_tools = tuple(
+        _build_searchable_tool(entry) for entry in authorized_tools
+    )
+    avg_weighted_length = (
+        sum(item.weighted_length for item in searchable_tools) / len(searchable_tools)
+        if searchable_tools
+        else 1.0
+    )
+    document_frequency = _document_frequency(searchable_tools, query_terms)
+
+    scored_matches: list[tuple[float, RuntimeToolSnapshotEntry]] = []
+    for searchable in searchable_tools:
+        score = _score_tool_match(
+            searchable=searchable,
+            normalized_query=normalized_query,
+            query_terms=query_terms,
+            document_frequency=document_frequency,
+            total_documents=len(searchable_tools),
+            avg_weighted_length=avg_weighted_length,
+        )
+        if score <= 0:
+            continue
+        scored_matches.append((score, searchable.entry))
+
+    scored_matches.sort(key=lambda item: (-item[0], item[1].name.casefold()))
+    return tuple(entry for _score, entry in scored_matches[:max_results])
+
+
+def _score_tool_match(
+    *,
+    searchable: _SearchableTool,
+    normalized_query: str,
+    query_terms: tuple[str, ...],
+    document_frequency: Mapping[str, int],
+    total_documents: int,
+    avg_weighted_length: float,
+) -> float:
+    entry = searchable.entry
+    score = 0.0
+    matched_terms: set[str] = set()
+
+    if normalized_query and normalized_query == entry.name.casefold():
+        return 1_000.0
+    if normalized_query and normalized_query in searchable.name_text:
+        score += 4.0
+    elif normalized_query and normalized_query in searchable.server_text:
+        score += 2.5
+    elif normalized_query and normalized_query in searchable.description_text:
+        score += 1.5
+
+    for term in query_terms:
+        idf = _inverse_document_frequency(
+            term=term,
+            document_frequency=document_frequency,
+            total_documents=total_documents,
+        )
+        weighted_tf = float(searchable.weighted_terms.get(term, 0.0))
+        if weighted_tf > 0:
+            matched_terms.add(term)
+            score += _bm25_score(
+                weighted_tf=weighted_tf,
+                weighted_length=searchable.weighted_length,
+                avg_weighted_length=avg_weighted_length,
+                idf=idf,
+            )
+            continue
+        if term in searchable.name_text:
+            matched_terms.add(term)
+            score += idf * 1.2
+        elif term in searchable.server_text:
+            matched_terms.add(term)
+            score += idf * 0.8
+
+    if len(matched_terms) < _minimum_required_term_matches(query_terms):
+        return 0.0
+    if len(matched_terms) == len(query_terms):
+        score += 1.0
+    return score
+
+
+def _schema_tokens(schema: Mapping[str, JsonValue]) -> tuple[str, ...]:
+    collected_tokens: list[str] = []
+    _collect_schema_tokens(cast(JsonValue, dict(schema)), collected_tokens, depth=0)
+    return tuple(collected_tokens)
+
+
+def _collect_schema_tokens(
+    value: JsonValue,
+    collected_tokens: list[str],
+    *,
+    depth: int,
+) -> None:
+    if depth > 3:
+        return
+    if isinstance(value, dict):
+        mapping = cast(Mapping[str, JsonValue], value)
+        for key, item in mapping.items():
+            collected_tokens.extend(_tokenize(key))
+            if key in {"title", "description"} and isinstance(item, str):
+                collected_tokens.extend(_tokenize(item))
+            _collect_schema_tokens(item, collected_tokens, depth=depth + 1)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _collect_schema_tokens(item, collected_tokens, depth=depth + 1)
+
+
+def _tokenize(value: str) -> tuple[str, ...]:
+    normalized_value = value.casefold()
+    return tuple(
+        token
+        for token in _TOKEN_PATTERN.findall(normalized_value)
+        if len(token) >= _MIN_TOKEN_LENGTH
+    )
+
+
+def _minimum_required_term_matches(query_terms: tuple[str, ...]) -> int:
+    if len(query_terms) <= 2:
+        return len(query_terms)
+    return math.ceil(len(query_terms) * 0.6)
+
+
+def _query_terms(query: str) -> tuple[str, ...]:
+    raw_terms = _tokenize(query)
+    filtered_terms = tuple(term for term in raw_terms if term not in _STOPWORDS)
+    if filtered_terms:
+        return filtered_terms
+    return raw_terms
+
+
+def _build_searchable_tool(entry: RuntimeToolSnapshotEntry) -> _SearchableTool:
+    name_terms = _tokenize(entry.name)
+    server_terms = _tokenize(entry.server_name)
+    keyword_terms = _schema_tokens(entry.parameters_json_schema)
+    description_terms = _tokenize(entry.description)
+    source_terms = _tokenize(entry.source)
+
+    weighted_terms: Counter[str] = Counter()
+    weighted_terms.update({term: _NAME_WEIGHT for term in name_terms})
+    weighted_terms.update({term: _SERVER_WEIGHT for term in server_terms})
+    weighted_terms.update({term: _KEYWORD_WEIGHT for term in keyword_terms})
+    weighted_terms.update({term: _DESCRIPTION_WEIGHT for term in description_terms})
+    weighted_terms.update({term: _SOURCE_WEIGHT for term in source_terms})
+
+    return _SearchableTool(
+        entry=entry,
+        weighted_terms=weighted_terms,
+        matched_terms=frozenset(weighted_terms.keys()),
+        weighted_length=sum(weighted_terms.values()) or 1.0,
+        name_text=_normalize_search_text(entry.name),
+        server_text=_normalize_search_text(entry.server_name),
+        description_text=_normalize_search_text(entry.description),
+    )
+
+
+def _document_frequency(
+    searchable_tools: tuple[_SearchableTool, ...],
+    query_terms: tuple[str, ...],
+) -> dict[str, int]:
+    return {
+        term: sum(1 for item in searchable_tools if term in item.matched_terms)
+        for term in query_terms
+    }
+
+
+def _inverse_document_frequency(
+    *,
+    term: str,
+    document_frequency: Mapping[str, int],
+    total_documents: int,
+) -> float:
+    df = document_frequency.get(term, 0)
+    return math.log(1.0 + ((total_documents - df + 0.5) / (df + 0.5)))
+
+
+def _bm25_score(
+    *,
+    weighted_tf: float,
+    weighted_length: float,
+    avg_weighted_length: float,
+    idf: float,
+) -> float:
+    normalized_length = avg_weighted_length or 1.0
+    denominator = weighted_tf + _BM25_K1 * (
+        1.0 - _BM25_B + _BM25_B * (weighted_length / normalized_length)
+    )
+    if denominator <= 0:
+        return 0.0
+    return idf * ((weighted_tf * (_BM25_K1 + 1.0)) / denominator)
+
+
+def _normalize_search_text(value: str) -> str:
+    normalized = value.casefold().replace("_", " ")
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+    return " ".join(part for part in normalized.split() if part)
+
+
+def _build_search_response(
+    *,
+    query: str,
+    mode: str,
+    matches: tuple[RuntimeToolSnapshotEntry, ...],
+    total_authorized_tools: int,
+    include_schema: bool = False,
+    warning: str | None = None,
+) -> dict[str, JsonValue]:
+    payload: dict[str, JsonValue] = {
+        "query": query,
+        "mode": mode,
+        "total_authorized_tools": total_authorized_tools,
+        "matches": [
+            _serialize_match(entry, include_schema=include_schema) for entry in matches
+        ],
+    }
+    if warning:
+        payload["warning"] = warning
+    return payload
+
+
+def _serialize_match(
+    entry: RuntimeToolSnapshotEntry,
+    *,
+    include_schema: bool,
+) -> dict[str, JsonValue]:
+    payload: dict[str, JsonValue] = {
+        "name": entry.name,
+        "source": entry.source,
+        "description": entry.description,
+        "kind": entry.kind,
+        "sequential": entry.sequential,
+    }
+    if entry.server_name:
+        payload["server_name"] = entry.server_name
+    if entry.strict is not None:
+        payload["strict"] = entry.strict
+    if include_schema:
+        payload["parameters_json_schema"] = dict(entry.parameters_json_schema)
+    return payload
+
+
+def _clamp_max_results(value: int) -> int:
+    return max(1, min(_MAX_RESULTS_LIMIT, int(value)))

--- a/src/relay_teams/tools/discovery_tools/tool_search.py
+++ b/src/relay_teams/tools/discovery_tools/tool_search.py
@@ -108,18 +108,8 @@ def _search_runtime_tools(
     query: str,
     max_results: int,
 ) -> dict[str, JsonValue]:
-    if not query:
-        return _build_search_response(
-            query=query,
-            mode="keyword",
-            matches=(),
-            total_authorized_tools=0,
-            warning="Query must not be empty.",
-        )
-
-    try:
-        runtime_record = ctx.deps.agent_repo.get_instance(ctx.deps.instance_id)
-    except KeyError:
+    authorized_tools, total_authorized_tools = _load_authorized_tools(ctx)
+    if authorized_tools is None:
         return _build_search_response(
             query=query,
             mode="keyword",
@@ -128,28 +118,39 @@ def _search_runtime_tools(
             warning="Runtime tool snapshot is unavailable for the current instance.",
         )
 
-    snapshot = _parse_runtime_tools_snapshot(runtime_record.runtime_tools_json)
-    authorized_tools = _flatten_runtime_tools(snapshot)
-    total_authorized_tools = len(authorized_tools)
+    if not query:
+        return _build_search_response(
+            query=query,
+            mode="keyword",
+            matches=(),
+            total_authorized_tools=total_authorized_tools,
+            warning="Query must not be empty.",
+        )
 
     if query.casefold().startswith(_SELECT_PREFIX):
         requested_names = _parse_select_query(query)
-        matches = tuple(
+        requested_matches = tuple(
             entry
             for name in requested_names
             if (entry := _find_tool_by_name(authorized_tools, name)) is not None
         )
+        matches = requested_matches[:max_results]
         missing_names = tuple(
             name
             for name in requested_names
             if _find_tool_by_name(authorized_tools, name) is None
         )
-        warning = (
-            "Some requested tools were not authorized for this runtime: "
-            + ", ".join(missing_names)
-            if missing_names
-            else None
-        )
+        warning_parts: list[str] = []
+        if missing_names:
+            warning_parts.append(
+                "Some requested tools were not authorized for this runtime: "
+                + ", ".join(missing_names)
+            )
+        if len(requested_matches) > max_results:
+            warning_parts.append(
+                f"Only the first {max_results} matched tools were returned due to max_results."
+            )
+        warning = " ".join(warning_parts) if warning_parts else None
         return _build_search_response(
             query=query,
             mode="select",
@@ -190,6 +191,18 @@ def _search_runtime_tools(
         matches=matches,
         total_authorized_tools=total_authorized_tools,
     )
+
+
+def _load_authorized_tools(
+    ctx: ToolContext,
+) -> tuple[tuple[RuntimeToolSnapshotEntry, ...], int] | tuple[None, int]:
+    try:
+        runtime_record = ctx.deps.agent_repo.get_instance(ctx.deps.instance_id)
+    except KeyError:
+        return None, 0
+    snapshot = _parse_runtime_tools_snapshot(runtime_record.runtime_tools_json)
+    authorized_tools = _flatten_runtime_tools(snapshot)
+    return authorized_tools, len(authorized_tools)
 
 
 def _parse_runtime_tools_snapshot(raw_snapshot: str) -> RuntimeToolsSnapshot:

--- a/src/relay_teams/tools/discovery_tools/tool_search.txt
+++ b/src/relay_teams/tools/discovery_tools/tool_search.txt
@@ -1,0 +1,13 @@
+Discover tools authorized for the current runtime without relying on a long prompt listing.
+
+Use this tool when you need to find which local, skill, or MCP tools are available right now, or when you need to inspect a tool's parameter schema before calling it.
+
+Query forms:
+- Keyword search: `files read markdown`
+- Exact lookup by tool name: `read`
+- Direct schema retrieval: `select:read,websearch`
+
+Behavior:
+- Keyword search returns compact matches with source, description, and server context.
+- Exact lookup and `select:` include the tool's full `parameters_json_schema`.
+- Results are limited to tools already authorized for the current runtime instance.

--- a/src/relay_teams/tools/registry/__init__.py
+++ b/src/relay_teams/tools/registry/__init__.py
@@ -6,6 +6,13 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from relay_teams.tools.registry.defaults import build_default_registry
+    from relay_teams.tools.registry.runtime_activation import (
+        ActivationApplyResult,
+        ActivationValidationResult,
+        build_initial_active_tools,
+        apply_tool_activation,
+        validate_activation_request,
+    )
     from relay_teams.tools.registry.registry import (
         ToolAvailabilityRecord,
         ToolImplicitResolver,
@@ -27,6 +34,11 @@ __all__ = [
     "ToolGroupDefinition",
     "build_default_registry",
     "list_default_tool_groups",
+    "ActivationApplyResult",
+    "ActivationValidationResult",
+    "apply_tool_activation",
+    "build_initial_active_tools",
+    "validate_activation_request",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
@@ -55,6 +67,26 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "list_default_tool_groups": (
         "relay_teams.tools.registry.tool_groups",
         "list_default_tool_groups",
+    ),
+    "ActivationApplyResult": (
+        "relay_teams.tools.registry.runtime_activation",
+        "ActivationApplyResult",
+    ),
+    "ActivationValidationResult": (
+        "relay_teams.tools.registry.runtime_activation",
+        "ActivationValidationResult",
+    ),
+    "apply_tool_activation": (
+        "relay_teams.tools.registry.runtime_activation",
+        "apply_tool_activation",
+    ),
+    "build_initial_active_tools": (
+        "relay_teams.tools.registry.runtime_activation",
+        "build_initial_active_tools",
+    ),
+    "validate_activation_request": (
+        "relay_teams.tools.registry.runtime_activation",
+        "validate_activation_request",
     ),
 }
 

--- a/src/relay_teams/tools/registry/defaults.py
+++ b/src/relay_teams/tools/registry/defaults.py
@@ -17,7 +17,11 @@ from relay_teams.tools.workspace_tools import TOOLS as WORKSPACE_TOOLS
 IM_TOOLS = {
     "im_send": register_im_send,
 }
-HIDDEN_FROM_ROLE_CONFIG: tuple[str, ...] = ("im_send", "tool_search")
+HIDDEN_FROM_ROLE_CONFIG: tuple[str, ...] = (
+    "im_send",
+    "tool_search",
+    "activate_tools",
+)
 
 
 def build_default_registry() -> ToolRegistry:

--- a/src/relay_teams/tools/registry/defaults.py
+++ b/src/relay_teams/tools/registry/defaults.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from relay_teams.tools.discovery_tools import (
+    DiscoveryToolResolver,
+    TOOLS as DISCOVERY_TOOLS,
+)
 from relay_teams.tools.computer_tools import TOOLS as COMPUTER_TOOLS
 from relay_teams.tools.im_tools.im_send import register as register_im_send
 from relay_teams.tools.orchestration_tools import TOOLS as ORCHESTRATION_TOOLS
@@ -13,7 +17,7 @@ from relay_teams.tools.workspace_tools import TOOLS as WORKSPACE_TOOLS
 IM_TOOLS = {
     "im_send": register_im_send,
 }
-HIDDEN_FROM_ROLE_CONFIG: tuple[str, ...] = ("im_send",)
+HIDDEN_FROM_ROLE_CONFIG: tuple[str, ...] = ("im_send", "tool_search")
 
 
 def build_default_registry() -> ToolRegistry:
@@ -24,9 +28,12 @@ def build_default_registry() -> ToolRegistry:
         **WEB_TOOLS,
         **WORKSPACE_TOOLS,
         **COMPUTER_TOOLS,
+        **DISCOVERY_TOOLS,
         **IM_TOOLS,
     }
-    return ToolRegistry(
+    registry = ToolRegistry(
         tools,
         hidden_from_config=HIDDEN_FROM_ROLE_CONFIG,
     )
+    registry.register_implicit_resolver(DiscoveryToolResolver())
+    return registry

--- a/src/relay_teams/tools/registry/runtime_activation.py
+++ b/src/relay_teams/tools/registry/runtime_activation.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+DEFAULT_ALWAYS_ACTIVE_TOOLS: tuple[str, ...] = (
+    "tool_search",
+    "activate_tools",
+)
+
+
+class ActivationValidationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    requested: tuple[str, ...] = ()
+    authorized: tuple[str, ...] = ()
+    active: tuple[str, ...] = ()
+    deferred: tuple[str, ...] = ()
+    already_active: tuple[str, ...] = ()
+    unknown_or_unauthorized: tuple[str, ...] = ()
+    activatable: tuple[str, ...] = ()
+
+
+class ActivationApplyResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    requested: tuple[str, ...] = ()
+    activated: tuple[str, ...] = ()
+    already_active: tuple[str, ...] = ()
+    unknown_or_unauthorized: tuple[str, ...] = ()
+    rejected_due_to_limit: tuple[str, ...] = ()
+    active_tools: tuple[str, ...] = ()
+    deferred_tools: tuple[str, ...] = ()
+    max_active_tools: int | None = Field(default=None, ge=1)
+
+
+def build_initial_active_tools(
+    authorized_tools: tuple[str, ...],
+    *,
+    always_active_tools: tuple[str, ...] = DEFAULT_ALWAYS_ACTIVE_TOOLS,
+) -> tuple[str, ...]:
+    authorized_set = set(authorized_tools)
+    return _dedupe_names(
+        tuple(name for name in always_active_tools if name in authorized_set)
+    )
+
+
+def validate_activation_request(
+    *,
+    authorized_tools: tuple[str, ...],
+    active_tools: tuple[str, ...],
+    requested_tool_names: tuple[str, ...],
+) -> ActivationValidationResult:
+    authorized = _dedupe_names(authorized_tools)
+    active = tuple(name for name in _dedupe_names(active_tools) if name in authorized)
+    authorized_set = set(authorized)
+    active_set = set(active)
+    requested = _dedupe_names(requested_tool_names)
+
+    already_active = tuple(name for name in requested if name in active_set)
+    unknown_or_unauthorized = tuple(
+        name for name in requested if name not in authorized_set
+    )
+    activatable = tuple(
+        name for name in requested if name in authorized_set and name not in active_set
+    )
+    deferred = tuple(name for name in authorized if name not in active_set)
+
+    return ActivationValidationResult(
+        requested=requested,
+        authorized=authorized,
+        active=active,
+        deferred=deferred,
+        already_active=already_active,
+        unknown_or_unauthorized=unknown_or_unauthorized,
+        activatable=activatable,
+    )
+
+
+def apply_tool_activation(
+    *,
+    authorized_tools: tuple[str, ...],
+    active_tools: tuple[str, ...],
+    requested_tool_names: tuple[str, ...],
+    max_active_tools: int | None = None,
+) -> ActivationApplyResult:
+    validation = validate_activation_request(
+        authorized_tools=authorized_tools,
+        active_tools=active_tools,
+        requested_tool_names=requested_tool_names,
+    )
+    next_active = list(validation.active)
+    activated: list[str] = []
+    rejected_due_to_limit: list[str] = []
+
+    for name in validation.activatable:
+        if max_active_tools is not None and len(next_active) >= max_active_tools:
+            rejected_due_to_limit.append(name)
+            continue
+        next_active.append(name)
+        activated.append(name)
+
+    active_result = tuple(next_active)
+    return ActivationApplyResult(
+        requested=validation.requested,
+        activated=tuple(activated),
+        already_active=validation.already_active,
+        unknown_or_unauthorized=validation.unknown_or_unauthorized,
+        rejected_due_to_limit=tuple(rejected_due_to_limit),
+        active_tools=active_result,
+        deferred_tools=tuple(
+            name for name in validation.authorized if name not in set(active_result)
+        ),
+        max_active_tools=max_active_tools,
+    )
+
+
+def _dedupe_names(names: tuple[str, ...]) -> tuple[str, ...]:
+    deduplicated: list[str] = []
+    seen: set[str] = set()
+    for raw_name in names:
+        name = str(raw_name).strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        deduplicated.append(name)
+    return tuple(deduplicated)

--- a/src/relay_teams/tools/registry/runtime_activation.py
+++ b/src/relay_teams/tools/registry/runtime_activation.py
@@ -40,9 +40,12 @@ def build_initial_active_tools(
     always_active_tools: tuple[str, ...] = DEFAULT_ALWAYS_ACTIVE_TOOLS,
 ) -> tuple[str, ...]:
     authorized_set = set(authorized_tools)
-    return _dedupe_names(
+    initial_active_tools = _dedupe_names(
         tuple(name for name in always_active_tools if name in authorized_set)
     )
+    if initial_active_tools:
+        return initial_active_tools
+    return _dedupe_names(authorized_tools)
 
 
 def validate_activation_request(

--- a/tests/unit_tests/agents/execution/test_llm_session.py
+++ b/tests/unit_tests/agents/execution/test_llm_session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 
 import httpx
 from datetime import UTC, datetime
@@ -158,6 +159,25 @@ def test_normalize_committable_messages_keeps_request_fields() -> None:
 
 def test_normalize_committable_messages_adds_deferred_tool_guidance() -> None:
     session = object.__new__(AgentLlmSession)
+    session.__dict__["_agent_repo"] = type(
+        "_AgentRepo",
+        (),
+        {
+            "get_instance": lambda self, instance_id: SimpleNamespace(
+                runtime_tools_json=json.dumps(
+                    {
+                        "local_tools": [
+                            {"name": "tool_search"},
+                            {"name": "activate_tools"},
+                            {"name": "read"},
+                        ],
+                        "skill_tools": [],
+                        "mcp_tools": [],
+                    }
+                )
+            )
+        },
+    )()
     request = ModelRequest(
         parts=[
             RetryPromptPart(
@@ -168,7 +188,11 @@ def test_normalize_committable_messages_adds_deferred_tool_guidance() -> None:
         ]
     )
 
-    normalized = AgentLlmSession._normalize_committable_messages(session, [request])
+    normalized = AgentLlmSession._normalize_committable_messages(
+        session,
+        [request],
+        instance_id="instance-1",
+    )
 
     assert len(normalized) == 1
     normalized_request = normalized[0]
@@ -182,6 +206,51 @@ def test_normalize_committable_messages_adds_deferred_tool_guidance() -> None:
     assert "Unknown tool: read" in message
     assert "`tool_search`" in message
     assert "`activate_tools`" in message
+
+
+def test_normalize_committable_messages_omits_deferred_tool_guidance_without_discovery() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_agent_repo"] = type(
+        "_AgentRepo",
+        (),
+        {
+            "get_instance": lambda self, instance_id: SimpleNamespace(
+                runtime_tools_json=json.dumps(
+                    {
+                        "local_tools": [{"name": "read"}],
+                        "skill_tools": [],
+                        "mcp_tools": [],
+                    }
+                )
+            )
+        },
+    )()
+    request = ModelRequest(
+        parts=[
+            RetryPromptPart(
+                content="Unknown tool: read",
+                tool_name="read",
+                tool_call_id="call-1",
+            )
+        ]
+    )
+
+    normalized = AgentLlmSession._normalize_committable_messages(
+        session,
+        [request],
+        instance_id="instance-1",
+    )
+
+    normalized_request = normalized[0]
+    assert isinstance(normalized_request, ModelRequest)
+    normalized_part = normalized_request.parts[0]
+    assert isinstance(normalized_part, ToolReturnPart)
+    assert isinstance(normalized_part.content, dict)
+    error_payload = cast(dict[str, object], normalized_part.content["error"])
+    message = cast(str, error_payload["message"])
+    assert message == "Unknown tool: read"
 
 
 class _FakeMessageRepo:

--- a/tests/unit_tests/agents/execution/test_llm_session.py
+++ b/tests/unit_tests/agents/execution/test_llm_session.py
@@ -156,6 +156,34 @@ def test_normalize_committable_messages_keeps_request_fields() -> None:
     assert normalized_request.metadata == {"source": "test"}
 
 
+def test_normalize_committable_messages_adds_deferred_tool_guidance() -> None:
+    session = object.__new__(AgentLlmSession)
+    request = ModelRequest(
+        parts=[
+            RetryPromptPart(
+                content="Unknown tool: read",
+                tool_name="read",
+                tool_call_id="call-1",
+            )
+        ]
+    )
+
+    normalized = AgentLlmSession._normalize_committable_messages(session, [request])
+
+    assert len(normalized) == 1
+    normalized_request = normalized[0]
+    assert isinstance(normalized_request, ModelRequest)
+    normalized_part = normalized_request.parts[0]
+    assert isinstance(normalized_part, ToolReturnPart)
+    assert isinstance(normalized_part.content, dict)
+    error_payload = cast(dict[str, object], normalized_part.content["error"])
+    assert error_payload["code"] == "tool_input_validation_failed"
+    message = cast(str, error_payload["message"])
+    assert "Unknown tool: read" in message
+    assert "`tool_search`" in message
+    assert "`activate_tools`" in message
+
+
 class _FakeMessageRepo:
     def __init__(self, history: list[ModelRequest | ModelResponse]) -> None:
         self._history = history

--- a/tests/unit_tests/agents/execution/test_prompts.py
+++ b/tests/unit_tests/agents/execution/test_prompts.py
@@ -867,12 +867,32 @@ def test_build_runtime_tools_prompt_omits_tool_search_guidance_when_unavailable(
                     description="Read files.",
                 ),
             ),
+            skill_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="skill",
+                    name="load_skill",
+                    description="Load skills.",
+                ),
+            ),
+            mcp_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="mcp",
+                    name="docs_search",
+                    description="Search docs.",
+                    server_name="docs",
+                ),
+            ),
         )
     )
 
     assert "## Authorized Runtime Tools" in prompt
-    assert "Total Authorized Tools: 1" in prompt
+    assert "Total Authorized Tools: 3" in prompt
+    assert "Local Tools: read" in prompt
+    assert "Skill Tools: load_skill" in prompt
+    assert "MCP Tools docs: docs_search" in prompt
     assert "Local Tools: 1 authorized" in prompt
+    assert "Skill Tools: 1 authorized" in prompt
+    assert "MCP Tools: 1 authorized across 1 server(s)" in prompt
     assert "Use `tool_search` to discover authorized tools" not in prompt
 
 

--- a/tests/unit_tests/agents/execution/test_prompts.py
+++ b/tests/unit_tests/agents/execution/test_prompts.py
@@ -818,6 +818,11 @@ def test_build_runtime_tools_prompt_summarizes_authorized_tools() -> None:
             local_tools=(
                 RuntimeToolSnapshotEntry(
                     source="local",
+                    name="activate_tools",
+                    description="Activate tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
                     name="tool_search",
                     description="Discover tools.",
                 ),
@@ -842,17 +847,20 @@ def test_build_runtime_tools_prompt_summarizes_authorized_tools() -> None:
                     server_name="docs",
                 ),
             ),
-        )
+        ),
+        runtime_active_local_tools=("tool_search", "activate_tools"),
     )
 
     assert "## Authorized Runtime Tools" in prompt
+    assert "Active Local Tools: tool_search, activate_tools" in prompt
     assert "Use `tool_search` to discover authorized tools" in prompt
-    assert "Total Authorized Tools: 4" in prompt
-    assert "Local Tools: 2 authorized" in prompt
+    assert "call `activate_tools` before trying to use it" in prompt
+    assert "Total Authorized Tools: 5" in prompt
+    assert "Local Tools: 3 authorized" in prompt
     assert "Skill Tools: 1 authorized" in prompt
     assert "MCP Tools: 1 authorized across 1 server(s)" in prompt
     assert "MCP Tool Server: docs (1)" in prompt
-    assert "read, tool_search" not in prompt
+    assert "activate_tools, read, tool_search" not in prompt
 
 
 def test_build_runtime_tools_prompt_omits_tool_search_guidance_when_unavailable() -> (
@@ -886,6 +894,7 @@ def test_build_runtime_tools_prompt_omits_tool_search_guidance_when_unavailable(
     )
 
     assert "## Authorized Runtime Tools" in prompt
+    assert "Active Local Tools: none" in prompt
     assert "Total Authorized Tools: 3" in prompt
     assert "Local Tools: read" in prompt
     assert "Skill Tools: load_skill" in prompt

--- a/tests/unit_tests/agents/execution/test_prompts.py
+++ b/tests/unit_tests/agents/execution/test_prompts.py
@@ -11,12 +11,17 @@ from relay_teams.agents.execution import system_prompts
 from relay_teams.agents.execution.system_prompts import (
     PromptSkillInstruction,
     RuntimePromptBuildInput,
+    build_runtime_tools_prompt,
     SystemPromptSectionsInput,
     WorkspaceSshProfilePromptMetadata,
     build_workspace_ssh_profile_prompt_metadata,
     build_runtime_system_prompt,
     build_runtime_system_prompt_result,
     compose_system_prompt,
+)
+from relay_teams.agents.instances.models import (
+    RuntimeToolSnapshotEntry,
+    RuntimeToolsSnapshot,
 )
 from relay_teams.agents.execution.user_prompts import (
     UserPromptBuildInput,
@@ -805,6 +810,70 @@ def test_compose_system_prompt_places_skill_catalog_before_capability_summary() 
     assert prompt.index("## Available Roles") < prompt.index(
         "## Runtime Environment Information"
     )
+
+
+def test_build_runtime_tools_prompt_summarizes_authorized_tools() -> None:
+    prompt = build_runtime_tools_prompt(
+        RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read files.",
+                ),
+            ),
+            skill_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="skill",
+                    name="load_skill",
+                    description="Load skills.",
+                ),
+            ),
+            mcp_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="mcp",
+                    name="docs_search",
+                    description="Search docs.",
+                    server_name="docs",
+                ),
+            ),
+        )
+    )
+
+    assert "## Authorized Runtime Tools" in prompt
+    assert "Use `tool_search` to discover authorized tools" in prompt
+    assert "Total Authorized Tools: 4" in prompt
+    assert "Local Tools: 2 authorized" in prompt
+    assert "Skill Tools: 1 authorized" in prompt
+    assert "MCP Tools: 1 authorized across 1 server(s)" in prompt
+    assert "MCP Tool Server: docs (1)" in prompt
+    assert "read, tool_search" not in prompt
+
+
+def test_build_runtime_tools_prompt_omits_tool_search_guidance_when_unavailable() -> (
+    None
+):
+    prompt = build_runtime_tools_prompt(
+        RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read files.",
+                ),
+            ),
+        )
+    )
+
+    assert "## Authorized Runtime Tools" in prompt
+    assert "Total Authorized Tools: 1" in prompt
+    assert "Local Tools: 1 authorized" in prompt
+    assert "Use `tool_search` to discover authorized tools" not in prompt
 
 
 def test_user_prompt_builder_returns_raw_objective() -> None:

--- a/tests/unit_tests/agents/instances/test_repository.py
+++ b/tests/unit_tests/agents/instances/test_repository.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from relay_teams.agents.instances.enums import InstanceStatus
+from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
+
+
+def test_update_runtime_snapshot_persists_active_tools_json(tmp_path: Path) -> None:
+    repo = AgentInstanceRepository(tmp_path / "instances.db")
+    repo.upsert_instance(
+        run_id="run-1",
+        trace_id="trace-1",
+        session_id="session-1",
+        instance_id="instance-1",
+        role_id="reader",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        status=InstanceStatus.IDLE,
+    )
+
+    repo.update_runtime_snapshot(
+        "instance-1",
+        runtime_system_prompt="prompt",
+        runtime_tools_json='{"local_tools":[],"skill_tools":[],"mcp_tools":[]}',
+        runtime_active_tools_json='["tool_search"]',
+    )
+
+    record = repo.get_instance("instance-1")
+    assert record.runtime_system_prompt == "prompt"
+    assert record.runtime_tools_json == (
+        '{"local_tools":[],"skill_tools":[],"mcp_tools":[]}'
+    )
+    assert record.runtime_active_tools_json == '["tool_search"]'
+
+
+def test_repository_migrates_runtime_active_tools_column(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy_instances.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE agent_instances (
+            run_id TEXT NOT NULL,
+            trace_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            instance_id TEXT PRIMARY KEY,
+            role_id TEXT NOT NULL,
+            workspace_id TEXT NOT NULL DEFAULT '',
+            conversation_id TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL,
+            runtime_system_prompt TEXT NOT NULL DEFAULT '',
+            runtime_tools_json TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO agent_instances(
+            run_id,
+            trace_id,
+            session_id,
+            instance_id,
+            role_id,
+            workspace_id,
+            conversation_id,
+            status,
+            runtime_system_prompt,
+            runtime_tools_json,
+            created_at,
+            updated_at
+        )
+        VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "run-1",
+            "trace-1",
+            "session-1",
+            "instance-1",
+            "reader",
+            "workspace-1",
+            "conversation-1",
+            InstanceStatus.IDLE.value,
+            "prompt",
+            '{"local_tools":[],"skill_tools":[],"mcp_tools":[]}',
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T00:00:00+00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    repo = AgentInstanceRepository(db_path)
+
+    record = repo.get_instance("instance-1")
+    assert record.runtime_active_tools_json == ""

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from pydantic_ai.messages import ModelRequest, UserPromptPart
@@ -14,9 +16,19 @@ from relay_teams.media import (
     content_parts_from_text,
 )
 from relay_teams.agents.instances.enums import InstanceStatus
-from relay_teams.agents.instances.models import create_subagent_instance
-from relay_teams.agents.orchestration.task_execution_service import TaskExecutionService
-from relay_teams.agents.execution.system_prompts import RuntimePromptBuilder
+from relay_teams.agents.instances.models import (
+    RuntimeToolSnapshotEntry,
+    RuntimeToolsSnapshot,
+    create_subagent_instance,
+)
+from relay_teams.agents.orchestration.task_execution_service import (
+    PreparedRuntimeSnapshot,
+    TaskExecutionService,
+)
+from relay_teams.agents.execution.system_prompts import (
+    RuntimePromptBuilder,
+    RuntimePromptSections,
+)
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.retrieval import RetrievalService, SqliteFts5RetrievalStore
 from relay_teams.roles.memory_repository import RoleMemoryRepository
@@ -47,6 +59,10 @@ from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.skills.skill_routing_service import SkillRuntimeService
 from relay_teams.tools.registry import build_default_registry
+from relay_teams.tools.discovery_tools.activate_tools import (
+    _activate_runtime_tools as _activate_runtime_tools_for_test,
+)
+from relay_teams.tools.runtime import ToolContext
 from relay_teams.workspace import (
     WorkspaceManager,
     build_conversation_id,
@@ -74,6 +90,17 @@ class _CapturingProvider:
         self.thinking_enabled.append(getattr(thinking, "enabled", False) is True)
         self.thinking_efforts.append(getattr(thinking, "effort", None))
         return "ok"
+
+
+class _RoleCapturingProviderFactory:
+    def __init__(self) -> None:
+        self.role_tools_seen: list[tuple[str, ...]] = []
+        self.provider = _CapturingProvider()
+
+    def __call__(self, role: RoleDefinition, session_id: str | None = None) -> object:
+        del session_id
+        self.role_tools_seen.append(role.tools)
+        return self.provider
 
 
 class _InterruptingProvider:
@@ -358,9 +385,14 @@ async def test_execute_persists_objective_before_first_turn(
     runtime_record = agent_repo.get_instance(instance.instance_id)
     assert "You are the time role." in runtime_record.runtime_system_prompt
     runtime_tools = json.loads(runtime_record.runtime_tools_json)
-    assert [entry["name"] for entry in runtime_tools["local_tools"]] == ["tool_search"]
+    runtime_active_tools = json.loads(runtime_record.runtime_active_tools_json)
+    assert [entry["name"] for entry in runtime_tools["local_tools"]] == [
+        "activate_tools",
+        "tool_search",
+    ]
     assert runtime_tools["skill_tools"] == []
     assert runtime_tools["mcp_tools"] == []
+    assert runtime_active_tools == ["tool_search", "activate_tools"]
 
 
 @pytest.mark.asyncio
@@ -461,11 +493,16 @@ async def test_execute_runtime_snapshot_includes_skill_list_for_ui(
     assert "- time:" in runtime_record.runtime_system_prompt
     assert "missing_skill" not in runtime_record.runtime_system_prompt
     tools_snapshot = json.loads(runtime_record.runtime_tools_json)
-    assert [entry["name"] for entry in tools_snapshot["local_tools"]] == ["tool_search"]
+    runtime_active_tools = json.loads(runtime_record.runtime_active_tools_json)
+    assert [entry["name"] for entry in tools_snapshot["local_tools"]] == [
+        "activate_tools",
+        "tool_search",
+    ]
     assert len(tools_snapshot["skill_tools"]) == 1
     assert tools_snapshot["skill_tools"][0]["name"] == "load_skill"
     assert tools_snapshot["skill_tools"][0]["source"] == "skill"
     assert "absolute file paths" in tools_snapshot["skill_tools"][0]["description"]
+    assert runtime_active_tools == ["tool_search", "activate_tools"]
 
 
 @pytest.mark.asyncio
@@ -543,13 +580,364 @@ async def test_execute_runtime_prompt_lists_authorized_runtime_tools(
     )
 
     runtime_record = agent_repo.get_instance(instance.instance_id)
+    assert (
+        "Active Local Tools: tool_search, activate_tools"
+        in runtime_record.runtime_system_prompt
+    )
     assert "## Authorized Runtime Tools" in runtime_record.runtime_system_prompt
     assert (
         "Use `tool_search` to discover authorized tools"
         in runtime_record.runtime_system_prompt
     )
-    assert "Local Tools: 2 authorized" in runtime_record.runtime_system_prompt
+    assert "Local Tools: 3 authorized" in runtime_record.runtime_system_prompt
     assert "Local Tools: read" not in runtime_record.runtime_system_prompt
+
+
+@pytest.mark.asyncio
+async def test_execute_preserves_existing_runtime_active_tools(
+    tmp_path: Path,
+) -> None:
+    provider_factory = _RoleCapturingProviderFactory()
+    role = RoleDefinition(
+        role_id="reader",
+        name="reader",
+        description="Reads workspace files.",
+        version="1",
+        tools=("read",),
+        system_prompt="You are the reader role.",
+    )
+    role_registry = RoleRegistry()
+    role_registry.register(role)
+
+    db_path = tmp_path / "task_execution_service_runtime_active_tools.db"
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    message_repo = MessageRepository(db_path)
+    shared_store = SharedStateRepository(db_path)
+    service = TaskExecutionService(
+        role_registry=role_registry,
+        task_repo=task_repo,
+        shared_store=shared_store,
+        event_bus=EventLog(db_path),
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+        approval_ticket_repo=ApprovalTicketRepository(db_path),
+        run_runtime_repo=RunRuntimeRepository(db_path),
+        workspace_manager=WorkspaceManager(
+            project_root=Path("."), shared_store=shared_store
+        ),
+        prompt_builder=RuntimePromptBuilder(
+            role_registry=role_registry,
+            mcp_registry=McpRegistry(),
+        ),
+        provider_factory=provider_factory,
+        tool_registry=build_default_registry(),
+        skill_registry=SkillRegistry.from_config_dirs(app_config_dir=db_path.parent),
+        mcp_registry=McpRegistry(),
+        run_intent_repo=RunIntentRepository(db_path),
+    )
+    instance = create_subagent_instance(
+        "reader",
+        workspace_id="default",
+        conversation_id=build_conversation_id("session-1", "reader"),
+    )
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        parent_task_id="task-root",
+        trace_id="run-1",
+        objective="read a file",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(task)
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=instance.instance_id,
+        role_id="reader",
+        workspace_id=instance.workspace_id,
+        conversation_id=instance.conversation_id,
+        status=InstanceStatus.IDLE,
+    )
+    agent_repo.update_runtime_snapshot(
+        instance.instance_id,
+        runtime_system_prompt="older prompt",
+        runtime_tools_json='{"local_tools":[],"skill_tools":[],"mcp_tools":[]}',
+        runtime_active_tools_json='["tool_search","activate_tools","read"]',
+    )
+
+    _ = await service.execute(
+        instance_id=instance.instance_id,
+        role_id="reader",
+        task=task,
+    )
+
+    runtime_record = agent_repo.get_instance(instance.instance_id)
+    assert provider_factory.role_tools_seen == [("read",)]
+    assert json.loads(runtime_record.runtime_active_tools_json) == [
+        "tool_search",
+        "activate_tools",
+        "read",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_provider_uses_initial_active_local_tools_only(
+    tmp_path: Path,
+) -> None:
+    provider_factory = _RoleCapturingProviderFactory()
+    role = RoleDefinition(
+        role_id="reader",
+        name="reader",
+        description="Reads workspace files.",
+        version="1",
+        tools=("read",),
+        system_prompt="You are the reader role.",
+    )
+    role_registry = RoleRegistry()
+    role_registry.register(role)
+
+    db_path = tmp_path / "task_execution_service_active_local_tools_only.db"
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    message_repo = MessageRepository(db_path)
+    shared_store = SharedStateRepository(db_path)
+    service = TaskExecutionService(
+        role_registry=role_registry,
+        task_repo=task_repo,
+        shared_store=shared_store,
+        event_bus=EventLog(db_path),
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+        approval_ticket_repo=ApprovalTicketRepository(db_path),
+        run_runtime_repo=RunRuntimeRepository(db_path),
+        workspace_manager=WorkspaceManager(
+            project_root=Path("."), shared_store=shared_store
+        ),
+        prompt_builder=RuntimePromptBuilder(
+            role_registry=role_registry,
+            mcp_registry=McpRegistry(),
+        ),
+        provider_factory=provider_factory,
+        tool_registry=build_default_registry(),
+        skill_registry=SkillRegistry.from_config_dirs(app_config_dir=db_path.parent),
+        mcp_registry=McpRegistry(),
+        run_intent_repo=RunIntentRepository(db_path),
+    )
+    instance = create_subagent_instance(
+        "reader",
+        workspace_id="default",
+        conversation_id=build_conversation_id("session-1", "reader"),
+    )
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        parent_task_id="task-root",
+        trace_id="run-1",
+        objective="read a file",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(task)
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=instance.instance_id,
+        role_id="reader",
+        workspace_id=instance.workspace_id,
+        conversation_id=instance.conversation_id,
+        status=InstanceStatus.IDLE,
+    )
+
+    _ = await service.execute(
+        instance_id=instance.instance_id,
+        role_id="reader",
+        task=task,
+    )
+
+    runtime_record = agent_repo.get_instance(instance.instance_id)
+    assert provider_factory.role_tools_seen == [()]
+    assert json.loads(runtime_record.runtime_active_tools_json) == [
+        "tool_search",
+        "activate_tools",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_next_turn_uses_tools_activated_by_activate_tools(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_factory = _RoleCapturingProviderFactory()
+    role = RoleDefinition(
+        role_id="reader",
+        name="reader",
+        description="Reads workspace files.",
+        version="1",
+        tools=("read",),
+        system_prompt="You are the reader role.",
+    )
+    role_registry = RoleRegistry()
+    role_registry.register(role)
+
+    db_path = tmp_path / "task_execution_service_activate_next_turn.db"
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    message_repo = MessageRepository(db_path)
+    shared_store = SharedStateRepository(db_path)
+    service = TaskExecutionService(
+        role_registry=role_registry,
+        task_repo=task_repo,
+        shared_store=shared_store,
+        event_bus=EventLog(db_path),
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+        approval_ticket_repo=ApprovalTicketRepository(db_path),
+        run_runtime_repo=RunRuntimeRepository(db_path),
+        workspace_manager=WorkspaceManager(
+            project_root=Path("."), shared_store=shared_store
+        ),
+        prompt_builder=RuntimePromptBuilder(
+            role_registry=role_registry,
+            mcp_registry=McpRegistry(),
+        ),
+        provider_factory=provider_factory,
+        tool_registry=build_default_registry(),
+        skill_registry=SkillRegistry.from_config_dirs(app_config_dir=db_path.parent),
+        mcp_registry=McpRegistry(),
+        run_intent_repo=RunIntentRepository(db_path),
+    )
+    fake_workspace = SimpleNamespace(
+        ref=SimpleNamespace(
+            workspace_id="default",
+            conversation_id=build_conversation_id("session-1", "reader"),
+        ),
+        scope_root=tmp_path,
+        resolve_workdir=lambda: tmp_path,
+    )
+    runtime_tools = RuntimeToolsSnapshot(
+        local_tools=(
+            RuntimeToolSnapshotEntry(
+                source="local",
+                name="activate_tools",
+                description="Activate tools.",
+            ),
+            RuntimeToolSnapshotEntry(
+                source="local",
+                name="tool_search",
+                description="Discover tools.",
+            ),
+            RuntimeToolSnapshotEntry(
+                source="local",
+                name="read",
+                description="Read files.",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        type(service.workspace_manager),
+        "resolve",
+        lambda self, **kwargs: fake_workspace,
+    )
+
+    async def _fake_prepare_runtime_snapshot(
+        *,
+        role: RoleDefinition,
+        task: TaskEnvelope,
+        working_directory: Path | None,
+        worktree_root: Path | None,
+        workspace: object | None,
+        shared_state_snapshot: tuple[tuple[str, str], ...],
+        objective: str,
+        existing_runtime_active_tools_json: str = "",
+    ) -> PreparedRuntimeSnapshot:
+        del role, task, working_directory, worktree_root, workspace
+        del shared_state_snapshot, objective
+        return PreparedRuntimeSnapshot(
+            prompt_sections=RuntimePromptSections(
+                prompt="runtime prompt",
+                base_instructions="base instructions",
+            ),
+            runtime_tools_json=json.dumps(runtime_tools.model_dump(mode="json")),
+            runtime_active_tools_json=service._build_runtime_active_tools_json(
+                runtime_tools=runtime_tools,
+                existing_runtime_active_tools_json=existing_runtime_active_tools_json,
+            ),
+            user_prompt="read a file",
+        )
+
+    monkeypatch.setattr(
+        service,
+        "_prepare_runtime_snapshot",
+        _fake_prepare_runtime_snapshot,
+    )
+    instance = create_subagent_instance(
+        "reader",
+        workspace_id="default",
+        conversation_id=build_conversation_id("session-1", "reader"),
+    )
+    first_task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        parent_task_id="task-root",
+        trace_id="run-1",
+        objective="read a file",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    second_task = TaskEnvelope(
+        task_id="task-2",
+        session_id="session-1",
+        parent_task_id="task-root",
+        trace_id="run-1",
+        objective="read the second file",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(first_task)
+    _ = task_repo.create(second_task)
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=instance.instance_id,
+        role_id="reader",
+        workspace_id=instance.workspace_id,
+        conversation_id=instance.conversation_id,
+        status=InstanceStatus.IDLE,
+    )
+
+    _ = await service.execute(
+        instance_id=instance.instance_id,
+        role_id="reader",
+        task=first_task,
+    )
+
+    _activate_runtime_tools_for_test(
+        ctx=cast(
+            ToolContext,
+            SimpleNamespace(
+                deps=SimpleNamespace(
+                    agent_repo=agent_repo,
+                    instance_id=instance.instance_id,
+                )
+            ),
+        ),
+        tool_names=["read"],
+    )
+
+    _ = await service.execute(
+        instance_id=instance.instance_id,
+        role_id="reader",
+        task=second_task,
+    )
+
+    runtime_record = agent_repo.get_instance(instance.instance_id)
+    assert provider_factory.role_tools_seen == [(), ("read",)]
+    assert json.loads(runtime_record.runtime_active_tools_json) == [
+        "tool_search",
+        "activate_tools",
+        "read",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -357,11 +357,10 @@ async def test_execute_persists_objective_before_first_turn(
     assert history[0].parts[0].content == "query time"
     runtime_record = agent_repo.get_instance(instance.instance_id)
     assert "You are the time role." in runtime_record.runtime_system_prompt
-    assert json.loads(runtime_record.runtime_tools_json) == {
-        "local_tools": [],
-        "skill_tools": [],
-        "mcp_tools": [],
-    }
+    runtime_tools = json.loads(runtime_record.runtime_tools_json)
+    assert [entry["name"] for entry in runtime_tools["local_tools"]] == ["tool_search"]
+    assert runtime_tools["skill_tools"] == []
+    assert runtime_tools["mcp_tools"] == []
 
 
 @pytest.mark.asyncio
@@ -462,6 +461,7 @@ async def test_execute_runtime_snapshot_includes_skill_list_for_ui(
     assert "- time:" in runtime_record.runtime_system_prompt
     assert "missing_skill" not in runtime_record.runtime_system_prompt
     tools_snapshot = json.loads(runtime_record.runtime_tools_json)
+    assert [entry["name"] for entry in tools_snapshot["local_tools"]] == ["tool_search"]
     assert len(tools_snapshot["skill_tools"]) == 1
     assert tools_snapshot["skill_tools"][0]["name"] == "load_skill"
     assert tools_snapshot["skill_tools"][0]["source"] == "skill"
@@ -544,7 +544,12 @@ async def test_execute_runtime_prompt_lists_authorized_runtime_tools(
 
     runtime_record = agent_repo.get_instance(instance.instance_id)
     assert "## Authorized Runtime Tools" in runtime_record.runtime_system_prompt
-    assert "Local Tools: read" in runtime_record.runtime_system_prompt
+    assert (
+        "Use `tool_search` to discover authorized tools"
+        in runtime_record.runtime_system_prompt
+    )
+    assert "Local Tools: 2 authorized" in runtime_record.runtime_system_prompt
+    assert "Local Tools: read" not in runtime_record.runtime_system_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -59,10 +59,12 @@ from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.skills.skill_routing_service import SkillRuntimeService
 from relay_teams.tools.registry import build_default_registry
+from relay_teams.tools.registry.registry import ToolRegistry
 from relay_teams.tools.discovery_tools.activate_tools import (
     _activate_runtime_tools as _activate_runtime_tools_for_test,
 )
 from relay_teams.tools.runtime import ToolContext
+from relay_teams.tools.workspace_tools.read import register as register_read
 from relay_teams.workspace import (
     WorkspaceManager,
     build_conversation_id,
@@ -762,6 +764,87 @@ async def test_execute_provider_uses_initial_active_local_tools_only(
         "tool_search",
         "activate_tools",
     ]
+
+
+@pytest.mark.asyncio
+async def test_execute_keeps_explicit_tools_callable_without_discovery_tools(
+    tmp_path: Path,
+) -> None:
+    provider_factory = _RoleCapturingProviderFactory()
+    role = RoleDefinition(
+        role_id="reader",
+        name="reader",
+        description="Reads workspace files.",
+        version="1",
+        tools=("read",),
+        system_prompt="You are the reader role.",
+    )
+    role_registry = RoleRegistry()
+    role_registry.register(role)
+
+    db_path = tmp_path / "task_execution_service_without_discovery_tools.db"
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    message_repo = MessageRepository(db_path)
+    shared_store = SharedStateRepository(db_path)
+    service = TaskExecutionService(
+        role_registry=role_registry,
+        task_repo=task_repo,
+        shared_store=shared_store,
+        event_bus=EventLog(db_path),
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+        approval_ticket_repo=ApprovalTicketRepository(db_path),
+        run_runtime_repo=RunRuntimeRepository(db_path),
+        workspace_manager=WorkspaceManager(
+            project_root=Path("."), shared_store=shared_store
+        ),
+        prompt_builder=RuntimePromptBuilder(
+            role_registry=role_registry,
+            mcp_registry=McpRegistry(),
+        ),
+        provider_factory=provider_factory,
+        tool_registry=ToolRegistry({"read": register_read}),
+        skill_registry=SkillRegistry.from_config_dirs(app_config_dir=db_path.parent),
+        mcp_registry=McpRegistry(),
+        run_intent_repo=RunIntentRepository(db_path),
+    )
+    instance = create_subagent_instance(
+        "reader",
+        workspace_id="default",
+        conversation_id=build_conversation_id("session-1", "reader"),
+    )
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        parent_task_id="task-root",
+        trace_id="run-1",
+        objective="read a file",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(task)
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=instance.instance_id,
+        role_id="reader",
+        workspace_id=instance.workspace_id,
+        conversation_id=instance.conversation_id,
+        status=InstanceStatus.IDLE,
+    )
+
+    _ = await service.execute(
+        instance_id=instance.instance_id,
+        role_id="reader",
+        task=task,
+    )
+
+    runtime_record = agent_repo.get_instance(instance.instance_id)
+    assert provider_factory.role_tools_seen == [("read",)]
+    assert json.loads(runtime_record.runtime_active_tools_json) == ["read"]
+    assert "Active Local Tools: read" in runtime_record.runtime_system_prompt
+    assert "Local Tools: read" in runtime_record.runtime_system_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/tools/discovery_tools/test_activate_tools.py
+++ b/tests/unit_tests/tools/discovery_tools/test_activate_tools.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import inspect
+import json
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pydantic_ai import Agent
+
+from relay_teams.agents.instances.enums import InstanceStatus
+from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
+from relay_teams.agents.instances.models import (
+    RuntimeToolSnapshotEntry,
+    RuntimeToolsSnapshot,
+)
+from relay_teams.tools.discovery_tools import activate_tools as activate_tools_module
+from relay_teams.tools.discovery_tools import register_activate_tools
+from relay_teams.tools.runtime import ToolDeps
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., object]] = {}
+        self.tool_descriptions: dict[str, str] = {}
+
+    def tool(
+        self, *, description: str
+    ) -> Callable[[Callable[..., object]], Callable[..., object]]:
+        def decorator(func: Callable[..., object]) -> Callable[..., object]:
+            self.tools[func.__name__] = func
+            self.tool_descriptions[func.__name__] = description
+            return func
+
+        return decorator
+
+
+def _invoke_tool_action(
+    action: Callable[..., object],
+    raw_args: dict[str, object] | None = None,
+) -> object:
+    if raw_args is None:
+        return action()
+    signature = inspect.signature(action)
+    bound_args = {
+        name: raw_args[name]
+        for name in signature.parameters
+        if name in raw_args and name != "ctx"
+    }
+    return action(**bound_args)
+
+
+def _seed_runtime_snapshot(
+    *,
+    agent_repo: AgentInstanceRepository,
+    instance_id: str,
+    runtime_tools: RuntimeToolsSnapshot,
+    runtime_active_tools_json: str = "",
+) -> None:
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="trace-1",
+        session_id="session-1",
+        instance_id=instance_id,
+        role_id="reader",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        status=InstanceStatus.IDLE,
+    )
+    agent_repo.update_runtime_snapshot(
+        instance_id,
+        runtime_system_prompt="prompt",
+        runtime_tools_json=json.dumps(runtime_tools.model_dump(mode="json")),
+        runtime_active_tools_json=runtime_active_tools_json,
+    )
+
+
+@pytest.mark.asyncio
+async def test_activate_tools_persists_new_local_tool_activation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_activate_tools(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["activate_tools"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="activate_tools",
+                    description="Activate tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read files.",
+                ),
+            ),
+        ),
+        runtime_active_tools_json='["tool_search","activate_tools"]',
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
+        )
+
+    monkeypatch.setattr(
+        activate_tools_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
+
+    result = await tool(ctx, tool_names=["read"])
+
+    assert result["activated"] == ["read"]
+    assert result["already_active"] == []
+    assert result["unknown_or_unauthorized"] == []
+    assert result["active_tools"] == ["tool_search", "activate_tools", "read"]
+    persisted = agent_repo.get_instance("instance-1")
+    assert json.loads(persisted.runtime_active_tools_json) == [
+        "tool_search",
+        "activate_tools",
+        "read",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_activate_tools_reports_unknown_requested_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_activate_tools(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["activate_tools"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="activate_tools",
+                    description="Activate tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover tools.",
+                ),
+            ),
+        ),
+        runtime_active_tools_json='["tool_search","activate_tools"]',
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
+        )
+
+    monkeypatch.setattr(
+        activate_tools_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
+
+    result = await tool(ctx, tool_names=["read", "missing_tool"])
+
+    assert result["activated"] == []
+    assert result["unknown_or_unauthorized"] == ["read", "missing_tool"]
+    assert "not authorized local tools" in str(result["warning"])
+
+
+@pytest.mark.asyncio
+async def test_activate_tools_accepts_single_string_tool_name(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_activate_tools(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["activate_tools"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="activate_tools",
+                    description="Activate tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read files.",
+                ),
+            ),
+        ),
+        runtime_active_tools_json='["tool_search","activate_tools"]',
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
+        )
+
+    monkeypatch.setattr(
+        activate_tools_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
+
+    result = await tool(ctx, tool_names="read")
+
+    assert result["activated"] == ["read"]
+    assert result["unknown_or_unauthorized"] == []
+    assert result["active_tools"] == ["tool_search", "activate_tools", "read"]

--- a/tests/unit_tests/tools/discovery_tools/test_activate_tools.py
+++ b/tests/unit_tests/tools/discovery_tools/test_activate_tools.py
@@ -276,3 +276,71 @@ async def test_activate_tools_accepts_single_string_tool_name(
     assert result["activated"] == ["read"]
     assert result["unknown_or_unauthorized"] == []
     assert result["active_tools"] == ["tool_search", "activate_tools", "read"]
+
+
+@pytest.mark.asyncio
+async def test_activate_tools_empty_input_preserves_current_runtime_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_activate_tools(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["activate_tools"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="activate_tools",
+                    description="Activate tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read files.",
+                ),
+            ),
+        ),
+        runtime_active_tools_json='["tool_search","activate_tools"]',
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
+        )
+
+    monkeypatch.setattr(
+        activate_tools_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
+
+    result = await tool(ctx, tool_names=["", "  "])
+
+    assert result["activated"] == []
+    assert result["active_tools"] == ["tool_search", "activate_tools"]
+    assert result["active_tools_count"] == 2
+    assert result["deferred_tools_count"] == 1
+    assert "must contain at least one non-empty tool name" in str(result["warning"])

--- a/tests/unit_tests/tools/discovery_tools/test_tool_search.py
+++ b/tests/unit_tests/tools/discovery_tools/test_tool_search.py
@@ -199,6 +199,65 @@ async def test_tool_search_select_includes_schema(
 
 
 @pytest.mark.asyncio
+async def test_tool_search_select_respects_max_results(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_tool_search(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["tool_search"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read a file or directory from disk.",
+                    parameters_json_schema={"type": "object"},
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="write",
+                    description="Write full file contents.",
+                    parameters_json_schema={"type": "object"},
+                ),
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+        )
+
+    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, query="select:read,write", max_results=1)
+
+    assert result["mode"] == "select"
+    assert (
+        result["warning"]
+        == "Only the first 1 matched tools were returned due to max_results."
+    )
+    matches = cast(list[dict[str, object]], result["matches"])
+    assert [match["name"] for match in matches] == ["read"]
+
+
+@pytest.mark.asyncio
 async def test_tool_search_exact_name_returns_schema_without_select_prefix(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -423,3 +482,66 @@ async def test_tool_search_keyword_search_matches_compound_tool_names(
     assert result["mode"] == "keyword"
     matches = cast(list[dict[str, object]], result["matches"])
     assert [match["name"] for match in matches] == ["webfetch"]
+
+
+@pytest.mark.asyncio
+async def test_tool_search_empty_query_reports_actual_authorized_count(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_tool_search(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["tool_search"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read a file or directory from disk.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover tools.",
+                ),
+            ),
+            mcp_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="mcp",
+                    name="docs_search",
+                    description="Search developer documentation.",
+                    server_name="docs",
+                ),
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+        )
+
+    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, query="   ")
+
+    assert result["mode"] == "keyword"
+    assert result["warning"] == "Query must not be empty."
+    assert result["total_authorized_tools"] == 3
+    matches = cast(list[dict[str, object]], result["matches"])
+    assert matches == []

--- a/tests/unit_tests/tools/discovery_tools/test_tool_search.py
+++ b/tests/unit_tests/tools/discovery_tools/test_tool_search.py
@@ -1,0 +1,425 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pydantic_ai import Agent
+
+from relay_teams.agents.instances.enums import InstanceStatus
+from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
+from relay_teams.agents.instances.models import (
+    RuntimeToolSnapshotEntry,
+    RuntimeToolsSnapshot,
+)
+from relay_teams.tools.discovery_tools import register_tool_search
+from relay_teams.tools.runtime import ToolDeps
+from relay_teams.tools.discovery_tools import tool_search as tool_search_module
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., object]] = {}
+        self.tool_descriptions: dict[str, str] = {}
+
+    def tool(
+        self, *, description: str
+    ) -> Callable[[Callable[..., object]], Callable[..., object]]:
+        def decorator(func: Callable[..., object]) -> Callable[..., object]:
+            self.tools[func.__name__] = func
+            self.tool_descriptions[func.__name__] = description
+            return func
+
+        return decorator
+
+
+def _invoke_tool_action(
+    action: Callable[..., object],
+) -> object:
+    return action()
+
+
+def _seed_runtime_snapshot(
+    *,
+    agent_repo: AgentInstanceRepository,
+    instance_id: str,
+    runtime_tools: RuntimeToolsSnapshot,
+) -> None:
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="trace-1",
+        session_id="session-1",
+        instance_id=instance_id,
+        role_id="reader",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        status=InstanceStatus.IDLE,
+    )
+    agent_repo.update_runtime_snapshot(
+        instance_id,
+        runtime_system_prompt="prompt",
+        runtime_tools_json=json.dumps(runtime_tools.model_dump(mode="json")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_search_keyword_search_returns_compact_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_tool_search(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["tool_search"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read a file or directory from disk.",
+                ),
+            ),
+            mcp_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="mcp",
+                    name="docs_search",
+                    description="Search developer documentation.",
+                    server_name="docs",
+                ),
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+        )
+
+    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, query="docs search")
+
+    assert result["mode"] == "keyword"
+    assert result["total_authorized_tools"] == 3
+    matches = cast(list[dict[str, object]], result["matches"])
+    assert matches[0]["name"] == "docs_search"
+    assert matches[0]["server_name"] == "docs"
+    assert "parameters_json_schema" not in matches[0]
+
+
+@pytest.mark.asyncio
+async def test_tool_search_select_includes_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_tool_search(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["tool_search"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="read",
+                    description="Read a file or directory from disk.",
+                    parameters_json_schema={
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                        },
+                    },
+                ),
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+        )
+
+    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, query="select:read")
+
+    assert result["mode"] == "select"
+    matches = cast(list[dict[str, object]], result["matches"])
+    assert matches == [
+        {
+            "name": "read",
+            "source": "local",
+            "description": "Read a file or directory from disk.",
+            "kind": "function",
+            "sequential": False,
+            "parameters_json_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                },
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tool_search_exact_name_returns_schema_without_select_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_tool_search(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["tool_search"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover tools.",
+                ),
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+        )
+
+    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, query="tool_search")
+
+    assert result["mode"] == "exact"
+    matches = cast(list[dict[str, object]], result["matches"])
+    assert len(matches) == 1
+    assert matches[0]["name"] == "tool_search"
+    assert "parameters_json_schema" in matches[0]
+
+
+@pytest.mark.asyncio
+async def test_tool_search_exact_name_prioritizes_exact_match_and_includes_related_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_tool_search(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["tool_search"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="edit",
+                    description="Edit a file in the workspace.",
+                    parameters_json_schema={"type": "object"},
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="notebook_edit",
+                    description="Edit a notebook cell by index.",
+                    parameters_json_schema={"type": "object"},
+                ),
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+        )
+
+    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, query="edit")
+
+    assert result["mode"] == "exact"
+    matches = cast(list[dict[str, object]], result["matches"])
+    assert [match["name"] for match in matches] == ["edit", "notebook_edit"]
+    assert all("parameters_json_schema" in match for match in matches)
+
+
+@pytest.mark.asyncio
+async def test_tool_search_keyword_search_filters_low_signal_false_positives(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_tool_search(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["tool_search"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="tool_search",
+                    description="Discover authorized runtime tools.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="notebook_edit",
+                    description="Edit a notebook cell by index.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="spawn_subagent",
+                    description="Delegate work to another agent.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="webfetch",
+                    description="Fetch a web page.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="edit",
+                    description="Edit a file in the workspace.",
+                ),
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+        )
+
+    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, query="definitely_not_a_real_tool")
+
+    assert result["mode"] == "keyword"
+    matches = cast(list[dict[str, object]], result["matches"])
+    assert matches == []
+
+
+@pytest.mark.asyncio
+async def test_tool_search_keyword_search_matches_compound_tool_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_tool_search(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["tool_search"],
+    )
+    agent_repo = AgentInstanceRepository(tmp_path / "instances.db")
+    _seed_runtime_snapshot(
+        agent_repo=agent_repo,
+        instance_id="instance-1",
+        runtime_tools=RuntimeToolsSnapshot(
+            local_tools=(
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="webfetch",
+                    description="Fetch a web page.",
+                ),
+                RuntimeToolSnapshotEntry(
+                    source="local",
+                    name="websearch",
+                    description="Search the web.",
+                ),
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            agent_repo=agent_repo,
+            instance_id="instance-1",
+        )
+    )
+
+    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+        del ctx
+        return cast(
+            dict[str, object],
+            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+        )
+
+    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(ctx, query="web fetch")
+
+    assert result["mode"] == "keyword"
+    matches = cast(list[dict[str, object]], result["matches"])
+    assert [match["name"] for match in matches] == ["webfetch"]

--- a/tests/unit_tests/tools/discovery_tools/test_tool_search.py
+++ b/tests/unit_tests/tools/discovery_tools/test_tool_search.py
@@ -58,6 +58,7 @@ def _seed_runtime_snapshot(
     agent_repo: AgentInstanceRepository,
     instance_id: str,
     runtime_tools: RuntimeToolsSnapshot,
+    runtime_active_tools_json: str = "",
 ) -> None:
     agent_repo.upsert_instance(
         run_id="run-1",
@@ -73,6 +74,7 @@ def _seed_runtime_snapshot(
         instance_id,
         runtime_system_prompt="prompt",
         runtime_tools_json=json.dumps(runtime_tools.model_dump(mode="json")),
+        runtime_active_tools_json=runtime_active_tools_json,
     )
 
 
@@ -113,6 +115,7 @@ async def test_tool_search_keyword_search_returns_compact_matches(
                 ),
             ),
         ),
+        runtime_active_tools_json='["tool_search"]',
     )
     ctx = SimpleNamespace(
         deps=SimpleNamespace(
@@ -144,6 +147,7 @@ async def test_tool_search_keyword_search_returns_compact_matches(
     matches = cast(list[dict[str, object]], result["matches"])
     assert matches[0]["name"] == "docs_search"
     assert matches[0]["server_name"] == "docs"
+    assert matches[0]["activation_state"] == "active"
     assert "parameters_json_schema" not in matches[0]
 
 
@@ -177,6 +181,7 @@ async def test_tool_search_select_includes_schema(
                 ),
             ),
         ),
+        runtime_active_tools_json='["tool_search"]',
     )
     ctx = SimpleNamespace(
         deps=SimpleNamespace(
@@ -212,6 +217,7 @@ async def test_tool_search_select_includes_schema(
             "description": "Read a file or directory from disk.",
             "kind": "function",
             "sequential": False,
+            "activation_state": "deferred",
             "parameters_json_schema": {
                 "type": "object",
                 "properties": {

--- a/tests/unit_tests/tools/discovery_tools/test_tool_search.py
+++ b/tests/unit_tests/tools/discovery_tools/test_tool_search.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import inspect
 import json
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -39,8 +40,17 @@ class _FakeAgent:
 
 def _invoke_tool_action(
     action: Callable[..., object],
+    raw_args: dict[str, object] | None = None,
 ) -> object:
-    return action()
+    if raw_args is None:
+        return action()
+    signature = inspect.signature(action)
+    bound_args = {
+        name: raw_args[name]
+        for name in signature.parameters
+        if name in raw_args and name != "ctx"
+    }
+    return action(**bound_args)
 
 
 def _seed_runtime_snapshot(
@@ -111,14 +121,21 @@ async def test_tool_search_keyword_search_returns_compact_matches(
         )
     )
 
-    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
         del ctx
         return cast(
             dict[str, object],
-            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
         )
 
-    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(
+        tool_search_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
 
     result = await tool(ctx, query="docs search")
 
@@ -168,14 +185,21 @@ async def test_tool_search_select_includes_schema(
         )
     )
 
-    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
         del ctx
         return cast(
             dict[str, object],
-            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
         )
 
-    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(
+        tool_search_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
 
     result = await tool(ctx, query="select:read")
 
@@ -237,14 +261,21 @@ async def test_tool_search_select_respects_max_results(
         )
     )
 
-    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
         del ctx
         return cast(
             dict[str, object],
-            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
         )
 
-    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(
+        tool_search_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
 
     result = await tool(ctx, query="select:read,write", max_results=1)
 
@@ -289,14 +320,21 @@ async def test_tool_search_exact_name_returns_schema_without_select_prefix(
         )
     )
 
-    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
         del ctx
         return cast(
             dict[str, object],
-            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
         )
 
-    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(
+        tool_search_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
 
     result = await tool(ctx, query="tool_search")
 
@@ -346,14 +384,21 @@ async def test_tool_search_exact_name_prioritizes_exact_match_and_includes_relat
         )
     )
 
-    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
         del ctx
         return cast(
             dict[str, object],
-            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
         )
 
-    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(
+        tool_search_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
 
     result = await tool(ctx, query="edit")
 
@@ -415,14 +460,21 @@ async def test_tool_search_keyword_search_filters_low_signal_false_positives(
         )
     )
 
-    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
         del ctx
         return cast(
             dict[str, object],
-            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
         )
 
-    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(
+        tool_search_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
 
     result = await tool(ctx, query="definitely_not_a_real_tool")
 
@@ -468,14 +520,21 @@ async def test_tool_search_keyword_search_matches_compound_tool_names(
         )
     )
 
-    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
         del ctx
         return cast(
             dict[str, object],
-            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
         )
 
-    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(
+        tool_search_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
 
     result = await tool(ctx, query="web fetch")
 
@@ -529,14 +588,21 @@ async def test_tool_search_empty_query_reports_actual_authorized_count(
         )
     )
 
-    async def _fake_execute_tool(ctx, **kwargs: object) -> dict[str, object]:
+    async def _fake_execute_tool_call(ctx, **kwargs: object) -> dict[str, object]:
         del ctx
         return cast(
             dict[str, object],
-            _invoke_tool_action(cast(Callable[..., object], kwargs["action"])),
+            _invoke_tool_action(
+                cast(Callable[..., object], kwargs["action"]),
+                cast(dict[str, object], kwargs.get("raw_args")),
+            ),
         )
 
-    monkeypatch.setattr(tool_search_module, "execute_tool", _fake_execute_tool)
+    monkeypatch.setattr(
+        tool_search_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
 
     result = await tool(ctx, query="   ")
 

--- a/tests/unit_tests/tools/registry/test_defaults.py
+++ b/tests/unit_tests/tools/registry/test_defaults.py
@@ -15,6 +15,7 @@ def test_registry_rejects_unknown_tools() -> None:
 def test_registry_contains_registered_local_tools() -> None:
     registry = build_default_registry()
     assert registry.list_names() == (
+        "activate_tools",
         "ask_question",
         "capture_screen",
         "click_at",
@@ -63,6 +64,7 @@ def test_registry_hides_im_send_from_manual_role_configuration() -> None:
 
     assert "im_send" not in registry.list_configurable_names()
     assert "tool_search" not in registry.list_configurable_names()
+    assert "activate_tools" not in registry.list_configurable_names()
 
 
 def test_default_registry_ignores_unknown_tools_for_runtime_resolution() -> None:
@@ -94,8 +96,12 @@ def test_default_registry_implicitly_adds_tool_search() -> None:
 
     context = ToolResolutionContext(session_id="session-1")
 
-    assert registry.resolve_names((), context=context) == ("tool_search",)
+    assert registry.resolve_names((), context=context) == (
+        "tool_search",
+        "activate_tools",
+    )
     assert registry.resolve_names(("read",), context=context) == (
         "read",
         "tool_search",
+        "activate_tools",
     )

--- a/tests/unit_tests/tools/registry/test_defaults.py
+++ b/tests/unit_tests/tools/registry/test_defaults.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pytest
 
-from relay_teams.tools.registry import build_default_registry
+from relay_teams.tools.registry import ToolResolutionContext, build_default_registry
 
 
 def test_registry_rejects_unknown_tools() -> None:
@@ -47,6 +47,7 @@ def test_registry_contains_registered_local_tools() -> None:
         "stop_monitor",
         "todo_read",
         "todo_write",
+        "tool_search",
         "type_text",
         "wait_background_task",
         "wait_for_window",
@@ -61,6 +62,7 @@ def test_registry_hides_im_send_from_manual_role_configuration() -> None:
     registry = build_default_registry()
 
     assert "im_send" not in registry.list_configurable_names()
+    assert "tool_search" not in registry.list_configurable_names()
 
 
 def test_default_registry_ignores_unknown_tools_for_runtime_resolution() -> None:
@@ -85,3 +87,15 @@ def test_default_registry_rejects_unknown_tools_for_explicit_validation() -> Non
         registry.validate_known(("missing_background_tool",))
     with pytest.raises(ValueError, match="Unknown tools"):
         registry.validate_known(("deprecated_writer",))
+
+
+def test_default_registry_implicitly_adds_tool_search() -> None:
+    registry = build_default_registry()
+
+    context = ToolResolutionContext(session_id="session-1")
+
+    assert registry.resolve_names((), context=context) == ("tool_search",)
+    assert registry.resolve_names(("read",), context=context) == (
+        "read",
+        "tool_search",
+    )

--- a/tests/unit_tests/tools/registry/test_runtime_activation.py
+++ b/tests/unit_tests/tools/registry/test_runtime_activation.py
@@ -19,6 +19,10 @@ def test_build_initial_active_tools_keeps_implicit_tool_search_when_authorized()
     )
 
 
+def test_build_initial_active_tools_falls_back_to_all_authorized_tools() -> None:
+    assert build_initial_active_tools(("read", "write")) == ("read", "write")
+
+
 def test_validate_activation_request_separates_active_deferred_and_unknown() -> None:
     result = validate_activation_request(
         authorized_tools=("tool_search", "activate_tools", "read", "write"),

--- a/tests/unit_tests/tools/registry/test_runtime_activation.py
+++ b/tests/unit_tests/tools/registry/test_runtime_activation.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from relay_teams.tools.registry.runtime_activation import (
+    apply_tool_activation,
+    build_initial_active_tools,
+    validate_activation_request,
+)
+
+
+def test_build_initial_active_tools_keeps_implicit_tool_search_when_authorized() -> (
+    None
+):
+    assert build_initial_active_tools(
+        ("read", "activate_tools", "tool_search", "write")
+    ) == (
+        "tool_search",
+        "activate_tools",
+    )
+
+
+def test_validate_activation_request_separates_active_deferred_and_unknown() -> None:
+    result = validate_activation_request(
+        authorized_tools=("tool_search", "activate_tools", "read", "write"),
+        active_tools=("tool_search", "activate_tools"),
+        requested_tool_names=("read", "tool_search", "unknown_tool", "read"),
+    )
+
+    assert result.active == ("tool_search", "activate_tools")
+    assert result.deferred == ("read", "write")
+    assert result.activatable == ("read",)
+    assert result.already_active == ("tool_search",)
+    assert result.unknown_or_unauthorized == ("unknown_tool",)
+
+
+def test_apply_tool_activation_is_idempotent_and_respects_max_active_limit() -> None:
+    result = apply_tool_activation(
+        authorized_tools=("tool_search", "activate_tools", "read", "write"),
+        active_tools=("tool_search", "activate_tools"),
+        requested_tool_names=("read", "write", "tool_search"),
+        max_active_tools=3,
+    )
+
+    assert result.activated == ("read",)
+    assert result.already_active == ("tool_search",)
+    assert result.rejected_due_to_limit == ("write",)
+    assert result.active_tools == ("tool_search", "activate_tools", "read")
+    assert result.deferred_tools == ("write",)


### PR DESCRIPTION
## Summary
- add an implicit `tool_search` discovery tool to runtime-authorized tools
- summarize runtime tool availability in the system prompt instead of listing every tool schema inline
- improve `tool_search` ranking and matching so exact hits stay first while related tools are also suggested

## Why
- avoids exposing the full runtime tool inventory and descriptions inline in the prompt
- gives the model a compact way to discover local, skill, and MCP tools on demand
- reduces false-positive matches and makes exact tool-name lookups more useful for discovery

## Impact
- runtime-authorized tool prompts are more compact and point models to `tool_search`
- `tool_search` is always available implicitly but hidden from manual role config
- exact queries like `edit` now return `edit` first and can include related tools like `notebook_edit`

## Validation
- `uv run pytest tests/unit_tests/tools/discovery_tools/test_tool_search.py tests/unit_tests/tools/registry/test_defaults.py tests/unit_tests/agents/execution/test_prompts.py::test_build_runtime_tools_prompt_summarizes_authorized_tools -q --tb=line`
- `$env:PYTHON_KEYRING_BACKEND='keyring.backends.null.Keyring'; uv run pytest tests/unit_tests/agents/orchestration/test_task_execution_service.py::test_execute_persists_objective_before_first_turn tests/unit_tests/agents/orchestration/test_task_execution_service.py::test_execute_runtime_snapshot_includes_skill_list_for_ui tests/unit_tests/agents/orchestration/test_task_execution_service.py::test_execute_runtime_prompt_lists_authorized_runtime_tools -q --tb=line`
- `uv run ruff check src/relay_teams/tools/discovery_tools src/relay_teams/tools/registry/defaults.py src/relay_teams/agents/execution/system_prompts.py tests/unit_tests/tools/discovery_tools/test_tool_search.py tests/unit_tests/tools/registry/test_defaults.py tests/unit_tests/agents/execution/test_prompts.py tests/unit_tests/agents/orchestration/test_task_execution_service.py`

Closes #442