### PR TITLE
feat: support upstream markdown webfetch responses

### DIFF
--- a/src/relay_teams/tools/web_tools/webfetch.py
+++ b/src/relay_teams/tools/web_tools/webfetch.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from enum import StrEnum
 import asyncio
 from html import unescape
@@ -71,6 +71,10 @@ FALLBACK_USER_AGENT = "agent-teams"
 READER_FALLBACK_BASE_URL = "https://r.jina.ai/"
 ANTI_BOT_STATUS_CODES = {403, 429, 503}
 TEXTUAL_CHALLENGE_CONTENT_TYPES = {"text/html", "application/xhtml+xml", "text/plain"}
+MARKDOWN_CONTENT_TYPES = {"text/markdown", "text/x-markdown"}
+MARKDOWN_TOKENS_HEADER = "x-markdown-tokens"
+ORIGINAL_TOKENS_HEADER = "x-original-tokens"
+CONTENT_SIGNAL_HEADER = "content-signal"
 ENTERPRISE_PROXY_BLOCK_URL_MARKERS = ("proxycontrolwarn", "httpwarning_2907")
 ENTERPRISE_PROXY_BLOCK_MARKERS = (
     "his proxy notification",
@@ -398,6 +402,7 @@ async def fetch_webfetch_projection(
             final_url=resolve_webfetch_response_url(response),
             response_format=response_format,
             content_type=content_type,
+            response_headers=response.headers,
             body=body,
             extract=extract,
             item_limit=item_limit,
@@ -1032,6 +1037,7 @@ def build_webfetch_projection(
     final_url: str,
     response_format: str,
     content_type: str,
+    response_headers: Mapping[str, str] | None = None,
     body: bytes,
     extract: WebFetchExtractMode,
     item_limit: int,
@@ -1080,6 +1086,7 @@ def build_webfetch_projection(
         final_url=final_url,
         content_type=content_type,
         output=rendered_output,
+        metadata=build_text_result_metadata(response_headers),
     )
 
 
@@ -1091,6 +1098,8 @@ def is_binary_response(content_type: str) -> bool:
 
 def is_textual_content_type(content_type: str) -> bool:
     if not content_type:
+        return True
+    if is_markdown_content_type(content_type):
         return True
     if content_type.startswith("text/"):
         return True
@@ -1104,6 +1113,10 @@ def is_textual_content_type(content_type: str) -> bool:
     return content_type.endswith("+xml") or content_type.endswith("+json")
 
 
+def is_markdown_content_type(content_type: str) -> bool:
+    return content_type in MARKDOWN_CONTENT_TYPES
+
+
 def render_text_output(
     *,
     response_format: str,
@@ -1113,11 +1126,72 @@ def render_text_output(
 ) -> str:
     if response_format == "html":
         return body
+    if is_markdown_content_type(content_type):
+        return body
     if content_type == "text/html" or content_type == "application/xhtml+xml":
         if response_format == "text":
             return extract_text_from_html(body)
         return convert_html_to_markdown(body, base_url=final_url)
     return body
+
+
+def build_text_result_metadata(
+    response_headers: Mapping[str, str] | None,
+) -> dict[str, JsonValue]:
+    if response_headers is None:
+        return {}
+
+    metadata: dict[str, JsonValue] = {}
+    markdown_tokens = parse_non_negative_int_header(
+        response_headers,
+        MARKDOWN_TOKENS_HEADER,
+    )
+    if markdown_tokens is not None:
+        metadata["markdown_tokens"] = markdown_tokens
+
+    original_tokens = parse_non_negative_int_header(
+        response_headers,
+        ORIGINAL_TOKENS_HEADER,
+    )
+    if original_tokens is not None:
+        metadata["original_tokens"] = original_tokens
+
+    content_signal = get_header_value(response_headers, CONTENT_SIGNAL_HEADER)
+    if content_signal is not None:
+        stripped_content_signal = content_signal.strip()
+        if stripped_content_signal:
+            metadata["content_signal"] = stripped_content_signal
+    return metadata
+
+
+def parse_non_negative_int_header(
+    response_headers: Mapping[str, str],
+    header_name: str,
+) -> int | None:
+    value = get_header_value(response_headers, header_name)
+    if value is None:
+        return None
+    try:
+        parsed = int(value.strip())
+    except ValueError:
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def get_header_value(
+    response_headers: Mapping[str, str],
+    header_name: str,
+) -> str | None:
+    value = response_headers.get(header_name)
+    if value is not None:
+        return value
+    normalized_name = header_name.lower()
+    for candidate_name, candidate_value in response_headers.items():
+        if candidate_name.lower() == normalized_name:
+            return candidate_value
+    return None
 
 
 def finalize_text_result(
@@ -1128,6 +1202,7 @@ def finalize_text_result(
     final_url: str,
     content_type: str,
     output: str,
+    metadata: dict[str, JsonValue] | None = None,
 ) -> ToolResultProjection:
     visible_data: dict[str, JsonValue] = {
         "output": output,
@@ -1135,6 +1210,8 @@ def finalize_text_result(
         "content_type": content_type,
         "truncated": False,
     }
+    if metadata:
+        visible_data.update(metadata)
     if len(output) <= MAX_TEXT_OUTPUT_CHARS:
         return ToolResultProjection(
             visible_data=visible_data,

--- a/src/relay_teams/tools/web_tools/webfetch.txt
+++ b/src/relay_teams/tools/web_tools/webfetch.txt
@@ -5,6 +5,11 @@ Use this for:
 - Downloading network files such as PDFs, images, archives, and other binary payloads.
 - Extracting structured data from RSS/Atom feeds and OPML subscription lists.
 
+Markdown behavior:
+- The default `format="markdown"` sends an `Accept` preference for `text/markdown`.
+- If the origin returns `text/markdown` or `text/x-markdown`, the upstream Markdown is returned directly.
+- If the origin returns HTML, `webfetch` converts the cleaned page body to Markdown locally.
+
 Binary download behavior:
 - Binary responses are streamed to the workspace temp directory and returned as `saved_path`; they are not inlined into the conversation.
 - Large binary downloads are supported up to 512 MiB.

--- a/tests/unit_tests/tools/web_tools/test_webfetch.py
+++ b/tests/unit_tests/tools/web_tools/test_webfetch.py
@@ -299,11 +299,26 @@ def test_build_accept_header_changes_by_format() -> None:
     assert "text/html" in webfetch.build_accept_header("html")
 
 
+def test_build_accept_header_prefers_markdown_for_markdown_format() -> None:
+    header = webfetch.build_accept_header("markdown")
+
+    assert header.startswith("text/markdown;q=1.0, text/x-markdown;q=0.9")
+    assert header.index("text/markdown") < header.index("text/plain")
+    assert header.index("text/markdown") < header.index("text/html")
+
+
 def test_is_textual_content_type_supports_feed_media_types() -> None:
     assert webfetch.is_textual_content_type("application/rss+xml") is True
     assert webfetch.is_textual_content_type("application/atom+xml") is True
     assert webfetch.is_textual_content_type("application/opml+xml") is True
     assert webfetch.is_binary_response("application/rss+xml") is False
+
+
+def test_is_textual_content_type_supports_markdown_media_types() -> None:
+    assert webfetch.is_textual_content_type("text/markdown") is True
+    assert webfetch.is_textual_content_type("text/x-markdown") is True
+    assert webfetch.is_markdown_content_type("text/markdown") is True
+    assert webfetch.is_markdown_content_type("text/x-markdown") is True
 
 
 def test_preapproved_webfetch_url_honors_path_boundaries() -> None:
@@ -328,6 +343,33 @@ def test_build_webfetch_approval_request_marks_preapproved_hosts_safe() -> None:
     assert request.target_summary == "docs.python.org"
     assert request.source == "https://docs.python.org/3/"
     assert decision.required is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_sends_markdown_accept_header() -> None:
+    accept_headers: list[str] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        accept_headers.append(request.headers["Accept"])
+        return httpx.Response(
+            200,
+            request=request,
+            text="# Upstream Markdown",
+            headers={"content-type": "text/markdown; charset=utf-8"},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        response = await webfetch.fetch_url(
+            client=client,
+            url="https://example.com/docs",
+            response_format="markdown",
+        )
+    finally:
+        await client.aclose()
+
+    assert accept_headers == [webfetch.build_accept_header("markdown")]
+    await response.aclose()
 
 
 @pytest.mark.asyncio
@@ -1876,6 +1918,54 @@ def test_build_webfetch_projection_uses_absolute_markdown_links(tmp_path: Path) 
     data = projection.visible_data
     assert isinstance(data, dict)
     assert data["output"] == "[Install](https://example.com/install)"
+
+
+def test_build_webfetch_projection_preserves_upstream_markdown(
+    tmp_path: Path,
+) -> None:
+    projection = webfetch.build_webfetch_projection(
+        workspace_dir=tmp_path,
+        tool_call_id="call_8",
+        requested_url="https://example.com/docs",
+        final_url="https://example.com/docs",
+        response_format="markdown",
+        content_type="text/markdown",
+        response_headers={
+            "x-markdown-tokens": "2882",
+            "x-original-tokens": "55237",
+            "content-signal": "ai-train=yes, search=yes, ai-input=yes",
+        },
+        body=b"# Guide\n\nSee [Install](../install).",
+        extract=webfetch.WebFetchExtractMode.NONE,
+        item_limit=webfetch.DEFAULT_ITEM_LIMIT,
+    )
+
+    assert projection.visible_data is not None
+    visible_data = projection.visible_data
+    assert isinstance(visible_data, dict)
+    assert visible_data["output"] == "# Guide\n\nSee [Install](../install)."
+    assert visible_data["content_type"] == "text/markdown"
+    assert visible_data["markdown_tokens"] == 2882
+    assert visible_data["original_tokens"] == 55237
+    assert visible_data["content_signal"] == "ai-train=yes, search=yes, ai-input=yes"
+    assert projection.internal_data is not None
+    internal_data = projection.internal_data
+    assert isinstance(internal_data, dict)
+    assert internal_data["markdown_tokens"] == 2882
+    assert internal_data["original_tokens"] == 55237
+    assert internal_data["requested_url"] == "https://example.com/docs"
+
+
+def test_build_text_result_metadata_ignores_invalid_markdown_headers() -> None:
+    metadata = webfetch.build_text_result_metadata(
+        {
+            "X-Markdown-Tokens": "not-a-number",
+            "X-Original-Tokens": "-1",
+            "Content-Signal": "  ",
+        }
+    )
+
+    assert metadata == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Treat upstream `text/markdown` and `text/x-markdown` webfetch responses as first-class textual Markdown.
- Preserve upstream Markdown directly instead of routing it through HTML conversion.
- Surface Cloudflare Markdown for Agents metadata headers as additive result fields: `markdown_tokens`, `original_tokens`, and `content_signal`.
- Document markdown negotiation behavior in the webfetch tool description.

Closes #446

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright` (0 errors; existing setup.py setuptools source warnings only)
- `uv run --extra dev pytest -q tests/unit_tests` (2519 passed, 5 skipped)
- `uv run --extra dev pytest -q tests/integration_tests` (43 passed, 3 skipped on rerun)
- Browser smoke against Cloudflare Markdown for Agents example through the frontend and real backend `webfetch` path:
  - `content_type`: `text/markdown`
  - `markdown_tokens`: `2882`
  - `original_tokens`: `55237`
  - `content_signal`: `ai-train=yes, search=yes, ai-input=yes`
