### PR TITLE
feat: support multimodal image input and reads

### DIFF
--- a/frontend/dist/css/components/settings.css
+++ b/frontend/dist/css/components/settings.css
@@ -1488,7 +1488,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.25rem;
+    gap: 0.375rem;
     margin-bottom: 0.8rem;
 }
 
@@ -1538,15 +1538,22 @@
     margin-bottom: 0;
 }
 
-.workspace-private-key-label-row .settings-inline-action-row {
+.workspace-private-key-field {
+    position: relative;
+}
+
+.workspace-private-key-action-row {
+    position: absolute;
+    top: 0;
+    right: 0;
     justify-content: flex-end;
-    margin-left: auto;
     width: auto;
 }
 
 .workspace-private-key-label-row {
-    align-items: flex-end;
-    margin-bottom: 0.375rem;
+    display: block;
+    padding-right: 11rem;
+    margin-bottom: 0;
 }
 
 .profile-discovery-btn {
@@ -2669,6 +2676,17 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
     .workspace-auth-field,
     .workspace-auth-field-span-2 {
         grid-column: auto;
+    }
+
+    .workspace-private-key-label-row {
+        padding-right: 0;
+    }
+
+    .workspace-private-key-action-row {
+        position: static;
+        top: auto;
+        right: auto;
+        margin-left: auto;
     }
 
     .profile-editor-subsection-header {

--- a/frontend/dist/js/components/messageRenderer/helpers/block.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/block.js
@@ -211,7 +211,9 @@ export function appendThinkingText(contentEl, text, options = {}) {
 }
 
 export function updateMessageText(textEl, text, options = {}) {
-    renderRichContent(textEl, String(text || ''));
+    renderRichContent(textEl, String(text || ''), {
+        enableWorkspaceImagePreview: options.enableWorkspaceImagePreview !== false,
+    });
     syncStreamingCursor(textEl, options.streaming === true);
     return textEl;
 }
@@ -223,7 +225,10 @@ export function updateUserPromptText(promptEl, text) {
 }
 
 export function updateThinkingText(textEl, text, options = {}) {
-    updateMessageText(textEl, text, options);
+    updateMessageText(textEl, text, {
+        ...options,
+        enableWorkspaceImagePreview: false,
+    });
     const thinkingBlock = textEl?.closest?.('.thinking-block');
     if (thinkingBlock) {
         const liveEl = thinkingBlock.querySelector('.thinking-live');

--- a/frontend/dist/js/components/messageRenderer/helpers/content.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/content.js
@@ -15,8 +15,9 @@ const IMAGE_BARE_PATH_PATTERN =
     /((?:\/|\.{1,2}\/|[A-Za-z]:[\\/])[^"'`\s<>]+?\.(?:avif|bmp|gif|jpe?g|png|webp))/gi;
 const TRAILING_PATH_PUNCTUATION_PATTERN = /[),.:;!?\\\]}>，。！？；：）】》]+$/u;
 
-export function renderRichContent(targetEl, source) {
+export function renderRichContent(targetEl, source, options = {}) {
     const text = String(source || '');
+    const enableWorkspaceImagePreview = options.enableWorkspaceImagePreview !== false;
     const standaloneImageUrl = resolveStandaloneImageDataUrl(text);
     if (standaloneImageUrl) {
         targetEl.replaceChildren(buildImageFigure(standaloneImageUrl));
@@ -24,17 +25,19 @@ export function renderRichContent(targetEl, source) {
     }
 
     targetEl.innerHTML = parseMarkdown(text);
-    const previewUrls = resolveWorkspaceImagePreviewUrls(
-        text,
-        state.currentWorkspaceId || state.currentProjectViewWorkspaceId,
-    );
-    previewUrls.forEach(previewUrl => {
-        targetEl.appendChild(buildImageFigure(previewUrl));
-    });
+    if (enableWorkspaceImagePreview) {
+        const previewUrls = resolveWorkspaceImagePreviewUrls(
+            text,
+            state.currentWorkspaceId || state.currentProjectViewWorkspaceId,
+        );
+        previewUrls.forEach(previewUrl => {
+            targetEl.appendChild(buildImageFigure(previewUrl));
+        });
+    }
     return targetEl;
 }
 
-export function appendStructuredContentPart(targetEl, part) {
+export function appendStructuredContentPart(targetEl, part, options = {}) {
     if (!targetEl || !part || typeof part !== 'object') {
         return null;
     }
@@ -42,7 +45,7 @@ export function appendStructuredContentPart(targetEl, part) {
     if (kind === 'text') {
         const textEl = document.createElement('div');
         textEl.className = 'msg-text';
-        renderRichContent(textEl, String(part.text || ''));
+        renderRichContent(textEl, String(part.text || ''), options.richContent || {});
         targetEl.appendChild(textEl);
         return textEl;
     }

--- a/frontend/dist/js/components/messageRenderer/helpers/prompt.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/prompt.js
@@ -165,19 +165,23 @@ export function updatePromptContentBlock(promptEl, promptPayload, options = {}) 
         previewEl.textContent = preview;
     }
     if (bodyEl) {
-        renderPromptContentParts(bodyEl, normalizedParts || []);
+        renderPromptContentParts(bodyEl, normalizedParts || [], options);
     }
     return promptEl;
 }
 
-export function renderPromptContentParts(targetEl, parts) {
+export function renderPromptContentParts(targetEl, parts, options = {}) {
     if (!targetEl) {
         return targetEl;
     }
     targetEl.replaceChildren();
     const normalizedParts = Array.isArray(parts) ? parts : [];
     normalizedParts.forEach(part => {
-        appendStructuredContentPart(targetEl, part);
+        appendStructuredContentPart(targetEl, part, {
+            richContent: {
+                enableWorkspaceImagePreview: options.enableWorkspaceImagePreview !== false,
+            },
+        });
     });
     return targetEl;
 }

--- a/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
@@ -580,6 +580,9 @@ function renderEnvelopeResult(targetEl, envelope, toolName) {
     }
 
     if (toolName === 'read' && data != null) {
+        if (renderStructuredPayload(targetEl, data, envelope.meta)) {
+            return;
+        }
         renderReadOutput(targetEl, data);
         return;
     }
@@ -750,7 +753,9 @@ function renderStructuredPayload(targetEl, payload, meta = null) {
     if (hasText) {
         const textEl = document.createElement('div');
         textEl.className = 'msg-text';
-        renderRichContent(textEl, String(payload.text || ''));
+        renderRichContent(textEl, String(payload.text || ''), {
+            enableWorkspaceImagePreview: !hasStructuredContent,
+        });
         targetEl.appendChild(textEl);
     }
     if (hasStructuredContent) {

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -628,7 +628,9 @@ function buildRoundIntentBlock(intentText, intentParts = null) {
 }
 
 function renderRoundIntentStructuredContent(bodyEl, parts) {
-    renderPromptContentParts(bodyEl, parts);
+    renderPromptContentParts(bodyEl, parts, {
+        enableWorkspaceImagePreview: false,
+    });
 }
 
 function normalizeRoundIntentText(intentText) {

--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -848,12 +848,10 @@ function createModal() {
                                                         </button>
                                                     </div>
                                                 </div>
-                                                <div class="form-group form-group-span-2 workspace-auth-field workspace-auth-field-span-2">
-                                                    <div class="form-label-row workspace-private-key-label-row">
-                                                        <label for="workspace-ssh-profile-private-key" data-i18n="settings.workspace.private_key">Private Key</label>
-                                                        <div class="settings-inline-action-row">
-                                                            <button class="secondary-btn section-action-btn" id="workspace-ssh-profile-import-private-key-btn" type="button" data-i18n="settings.workspace.private_key_import">Import Private Key</button>
-                                                        </div>
+                                                <div class="form-group form-group-span-2 workspace-auth-field workspace-auth-field-span-2 workspace-private-key-field">
+                                                    <label class="workspace-private-key-label-row" for="workspace-ssh-profile-private-key" data-i18n="settings.workspace.private_key">Private Key</label>
+                                                    <div class="settings-inline-action-row workspace-private-key-action-row">
+                                                        <button class="secondary-btn section-action-btn" id="workspace-ssh-profile-import-private-key-btn" type="button" data-i18n="settings.workspace.private_key_import">Import Private Key</button>
                                                     </div>
                                                     <textarea class="config-textarea workspace-private-key-textarea" id="workspace-ssh-profile-private-key" placeholder="Paste a private key or import one from a file" data-i18n-placeholder="settings.workspace.private_key_placeholder" autocapitalize="off" autocorrect="off" spellcheck="false"></textarea>
                                                     <input type="hidden" id="workspace-ssh-profile-private-key-name">

--- a/src/relay_teams/agents/execution/llm_session.py
+++ b/src/relay_teams/agents/execution/llm_session.py
@@ -220,6 +220,17 @@ class _PromptContentHydrationService(Protocol):
     ) -> UserPromptContent: ...
 
 
+@runtime_checkable
+class _PromptContentProviderService(Protocol):
+    def to_provider_user_prompt_content(
+        self,
+        *,
+        parts: tuple[
+            TextContentPart | MediaRefContentPart | InlineMediaContentPart, ...
+        ],
+    ) -> UserPromptContent: ...
+
+
 class _PreparedPromptContext(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -714,6 +725,7 @@ class AgentLlmSession:
                 notification_service=self._notification_service,
                 im_tool_service=self._im_tool_service,
                 hook_service=hook_service,
+                model_capabilities=self._config.capabilities,
                 hook_runtime_env=hook_runtime_env,
             )
             control_ctx = self._run_control_manager.context(
@@ -779,7 +791,6 @@ class AgentLlmSession:
                     )
                 else:
                     history = persisted_history
-            history = self._hydrate_history_media_content(history)
             seen_count = 0
             buffered_messages: list[ModelRequest | ModelResponse] = []
             restarted = False
@@ -801,10 +812,14 @@ class AgentLlmSession:
                 while True:
                     control_ctx.raise_if_cancelled()
                     restarted = False
+                    provider_history = self._provider_history_for_model_turn(
+                        request=request,
+                        history=history,
+                    )
                     async with agent.iter(
                         None,
                         deps=deps,
-                        message_history=history,
+                        message_history=provider_history,
                         usage_limits=UsageLimits(request_limit=LLM_REQUEST_LIMIT),
                     ) as agent_run:
                         async for node in agent_run:
@@ -902,7 +917,7 @@ class AgentLlmSession:
                             all_new = agent_run.new_messages()
                             new_batch = list(all_new)[seen_count:]
                             new_to_process = self._drop_duplicate_leading_request(
-                                history=history,
+                                history=provider_history,
                                 new_messages=new_batch,
                             )
                             new_to_process = self._apply_streamed_text_fallback(
@@ -1035,7 +1050,7 @@ class AgentLlmSession:
                         # Flush any remaining messages (e.g. final tool results)
                         all_new = maybe_result.new_messages()
                         to_save = self._drop_duplicate_leading_request(
-                            history=history,
+                            history=provider_history,
                             new_messages=list(all_new)[seen_count:],
                         )
                         to_save = self._apply_streamed_text_fallback(
@@ -1579,6 +1594,7 @@ class AgentLlmSession:
             cache_scope=request.run_id,
         )
 
+    # noinspection PyUnusedLocal
     def _log_generate_failure_diagnostics(
         self,
         *,
@@ -2057,6 +2073,7 @@ class AgentLlmSession:
             )
         )
 
+    # noinspection PyTypeHints
     def _raise_assistant_run_error(
         self,
         *,
@@ -4075,7 +4092,11 @@ class AgentLlmSession:
         if not isinstance(first_new, ModelRequest):
             return new_messages
         if not self._model_requests_match_user_prompt(last_history, first_new):
-            return new_messages
+            if not self._model_request_matches_tool_result_replay(
+                history=history,
+                replayed_request=first_new,
+            ):
+                return new_messages
         return new_messages[1:]
 
     def _model_requests_match_user_prompt(
@@ -4083,13 +4104,13 @@ class AgentLlmSession:
         left: ModelRequest,
         right: ModelRequest,
     ) -> bool:
-        left_prompt = self._extract_user_prompt_text(left)
-        if left_prompt is None:
+        left_prompt_key = self._user_prompt_parts_key(parts=left.parts)
+        if left_prompt_key is None:
             return False
-        right_prompt = self._extract_user_prompt_text(right)
-        if right_prompt is None:
+        right_prompt_key = self._user_prompt_parts_key(parts=right.parts)
+        if right_prompt_key is None:
             return False
-        return left_prompt == right_prompt
+        return left_prompt_key == right_prompt_key
 
     def _extract_user_prompt_text(self, message: ModelRequest) -> str | None:
         prompt_parts = [
@@ -4101,6 +4122,140 @@ class AgentLlmSession:
             user_prompt_content_to_text(part.content) for part in prompt_parts
         ).strip()
         return combined or None
+
+    def _model_request_matches_tool_result_replay(
+        self,
+        *,
+        history: Sequence[ModelRequest | ModelResponse],
+        replayed_request: ModelRequest,
+    ) -> bool:
+        expected_parts = self._tool_result_replay_parts(history=history)
+        if expected_parts is None:
+            return False
+        expected_tool_returns, expected_user_prompts = expected_parts
+        actual_tool_returns = [
+            part for part in replayed_request.parts if isinstance(part, ToolReturnPart)
+        ]
+        actual_user_prompts = [
+            part for part in replayed_request.parts if isinstance(part, UserPromptPart)
+        ]
+        if len(actual_tool_returns) + len(actual_user_prompts) != len(
+            replayed_request.parts
+        ):
+            return False
+        if len(expected_tool_returns) != len(actual_tool_returns):
+            return False
+        if any(
+            not self._tool_return_parts_match(
+                expected_part=expected_part,
+                actual_part=actual_part,
+            )
+            for expected_part, actual_part in zip(
+                expected_tool_returns, actual_tool_returns
+            )
+        ):
+            return False
+        expected_prompt_key = self._user_prompt_parts_key(parts=expected_user_prompts)
+        actual_prompt_key = self._user_prompt_parts_key(parts=actual_user_prompts)
+        if expected_prompt_key is None or actual_prompt_key is None:
+            return False
+        return expected_prompt_key == actual_prompt_key
+
+    # noinspection PyTypeHints
+    def _tool_result_replay_parts(
+        self,
+        *,
+        history: Sequence[ModelRequest | ModelResponse],
+    ) -> tuple[list[ToolReturnPart], list[UserPromptPart]] | None:
+        if not history:
+            return None
+        mixed_replay = self._mixed_tool_result_replay_parts(history[-1])
+        if mixed_replay is not None:
+            return mixed_replay
+        if len(history) < 2:
+            return None
+        previous_message = history[-2]
+        synthetic_prompt = history[-1]
+        if not isinstance(previous_message, ModelRequest):
+            return None
+        if not isinstance(synthetic_prompt, ModelRequest):
+            return None
+        if not self._model_request_contains_only_tool_returns(previous_message):
+            return None
+        if not self._model_request_contains_only_user_prompts(synthetic_prompt):
+            return None
+        expected_tool_returns = [
+            part for part in previous_message.parts if isinstance(part, ToolReturnPart)
+        ]
+        expected_user_prompts = [
+            part for part in synthetic_prompt.parts if isinstance(part, UserPromptPart)
+        ]
+        return expected_tool_returns, expected_user_prompts
+
+    # noinspection PyMethodMayBeStatic,PyTypeHints
+    def _mixed_tool_result_replay_parts(
+        self,
+        message: ModelRequest | ModelResponse,
+    ) -> tuple[list[ToolReturnPart], list[UserPromptPart]] | None:
+        if not isinstance(message, ModelRequest):
+            return None
+        tool_returns = [
+            part for part in message.parts if isinstance(part, ToolReturnPart)
+        ]
+        user_prompts = [
+            part for part in message.parts if isinstance(part, UserPromptPart)
+        ]
+        if not tool_returns or not user_prompts:
+            return None
+        if len(tool_returns) + len(user_prompts) != len(message.parts):
+            return None
+        return tool_returns, user_prompts
+
+    # noinspection PyMethodMayBeStatic
+    def _model_request_contains_only_tool_returns(
+        self,
+        message: ModelRequest,
+    ) -> bool:
+        return bool(message.parts) and all(
+            isinstance(part, ToolReturnPart) for part in message.parts
+        )
+
+    # noinspection PyMethodMayBeStatic
+    def _model_request_contains_only_user_prompts(
+        self,
+        message: ModelRequest,
+    ) -> bool:
+        return bool(message.parts) and all(
+            isinstance(part, UserPromptPart) for part in message.parts
+        )
+
+    # noinspection PyMethodMayBeStatic
+    def _user_prompt_parts_key(
+        self,
+        *,
+        parts: Sequence[ModelRequestPart],
+    ) -> str | None:
+        if not parts or not all(isinstance(part, UserPromptPart) for part in parts):
+            return None
+        prompt_contents = [
+            part.content for part in parts if isinstance(part, UserPromptPart)
+        ]
+        return user_prompt_content_key(
+            prompt_contents[0] if len(prompt_contents) == 1 else prompt_contents
+        )
+
+    # noinspection PyMethodMayBeStatic
+    def _tool_return_parts_match(
+        self,
+        *,
+        expected_part: ToolReturnPart,
+        actual_part: ToolReturnPart,
+    ) -> bool:
+        return (
+            expected_part.tool_name == actual_part.tool_name
+            and expected_part.tool_call_id == actual_part.tool_call_id
+            and expected_part.content == actual_part.content
+        )
 
     def _current_request_prompt_content(
         self,
@@ -4261,6 +4416,29 @@ class AgentLlmSession:
             hydrated_messages.append(message)
         return hydrated_messages
 
+    def _provider_history_for_model_turn(
+        self,
+        *,
+        request: LLMRequest,
+        history: Sequence[ModelRequest | ModelResponse],
+    ) -> list[ModelRequest | ModelResponse]:
+        provider_history, _ = self._provider_history_for_model_turn_details(
+            request=request,
+            history=history,
+        )
+        return provider_history
+
+    # noinspection PyUnusedLocal,PyTypeHints
+    def _provider_history_for_model_turn_details(
+        self,
+        *,
+        request: LLMRequest,
+        history: Sequence[ModelRequest | ModelResponse],
+        consumed_tool_call_ids: set[str] | None = None,
+    ) -> tuple[list[ModelRequest | ModelResponse], tuple[str, ...]]:
+        del request, consumed_tool_call_ids
+        return self._hydrate_history_media_content(history), ()
+
     def _prompt_content_persistence_service(
         self,
     ) -> _PromptContentPersistenceService | None:
@@ -4274,6 +4452,14 @@ class AgentLlmSession:
     ) -> _PromptContentHydrationService | None:
         media_asset_service = getattr(self, "_media_asset_service", None)
         if not isinstance(media_asset_service, _PromptContentHydrationService):
+            return None
+        return media_asset_service
+
+    def _prompt_content_provider_service(
+        self,
+    ) -> _PromptContentProviderService | None:
+        media_asset_service = getattr(self, "_media_asset_service", None)
+        if not isinstance(media_asset_service, _PromptContentProviderService):
             return None
         return media_asset_service
 
@@ -4296,7 +4482,10 @@ class AgentLlmSession:
         committed_tool_validation_failures = self._has_tool_input_validation_failures(
             raw_ready
         )
-        ready = self._normalize_committable_messages(raw_ready)
+        ready = self._normalize_committable_messages(
+            request=request,
+            messages=raw_ready,
+        )
         self._message_repo.append(
             session_id=request.session_id,
             workspace_id=self._workspace_id(request),
@@ -4384,8 +4573,11 @@ class AgentLlmSession:
 
     def _normalize_committable_messages(
         self,
+        *,
+        request: LLMRequest,
         messages: Sequence[ModelRequest | ModelResponse],
     ) -> list[ModelRequest | ModelResponse]:
+        del request
         normalized: list[ModelRequest | ModelResponse] = []
         for message in messages:
             if isinstance(message, ModelResponse):

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import importlib
 import inspect
 import json
 import sys
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 from uuid import uuid4
@@ -19,6 +20,14 @@ from mcp.shared.memory import create_client_server_memory_streams
 from mcp.shared.message import SessionMessage
 from pydantic import JsonValue, PrivateAttr
 from pydantic_ai import RunContext
+from pydantic_ai.messages import (
+    AudioUrl,
+    BinaryContent,
+    ImageUrl,
+    ToolReturn,
+    UserContent,
+    VideoUrl,
+)
 from pydantic_ai.models import Model
 from pydantic_ai.tools import Tool as PydanticTool
 from pydantic_ai.usage import RunUsage
@@ -30,6 +39,7 @@ from relay_teams.computer import ComputerRuntime
 from relay_teams.media import MediaAssetService
 from relay_teams.monitors import MonitorService
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.providers.model_config import ModelCapabilities, ModelEndpointConfig
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
@@ -118,6 +128,7 @@ HOST_TOOL_ROLE_ID_ENV = "AGENT_TEAMS_HOST_TOOL_ROLE_ID"
 
 
 class HostedToolDefinition:
+    # noinspection PyTypeHints
     def __init__(
         self,
         *,
@@ -137,6 +148,7 @@ class HostedToolDefinition:
 
 
 class ExternalAcpHostToolBridge:
+    # noinspection PyTypeHints
     def __init__(
         self,
         *,
@@ -167,6 +179,9 @@ class ExternalAcpHostToolBridge:
         user_question_manager: UserQuestionManager | None,
         tool_approval_policy: ToolApprovalPolicy,
         get_notification_service: Callable[[], NotificationService | None],
+        resolve_model_config: (
+            Callable[[RoleDefinition, LLMRequest], ModelEndpointConfig | None] | None
+        ) = None,
         media_asset_service: MediaAssetService | None = None,
         metric_recorder: MetricRecorder | None = None,
         im_tool_service: ImToolService | None = None,
@@ -201,6 +216,7 @@ class ExternalAcpHostToolBridge:
         self._user_question_manager = user_question_manager
         self._tool_approval_policy = tool_approval_policy
         self._get_notification_service = get_notification_service
+        self._resolve_model_config = resolve_model_config
         self._metric_recorder = metric_recorder
         self._im_tool_service = im_tool_service
         self._computer_runtime = computer_runtime
@@ -536,7 +552,22 @@ class ExternalAcpHostToolBridge:
             metric_recorder=self._metric_recorder,
             notification_service=self._get_notification_service(),
             im_tool_service=self._im_tool_service,
+            model_capabilities=self._resolve_request_model_capabilities(
+                request=request
+            ),
         )
+
+    def _resolve_request_model_capabilities(
+        self,
+        *,
+        request: LLMRequest,
+    ) -> ModelCapabilities:
+        if self._role is None or self._resolve_model_config is None:
+            return ModelCapabilities()
+        model_config = self._resolve_model_config(self._role, request)
+        if model_config is None:
+            return ModelCapabilities()
+        return model_config.capabilities
 
 
 class _HostedFastMcpTool(FastMcpTool):
@@ -563,9 +594,84 @@ class _HostedFastMcpTool(FastMcpTool):
             definition=self._definition,
             arguments=arguments,
         )
+        if isinstance(result, ToolReturn):
+            return _tool_return_to_fastmcp_result(result)
         if isinstance(result, dict):
             return ToolResult(structured_content=result)
         return ToolResult(content=result)
+
+
+def _tool_return_to_fastmcp_result(result: ToolReturn) -> ToolResult:
+    content_blocks = _tool_return_content_blocks(result.content)
+    if isinstance(result.return_value, dict):
+        if content_blocks:
+            return ToolResult(
+                content=content_blocks,
+                structured_content=result.return_value,
+            )
+        return ToolResult(structured_content=result.return_value)
+    if content_blocks:
+        return_value_block = _tool_return_value_content_block(result.return_value)
+        if return_value_block is not None:
+            return ToolResult(content=[return_value_block, *content_blocks])
+        return ToolResult(content=content_blocks)
+    return ToolResult(content=result.return_value)
+
+
+# noinspection PyTypeHints
+def _tool_return_value_content_block(value: object) -> mcp_types.ContentBlock | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value
+    else:
+        text = json.dumps(value, ensure_ascii=False, default=str)
+    return mcp_types.TextContent(type="text", text=text)
+
+
+# noinspection PyTypeHints
+def _tool_return_content_blocks(
+    content: str | Sequence[UserContent] | None,
+) -> list[mcp_types.ContentBlock]:
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [mcp_types.TextContent(type="text", text=content)] if content else []
+
+    blocks: list[mcp_types.ContentBlock] = []
+    for item in content:
+        block = _tool_return_content_block(item)
+        if block is not None:
+            blocks.append(block)
+    return blocks
+
+
+# noinspection PyTypeHints
+def _tool_return_content_block(item: UserContent) -> mcp_types.ContentBlock | None:
+    if isinstance(item, str):
+        return mcp_types.TextContent(type="text", text=item)
+    if isinstance(item, BinaryContent):
+        encoded = base64.b64encode(item.data).decode("ascii")
+        media_type = str(item.media_type)
+        if media_type.startswith("image/"):
+            return mcp_types.ImageContent(
+                type="image",
+                data=encoded,
+                mimeType=media_type,
+            )
+        if media_type.startswith("audio/"):
+            return mcp_types.AudioContent(
+                type="audio",
+                data=encoded,
+                mimeType=media_type,
+            )
+        return mcp_types.TextContent(
+            type="text",
+            text=f"[binary: {media_type}, {len(item.data)} bytes]",
+        )
+    if isinstance(item, (ImageUrl, AudioUrl, VideoUrl)):
+        return mcp_types.TextContent(type="text", text=str(item.url))
+    return None
 
 
 class _HostedMcpConnection:

--- a/src/relay_teams/external_agents/provider.py
+++ b/src/relay_teams/external_agents/provider.py
@@ -968,6 +968,7 @@ class ExternalAcpSessionManager:
             tool_approval_policy=self._tool_approval_policy,
             shell_approval_repo=self._shell_approval_repo,
             get_notification_service=self._get_notification_service,
+            resolve_model_config=self._resolve_model_config,
             metric_recorder=self._metric_recorder,
             im_tool_service=self._im_tool_service,
             computer_runtime=self._computer_runtime,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -611,7 +611,7 @@ class ServerContainer:
             tool_approval_policy=self.tool_approval_policy,
             shell_approval_repo=self.shell_approval_repo,
             get_notification_service=lambda: self.notification_service,
-            resolve_model_config=self._resolve_external_agent_model_config,
+            resolve_model_config=self.resolve_external_agent_model_config,
             metric_recorder=self.metric_recorder,
             im_tool_service=self.im_tool_service,
             computer_runtime=self.computer_runtime,
@@ -1038,7 +1038,7 @@ class ServerContainer:
             ),
         )
 
-    def _resolve_external_agent_model_config(
+    def resolve_external_agent_model_config(
         self,
         role: RoleDefinition,
         request: LLMRequest,

--- a/src/relay_teams/interfaces/server/host_tool_stdio_server.py
+++ b/src/relay_teams/interfaces/server/host_tool_stdio_server.py
@@ -74,6 +74,7 @@ async def _run_stdio_server() -> None:
         tool_approval_policy=container.tool_approval_policy,
         shell_approval_repo=container.shell_approval_repo,
         get_notification_service=lambda: container.notification_service,
+        resolve_model_config=container.resolve_external_agent_model_config,
         metric_recorder=container.metric_recorder,
         im_tool_service=container.im_tool_service,
         computer_runtime=container.computer_runtime,

--- a/src/relay_teams/interfaces/server/routers/runs.py
+++ b/src/relay_teams/interfaces/server/routers/runs.py
@@ -7,7 +7,7 @@ from typing import Annotated, ClassVar, Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from relay_teams.interfaces.server.deps import get_run_service
 from relay_teams.interfaces.server.router_error_mapping import http_exception_for
@@ -62,6 +62,13 @@ class InjectMessageRequest(BaseModel):
     source: InjectionSource = InjectionSource.USER
     content: str = Field(min_length=1)
 
+    @field_validator("content")
+    @classmethod
+    def _reject_blank_content(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Injection content must not be empty")
+        return value
+
 
 class ResolveToolApprovalRequest(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
@@ -93,6 +100,13 @@ class InjectSubagentRequest(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
 
     content: str = Field(min_length=1)
+
+    @field_validator("content")
+    @classmethod
+    def _reject_blank_content(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Injection content must not be empty")
+        return value
 
 
 class StopBackgroundTaskResponse(BaseModel):
@@ -332,8 +346,11 @@ def inject_message(
                 payload={"source": req.source.value, "length": len(req.content)},
             )
         return result.model_dump()
-    except KeyError as exc:
-        raise http_exception_for(exc) from exc
+    except (KeyError, ValueError) as exc:
+        raise http_exception_for(
+            exc,
+            mappings=((ValueError, 400),),
+        ) from exc
 
 
 @router.get("/{run_id}/tool-approvals")
@@ -582,8 +599,8 @@ def inject_subagent(
                 payload={"length": len(req.content)},
             )
         return {"status": "ok", "instance_id": instance_id}
-    except (KeyError, RuntimeError) as exc:
+    except (KeyError, RuntimeError, ValueError) as exc:
         raise http_exception_for(
             exc,
-            mappings=((RuntimeError, 409),),
+            mappings=((RuntimeError, 409), (ValueError, 400)),
         ) from exc

--- a/src/relay_teams/media/asset_service.py
+++ b/src/relay_teams/media/asset_service.py
@@ -6,6 +6,7 @@ import mimetypes
 import re
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import ParseResult, urlparse
 from uuid import uuid4
 
 from pydantic_ai.messages import (
@@ -32,6 +33,8 @@ from relay_teams.workspace import WorkspaceManager
 _LOCAL_ASSET_URL_PATTERN = re.compile(
     r"^/api/sessions/(?P<session_id>[^/]+)/media/(?P<asset_id>[^/]+)/file$"
 )
+_LOCAL_PROVIDER_HOSTS = {"127.0.0.1", "localhost", "::1"}
+_DEFAULT_LOCAL_SERVER_BASE_URL = "http://127.0.0.1:8000"
 
 
 class MediaAssetService:
@@ -40,9 +43,16 @@ class MediaAssetService:
         *,
         repository: MediaAssetRepository,
         workspace_manager: WorkspaceManager,
+        local_server_base_url: str = _DEFAULT_LOCAL_SERVER_BASE_URL,
     ) -> None:
         self._repository = repository
         self._workspace_manager = workspace_manager
+        self._local_server_base_url = local_server_base_url.rstrip("/")
+        parsed_base_url = urlparse(self._local_server_base_url)
+        self._local_provider_netloc = parsed_base_url.netloc.strip().lower()
+        self._local_provider_host = (parsed_base_url.hostname or "").strip().lower()
+        self._local_provider_port = parsed_base_url.port
+        self._local_provider_base_path = parsed_base_url.path.rstrip("/")
 
     def normalize_content_parts(
         self,
@@ -239,22 +249,38 @@ class MediaAssetService:
         part: MediaRefContentPart,
     ) -> ImageUrl | AudioUrl | VideoUrl | BinaryContent:
         record = self._repository.get(part.asset_id)
-        if record.storage_kind == MediaAssetStorageKind.REMOTE:
-            url = self.asset_url(
-                record.session_id, record.asset_id, record.external_url
-            )
-            if record.modality == MediaModality.IMAGE:
-                return ImageUrl(url=url, media_type=record.mime_type)
-            if record.modality == MediaModality.AUDIO:
-                return AudioUrl(url=url, media_type=record.mime_type)
-            return VideoUrl(url=url, media_type=record.mime_type)
-        file_path, _ = self.get_asset_file(
-            session_id=record.session_id,
-            asset_id=record.asset_id,
+        url = (
+            self.asset_url(record.session_id, record.asset_id, record.external_url)
+            if record.storage_kind == MediaAssetStorageKind.REMOTE
+            else self.provider_asset_url(record.session_id, record.asset_id)
         )
-        return BinaryContent(
-            data=file_path.read_bytes(),
+        force_download = (
+            False
+            if record.storage_kind == MediaAssetStorageKind.REMOTE
+            else "allow-local"
+        )
+        if record.modality == MediaModality.IMAGE:
+            return ImageUrl(
+                url=url,
+                media_type=record.mime_type,
+                force_download=force_download,
+            )
+        if record.modality == MediaModality.AUDIO:
+            return AudioUrl(
+                url=url,
+                media_type=record.mime_type,
+                force_download=force_download,
+            )
+        return VideoUrl(
+            url=url,
             media_type=record.mime_type,
+            force_download=force_download,
+        )
+
+    def provider_asset_url(self, session_id: str, asset_id: str) -> str:
+        return (
+            f"{self._local_server_base_url}"
+            f"/api/sessions/{session_id}/media/{asset_id}/file"
         )
 
     def to_persisted_user_prompt_content(
@@ -353,10 +379,38 @@ class MediaAssetService:
             url = str(item.url).strip()
         if not url:
             return None
-        match = _LOCAL_ASSET_URL_PATTERN.match(url)
+        parsed = urlparse(url)
+        candidate_path = url
+        if parsed.scheme or parsed.netloc:
+            is_configured_local = self._matches_local_provider_url(parsed)
+            if not is_configured_local:
+                return None
+            candidate_path = parsed.path or ""
+            if (
+                is_configured_local
+                and self._local_provider_base_path
+                and candidate_path.startswith(f"{self._local_provider_base_path}/")
+            ):
+                candidate_path = candidate_path[len(self._local_provider_base_path) :]
+        match = _LOCAL_ASSET_URL_PATTERN.match(candidate_path)
         if match is None:
             return None
         return match.group("session_id"), match.group("asset_id")
+
+    def _matches_local_provider_url(self, parsed_url: ParseResult) -> bool:
+        netloc = parsed_url.netloc.strip().lower()
+        if netloc == self._local_provider_netloc:
+            return True
+        host = (parsed_url.hostname or "").strip().lower()
+        if host not in _LOCAL_PROVIDER_HOSTS:
+            return False
+        if self._local_provider_host not in _LOCAL_PROVIDER_HOSTS:
+            return False
+        try:
+            port = parsed_url.port
+        except ValueError:
+            return False
+        return port == self._local_provider_port
 
 
 def infer_media_modality(content_type: str, filename: str = "") -> MediaModality:

--- a/src/relay_teams/sessions/runs/injection_queue.py
+++ b/src/relay_teams/sessions/runs/injection_queue.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from threading import Lock
 
+from relay_teams.media import UserPromptContent
 from relay_teams.sessions.runs.enums import InjectionSource
 from relay_teams.sessions.runs.run_models import InjectionMessage
 
@@ -26,12 +27,13 @@ class RunInjectionManager:
         with self._lock:
             return run_id in self._active_runs
 
+    # noinspection PyTypeHints
     def enqueue(
         self,
         run_id: str,
         recipient_instance_id: str,
         source: InjectionSource,
-        content: str,
+        content: UserPromptContent,
         sender_instance_id: str | None = None,
         sender_role_id: str | None = None,
     ) -> InjectionMessage:

--- a/src/relay_teams/sessions/runs/run_models.py
+++ b/src/relay_teams/sessions/runs/run_models.py
@@ -8,8 +8,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from relay_teams.media import ContentPart
 from relay_teams.media import ContentPartsAdapter
+from relay_teams.media import UserPromptContent
 from relay_teams.media import content_parts_from_text
 from relay_teams.media import content_parts_to_text
+from relay_teams.media import user_prompt_content_to_text
 from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
 from relay_teams.sessions.runs.enums import (
     ExecutionMode,
@@ -154,11 +156,18 @@ class InjectionMessage(BaseModel):
     run_id: RequiredIdentifierStr
     recipient_instance_id: RequiredIdentifierStr
     source: InjectionSource
-    content: str = Field(min_length=1)
+    # noinspection PyTypeHints
+    content: UserPromptContent
     sender_instance_id: OptionalIdentifierStr = None
     sender_role_id: OptionalIdentifierStr = None
     priority: int = Field(ge=0)
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+    @model_validator(mode="after")
+    def _validate_content(self) -> "InjectionMessage":
+        if not user_prompt_content_to_text(self.content):
+            raise ValueError("Injection content must not be empty")
+        return self
 
 
 class RunEvent(BaseModel):

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -264,9 +264,14 @@ def build_session_rounds(
             if isinstance(candidate_role_id, str) and candidate_role_id:
                 coordinator_role_id = candidate_role_id
         coordinator_messages = [
-            message
+            projected
             for message in run_messages
-            if _is_round_coordinator_message(message, coordinator_role_id)
+            if (
+                projected := _round_coordinator_message_projection(
+                    message, coordinator_role_id
+                )
+            )
+            is not None
         ]
         if not coordinator_messages:
             reconstructed = _reconstruct_completed_output_message(
@@ -576,42 +581,58 @@ def _intent_parts_to_text(intent_parts: list[dict[str, object]]) -> str | None:
     return "\n\n".join(fragments)
 
 
-def _is_round_coordinator_message(
+# noinspection PyTypeHints
+def _round_coordinator_message_projection(
     message: dict[str, object],
     coordinator_role_id: str | None,
-) -> bool:
+) -> dict[str, object] | None:
     if coordinator_role_id is None:
-        return False
+        return None
     if str(message.get("role_id") or "") != coordinator_role_id:
-        return False
+        return None
     role = str(message.get("role") or "")
     if role != "user":
-        return True
-    return _is_tool_outcome_message(cast(object, message.get("message")))
+        return message
+    projected_message = _tool_outcome_message_projection(
+        cast(object, message.get("message"))
+    )
+    if projected_message is None:
+        return None
+    projected = dict(message)
+    projected["message"] = projected_message
+    return projected
 
 
-def _is_tool_outcome_message(message: object) -> bool:
+# noinspection PyTypeHints
+def _tool_outcome_message_projection(message: object) -> dict[str, object] | None:
     if not isinstance(message, dict):
-        return False
+        return None
     parts = message.get("parts")
     if not isinstance(parts, list) or not parts:
-        return False
+        return None
+    outcome_parts: list[object] = []
     for part in parts:
         if not isinstance(part, dict):
-            return False
+            continue
         part_kind = str(part.get("part_kind") or "")
         if part_kind in {"tool-return", "retry-prompt"}:
+            outcome_parts.append(part)
             continue
         if (
             part.get("tool_name") is not None
             and part.get("content") is not None
             and part.get("args") is None
         ):
+            outcome_parts.append(part)
             continue
-        return False
-    return True
+    if not outcome_parts:
+        return None
+    projected = dict(message)
+    projected["parts"] = outcome_parts
+    return projected
 
 
+# noinspection PyTypeHints
 def _parse_event_payload(payload_json: object) -> dict[str, object]:
     if not isinstance(payload_json, str) or not payload_json:
         return {}
@@ -624,6 +645,7 @@ def _parse_event_payload(payload_json: object) -> dict[str, object]:
     return {str(key): value for key, value in decoded.items() if isinstance(key, str)}
 
 
+# noinspection PyTypeHints
 def _reconstruct_completed_output_message(
     *,
     run_id: str,

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -21,6 +21,7 @@ from relay_teams.media import MediaAssetService
 from relay_teams.monitors import MonitorService
 from relay_teams.notifications import NotificationService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.providers.model_config import ModelCapabilities
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
@@ -107,6 +108,9 @@ class ToolDeps(BaseModel):
     notification_service: SkipValidation[NotificationService | None] = None
     im_tool_service: SkipValidation[ImToolServiceLike | None] = None
     hook_service: SkipValidation[HookService | None] = None
+    model_capabilities: SkipValidation[ModelCapabilities] = Field(
+        default_factory=ModelCapabilities
+    )
     hook_runtime_env: dict[str, str] = Field(default_factory=dict)
 
 

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pydantic import BaseModel, JsonValue
+from pydantic_ai.messages import ToolReturn
 
 import asyncio
 import inspect
@@ -12,10 +13,19 @@ import time
 from collections.abc import Awaitable, Callable, Mapping
 from enum import Enum
 from json import dumps
-from typing import Protocol, cast, get_args, get_origin, get_type_hints
+from typing import (
+    Literal,
+    Protocol,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+    overload,
+)
 from uuid import uuid4
 
 from relay_teams.logger import get_logger, log_event, log_tool_error
+from relay_teams.media import ContentPart, TextContentPart, UserPromptContent
 from relay_teams.metrics.adapters import record_tool_execution
 from relay_teams.notifications import NotificationContext, NotificationType
 from relay_teams.persistence import is_retryable_sqlite_error
@@ -47,6 +57,7 @@ from relay_teams.tools.runtime.persisted_state import (
     ToolApprovalMode,
     ToolApprovalStatus,
     ToolExecutionStatus,
+    load_tool_call_state,
     merge_tool_call_state,
 )
 from relay_teams.env.hook_runtime_env import (
@@ -66,6 +77,8 @@ from relay_teams.hooks import (
 LOGGER = get_logger(__name__)
 
 
+# noinspection PyUnusedLocal,PyTypeHints
+@overload
 async def execute_tool(
     ctx: ToolContext,
     *,
@@ -86,7 +99,59 @@ async def execute_tool(
     ]
     | None = None,
     keep_approval_ticket_reusable: bool = False,
-) -> dict[str, JsonValue]:
+    allow_tool_return: Literal[False] = False,
+) -> dict[str, JsonValue]: ...
+
+
+# noinspection PyUnusedLocal,PyTypeHints
+@overload
+async def execute_tool(
+    ctx: ToolContext,
+    *,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    action: Callable[[dict[str, JsonValue]], object | Awaitable[object]]
+    | Callable[[], object | Awaitable[object]]
+    | object,
+    tool_input: dict[str, JsonValue] | None = None,
+    approval_request: ToolApprovalRequest | None = None,
+    approval_request_factory: Callable[
+        [dict[str, JsonValue]], ToolApprovalRequest | None
+    ]
+    | None = None,
+    approval_args_summary: dict[str, JsonValue] | None = None,
+    approval_args_summary_factory: Callable[
+        [dict[str, JsonValue]], dict[str, JsonValue] | None
+    ]
+    | None = None,
+    keep_approval_ticket_reusable: bool = False,
+    allow_tool_return: Literal[True] = True,
+) -> ToolReturn | dict[str, JsonValue]: ...
+
+
+# noinspection PyUnusedLocal,PyTypeHints,PyRedeclaration
+async def execute_tool(
+    ctx: ToolContext,
+    *,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    action: Callable[[dict[str, JsonValue]], object | Awaitable[object]]
+    | Callable[[], object | Awaitable[object]]
+    | object,
+    tool_input: dict[str, JsonValue] | None = None,
+    approval_request: ToolApprovalRequest | None = None,
+    approval_request_factory: Callable[
+        [dict[str, JsonValue]], ToolApprovalRequest | None
+    ]
+    | None = None,
+    approval_args_summary: dict[str, JsonValue] | None = None,
+    approval_args_summary_factory: Callable[
+        [dict[str, JsonValue]], dict[str, JsonValue] | None
+    ]
+    | None = None,
+    keep_approval_ticket_reusable: bool = False,
+    allow_tool_return: bool = False,
+) -> ToolReturn | dict[str, JsonValue]:
     """Run a tool action with approval, logging, and normalized envelopes."""
     tool_call_id = ctx.tool_call_id or f"toolcall_{uuid4().hex[:12]}"
     with trace_span(
@@ -223,7 +288,9 @@ async def execute_tool(
             finally:
                 reset_tool_hook_runtime_env(hook_env_token)
             _raise_if_stopped(ctx)
-            visible_data, internal_data = _normalize_result_payload(result)
+            visible_data, internal_data, tool_content_parts = _normalize_result_payload(
+                result
+            )
 
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             meta["duration_ms"] = elapsed_ms
@@ -243,6 +310,19 @@ async def execute_tool(
                 data=visible_data,
                 meta=meta,
             )
+            tool_return_content: UserPromptContent | None = None
+            if tool_content_parts:
+                if not allow_tool_return:
+                    raise ValueError(
+                        f"Tool {tool_name} produced model content without enabling tool returns."
+                    )
+                tool_return_content = _tool_return_content(
+                    ctx=ctx,
+                    tool_name=tool_name,
+                    tool_content_parts=tool_content_parts,
+                )
+
+            meta["tool_result_event_published"] = True
             envelope = await _apply_post_tool_hooks(
                 ctx=ctx,
                 tool_name=tool_name,
@@ -274,6 +354,11 @@ async def execute_tool(
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
                 ctx.deps.approval_ticket_repo.mark_completed(approval_ticket_id)
+            if tool_return_content is not None:
+                return ToolReturn(
+                    return_value=envelope,
+                    content=tool_return_content,
+                )
             return envelope
         except Exception as exc:
             elapsed_ms = int((time.perf_counter() - started) * 1000)
@@ -345,6 +430,8 @@ async def execute_tool(
             return envelope
 
 
+# noinspection PyUnusedLocal,PyTypeHints
+@overload
 async def execute_tool_call(
     ctx: ToolContext,
     *,
@@ -364,7 +451,57 @@ async def execute_tool_call(
     ]
     | None = None,
     keep_approval_ticket_reusable: bool = False,
-) -> dict[str, JsonValue]:
+    allow_tool_return: Literal[False] = False,
+) -> dict[str, JsonValue]: ...
+
+
+# noinspection PyUnusedLocal,PyTypeHints
+@overload
+async def execute_tool_call(
+    ctx: ToolContext,
+    *,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    action: Callable[..., object | Awaitable[object]] | object,
+    raw_args: Mapping[str, object] | None = None,
+    args_exclude: tuple[str, ...] = ("ctx",),
+    approval_request: ToolApprovalRequest | None = None,
+    approval_request_factory: Callable[
+        [dict[str, JsonValue]], ToolApprovalRequest | None
+    ]
+    | None = None,
+    approval_args_summary: dict[str, JsonValue] | None = None,
+    approval_args_summary_factory: Callable[
+        [dict[str, JsonValue]], dict[str, JsonValue] | None
+    ]
+    | None = None,
+    keep_approval_ticket_reusable: bool = False,
+    allow_tool_return: Literal[True] = True,
+) -> ToolReturn | dict[str, JsonValue]: ...
+
+
+# noinspection PyUnusedLocal,PyTypeHints,PyRedeclaration
+async def execute_tool_call(
+    ctx: ToolContext,
+    *,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    action: Callable[..., object | Awaitable[object]] | object,
+    raw_args: Mapping[str, object] | None = None,
+    args_exclude: tuple[str, ...] = ("ctx",),
+    approval_request: ToolApprovalRequest | None = None,
+    approval_request_factory: Callable[
+        [dict[str, JsonValue]], ToolApprovalRequest | None
+    ]
+    | None = None,
+    approval_args_summary: dict[str, JsonValue] | None = None,
+    approval_args_summary_factory: Callable[
+        [dict[str, JsonValue]], dict[str, JsonValue] | None
+    ]
+    | None = None,
+    keep_approval_ticket_reusable: bool = False,
+    allow_tool_return: bool = False,
+) -> ToolReturn | dict[str, JsonValue]:
     """Run a tool through the hook-aware runtime using natural Python params.
 
     Tool authors should prefer this wrapper for new tools:
@@ -396,6 +533,7 @@ async def execute_tool_call(
         approval_args_summary=approval_args_summary,
         approval_args_summary_factory=approval_args_summary_factory,
         keep_approval_ticket_reusable=keep_approval_ticket_reusable,
+        allow_tool_return=allow_tool_return,
     )
 
 
@@ -493,14 +631,46 @@ def _error_payload(exc: Exception) -> ToolError:
 
 def _normalize_result_payload(
     result: object,
-) -> tuple[JsonValue | None, JsonValue | None]:
+) -> tuple[JsonValue | None, JsonValue | None, tuple[ContentPart, ...]]:
     if isinstance(result, ToolResultProjection):
         return (
             _normalize_json_value(result.visible_data),
             _normalize_json_value(result.internal_data),
+            tuple(result.tool_content_parts),
         )
     normalized = _normalize_json_value(result)
-    return normalized, normalized
+    return normalized, normalized, ()
+
+
+# noinspection PyTypeHints
+def _tool_return_content(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_content_parts: tuple[ContentPart, ...],
+) -> UserPromptContent:
+    if not tool_content_parts:
+        return ""
+    if all(isinstance(part, TextContentPart) for part in tool_content_parts):
+        return "\n\n".join(
+            part.text
+            for part in tool_content_parts
+            if isinstance(part, TextContentPart)
+        ).strip()
+    media_asset_service = ctx.deps.media_asset_service
+    if media_asset_service is None:
+        raise ValueError(
+            f"Tool {tool_name} returned media content without media asset support."
+        )
+    provider_content = media_asset_service.to_provider_user_prompt_content(
+        parts=tool_content_parts
+    )
+    hydrated_content = media_asset_service.hydrate_user_prompt_content(
+        content=provider_content
+    )
+    if isinstance(hydrated_content, str):
+        return hydrated_content
+    return tuple(hydrated_content)
 
 
 def _safe_json(value: object) -> str:
@@ -1543,6 +1713,7 @@ def _publish_tool_approval_event(
     )
 
 
+# noinspection PyTypeHints
 def _visible_envelope(
     *,
     ok: bool,
@@ -1621,6 +1792,20 @@ def _persist_tool_record(
 ) -> None:
     approval_status = _approval_status_from_meta(runtime_meta)
     approval_mode = _approval_mode_from_meta(runtime_meta)
+    result_record = _internal_record(
+        tool_name=tool_name,
+        visible_envelope=visible_envelope,
+        internal_data=internal_data,
+        runtime_meta=runtime_meta,
+    )
+    current_state = load_tool_call_state(
+        shared_store=ctx.deps.shared_store,
+        task_id=ctx.deps.task_id,
+        tool_call_id=tool_call_id,
+    )
+    existing_call_state = (
+        dict(current_state.call_state) if current_state is not None else {}
+    )
     merge_tool_call_state(
         shared_store=ctx.deps.shared_store,
         task_id=ctx.deps.task_id,
@@ -1636,12 +1821,8 @@ def _persist_tool_record(
         approval_status=approval_status,
         approval_feedback=str(runtime_meta.get("approval_feedback") or ""),
         execution_status=execution_status,
-        result_envelope=_internal_record(
-            tool_name=tool_name,
-            visible_envelope=visible_envelope,
-            internal_data=internal_data,
-            runtime_meta=runtime_meta,
-        ),
+        result_envelope=result_record,
+        call_state=existing_call_state,
     )
 
 

--- a/src/relay_teams/tools/runtime/models.py
+++ b/src/relay_teams/tools/runtime/models.py
@@ -6,6 +6,7 @@ from relay_teams.computer import (
     ComputerPermissionScope,
     ExecutionSurface,
 )
+from relay_teams.media import ContentPart
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_serializer
 
 
@@ -63,6 +64,7 @@ class ToolResultProjection(BaseModel):
 
     visible_data: JsonValue | None = None
     internal_data: JsonValue | None = None
+    tool_content_parts: tuple[ContentPart, ...] = ()
 
 
 class ToolApprovalRequest(BaseModel):

--- a/src/relay_teams/tools/workspace_tools/read.py
+++ b/src/relay_teams/tools/workspace_tools/read.py
@@ -1,11 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import mimetypes
 from pathlib import Path
 
+from PIL import (
+    Image,
+    UnidentifiedImageError,
+)
 from pydantic import JsonValue
 from pydantic_ai import Agent
+from pydantic_ai.messages import ToolReturn
 
+from relay_teams.media import (
+    MediaModality,
+    infer_media_modality,
+)
 from relay_teams.paths import (
     iter_dir_paths,
     open_binary_file,
@@ -38,6 +48,9 @@ from relay_teams.tools.workspace_tools.read_support import (
 )
 
 DESCRIPTION = load_tool_description(__file__)
+_READ_TOOL_IMAGE_SOURCE = "read_tool"
+_READ_TOOL_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+_READ_TOOL_MAX_IMAGE_BYTES_LABEL = "10 MB"
 
 BINARY_EXTENSIONS = {
     ".zip",
@@ -194,7 +207,132 @@ def _inject_instruction_sections(
     return "\n".join([*instructions, output])
 
 
+def _detect_image_mime_type(file_path: Path) -> str | None:
+    try:
+        with open_binary_file(file_path) as handle:
+            with Image.open(handle) as image:
+                detected_format = image.format
+                image.verify()
+    except (OSError, UnidentifiedImageError):
+        return None
+    detected_mime_type = Image.MIME.get(detected_format or "")
+    guessed_mime_type, _ = mimetypes.guess_type(file_path.name, strict=False)
+    mime_type = (
+        detected_mime_type
+        if isinstance(detected_mime_type, str) and detected_mime_type.strip()
+        else guessed_mime_type
+    )
+    if not isinstance(mime_type, str) or not mime_type.strip():
+        return None
+    try:
+        modality = infer_media_modality(mime_type, file_path.name)
+    except ValueError:
+        return None
+    if modality != MediaModality.IMAGE:
+        return None
+    return mime_type
+
+
+# noinspection PyTypeHints
+def _read_image_capability_error(path: str, support: bool | None) -> str:
+    if support is True:
+        return ""
+    if support is False:
+        return (
+            "The current model does not have image input enabled for read(). "
+            "Enable image input in provider settings if this model supports vision, "
+            f"or switch to a vision-capable model, then retry: {path}"
+        )
+    return (
+        "Image input support for the current model is unknown, so read() cannot "
+        "attach this image yet. Enable image input in provider settings if this "
+        f"model supports vision, or switch to a vision-capable model, then retry: {path}"
+    )
+
+
+# noinspection PyTypeHints
+def _image_support(ctx: ToolContext) -> bool | None:
+    return ctx.deps.model_capabilities.input.image
+
+
+def _project_image_read_result(
+    *,
+    ctx: ToolContext,
+    file_path: Path,
+    path: str,
+) -> ToolResultProjection:
+    media_asset_service = ctx.deps.media_asset_service
+    if media_asset_service is None:
+        raise ValueError("Cannot read image file without media asset support.")
+    mime_type = _detect_image_mime_type(file_path)
+    if mime_type is None:
+        raise ValueError(f"Cannot read binary file: {path}")
+    support = _image_support(ctx)
+    if support is not True:
+        raise ValueError(_read_image_capability_error(path, support))
+    image_size_bytes = path_stat(file_path).st_size
+    if image_size_bytes > _READ_TOOL_MAX_IMAGE_BYTES:
+        raise ValueError(
+            "Image file is too large for read(). "
+            f"Maximum supported size is {_READ_TOOL_MAX_IMAGE_BYTES_LABEL}: {path}"
+        )
+
+    with open_binary_file(file_path) as handle:
+        data = handle.read()
+
+    record = media_asset_service.store_bytes(
+        session_id=ctx.deps.session_id,
+        workspace_id=ctx.deps.workspace_id,
+        modality=MediaModality.IMAGE,
+        mime_type=mime_type,
+        data=data,
+        name=file_path.name,
+        source=_READ_TOOL_IMAGE_SOURCE,
+    )
+    media_content_part = media_asset_service.to_content_part(record)
+    media_part = media_content_part.model_dump(mode="json")
+    record_file_read(
+        shared_store=ctx.deps.shared_store,
+        task_id=ctx.deps.task_id,
+        path=file_path,
+    )
+    output = "\n".join(
+        [
+            f"<path>{file_path}</path>",
+            "<type>image</type>",
+            "<content>",
+            f"[image: {file_path.name}]",
+            "</content>",
+        ]
+    )
+    return _project_read_result(
+        output=output,
+        truncated=False,
+        next_offset=None,
+        metadata={
+            "path": str(file_path),
+            "type": "image",
+            "mime_type": mime_type,
+            "content": [media_part],
+        },
+    ).model_copy(
+        update={
+            "internal_data": {
+                "output": output,
+                "truncated": False,
+                "next_offset": None,
+                "path": str(file_path),
+                "type": "image",
+                "mime_type": mime_type,
+                "content": [media_part],
+            },
+            "tool_content_parts": (media_content_part,),
+        }
+    )
+
+
 def register(agent: Agent[ToolDeps, str]) -> None:
+    # noinspection PyTypeHints
     @agent.tool(description=DESCRIPTION)
     async def read(
         ctx: ToolContext,
@@ -203,7 +341,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         limit: int = DEFAULT_READ_LIMIT,
         cell_id: str | None = None,
         include_outputs: bool = True,
-    ) -> dict[str, JsonValue]:
+    ) -> ToolReturn | dict[str, JsonValue]:
         """Read a file or directory content.
 
         Args:
@@ -284,7 +422,15 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                     "include_outputs only applies to Jupyter notebooks (.ipynb)."
                 )
 
-            if is_binary_file(file_path, path_stat(file_path).st_size):
+            file_size = path_stat(file_path).st_size
+            if is_binary_file(file_path, file_size):
+                image_mime_type = _detect_image_mime_type(file_path)
+                if image_mime_type is not None:
+                    return _project_image_read_result(
+                        ctx=ctx,
+                        file_path=file_path,
+                        path=path,
+                    )
                 raise ValueError(f"Cannot read binary file: {path}")
 
             (
@@ -357,4 +503,5 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             },
             action=_action,
             raw_args=locals(),
+            allow_tool_return=True,
         )

--- a/src/relay_teams/tools/workspace_tools/read.txt
+++ b/src/relay_teams/tools/workspace_tools/read.txt
@@ -10,6 +10,7 @@ Usage:
 - Jupyter notebooks (`.ipynb`) are returned as structured cells instead of raw JSON.
 - For notebooks, use optional `cell_id` and `include_outputs` to inspect a specific cell or omit outputs.
 - Text output is capped by line length, line count, and total bytes; the response tells you how to continue.
-- Binary files are rejected.
+- Image files can be returned as image content when the current model has image input enabled.
+- Other binary files are rejected.
 - Use `glob` to find candidate file paths and `grep` to locate specific content before reading large files.
 - Read larger windows instead of many tiny slices when you need surrounding context.

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -2220,24 +2220,26 @@ def _emit_gateway_observability_probe() -> None:
     previous_computer_runtime = os.environ.get("AGENT_TEAMS_COMPUTER_RUNTIME")
     os.environ["AGENT_TEAMS_COMPUTER_RUNTIME"] = "fake"
     try:
-        runtime = _build_acp_stdio_runtime()
-        server = cast(AcpGatewayServer, getattr(runtime, "_server"))
-
-        async def discard_notify(_message: dict[str, JsonValue]) -> None:
-            return None
-
-        server.set_notify(discard_notify)
         failure: list[BaseException] = []
 
         def runner() -> None:
             try:
-                asyncio.run(_run_gateway_observability_probe(server))
+                runtime = _build_acp_stdio_runtime()
+                server = cast(AcpGatewayServer, getattr(runtime, "_server"))
+
+                async def discard_notify(_message: dict[str, JsonValue]) -> None:
+                    return None
+
+                server.set_notify(discard_notify)
+                asyncio.run(
+                    asyncio.wait_for(_run_gateway_observability_probe(server), 30.0)
+                )
             except BaseException as exc:  # pragma: no cover - re-raised below
                 failure.append(exc)
 
         thread = threading.Thread(target=runner, daemon=True)
         thread.start()
-        thread.join(timeout=30.0)
+        thread.join(timeout=35.0)
         if thread.is_alive():
             raise AssertionError(
                 "Timed out while emitting gateway observability probe."
@@ -2314,7 +2316,9 @@ async def _run_gateway_observability_probe(server: AcpGatewayServer) -> None:
     )
     assert isinstance(prompt_response, dict)
     prompt_result = prompt_response.get("result")
-    assert isinstance(prompt_result, dict)
+    assert isinstance(prompt_result, dict), (
+        f"unexpected ACP prompt response: {prompt_response!r}"
+    )
     assert prompt_result.get("runStatus") == "completed"
 
 

--- a/tests/unit_tests/agents/execution/test_llm_session.py
+++ b/tests/unit_tests/agents/execution/test_llm_session.py
@@ -6,7 +6,10 @@ import json
 
 import httpx
 from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
+from collections.abc import Sequence
 
 import pytest
 from openai import APIStatusError
@@ -43,12 +46,14 @@ from relay_teams.tools.runtime.persisted_state import (
     ToolExecutionStatus,
 )
 from relay_teams.hooks import HookDecisionBundle, HookDecisionType, HookEventName
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.assistant_errors import AssistantRunError
 from pydantic_ai.messages import (
     BinaryContent,
     ImageUrl,
     ModelRequest,
+    ModelRequestPart,
     ModelResponse,
     RetryPromptPart,
     TextPart,
@@ -147,7 +152,11 @@ def test_normalize_committable_messages_keeps_request_fields() -> None:
         metadata={"source": "test"},
     )
 
-    normalized = AgentLlmSession._normalize_committable_messages(session, [request])
+    normalized = AgentLlmSession._normalize_committable_messages(
+        session,
+        request=_build_request(),
+        messages=[request],
+    )
 
     assert len(normalized) == 1
     normalized_request = normalized[0]
@@ -162,6 +171,7 @@ class _FakeMessageRepo:
     def __init__(self, history: list[ModelRequest | ModelResponse]) -> None:
         self._history = history
         self.append_calls: list[list[ModelRequest | ModelResponse]] = []
+        self.appended_user_prompts: list[object] = []
         self.pruned_conversation_ids: list[str] = []
 
     def get_history_for_conversation(
@@ -195,6 +205,7 @@ class _FakeMessageRepo:
             trace_id,
         )
         self.append_calls.append(list(messages))
+        self._history.extend(messages)
 
     def replace_pending_user_prompt(
         self,
@@ -219,6 +230,30 @@ class _FakeMessageRepo:
             content,
         )
         return False
+
+    def append_user_prompt_if_missing(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: object,
+    ) -> bool:
+        _ = (
+            session_id,
+            workspace_id,
+            conversation_id,
+            agent_role_id,
+            instance_id,
+            task_id,
+            trace_id,
+        )
+        self.appended_user_prompts.append(content)
+        return True
 
 
 class _FakeMicrocompactService:
@@ -921,6 +956,1753 @@ def test_hydrate_history_media_content_replaces_local_urls_before_provider_send(
     assert hydrated_part.content[0] == "describe this image"
     assert isinstance(hydrated_part.content[1], BinaryContent)
     assert hydrated_part.content[1].data == b"image-bytes"
+
+
+def test_provider_history_for_model_turn_details_returns_hydrated_history_only() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    persisted_prompt = (
+        "describe this image",
+        ImageUrl(
+            url="http://127.0.0.1:8000/api/sessions/session-1/media/asset-1/file",
+            media_type="image/png",
+            force_download="allow-local",
+        ),
+    )
+
+    class _FakeMediaAssetService:
+        def hydrate_user_prompt_content(self, *, content: object) -> object:
+            if content == persisted_prompt:
+                return (
+                    "describe this image",
+                    BinaryContent(
+                        data=b"image-bytes",
+                        media_type="image/png",
+                    ),
+                )
+            return content
+
+    session.__dict__["_media_asset_service"] = _FakeMediaAssetService()
+
+    provider_history, injected_tool_call_ids = (
+        AgentLlmSession._provider_history_for_model_turn_details(
+            session,
+            request=_build_request(),
+            history=[ModelRequest(parts=[UserPromptPart(content=persisted_prompt)])],
+            consumed_tool_call_ids={"call-read-1"},
+        )
+    )
+
+    assert injected_tool_call_ids == ()
+    assert len(provider_history) == 1
+    hydrated_request = provider_history[0]
+    assert isinstance(hydrated_request, ModelRequest)
+    hydrated_part = hydrated_request.parts[0]
+    assert isinstance(hydrated_part, UserPromptPart)
+    assert hydrated_part.content[0] == "describe this image"
+    assert isinstance(hydrated_part.content[1], BinaryContent)
+    assert hydrated_part.content[1].data == b"image-bytes"
+
+
+def test_model_request_matches_tool_result_replay_helpers_accept_matching_replay() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    expected_tool_return = ToolReturnPart(
+        tool_name="read",
+        tool_call_id="call-read-1",
+        content={"ok": True},
+    )
+    previous_message = ModelRequest(parts=[expected_tool_return])
+    synthetic_prompt = ModelRequest(
+        parts=[UserPromptPart(content=("describe this image", "second line"))]
+    )
+    replayed_request = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="read",
+                tool_call_id="call-read-1",
+                content={"ok": True},
+            ),
+            UserPromptPart(content=("describe this image", "second line")),
+        ]
+    )
+
+    assert AgentLlmSession._model_request_contains_only_tool_returns(
+        session, previous_message
+    )
+    assert AgentLlmSession._model_request_contains_only_user_prompts(
+        session, synthetic_prompt
+    )
+    assert AgentLlmSession._tool_return_parts_match(
+        session,
+        expected_part=expected_tool_return,
+        actual_part=cast(ToolReturnPart, replayed_request.parts[0]),
+    )
+    assert (
+        AgentLlmSession._user_prompt_parts_key(
+            session,
+            parts=cast(Sequence[ModelRequestPart], synthetic_prompt.parts),
+        )
+        is not None
+    )
+    assert AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[previous_message, synthetic_prompt],
+        replayed_request=replayed_request,
+    )
+    assert AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[
+            ModelRequest(
+                parts=[
+                    expected_tool_return,
+                    UserPromptPart(content=("describe this image", "second line")),
+                ]
+            )
+        ],
+        replayed_request=replayed_request,
+    )
+
+
+def test_model_request_matches_tool_result_replay_helpers_reject_invalid_shapes() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    expected_tool_return = ToolReturnPart(
+        tool_name="read",
+        tool_call_id="call-read-1",
+        content={"ok": True},
+    )
+    previous_message = ModelRequest(parts=[expected_tool_return])
+    synthetic_prompt = ModelRequest(
+        parts=[UserPromptPart(content="describe this image")]
+    )
+    matching_replayed_request = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="read",
+                tool_call_id="call-read-1",
+                content={"ok": True},
+            ),
+            UserPromptPart(content="describe this image"),
+        ]
+    )
+
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[previous_message],
+        replayed_request=matching_replayed_request,
+    )
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[
+            ModelResponse(parts=[TextPart(content="done")], model_name="fake"),
+            synthetic_prompt,
+        ],
+        replayed_request=matching_replayed_request,
+    )
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[
+            previous_message,
+            ModelResponse(parts=[TextPart(content="done")], model_name="fake"),
+        ],
+        replayed_request=matching_replayed_request,
+    )
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[
+            ModelRequest(
+                parts=[expected_tool_return, UserPromptPart(content="unexpected")]
+            ),
+            synthetic_prompt,
+        ],
+        replayed_request=matching_replayed_request,
+    )
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[
+            previous_message,
+            ModelRequest(
+                parts=[
+                    UserPromptPart(content="describe"),
+                    cast(ModelRequestPart, TextPart(content="unexpected")),
+                ]
+            ),
+        ],
+        replayed_request=matching_replayed_request,
+    )
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[previous_message, synthetic_prompt],
+        replayed_request=ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="read",
+                    tool_call_id="call-read-1",
+                    content={"ok": True},
+                ),
+                cast(ModelRequestPart, TextPart(content="unexpected")),
+            ]
+        ),
+    )
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[previous_message, synthetic_prompt],
+        replayed_request=ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="read",
+                    tool_call_id="call-read-2",
+                    content={"ok": True},
+                ),
+                UserPromptPart(content="describe this image"),
+            ]
+        ),
+    )
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[previous_message, synthetic_prompt],
+        replayed_request=ModelRequest(parts=[expected_tool_return]),
+    )
+    assert not AgentLlmSession._model_request_contains_only_tool_returns(
+        session, ModelRequest(parts=[])
+    )
+    assert not AgentLlmSession._model_request_contains_only_user_prompts(
+        session, ModelRequest(parts=[])
+    )
+    assert (
+        AgentLlmSession._user_prompt_parts_key(
+            session,
+            parts=cast(
+                Sequence[ModelRequestPart],
+                [cast(ModelRequestPart, TextPart(content="not a prompt"))],
+            ),
+        )
+        is None
+    )
+    assert not AgentLlmSession._tool_return_parts_match(
+        session,
+        expected_part=expected_tool_return,
+        actual_part=ToolReturnPart(
+            tool_name="read",
+            tool_call_id="call-read-1",
+            content={"ok": False},
+        ),
+    )
+
+
+def test_prompt_content_provider_service_requires_provider_capability() -> None:
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_media_asset_service"] = object()
+
+    assert AgentLlmSession._prompt_content_provider_service(session) is None
+
+    class _FakeProviderService:
+        def to_provider_user_prompt_content(self, *, parts: object) -> object:
+            _ = parts
+            return "attached"
+
+    provider_service = _FakeProviderService()
+    session.__dict__["_media_asset_service"] = provider_service
+
+    assert AgentLlmSession._prompt_content_provider_service(session) is provider_service
+
+
+def test_model_requests_match_user_prompt_uses_normalized_prompt_text() -> None:
+    session = object.__new__(AgentLlmSession)
+    matching_left = ModelRequest(parts=[UserPromptPart(content="describe this image")])
+    matching_right = ModelRequest(
+        parts=[UserPromptPart(content="  describe this image  ")]
+    )
+
+    assert AgentLlmSession._model_requests_match_user_prompt(
+        session,
+        matching_left,
+        matching_right,
+    )
+    assert not AgentLlmSession._model_requests_match_user_prompt(
+        session,
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="read",
+                    tool_call_id="call-read-1",
+                    content={"ok": True},
+                )
+            ]
+        ),
+        matching_right,
+    )
+    assert not AgentLlmSession._model_requests_match_user_prompt(
+        session,
+        matching_left,
+        ModelRequest(
+            parts=[
+                UserPromptPart(content="describe this image"),
+                cast(ModelRequestPart, RetryPromptPart(content="retry")),
+            ]
+        ),
+    )
+
+
+def test_model_requests_match_user_prompt_compares_binary_content_identity() -> None:
+    session = object.__new__(AgentLlmSession)
+    left = ModelRequest(
+        parts=[
+            UserPromptPart(
+                content=(
+                    "describe this image",
+                    BinaryContent(data=b"image-one", media_type="image/png"),
+                )
+            )
+        ]
+    )
+    right = ModelRequest(
+        parts=[
+            UserPromptPart(
+                content=(
+                    "describe this image",
+                    BinaryContent(data=b"image-two", media_type="image/png"),
+                )
+            )
+        ]
+    )
+
+    assert not AgentLlmSession._model_requests_match_user_prompt(
+        session,
+        left,
+        right,
+    )
+    assert AgentLlmSession._drop_duplicate_leading_request(
+        session,
+        history=[left],
+        new_messages=[right],
+    ) == [right]
+
+
+def test_drop_duplicate_leading_request_handles_prompt_and_tool_replay_matches() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    prompt_request = ModelRequest(parts=[UserPromptPart(content="describe this image")])
+    response = ModelResponse(parts=[TextPart(content="done")], model_name="fake")
+
+    assert AgentLlmSession._drop_duplicate_leading_request(
+        session,
+        history=[prompt_request],
+        new_messages=[prompt_request, response],
+    ) == [response]
+    unchanged_messages = AgentLlmSession._drop_duplicate_leading_request(
+        session,
+        history=[prompt_request],
+        new_messages=[
+            ModelResponse(parts=[TextPart(content="done")], model_name="fake")
+        ],
+    )
+    unchanged_response = unchanged_messages[0]
+    assert isinstance(unchanged_response, ModelResponse)
+    unchanged_part = unchanged_response.parts[0]
+    assert isinstance(unchanged_part, TextPart)
+    assert unchanged_part.content == "done"
+
+    expected_tool_return = ToolReturnPart(
+        tool_name="read",
+        tool_call_id="call-read-1",
+        content={"ok": True},
+    )
+    synthetic_prompt = ModelRequest(
+        parts=[UserPromptPart(content="describe this image")]
+    )
+    replayed_request = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="read",
+                tool_call_id="call-read-1",
+                content={"ok": True},
+            ),
+            UserPromptPart(content="describe this image"),
+        ]
+    )
+
+    assert AgentLlmSession._drop_duplicate_leading_request(
+        session,
+        history=[ModelRequest(parts=[expected_tool_return]), synthetic_prompt],
+        new_messages=[replayed_request, response],
+    ) == [response]
+    assert AgentLlmSession._drop_duplicate_leading_request(
+        session,
+        history=[
+            ModelRequest(
+                parts=[
+                    expected_tool_return,
+                    UserPromptPart(content="describe this image"),
+                ]
+            )
+        ],
+        new_messages=[replayed_request, response],
+    ) == [response]
+    preserved_messages = AgentLlmSession._drop_duplicate_leading_request(
+        session,
+        history=[prompt_request],
+        new_messages=[
+            ModelRequest(parts=[UserPromptPart(content="different prompt")]),
+            response,
+        ],
+    )
+    preserved_request = preserved_messages[0]
+    assert isinstance(preserved_request, ModelRequest)
+    preserved_part = preserved_request.parts[0]
+    assert isinstance(preserved_part, UserPromptPart)
+    assert preserved_part.content == "different prompt"
+    assert preserved_messages[1] == response
+
+
+def test_model_request_matches_tool_result_replay_rejects_tool_return_count_mismatch() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+
+    assert not AgentLlmSession._model_request_matches_tool_result_replay(
+        session,
+        history=[
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="read",
+                        tool_call_id="call-read-1",
+                        content={"ok": True},
+                    ),
+                    ToolReturnPart(
+                        tool_name="read",
+                        tool_call_id="call-read-2",
+                        content={"ok": True},
+                    ),
+                ]
+            ),
+            ModelRequest(parts=[UserPromptPart(content="describe this image")]),
+        ],
+        replayed_request=ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="read",
+                    tool_call_id="call-read-1",
+                    content={"ok": True},
+                ),
+                UserPromptPart(content="describe this image"),
+            ]
+        ),
+    )
+
+
+def test_normalize_committable_messages_keeps_tool_return_metadata_without_state_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+
+    def _unexpected_load_tool_call_state(**kwargs: object) -> object:
+        _ = kwargs
+        raise AssertionError("tool state lookup should not happen")
+
+    monkeypatch.setattr(
+        llm_module,
+        "load_tool_call_state",
+        _unexpected_load_tool_call_state,
+    )
+
+    normalized = AgentLlmSession._normalize_committable_messages(
+        session,
+        request=_build_request(),
+        messages=[
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="read",
+                        tool_call_id="call-read-1",
+                        content={"ok": True, "data": {"type": "image"}},
+                        metadata={"keep": "me"},
+                    )
+                ]
+            )
+        ],
+    )
+
+    request_message = normalized[0]
+    assert isinstance(request_message, ModelRequest)
+    tool_return = request_message.parts[0]
+    assert isinstance(tool_return, ToolReturnPart)
+    assert tool_return.metadata == {"keep": "me"}
+
+
+@pytest.mark.asyncio
+async def test_generate_async_commits_final_result_messages_when_iteration_emits_none() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+
+    class _FakeInjectionManager:
+        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
+            _ = (run_id, instance_id)
+            return []
+
+    class _FakeControlContext:
+        def raise_if_cancelled(self) -> None:
+            return None
+
+    class _FakeRunControlManager:
+        def context(self, *, run_id: str, instance_id: str) -> _FakeControlContext:
+            _ = (run_id, instance_id)
+            return _FakeControlContext()
+
+    usage = SimpleNamespace(
+        input_tokens=0,
+        cache_read_tokens=0,
+        output_tokens=0,
+        requests=0,
+        tool_calls=0,
+        details={},
+    )
+    final_response = ModelResponse(
+        parts=[TextPart(content="done")],
+        model_name="fake-model",
+    )
+    message_repo = _FakeMessageRepo(history=[])
+
+    class _FakeResult:
+        response = final_response
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return [final_response]
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgentRun:
+        def __init__(self) -> None:
+            self.result = _FakeResult()
+            self._yielded = False
+
+        async def __aenter__(self) -> "_FakeAgentRun":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: object,
+        ) -> bool | None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def __aiter__(self) -> "_FakeAgentRun":
+            self._yielded = False
+            return self
+
+        async def __anext__(self) -> object:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return object()
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return []
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgent:
+        def iter(
+            self,
+            prompt: str | None,
+            *,
+            deps: object,
+            message_history: Sequence[ModelRequest | ModelResponse],
+            usage_limits: object,
+        ) -> _FakeAgentRun:
+            _ = (prompt, deps, message_history, usage_limits)
+            return _FakeAgentRun()
+
+    session.__dict__["_config"] = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        capabilities=ModelCapabilities(
+            input=ModelModalityMatrix(text=True),
+            output=ModelModalityMatrix(text=True),
+        ),
+    )
+    session.__dict__["_profile_name"] = None
+    session.__dict__["_retry_config"] = LlmRetryConfig()
+    session.__dict__["_metric_recorder"] = None
+    session.__dict__["_tool_registry"] = cast(object, None)
+    session.__dict__["_allowed_tools"] = ()
+    session.__dict__["_allowed_mcp_servers"] = ()
+    session.__dict__["_allowed_skills"] = ()
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_shared_store"] = cast(object, None)
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_message_repo"] = cast(MessageRepository, message_repo)
+    session.__dict__["_approval_ticket_repo"] = cast(object, None)
+    session.__dict__["_user_question_repo"] = None
+    session.__dict__["_run_runtime_repo"] = cast(object, None)
+    session.__dict__["_run_intent_repo"] = cast(object, None)
+    session.__dict__["_background_task_service"] = None
+    session.__dict__["_todo_service"] = None
+    session.__dict__["_monitor_service"] = None
+    session.__dict__["_workspace_manager"] = type(
+        "_WorkspaceManager",
+        (),
+        {"resolve": lambda self, **kwargs: cast(object, None)},
+    )()
+    session.__dict__["_media_asset_service"] = cast(object, None)
+    session.__dict__["_role_memory_service"] = None
+    session.__dict__["_subagent_reflection_service"] = None
+    session.__dict__["_conversation_compaction_service"] = None
+    session.__dict__["_conversation_microcompact_service"] = None
+    session.__dict__["_mcp_registry"] = McpRegistry()
+    session.__dict__["_skill_registry"] = cast(object, None)
+    session.__dict__["_role_registry"] = cast(object, None)
+    session.__dict__["_task_execution_service"] = cast(object, object())
+    session.__dict__["_task_service"] = cast(object, None)
+    session.__dict__["_run_control_manager"] = _FakeRunControlManager()
+    session.__dict__["_tool_approval_manager"] = cast(object, None)
+    session.__dict__["_user_question_manager"] = None
+    session.__dict__["_tool_approval_policy"] = cast(object, None)
+    session.__dict__["_notification_service"] = None
+    session.__dict__["_token_usage_repo"] = None
+    session.__dict__["_fallback_middleware"] = cast(object, None)
+    session.__dict__["_im_tool_service"] = None
+    session.__dict__["_computer_runtime"] = None
+    session.__dict__["_shell_approval_repo"] = None
+    session.__dict__["_hook_service"] = None
+    session.__dict__["_injection_manager"] = _FakeInjectionManager()
+    session.__dict__["_run_event_hub"] = type(
+        "_RunEventHub", (), {"publish": lambda self, event: None}
+    )()
+    session.__dict__["_agent_repo"] = cast(object, None)
+    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
+        object, None
+    )
+
+    async def _build_agent_iteration_context(
+        **kwargs: object,
+    ) -> tuple[object, Sequence[ModelRequest | ModelResponse], str, object]:
+        _ = kwargs
+        prepared_prompt = SimpleNamespace(
+            history=(),
+            system_prompt="System prompt",
+            budget=SimpleNamespace(),
+            estimated_history_tokens_before_microcompact=0,
+            estimated_history_tokens_after_microcompact=0,
+            microcompact_compacted_message_count=0,
+            microcompact_compacted_part_count=0,
+        )
+        return prepared_prompt, [], "System prompt", _FakeAgent()
+
+    async def _close_run_scoped_llm_http_client(*, request: LLMRequest) -> None:
+        _ = request
+        return None
+
+    session.__dict__["_build_agent_iteration_context"] = _build_agent_iteration_context
+    session.__dict__["_close_run_scoped_llm_http_client"] = (
+        _close_run_scoped_llm_http_client
+    )
+
+    result = await AgentLlmSession._generate_async(
+        session,
+        _build_request(user_prompt=None),
+        skip_initial_user_prompt_persist=True,
+    )
+
+    assert result == "done"
+    assert len(message_repo.append_calls) == 1
+    assert message_repo.append_calls[0] == [final_response]
+
+
+@pytest.mark.asyncio
+async def test_generate_async_marks_tool_call_events_from_streamed_messages() -> None:
+    session = object.__new__(AgentLlmSession)
+
+    class _FakeInjectionManager:
+        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
+            _ = (run_id, instance_id)
+            return []
+
+    class _FakeControlContext:
+        def raise_if_cancelled(self) -> None:
+            return None
+
+    class _FakeRunControlManager:
+        def context(self, *, run_id: str, instance_id: str) -> _FakeControlContext:
+            _ = (run_id, instance_id)
+            return _FakeControlContext()
+
+    usage = SimpleNamespace(
+        input_tokens=0,
+        cache_read_tokens=0,
+        output_tokens=0,
+        requests=0,
+        tool_calls=0,
+        details={},
+    )
+    tool_call_message = ModelResponse(
+        parts=[
+            ToolCallPart(
+                tool_name="read",
+                args='{"path":"docs/relay_teams.png"}',
+                tool_call_id="call-read-1",
+            )
+        ],
+        model_name="fake-model",
+    )
+    final_response = ModelResponse(
+        parts=[TextPart(content="done")],
+        model_name="fake-model",
+    )
+    message_repo = _FakeMessageRepo(history=[])
+
+    class _FakeResult:
+        response = final_response
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return [tool_call_message, final_response]
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgentRun:
+        def __init__(self) -> None:
+            self.result = _FakeResult()
+            self._yielded = False
+
+        async def __aenter__(self) -> "_FakeAgentRun":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: object,
+        ) -> bool | None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def __aiter__(self) -> "_FakeAgentRun":
+            self._yielded = False
+            return self
+
+        async def __anext__(self) -> object:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return object()
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return [tool_call_message]
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgent:
+        def iter(
+            self,
+            prompt: str | None,
+            *,
+            deps: object,
+            message_history: Sequence[ModelRequest | ModelResponse],
+            usage_limits: object,
+        ) -> _FakeAgentRun:
+            _ = (prompt, deps, message_history, usage_limits)
+            return _FakeAgentRun()
+
+    session.__dict__["_config"] = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        capabilities=ModelCapabilities(
+            input=ModelModalityMatrix(text=True),
+            output=ModelModalityMatrix(text=True),
+        ),
+    )
+    session.__dict__["_profile_name"] = None
+    session.__dict__["_retry_config"] = LlmRetryConfig()
+    session.__dict__["_metric_recorder"] = None
+    session.__dict__["_tool_registry"] = cast(object, None)
+    session.__dict__["_allowed_tools"] = ()
+    session.__dict__["_allowed_mcp_servers"] = ()
+    session.__dict__["_allowed_skills"] = ()
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_shared_store"] = cast(object, None)
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_message_repo"] = cast(MessageRepository, message_repo)
+    session.__dict__["_approval_ticket_repo"] = cast(object, None)
+    session.__dict__["_user_question_repo"] = None
+    session.__dict__["_run_runtime_repo"] = cast(object, None)
+    session.__dict__["_run_intent_repo"] = cast(object, None)
+    session.__dict__["_background_task_service"] = None
+    session.__dict__["_todo_service"] = None
+    session.__dict__["_monitor_service"] = None
+    session.__dict__["_workspace_manager"] = type(
+        "_WorkspaceManager",
+        (),
+        {"resolve": lambda self, **kwargs: cast(object, None)},
+    )()
+    session.__dict__["_media_asset_service"] = cast(object, None)
+    session.__dict__["_role_memory_service"] = None
+    session.__dict__["_subagent_reflection_service"] = None
+    session.__dict__["_conversation_compaction_service"] = None
+    session.__dict__["_conversation_microcompact_service"] = None
+    session.__dict__["_mcp_registry"] = McpRegistry()
+    session.__dict__["_skill_registry"] = cast(object, None)
+    session.__dict__["_role_registry"] = cast(object, None)
+    session.__dict__["_task_execution_service"] = cast(object, object())
+    session.__dict__["_task_service"] = cast(object, None)
+    session.__dict__["_run_control_manager"] = _FakeRunControlManager()
+    session.__dict__["_tool_approval_manager"] = cast(object, None)
+    session.__dict__["_user_question_manager"] = None
+    session.__dict__["_tool_approval_policy"] = cast(object, None)
+    session.__dict__["_notification_service"] = None
+    session.__dict__["_token_usage_repo"] = None
+    session.__dict__["_fallback_middleware"] = cast(object, None)
+    session.__dict__["_im_tool_service"] = None
+    session.__dict__["_computer_runtime"] = None
+    session.__dict__["_shell_approval_repo"] = None
+    session.__dict__["_hook_service"] = None
+    session.__dict__["_injection_manager"] = _FakeInjectionManager()
+    session.__dict__["_run_event_hub"] = type(
+        "_RunEventHub", (), {"publish": lambda self, event: None}
+    )()
+    session.__dict__["_agent_repo"] = cast(object, None)
+    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
+        object, None
+    )
+
+    async def _build_agent_iteration_context(
+        **kwargs: object,
+    ) -> tuple[object, Sequence[ModelRequest | ModelResponse], str, object]:
+        _ = kwargs
+        prepared_prompt = SimpleNamespace(
+            history=(),
+            system_prompt="System prompt",
+            budget=SimpleNamespace(),
+            estimated_history_tokens_before_microcompact=0,
+            estimated_history_tokens_after_microcompact=0,
+            microcompact_compacted_message_count=0,
+            microcompact_compacted_part_count=0,
+        )
+        return prepared_prompt, [], "System prompt", _FakeAgent()
+
+    async def _close_run_scoped_llm_http_client(*, request: LLMRequest) -> None:
+        _ = request
+        return None
+
+    session.__dict__["_build_agent_iteration_context"] = _build_agent_iteration_context
+    session.__dict__["_close_run_scoped_llm_http_client"] = (
+        _close_run_scoped_llm_http_client
+    )
+
+    result = await AgentLlmSession._generate_async(
+        session,
+        _build_request(user_prompt=None),
+        skip_initial_user_prompt_persist=True,
+    )
+
+    assert result == "done"
+    assert message_repo.append_calls == []
+
+
+@pytest.mark.asyncio
+async def test_generate_async_hydrates_history_before_each_agent_iteration() -> None:
+    session = object.__new__(AgentLlmSession)
+    persisted_prompt = (
+        "describe this image",
+        ImageUrl(
+            url="/api/sessions/session-1/media/asset-1/file",
+            media_type="image/png",
+        ),
+    )
+
+    class _FakeMediaAssetService:
+        def hydrate_user_prompt_content(self, *, content: object) -> object:
+            if content == persisted_prompt:
+                return (
+                    "describe this image",
+                    BinaryContent(
+                        data=b"image-bytes",
+                        media_type="image/png",
+                    ),
+                )
+            return content
+
+    class _FakeInjectionManager:
+        def __init__(self) -> None:
+            self._calls = 0
+
+        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
+            _ = (run_id, instance_id)
+            self._calls += 1
+            if self._calls == 1:
+                return [
+                    SimpleNamespace(
+                        content=persisted_prompt,
+                        parts=[UserPromptPart(content=persisted_prompt)],
+                        model_dump_json=lambda: "{}",
+                    )
+                ]
+            return []
+
+    class _FakeControlContext:
+        def raise_if_cancelled(self) -> None:
+            return None
+
+    class _FakeRunControlManager:
+        def context(self, *, run_id: str, instance_id: str) -> _FakeControlContext:
+            _ = (run_id, instance_id)
+            return _FakeControlContext()
+
+    usage = SimpleNamespace(
+        input_tokens=0,
+        cache_read_tokens=0,
+        output_tokens=0,
+        requests=0,
+        tool_calls=0,
+        details={},
+    )
+
+    class _FakeResult:
+        def __init__(self) -> None:
+            self.response = ModelResponse(
+                parts=[TextPart(content="done")],
+                model_name="fake-model",
+            )
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return []
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgentRun:
+        def __init__(self) -> None:
+            self.result = _FakeResult()
+            self._yielded = False
+
+        async def __aenter__(self) -> "_FakeAgentRun":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: object,
+        ) -> bool | None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def __aiter__(self) -> "_FakeAgentRun":
+            self._yielded = False
+            return self
+
+        async def __anext__(self) -> object:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return object()
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return []
+
+        def usage(self) -> object:
+            return usage
+
+    iter_histories: list[list[ModelRequest | ModelResponse]] = []
+
+    class _FakeAgent:
+        def iter(
+            self,
+            prompt: str | None,
+            *,
+            deps: object,
+            message_history: Sequence[ModelRequest | ModelResponse],
+            usage_limits: object,
+        ) -> _FakeAgentRun:
+            _ = (prompt, deps, usage_limits)
+            iter_histories.append(list(message_history))
+            return _FakeAgentRun()
+
+    prepared_prompt = SimpleNamespace(
+        history=(ModelRequest(parts=[UserPromptPart(content=persisted_prompt)]),),
+        system_prompt="System prompt",
+        budget=SimpleNamespace(),
+        estimated_history_tokens_before_microcompact=0,
+        estimated_history_tokens_after_microcompact=0,
+        microcompact_compacted_message_count=0,
+        microcompact_compacted_part_count=0,
+    )
+
+    session.__dict__["_config"] = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        capabilities=ModelCapabilities(
+            input=ModelModalityMatrix(text=True, image=True),
+            output=ModelModalityMatrix(text=True),
+        ),
+    )
+    session.__dict__["_profile_name"] = None
+    session.__dict__["_retry_config"] = LlmRetryConfig()
+    session.__dict__["_metric_recorder"] = None
+    session.__dict__["_tool_registry"] = cast(object, None)
+    session.__dict__["_allowed_tools"] = ()
+    session.__dict__["_allowed_mcp_servers"] = ()
+    session.__dict__["_allowed_skills"] = ()
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_shared_store"] = cast(object, None)
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_message_repo"] = cast(
+        MessageRepository, _FakeMessageRepo(history=[])
+    )
+    session.__dict__["_approval_ticket_repo"] = cast(object, None)
+    session.__dict__["_user_question_repo"] = None
+    session.__dict__["_run_runtime_repo"] = cast(object, None)
+    session.__dict__["_run_intent_repo"] = cast(object, None)
+    session.__dict__["_background_task_service"] = None
+    session.__dict__["_todo_service"] = None
+    session.__dict__["_monitor_service"] = None
+    session.__dict__["_workspace_manager"] = type(
+        "_WorkspaceManager",
+        (),
+        {"resolve": lambda self, **kwargs: cast(object, None)},
+    )()
+    session.__dict__["_media_asset_service"] = _FakeMediaAssetService()
+    session.__dict__["_role_memory_service"] = None
+    session.__dict__["_subagent_reflection_service"] = None
+    session.__dict__["_conversation_compaction_service"] = None
+    session.__dict__["_conversation_microcompact_service"] = None
+    session.__dict__["_mcp_registry"] = McpRegistry()
+    session.__dict__["_skill_registry"] = cast(object, None)
+    session.__dict__["_role_registry"] = cast(object, None)
+    session.__dict__["_task_execution_service"] = cast(object, object())
+    session.__dict__["_task_service"] = cast(object, None)
+    session.__dict__["_run_control_manager"] = _FakeRunControlManager()
+    session.__dict__["_tool_approval_manager"] = cast(object, None)
+    session.__dict__["_user_question_manager"] = None
+    session.__dict__["_tool_approval_policy"] = cast(object, None)
+    session.__dict__["_notification_service"] = None
+    session.__dict__["_token_usage_repo"] = None
+    session.__dict__["_fallback_middleware"] = cast(object, None)
+    session.__dict__["_im_tool_service"] = None
+    session.__dict__["_computer_runtime"] = None
+    session.__dict__["_shell_approval_repo"] = None
+    session.__dict__["_hook_service"] = None
+    session.__dict__["_injection_manager"] = _FakeInjectionManager()
+    session.__dict__["_run_event_hub"] = type(
+        "_RunEventHub", (), {"publish": lambda self, event: None}
+    )()
+    session.__dict__["_agent_repo"] = cast(object, None)
+    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
+        object, None
+    )
+
+    build_calls = 0
+
+    async def _build_agent_iteration_context(
+        **kwargs: object,
+    ) -> tuple[object, Sequence[ModelRequest | ModelResponse], str, object]:
+        nonlocal build_calls
+        _ = kwargs
+        build_calls += 1
+        history = [ModelRequest(parts=[UserPromptPart(content=persisted_prompt)])]
+        return prepared_prompt, history, "System prompt", _FakeAgent()
+
+    async def _close_run_scoped_llm_http_client(*, request: LLMRequest) -> None:
+        _ = request
+        return None
+
+    session.__dict__["_build_agent_iteration_context"] = _build_agent_iteration_context
+    session.__dict__["_close_run_scoped_llm_http_client"] = (
+        _close_run_scoped_llm_http_client
+    )
+
+    result = await AgentLlmSession._generate_async(
+        session,
+        _build_request(user_prompt=None),
+        skip_initial_user_prompt_persist=True,
+    )
+
+    assert result == "done"
+    assert build_calls == 2
+    assert len(iter_histories) == 2
+    for history in iter_histories:
+        assert len(history) == 1
+        message = history[0]
+        assert isinstance(message, ModelRequest)
+        prompt = message.parts[0]
+        assert isinstance(prompt, UserPromptPart)
+        assert prompt.content[0] == "describe this image"
+        assert isinstance(prompt.content[1], BinaryContent)
+        assert prompt.content[1].data == b"image-bytes"
+
+
+@pytest.mark.asyncio
+async def test_generate_async_commits_inline_image_tool_result_without_restart(
+    tmp_path: Path,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "tool-state.db")
+
+    class _FakeInjectionManager:
+        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
+            _ = (run_id, instance_id)
+            return []
+
+    class _FakeControlContext:
+        def raise_if_cancelled(self) -> None:
+            return None
+
+    class _FakeRunControlManager:
+        def context(self, *, run_id: str, instance_id: str) -> _FakeControlContext:
+            _ = (run_id, instance_id)
+            return _FakeControlContext()
+
+    usage = SimpleNamespace(
+        input_tokens=0,
+        cache_read_tokens=0,
+        output_tokens=0,
+        requests=0,
+        tool_calls=0,
+        details={},
+    )
+    inline_tool_request = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="read",
+                tool_call_id="call-read-1",
+                content={"ok": True, "data": {"type": "image"}},
+            ),
+            UserPromptPart(
+                content=(
+                    ImageUrl(
+                        url="http://127.0.0.1:8000/api/sessions/session-1/media/asset-1/file",
+                        media_type="image/png",
+                        force_download="allow-local",
+                    ),
+                )
+            ),
+        ]
+    )
+    final_response = ModelResponse(
+        parts=[TextPart(content="done")],
+        model_name="fake-model",
+    )
+
+    class _FakeResult:
+        response = final_response
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return []
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgentRun:
+        def __init__(self) -> None:
+            self.result = _FakeResult()
+            self._yielded = False
+
+        async def __aenter__(self) -> "_FakeAgentRun":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: object,
+        ) -> bool | None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def __aiter__(self) -> "_FakeAgentRun":
+            self._yielded = False
+            return self
+
+        async def __anext__(self) -> object:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return object()
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return [inline_tool_request, final_response]
+
+        def usage(self) -> object:
+            return usage
+
+    iter_histories: list[list[ModelRequest | ModelResponse]] = []
+
+    class _FakeAgent:
+        def iter(
+            self,
+            prompt: str | None,
+            *,
+            deps: object,
+            message_history: Sequence[ModelRequest | ModelResponse],
+            usage_limits: object,
+        ) -> _FakeAgentRun:
+            _ = (prompt, deps, usage_limits)
+            iter_histories.append(list(message_history))
+            return _FakeAgentRun()
+
+    session.__dict__["_config"] = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        capabilities=ModelCapabilities(
+            input=ModelModalityMatrix(text=True, image=True),
+            output=ModelModalityMatrix(text=True),
+        ),
+    )
+    session.__dict__["_profile_name"] = None
+    session.__dict__["_retry_config"] = LlmRetryConfig()
+    session.__dict__["_metric_recorder"] = None
+    session.__dict__["_tool_registry"] = cast(object, None)
+    session.__dict__["_allowed_tools"] = ()
+    session.__dict__["_allowed_mcp_servers"] = ()
+    session.__dict__["_allowed_skills"] = ()
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_message_repo"] = cast(
+        MessageRepository, _FakeMessageRepo(history=[])
+    )
+    session.__dict__["_approval_ticket_repo"] = cast(object, None)
+    session.__dict__["_user_question_repo"] = None
+    session.__dict__["_run_runtime_repo"] = cast(object, None)
+    session.__dict__["_run_intent_repo"] = cast(object, None)
+    session.__dict__["_background_task_service"] = None
+    session.__dict__["_todo_service"] = None
+    session.__dict__["_monitor_service"] = None
+    session.__dict__["_workspace_manager"] = type(
+        "_WorkspaceManager",
+        (),
+        {"resolve": lambda self, **kwargs: cast(object, None)},
+    )()
+    session.__dict__["_media_asset_service"] = cast(object, None)
+    session.__dict__["_role_memory_service"] = None
+    session.__dict__["_subagent_reflection_service"] = None
+    session.__dict__["_conversation_compaction_service"] = None
+    session.__dict__["_conversation_microcompact_service"] = None
+    session.__dict__["_mcp_registry"] = McpRegistry()
+    session.__dict__["_skill_registry"] = cast(object, None)
+    session.__dict__["_role_registry"] = cast(object, None)
+    session.__dict__["_task_execution_service"] = cast(object, object())
+    session.__dict__["_task_service"] = cast(object, None)
+    session.__dict__["_run_control_manager"] = _FakeRunControlManager()
+    session.__dict__["_tool_approval_manager"] = cast(object, None)
+    session.__dict__["_user_question_manager"] = None
+    session.__dict__["_tool_approval_policy"] = cast(object, None)
+    session.__dict__["_notification_service"] = None
+    session.__dict__["_token_usage_repo"] = None
+    session.__dict__["_fallback_middleware"] = cast(object, None)
+    session.__dict__["_im_tool_service"] = None
+    session.__dict__["_computer_runtime"] = None
+    session.__dict__["_shell_approval_repo"] = None
+    session.__dict__["_hook_service"] = None
+    session.__dict__["_injection_manager"] = _FakeInjectionManager()
+    session.__dict__["_run_event_hub"] = type(
+        "_RunEventHub", (), {"publish": lambda self, event: None}
+    )()
+    session.__dict__["_agent_repo"] = cast(object, None)
+    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
+        object, None
+    )
+
+    build_calls = 0
+
+    async def _build_agent_iteration_context(
+        **kwargs: object,
+    ) -> tuple[object, Sequence[ModelRequest | ModelResponse], str, object]:
+        nonlocal build_calls
+        _ = kwargs
+        build_calls += 1
+        prepared_prompt = SimpleNamespace(
+            history=(),
+            system_prompt="System prompt",
+            budget=SimpleNamespace(),
+            estimated_history_tokens_before_microcompact=0,
+            estimated_history_tokens_after_microcompact=0,
+            microcompact_compacted_message_count=0,
+            microcompact_compacted_part_count=0,
+        )
+        return prepared_prompt, [], "System prompt", _FakeAgent()
+
+    async def _close_run_scoped_llm_http_client(*, request: LLMRequest) -> None:
+        _ = request
+        return None
+
+    session.__dict__["_build_agent_iteration_context"] = _build_agent_iteration_context
+    session.__dict__["_close_run_scoped_llm_http_client"] = (
+        _close_run_scoped_llm_http_client
+    )
+
+    result = await AgentLlmSession._generate_async(
+        session,
+        _build_request(user_prompt=None),
+        skip_initial_user_prompt_persist=True,
+    )
+
+    assert result == "done"
+    assert build_calls == 1
+    assert iter_histories == [[]]
+    message_repo = cast(_FakeMessageRepo, session._message_repo)
+    assert len(message_repo.append_calls) == 1
+    appended_messages = message_repo.append_calls[0]
+    assert appended_messages == [inline_tool_request, final_response]
+    appended_request = appended_messages[0]
+    assert isinstance(appended_request, ModelRequest)
+    appended_prompt = appended_request.parts[1]
+    assert isinstance(appended_prompt, UserPromptPart)
+    inline_image = appended_prompt.content[0]
+    assert isinstance(inline_image, ImageUrl)
+    assert inline_image.force_download == "allow-local"
+
+
+@pytest.mark.asyncio
+async def test_generate_async_reuses_inline_tool_result_history_without_restart(
+    tmp_path: Path,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "tool-state-replayed.db")
+
+    class _FakeInjectionManager:
+        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
+            _ = (run_id, instance_id)
+            return []
+
+    class _FakeControlContext:
+        def raise_if_cancelled(self) -> None:
+            return None
+
+    class _FakeRunControlManager:
+        def context(self, *, run_id: str, instance_id: str) -> _FakeControlContext:
+            _ = (run_id, instance_id)
+            return _FakeControlContext()
+
+    usage = SimpleNamespace(
+        input_tokens=0,
+        cache_read_tokens=0,
+        output_tokens=0,
+        requests=0,
+        tool_calls=0,
+        details={},
+    )
+    replayed_request = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="read",
+                tool_call_id="call-read-1",
+                content={"ok": True, "data": {"type": "image"}},
+            ),
+            UserPromptPart(
+                content=(
+                    ImageUrl(
+                        url="http://127.0.0.1:8000/api/sessions/session-1/media/asset-1/file",
+                        media_type="image/png",
+                        force_download="allow-local",
+                    ),
+                )
+            ),
+        ]
+    )
+    final_response = ModelResponse(
+        parts=[TextPart(content="done")],
+        model_name="fake-model",
+    )
+    message_repo = _FakeMessageRepo(history=[replayed_request])
+
+    class _FakeResult:
+        response = final_response
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return []
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgentRun:
+        def __init__(self) -> None:
+            self.result = _FakeResult()
+            self._yielded = False
+
+        async def __aenter__(self) -> "_FakeAgentRun":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: object,
+        ) -> bool | None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def __aiter__(self) -> "_FakeAgentRun":
+            self._yielded = False
+            return self
+
+        async def __anext__(self) -> object:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return object()
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return [final_response]
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgent:
+        def iter(
+            self,
+            prompt: str | None,
+            *,
+            deps: object,
+            message_history: Sequence[ModelRequest | ModelResponse],
+            usage_limits: object,
+        ) -> _FakeAgentRun:
+            _ = (prompt, deps, usage_limits)
+            assert list(message_history) == [replayed_request]
+            return _FakeAgentRun()
+
+    session.__dict__["_config"] = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        capabilities=ModelCapabilities(
+            input=ModelModalityMatrix(text=True, image=True),
+            output=ModelModalityMatrix(text=True),
+        ),
+    )
+    session.__dict__["_profile_name"] = None
+    session.__dict__["_retry_config"] = LlmRetryConfig()
+    session.__dict__["_metric_recorder"] = None
+    session.__dict__["_tool_registry"] = cast(object, None)
+    session.__dict__["_allowed_tools"] = ()
+    session.__dict__["_allowed_mcp_servers"] = ()
+    session.__dict__["_allowed_skills"] = ()
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_message_repo"] = cast(MessageRepository, message_repo)
+    session.__dict__["_approval_ticket_repo"] = cast(object, None)
+    session.__dict__["_user_question_repo"] = None
+    session.__dict__["_run_runtime_repo"] = cast(object, None)
+    session.__dict__["_run_intent_repo"] = cast(object, None)
+    session.__dict__["_background_task_service"] = None
+    session.__dict__["_todo_service"] = None
+    session.__dict__["_monitor_service"] = None
+    session.__dict__["_workspace_manager"] = type(
+        "_WorkspaceManager",
+        (),
+        {"resolve": lambda self, **kwargs: cast(object, None)},
+    )()
+    session.__dict__["_media_asset_service"] = cast(object, None)
+    session.__dict__["_role_memory_service"] = None
+    session.__dict__["_subagent_reflection_service"] = None
+    session.__dict__["_conversation_compaction_service"] = None
+    session.__dict__["_conversation_microcompact_service"] = None
+    session.__dict__["_mcp_registry"] = McpRegistry()
+    session.__dict__["_skill_registry"] = cast(object, None)
+    session.__dict__["_role_registry"] = cast(object, None)
+    session.__dict__["_task_execution_service"] = cast(object, object())
+    session.__dict__["_task_service"] = cast(object, None)
+    session.__dict__["_run_control_manager"] = _FakeRunControlManager()
+    session.__dict__["_tool_approval_manager"] = cast(object, None)
+    session.__dict__["_user_question_manager"] = None
+    session.__dict__["_tool_approval_policy"] = cast(object, None)
+    session.__dict__["_notification_service"] = None
+    session.__dict__["_token_usage_repo"] = None
+    session.__dict__["_fallback_middleware"] = cast(object, None)
+    session.__dict__["_im_tool_service"] = None
+    session.__dict__["_computer_runtime"] = None
+    session.__dict__["_shell_approval_repo"] = None
+    session.__dict__["_hook_service"] = None
+    session.__dict__["_injection_manager"] = _FakeInjectionManager()
+    session.__dict__["_run_event_hub"] = type(
+        "_RunEventHub", (), {"publish": lambda self, event: None}
+    )()
+    session.__dict__["_agent_repo"] = cast(object, None)
+    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
+        object, None
+    )
+
+    build_calls = 0
+
+    async def _build_agent_iteration_context(
+        **kwargs: object,
+    ) -> tuple[object, Sequence[ModelRequest | ModelResponse], str, object]:
+        nonlocal build_calls
+        _ = kwargs
+        build_calls += 1
+        prepared_prompt = SimpleNamespace(
+            history=(),
+            system_prompt="System prompt",
+            budget=SimpleNamespace(),
+            estimated_history_tokens_before_microcompact=0,
+            estimated_history_tokens_after_microcompact=0,
+            microcompact_compacted_message_count=0,
+            microcompact_compacted_part_count=0,
+        )
+        history = message_repo.get_history_for_conversation("conv-1")
+        return prepared_prompt, history, "System prompt", _FakeAgent()
+
+    async def _close_run_scoped_llm_http_client(*, request: LLMRequest) -> None:
+        _ = request
+        return None
+
+    session.__dict__["_build_agent_iteration_context"] = _build_agent_iteration_context
+    session.__dict__["_close_run_scoped_llm_http_client"] = (
+        _close_run_scoped_llm_http_client
+    )
+
+    result = await AgentLlmSession._generate_async(
+        session,
+        _build_request(user_prompt=None),
+        skip_initial_user_prompt_persist=True,
+    )
+
+    assert result == "done"
+    assert build_calls == 1
+    assert len(message_repo.append_calls) == 1
+    assert message_repo.append_calls[0] == [final_response]
+
+
+@pytest.mark.asyncio
+async def test_generate_async_deduplicates_against_provider_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    monkeypatch.setattr(
+        llm_module,
+        "load_tool_call_state",
+        lambda **kwargs: None,
+    )
+
+    class _FakeInjectionManager:
+        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
+            _ = (run_id, instance_id)
+            return []
+
+    class _FakeControlContext:
+        def raise_if_cancelled(self) -> None:
+            return None
+
+    class _FakeRunControlManager:
+        def context(self, *, run_id: str, instance_id: str) -> _FakeControlContext:
+            _ = (run_id, instance_id)
+            return _FakeControlContext()
+
+    usage = SimpleNamespace(
+        input_tokens=0,
+        cache_read_tokens=0,
+        output_tokens=0,
+        requests=0,
+        tool_calls=0,
+        details={},
+    )
+    echoed_request = ModelRequest(
+        parts=[
+            UserPromptPart(
+                content=(
+                    "describe this image",
+                    BinaryContent(data=b"image-bytes", media_type="image/png"),
+                )
+            )
+        ]
+    )
+    final_response = ModelResponse(
+        parts=[TextPart(content="done")],
+        model_name="fake-model",
+    )
+    provider_history = [echoed_request]
+    message_repo = _FakeMessageRepo(history=[])
+
+    class _FakeResult:
+        response = final_response
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return [echoed_request, final_response]
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgentRun:
+        def __init__(self) -> None:
+            self.result = _FakeResult()
+            self._yielded = False
+
+        async def __aenter__(self) -> "_FakeAgentRun":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: object,
+        ) -> bool | None:
+            _ = (exc_type, exc, tb)
+            return None
+
+        def __aiter__(self) -> "_FakeAgentRun":
+            self._yielded = False
+            return self
+
+        async def __anext__(self) -> object:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return object()
+
+        def new_messages(self) -> list[ModelRequest | ModelResponse]:
+            return [echoed_request, final_response]
+
+        def usage(self) -> object:
+            return usage
+
+    class _FakeAgent:
+        def iter(
+            self,
+            prompt: str | None,
+            *,
+            deps: object,
+            message_history: Sequence[ModelRequest | ModelResponse],
+            usage_limits: object,
+        ) -> _FakeAgentRun:
+            _ = (prompt, deps, message_history, usage_limits)
+            return _FakeAgentRun()
+
+    session.__dict__["_config"] = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        capabilities=ModelCapabilities(
+            input=ModelModalityMatrix(text=True, image=True),
+            output=ModelModalityMatrix(text=True),
+        ),
+    )
+    session.__dict__["_profile_name"] = None
+    session.__dict__["_retry_config"] = LlmRetryConfig()
+    session.__dict__["_metric_recorder"] = None
+    session.__dict__["_tool_registry"] = cast(object, None)
+    session.__dict__["_allowed_tools"] = ()
+    session.__dict__["_allowed_mcp_servers"] = ()
+    session.__dict__["_allowed_skills"] = ()
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_shared_store"] = cast(object, None)
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_message_repo"] = cast(MessageRepository, message_repo)
+    session.__dict__["_approval_ticket_repo"] = cast(object, None)
+    session.__dict__["_user_question_repo"] = None
+    session.__dict__["_run_runtime_repo"] = cast(object, None)
+    session.__dict__["_run_intent_repo"] = cast(object, None)
+    session.__dict__["_background_task_service"] = None
+    session.__dict__["_todo_service"] = None
+    session.__dict__["_monitor_service"] = None
+    session.__dict__["_workspace_manager"] = type(
+        "_WorkspaceManager",
+        (),
+        {"resolve": lambda self, **kwargs: cast(object, None)},
+    )()
+    session.__dict__["_media_asset_service"] = cast(object, None)
+    session.__dict__["_role_memory_service"] = None
+    session.__dict__["_subagent_reflection_service"] = None
+    session.__dict__["_conversation_compaction_service"] = None
+    session.__dict__["_conversation_microcompact_service"] = None
+    session.__dict__["_mcp_registry"] = McpRegistry()
+    session.__dict__["_skill_registry"] = cast(object, None)
+    session.__dict__["_role_registry"] = cast(object, None)
+    session.__dict__["_task_execution_service"] = cast(object, object())
+    session.__dict__["_task_service"] = cast(object, None)
+    session.__dict__["_run_control_manager"] = _FakeRunControlManager()
+    session.__dict__["_tool_approval_manager"] = cast(object, None)
+    session.__dict__["_user_question_manager"] = None
+    session.__dict__["_tool_approval_policy"] = cast(object, None)
+    session.__dict__["_notification_service"] = None
+    session.__dict__["_token_usage_repo"] = None
+    session.__dict__["_fallback_middleware"] = cast(object, None)
+    session.__dict__["_im_tool_service"] = None
+    session.__dict__["_computer_runtime"] = None
+    session.__dict__["_shell_approval_repo"] = None
+    session.__dict__["_hook_service"] = None
+    session.__dict__["_injection_manager"] = _FakeInjectionManager()
+    session.__dict__["_run_event_hub"] = type(
+        "_RunEventHub", (), {"publish": lambda self, event: None}
+    )()
+    session.__dict__["_agent_repo"] = cast(object, None)
+    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
+        object, None
+    )
+
+    async def _build_agent_iteration_context(
+        **kwargs: object,
+    ) -> tuple[object, Sequence[ModelRequest | ModelResponse], str, object]:
+        _ = kwargs
+        prepared_prompt = SimpleNamespace(
+            history=(),
+            system_prompt="System prompt",
+            budget=SimpleNamespace(),
+            estimated_history_tokens_before_microcompact=0,
+            estimated_history_tokens_after_microcompact=0,
+            microcompact_compacted_message_count=0,
+            microcompact_compacted_part_count=0,
+        )
+        return prepared_prompt, [], "System prompt", _FakeAgent()
+
+    async def _close_run_scoped_llm_http_client(*, request: LLMRequest) -> None:
+        _ = request
+        return None
+
+    observed_histories: list[Sequence[ModelRequest | ModelResponse]] = []
+
+    def _drop_duplicate_leading_request(
+        *,
+        history: Sequence[ModelRequest | ModelResponse],
+        new_messages: list[ModelRequest | ModelResponse],
+    ) -> list[ModelRequest | ModelResponse]:
+        observed_histories.append(history)
+        return AgentLlmSession._drop_duplicate_leading_request(
+            session,
+            history=history,
+            new_messages=new_messages,
+        )
+
+    session.__dict__["_provider_history_for_model_turn_details"] = lambda **kwargs: (
+        provider_history,
+        (),
+    )
+    session.__dict__["_drop_duplicate_leading_request"] = (
+        _drop_duplicate_leading_request
+    )
+    session.__dict__["_build_agent_iteration_context"] = _build_agent_iteration_context
+    session.__dict__["_close_run_scoped_llm_http_client"] = (
+        _close_run_scoped_llm_http_client
+    )
+
+    result = await AgentLlmSession._generate_async(
+        session,
+        _build_request(user_prompt=None),
+        skip_initial_user_prompt_persist=True,
+    )
+
+    assert result == "done"
+    assert observed_histories
+    assert all(list(history) == provider_history for history in observed_histories)
+    assert len(message_repo.append_calls) == 1
+    appended_messages = message_repo.append_calls[0]
+    assert appended_messages == [final_response]
 
 
 def test_apply_streamed_text_fallback_repairs_truncated_final_message() -> None:

--- a/tests/unit_tests/external_agents/test_host_tool_bridge.py
+++ b/tests/unit_tests/external_agents/test_host_tool_bridge.py
@@ -1,9 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import ModuleType
+from types import SimpleNamespace
+from typing import cast
 
 import relay_teams.external_agents.host_tool_bridge as host_tool_bridge_module
+from pydantic_ai.messages import BinaryContent, ToolReturn
+from relay_teams.providers.model_config import (
+    ModelCapabilities,
+    ModelEndpointConfig,
+    ProviderType,
+)
+from relay_teams.providers.provider_contracts import LLMRequest
+from relay_teams.roles.role_models import RoleDefinition
 
 
 class _PublicTool:
@@ -20,6 +31,21 @@ class _LegacyTool:
 
 class _LegacyToolResult:
     pass
+
+
+class _MissingRunIntentRepo:
+    def get(self, _run_id: str) -> object:
+        raise KeyError
+
+
+class _FakeToolApprovalPolicy:
+    def with_yolo(self, _yolo: bool) -> "_FakeToolApprovalPolicy":
+        return self
+
+
+class _FakeWorkspaceManager:
+    def resolve(self, **_kwargs: object) -> object:
+        return object()
 
 
 def test_load_fastmcp_tool_types_prefers_public_exports(monkeypatch) -> None:
@@ -65,3 +91,225 @@ def test_load_fastmcp_tool_types_falls_back_to_legacy_module(monkeypatch) -> Non
     assert requested_modules == ["fastmcp.tools", "fastmcp.tools.tool"]
     assert tool_cls is _LegacyTool
     assert tool_result_cls is _LegacyToolResult
+
+
+def test_tool_return_to_fastmcp_result_preserves_envelope_and_image_content() -> None:
+    tool_result = host_tool_bridge_module._tool_return_to_fastmcp_result(
+        ToolReturn(
+            return_value={"ok": True, "data": {"path": "docs/diagram.png"}},
+            content=(
+                "Image attached for model inspection.",
+                BinaryContent(data=b"png-bytes", media_type="image/png"),
+            ),
+        )
+    )
+
+    assert tool_result.structured_content == {
+        "ok": True,
+        "data": {"path": "docs/diagram.png"},
+    }
+    assert len(tool_result.content) == 2
+    assert tool_result.content[0].type == "text"
+    assert tool_result.content[1].type == "image"
+    assert tool_result.content[1].data == "cG5nLWJ5dGVz"
+    assert tool_result.content[1].mimeType == "image/png"
+
+
+def test_tool_return_to_fastmcp_result_preserves_scalar_value_with_media_content() -> (
+    None
+):
+    tool_result = host_tool_bridge_module._tool_return_to_fastmcp_result(
+        ToolReturn(
+            return_value="primary result",
+            content=(BinaryContent(data=b"png-bytes", media_type="image/png"),),
+        )
+    )
+
+    assert tool_result.structured_content is None
+    assert len(tool_result.content) == 2
+    assert tool_result.content[0].type == "text"
+    assert tool_result.content[0].text == "primary result"
+    assert tool_result.content[1].type == "image"
+    assert tool_result.content[1].data == "cG5nLWJ5dGVz"
+
+
+def test_build_tool_deps_uses_resolved_model_capabilities() -> None:
+    resolved_config = ModelEndpointConfig(
+        provider=ProviderType.OPENAI_COMPATIBLE,
+        model="qwen3-vl",
+        base_url="https://example.com/v1",
+        api_key="test-key",
+        capabilities=ModelCapabilities.model_validate(
+            {
+                "input": {
+                    "text": True,
+                    "image": True,
+                },
+                "output": {
+                    "text": True,
+                },
+            }
+        ),
+    )
+    requested: list[tuple[RoleDefinition, LLMRequest]] = []
+
+    def resolve_model_config(
+        role: RoleDefinition,
+        request: LLMRequest,
+    ) -> ModelEndpointConfig | None:
+        requested.append((role, request))
+        return resolved_config
+
+    bridge = object.__new__(host_tool_bridge_module.ExternalAcpHostToolBridge)
+    role = RoleDefinition(
+        role_id="main-agent",
+        name="Main Agent",
+        description="Handles ACP prompts",
+        version="1.0.0",
+        system_prompt="You are a helpful assistant.",
+    )
+    request = LLMRequest(
+        run_id="run-1",
+        trace_id="trace-1",
+        task_id="task-1",
+        session_id="session-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        instance_id="instance-1",
+        role_id=role.role_id,
+        system_prompt="system",
+        user_prompt="hello",
+    )
+    bridge.__dict__.update(
+        {
+            "_task_repo": object(),
+            "_shared_store": object(),
+            "_event_bus": object(),
+            "_message_repo": object(),
+            "_approval_ticket_repo": object(),
+            "_user_question_repo": None,
+            "_run_runtime_repo": object(),
+            "_injection_manager": object(),
+            "_run_event_hub": object(),
+            "_agent_repo": object(),
+            "_workspace_manager": _FakeWorkspaceManager(),
+            "_role_memory_service": None,
+            "_media_asset_service": None,
+            "_computer_runtime": None,
+            "_background_task_service": None,
+            "_monitor_service": None,
+            "_todo_service": None,
+            "_run_intent_repo": _MissingRunIntentRepo(),
+            "_get_role_registry": lambda: object(),
+            "_get_mcp_registry": lambda: object(),
+            "_get_task_service": lambda: object(),
+            "_get_task_execution_service": lambda: object(),
+            "_run_control_manager": object(),
+            "_tool_approval_manager": object(),
+            "_user_question_manager": None,
+            "_tool_approval_policy": _FakeToolApprovalPolicy(),
+            "_shell_approval_repo": None,
+            "_metric_recorder": None,
+            "_get_notification_service": lambda: None,
+            "_im_tool_service": None,
+            "_resolve_model_config": resolve_model_config,
+            "_role": role,
+        }
+    )
+
+    deps = bridge._build_tool_deps(request=request)
+
+    assert requested == [(role, request)]
+    assert deps.model_capabilities == resolved_config.capabilities
+
+
+def test_host_tool_bridge_init_stores_model_resolver(
+    monkeypatch,
+) -> None:
+    def resolver(role, request):
+        _ = (role, request)
+        return None
+
+    monkeypatch.setattr(
+        host_tool_bridge_module,
+        "build_coordination_agent",
+        lambda **kwargs: SimpleNamespace(model=object()),
+    )
+    kwargs: dict[str, object] = {
+        "task_repo": cast(object, object()),
+        "shared_store": cast(object, object()),
+        "event_bus": cast(object, object()),
+        "injection_manager": cast(object, object()),
+        "run_event_hub": cast(object, object()),
+        "agent_repo": cast(object, object()),
+        "approval_ticket_repo": cast(object, object()),
+        "user_question_repo": None,
+        "run_runtime_repo": cast(object, object()),
+        "run_intent_repo": cast(object, object()),
+        "background_task_service": None,
+        "todo_service": None,
+        "monitor_service": None,
+        "workspace_manager": cast(object, object()),
+        "role_memory_service": None,
+        "tool_registry": cast(object, object()),
+        "message_repo": cast(object, object()),
+        "get_mcp_registry": lambda: cast(object, object()),
+        "get_skill_registry": lambda: cast(object, object()),
+        "get_role_registry": lambda: cast(object, object()),
+        "get_task_execution_service": lambda: cast(object, object()),
+        "get_task_service": lambda: cast(object, object()),
+        "run_control_manager": cast(object, object()),
+        "tool_approval_manager": cast(object, object()),
+        "user_question_manager": None,
+        "tool_approval_policy": _FakeToolApprovalPolicy(),
+        "get_notification_service": lambda: None,
+        "resolve_model_config": resolver,
+    }
+    bridge_ctor = cast(
+        Callable[..., object], host_tool_bridge_module.ExternalAcpHostToolBridge
+    )
+    bridge = cast(
+        host_tool_bridge_module.ExternalAcpHostToolBridge, bridge_ctor(**kwargs)
+    )
+
+    assert bridge._resolve_model_config is resolver
+
+
+def test_resolve_request_model_capabilities_defaults_when_resolution_is_unavailable() -> (
+    None
+):
+    request = LLMRequest(
+        run_id="run-1",
+        trace_id="trace-1",
+        task_id="task-1",
+        session_id="session-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        instance_id="instance-1",
+        role_id="main-agent",
+        system_prompt="system",
+        user_prompt="hello",
+    )
+    bridge = object.__new__(host_tool_bridge_module.ExternalAcpHostToolBridge)
+
+    bridge.__dict__["_role"] = None
+    bridge.__dict__["_resolve_model_config"] = None
+    assert (
+        bridge._resolve_request_model_capabilities(request=request)
+        == ModelCapabilities()
+    )
+
+    role = RoleDefinition(
+        role_id="main-agent",
+        name="Main Agent",
+        description="Handles ACP prompts",
+        version="1.0.0",
+        system_prompt="You are a helpful assistant.",
+    )
+    bridge.__dict__["_role"] = role
+    bridge.__dict__["_resolve_model_config"] = lambda _role, _request: None
+
+    assert (
+        bridge._resolve_request_model_capabilities(request=request)
+        == ModelCapabilities()
+    )

--- a/tests/unit_tests/frontend/test_message_rich_content_ui.py
+++ b/tests/unit_tests/frontend/test_message_rich_content_ui.py
@@ -136,3 +136,399 @@ console.log(JSON.stringify({
     assert payload["childCount"] == 1
     assert payload["figureClassName"] == "msg-image"
     assert payload["imageSrc"] == "/preview/hello/ai_briefing.png"
+
+
+def test_render_rich_content_can_disable_workspace_image_preview(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "content.js"
+    )
+    module_under_test_path = tmp_path / "content.mjs"
+    runner_path = tmp_path / "runner.mjs"
+
+    source_text = (
+        source_path.read_text(encoding="utf-8")
+        .replace("../../../core/api/workspaces.js", "./mockWorkspacesApi.mjs")
+        .replace("../../../core/state.js", "./mockState.mjs")
+        .replace("../../../utils/i18n.js", "./mockI18n.mjs")
+        .replace("../../../utils/markdown.js", "./mockMarkdown.mjs")
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+
+    (tmp_path / "mockWorkspacesApi.mjs").write_text(
+        """
+export function buildWorkspaceImagePreviewUrl(workspaceId, path) {
+    return `/preview/${workspaceId}/${encodeURIComponent(path)}`;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+    export const state = {
+        currentWorkspaceId: 'hello',
+        currentProjectViewWorkspaceId: null,
+    };
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockI18n.mjs").write_text(
+        """
+export function t(key) {
+    return String(key || '');
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockMarkdown.mjs").write_text(
+        """
+export function parseMarkdown(text) {
+    return `<p>${text}</p>`;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    runner_path.write_text(
+        """
+class FakeElement {
+    constructor(tagName = 'div') {
+        this.tagName = tagName;
+        this.children = [];
+        this.className = '';
+        this.innerHTML = '';
+        this.src = '';
+        this.alt = '';
+        this.loading = '';
+        this.decoding = '';
+        this.attributes = {};
+    }
+
+    appendChild(child) {
+        this.children.push(child);
+        return child;
+    }
+
+    replaceChildren(...children) {
+        this.innerHTML = '';
+        this.children = children;
+    }
+
+    setAttribute(name, value) {
+        this.attributes[name] = value;
+    }
+}
+
+globalThis.document = {
+    createElement(tagName) {
+        return new FakeElement(tagName);
+    },
+};
+
+const { renderRichContent } = await import('./content.mjs');
+const targetEl = new FakeElement('div');
+
+renderRichContent(targetEl, 'Attached image from docs/relay_teams.png', {
+    enableWorkspaceImagePreview: false,
+});
+
+console.log(JSON.stringify({
+    innerHTML: targetEl.innerHTML,
+    childCount: targetEl.children.length,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+    assert "relay_teams.png" in payload["innerHTML"]
+    assert payload["childCount"] == 0
+
+
+def test_read_tool_return_renders_media_ref_preview(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    content_source_path = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "content.js"
+    )
+    tool_blocks_source_path = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "toolBlocks.js"
+    )
+    content_module_path = tmp_path / "content.mjs"
+    tool_blocks_module_path = tmp_path / "toolBlocks.mjs"
+    runner_path = tmp_path / "runner.mjs"
+
+    content_module_path.write_text(
+        content_source_path.read_text(encoding="utf-8")
+        .replace("../../../core/api/workspaces.js", "./mockWorkspacesApi.mjs")
+        .replace("../../../core/state.js", "./mockState.mjs")
+        .replace("../../../utils/i18n.js", "./mockI18n.mjs")
+        .replace("../../../utils/markdown.js", "./mockMarkdown.mjs"),
+        encoding="utf-8",
+    )
+    tool_blocks_module_path.write_text(
+        tool_blocks_source_path.read_text(encoding="utf-8")
+        .replace("./approval.js", "./mockApproval.mjs")
+        .replace("./content.js", "./content.mjs")
+        .replace("../../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+
+    (tmp_path / "mockApproval.mjs").write_text(
+        """
+export function syncApprovalStateFromEnvelope() {}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockWorkspacesApi.mjs").write_text(
+        """
+export function buildWorkspaceImagePreviewUrl(workspaceId, path) {
+    return `/preview/${workspaceId}/${encodeURIComponent(path)}`;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentWorkspaceId: 'hello',
+    currentProjectViewWorkspaceId: null,
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(key, values = {}) {
+    return `${key}:${JSON.stringify(values)}`;
+}
+
+export function t(key) {
+    return String(key || '');
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockMarkdown.mjs").write_text(
+        """
+export function parseMarkdown(text) {
+    return `<p>${text}</p>`;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    runner_path.write_text(
+        """
+class FakeClassList {
+    constructor(element) {
+        this.element = element;
+    }
+
+    add(...names) {
+        const tokens = new Set(String(this.element.className || '').split(/\\s+/).filter(Boolean));
+        names.forEach(name => tokens.add(name));
+        this.element.className = Array.from(tokens).join(' ');
+    }
+
+    remove(...names) {
+        const removeSet = new Set(names);
+        const tokens = String(this.element.className || '').split(/\\s+/).filter(Boolean)
+            .filter(name => !removeSet.has(name));
+        this.element.className = tokens.join(' ');
+    }
+}
+
+class FakeElement {
+    constructor(tagName = 'div') {
+        this.tagName = tagName;
+        this.children = [];
+        this.parentElement = null;
+        this.className = '';
+        this.dataset = {};
+        this.attributes = {};
+        this.src = '';
+        this.alt = '';
+        this.loading = '';
+        this.decoding = '';
+        this.textContent = '';
+        this._innerHTML = '';
+        this.classList = new FakeClassList(this);
+    }
+
+    get innerHTML() {
+        return this._innerHTML;
+    }
+
+    set innerHTML(value) {
+        this._innerHTML = String(value || '');
+        this.children = [];
+        if (this._innerHTML.includes('tool-output')) {
+            const output = new FakeElement('div');
+            output.className = 'tool-output';
+            this.appendChild(output);
+        }
+        if (this._innerHTML.includes('tool-copy-btn')) {
+            const button = new FakeElement('button');
+            button.className = 'tool-copy-btn';
+            this.appendChild(button);
+        }
+        if (this._innerHTML.includes('tool-status')) {
+            const status = new FakeElement('span');
+            status.className = 'tool-status';
+            this.appendChild(status);
+        }
+    }
+
+    appendChild(child) {
+        child.parentElement = this;
+        this.children.push(child);
+        return child;
+    }
+
+    replaceChildren(...children) {
+        this._innerHTML = '';
+        this.children = [];
+        children.forEach(child => this.appendChild(child));
+    }
+
+    setAttribute(name, value) {
+        this.attributes[name] = String(value);
+    }
+
+    addEventListener() {}
+
+    querySelector(selector) {
+        if (!String(selector || '').startsWith('.')) {
+            return null;
+        }
+        const className = selector.slice(1);
+        return this.findByClass(className);
+    }
+
+    findByClass(className) {
+        const tokens = String(this.className || '').split(/\\s+/).filter(Boolean);
+        if (tokens.includes(className)) {
+            return this;
+        }
+        for (const child of this.children) {
+            const found = child.findByClass(className);
+            if (found) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    closest(selector) {
+        if (!String(selector || '').startsWith('.')) {
+            return null;
+        }
+        const className = selector.slice(1);
+        let current = this;
+        while (current) {
+            const tokens = String(current.className || '').split(/\\s+/).filter(Boolean);
+            if (tokens.includes(className)) {
+                return current;
+            }
+            current = current.parentElement;
+        }
+        return null;
+    }
+}
+
+globalThis.document = {
+    createElement(tagName) {
+        return new FakeElement(tagName);
+    },
+};
+
+const { buildToolBlock, applyToolReturn } = await import('./toolBlocks.mjs');
+const toolBlock = buildToolBlock('read', { path: 'docs/relay_teams.png' }, 'call-read-image');
+applyToolReturn(toolBlock, {
+    ok: true,
+    data: {
+        type: 'image',
+        path: 'docs/relay_teams.png',
+        content: [{
+            kind: 'media_ref',
+            modality: 'image',
+            mime_type: 'image/png',
+            name: 'relay_teams.png',
+            url: '/api/sessions/session-1/media/asset-1/file',
+        }],
+    },
+    error: null,
+    meta: { tool_result_event_published: true },
+});
+
+const imageEl = toolBlock.querySelector('.msg-image-preview');
+console.log(JSON.stringify({
+    hasImage: Boolean(imageEl),
+    imageSrc: imageEl?.src || '',
+    previewTrigger: imageEl?.attributes?.['data-image-preview-trigger'] || '',
+    previewSrc: imageEl?.attributes?.['data-image-preview-src'] || '',
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+    assert payload["hasImage"] is True
+    assert payload["imageSrc"] == "/api/sessions/session-1/media/asset-1/file"
+    assert payload["previewTrigger"] == "true"
+    assert payload["previewSrc"] == "/api/sessions/session-1/media/asset-1/file"

--- a/tests/unit_tests/frontend/test_round_user_prompt_ui.py
+++ b/tests/unit_tests/frontend/test_round_user_prompt_ui.py
@@ -42,8 +42,19 @@ def test_round_user_prompts_are_collapsible_plaintext_blocks() -> None:
     )
     assert "function appendUserPromptText(contentEl, text) {" in block_script
     assert "function updateUserPromptText(promptEl, text) {" in block_script
+    assert "function updateThinkingText(textEl, text, options = {}) {" in block_script
     assert "appendPromptContentBlock(contentEl, text, {" in block_script
     assert "return updatePromptContentBlock(promptEl, text, {" in block_script
+    assert (
+        "enableWorkspaceImagePreview: options.enableWorkspaceImagePreview !== false,"
+        in block_script
+    )
+    assert (
+        "updateMessageText(textEl, text, {\n"
+        "        ...options,\n"
+        "        enableWorkspaceImagePreview: false,\n"
+        "    });" in block_script
+    )
     assert ".user-prompt-block {" in components_css
     assert ".user-prompt-summary {" in components_css
     assert ".user-prompt-preview {" in components_css
@@ -59,6 +70,11 @@ def test_round_user_prompts_are_collapsible_plaintext_blocks() -> None:
     assert (
         "function renderRoundIntentStructuredContent(bodyEl, parts) {"
         in timeline_script
+    )
+    assert (
+        "renderPromptContentParts(bodyEl, parts, {\n"
+        "        enableWorkspaceImagePreview: false,\n"
+        "    });" in timeline_script
     )
     assert (
         "header.appendChild(buildRoundIntentBlock(round.intent, round.intent_parts));"
@@ -88,6 +104,24 @@ def test_round_user_prompts_are_collapsible_plaintext_blocks() -> None:
     assert ".round-detail-intent-body {" in components_css
     assert ".round-detail-intent-actions {" in components_css
     assert ".round-detail-intent-collapse {" in components_css
+    prompt_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "prompt.js"
+    ).read_text(encoding="utf-8")
+    assert (
+        "export function renderPromptContentParts(targetEl, parts, options = {}) {"
+        in prompt_script
+    )
+    assert (
+        "enableWorkspaceImagePreview: options.enableWorkspaceImagePreview !== false,"
+        in prompt_script
+    )
 
 
 def test_thinking_blocks_use_compact_summary_spacing() -> None:

--- a/tests/unit_tests/frontend/test_streaming_tool_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_tool_ui.py
@@ -187,6 +187,15 @@ def test_tool_blocks_parse_tagged_read_payloads_and_cap_large_diffs() -> None:
         "function buildBoundedPreview(text, { maxLines, maxChars }) {"
         in tool_blocks_script
     )
+    read_branch = "if (toolName === 'read' && data != null) {"
+    assert read_branch in tool_blocks_script
+    assert "if (renderStructuredPayload(targetEl, data, envelope.meta)) {" in (
+        tool_blocks_script
+    )
+    assert tool_blocks_script.index(
+        "if (renderStructuredPayload(targetEl, data, envelope.meta)) {"
+    ) < tool_blocks_script.index("renderReadOutput(targetEl, data);")
+    assert "enableWorkspaceImagePreview: !hasStructuredContent" in tool_blocks_script
     assert "Preview truncated. Showing first" in tool_blocks_script
     assert "return pairLinesByIndex(oldLines, newLines);" in tool_blocks_script
     assert 'class="tool-diff-no"' not in tool_blocks_script

--- a/tests/unit_tests/interfaces/server/test_host_tool_stdio_server.py
+++ b/tests/unit_tests/interfaces/server/test_host_tool_stdio_server.py
@@ -60,6 +60,7 @@ async def test_run_stdio_server_passes_todo_service_to_host_tool_bridge(
     config_dir.mkdir()
     fake_role = object()
     fake_todo_service = object()
+    fake_resolve_model_config = object()
     fake_container = SimpleNamespace(
         role_registry=SimpleNamespace(get=lambda role_id: fake_role),
         task_repo=object(),
@@ -93,6 +94,7 @@ async def test_run_stdio_server_passes_todo_service_to_host_tool_bridge(
         metric_recorder=object(),
         im_tool_service=object(),
         computer_runtime=object(),
+        resolve_external_agent_model_config=fake_resolve_model_config,
     )
 
     monkeypatch.setenv(stdio_server.HOST_TOOL_CONFIG_DIR_ENV, str(config_dir))
@@ -119,6 +121,7 @@ async def test_run_stdio_server_passes_todo_service_to_host_tool_bridge(
     bridge = _FakeBridge.last_instance
     assert bridge is not None
     assert bridge.init_kwargs["todo_service"] is fake_todo_service
+    assert bridge.init_kwargs["resolve_model_config"] is fake_resolve_model_config
     assert bridge.configure_calls[0]["role"] is fake_role
     assert bridge.configure_calls[0]["session_id"] == "session-1"
     assert len(bridge.bound_requests) == 1

--- a/tests/unit_tests/interfaces/server/test_runs_router.py
+++ b/tests/unit_tests/interfaces/server/test_runs_router.py
@@ -15,6 +15,10 @@ class _FakeRunService:
         self.started_run_ids: list[str] = []
         self.resolved_tool_approvals: list[tuple[str, str, str, str]] = []
         self.raise_on_tool_approval = False
+        self.inject_calls: list[tuple[str, str, str]] = []
+        self.subagent_inject_calls: list[tuple[str, str, str]] = []
+        self.raise_on_inject = False
+        self.raise_on_subagent_inject = False
         self.created_run_inputs: list[IntentInput] = []
         self.background_tasks: dict[str, dict[str, object]] = {
             "exec-1": {
@@ -70,6 +74,27 @@ class _FakeRunService:
 
     def ensure_run_started(self, run_id: str) -> None:
         self.started_run_ids.append(run_id)
+
+    def inject_message(self, *, run_id: str, source, content: str):
+        if self.raise_on_inject:
+            raise ValueError("Injection content must not be empty")
+        self.inject_calls.append((run_id, source.value, content))
+        return type(
+            "_InjectedRecord",
+            (),
+            {"model_dump": lambda self: {"run_id": run_id, "content": content}},
+        )()
+
+    def inject_subagent_message(
+        self,
+        *,
+        run_id: str,
+        instance_id: str,
+        content: str,
+    ) -> None:
+        if self.raise_on_subagent_inject:
+            raise ValueError("Injection content must not be empty")
+        self.subagent_inject_calls.append((run_id, instance_id, content))
 
     def list_background_tasks(self, run_id: str) -> tuple[dict[str, object], ...]:
         _ = run_id
@@ -255,6 +280,60 @@ def test_create_run_route_accepts_target_role_id() -> None:
     assert created.intent == "hello"
     assert created.target_role_id == "writer"
     assert fake_service.started_run_ids == ["run-1"]
+
+
+def test_inject_message_route_rejects_whitespace_only_content() -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/runs/run-1/inject",
+        json={"source": "user", "content": "   "},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.inject_calls == []
+
+
+def test_inject_message_route_maps_service_validation_errors_to_bad_request() -> None:
+    fake_service = _FakeRunService()
+    fake_service.raise_on_inject = True
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/runs/run-1/inject",
+        json={"source": "user", "content": "hello"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Injection content must not be empty"
+
+
+def test_inject_subagent_route_rejects_whitespace_only_content() -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/runs/run-1/subagents/inst-1/inject",
+        json={"content": "\t"},
+    )
+
+    assert response.status_code == 422
+    assert fake_service.subagent_inject_calls == []
+
+
+def test_inject_subagent_route_maps_service_validation_errors_to_bad_request() -> None:
+    fake_service = _FakeRunService()
+    fake_service.raise_on_subagent_inject = True
+    client = _create_client(fake_service)
+
+    response = client.post(
+        "/api/runs/run-1/subagents/inst-1/inject",
+        json={"content": "continue"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Injection content must not be empty"
 
 
 def test_create_run_route_rejects_legacy_intent_field() -> None:

--- a/tests/unit_tests/media/test_asset_service.py
+++ b/tests/unit_tests/media/test_asset_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic_ai.messages import ImageUrl
+from pydantic_ai.messages import AudioUrl, BinaryContent, ImageUrl, VideoUrl
 
 from relay_teams.media import (
     MediaAssetRecord,
@@ -80,8 +80,218 @@ def test_hydrate_user_prompt_content_keeps_remote_asset_urls_as_urls(
     )
 
 
-def _build_service(tmp_path: Path) -> MediaAssetService:
+def test_load_provider_content_for_local_asset_uses_force_download_local_url(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    record = service.store_bytes(
+        session_id="session-local-1",
+        workspace_id="default",
+        modality=MediaModality.IMAGE,
+        mime_type="image/png",
+        data=b"png-bytes",
+        name="diagram.png",
+        source="local-test",
+    )
+
+    provider_content = service.load_provider_content(
+        part=service.to_content_part(record)
+    )
+
+    assert provider_content == ImageUrl(
+        url=(
+            "http://127.0.0.1:8000"
+            f"/api/sessions/{record.session_id}/media/{record.asset_id}/file"
+        ),
+        media_type="image/png",
+        force_download="allow-local",
+    )
+
+
+def test_hydrate_user_prompt_content_resolves_absolute_local_asset_urls(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    record = service.store_bytes(
+        session_id="session-local-2",
+        workspace_id="default",
+        modality=MediaModality.IMAGE,
+        mime_type="image/png",
+        data=b"png-bytes",
+        name="diagram.png",
+        source="local-test",
+    )
+
+    hydrated = service.hydrate_user_prompt_content(
+        content=(
+            ImageUrl(
+                url=(
+                    "http://127.0.0.1:8000"
+                    f"/api/sessions/{record.session_id}/media/{record.asset_id}/file"
+                ),
+                media_type="image/png",
+                force_download="allow-local",
+            ),
+        )
+    )
+
+    assert hydrated == (BinaryContent(data=b"png-bytes", media_type="image/png"),)
+
+
+def test_hydrate_user_prompt_content_resolves_configured_local_asset_host(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(
+        tmp_path,
+        local_server_base_url="http://agent-teams.local:9100",
+    )
+    record = service.store_bytes(
+        session_id="session-local-custom-host",
+        workspace_id="default",
+        modality=MediaModality.IMAGE,
+        mime_type="image/png",
+        data=b"png-bytes",
+        name="diagram.png",
+        source="local-test",
+    )
+
+    hydrated = service.hydrate_user_prompt_content(
+        content=(
+            ImageUrl(
+                url=service.provider_asset_url(record.session_id, record.asset_id),
+                media_type="image/png",
+                force_download="allow-local",
+            ),
+        )
+    )
+
+    assert hydrated == (BinaryContent(data=b"png-bytes", media_type="image/png"),)
+
+
+def test_hydrate_user_prompt_content_resolves_configured_local_asset_base_path(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(
+        tmp_path,
+        local_server_base_url="https://agent-teams.local/app",
+    )
+    record = service.store_bytes(
+        session_id="session-local-custom-path",
+        workspace_id="default",
+        modality=MediaModality.IMAGE,
+        mime_type="image/png",
+        data=b"png-bytes",
+        name="diagram.png",
+        source="local-test",
+    )
+    provider_url = service.provider_asset_url(record.session_id, record.asset_id)
+
+    hydrated = service.hydrate_user_prompt_content(
+        content=(
+            ImageUrl(
+                url=provider_url,
+                media_type="image/png",
+                force_download="allow-local",
+            ),
+        )
+    )
+
+    assert provider_url == (
+        "https://agent-teams.local/app"
+        f"/api/sessions/{record.session_id}/media/{record.asset_id}/file"
+    )
+    assert hydrated == (BinaryContent(data=b"png-bytes", media_type="image/png"),)
+
+
+def test_hydrate_user_prompt_content_ignores_localhost_url_with_wrong_port(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path, local_server_base_url="http://127.0.0.1:8000")
+    image_url = ImageUrl(
+        url=("http://127.0.0.1:9999/api/sessions/session-other/media/asset-other/file"),
+        media_type="image/png",
+        force_download="allow-local",
+    )
+
+    hydrated = service.hydrate_user_prompt_content(content=(image_url,))
+
+    assert hydrated == (image_url,)
+
+
+def test_hydrate_user_prompt_content_resolves_localhost_alias_with_same_port(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path, local_server_base_url="http://127.0.0.1:8000")
+    record = service.store_bytes(
+        session_id="session-local-alias",
+        workspace_id="default",
+        modality=MediaModality.IMAGE,
+        mime_type="image/png",
+        data=b"png-bytes",
+        name="diagram.png",
+        source="local-test",
+    )
+
+    hydrated = service.hydrate_user_prompt_content(
+        content=(
+            ImageUrl(
+                url=(
+                    "http://localhost:8000"
+                    f"/api/sessions/{record.session_id}/media/{record.asset_id}/file"
+                ),
+                media_type="image/png",
+                force_download="allow-local",
+            ),
+        )
+    )
+
+    assert hydrated == (BinaryContent(data=b"png-bytes", media_type="image/png"),)
+
+
+def test_load_provider_content_for_local_audio_and_video_assets(tmp_path: Path) -> None:
+    service = _build_service(tmp_path)
+    audio_record = service.store_bytes(
+        session_id="session-local-audio",
+        workspace_id="default",
+        modality=MediaModality.AUDIO,
+        mime_type="audio/mpeg",
+        data=b"mp3-bytes",
+        name="demo.mp3",
+        source="local-test",
+    )
+    video_record = service.store_bytes(
+        session_id="session-local-video",
+        workspace_id="default",
+        modality=MediaModality.VIDEO,
+        mime_type="video/mp4",
+        data=b"mp4-bytes",
+        name="demo.mp4",
+        source="local-test",
+    )
+
+    assert service.load_provider_content(
+        part=service.to_content_part(audio_record)
+    ) == AudioUrl(
+        url=service.provider_asset_url(audio_record.session_id, audio_record.asset_id),
+        media_type="audio/mpeg",
+        force_download="allow-local",
+    )
+    assert service.load_provider_content(
+        part=service.to_content_part(video_record)
+    ) == VideoUrl(
+        url=service.provider_asset_url(video_record.session_id, video_record.asset_id),
+        media_type="video/mp4",
+        force_download="allow-local",
+    )
+
+
+def _build_service(
+    tmp_path: Path,
+    *,
+    local_server_base_url: str = "http://127.0.0.1:8000",
+) -> MediaAssetService:
     return MediaAssetService(
         repository=MediaAssetRepository(tmp_path / "media-assets.db"),
         workspace_manager=WorkspaceManager(project_root=tmp_path),
+        local_server_base_url=local_server_base_url,
     )

--- a/tests/unit_tests/sessions/runs/test_injection_queue.py
+++ b/tests/unit_tests/sessions/runs/test_injection_queue.py
@@ -1,5 +1,11 @@
+import pytest
+from pydantic import ValidationError
+from pydantic_ai.messages import ImageUrl
+
+from relay_teams.media import user_prompt_content_to_text
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.enums import InjectionSource
+from relay_teams.sessions.runs.run_models import InjectionMessage
 
 
 def test_injection_manager_isolated_by_recipient() -> None:
@@ -30,3 +36,63 @@ def test_injection_manager_isolated_by_recipient() -> None:
     assert a1[0].content == "m1"
     assert len(a2) == 1
     assert a2[0].content == "m2"
+
+
+def test_injection_manager_preserves_structured_prompt_content() -> None:
+    mgr = RunInjectionManager()
+    mgr.activate("run1")
+
+    mgr.enqueue(
+        "run1",
+        "a1",
+        InjectionSource.SYSTEM,
+        (
+            "inspect this image",
+            ImageUrl(
+                url="/api/sessions/session-1/media/asset-1/file",
+                media_type="image/png",
+            ),
+        ),
+    )
+
+    injected = mgr.drain_at_boundary("run1", "a1")
+
+    assert len(injected) == 1
+    assert user_prompt_content_to_text(injected[0].content) == (
+        "inspect this image\n\n[image: file]"
+    )
+
+
+def test_injection_message_serializes_structured_prompt_content() -> None:
+    message = InjectionMessage(
+        run_id="run-1",
+        recipient_instance_id="a1",
+        source=InjectionSource.SYSTEM,
+        content=(
+            "inspect this image",
+            ImageUrl(
+                url="/api/sessions/session-1/media/asset-1/file",
+                media_type="image/png",
+            ),
+        ),
+        priority=0,
+    )
+
+    payload = message.model_dump(mode="json")
+
+    assert payload["content"][0] == "inspect this image"
+    image_payload = payload["content"][1]
+    assert image_payload["url"] == "/api/sessions/session-1/media/asset-1/file"
+    assert image_payload["kind"] == "image-url"
+    assert image_payload["media_type"] == "image/png"
+
+
+def test_injection_message_rejects_whitespace_only_content() -> None:
+    with pytest.raises(ValidationError, match="Injection content must not be empty"):
+        InjectionMessage(
+            run_id="run-1",
+            recipient_instance_id="a1",
+            source=InjectionSource.SYSTEM,
+            content="   ",
+            priority=0,
+        )

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -7,6 +7,7 @@ import pytest
 from typing import cast
 
 from pydantic_ai.messages import (
+    ImageUrl,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -220,6 +221,131 @@ def test_build_session_rounds_keeps_tool_outcome_messages_for_recovery(
     ]
     assert len(coordinator_messages) == 3
     assert part_kinds == ["tool-call", "tool-return", "retry-prompt"]
+
+
+def test_build_session_rounds_keeps_tool_return_from_mixed_media_replay_message(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_mixed_media_tool_return.db"
+    session_id = "session-1"
+    run_id = "run-1"
+    coordinator_instance_id = "inst-coordinator-1"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    message_repo = MessageRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id="task-root",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="MainAgent",
+            objective="read image",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    agent_repo.upsert_instance(
+        run_id=run_id,
+        trace_id=run_id,
+        session_id=session_id,
+        instance_id=coordinator_instance_id,
+        role_id="MainAgent",
+        workspace_id="default",
+        status=InstanceStatus.COMPLETED,
+    )
+    run_runtime_repo.ensure(
+        run_id=run_id,
+        session_id=session_id,
+        root_task_id="task-root",
+    )
+    media_part = {
+        "kind": "media_ref",
+        "asset_id": "asset-1",
+        "session_id": session_id,
+        "modality": "image",
+        "mime_type": "image/png",
+        "name": "relay_teams.png",
+        "url": f"/api/sessions/{session_id}/media/asset-1/file",
+    }
+
+    message_repo.append(
+        session_id=session_id,
+        workspace_id="default",
+        instance_id=coordinator_instance_id,
+        task_id="task-root",
+        trace_id=run_id,
+        agent_role_id="MainAgent",
+        messages=[
+            ModelRequest(parts=[UserPromptPart(content="read docs/relay_teams.png")]),
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="read",
+                        args={"path": "docs/relay_teams.png"},
+                        tool_call_id="call-read-image",
+                    )
+                ]
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="read",
+                        tool_call_id="call-read-image",
+                        content={
+                            "ok": True,
+                            "data": {
+                                "type": "image",
+                                "path": "docs/relay_teams.png",
+                                "content": [media_part],
+                            },
+                            "error": None,
+                            "meta": {"tool_result_event_published": True},
+                        },
+                    ),
+                    UserPromptPart(
+                        content=[
+                            "The model can inspect this image.",
+                            ImageUrl(
+                                url=f"/api/sessions/{session_id}/media/asset-1/file",
+                                media_type="image/png",
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+        ],
+    )
+
+    def _session_messages(sid: str) -> list[dict[str, object]]:
+        return cast(list[dict[str, object]], message_repo.get_messages_by_session(sid))
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=_session_messages,
+    )
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+
+    coordinator_messages = cast(
+        list[dict[str, object]], round_item["coordinator_messages"]
+    )
+    assert len(coordinator_messages) == 2
+    tool_return_message = cast(dict[str, object], coordinator_messages[1]["message"])
+    tool_return_parts = cast(list[dict[str, object]], tool_return_message["parts"])
+    assert [part["part_kind"] for part in tool_return_parts] == ["tool-return"]
+    tool_return_content = cast(dict[str, object], tool_return_parts[0]["content"])
+    tool_return_data = cast(dict[str, object], tool_return_content["data"])
+    tool_return_media = cast(list[dict[str, object]], tool_return_data["content"])
+    assert tool_return_media[0]["kind"] == "media_ref"
+    assert (
+        tool_return_media[0]["url"] == f"/api/sessions/{session_id}/media/asset-1/file"
+    )
 
 
 def test_build_session_rounds_clears_stale_microcompact_badge_on_later_false_event(

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -9,10 +9,13 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkdtemp
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
+from pydantic_ai.messages import BinaryContent, ImageUrl, ToolReturn
 
+import relay_teams.tools.runtime.execution as execution_module
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.notifications import NotificationService, default_notification_config
@@ -21,6 +24,12 @@ from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.hooks import HookDecisionBundle, HookDecisionType, HookEventName
 from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.media import (
+    MediaModality,
+    MediaRefContentPart,
+    TextContentPart,
+    UserPromptContent,
+)
 
 from relay_teams.tools.runtime.approval_ticket_repo import (
     ApprovalTicketRepository,
@@ -42,8 +51,11 @@ from relay_teams.tools.runtime.models import (
     ToolResultProjection,
 )
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
-from relay_teams.tools.runtime.persisted_state import load_tool_call_state
-from relay_teams.tools.runtime.persisted_state import ToolApprovalMode
+from relay_teams.tools.runtime.persisted_state import (
+    ToolApprovalMode,
+    ToolExecutionStatus,
+    load_tool_call_state,
+)
 
 
 class _TaskDraftPayload(BaseModel):
@@ -60,7 +72,7 @@ class _FakeRunEventHub:
 
 
 class _FakeInjectionRecord:
-    def __init__(self, *, source: InjectionSource, content: str) -> None:
+    def __init__(self, *, source: InjectionSource, content: UserPromptContent) -> None:
         self.source = source
         self.content = content
 
@@ -79,7 +91,7 @@ class _FakeInjectionManager:
         recipient_instance_id: str,
         *,
         source: InjectionSource,
-        content: str,
+        content: UserPromptContent,
     ) -> _FakeInjectionRecord:
         _ = (run_id, recipient_instance_id)
         record = _FakeInjectionRecord(source=source, content=content)
@@ -135,6 +147,7 @@ class _FakeDeps:
         self.trace_id = "trace-1"
         self.task_id = "task-1"
         self.session_id = "session-1"
+        self.workspace_id = "workspace-1"
         self.instance_id = "inst-1"
         self.role_id = "spec_coder"
         self.role_registry = RoleRegistry()
@@ -156,6 +169,7 @@ class _FakeDeps:
         self.hook_service: object | None = None
         self.hook_runtime_env: dict[str, str] = {}
         self.injection_manager = _FakeInjectionManager()
+        self.media_asset_service: object | None = None
         self.approval_ticket_repo = ApprovalTicketRepository(db_path)
         self.run_runtime_repo = RunRuntimeRepository(db_path)
         self.shared_store = SharedStateRepository(Path(mkdtemp()) / "state.db")
@@ -877,6 +891,214 @@ def test_execute_tool_supports_projection_with_separate_visible_and_internal_dat
         cast(dict[str, JsonValue], state.result_envelope)["internal_data"],
     )
     assert internal_data["stdout"] == "/tmp\n"
+
+
+def test_execute_tool_returns_tool_return_for_tool_content_parts() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    deps.media_asset_service = SimpleNamespace()
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-read-image-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "docs/relay_teams.png"},
+            action=lambda: ToolResultProjection(
+                visible_data={"type": "image"},
+                tool_content_parts=(TextContentPart(text="attached image"),),
+            ),
+            allow_tool_return=True,
+        )
+    )
+
+    state = load_tool_call_state(
+        shared_store=deps.shared_store,
+        task_id=deps.task_id,
+        tool_call_id="call-read-image-1",
+    )
+
+    assert isinstance(result, ToolReturn)
+    payload = cast(dict[str, JsonValue], result.return_value)
+    meta = cast(dict[str, JsonValue], payload["meta"])
+    assert payload["ok"] is True
+    assert payload["data"] == {"type": "image"}
+    assert payload["error"] is None
+    assert isinstance(meta["duration_ms"], int | float)
+    assert meta["approval_required"] is False
+    assert meta["approval_status"] == "not_required"
+    assert meta["approval_mode"] == "policy_exempt"
+    assert meta["run_yolo"] is False
+    assert meta["tool_result_event_published"] is True
+    assert result.content == "attached image"
+    assert state is not None
+    assert state.result_envelope is not None
+    assert state.call_state == {}
+
+
+def test_execute_tool_hydrates_local_media_tool_return_content() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+
+    class _FakeMediaAssetService:
+        def to_provider_user_prompt_content(self, *, parts: object) -> object:
+            _ = parts
+            return (
+                ImageUrl(
+                    url="http://127.0.0.1:8000/api/sessions/session-1/media/asset-1/file",
+                    media_type="image/png",
+                    force_download="allow-local",
+                ),
+            )
+
+        def hydrate_user_prompt_content(self, *, content: object) -> object:
+            if isinstance(content, tuple):
+                return (
+                    BinaryContent(
+                        data=b"image-bytes",
+                        media_type="image/png",
+                    ),
+                )
+            return content
+
+    deps.media_asset_service = _FakeMediaAssetService()
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-read-image-hydrated-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "docs/relay_teams.png"},
+            action=lambda: ToolResultProjection(
+                visible_data={"type": "image"},
+                tool_content_parts=(
+                    MediaRefContentPart(
+                        asset_id="asset-1",
+                        session_id=deps.session_id,
+                        modality=MediaModality.IMAGE,
+                        mime_type="image/png",
+                        url="/api/sessions/session-1/media/asset-1/file",
+                        name="relay_teams.png",
+                    ),
+                ),
+            ),
+            allow_tool_return=True,
+        )
+    )
+
+    assert isinstance(result, ToolReturn)
+    assert isinstance(result.content, tuple)
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], BinaryContent)
+    assert result.content[0].data == b"image-bytes"
+
+
+def test_execute_tool_rejects_model_content_without_tool_return_support() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-read-image-no-tool-return-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "docs/relay_teams.png"},
+            action=lambda: ToolResultProjection(
+                visible_data={"type": "image"},
+                tool_content_parts=(TextContentPart(text="attached image"),),
+            ),
+        )
+    )
+
+    state = load_tool_call_state(
+        shared_store=deps.shared_store,
+        task_id=deps.task_id,
+        tool_call_id="call-read-image-no-tool-return-1",
+    )
+
+    assert isinstance(result, dict)
+    assert result["ok"] is False
+    error = cast(dict[str, JsonValue], result["error"])
+    assert error["message"] == (
+        "Tool read produced model content without enabling tool returns."
+    )
+    assert state is not None
+    assert state.execution_status == ToolExecutionStatus.FAILED
+    assert state.result_envelope is not None
+    record = cast(dict[str, JsonValue], state.result_envelope)
+    assert record["tool"] == "read"
+    assert cast(dict[str, JsonValue], record["visible_result"]) == result
+    tool_result_payloads = _tool_result_payloads(deps)
+    assert len(tool_result_payloads) == 1
+    assert tool_result_payloads[0]["tool_name"] == "read"
+    assert tool_result_payloads[0]["tool_call_id"] == "call-read-image-no-tool-return-1"
+    assert tool_result_payloads[0]["error"] is True
+    assert tool_result_payloads[0]["result"] == result
+
+
+def test_tool_return_content_handles_empty_missing_media_and_hydrated_text() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+
+    assert (
+        execution_module._tool_return_content(
+            ctx=cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            tool_content_parts=(),
+        )
+        == ""
+    )
+
+    media_part = MediaRefContentPart(
+        asset_id="asset-1",
+        session_id=deps.session_id,
+        modality=MediaModality.IMAGE,
+        mime_type="image/png",
+        url="/api/sessions/session-1/media/asset-1/file",
+        name="relay_teams.png",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Tool read returned media content without media asset support",
+    ):
+        execution_module._tool_return_content(
+            ctx=cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            tool_content_parts=(media_part,),
+        )
+
+    class _FakeMediaAssetService:
+        def to_provider_user_prompt_content(self, *, parts: object) -> object:
+            _ = parts
+            return ("attached image",)
+
+        def hydrate_user_prompt_content(self, *, content: object) -> object:
+            _ = content
+            return "flattened image"
+
+    deps.media_asset_service = _FakeMediaAssetService()
+
+    assert (
+        execution_module._tool_return_content(
+            ctx=cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            tool_content_parts=(media_part,),
+        )
+        == "flattened image"
+    )
 
 
 def test_load_tool_call_state_tolerates_legacy_rows_without_yolo_fields() -> None:

--- a/tests/unit_tests/tools/workspace_tools/test_read.py
+++ b/tests/unit_tests/tools/workspace_tools/test_read.py
@@ -2,16 +2,25 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 import inspect
+from io import BytesIO
 import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
-import pytest
-from pydantic_ai import Agent
 
+import pytest
+from PIL import Image
+from pydantic_ai import Agent
+from pydantic_ai.messages import ImageUrl
+
+from relay_teams.media import (
+    MediaModality,
+    TextContentPart,
+)
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.providers.model_config import ModelCapabilities, ModelModalityMatrix
+from relay_teams.tools.runtime.context import ToolContext, ToolDeps
 from relay_teams.tools.runtime.models import ToolResultProjection
-from relay_teams.tools.runtime.context import ToolDeps
 from relay_teams.tools.workspace_tools import register_read
 from relay_teams.tools.workspace_tools.edit_state import load_file_read_state
 
@@ -40,6 +49,215 @@ class _FakeWorkspace:
 
     def resolve_read_path(self, relative_path: str) -> Path:
         return (self.scope_root / relative_path).resolve()
+
+
+class _FakeMediaAssetService:
+    def __init__(self) -> None:
+        self.store_calls: list[dict[str, object]] = []
+
+    def store_bytes(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        modality: MediaModality,
+        mime_type: str,
+        data: bytes,
+        name: str = "",
+        source: str = "generated",
+        **kwargs: object,
+    ) -> SimpleNamespace:
+        _ = kwargs
+        self.store_calls.append(
+            {
+                "session_id": session_id,
+                "workspace_id": workspace_id,
+                "modality": modality,
+                "mime_type": mime_type,
+                "data": data,
+                "name": name,
+                "source": source,
+            }
+        )
+        return SimpleNamespace(
+            asset_id="asset-1",
+            session_id=session_id,
+            modality=modality,
+            mime_type=mime_type,
+            name=name,
+            size_bytes=len(data),
+            width=None,
+            height=None,
+            duration_ms=None,
+            thumbnail_asset_id=None,
+        )
+
+    def to_content_part(self, record: SimpleNamespace) -> SimpleNamespace:
+        return SimpleNamespace(
+            model_dump=lambda mode="json": {
+                "kind": "media_ref",
+                "asset_id": record.asset_id,
+                "session_id": record.session_id,
+                "modality": record.modality.value,
+                "mime_type": record.mime_type,
+                "name": record.name,
+                "url": f"/api/sessions/{record.session_id}/media/{record.asset_id}/file",
+                "size_bytes": record.size_bytes,
+                "width": record.width,
+                "height": record.height,
+                "duration_ms": record.duration_ms,
+                "thumbnail_asset_id": record.thumbnail_asset_id,
+            },
+            url=f"/api/sessions/{record.session_id}/media/{record.asset_id}/file",
+            mime_type=record.mime_type,
+            modality=record.modality,
+            asset_id=record.asset_id,
+            session_id=record.session_id,
+            name=record.name,
+            size_bytes=record.size_bytes,
+            width=record.width,
+            height=record.height,
+            duration_ms=record.duration_ms,
+            thumbnail_asset_id=record.thumbnail_asset_id,
+        )
+
+    def to_persisted_user_prompt_content(
+        self,
+        *,
+        parts: tuple[TextContentPart | SimpleNamespace, ...],
+    ) -> tuple[str | ImageUrl, ...]:
+        content: list[str | ImageUrl] = []
+        for part in parts:
+            if isinstance(part, TextContentPart):
+                content.append(part.text)
+                continue
+            content.append(ImageUrl(url=part.url, media_type=part.mime_type))
+        return tuple(content)
+
+
+class _FakeInjectionManager:
+    def __init__(self, *, active: bool = True) -> None:
+        self.active = active
+        self.records: list[dict[str, object]] = []
+
+    def is_active(self, run_id: str) -> bool:
+        _ = run_id
+        return self.active
+
+    def enqueue(
+        self,
+        run_id: str,
+        recipient_instance_id: str,
+        *,
+        source: object,
+        content: object,
+    ) -> SimpleNamespace:
+        record = {
+            "run_id": run_id,
+            "recipient_instance_id": recipient_instance_id,
+            "source": source,
+            "content": content,
+        }
+        self.records.append(record)
+        return SimpleNamespace(**record)
+
+
+def _make_png_bytes() -> bytes:
+    with BytesIO() as buffer:
+        Image.new("RGB", (1, 1), color=(0, 128, 255)).save(buffer, format="PNG")
+        return buffer.getvalue()
+
+
+def test_detect_image_mime_type_returns_none_for_unsupported_or_invalid_modalities(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    file_path = tmp_path / "diagram.png"
+    file_path.write_bytes(_make_png_bytes())
+
+    monkeypatch.setattr(
+        read_module.mimetypes,
+        "guess_type",
+        lambda *_args, **_kwargs: (None, None),
+    )
+    monkeypatch.setattr(read_module.Image, "MIME", {})
+    assert read_module._detect_image_mime_type(file_path) is None
+
+    monkeypatch.setattr(
+        read_module.mimetypes,
+        "guess_type",
+        lambda *_args, **_kwargs: ("image/png", None),
+    )
+
+    def _raise_value_error(*_args: object, **_kwargs: object) -> MediaModality:
+        raise ValueError("bad mime")
+
+    monkeypatch.setattr(read_module, "infer_media_modality", _raise_value_error)
+    assert read_module._detect_image_mime_type(file_path) is None
+
+    monkeypatch.setattr(
+        read_module,
+        "infer_media_modality",
+        lambda *_args, **_kwargs: MediaModality.AUDIO,
+    )
+    assert read_module._detect_image_mime_type(file_path) is None
+
+
+def test_read_image_capability_error_allows_explicit_support() -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    assert read_module._read_image_capability_error("src/diagram.png", True) == ""
+
+
+def test_project_image_read_result_rejects_missing_media_service_and_invalid_image(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    file_path = tmp_path / "diagram.png"
+    file_path.write_bytes(_make_png_bytes())
+    ctx_without_media = SimpleNamespace(
+        deps=SimpleNamespace(
+            media_asset_service=None,
+            model_capabilities=ModelCapabilities(
+                input=ModelModalityMatrix(text=True, image=True)
+            ),
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot read image file without media asset support",
+    ):
+        read_module._project_image_read_result(
+            ctx=cast(ToolContext, cast(object, ctx_without_media)),
+            file_path=file_path,
+            path="src/diagram.png",
+        )
+
+    ctx_with_media = SimpleNamespace(
+        deps=SimpleNamespace(
+            media_asset_service=_FakeMediaAssetService(),
+            model_capabilities=ModelCapabilities(
+                input=ModelModalityMatrix(text=True, image=True)
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        read_module,
+        "_detect_image_mime_type",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(ValueError, match="Cannot read binary file: src/diagram.png"):
+        read_module._project_image_read_result(
+            ctx=cast(ToolContext, cast(object, ctx_with_media)),
+            file_path=file_path,
+            path="src/diagram.png",
+        )
 
 
 class TestIsBinaryFile:
@@ -292,7 +510,10 @@ async def test_read_tool_reads_notebook_cell_without_outputs(
         action_args = {
             key: value for key, value in args_summary.items() if key in parameter_names
         }
-        return cast(dict[str, object], (await action(**action_args)).internal_data)
+        projected = await action(**action_args)
+        payload = cast(dict[str, object], projected.internal_data)
+        payload["tool_content_parts"] = projected.tool_content_parts
+        return payload
 
     monkeypatch.setattr(read_module, "execute_tool_call", _fake_execute_tool)
 
@@ -449,9 +670,298 @@ async def test_read_tool_rejects_office_documents(
         action_args = {
             key: value for key, value in args_summary.items() if key in parameter_names
         }
-        return cast(dict[str, object], (await action(**action_args)).internal_data)
+        projected = await action(**action_args)
+        payload = cast(dict[str, object], projected.internal_data)
+        payload["tool_content_parts"] = projected.tool_content_parts
+        return payload
 
     monkeypatch.setattr(read_module, "execute_tool_call", _fake_execute_tool)
 
     with pytest.raises(ValueError, match="Cannot read binary file: src/report.pdf"):
         await tool(ctx, path="src/report.pdf")
+
+
+@pytest.mark.asyncio
+async def test_read_tool_projects_images_for_model_inspection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    file_path = source_dir / "diagram.png"
+    file_path.write_bytes(_make_png_bytes())
+    media_asset_service = _FakeMediaAssetService()
+    injection_manager = _FakeInjectionManager()
+    fake_agent = _FakeAgent()
+    register_read(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["read"],
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            workspace=_FakeWorkspace(tmp_path),
+            shared_store=SharedStateRepository(tmp_path / "state.db"),
+            task_id="task-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            run_id="run-1",
+            instance_id="inst-1",
+            media_asset_service=media_asset_service,
+            injection_manager=injection_manager,
+            model_capabilities=ModelCapabilities(
+                input=ModelModalityMatrix(text=True, image=True)
+            ),
+        )
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[ToolResultProjection]],
+        approval_request=None,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        del ctx, tool_name, approval_request, kwargs
+        parameter_names = set(inspect.signature(action).parameters)
+        action_args = {
+            key: value for key, value in args_summary.items() if key in parameter_names
+        }
+        projected = await action(**action_args)
+        payload = cast(dict[str, object], projected.internal_data)
+        payload["tool_content_parts"] = projected.tool_content_parts
+        return payload
+
+    monkeypatch.setattr(read_module, "execute_tool_call", _fake_execute_tool)
+
+    result = await tool(ctx, path="src/diagram.png")
+
+    assert result["type"] == "image"
+    assert cast(str, result["mime_type"]) == "image/png"
+    assert "text" not in result
+    content = cast(list[dict[str, object]], result["content"])
+    assert len(content) == 1
+    assert content[0]["kind"] == "media_ref"
+    assert content[0]["asset_id"] == "asset-1"
+    assert len(media_asset_service.store_calls) == 1
+    assert media_asset_service.store_calls[0]["source"] == "read_tool"
+    assert injection_manager.records == []
+    tool_content_parts = cast(tuple[object, ...], result["tool_content_parts"])
+    assert len(tool_content_parts) == 1
+    assert (
+        load_file_read_state(
+            shared_store=ctx.deps.shared_store,
+            task_id="task-1",
+            path=file_path.resolve(),
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_tool_rejects_images_larger_than_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    file_path = source_dir / "diagram.png"
+    file_path.write_bytes(_make_png_bytes())
+    media_asset_service = _FakeMediaAssetService()
+    fake_agent = _FakeAgent()
+    register_read(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["read"],
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            workspace=_FakeWorkspace(tmp_path),
+            shared_store=SharedStateRepository(tmp_path / "state.db"),
+            task_id="task-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            run_id="run-1",
+            instance_id="inst-1",
+            media_asset_service=media_asset_service,
+            injection_manager=_FakeInjectionManager(),
+            model_capabilities=ModelCapabilities(
+                input=ModelModalityMatrix(text=True, image=True)
+            ),
+        )
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[ToolResultProjection]],
+        approval_request=None,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        del ctx, tool_name, approval_request, kwargs
+        parameter_names = set(inspect.signature(action).parameters)
+        action_args = {
+            key: value for key, value in args_summary.items() if key in parameter_names
+        }
+        projected = await action(**action_args)
+        payload = cast(dict[str, object], projected.internal_data)
+        payload["tool_content_parts"] = projected.tool_content_parts
+        return payload
+
+    monkeypatch.setattr(read_module, "execute_tool_call", _fake_execute_tool)
+    monkeypatch.setattr(
+        read_module,
+        "path_stat",
+        lambda _: SimpleNamespace(st_size=read_module._READ_TOOL_MAX_IMAGE_BYTES + 1),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Image file is too large for read\\(\\).*10 MB.*src/diagram.png",
+    ):
+        await tool(ctx, path="src/diagram.png")
+
+    assert media_asset_service.store_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("image_support", "message_fragment"),
+    [
+        (False, "does not have image input enabled"),
+        (None, "Image input support for the current model is unknown"),
+    ],
+)
+async def test_read_tool_rejects_images_without_model_image_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    image_support: bool | None,
+    message_fragment: str,
+) -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    file_path = source_dir / "diagram.png"
+    file_path.write_bytes(_make_png_bytes())
+    fake_agent = _FakeAgent()
+    register_read(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["read"],
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            workspace=_FakeWorkspace(tmp_path),
+            shared_store=SharedStateRepository(tmp_path / "state.db"),
+            task_id="task-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            run_id="run-1",
+            instance_id="inst-1",
+            media_asset_service=_FakeMediaAssetService(),
+            injection_manager=_FakeInjectionManager(),
+            model_capabilities=ModelCapabilities(
+                input=ModelModalityMatrix(text=True, image=image_support)
+            ),
+        )
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[ToolResultProjection]],
+        approval_request=None,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        del ctx, tool_name, approval_request, kwargs
+        parameter_names = set(inspect.signature(action).parameters)
+        action_args = {
+            key: value for key, value in args_summary.items() if key in parameter_names
+        }
+        projected = await action(**action_args)
+        payload = cast(dict[str, object], projected.internal_data)
+        payload["tool_content_parts"] = projected.tool_content_parts
+        return payload
+
+    monkeypatch.setattr(read_module, "execute_tool_call", _fake_execute_tool)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"{message_fragment}.*Enable image input in provider settings.*src/diagram.png"
+        ),
+    ):
+        await tool(ctx, path="src/diagram.png")
+
+
+@pytest.mark.asyncio
+async def test_read_tool_rejects_invalid_image_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    file_path = source_dir / "report.png"
+    file_path.write_bytes(b"not-a-real-image")
+    media_asset_service = _FakeMediaAssetService()
+    fake_agent = _FakeAgent()
+    register_read(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["read"],
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            workspace=_FakeWorkspace(tmp_path),
+            shared_store=SharedStateRepository(tmp_path / "state.db"),
+            task_id="task-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            run_id="run-1",
+            instance_id="inst-1",
+            media_asset_service=media_asset_service,
+            injection_manager=_FakeInjectionManager(),
+            model_capabilities=ModelCapabilities(
+                input=ModelModalityMatrix(text=True, image=True)
+            ),
+        )
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[ToolResultProjection]],
+        approval_request=None,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        del ctx, tool_name, approval_request, kwargs
+        parameter_names = set(inspect.signature(action).parameters)
+        action_args = {
+            key: value for key, value in args_summary.items() if key in parameter_names
+        }
+        projected = await action(**action_args)
+        payload = cast(dict[str, object], projected.internal_data)
+        payload["tool_content_parts"] = projected.tool_content_parts
+        return payload
+
+    monkeypatch.setattr(read_module, "execute_tool_call", _fake_execute_tool)
+
+    with pytest.raises(ValueError, match="Cannot read binary file: src/report.png"):
+        await tool(ctx, path="src/report.png")
+
+    assert media_asset_service.store_calls == []


### PR DESCRIPTION
Closes #431

## Summary
- add provider-side image capability detection and manual override support for models with unknown vision capability
- support pasted image attachments, rendered image previews, and larger interactive preview dialogs throughout the chat UI
- make `read()` image results flow into the next model turn as real multimodal input instead of a second injected follow-up step

## Validation
- `uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_llm_session.py tests/unit_tests/tools/workspace_tools/test_read.py tests/unit_tests/frontend/test_message_rich_content_ui.py tests/unit_tests/frontend/test_round_user_prompt_ui.py tests/unit_tests/frontend/test_streaming_tool_ui.py tests/unit_tests/sessions/runs/test_injection_queue.py tests/unit_tests/tools/runtime/test_execution.py`


<img width="2405" height="1380" alt="image" src="https://github.com/user-attachments/assets/ade9456d-7796-4277-a272-350fd47e2a34" />

