### PR TITLE
fix(workspace): sort mounts by provider

### DIFF
--- a/frontend/dist/js/components/projectView.js
+++ b/frontend/dist/js/components/projectView.js
@@ -2537,7 +2537,8 @@ function syncActionLabels() {
 }
 
 export async function openWorkspaceProjectView(workspace) {
-    const workspaceId = String(workspace?.workspace_id || '').trim();
+    const orderedWorkspace = normalizeWorkspaceRecordMountOrder(workspace);
+    const workspaceId = String(orderedWorkspace?.workspace_id || '').trim();
     if (!workspaceId) {
         return;
     }
@@ -2547,7 +2548,7 @@ export async function openWorkspaceProjectView(workspace) {
     currentAutomationProject = null;
     currentFeatureViewId = '';
     state.currentFeatureViewId = null;
-    currentWorkspace = workspace;
+    currentWorkspace = orderedWorkspace;
     currentSnapshotWorkspaceId = workspaceId;
     state.currentMainView = 'project';
     state.currentProjectViewWorkspaceId = workspaceId;
@@ -2560,18 +2561,18 @@ export async function openWorkspaceProjectView(workspace) {
 
     const restoredFromCache = restoreProjectViewState(workspaceId);
     if (restoredFromCache && currentSnapshot) {
-        renderWorkspaceSnapshot(workspace, currentSnapshot);
+        renderWorkspaceSnapshot(orderedWorkspace, currentSnapshot);
         if (selectedTreePath && findDiffSummary(selectedTreePath)) {
             void ensureDiffFileLoaded(selectedTreePath);
         }
     } else {
         resetProjectViewState(workspaceId);
-        currentMountName = resolveWorkspaceInitialMountName(workspace);
+        currentMountName = resolveWorkspaceInitialMountName(orderedWorkspace);
         currentDiffState = {
             ...createInitialDiffState(),
             status: 'loading',
         };
-        renderLoadingState(workspace);
+        renderLoadingState(orderedWorkspace);
     }
 
     const loadToken = ++currentLoadToken;
@@ -5241,7 +5242,8 @@ function resolveWorkspaceInitialMountName(workspace) {
     if (explicitMountName) {
         return explicitMountName;
     }
-    const firstMount = Array.isArray(workspace?.mounts) ? workspace.mounts.find(Boolean) : null;
+    const mounts = Array.isArray(workspace?.mounts) ? sortWorkspaceMounts(workspace.mounts) : [];
+    const firstMount = mounts.find(Boolean) || null;
     return String(firstMount?.mount_name || '').trim() || null;
 }
 
@@ -5253,18 +5255,28 @@ function isMountShellSnapshot(snapshot) {
         || Object.prototype.hasOwnProperty.call(snapshot, 'default_mount_root');
 }
 
+function normalizeWorkspaceRecordMountOrder(workspace) {
+    if (!workspace || typeof workspace !== 'object' || !Array.isArray(workspace.mounts)) {
+        return workspace;
+    }
+    return {
+        ...workspace,
+        mounts: sortWorkspaceMounts(workspace.mounts),
+    };
+}
+
 function normalizeWorkspaceMounts(workspace, snapshot, defaultMountName, rootPath) {
     const workspaceMounts = Array.isArray(workspace?.mounts)
-        ? workspace.mounts
+        ? sortWorkspaceMounts(workspace.mounts)
             .map(mount => normalizeWorkspaceMount(mount, defaultMountName, rootPath))
             .filter(Boolean)
         : [];
     if (workspaceMounts.length > 0) {
-        return workspaceMounts;
+        return sortWorkspaceMounts(workspaceMounts);
     }
     const shellChildren = Array.isArray(snapshot?.tree?.children) ? snapshot.tree.children : [];
     if (shellChildren.length > 0 && isMountShellSnapshot(snapshot)) {
-        const mounts = shellChildren
+        const mounts = sortWorkspaceMounts(shellChildren
             .map(child => {
                 const mountName = String(child?.path || child?.name || '').trim();
                 if (!mountName) {
@@ -5280,7 +5292,7 @@ function normalizeWorkspaceMounts(workspace, snapshot, defaultMountName, rootPat
                     hasChildren: child?.has_children === true || child?.hasChildren === true,
                 };
             })
-            .filter(Boolean);
+            .filter(Boolean));
         if (mounts.length > 0) {
             return mounts;
         }
@@ -5295,6 +5307,53 @@ function normalizeWorkspaceMounts(workspace, snapshot, defaultMountName, rootPat
             hasChildren: snapshot?.tree?.has_children === true || snapshot?.tree?.hasChildren === true,
         },
     ];
+}
+
+function sortWorkspaceMounts(mounts = []) {
+    return [...mounts].sort(compareWorkspaceMounts);
+}
+
+function compareWorkspaceMounts(left, right) {
+    const providerDelta = workspaceMountProviderOrder(left) - workspaceMountProviderOrder(right);
+    if (providerDelta !== 0) {
+        return providerDelta;
+    }
+    return compareWorkspaceMountNames(workspaceMountSortName(left), workspaceMountSortName(right));
+}
+
+function workspaceMountProviderOrder(mount) {
+    const provider = String(mount?.provider || '').trim();
+    if (provider === 'local') {
+        return 0;
+    }
+    if (provider === 'ssh') {
+        return 1;
+    }
+    return 2;
+}
+
+function workspaceMountSortName(mount) {
+    return String(mount?.mount_name || mount?.mountName || '').trim();
+}
+
+function compareWorkspaceMountNames(leftName, rightName) {
+    const left = String(leftName || '').toLowerCase();
+    const right = String(rightName || '').toLowerCase();
+    if (left < right) {
+        return -1;
+    }
+    if (left > right) {
+        return 1;
+    }
+    const originalLeft = String(leftName || '');
+    const originalRight = String(rightName || '');
+    if (originalLeft < originalRight) {
+        return -1;
+    }
+    if (originalLeft > originalRight) {
+        return 1;
+    }
+    return 0;
 }
 
 function normalizeWorkspaceMount(mount, defaultMountName, rootPath) {
@@ -5323,7 +5382,7 @@ function normalizeWorkspaceMount(mount, defaultMountName, rootPath) {
 }
 
 function renderWorkspaceMountStrip(snapshot) {
-    const mounts = Array.isArray(snapshot?.mounts) ? snapshot.mounts : [];
+    const mounts = Array.isArray(snapshot?.mounts) ? sortWorkspaceMounts(snapshot.mounts) : [];
     if (!shouldRenderWorkspaceMountStrip(snapshot)) {
         return '';
     }
@@ -5384,7 +5443,7 @@ function renderMountProviderLabel(mount) {
 }
 
 function resolveWorkspaceMountName(candidateMountName, snapshot) {
-    const mounts = Array.isArray(snapshot?.mounts) ? snapshot.mounts : [];
+    const mounts = Array.isArray(snapshot?.mounts) ? sortWorkspaceMounts(snapshot.mounts) : [];
     const normalizedCandidate = String(candidateMountName || '').trim();
     if (normalizedCandidate && mounts.some(mount => mount?.mountName === normalizedCandidate)) {
         return normalizedCandidate;
@@ -6049,7 +6108,9 @@ async function handleDeleteWorkspaceMount() {
     if (confirmed !== true) {
         return;
     }
-    const nextMounts = mounts.filter(mount => String(mount?.mount_name || '').trim() !== activeMount.mountName);
+    const nextMounts = sortWorkspaceMounts(
+        mounts.filter(mount => String(mount?.mount_name || '').trim() !== activeMount.mountName),
+    );
     const nextDefaultMountName = resolveUpdatedDefaultMountName({
         nextMounts,
         requestedDefaultMountName: String(currentWorkspace.default_mount_name || '').trim(),
@@ -6208,11 +6269,11 @@ async function submitWorkspaceMountChange({
         sourceMountName: normalizedSourceMountName,
         existingMounts,
     });
-    const nextMounts = mode === 'edit'
+    const nextMounts = sortWorkspaceMounts(mode === 'edit'
         ? existingMounts.map(mount => {
             return String(mount?.mount_name || '').trim() === normalizedSourceMountName ? nextMountRecord : mount;
         })
-        : [...existingMounts, nextMountRecord];
+        : [...existingMounts, nextMountRecord]);
     const nextDefaultMountName = resolveUpdatedDefaultMountName({
         nextMounts,
         requestedDefaultMountName: values?.set_default === true && String(nextMountRecord?.provider || '').trim() === 'local'
@@ -6350,17 +6411,18 @@ function resolveUpdatedDefaultMountName({
     removedMountName = '',
     replacementMountName = '',
 } = {}) {
+    const orderedMounts = sortWorkspaceMounts(nextMounts);
     const normalizedRequested = String(requestedDefaultMountName || '').trim();
     const normalizedRemoved = String(removedMountName || '').trim();
     const normalizedReplacement = String(replacementMountName || '').trim();
-    const nextMountNames = nextMounts
+    const nextMountNames = orderedMounts
         .map(mount => String(mount?.mount_name || '').trim())
         .filter(Boolean);
-    const requestedMount = findWorkspaceMountByName(nextMounts, normalizedRequested);
+    const requestedMount = findWorkspaceMountByName(orderedMounts, normalizedRequested);
     if (requestedMount && isLocalWorkspaceMount(requestedMount)) {
         return normalizedRequested;
     }
-    const replacementMount = findWorkspaceMountByName(nextMounts, normalizedReplacement);
+    const replacementMount = findWorkspaceMountByName(orderedMounts, normalizedReplacement);
     if (
         normalizedRequested
         && normalizedRemoved
@@ -6370,7 +6432,7 @@ function resolveUpdatedDefaultMountName({
     ) {
         return normalizedReplacement;
     }
-    const firstLocalMount = nextMounts.find(mount => isLocalWorkspaceMount(mount)) || null;
+    const firstLocalMount = orderedMounts.find(mount => isLocalWorkspaceMount(mount)) || null;
     if (firstLocalMount) {
         return String(firstLocalMount.mount_name || '').trim() || 'default';
     }
@@ -6390,22 +6452,23 @@ function isLocalWorkspaceMount(mount) {
 }
 
 async function applyUpdatedWorkspaceRecord(updatedWorkspace, preferredMountName = '') {
-    const workspaceId = String(updatedWorkspace?.workspace_id || '').trim();
+    const orderedWorkspace = normalizeWorkspaceRecordMountOrder(updatedWorkspace);
+    const workspaceId = String(orderedWorkspace?.workspace_id || '').trim();
     if (!workspaceId) {
         return;
     }
-    currentWorkspace = updatedWorkspace;
+    currentWorkspace = orderedWorkspace;
     currentSnapshotWorkspaceId = workspaceId;
     state.currentWorkspaceId = workspaceId;
     workspaceViewCache.delete(workspaceId);
     resetProjectViewState(workspaceId);
-    currentMountName = String(preferredMountName || updatedWorkspace.default_mount_name || '').trim() || resolveWorkspaceInitialMountName(updatedWorkspace);
+    currentMountName = String(preferredMountName || orderedWorkspace.default_mount_name || '').trim() || resolveWorkspaceInitialMountName(orderedWorkspace);
     currentDiffState = {
         ...createInitialDiffState(),
         status: 'loading',
         mountName: currentMountName,
     };
-    renderLoadingState(updatedWorkspace);
+    renderLoadingState(orderedWorkspace);
     const loadToken = ++currentLoadToken;
     void loadWorkspaceSnapshot(workspaceId, loadToken);
     void loadWorkspaceDiffs(workspaceId, loadToken);

--- a/src/relay_teams/workspace/workspace_models.py
+++ b/src/relay_teams/workspace/workspace_models.py
@@ -152,6 +152,17 @@ class WorkspaceMountRecord(BaseModel):
         return self.provider_config.root_path.resolve()
 
 
+def _sort_workspace_mounts(
+    mounts: tuple[WorkspaceMountRecord, ...],
+) -> tuple[WorkspaceMountRecord, ...]:
+    return tuple(sorted(mounts, key=_workspace_mount_sort_key))
+
+
+def _workspace_mount_sort_key(mount: WorkspaceMountRecord) -> tuple[int, str, str]:
+    provider_order = 0 if mount.provider == WorkspaceMountProvider.LOCAL else 1
+    return (provider_order, mount.mount_name.casefold(), mount.mount_name)
+
+
 def build_local_workspace_mount(
     *,
     mount_name: str,
@@ -317,6 +328,7 @@ class WorkspaceRecord(BaseModel):
             seen.add(mount.mount_name)
         if self.default_mount_name not in seen:
             raise ValueError(f"default mount does not exist: {self.default_mount_name}")
+        self.mounts = _sort_workspace_mounts(self.mounts)
         return self
 
     def mount_by_name(self, mount_name: str) -> WorkspaceMountRecord:

--- a/src/relay_teams/workspace/workspace_repository.py
+++ b/src/relay_teams/workspace/workspace_repository.py
@@ -189,7 +189,13 @@ class WorkspaceRepository:
                 """
                 SELECT * FROM workspace_mounts
                 WHERE workspace_id=?
-                ORDER BY mount_name ASC
+                ORDER BY
+                    CASE provider
+                        WHEN 'local' THEN 0
+                        WHEN 'ssh' THEN 1
+                        ELSE 2
+                    END ASC,
+                    mount_name ASC
                 """,
                 (workspace_id,),
             ).fetchall()
@@ -270,7 +276,14 @@ class WorkspaceRepository:
             mount_rows = self._conn.execute(
                 """
                 SELECT * FROM workspace_mounts
-                ORDER BY workspace_id ASC, mount_name ASC
+                ORDER BY
+                    workspace_id ASC,
+                    CASE provider
+                        WHEN 'local' THEN 0
+                        WHEN 'ssh' THEN 1
+                        ELSE 2
+                    END ASC,
+                    mount_name ASC
                 """
             ).fetchall()
         mounts_by_workspace: dict[str, list[sqlite3.Row]] = {}

--- a/tests/unit_tests/frontend/test_project_view_ui.py
+++ b/tests/unit_tests/frontend/test_project_view_ui.py
@@ -749,6 +749,7 @@ await flushTasks();
 await flushTasks();
 
 const mountButtons = Array.from(els.projectViewContent.querySelectorAll("[data-workspace-mount]"));
+const mountOrder = mountButtons.map(button => button.getAttribute("data-workspace-mount"));
 const defaultMountButton = mountButtons.find(button => button.getAttribute("data-mount-name") === "default") || null;
 defaultMountButton?.click();
 await flushTasks();
@@ -760,30 +761,32 @@ await flushTasks();
 await flushTasks();
 
 console.log(JSON.stringify({
+    mountOrder,
     updatedWorkspacePayload: globalThis.__updatedWorkspacePayload,
     toastCalls: globalThis.__toastCalls || [],
 }));
 """.strip(),
     )
 
+    assert payload["mountOrder"] == ["default", "ops", "prod"]
     assert payload["updatedWorkspacePayload"] == {
         "workspaceId": "alpha-project",
         "payload": {
             "default_mount_name": "ops",
             "mounts": [
                 {
+                    "mount_name": "ops",
+                    "provider": "local",
+                    "provider_config": {
+                        "root_path": "/work/ops",
+                    },
+                },
+                {
                     "mount_name": "prod",
                     "provider": "ssh",
                     "provider_config": {
                         "ssh_profile_id": "prod",
                         "remote_root": "/srv/app",
-                    },
-                },
-                {
-                    "mount_name": "ops",
-                    "provider": "local",
-                    "provider_config": {
-                        "root_path": "/work/ops",
                     },
                 },
             ],

--- a/tests/unit_tests/interfaces/server/test_workspaces_router.py
+++ b/tests/unit_tests/interfaces/server/test_workspaces_router.py
@@ -185,6 +185,60 @@ def test_create_workspace_with_mounts_and_mount_scoped_tree_query(
     assert [item["path"] for item in tree_payload["children"]] == ["deploy.sh"]
 
 
+def test_create_workspace_returns_mounts_in_provider_then_name_order(
+    tmp_path: Path,
+) -> None:
+    client, _ = _create_test_client(tmp_path)
+    app_root = tmp_path / "app-root"
+    ops_root = tmp_path / "ops-root"
+    app_root.mkdir()
+    ops_root.mkdir()
+
+    response = client.post(
+        "/api/workspaces",
+        json={
+            "workspace_id": "project-alpha",
+            "default_mount_name": "prod",
+            "mounts": [
+                {
+                    "mount_name": "prod",
+                    "provider": "ssh",
+                    "provider_config": {
+                        "ssh_profile_id": "prod",
+                        "remote_root": "/srv/prod",
+                    },
+                },
+                {
+                    "mount_name": "ops",
+                    "provider": "local",
+                    "provider_config": {"root_path": str(ops_root)},
+                },
+                {
+                    "mount_name": "app",
+                    "provider": "local",
+                    "provider_config": {"root_path": str(app_root)},
+                },
+                {
+                    "mount_name": "stage",
+                    "provider": "ssh",
+                    "provider_config": {
+                        "ssh_profile_id": "stage",
+                        "remote_root": "/srv/stage",
+                    },
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert [item["mount_name"] for item in response.json()["mounts"]] == [
+        "app",
+        "ops",
+        "prod",
+        "stage",
+    ]
+
+
 def test_create_workspace_rejects_missing_ssh_profile_as_client_error(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/workspace/test_repository.py
+++ b/tests/unit_tests/workspace/test_repository.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import sqlite3
 
 import pytest
-from relay_teams.workspace import WorkspaceRepository
+from relay_teams.workspace import (
+    WorkspaceLocalMountConfig,
+    WorkspaceMountProvider,
+    WorkspaceMountRecord,
+    WorkspaceRepository,
+    WorkspaceSshMountConfig,
+)
 
 
 def test_workspace_repository_supports_concurrent_reads(tmp_path: Path) -> None:
@@ -56,6 +62,57 @@ def test_workspace_repository_skips_invalid_persisted_rows(tmp_path: Path) -> No
     assert [record.workspace_id for record in records] == ["project-alpha"]
     with pytest.raises(KeyError):
         repository.get("None")
+
+
+def test_workspace_repository_persists_mounts_in_provider_then_name_order(
+    tmp_path: Path,
+) -> None:
+    app_root = tmp_path / "app-root"
+    ops_root = tmp_path / "ops-root"
+    app_root.mkdir()
+    ops_root.mkdir()
+    repository = WorkspaceRepository(tmp_path / "workspace_mount_order.db")
+
+    created = repository.create(
+        workspace_id="project-alpha",
+        default_mount_name="prod",
+        mounts=(
+            WorkspaceMountRecord(
+                mount_name="prod",
+                provider=WorkspaceMountProvider.SSH,
+                provider_config=WorkspaceSshMountConfig(
+                    ssh_profile_id="prod",
+                    remote_root="/srv/prod",
+                ),
+            ),
+            WorkspaceMountRecord(
+                mount_name="ops",
+                provider=WorkspaceMountProvider.LOCAL,
+                provider_config=WorkspaceLocalMountConfig(root_path=ops_root),
+            ),
+            WorkspaceMountRecord(
+                mount_name="app",
+                provider=WorkspaceMountProvider.LOCAL,
+                provider_config=WorkspaceLocalMountConfig(root_path=app_root),
+            ),
+            WorkspaceMountRecord(
+                mount_name="stage",
+                provider=WorkspaceMountProvider.SSH,
+                provider_config=WorkspaceSshMountConfig(
+                    ssh_profile_id="stage",
+                    remote_root="/srv/stage",
+                ),
+            ),
+        ),
+    )
+
+    fetched = repository.get("project-alpha")
+    listed = repository.list_all()[0]
+    expected_order = ["app", "ops", "prod", "stage"]
+
+    assert [mount.mount_name for mount in created.mounts] == expected_order
+    assert [mount.mount_name for mount in fetched.mounts] == expected_order
+    assert [mount.mount_name for mount in listed.mounts] == expected_order
 
 
 def test_workspace_repository_skips_invalid_legacy_profile_rows_on_init(


### PR DESCRIPTION
## Summary
- enforce canonical workspace mount ordering with local mounts before ssh mounts
- keep persisted reads, API responses, project view rendering, and workspace update payloads in the same order
- add backend, router, and frontend regression coverage for mount ordering

## Tests
- node --check frontend/dist/js/components/projectView.js
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests

Fixes #453