### PR TITLE
ci: enforce changed-line unit coverage

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -54,8 +56,15 @@ jobs:
       - name: basedpyright
         run: uv run --extra dev basedpyright
 
-      - name: Unit tests
-        run: uv run --extra dev pytest -q tests/unit_tests
+      - name: Unit tests with coverage
+        run: >
+          uv run --extra dev pytest -q tests/unit_tests
+          --cov=src/relay_teams
+          --cov=src/relay_teams_evals
+          --cov-report=xml:coverage.xml
+
+      - name: Enforce changed-line unit coverage
+        run: uv run --extra dev diff-cover coverage.xml --config-file pyproject.toml
 
       - name: Install Playwright Chromium
         run: uv run --extra dev python -m playwright install --with-deps chromium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
   "pytest-timeout >= 2.1.0",
   "pytest-asyncio >= 1.2.0",
   "coverage >= 7.8.0",
+  "diff-cover>=9.0.0",
   "pytest-cov>=6.0.0",
   "pytest-html>=4.1.1",
   "playwright>=1.49.0",
@@ -51,6 +52,26 @@ pythonpath = ["src", "tests", "."]
 markers = [
   "timeout: override per-test timeout budget",
 ]
+
+[tool.coverage.run]
+source = [
+  "src/relay_teams",
+  "src/relay_teams_evals",
+]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = true
+
+[tool.diff_cover]
+compare_branch = "origin/main"
+fail_under = 90
+include = [
+  "src/relay_teams/**/*.py",
+  "src/relay_teams_evals/**/*.py",
+]
+show_uncovered = true
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/tests/unit_tests/release/test_packaging_metadata.py
+++ b/tests/unit_tests/release/test_packaging_metadata.py
@@ -47,6 +47,34 @@ def test_release_workflow_and_runtime_wrapper_reference_relay_teams() -> None:
     assert 'relay-teams-evals = "relay_teams_evals.run:app"' in runtime_pyproject_script
 
 
+def test_pr_checks_gate_changed_line_unit_coverage() -> None:
+    project_root = _project_root()
+    pr_workflow = (project_root / ".github" / "workflows" / "pr-checks.yml").read_text(
+        encoding="utf-8"
+    )
+    pyproject_path = project_root / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+
+    dev_dependencies = pyproject["project"]["optional-dependencies"]["dev"]
+    coverage_run = pyproject["tool"]["coverage"]["run"]
+    diff_cover = pyproject["tool"]["diff_cover"]
+
+    assert "diff-cover>=9.0.0" in dev_dependencies
+    assert coverage_run["source"] == ["src/relay_teams", "src/relay_teams_evals"]
+    assert diff_cover["compare_branch"] == "origin/main"
+    assert diff_cover["fail_under"] == 90
+    assert diff_cover["include"] == [
+        "src/relay_teams/**/*.py",
+        "src/relay_teams_evals/**/*.py",
+    ]
+    assert "fetch-depth: 0" in pr_workflow
+    assert "--cov=src/relay_teams" in pr_workflow
+    assert "--cov=src/relay_teams_evals" in pr_workflow
+    assert "--cov-report=xml:coverage.xml" in pr_workflow
+    assert "diff-cover coverage.xml --config-file pyproject.toml" in pr_workflow
+
+
 def test_pptx_craft_package_metadata_preserves_esm_runtime_contract() -> None:
     package_json_path = (
         _project_root()

--- a/uv.lock
+++ b/uv.lock
@@ -751,6 +751,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "10.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b4/eee71d1e338bc1f9bd3539b46b70e303dac061324b759c9a80fa3c96d90d/diff_cover-10.2.0.tar.gz", hash = "sha256:61bf83025f10510c76ef6a5820680cf61b9b974e8f81de70c57ac926fa63872a", size = 102473, upload-time = "2026-01-09T01:59:07.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/2c/61eeb887055a37150db824b6bf830e821a736580769ac2fea4eadb0d613f/diff_cover-10.2.0-py3-none-any.whl", hash = "sha256:59c328595e0b8948617cc5269af9e484c86462e2844bfcafa3fb37f8fca0af87", size = 56748, upload-time = "2026-01-09T01:59:06.028Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3679,6 +3694,7 @@ dependencies = [
 dev = [
     { name = "basedpyright" },
     { name = "coverage" },
+    { name = "diff-cover" },
     { name = "playwright" },
     { name = "pre-commit" },
     { name = "pyright" },
@@ -3703,6 +3719,7 @@ requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.36.2" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.8.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
+    { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=9.0.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "json-repair", specifier = ">=0.58.7" },


### PR DESCRIPTION
Closes #459

## Summary
- generate unit-test coverage XML in PR checks
- enforce 90% changed-line coverage with diff-cover
- add a regression test for the workflow/config contract

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests --cov=src/relay_teams --cov=src/relay_teams_evals --cov-report=xml:coverage.xml
- uv run --extra dev diff-cover coverage.xml --config-file pyproject.toml
- uv run --extra dev pytest -q tests/integration_tests