### PR TITLE
Add animated expand/collapse for subagent sessions

### DIFF
--- a/frontend/dist/css/components/subagent.css
+++ b/frontend/dist/css/components/subagent.css
@@ -107,12 +107,34 @@
 }
 
 .projects-list .session-subagent-list {
+    --session-subagent-list-height: 0px;
     position: relative;
     display: flex;
     flex-direction: column;
     gap: 0.06rem;
     margin-left: 0.78rem;
     padding-left: 0.78rem;
+    overflow: hidden;
+    max-height: var(--session-subagent-list-height);
+    opacity: 1;
+    transform: translateY(0);
+    transform-origin: top;
+    transition: max-height 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: auto;
+}
+
+.projects-list .session-subagent-list.is-expanded {
+    max-height: 100rem;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.projects-list .session-subagent-list.is-collapsed {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-1px);
+    pointer-events: none;
 }
 
 .projects-list .session-subagent-list::before {
@@ -124,6 +146,14 @@
     width: 1px;
     background: color-mix(in srgb, var(--border-color) 82%, transparent);
     opacity: 0.95;
+    transform-origin: top;
+    transform: scaleY(1);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.projects-list .session-subagent-list.is-collapsed::before {
+    opacity: 0;
+    transform: scaleY(0);
 }
 
 .projects-list .session-subagent-item {

--- a/frontend/dist/js/components/sidebar.js
+++ b/frontend/dist/js/components/sidebar.js
@@ -65,6 +65,7 @@ const expandedProjectSessionIds = new Set();
 const initializedProjectIds = new Set();
 const sessionWorkspaceMap = new Map();
 const automationBoundSessionIds = new Set();
+const renderedSubagentListExpandedState = new Map();
 let projectSortMode = 'recent';
 let openProjectMenuId = null;
 let projectMenuDismissBound = false;
@@ -267,24 +268,37 @@ function renderSubagentChildren(session) {
         return '';
     }
     const expanded = isSubagentSessionListExpanded(sessionId);
-    if (!expanded) {
-        return '';
-    }
+    const listWasExpanded = renderedSubagentListExpandedState.has(sessionId)
+        ? renderedSubagentListExpandedState.get(sessionId)
+        : expanded;
+    const hasChildren = hasLoadedSessionSubagents(sessionId)
+        && getSessionSubagentSessions(sessionId).length > 0;
     const loading = isSubagentSessionListLoading(sessionId);
     const children = getSessionSubagentSessions(sessionId);
+    const listClass = listWasExpanded ? 'is-expanded' : 'is-collapsed';
+    const listExpanded = listClass === 'is-expanded';
+    const listItemTabIndex = listExpanded ? '0' : '-1';
     if (loading && children.length === 0) {
         return `
-            <div class="session-subagent-list">
+            <div
+                class="session-subagent-list ${listClass}"
+                data-session-id="${escapeHtml(sessionId)}"
+                aria-hidden="${expanded ? 'false' : 'true'}"
+            >
                 <div class="session-subagent-empty">${escapeHtml(t('sidebar.subagent_sessions_loading'))}</div>
             </div>
         `;
     }
-    if (children.length === 0) {
+    if (!hasChildren) {
         return '';
     }
     const activeSubagent = getActiveSubagentSession();
     return `
-        <div class="session-subagent-list">
+        <div
+            class="session-subagent-list ${listClass}"
+            data-session-id="${escapeHtml(sessionId)}"
+            aria-hidden="${expanded ? 'false' : 'true'}"
+        >
             ${children.map(child => {
                 const active = !!(
                     activeSubagent
@@ -294,7 +308,7 @@ function renderSubagentChildren(session) {
                 return `
                     <div
                         class="session-item session-subagent-item${active ? ' active' : ''}"
-                        tabindex="0"
+                        tabindex="${listItemTabIndex}"
                         role="button"
                         data-session-id="${escapeHtml(sessionId)}"
                         data-subagent-instance-id="${escapeHtml(child.instanceId)}"
@@ -313,6 +327,7 @@ function renderSubagentChildren(session) {
                                 <button
                                     class="session-delete-btn session-subagent-delete-btn"
                                     type="button"
+                                    tabindex="${listItemTabIndex}"
                                     data-session-id="${escapeHtml(sessionId)}"
                                     data-subagent-instance-id="${escapeHtml(child.instanceId)}"
                                     data-subagent-run-id="${escapeHtml(child.runId)}"
@@ -331,6 +346,58 @@ function renderSubagentChildren(session) {
             }).join('')}
         </div>
     `;
+}
+
+function syncSubagentSessionListVisualState() {
+    if (!els.projectsList || typeof els.projectsList.querySelectorAll !== 'function') {
+        return;
+    }
+    const nextRenderedSessionIds = new Set();
+    const lists = Array.from(els.projectsList.querySelectorAll('.session-subagent-list[data-session-id]'));
+    if (!lists.length) {
+        return;
+    }
+
+    const applyState = () => {
+        for (const list of lists) {
+            const sessionId = String(list?.getAttribute?.('data-session-id') || '').trim();
+            if (!sessionId) {
+                continue;
+            }
+            nextRenderedSessionIds.add(sessionId);
+            const expanded = isSubagentSessionListExpanded(sessionId);
+            list.classList?.remove?.('is-expanded', 'is-collapsed');
+            list.classList?.add?.(expanded ? 'is-expanded' : 'is-collapsed');
+            list.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+            const shouldExpand = !!expanded;
+            list.style.setProperty(
+                '--session-subagent-list-height',
+                shouldExpand ? `${list.scrollHeight}px` : '0px',
+            );
+            list.style.pointerEvents = expanded ? '' : 'none';
+            const listItemTabIndex = shouldExpand ? '0' : '-1';
+            for (const item of Array.from(list.querySelectorAll('.session-subagent-item'))) {
+                item.setAttribute('tabindex', listItemTabIndex);
+            }
+            for (const deleteButton of Array.from(
+                list.querySelectorAll('.session-subagent-delete-btn'),
+            )) {
+                deleteButton.setAttribute('tabindex', listItemTabIndex);
+            }
+            renderedSubagentListExpandedState.set(sessionId, expanded);
+        }
+        for (const sessionId of renderedSubagentListExpandedState.keys()) {
+            if (!nextRenderedSessionIds.has(sessionId)) {
+                renderedSubagentListExpandedState.delete(sessionId);
+            }
+        }
+    };
+
+    if (typeof globalThis.requestAnimationFrame === 'function') {
+        globalThis.requestAnimationFrame(applyState);
+        return;
+    }
+    applyState();
 }
 
 function timestampValue(value) {
@@ -1080,7 +1147,15 @@ export async function loadProjects() {
     if (!languageRefreshBound && typeof document.addEventListener === 'function') {
         document.addEventListener('agent-teams-language-changed', () => void loadProjects());
         document.addEventListener('agent-teams-projects-changed', () => void loadProjects());
-        document.addEventListener('agent-teams-subagent-sessions-changed', () => scheduleSessionsRefresh(90));
+        document.addEventListener('agent-teams-subagent-sessions-changed', event => {
+            const detail = event?.detail;
+            const forceRefresh = detail && typeof detail === 'object' && 'forceRefresh' in detail
+                ? detail.forceRefresh === true
+                : true;
+            scheduleSessionsRefresh(90, {
+                forceRefresh,
+            });
+        });
         document.addEventListener('agent-teams-session-selected', () => void loadProjects());
         document.addEventListener('agent-teams-subagent-session-selected', () => void loadProjects());
         languageRefreshBound = true;
@@ -1136,6 +1211,7 @@ export async function loadProjects() {
         els.projectsList.innerHTML = '';
         nextNodes.forEach(node => els.projectsList.appendChild(node));
         syncProjectSortButton();
+        syncSubagentSessionListVisualState();
         playPendingSessionAnimation();
     } catch (error) {
         if (requestId !== loadProjectsRequestId) {
@@ -1145,12 +1221,13 @@ export async function loadProjects() {
     }
 }
 
-export function scheduleSessionsRefresh(delayMs = 120) {
+export function scheduleSessionsRefresh(delayMs = 120, { forceRefresh = false } = {}) {
     if (refreshTimer) clearTimeout(refreshTimer);
     const safeDelayMs = Math.max(0, Number(delayMs) || 0);
+    const forceNow = forceRefresh === true;
     refreshTimer = setTimeout(() => {
         refreshTimer = null;
-        if (isProjectsListInteracting()) {
+        if (!forceNow && isProjectsListInteracting()) {
             scheduleSessionsRefresh(Math.max(safeDelayMs, SIDEBAR_INTERACTION_REFRESH_DELAY_MS));
             return;
         }

--- a/tests/unit_tests/frontend/test_projects_sidebar_ui.py
+++ b/tests/unit_tests/frontend/test_projects_sidebar_ui.py
@@ -348,6 +348,171 @@ export async function runAutomationProject() {
     }
 
 
+def test_projects_sidebar_subagent_children_keep_state_for_transition_classes(
+    tmp_path: Path,
+) -> None:
+    payload = _run_sidebar_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import {
+    loadProjects,
+} from "./sidebar.mjs";
+
+globalThis.__sessionSubagentSessionsMap = {
+    "session-1": [
+        {
+            sessionId: "session-1",
+            instanceId: "inst-sub-1",
+            roleId: "Explorer",
+            runId: "subagent_run_1",
+            title: "Explore history",
+            updatedAt: "2026-03-14T10:12:00Z",
+        },
+        {
+            sessionId: "session-1",
+            instanceId: "inst-sub-2",
+            roleId: "Crafter",
+            runId: "subagent_run_2",
+            title: "Draft summary",
+            updatedAt: "2026-03-14T10:13:00Z",
+        },
+    ],
+};
+globalThis.__expandedSubagentSessionIds.add("session-1");
+
+await loadProjects();
+
+let projectsList = document.getElementById("projects-list");
+let firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
+const firstRenderList = firstProject.querySelector(".session-subagent-list");
+
+globalThis.__expandedSubagentSessionIds.delete("session-1");
+await loadProjects();
+await flushTasks();
+
+projectsList = document.getElementById("projects-list");
+firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
+const collapsedRenderList = firstProject.querySelector(".session-subagent-list");
+
+globalThis.__expandedSubagentSessionIds.add("session-1");
+await loadProjects();
+await flushTasks();
+
+projectsList = document.getElementById("projects-list");
+firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
+const reopenRenderList = firstProject.querySelector(".session-subagent-list");
+
+console.log(JSON.stringify({
+    firstRenderClass: firstRenderList.className,
+    collapsedRenderClass: collapsedRenderList.className,
+    collapsedAria: collapsedRenderList.getAttribute("aria-hidden"),
+    reopenedRenderClass: reopenRenderList.className,
+    collapsedChildCount: firstProject.querySelectorAll(".session-subagent-item").length,
+}));
+""".strip(),
+        mock_api_source="""
+const workspaces = [
+    {
+        workspace_id: "alpha-project",
+        root_path: "/work/Alpha Project",
+        updated_at: "2026-03-14T10:00:00Z",
+        profile: {
+            file_scope: {
+                backend: "project",
+            },
+        },
+    },
+];
+
+const sessions = [
+    {
+        session_id: "session-1",
+        workspace_id: "alpha-project",
+        session_mode: "normal",
+        updated_at: "2026-03-14T10:11:00Z",
+        pending_tool_approval_count: 0,
+        metadata: { title: "Root session" },
+    },
+];
+
+export async function fetchWorkspaces() {
+    return workspaces;
+}
+
+export async function fetchSessions() {
+    return sessions;
+}
+
+export async function fetchAutomationProjects() {
+    return [];
+}
+
+export async function fetchAutomationFeishuBindings() {
+    return [];
+}
+
+export async function startNewSession() {
+    throw new Error("not used");
+}
+
+export async function updateSession() {
+    return { status: "ok" };
+}
+
+export async function pickWorkspace() {
+    throw new Error("not used");
+}
+
+export async function forkWorkspace() {
+    throw new Error("not used");
+}
+
+export async function deleteSession() {
+    return undefined;
+}
+
+export async function deleteWorkspace() {
+    return { status: "ok" };
+}
+
+export async function createAutomationProject() {
+    throw new Error("not used");
+}
+
+export async function deleteAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function disableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function enableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function runAutomationProject() {
+    throw new Error("not used");
+}
+""".strip(),
+    )
+
+    repo_root = Path(__file__).resolve().parents[3]
+    sidebar_script = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sidebar.js"
+    ).read_text(encoding="utf-8")
+    components_css = load_components_css()
+
+    assert "is-expanded" in str(payload["firstRenderClass"])
+    assert "is-collapsed" in str(payload["collapsedRenderClass"])
+    assert payload["collapsedAria"] == "true"
+    assert "is-expanded" in str(payload["reopenedRenderClass"])
+    assert payload["collapsedChildCount"] == 2
+    assert ".session-subagent-list.is-collapsed" in components_css
+    assert ".session-subagent-list.is-expanded" in components_css
+    assert "function syncSubagentSessionListVisualState" in sidebar_script
+
+
 def test_projects_sidebar_uses_session_summary_for_subagent_toggle_without_prefetch(
     tmp_path: Path,
 ) -> None:
@@ -1978,6 +2143,269 @@ console.log(JSON.stringify({
     }
 
 
+def test_projects_sidebar_force_refreshes_subagent_events_even_when_hovering(
+    tmp_path: Path,
+) -> None:
+    payload = _run_sidebar_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { loadProjects } from "./sidebar.mjs";
+
+await loadProjects();
+
+const initialCounts = { ...globalThis.__fetchCounts };
+globalThis.__projectsListHover = true;
+document.dispatchEvent({
+    type: "agent-teams-subagent-sessions-changed",
+    detail: { forceRefresh: true },
+});
+await new Promise(resolve => setTimeout(resolve, 160));
+
+const refreshedCounts = { ...globalThis.__fetchCounts };
+
+console.log(JSON.stringify({
+    initialCounts,
+    refreshedCounts,
+}));
+""".strip(),
+        mock_api_source="""
+const workspaces = [
+    {
+        workspace_id: "alpha-project",
+        root_path: "/work/Alpha Project",
+        updated_at: "2026-03-14T10:00:00Z",
+        profile: {
+            file_scope: {
+                backend: "project",
+            },
+        },
+    },
+];
+
+const sessions = [
+    {
+        session_id: "session-1",
+        workspace_id: "alpha-project",
+        session_mode: "normal",
+        updated_at: "2026-03-14T10:11:00Z",
+        pending_tool_approval_count: 0,
+        metadata: { title: "Root session" },
+    },
+];
+
+globalThis.__fetchCounts = {
+    workspaces: 0,
+    sessions: 0,
+    automationProjects: 0,
+};
+
+export async function fetchWorkspaces() {
+    globalThis.__fetchCounts.workspaces += 1;
+    return workspaces;
+}
+
+export async function fetchSessions() {
+    globalThis.__fetchCounts.sessions += 1;
+    return sessions;
+}
+
+export async function fetchAutomationProjects() {
+    globalThis.__fetchCounts.automationProjects += 1;
+    return [];
+}
+
+export async function fetchAutomationFeishuBindings() {
+    return [];
+}
+
+export async function startNewSession() {
+    throw new Error("not used");
+}
+
+export async function updateSession() {
+    return { status: "ok" };
+}
+
+export async function pickWorkspace() {
+    throw new Error("not used");
+}
+
+export async function forkWorkspace() {
+    throw new Error("not used");
+}
+
+export async function deleteSession() {
+    return undefined;
+}
+
+export async function deleteWorkspace() {
+    return { status: "ok" };
+}
+
+export async function createAutomationProject() {
+    throw new Error("not used");
+}
+
+export async function deleteAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function disableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function enableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function runAutomationProject() {
+    throw new Error("not used");
+}
+""".strip(),
+    )
+
+    assert payload["initialCounts"] == {
+        "workspaces": 1,
+        "sessions": 1,
+        "automationProjects": 1,
+    }
+    assert payload["refreshedCounts"] == {
+        "workspaces": 2,
+        "sessions": 2,
+        "automationProjects": 2,
+    }
+
+
+def test_projects_sidebar_defaults_subagent_events_to_force_refresh_when_detail_missing(
+    tmp_path: Path,
+) -> None:
+    payload = _run_sidebar_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { loadProjects } from "./sidebar.mjs";
+
+await loadProjects();
+
+const initialCounts = { ...globalThis.__fetchCounts };
+globalThis.__projectsListHover = true;
+document.dispatchEvent({
+    type: "agent-teams-subagent-sessions-changed",
+});
+await new Promise(resolve => setTimeout(resolve, 180));
+
+const refreshedCounts = { ...globalThis.__fetchCounts };
+
+console.log(JSON.stringify({
+    initialCounts,
+    refreshedCounts,
+}));""".strip(),
+        mock_api_source="""
+const workspaces = [
+    {
+        workspace_id: "alpha-project",
+        root_path: "/work/Alpha Project",
+        updated_at: "2026-03-14T10:00:00Z",
+        profile: {
+            file_scope: {
+                backend: "project",
+            },
+        },
+    },
+];
+
+const sessions = [
+    {
+        session_id: "session-1",
+        workspace_id: "alpha-project",
+        session_mode: "normal",
+        updated_at: "2026-03-14T10:11:00Z",
+        pending_tool_approval_count: 0,
+        metadata: { title: "Root session" },
+    },
+];
+
+globalThis.__fetchCounts = {
+    workspaces: 0,
+    sessions: 0,
+    automationProjects: 0,
+};
+
+export async function fetchWorkspaces() {
+    globalThis.__fetchCounts.workspaces += 1;
+    return workspaces;
+}
+
+export async function fetchSessions() {
+    globalThis.__fetchCounts.sessions += 1;
+    return sessions;
+}
+
+export async function fetchAutomationProjects() {
+    globalThis.__fetchCounts.automationProjects += 1;
+    return [];
+}
+
+export async function fetchAutomationFeishuBindings() {
+    return [];
+}
+
+export async function startNewSession() {
+    throw new Error("not used");
+}
+
+export async function updateSession() {
+    return { status: "ok" };
+}
+
+export async function pickWorkspace() {
+    throw new Error("not used");
+}
+
+export async function forkWorkspace() {
+    throw new Error("not used");
+}
+
+export async function deleteSession() {
+    return undefined;
+}
+
+export async function deleteWorkspace() {
+    return { status: "ok" };
+}
+
+export async function createAutomationProject() {
+    throw new Error("not used");
+}
+
+export async function deleteAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function disableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function enableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function runAutomationProject() {
+    throw new Error("not used");
+}""".strip(),
+    )
+
+    assert payload["initialCounts"] == {
+        "workspaces": 1,
+        "sessions": 1,
+        "automationProjects": 1,
+    }
+    assert payload["refreshedCounts"] == {
+        "workspaces": 2,
+        "sessions": 2,
+        "automationProjects": 2,
+    }
+
+
 def test_projects_sidebar_hover_hint_preserves_project_action_space() -> None:
     components_css = load_components_css()
 
@@ -2163,8 +2591,9 @@ function parseElements(source, selector) {
             ".project-fork-btn": /class="[^"]*project-fork-btn[^"]*"[^>]*>/g,
             ".project-remove-btn": /class="[^"]*project-remove-btn[^"]*"[^>]*>/g,
         ".project-session-visibility-btn": /class="project-session-visibility-btn"[^>]*>([\s\S]*?)<\/button>/g,
-        ".session-subagents-toggle": /class="session-subagents-toggle"[^>]*data-session-id="([^"]+)"[^>]*aria-expanded="([^"]+)"[^>]*>/g,
-        ".session-subagent-item": /class="([^"]*session-subagent-item[^"]*)"[^>]*data-session-id="([^"]+)"[^>]*data-subagent-instance-id="([^"]+)"[^>]*data-subagent-role-id="([^"]+)"[^>]*data-subagent-run-id="([^"]+)"[^>]*data-subagent-title="([^"]*)"[^>]*>[\s\S]*?<span class="session-label-text">([\s\S]*?)<\/span>/g,
+            ".session-subagents-toggle": /class="session-subagents-toggle"[^>]*data-session-id="([^"]+)"[^>]*aria-expanded="([^"]+)"[^>]*>/g,
+            ".session-subagent-list": /class="([^"]*session-subagent-list[^"]*)"[^>]*data-session-id="([^"]+)"[^>]*aria-hidden="([^"]+)"[^>]*>/g,
+            ".session-subagent-item": /class="([^"]*session-subagent-item[^"]*)"[^>]*data-session-id="([^"]+)"[^>]*data-subagent-instance-id="([^"]+)"[^>]*data-subagent-role-id="([^"]+)"[^>]*data-subagent-run-id="([^"]+)"[^>]*data-subagent-title="([^"]*)"[^>]*>[\s\S]*?<span class="session-label-text">([\s\S]*?)<\/span>/g,
         ".session-subagent-delete-btn": /class="([^"]*session-subagent-delete-btn[^"]*)"[^>]*data-session-id="([^"]+)"[^>]*data-subagent-instance-id="([^"]+)"[^>]*data-subagent-run-id="([^"]+)"[^>]*data-subagent-label="([^"]*)"[^>]*>/g,
         ".session-subagent-empty": /class="session-subagent-empty"[^>]*>([\s\S]*?)<\/div>/g,
         ".session-rename-btn": /class="session-rename-btn"[^>]*data-session-id="([^"]+)"[^>]*data-session-metadata="([^"]*)"[^>]*>/g,
@@ -2213,6 +2642,14 @@ function parseElements(source, selector) {
                 attributes: {
                     "data-session-id": match[1],
                     "aria-expanded": match[2],
+                },
+            }));
+        } else if (selector === ".session-subagent-list") {
+            results.push(createNode({
+                className: match[1],
+                attributes: {
+                    "data-session-id": match[2],
+                    "aria-hidden": match[3],
                 },
             }));
         } else if (selector === ".session-subagent-item") {


### PR DESCRIPTION
Fixes #458

Add animated expand/collapse for subagent sessions in sidebar and keep list state for smooth transitions. The UI now preserves DOM for transition, updates a11y/pointer state, and includes unit coverage for class/state rendering.