### PR TITLE
feat: add event-driven system reminders

### DIFF
--- a/docs/relay-teams-runtime-hooks-design.md
+++ b/docs/relay-teams-runtime-hooks-design.md
@@ -792,6 +792,21 @@ The current implementation is still intentionally narrower than the full design 
 - hook conflict warning events described in section 7.2 are not yet implemented; the runtime currently applies the merged winning decision without a dedicated conflict event
 
 These remaining gaps do not block the current phase 1 rollout target.
+
+### 17.1.2 Hooks vs Built-In System Reminders
+
+Runtime hooks are the user/project/role/skill extension layer. They remain the right
+place for custom command, HTTP, prompt, or agent handlers.
+
+Built-in system reminders live in `src/relay_teams/reminders/` and own product
+runtime policy such as tool failure nudges, read-only streak nudges, incomplete todo
+completion guards, and post-compaction reminders. These policies must not be modeled
+as default hooks because they need deterministic execution, run-scoped state, and
+pre-terminal completion decisions.
+
+Hooks and reminders share the low-level `SystemInjectionSink`, but hooks do not own
+the reminder policy engine.
+
 ### 17.2 Phase 2
 
 Deliver:
@@ -917,5 +932,4 @@ The recommended first implementation cut is intentionally narrow:
 - add unit tests before expanding to prompt and agent hooks
 
 This gives Relay Teams a strong first cut of runtime hooks with limited architectural risk and minimal conflict with the current approval and orchestration model.
-
 

--- a/docs/system-module-boundaries.md
+++ b/docs/system-module-boundaries.md
@@ -29,6 +29,9 @@ With the current layout, that means:
 - `monitors/*` owns the event-driven substrate itself: normalized envelopes,
   subscription persistence, deterministic matching, cooldown/dedupe, and action
   dispatch.
+- `reminders/*` owns built-in runtime reminder policy, reminder state, and
+  `<system-reminder>` rendering. It consumes typed observations from execution,
+  orchestration, and prompt maintenance boundaries.
 - `notifications/*` owns outbound notification delivery only.
 - `persistence/*` and module-local `repository.py` files own storage mechanics only;
   they should not perform orchestration decisions.
@@ -85,6 +88,8 @@ Boundary:
 
 ### Other Shared Infra
 
+- `sessions/runs/system_injection.py`: shared system-originated message delivery for
+  hooks, reminders, monitor follow-ups, and other runtime wake-up paths.
 - `logger/*`: structured logging and diagnostics.
 - `net/*`: proxy-aware HTTP client construction and transport policy.
 - `secrets/*`: secret persistence and masking.

--- a/docs/system-prompt-layering.md
+++ b/docs/system-prompt-layering.md
@@ -32,6 +32,15 @@
 
 `workspace_context` 是放置 workspace、日期、shell、run-specific 信息的默认位置。
 
+## System Reminders
+
+`<system-reminder>` 不属于 provider system prompt 的稳定前缀，也不应该作为
+`workspace_context` section 注入。它是运行时根据 tool、todo、compaction 等状态生成
+的 system-originated user-role message。
+
+这些消息进入会话历史或注入队列，由模型在下一次安全边界看到。这样可以避免为了短期
+运行时状态重写稳定 system prompt，同时保留完整的时间线可观测性。
+
 ## 稳定前缀规则
 
 为了保护 KV cache，下面内容不得因为 workspace、SSH profile、日期或 run 状态改变而移动或重写：

--- a/docs/system-reminders-design.md
+++ b/docs/system-reminders-design.md
@@ -1,0 +1,107 @@
+# System Reminders Design
+
+## 1. Goal
+
+Relay Teams needs built-in runtime reminders that turn important runtime state into
+deterministic guidance for the active agent loop.
+
+This feature covers:
+
+- tool failure reminders
+- consecutive read-only tool reminders
+- incomplete todo completion guards
+- context compaction reminders
+
+The goal is not to add another user-configurable extension system. Runtime reminders
+are product-owned behavior that should work without user hook configuration.
+
+## 2. Boundary With Runtime Hooks
+
+Runtime hooks and system reminders intentionally overlap at lifecycle boundaries, but
+they own different concerns.
+
+Hooks are external extension points:
+
+- configured by user, project, role, or skill sources
+- implemented through command, HTTP, prompt, or agent handlers
+- allowed to fail, timeout, or be absent without disabling core behavior
+- useful for custom governance and integrations
+
+System reminders are built-in runtime policy:
+
+- enabled by default
+- deterministic and covered by unit tests
+- stateful across a run for cooldowns and counters
+- allowed to block task completion before terminal state is written
+
+Both systems share the same message injection primitive. Hooks use it to enqueue
+`additional_context` or `deferred_action`; reminders use it to inject
+`<system-reminder>` messages.
+
+## 3. Runtime Flow
+
+The reminder pipeline is:
+
+```text
+runtime boundary
+-> typed observation
+-> SystemReminderPolicy
+-> ReminderStateRepository
+-> SystemReminderRenderer
+-> SystemInjectionSink
+-> active LLM loop or persisted retry history
+```
+
+`relay_teams.reminders` owns policy, state, and rendering. Execution, orchestration,
+and prompt modules only report observations and consume decisions.
+
+`sessions/runs/system_injection.py` owns the shared delivery boundary:
+
+- `enqueue_only` wakes an already-active loop at the next safe boundary.
+- `append_and_enqueue` also persists the reminder into conversation history before
+  retrying a completion attempt.
+
+## 4. V1 Policies
+
+Tool failure:
+
+- triggered after a failed tool result
+- deduped per run, tool name, and error type with a cooldown
+- reminds the agent to inspect the error and avoid repeating the same call unchanged
+
+Read-only streak:
+
+- triggered after five consecutive known read-only tools
+- unknown tools are neutral and do not count
+- `shell` is not considered read-only in v1
+
+Incomplete todos:
+
+- evaluated only for root task completion attempts
+- pending or in-progress todos block successful completion
+- the reminder is appended to history and the agent gets another turn
+- after three reminder retries, the task returns an assistant error instead of being
+  marked complete
+
+Context pressure:
+
+- triggered after compaction is applied
+- reminds the agent that old tool output may no longer be available verbatim
+
+## 5. Public Interfaces
+
+No new `/api/*`, CLI, SDK, or database schema is introduced.
+
+Reminder state is stored through `SharedStateRepository` with run-scoped keys under
+the session scope. The schema is private to `relay_teams.reminders`.
+
+## 6. Testing
+
+The feature is covered by focused unit tests for:
+
+- reminder rendering
+- policy decisions and cooldown behavior
+- persisted reminder state recovery
+- service-to-injection behavior
+- shared system injection sink behavior
+- root task retry when incomplete todos block completion

--- a/src/relay_teams/agents/execution/agent_llm_session.py
+++ b/src/relay_teams/agents/execution/agent_llm_session.py
@@ -54,6 +54,7 @@ from relay_teams.providers.model_fallback import (
     LlmFallbackMiddleware,
 )
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
+from relay_teams.reminders import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
@@ -139,6 +140,7 @@ class AgentLlmSession(
         computer_runtime: ComputerRuntime | None = None,
         shell_approval_repo: ShellApprovalRepository | None = None,
         hook_service: HookService | None = None,
+        reminder_service: SystemReminderService | None = None,
     ) -> None:
         self._config = config
         self._profile_name = (
@@ -192,6 +194,7 @@ class AgentLlmSession(
         self._computer_runtime = computer_runtime
         self._shell_approval_repo = shell_approval_repo
         self._hook_service = hook_service
+        self._reminder_service = reminder_service
         self._mcp_tool_context_token_cache: dict[str, int] = {}
 
 

--- a/src/relay_teams/agents/execution/conversation_compaction.py
+++ b/src/relay_teams/agents/execution/conversation_compaction.py
@@ -920,7 +920,7 @@ def _clip_rendered_message_suffix(text: str, *, max_chars: int) -> str:
     suffix = stripped[-max_chars:].lstrip()
     first_newline = suffix.find("\n")
     if first_newline < 0:
-        return ""
+        return suffix
     candidate = suffix[first_newline + 1 :].lstrip()
     return candidate or suffix
 

--- a/src/relay_teams/agents/execution/conversation_compaction.py
+++ b/src/relay_teams/agents/execution/conversation_compaction.py
@@ -800,12 +800,55 @@ def _render_transcript(
     *,
     max_chars: int,
 ) -> str:
+    rendered_messages = [
+        rendered for message in history if (rendered := _render_message(message))
+    ]
+    full_transcript = "\n\n".join(rendered_messages).strip()
+    if not full_transcript:
+        return ""
+    if len(full_transcript) <= max_chars:
+        return full_transcript
+    if len(rendered_messages) <= 1:
+        clipped, _ = _clip_rendered_message(full_transcript, max_chars=max_chars)
+        return clipped.strip()
+    marker = "[... transcript middle clipped; newest compacted turns preserved ...]"
+    separator_budget = len(marker) + 4
+    if max_chars <= separator_budget:
+        return _render_transcript_prefix(
+            rendered_messages,
+            max_chars=max_chars,
+        )
+    content_budget = max_chars - separator_budget
+    if content_budget < 80:
+        return _render_transcript_prefix(
+            rendered_messages,
+            max_chars=max_chars,
+        )
+    prefix_budget = max(1, content_budget // 2)
+    suffix_budget = max(1, content_budget - prefix_budget)
+    prefix = _render_transcript_prefix(
+        rendered_messages,
+        max_chars=prefix_budget,
+    )
+    suffix = _render_transcript_suffix(
+        rendered_messages,
+        max_chars=suffix_budget,
+    )
+    if not prefix:
+        return suffix.strip()
+    if not suffix:
+        return prefix.strip()
+    return f"{prefix}\n\n{marker}\n\n{suffix}".strip()
+
+
+def _render_transcript_prefix(
+    rendered_messages: Sequence[str],
+    *,
+    max_chars: int,
+) -> str:
     remaining = max_chars
     lines: list[str] = []
-    for message in history:
-        rendered = _render_message(message)
-        if not rendered:
-            continue
+    for rendered in rendered_messages:
         clipped, truncated = _clip_rendered_message(rendered, max_chars=remaining)
         if clipped:
             lines.append(clipped)
@@ -813,6 +856,26 @@ def _render_transcript(
         if truncated or remaining <= 0:
             break
     return "\n\n".join(lines).strip()
+
+
+def _render_transcript_suffix(
+    rendered_messages: Sequence[str],
+    *,
+    max_chars: int,
+) -> str:
+    selected: list[str] = []
+    for rendered in reversed(rendered_messages):
+        candidate_parts = [rendered, *selected]
+        candidate = "\n\n".join(candidate_parts).strip()
+        if len(candidate) <= max_chars:
+            selected.insert(0, rendered)
+            continue
+        if not selected:
+            clipped = _clip_rendered_message_suffix(rendered, max_chars=max_chars)
+            if clipped:
+                selected.insert(0, clipped)
+        break
+    return "\n\n".join(selected).strip()
 
 
 def _clip_rendered_message(text: str, *, max_chars: int) -> tuple[str, bool]:
@@ -846,6 +909,20 @@ def _clip_prefix_to_safe_boundary(prefix: str, *, minimum_index: int) -> str:
         if candidate:
             return candidate
     return prefix
+
+
+def _clip_rendered_message_suffix(text: str, *, max_chars: int) -> str:
+    stripped = text.strip()
+    if not stripped or max_chars <= 0:
+        return ""
+    if len(stripped) <= max_chars:
+        return stripped
+    suffix = stripped[-max_chars:].lstrip()
+    first_newline = suffix.find("\n")
+    if first_newline < 0:
+        return ""
+    candidate = suffix[first_newline + 1 :].lstrip()
+    return candidate or suffix
 
 
 def _render_message(message: ModelRequest | ModelResponse) -> str:

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -122,6 +122,12 @@ class PromptHistoryMessageRepository(Protocol):
         conversation_id: str,
     ) -> list[ModelRequest | ModelResponse]: ...
 
+    def get_history_for_conversation_task(
+        self,
+        conversation_id: str,
+        task_id: str,
+    ) -> list[ModelRequest | ModelResponse]: ...
+
     def prune_conversation_history_to_safe_boundary(
         self,
         conversation_id: str,
@@ -244,6 +250,12 @@ class PromptHistoryService:
         allowed_skills: tuple[str, ...],
     ) -> PreparedPromptContext:
         history = self._load_safe_history_for_conversation(conversation_id)
+        history, protected_current_prompt = self._split_protected_current_prompt(
+            request=request,
+            conversation_id=conversation_id,
+            history=history,
+            reserve_user_prompt_tokens=reserve_user_prompt_tokens,
+        )
         source_history = list(history)
         provisional_system_prompt = self.inject_compaction_summary(
             session_id=request.session_id,
@@ -288,6 +300,8 @@ class PromptHistoryService:
             request=request,
             history=history,
         )
+        if protected_current_prompt is not None:
+            history.append(protected_current_prompt)
         final_system_prompt = self.inject_compaction_summary(
             session_id=request.session_id,
             conversation_id=conversation_id,
@@ -311,6 +325,59 @@ class PromptHistoryService:
             microcompact_compacted_message_count=compacted_message_count,
             microcompact_compacted_part_count=compacted_part_count,
         )
+
+    def _split_protected_current_prompt(
+        self,
+        *,
+        request: LLMRequest,
+        conversation_id: str,
+        history: Sequence[ModelRequest | ModelResponse],
+        reserve_user_prompt_tokens: bool,
+    ) -> tuple[list[ModelRequest | ModelResponse], ModelRequest | None]:
+        candidate_history = list(history)
+        if not reserve_user_prompt_tokens:
+            return candidate_history, None
+        current_keys = self._current_request_prompt_keys(
+            request=request,
+            conversation_id=conversation_id,
+        )
+        if not current_keys:
+            return candidate_history, None
+        if not any(
+            history_ends_with_user_prompt(candidate_history, current_key)
+            for current_key in current_keys
+        ):
+            return candidate_history, None
+        protected_prompt = candidate_history.pop()
+        if not isinstance(protected_prompt, ModelRequest):
+            return candidate_history, None
+        return candidate_history, protected_prompt
+
+    def _current_request_prompt_keys(
+        self,
+        *,
+        request: LLMRequest,
+        conversation_id: str,
+    ) -> tuple[str, ...]:
+        keys: list[str] = []
+        current_content = self.current_request_prompt_content(request)
+        if current_content is not None:
+            current_key = user_prompt_content_key(current_content)
+            if current_key and current_key not in keys:
+                keys.append(current_key)
+        task_history = self._message_repo.get_history_for_conversation_task(
+            conversation_id,
+            request.task_id,
+        )
+        for message in reversed(task_history):
+            if not isinstance(message, ModelRequest):
+                continue
+            current_key = user_prompt_parts_key(parts=message.parts)
+            if current_key:
+                if current_key not in keys:
+                    keys.append(current_key)
+                break
+        return tuple(keys)
 
     def coerce_history_to_provider_safe_sequence(
         self,

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -68,6 +68,11 @@ from relay_teams.media import (
 )
 from relay_teams.providers.model_config import ModelEndpointConfig
 from relay_teams.providers.provider_contracts import LLMRequest
+from relay_teams.reminders import (
+    ContextPressureObservation,
+    ReminderKind,
+    SystemReminderService,
+)
 from relay_teams.sessions.runs.assistant_errors import (
     AssistantRunError,
     AssistantRunErrorPayload,
@@ -201,6 +206,7 @@ class PromptHistoryService:
         mcp_tool_context_token_cache: dict[str, int],
         media_asset_service: object | None,
         hook_service: object | None,
+        reminder_service: SystemReminderService | None,
         run_event_hub: object,
         load_safe_history_for_conversation: Callable[
             [str], list[ModelRequest | ModelResponse]
@@ -215,6 +221,7 @@ class PromptHistoryService:
         self._mcp_tool_context_token_cache = mcp_tool_context_token_cache
         self._media_asset_service = media_asset_service
         self._hook_service = hook_service
+        self._reminder_service = reminder_service
         self._run_event_hub = run_event_hub
         self._load_safe_history_for_conversation = load_safe_history_for_conversation
 
@@ -603,6 +610,27 @@ class PromptHistoryService:
                     ),
                 ),
                 run_event_hub=self._run_event_hub,
+            )
+        if compacted_result.applied and self._reminder_service is not None:
+            _ = self._reminder_service.observe_context_pressure(
+                ContextPressureObservation(
+                    session_id=request.session_id,
+                    run_id=request.run_id,
+                    trace_id=request.trace_id,
+                    task_id=request.task_id,
+                    instance_id=request.instance_id,
+                    role_id=request.role_id,
+                    conversation_id=conversation_id,
+                    kind=ReminderKind.POST_COMPACTION,
+                    message_count_before=len(history),
+                    message_count_after=len(compacted_history),
+                    estimated_tokens_before=estimated_tokens_before_microcompact or 0,
+                    estimated_tokens_after=ConversationTokenEstimator().estimate_history_tokens(
+                        compacted_history
+                    ),
+                    threshold_tokens=plan.threshold_tokens,
+                    target_tokens=plan.target_tokens,
+                )
             )
         return compacted_history
 

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -262,8 +262,12 @@ class PromptHistoryService:
             conversation_id=conversation_id,
             system_prompt=system_prompt,
         )
-        budget = await self.estimate_compaction_budget(
+        compaction_budget_request = self._request_with_protected_prompt_for_budget(
             request=request,
+            protected_prompt=protected_current_prompt,
+        )
+        budget = await self.estimate_compaction_budget(
+            request=compaction_budget_request,
             history=history,
             system_prompt=provisional_system_prompt,
             reserve_user_prompt_tokens=reserve_user_prompt_tokens,
@@ -378,6 +382,19 @@ class PromptHistoryService:
                     keys.append(current_key)
                 break
         return tuple(keys)
+
+    def _request_with_protected_prompt_for_budget(
+        self,
+        *,
+        request: LLMRequest,
+        protected_prompt: ModelRequest | None,
+    ) -> LLMRequest:
+        if protected_prompt is None or request.prompt_text.strip():
+            return request
+        prompt_text = extract_user_prompt_text(protected_prompt)
+        if prompt_text is None:
+            return request
+        return request.model_copy(update={"user_prompt": prompt_text, "input": ()})
 
     def coerce_history_to_provider_safe_sequence(
         self,

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -302,6 +302,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 notification_service=self._notification_service,
                 im_tool_service=self._im_tool_service,
                 hook_service=hook_service,
+                reminder_service=getattr(self, "_reminder_service", None),
                 model_capabilities=self._config.capabilities,
                 hook_runtime_env=hook_runtime_env,
             )

--- a/src/relay_teams/agents/execution/session_support.py
+++ b/src/relay_teams/agents/execution/session_support.py
@@ -1080,6 +1080,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             mcp_tool_context_token_cache=mcp_tool_context_token_cache,
             media_asset_service=getattr(self, "_media_asset_service", None),
             hook_service=getattr(self, "_hook_service", None),
+            reminder_service=getattr(self, "_reminder_service", None),
             run_event_hub=getattr(self, "_run_event_hub", None),
             load_safe_history_for_conversation=getattr(
                 self,

--- a/src/relay_teams/agents/execution/session_support.py
+++ b/src/relay_teams/agents/execution/session_support.py
@@ -66,6 +66,14 @@ class _NullPromptHistoryMessageRepo:
         _ = conversation_id
         return []
 
+    def get_history_for_conversation_task(
+        self,
+        conversation_id: str,
+        task_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        _ = (conversation_id, task_id)
+        return []
+
     def prune_conversation_history_to_safe_boundary(
         self,
         conversation_id: str,

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -43,6 +43,12 @@ from relay_teams.media import MediaAssetService, merge_user_prompt_content
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.reminders import (
+    CompletionAttemptObservation,
+    IncompleteTodoItem,
+    ReminderDecision,
+    SystemReminderService,
+)
 from relay_teams.roles.memory_injection import build_role_with_memory
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
@@ -71,6 +77,8 @@ from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeRepository,
     RunRuntimeStatus,
 )
+from relay_teams.sessions.runs.todo_models import TodoStatus
+from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.hooks import HookEventName, HookService, TaskCompletedInput
 from relay_teams.skills.skill_models import SkillInstructionEntry
 from relay_teams.skills.skill_registry import SkillRegistry
@@ -110,6 +118,8 @@ class TaskExecutionService(BaseModel):
     run_intent_repo: RunIntentRepository | None = None
     media_asset_service: MediaAssetService | None = None
     hook_service: HookService | None = None
+    todo_service: TodoService | None = None
+    reminder_service: SystemReminderService | None = None
 
     async def execute(
         self,
@@ -272,17 +282,19 @@ class TaskExecutionService(BaseModel):
                 runtime_prompt_sections=runtime_prompt_sections,
                 skill_instructions=prepared_runtime_snapshot.skill_instructions,
             )
-            result = await runner.run(
+            guarded_result = await self._run_with_completion_guard(
+                runner=runner,
                 task=task,
                 instance_id=instance_id,
-                workspace_id=workspace.ref.workspace_id,
-                working_directory=workspace.resolve_workdir(),
+                role_id=role_id,
+                workspace=workspace,
                 conversation_id=workspace.ref.conversation_id,
                 shared_state_snapshot=snapshot,
-                thinking=self._thinking_for_run(task.trace_id),
                 system_prompt_override=provider_system_prompt,
-                user_prompt=None,
             )
+            if isinstance(guarded_result, TaskExecutionResult):
+                return guarded_result
+            result = guarded_result
             self.task_repo.update_status(
                 task.task_id, TaskStatus.COMPLETED, result=result
             )
@@ -487,6 +499,139 @@ class TaskExecutionService(BaseModel):
                 error_code="internal_execution_error",
                 error_message=str(exc),
             )
+
+    async def _run_with_completion_guard(
+        self,
+        *,
+        runner: SubAgentRunner,
+        task: TaskEnvelope,
+        instance_id: str,
+        role_id: str,
+        workspace: WorkspaceHandle,
+        conversation_id: str,
+        shared_state_snapshot: tuple[tuple[str, str], ...],
+        system_prompt_override: str,
+    ) -> str | TaskExecutionResult:
+        result = await self._run_agent_once(
+            runner=runner,
+            task=task,
+            instance_id=instance_id,
+            workspace=workspace,
+            conversation_id=conversation_id,
+            shared_state_snapshot=shared_state_snapshot,
+            system_prompt_override=system_prompt_override,
+        )
+        while True:
+            decision = self._evaluate_completion_guard(
+                task=task,
+                instance_id=instance_id,
+                role_id=role_id,
+                workspace=workspace,
+                conversation_id=conversation_id,
+                output_text=result,
+            )
+            if not decision.issue:
+                return result
+            if decision.retry_completion:
+                log_event(
+                    LOGGER,
+                    logging.INFO,
+                    event="task.execution.completion_reminder_retry",
+                    message="Retrying task after system reminder blocked completion",
+                    payload={
+                        "task_id": task.task_id,
+                        "instance_id": instance_id,
+                        "role_id": role_id,
+                        "reason": decision.reason,
+                    },
+                )
+                result = await self._run_agent_once(
+                    runner=runner,
+                    task=task,
+                    instance_id=instance_id,
+                    workspace=workspace,
+                    conversation_id=conversation_id,
+                    shared_state_snapshot=shared_state_snapshot,
+                    system_prompt_override=system_prompt_override,
+                )
+                continue
+            if decision.fail_completion:
+                assistant_message = build_assistant_error_message(
+                    error_code="incomplete_todos",
+                    error_message=decision.content,
+                )
+                return self._complete_with_assistant_error(
+                    task=task,
+                    instance_id=instance_id,
+                    role_id=role_id,
+                    conversation_id=conversation_id,
+                    workspace_id=workspace.ref.workspace_id,
+                    assistant_message=assistant_message,
+                    error_code="incomplete_todos",
+                    error_message=decision.content,
+                )
+            return result
+
+    async def _run_agent_once(
+        self,
+        *,
+        runner: SubAgentRunner,
+        task: TaskEnvelope,
+        instance_id: str,
+        workspace: WorkspaceHandle,
+        conversation_id: str,
+        shared_state_snapshot: tuple[tuple[str, str], ...],
+        system_prompt_override: str,
+    ) -> str:
+        return await runner.run(
+            task=task,
+            instance_id=instance_id,
+            workspace_id=workspace.ref.workspace_id,
+            working_directory=workspace.resolve_workdir(),
+            conversation_id=conversation_id,
+            shared_state_snapshot=shared_state_snapshot,
+            thinking=self._thinking_for_run(task.trace_id),
+            system_prompt_override=system_prompt_override,
+            user_prompt=None,
+        )
+
+    def _evaluate_completion_guard(
+        self,
+        *,
+        task: TaskEnvelope,
+        instance_id: str,
+        role_id: str,
+        workspace: WorkspaceHandle,
+        conversation_id: str,
+        output_text: str,
+    ) -> ReminderDecision:
+        if self.reminder_service is None or self.todo_service is None:
+            return ReminderDecision()
+        if task.parent_task_id is not None:
+            return ReminderDecision()
+        snapshot = self.todo_service.get_for_run(
+            run_id=task.trace_id,
+            session_id=task.session_id,
+        )
+        incomplete = tuple(
+            IncompleteTodoItem(content=item.content, status=item.status.value)
+            for item in snapshot.items
+            if item.status != TodoStatus.COMPLETED
+        )
+        return self.reminder_service.evaluate_completion_attempt(
+            CompletionAttemptObservation(
+                session_id=task.session_id,
+                run_id=task.trace_id,
+                trace_id=task.trace_id,
+                task_id=task.task_id,
+                instance_id=instance_id,
+                role_id=role_id,
+                workspace_id=workspace.ref.workspace_id,
+                conversation_id=conversation_id,
+                output_text=output_text,
+                incomplete_todos=incomplete,
+            )
+        )
 
     def _thinking_for_run(self, run_id: str) -> RunThinkingConfig:
         if self.run_intent_repo is None:

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -6,7 +6,7 @@ import json
 import logging
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal, Union, cast
 
 from pydantic import BaseModel, ConfigDict, JsonValue
 from pydantic_ai.messages import ModelRequest, UserContent, UserPromptPart
@@ -511,7 +511,7 @@ class TaskExecutionService(BaseModel):
         conversation_id: str,
         shared_state_snapshot: tuple[tuple[str, str], ...],
         system_prompt_override: str,
-    ) -> str | TaskExecutionResult:
+    ) -> Union[str, TaskExecutionResult]:
         result = await self._run_agent_once(
             runner=runner,
             task=task,

--- a/src/relay_teams/agents/orchestration/task_execution_service_factory.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service_factory.py
@@ -24,7 +24,9 @@ from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.reminders import SystemReminderService
 from relay_teams.agents.tasks.task_repository import TaskRepository
+from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.skills.skill_routing_service import SkillRuntimeService
 from relay_teams.tools.registry import ToolRegistry
@@ -58,6 +60,8 @@ def create_task_execution_service(
     role_memory_service: RoleMemoryService | None = None,
     runtime_role_resolver: RuntimeRoleResolver | None = None,
     hook_service: HookService | None = None,
+    todo_service: TodoService | None = None,
+    reminder_service: SystemReminderService | None = None,
 ) -> TaskExecutionService:
     return TaskExecutionService(
         role_registry=role_registry,
@@ -91,4 +95,6 @@ def create_task_execution_service(
         run_intent_repo=run_intent_repo,
         media_asset_service=media_asset_service,
         hook_service=hook_service,
+        todo_service=todo_service,
+        reminder_service=reminder_service,
     )

--- a/src/relay_teams/builtin/roles/main_agent.md
+++ b/src/relay_teams/builtin/roles/main_agent.md
@@ -113,7 +113,7 @@ The user will primarily request you perform software engineering tasks. This inc
 - VERY IMPORTANT: When you have completed a task, you MUST run the lint and typecheck commands (e.g. npm run lint, npm run typecheck, ruff, etc.) with shell if they were provided to you to ensure your code is correct. If you are unable to find the correct command, ask the user for the command to run and if they supply it, proactively suggest writing it to AGENTS.md so that you will know to run it next time.
 NEVER commit changes unless the user explicitly asks you to. It is VERY IMPORTANT to only commit when explicitly asked, otherwise the user will feel that you are being too proactive.
 
-- Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are NOT part of the user's provided input or the tool result.
+- Tool results and user messages may include <system-reminder> tags. <system-reminder> tags are runtime-generated guidance. They are NOT part of the user's original input or the tool result, and they may not directly relate to the adjacent message. Treat them as active runtime constraints.
 
 # Tool usage policy
 - You have the capability to call multiple tools in a single response. When multiple independent pieces of information are requested, batch your tool calls together for optimal performance. When making multiple shell tool calls, you MUST send a single message with multiple tools calls to run the calls in parallel. For example, if you need to run "git status" and "git diff", send a single message with two tool calls to run the calls in parallel.

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -41,6 +41,7 @@ from relay_teams.monitors import MonitorService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.providers.model_config import ModelCapabilities, ModelEndpointConfig
 from relay_teams.providers.provider_contracts import LLMRequest
+from relay_teams.reminders import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
@@ -187,6 +188,7 @@ class ExternalAcpHostToolBridge:
         im_tool_service: ImToolService | None = None,
         computer_runtime: ComputerRuntime | None = None,
         shell_approval_repo: ShellApprovalRepository | None = None,
+        reminder_service: SystemReminderService | None = None,
     ) -> None:
         self._task_repo = task_repo
         self._shared_store = shared_store
@@ -221,6 +223,7 @@ class ExternalAcpHostToolBridge:
         self._im_tool_service = im_tool_service
         self._computer_runtime = computer_runtime
         self._shell_approval_repo = shell_approval_repo
+        self._reminder_service = reminder_service
 
         self._catalog_by_name: dict[str, HostedToolDefinition] = {}
         self._catalog_signature = ""
@@ -552,6 +555,7 @@ class ExternalAcpHostToolBridge:
             metric_recorder=self._metric_recorder,
             notification_service=self._get_notification_service(),
             im_tool_service=self._im_tool_service,
+            reminder_service=getattr(self, "_reminder_service", None),
             model_capabilities=self._resolve_request_model_capabilities(
                 request=request
             ),

--- a/src/relay_teams/external_agents/provider.py
+++ b/src/relay_teams/external_agents/provider.py
@@ -50,6 +50,7 @@ from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.providers.model_config import ModelEndpointConfig, ProviderType
 from relay_teams.providers.openai_support import build_model_request_headers
 from relay_teams.providers.provider_contracts import LLMProvider, LLMRequest
+from relay_teams.reminders import SystemReminderService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub
@@ -174,6 +175,7 @@ class ExternalAcpSessionManager:
         metric_recorder: MetricRecorder | None = None,
         im_tool_service: ImToolService | None = None,
         computer_runtime: ComputerRuntime | None = None,
+        reminder_service: SystemReminderService | None = None,
     ) -> None:
         self._config_dir = config_dir
         self._config_service = config_service
@@ -211,6 +213,7 @@ class ExternalAcpSessionManager:
         self._metric_recorder = metric_recorder
         self._im_tool_service = im_tool_service
         self._computer_runtime = computer_runtime
+        self._reminder_service = reminder_service
         self._conversations: dict[str, _ConversationHandle] = {}
         self._locks: dict[str, asyncio.Lock] = {}
 
@@ -972,6 +975,7 @@ class ExternalAcpSessionManager:
             metric_recorder=self._metric_recorder,
             im_tool_service=self._im_tool_service,
             computer_runtime=self._computer_runtime,
+            reminder_service=self._reminder_service,
         )
 
     def _resolve_transport_agent_config(

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -185,8 +185,10 @@ from relay_teams.sessions.runs.user_question_manager import UserQuestionManager
 from relay_teams.sessions.runs.user_question_repository import UserQuestionRepository
 from relay_teams.sessions.runs.todo_repository import TodoRepository
 from relay_teams.sessions.runs.todo_service import TodoService
+from relay_teams.sessions.runs.system_injection import SystemInjectionSink
 from relay_teams.sessions.session_repository import SessionRepository
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.reminders import ReminderStateRepository, SystemReminderService
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
@@ -532,6 +534,16 @@ class ServerContainer:
             repository=self.todo_repository,
             run_event_hub=self.run_event_hub,
         )
+        self.system_injection_sink = SystemInjectionSink(
+            injection_manager=self.injection_manager,
+            run_event_hub=self.run_event_hub,
+            message_repo=self.message_repo,
+        )
+        self.reminder_state_repository = ReminderStateRepository(self.shared_store)
+        self.reminder_service = SystemReminderService(
+            state_repository=self.reminder_state_repository,
+            injection_sink=self.system_injection_sink,
+        )
         self.feishu_client = FeishuClient()
         self.xiaoluban_account_repository = XiaolubanAccountRepository(
             runtime.paths.db_path
@@ -610,6 +622,7 @@ class ServerContainer:
             run_intent_repo=self.run_intent_repo,
             background_task_service=self.background_task_service,
             todo_service=self.todo_service,
+            reminder_service=self.reminder_service,
             monitor_service=self.monitor_service,
             role_memory_service=self.role_memory_service,
             tool_registry=self.tool_registry,
@@ -991,6 +1004,7 @@ class ServerContainer:
             external_agent_session_manager=self.external_acp_session_manager,
             session_model_profile_lookup=self._session_model_profile_lookup,
             hook_service=self.hook_service,
+            reminder_service=self.reminder_service,
         )
         self.task_execution_service = create_task_execution_service(
             role_registry=self.role_registry,
@@ -1017,6 +1031,8 @@ class ServerContainer:
             role_memory_service=self.role_memory_service,
             runtime_role_resolver=self.runtime_role_resolver,
             hook_service=self.hook_service,
+            todo_service=self.todo_service,
+            reminder_service=self.reminder_service,
         )
         self.task_service = TaskOrchestrationService(
             task_repo=self.task_repo,

--- a/src/relay_teams/interfaces/server/host_tool_stdio_server.py
+++ b/src/relay_teams/interfaces/server/host_tool_stdio_server.py
@@ -78,6 +78,7 @@ async def _run_stdio_server() -> None:
         metric_recorder=container.metric_recorder,
         im_tool_service=container.im_tool_service,
         computer_runtime=container.computer_runtime,
+        reminder_service=getattr(container, "reminder_service", None),
     )
 
     async def unavailable_request(

--- a/src/relay_teams/providers/openai_compatible.py
+++ b/src/relay_teams/providers/openai_compatible.py
@@ -52,6 +52,7 @@ from relay_teams.providers.provider_contracts import (
     ProviderCapabilities,
 )
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
+from relay_teams.reminders import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
@@ -133,6 +134,7 @@ class OpenAICompatibleProvider(LLMProvider):
         im_tool_service: ImToolService | None = None,
         computer_runtime: ComputerRuntime | None = None,
         hook_service: HookService | None = None,
+        reminder_service: SystemReminderService | None = None,
     ) -> None:
         self._config_ref = config
         self._media_asset_service = media_asset_service
@@ -189,6 +191,7 @@ class OpenAICompatibleProvider(LLMProvider):
             im_tool_service=im_tool_service,
             computer_runtime=computer_runtime,
             hook_service=hook_service,
+            reminder_service=reminder_service,
         )
 
     @override

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -59,6 +59,7 @@ from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
+from relay_teams.reminders import SystemReminderService
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
@@ -114,6 +115,7 @@ def create_provider_factory(
     session_model_profile_lookup: Callable[[str], ModelEndpointConfig | None]
     | None = None,
     hook_service: HookService | None = None,
+    reminder_service: SystemReminderService | None = None,
 ) -> Callable[[RoleDefinition, str | None], LLMProvider]:
     fallback_cooldown_registries: dict[tuple[str, ...], ProfileCooldownRegistry] = {}
     fallback_cooldown_registry_lock = Lock()
@@ -242,6 +244,7 @@ def create_provider_factory(
                 fallback_middleware=profile_fallback_middleware,
                 im_tool_service=im_tool_service,
                 hook_service=hook_service,
+                reminder_service=reminder_service,
             ),
         )
         return provider_registry.create(config_to_use)

--- a/src/relay_teams/reminders/__init__.py
+++ b/src/relay_teams/reminders/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from relay_teams.reminders.models import (
+    CompletionAttemptObservation,
+    ContextPressureObservation,
+    IncompleteTodoItem,
+    ReminderDecision,
+    ReminderKind,
+    ToolEffect,
+    ToolResultObservation,
+)
+from relay_teams.reminders.policy import ReminderPolicyConfig, SystemReminderPolicy
+from relay_teams.reminders.renderer import render_system_reminder
+from relay_teams.reminders.service import SystemReminderService
+from relay_teams.reminders.state import ReminderStateRepository, ReminderRunState
+from relay_teams.reminders.tool_effects import classify_tool_effect
+
+__all__ = [
+    "CompletionAttemptObservation",
+    "ContextPressureObservation",
+    "IncompleteTodoItem",
+    "ReminderDecision",
+    "ReminderKind",
+    "ReminderPolicyConfig",
+    "ReminderRunState",
+    "ReminderStateRepository",
+    "SystemReminderPolicy",
+    "SystemReminderService",
+    "ToolEffect",
+    "ToolResultObservation",
+    "classify_tool_effect",
+    "render_system_reminder",
+]

--- a/src/relay_teams/reminders/models.py
+++ b/src/relay_teams/reminders/models.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+
+class ReminderKind(str, Enum):
+    TOOL_FAILURE = "tool_failure"
+    READ_ONLY_STREAK = "read_only_streak"
+    INCOMPLETE_TODOS = "incomplete_todos"
+    CONTEXT_PRESSURE = "context_pressure"
+    POST_COMPACTION = "post_compaction"
+
+
+class ToolEffect(str, Enum):
+    READ_ONLY = "read_only"
+    MUTATING = "mutating"
+    NEUTRAL = "neutral"
+
+
+class IncompleteTodoItem(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    content: str = Field(min_length=1)
+    status: str = Field(min_length=1)
+
+
+class ToolResultObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    run_id: str
+    trace_id: str
+    task_id: str | None = None
+    instance_id: str
+    role_id: str
+    tool_name: str = Field(min_length=1)
+    tool_call_id: str = Field(min_length=1)
+    ok: bool
+    error_type: str = ""
+    error_message: str = ""
+    retryable: bool = False
+    meta: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+class CompletionAttemptObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    run_id: str
+    trace_id: str
+    task_id: str
+    instance_id: str
+    role_id: str
+    workspace_id: str
+    conversation_id: str
+    output_text: str = ""
+    incomplete_todos: tuple[IncompleteTodoItem, ...] = ()
+
+
+class ContextPressureObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    run_id: str
+    trace_id: str
+    task_id: str | None = None
+    instance_id: str
+    role_id: str
+    conversation_id: str
+    kind: ReminderKind
+    message_count_before: int = Field(default=0, ge=0)
+    message_count_after: int = Field(default=0, ge=0)
+    estimated_tokens_before: int = Field(default=0, ge=0)
+    estimated_tokens_after: int = Field(default=0, ge=0)
+    threshold_tokens: int = Field(default=0, ge=0)
+    target_tokens: int = Field(default=0, ge=0)
+
+
+class ReminderDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    issue: bool = False
+    kind: ReminderKind | None = None
+    issue_key: str = ""
+    content: str = ""
+    retry_completion: bool = False
+    fail_completion: bool = False
+    reason: str = ""

--- a/src/relay_teams/reminders/models.py
+++ b/src/relay_teams/reminders/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
@@ -32,7 +33,7 @@ class ToolResultObservation(BaseModel):
     session_id: str
     run_id: str
     trace_id: str
-    task_id: str | None = None
+    task_id: Optional[str] = None
     instance_id: str
     role_id: str
     tool_name: str = Field(min_length=1)
@@ -65,7 +66,7 @@ class ContextPressureObservation(BaseModel):
     session_id: str
     run_id: str
     trace_id: str
-    task_id: str | None = None
+    task_id: Optional[str] = None
     instance_id: str
     role_id: str
     conversation_id: str
@@ -82,7 +83,7 @@ class ReminderDecision(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     issue: bool = False
-    kind: ReminderKind | None = None
+    kind: Optional[ReminderKind] = None
     issue_key: str = ""
     content: str = ""
     retry_completion: bool = False

--- a/src/relay_teams/reminders/policy.py
+++ b/src/relay_teams/reminders/policy.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from relay_teams.reminders.models import (
+    CompletionAttemptObservation,
+    ContextPressureObservation,
+    ReminderDecision,
+    ReminderKind,
+    ToolResultObservation,
+)
+from relay_teams.reminders.state import ReminderRunState, can_issue
+from relay_teams.reminders.tool_effects import classify_tool_effect
+from relay_teams.reminders.models import ToolEffect
+
+
+class ReminderPolicyConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    tool_failure_cooldown_seconds: int = Field(default=60, ge=0)
+    read_only_streak_threshold: int = Field(default=5, ge=1)
+    read_only_streak_cooldown_seconds: int = Field(default=600, ge=0)
+    context_pressure_cooldown_seconds: int = Field(default=900, ge=0)
+    completion_max_retries: int = Field(default=3, ge=0)
+
+
+class SystemReminderPolicy:
+    def __init__(self, config: ReminderPolicyConfig | None = None) -> None:
+        self._config = config or ReminderPolicyConfig()
+
+    @property
+    def config(self) -> ReminderPolicyConfig:
+        return self._config
+
+    def evaluate_tool_result(
+        self,
+        *,
+        observation: ToolResultObservation,
+        state: ReminderRunState,
+    ) -> tuple[ReminderDecision, ReminderRunState]:
+        if not observation.ok:
+            next_state = state.model_copy(update={"read_only_streak": 0})
+            error_type = observation.error_type or "tool_error"
+            issue_key = f"tool_failure:{observation.tool_name}:{error_type}"
+            if not can_issue(
+                state=next_state,
+                issue_key=issue_key,
+                cooldown_seconds=self._config.tool_failure_cooldown_seconds,
+            ):
+                return ReminderDecision(), next_state
+            message = observation.error_message or "The tool returned an error."
+            return (
+                ReminderDecision(
+                    issue=True,
+                    kind=ReminderKind.TOOL_FAILURE,
+                    issue_key=issue_key,
+                    content=(
+                        f"The `{observation.tool_name}` tool failed with `{error_type}`: "
+                        f"{message}\n\nInspect the failure, adjust the approach, and do "
+                        "not repeat the same failing call unchanged."
+                    ),
+                    reason=error_type,
+                ),
+                next_state,
+            )
+
+        effect = classify_tool_effect(observation.tool_name)
+        if effect == ToolEffect.READ_ONLY:
+            next_streak = state.read_only_streak + 1
+        else:
+            next_streak = 0
+        next_state = state.model_copy(update={"read_only_streak": next_streak})
+        if effect != ToolEffect.READ_ONLY:
+            return ReminderDecision(), next_state
+        if next_streak < self._config.read_only_streak_threshold:
+            return ReminderDecision(), next_state
+        issue_key = "read_only_streak"
+        if not can_issue(
+            state=next_state,
+            issue_key=issue_key,
+            cooldown_seconds=self._config.read_only_streak_cooldown_seconds,
+        ):
+            return ReminderDecision(), next_state
+        return (
+            ReminderDecision(
+                issue=True,
+                kind=ReminderKind.READ_ONLY_STREAK,
+                issue_key=issue_key,
+                content=(
+                    f"You have used {next_streak} read-only tools in a row. If you "
+                    "have enough evidence, move toward a concrete change or final "
+                    "answer. If more inspection is required, state the specific "
+                    "missing fact before continuing."
+                ),
+                reason="read_only_streak",
+            ),
+            next_state,
+        )
+
+    def evaluate_completion_attempt(
+        self,
+        *,
+        observation: CompletionAttemptObservation,
+        state: ReminderRunState,
+    ) -> tuple[ReminderDecision, ReminderRunState]:
+        if not observation.incomplete_todos:
+            return (
+                ReminderDecision(),
+                state.model_copy(update={"completion_retry_count": 0}),
+            )
+        retry_count = state.completion_retry_count + 1
+        next_state = state.model_copy(update={"completion_retry_count": retry_count})
+        formatted_todos = "\n".join(
+            f"- [{item.status}] {item.content}" for item in observation.incomplete_todos
+        )
+        content = (
+            "You attempted to finish while run-scoped todos are still incomplete.\n\n"
+            f"{formatted_todos}\n\n"
+            "Before completing, either finish the pending work or update the todo list "
+            "to accurately reflect what remains."
+        )
+        if retry_count > self._config.completion_max_retries:
+            return (
+                ReminderDecision(
+                    issue=True,
+                    kind=ReminderKind.INCOMPLETE_TODOS,
+                    issue_key="incomplete_todos:failed_completion",
+                    content=content,
+                    fail_completion=True,
+                    reason="completion_retry_limit_exceeded",
+                ),
+                next_state,
+            )
+        return (
+            ReminderDecision(
+                issue=True,
+                kind=ReminderKind.INCOMPLETE_TODOS,
+                issue_key=f"incomplete_todos:retry:{retry_count}",
+                content=content,
+                retry_completion=True,
+                reason="incomplete_todos",
+            ),
+            next_state,
+        )
+
+    def evaluate_context_pressure(
+        self,
+        *,
+        observation: ContextPressureObservation,
+        state: ReminderRunState,
+    ) -> tuple[ReminderDecision, ReminderRunState]:
+        issue_key = observation.kind.value
+        if not can_issue(
+            state=state,
+            issue_key=issue_key,
+            cooldown_seconds=self._config.context_pressure_cooldown_seconds,
+        ):
+            return ReminderDecision(), state
+        if observation.kind == ReminderKind.POST_COMPACTION:
+            content = (
+                "Conversation history was compacted to preserve the context window. "
+                "Prefer using the current transcript and compacted summary rather than "
+                "assuming every prior tool output is still available verbatim."
+            )
+        else:
+            content = (
+                "The conversation is approaching the context budget. Preserve important "
+                "facts in the active answer or todo state before continuing with more "
+                "large outputs."
+            )
+        return (
+            ReminderDecision(
+                issue=True,
+                kind=observation.kind,
+                issue_key=issue_key,
+                content=content,
+                reason=observation.kind.value,
+            ),
+            state,
+        )

--- a/src/relay_teams/reminders/renderer.py
+++ b/src/relay_teams/reminders/renderer.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def render_system_reminder(content: str) -> str:
+    text = content.strip()
+    if not text:
+        return ""
+    return f"<system-reminder>\n{text}\n</system-reminder>"

--- a/src/relay_teams/reminders/service.py
+++ b/src/relay_teams/reminders/service.py
@@ -33,6 +33,8 @@ class SystemReminderService:
         self._injection_sink = injection_sink
         self._policy = policy or SystemReminderPolicy()
         self._fallback_states: dict[tuple[str, str], ReminderRunState] = {}
+        self._read_degraded_keys: set[tuple[str, str]] = set()
+        self._write_degraded_keys: set[tuple[str, str]] = set()
 
     @property
     def policy(self) -> SystemReminderPolicy:
@@ -137,24 +139,33 @@ class SystemReminderService:
 
     def _load_state(self, *, session_id: str, run_id: str) -> ReminderRunState:
         key = _state_cache_key(session_id=session_id, run_id=run_id)
-        fallback_state = self._fallback_states.get(key)
-        if fallback_state is not None:
-            return fallback_state
+        if key in self._write_degraded_keys:
+            fallback_state = self._fallback_states.get(key)
+            if fallback_state is not None:
+                return fallback_state
         try:
-            return self._state_repository.get_run_state(
+            state = self._state_repository.get_run_state(
                 session_id=session_id,
                 run_id=run_id,
             )
+            self._read_degraded_keys.discard(key)
+            self._fallback_states.pop(key, None)
+            return state
         except Exception as exc:
+            fallback_state = self._fallback_states.get(key)
+            if fallback_state is None:
+                fallback_state = ReminderRunState()
+                self._fallback_states[key] = fallback_state
+            self._read_degraded_keys.add(key)
             log_event(
                 LOGGER,
                 logging.WARNING,
                 event="reminders.state.load_failed",
-                message="Falling back to empty reminder state",
+                message="Falling back to in-memory reminder state",
                 payload={"session_id": session_id, "run_id": run_id},
                 exc_info=exc,
             )
-            return ReminderRunState()
+            return fallback_state
 
     def _save_state(
         self,
@@ -170,9 +181,14 @@ class SystemReminderService:
                 run_id=run_id,
                 state=state,
             )
-            self._fallback_states.pop(key, None)
+            self._write_degraded_keys.discard(key)
+            if key in self._read_degraded_keys:
+                self._fallback_states[key] = state
+            else:
+                self._fallback_states.pop(key, None)
         except Exception as exc:
             self._fallback_states[key] = state
+            self._write_degraded_keys.add(key)
             log_event(
                 LOGGER,
                 logging.WARNING,

--- a/src/relay_teams/reminders/service.py
+++ b/src/relay_teams/reminders/service.py
@@ -79,9 +79,8 @@ class SystemReminderService:
             next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
             content = render_system_reminder(decision.content)
             if content:
-                _ = self._injection_sink.append_and_enqueue(
+                _ = self._injection_sink.append_only(
                     session_id=observation.session_id,
-                    run_id=observation.run_id,
                     trace_id=observation.trace_id,
                     task_id=observation.task_id,
                     instance_id=observation.instance_id,

--- a/src/relay_teams/reminders/service.py
+++ b/src/relay_teams/reminders/service.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from relay_teams.reminders.models import (
+    CompletionAttemptObservation,
+    ContextPressureObservation,
+    ReminderDecision,
+    ToolResultObservation,
+)
+from relay_teams.reminders.policy import SystemReminderPolicy
+from relay_teams.reminders.renderer import render_system_reminder
+from relay_teams.reminders.state import (
+    ReminderStateRepository,
+    mark_issued,
+)
+from relay_teams.sessions.runs.system_injection import SystemInjectionSink
+
+
+class SystemReminderService:
+    def __init__(
+        self,
+        *,
+        state_repository: ReminderStateRepository,
+        injection_sink: SystemInjectionSink,
+        policy: SystemReminderPolicy | None = None,
+    ) -> None:
+        self._state_repository = state_repository
+        self._injection_sink = injection_sink
+        self._policy = policy or SystemReminderPolicy()
+
+    @property
+    def policy(self) -> SystemReminderPolicy:
+        return self._policy
+
+    def observe_tool_result(
+        self,
+        observation: ToolResultObservation,
+    ) -> ReminderDecision:
+        state = self._state_repository.get_run_state(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        )
+        decision, next_state = self._policy.evaluate_tool_result(
+            observation=observation,
+            state=state,
+        )
+        if decision.issue:
+            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+            content = render_system_reminder(decision.content)
+            if content:
+                _ = self._injection_sink.enqueue_only(
+                    session_id=observation.session_id,
+                    run_id=observation.run_id,
+                    trace_id=observation.trace_id,
+                    task_id=observation.task_id,
+                    instance_id=observation.instance_id,
+                    role_id=observation.role_id,
+                    content=content,
+                )
+        self._state_repository.save_run_state(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+            state=next_state,
+        )
+        return decision
+
+    def evaluate_completion_attempt(
+        self,
+        observation: CompletionAttemptObservation,
+    ) -> ReminderDecision:
+        state = self._state_repository.get_run_state(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        )
+        decision, next_state = self._policy.evaluate_completion_attempt(
+            observation=observation,
+            state=state,
+        )
+        if decision.issue and decision.retry_completion:
+            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+            content = render_system_reminder(decision.content)
+            if content:
+                _ = self._injection_sink.append_and_enqueue(
+                    session_id=observation.session_id,
+                    run_id=observation.run_id,
+                    trace_id=observation.trace_id,
+                    task_id=observation.task_id,
+                    instance_id=observation.instance_id,
+                    role_id=observation.role_id,
+                    workspace_id=observation.workspace_id,
+                    conversation_id=observation.conversation_id,
+                    content=content,
+                )
+        self._state_repository.save_run_state(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+            state=next_state,
+        )
+        return decision
+
+    def observe_context_pressure(
+        self,
+        observation: ContextPressureObservation,
+    ) -> ReminderDecision:
+        state = self._state_repository.get_run_state(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        )
+        decision, next_state = self._policy.evaluate_context_pressure(
+            observation=observation,
+            state=state,
+        )
+        if decision.issue:
+            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+            content = render_system_reminder(decision.content)
+            if content:
+                _ = self._injection_sink.enqueue_only(
+                    session_id=observation.session_id,
+                    run_id=observation.run_id,
+                    trace_id=observation.trace_id,
+                    task_id=observation.task_id,
+                    instance_id=observation.instance_id,
+                    role_id=observation.role_id,
+                    content=content,
+                )
+        self._state_repository.save_run_state(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+            state=next_state,
+        )
+        return decision

--- a/src/relay_teams/reminders/service.py
+++ b/src/relay_teams/reminders/service.py
@@ -32,6 +32,7 @@ class SystemReminderService:
         self._state_repository = state_repository
         self._injection_sink = injection_sink
         self._policy = policy or SystemReminderPolicy()
+        self._fallback_states: dict[tuple[str, str], ReminderRunState] = {}
 
     @property
     def policy(self) -> SystemReminderPolicy:
@@ -135,6 +136,10 @@ class SystemReminderService:
         return decision
 
     def _load_state(self, *, session_id: str, run_id: str) -> ReminderRunState:
+        key = _state_cache_key(session_id=session_id, run_id=run_id)
+        fallback_state = self._fallback_states.get(key)
+        if fallback_state is not None:
+            return fallback_state
         try:
             return self._state_repository.get_run_state(
                 session_id=session_id,
@@ -158,13 +163,16 @@ class SystemReminderService:
         run_id: str,
         state: ReminderRunState,
     ) -> None:
+        key = _state_cache_key(session_id=session_id, run_id=run_id)
         try:
             self._state_repository.save_run_state(
                 session_id=session_id,
                 run_id=run_id,
                 state=state,
             )
+            self._fallback_states.pop(key, None)
         except Exception as exc:
+            self._fallback_states[key] = state
             log_event(
                 LOGGER,
                 logging.WARNING,
@@ -173,3 +181,7 @@ class SystemReminderService:
                 payload={"session_id": session_id, "run_id": run_id},
                 exc_info=exc,
             )
+
+
+def _state_cache_key(*, session_id: str, run_id: str) -> tuple[str, str]:
+    return session_id, run_id

--- a/src/relay_teams/reminders/service.py
+++ b/src/relay_teams/reminders/service.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import logging
+
+from relay_teams.logger import get_logger, log_event
 from relay_teams.reminders.models import (
     CompletionAttemptObservation,
     ContextPressureObservation,
@@ -9,10 +12,13 @@ from relay_teams.reminders.models import (
 from relay_teams.reminders.policy import SystemReminderPolicy
 from relay_teams.reminders.renderer import render_system_reminder
 from relay_teams.reminders.state import (
+    ReminderRunState,
     ReminderStateRepository,
     mark_issued,
 )
 from relay_teams.sessions.runs.system_injection import SystemInjectionSink
+
+LOGGER = get_logger(__name__)
 
 
 class SystemReminderService:
@@ -35,7 +41,7 @@ class SystemReminderService:
         self,
         observation: ToolResultObservation,
     ) -> ReminderDecision:
-        state = self._state_repository.get_run_state(
+        state = self._load_state(
             session_id=observation.session_id,
             run_id=observation.run_id,
         )
@@ -56,7 +62,7 @@ class SystemReminderService:
                     role_id=observation.role_id,
                     content=content,
                 )
-        self._state_repository.save_run_state(
+        self._save_state(
             session_id=observation.session_id,
             run_id=observation.run_id,
             state=next_state,
@@ -67,7 +73,7 @@ class SystemReminderService:
         self,
         observation: CompletionAttemptObservation,
     ) -> ReminderDecision:
-        state = self._state_repository.get_run_state(
+        state = self._load_state(
             session_id=observation.session_id,
             run_id=observation.run_id,
         )
@@ -89,7 +95,7 @@ class SystemReminderService:
                     conversation_id=observation.conversation_id,
                     content=content,
                 )
-        self._state_repository.save_run_state(
+        self._save_state(
             session_id=observation.session_id,
             run_id=observation.run_id,
             state=next_state,
@@ -100,7 +106,7 @@ class SystemReminderService:
         self,
         observation: ContextPressureObservation,
     ) -> ReminderDecision:
-        state = self._state_repository.get_run_state(
+        state = self._load_state(
             session_id=observation.session_id,
             run_id=observation.run_id,
         )
@@ -121,9 +127,49 @@ class SystemReminderService:
                     role_id=observation.role_id,
                     content=content,
                 )
-        self._state_repository.save_run_state(
+        self._save_state(
             session_id=observation.session_id,
             run_id=observation.run_id,
             state=next_state,
         )
         return decision
+
+    def _load_state(self, *, session_id: str, run_id: str) -> ReminderRunState:
+        try:
+            return self._state_repository.get_run_state(
+                session_id=session_id,
+                run_id=run_id,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="reminders.state.load_failed",
+                message="Falling back to empty reminder state",
+                payload={"session_id": session_id, "run_id": run_id},
+                exc_info=exc,
+            )
+            return ReminderRunState()
+
+    def _save_state(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        state: ReminderRunState,
+    ) -> None:
+        try:
+            self._state_repository.save_run_state(
+                session_id=session_id,
+                run_id=run_id,
+                state=state,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="reminders.state.save_failed",
+                message="Ignoring reminder state persistence failure",
+                payload={"session_id": session_id, "run_id": run_id},
+                exc_info=exc,
+            )

--- a/src/relay_teams/reminders/state.py
+++ b/src/relay_teams/reminders/state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 from json import dumps
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -64,7 +65,7 @@ def can_issue(
     state: ReminderRunState,
     issue_key: str,
     cooldown_seconds: int,
-    now: datetime | None = None,
+    now: Optional[datetime] = None,
 ) -> bool:
     current_time = now or datetime.now(tz=timezone.utc)
     raw = state.issued_at_by_key.get(issue_key)
@@ -83,7 +84,7 @@ def mark_issued(
     *,
     state: ReminderRunState,
     issue_key: str,
-    now: datetime | None = None,
+    now: Optional[datetime] = None,
 ) -> ReminderRunState:
     current_time = now or datetime.now(tz=timezone.utc)
     issued_at_by_key = dict(state.issued_at_by_key)

--- a/src/relay_teams/reminders/state.py
+++ b/src/relay_teams/reminders/state.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from json import dumps
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+
+LOGGER = get_logger(__name__)
+STATE_KEY_PREFIX = "system_reminders"
+
+
+class ReminderRunState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    read_only_streak: int = Field(default=0, ge=0)
+    completion_retry_count: int = Field(default=0, ge=0)
+    issued_at_by_key: dict[str, str] = Field(default_factory=dict)
+
+
+class ReminderStateRepository:
+    def __init__(self, repository: SharedStateRepository) -> None:
+        self._repository = repository
+
+    def get_run_state(self, *, session_id: str, run_id: str) -> ReminderRunState:
+        raw = self._repository.get_state(_scope(session_id), _state_key(run_id))
+        if raw is None:
+            return ReminderRunState()
+        try:
+            return ReminderRunState.model_validate_json(raw)
+        except ValidationError as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="reminders.state.invalid",
+                message="Ignoring invalid persisted reminder state",
+                payload={"session_id": session_id, "run_id": run_id},
+                exc_info=exc,
+            )
+            return ReminderRunState()
+
+    def save_run_state(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        state: ReminderRunState,
+    ) -> None:
+        self._repository.manage_state(
+            StateMutation(
+                scope=_scope(session_id),
+                key=_state_key(run_id),
+                value_json=dumps(state.model_dump(mode="json"), ensure_ascii=False),
+            )
+        )
+
+
+def can_issue(
+    *,
+    state: ReminderRunState,
+    issue_key: str,
+    cooldown_seconds: int,
+    now: datetime | None = None,
+) -> bool:
+    current_time = now or datetime.now(tz=timezone.utc)
+    raw = state.issued_at_by_key.get(issue_key)
+    if not raw:
+        return True
+    try:
+        previous = datetime.fromisoformat(raw)
+    except ValueError:
+        return True
+    if previous.tzinfo is None:
+        previous = previous.replace(tzinfo=timezone.utc)
+    return (current_time - previous).total_seconds() >= cooldown_seconds
+
+
+def mark_issued(
+    *,
+    state: ReminderRunState,
+    issue_key: str,
+    now: datetime | None = None,
+) -> ReminderRunState:
+    current_time = now or datetime.now(tz=timezone.utc)
+    issued_at_by_key = dict(state.issued_at_by_key)
+    issued_at_by_key[issue_key] = current_time.isoformat()
+    return state.model_copy(update={"issued_at_by_key": issued_at_by_key})
+
+
+def _scope(session_id: str) -> ScopeRef:
+    return ScopeRef(scope_type=ScopeType.SESSION, scope_id=session_id)
+
+
+def _state_key(run_id: str) -> str:
+    return f"{STATE_KEY_PREFIX}:{run_id}"

--- a/src/relay_teams/reminders/tool_effects.py
+++ b/src/relay_teams/reminders/tool_effects.py
@@ -12,6 +12,8 @@ READ_ONLY_TOOLS = frozenset(
         "list_monitors",
         "list_run_tasks",
         "office_read_markdown",
+        "orch_list_available_roles",
+        "orch_list_delegated_tasks",
         "read",
         "ripgrep",
         "todo_read",

--- a/src/relay_teams/reminders/tool_effects.py
+++ b/src/relay_teams/reminders/tool_effects.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from relay_teams.reminders.models import ToolEffect
+
+READ_ONLY_TOOLS = frozenset(
+    {
+        "glob",
+        "grep",
+        "list_available_roles",
+        "list_background_tasks",
+        "list_delegated_tasks",
+        "list_monitors",
+        "list_run_tasks",
+        "office_read_markdown",
+        "read",
+        "ripgrep",
+        "todo_read",
+        "wait_background_task",
+        "webfetch",
+        "websearch",
+    }
+)
+
+MUTATING_TOOLS = frozenset(
+    {
+        "ask_question",
+        "create_monitor",
+        "create_tasks",
+        "create_temporary_role",
+        "dispatch_task",
+        "edit",
+        "im_send",
+        "notebook_edit",
+        "shell",
+        "spawn_subagent",
+        "stop_background_task",
+        "stop_monitor",
+        "todo_write",
+        "update_task",
+        "write",
+        "write_tmp",
+    }
+)
+
+
+def classify_tool_effect(tool_name: str) -> ToolEffect:
+    normalized = tool_name.strip()
+    if normalized in READ_ONLY_TOOLS:
+        return ToolEffect.READ_ONLY
+    if normalized in MUTATING_TOOLS:
+        return ToolEffect.MUTATING
+    return ToolEffect.NEUTRAL

--- a/src/relay_teams/sessions/runs/system_injection.py
+++ b/src/relay_teams/sessions/runs/system_injection.py
@@ -67,18 +67,16 @@ class SystemInjectionSink:
         content: UserPromptContent,
         source: InjectionSource = InjectionSource.SYSTEM,
     ) -> SystemInjectionResult:
-        appended = False
-        if self._message_repo is not None:
-            appended = self._message_repo.append_user_prompt_if_missing(
-                session_id=session_id,
-                workspace_id=workspace_id,
-                conversation_id=conversation_id,
-                agent_role_id=role_id,
-                instance_id=instance_id,
-                task_id=task_id,
-                trace_id=trace_id,
-                content=content,
-            )
+        appended = self._append(
+            session_id=session_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            content=content,
+        )
         record = self._enqueue(
             session_id=session_id,
             run_id=run_id,
@@ -90,6 +88,55 @@ class SystemInjectionSink:
             source=source,
         )
         return SystemInjectionResult(appended=appended, enqueued=record is not None)
+
+    def append_only(
+        self,
+        *,
+        session_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        content: UserPromptContent,
+    ) -> SystemInjectionResult:
+        appended = self._append(
+            session_id=session_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            content=content,
+        )
+        return SystemInjectionResult(appended=appended)
+
+    def _append(
+        self,
+        *,
+        session_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        content: UserPromptContent,
+    ) -> bool:
+        if self._message_repo is None:
+            return False
+        return self._message_repo.append_user_prompt_if_missing(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
+        )
 
     def _enqueue(
         self,

--- a/src/relay_teams/sessions/runs/system_injection.py
+++ b/src/relay_teams/sessions/runs/system_injection.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.media import UserPromptContent
+from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
+from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.injection_queue import RunInjectionManager
+from relay_teams.sessions.runs.run_models import InjectionMessage, RunEvent
+
+
+class SystemInjectionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    appended: bool = False
+    enqueued: bool = False
+
+
+class SystemInjectionSink:
+    def __init__(
+        self,
+        *,
+        injection_manager: RunInjectionManager,
+        run_event_hub: RunEventHub,
+        message_repo: MessageRepository | None = None,
+    ) -> None:
+        self._injection_manager = injection_manager
+        self._run_event_hub = run_event_hub
+        self._message_repo = message_repo
+
+    def enqueue_only(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: str | None,
+        instance_id: str,
+        role_id: str,
+        content: UserPromptContent,
+        source: InjectionSource = InjectionSource.SYSTEM,
+    ) -> SystemInjectionResult:
+        record = self._enqueue(
+            session_id=session_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            content=content,
+            source=source,
+        )
+        return SystemInjectionResult(enqueued=record is not None)
+
+    def append_and_enqueue(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        content: UserPromptContent,
+        source: InjectionSource = InjectionSource.SYSTEM,
+    ) -> SystemInjectionResult:
+        appended = False
+        if self._message_repo is not None:
+            appended = self._message_repo.append_user_prompt_if_missing(
+                session_id=session_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                agent_role_id=role_id,
+                instance_id=instance_id,
+                task_id=task_id,
+                trace_id=trace_id,
+                content=content,
+            )
+        record = self._enqueue(
+            session_id=session_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            content=content,
+            source=source,
+        )
+        return SystemInjectionResult(appended=appended, enqueued=record is not None)
+
+    def _enqueue(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: str | None,
+        instance_id: str,
+        role_id: str,
+        content: UserPromptContent,
+        source: InjectionSource,
+    ) -> InjectionMessage | None:
+        if not self._injection_manager.is_active(run_id):
+            return None
+        try:
+            record = self._injection_manager.enqueue(
+                run_id=run_id,
+                recipient_instance_id=instance_id,
+                source=source,
+                content=content,
+            )
+        except KeyError:
+            return None
+        self._run_event_hub.publish(
+            RunEvent(
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=trace_id,
+                task_id=task_id,
+                instance_id=instance_id,
+                role_id=role_id,
+                event_type=RunEventType.INJECTION_ENQUEUED,
+                payload_json=record.model_dump_json(),
+            )
+        )
+        return record

--- a/src/relay_teams/sessions/runs/system_injection.py
+++ b/src/relay_teams/sessions/runs/system_injection.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict
 
 from relay_teams.agents.execution.message_repository import MessageRepository
-from relay_teams.media import UserPromptContent
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
@@ -23,7 +24,7 @@ class SystemInjectionSink:
         *,
         injection_manager: RunInjectionManager,
         run_event_hub: RunEventHub,
-        message_repo: MessageRepository | None = None,
+        message_repo: Optional[MessageRepository] = None,
     ) -> None:
         self._injection_manager = injection_manager
         self._run_event_hub = run_event_hub
@@ -35,10 +36,10 @@ class SystemInjectionSink:
         session_id: str,
         run_id: str,
         trace_id: str,
-        task_id: str | None,
+        task_id: Optional[str],
         instance_id: str,
         role_id: str,
-        content: UserPromptContent,
+        content: str,
         source: InjectionSource = InjectionSource.SYSTEM,
     ) -> SystemInjectionResult:
         record = self._enqueue(
@@ -64,7 +65,7 @@ class SystemInjectionSink:
         role_id: str,
         workspace_id: str,
         conversation_id: str,
-        content: UserPromptContent,
+        content: str,
         source: InjectionSource = InjectionSource.SYSTEM,
     ) -> SystemInjectionResult:
         appended = self._append(
@@ -99,7 +100,7 @@ class SystemInjectionSink:
         role_id: str,
         workspace_id: str,
         conversation_id: str,
-        content: UserPromptContent,
+        content: str,
     ) -> SystemInjectionResult:
         appended = self._append(
             session_id=session_id,
@@ -123,7 +124,7 @@ class SystemInjectionSink:
         role_id: str,
         workspace_id: str,
         conversation_id: str,
-        content: UserPromptContent,
+        content: str,
     ) -> bool:
         if self._message_repo is None:
             return False
@@ -144,12 +145,12 @@ class SystemInjectionSink:
         session_id: str,
         run_id: str,
         trace_id: str,
-        task_id: str | None,
+        task_id: Optional[str],
         instance_id: str,
         role_id: str,
-        content: UserPromptContent,
+        content: str,
         source: InjectionSource,
-    ) -> InjectionMessage | None:
+    ) -> Optional[InjectionMessage]:
         if not self._injection_manager.is_active(run_id):
             return None
         try:

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -22,6 +22,7 @@ from relay_teams.monitors import MonitorService
 from relay_teams.notifications import NotificationService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.providers.model_config import ModelCapabilities
+from relay_teams.reminders import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
@@ -108,6 +109,7 @@ class ToolDeps(BaseModel):
     notification_service: SkipValidation[NotificationService | None] = None
     im_tool_service: SkipValidation[ImToolServiceLike | None] = None
     hook_service: SkipValidation[HookService | None] = None
+    reminder_service: SkipValidation[SystemReminderService | None] = None
     model_capabilities: SkipValidation[ModelCapabilities] = Field(
         default_factory=ModelCapabilities
     )

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -1305,7 +1305,10 @@ def _observe_tool_result_reminders(
         if isinstance(meta_payload, dict)
         else {}
     )
-    reported_failure = _reported_failure_from_success_envelope(envelope)
+    reported_failure = _reported_failure_from_success_envelope(
+        tool_name=tool_name,
+        envelope=envelope,
+    )
     observed_ok = bool(envelope.get("ok") is True)
     error_type = str(error.get("type") or "")
     error_message = str(error.get("message") or "")
@@ -1335,15 +1338,22 @@ def _observe_tool_result_reminders(
 
 
 def _reported_failure_from_success_envelope(
+    *,
+    tool_name: str,
     envelope: dict[str, JsonValue],
 ) -> tuple[str, str] | None:
     if envelope.get("ok") is not True:
+        return None
+    if tool_name != "shell":
         return None
     data_payload = envelope.get("data")
     if not isinstance(data_payload, dict):
         return None
     data = cast(dict[str, JsonValue], data_payload)
     if data.get("status") != "failed":
+        return None
+    exit_code = data.get("exit_code")
+    if not isinstance(exit_code, int) or exit_code == 0:
         return None
 
     message = _reported_failure_message(data)

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -15,6 +15,7 @@ from enum import Enum
 from json import dumps
 from typing import (
     Literal,
+    Optional,
     Protocol,
     cast,
     get_args,
@@ -1283,6 +1284,7 @@ def _system_injection_sink(ctx: ToolContext) -> SystemInjectionSink:
     )
 
 
+# noinspection PyTypeHints
 def _observe_tool_result_reminders(
     *,
     ctx: ToolContext,
@@ -1341,7 +1343,7 @@ def _reported_failure_from_success_envelope(
     *,
     tool_name: str,
     envelope: dict[str, JsonValue],
-) -> tuple[str, str] | None:
+) -> Optional[tuple[str, str]]:
     if envelope.get("ok") is not True:
         return None
     if tool_name != "shell":
@@ -1357,7 +1359,7 @@ def _reported_failure_from_success_envelope(
         return None
 
     message = _reported_failure_message(data)
-    return ("reported_failed_status", message)
+    return "reported_failed_status", message
 
 
 def _reported_failure_message(data: dict[str, JsonValue]) -> str:
@@ -1877,11 +1879,12 @@ class _RequiresApprovalPolicy(Protocol):
     def requires_approval(self, tool_name: str) -> bool: ...
 
 
+# noinspection PyTypeHints
 def _internal_record(
     *,
     tool_name: str,
     visible_envelope: dict[str, JsonValue],
-    internal_data: JsonValue | None,
+    internal_data: Optional[JsonValue],
     runtime_meta: dict[str, JsonValue],
 ) -> dict[str, JsonValue]:
     record = ToolInternalRecord(

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -1373,10 +1373,8 @@ def _reported_failure_message(data: dict[str, JsonValue]) -> str:
 
     command = data.get("command")
     exit_code = data.get("exit_code")
-    if isinstance(command, str) and command.strip():
-        if type(exit_code) is int:
-            return f"Command failed with exit code {exit_code}: {command}"
-        return f"Command reported failed status: {command}"
+    if isinstance(command, str) and command.strip() and type(exit_code) is int:
+        return f"Command failed with exit code {exit_code}: {command}"
     return "The tool result reported failed status."
 
 

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -32,8 +32,10 @@ from relay_teams.persistence import is_retryable_sqlite_error
 from relay_teams.agents.tasks.task_status_sanitizer import (
     sanitize_task_status_payload,
 )
+from relay_teams.reminders import ToolResultObservation
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.runs.system_injection import SystemInjectionSink
 
 from relay_teams.tools.runtime.approval_ticket_repo import (
     ApprovalTicketRecord,
@@ -229,6 +231,12 @@ async def execute_tool(
                 error=approval_error,
                 meta=meta,
             )
+            _observe_tool_result_reminders(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                envelope=envelope,
+            )
             _persist_tool_record(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
@@ -330,6 +338,12 @@ async def execute_tool(
                 args_summary=args_summary,
                 envelope=envelope,
             )
+            _observe_tool_result_reminders(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                envelope=envelope,
+            )
             _persist_tool_record(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
@@ -401,6 +415,12 @@ async def execute_tool(
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
                 args_summary=args_summary,
+                envelope=envelope,
+            )
+            _observe_tool_result_reminders(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
                 envelope=envelope,
             )
             _persist_tool_record(
@@ -1182,9 +1202,13 @@ def _apply_post_hook_bundle_to_envelope(
     runtime_meta = cast(dict[str, JsonValue], meta) if isinstance(meta, dict) else {}
     if bundle.additional_context:
         runtime_meta["hook_additional_context"] = list(bundle.additional_context)
-        _enqueue_additional_context_followup(
+        _enqueue_system_followup(
             ctx=ctx,
-            contexts=bundle.additional_context,
+            content="\n\n".join(
+                str(context).strip()
+                for context in bundle.additional_context
+                if str(context).strip()
+            ),
         )
     if bundle.deferred_action:
         runtime_meta["hook_deferred_action"] = bundle.deferred_action
@@ -1199,27 +1223,24 @@ def _apply_post_hook_bundle_to_envelope(
     return envelope
 
 
-def _enqueue_additional_context_followup(
+def _enqueue_system_followup(
     *,
     ctx: ToolContext,
-    contexts: tuple[str, ...],
-) -> None:
-    injection_manager = getattr(ctx.deps, "injection_manager", None)
-    if injection_manager is None:
-        return
-    if not injection_manager.is_active(ctx.deps.run_id):
-        return
-    content = "\n\n".join(
-        str(context).strip() for context in contexts if str(context).strip()
-    )
+    content: str,
+) -> bool:
     if not content:
-        return
-    _ = injection_manager.enqueue(
-        ctx.deps.run_id,
-        ctx.deps.instance_id,
-        source=InjectionSource.SYSTEM,
+        return False
+    result = _system_injection_sink(ctx).enqueue_only(
+        session_id=ctx.deps.session_id,
+        run_id=ctx.deps.run_id,
+        trace_id=ctx.deps.trace_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
         content=content,
+        source=InjectionSource.SYSTEM,
     )
+    return result.enqueued
 
 
 def _enqueue_deferred_followup(
@@ -1230,18 +1251,8 @@ def _enqueue_deferred_followup(
     tool_call_id: str,
     deferred_action: str,
 ) -> None:
-    injection_manager = getattr(ctx.deps, "injection_manager", None)
-    if injection_manager is None:
+    if not _enqueue_system_followup(ctx=ctx, content=deferred_action):
         return
-    if not injection_manager.is_active(ctx.deps.run_id):
-        return
-    record = injection_manager.enqueue(
-        ctx.deps.run_id,
-        ctx.deps.instance_id,
-        source=InjectionSource.SYSTEM,
-        content=deferred_action,
-    )
-    _ = record
     ctx.deps.run_event_hub.publish(
         RunEvent(
             session_id=ctx.deps.session_id,
@@ -1262,6 +1273,101 @@ def _enqueue_deferred_followup(
             ),
         )
     )
+
+
+def _system_injection_sink(ctx: ToolContext) -> SystemInjectionSink:
+    return SystemInjectionSink(
+        injection_manager=ctx.deps.injection_manager,
+        run_event_hub=ctx.deps.run_event_hub,
+        message_repo=ctx.deps.message_repo,
+    )
+
+
+def _observe_tool_result_reminders(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    envelope: dict[str, JsonValue],
+) -> None:
+    reminder_service = getattr(ctx.deps, "reminder_service", None)
+    if reminder_service is None:
+        return
+    error_payload = envelope.get("error")
+    error = (
+        cast(dict[str, JsonValue], error_payload)
+        if isinstance(error_payload, dict)
+        else {}
+    )
+    meta_payload = envelope.get("meta")
+    meta = (
+        cast(dict[str, JsonValue], meta_payload)
+        if isinstance(meta_payload, dict)
+        else {}
+    )
+    reported_failure = _reported_failure_from_success_envelope(envelope)
+    observed_ok = bool(envelope.get("ok") is True)
+    error_type = str(error.get("type") or "")
+    error_message = str(error.get("message") or "")
+    if reported_failure is not None:
+        observed_ok = False
+        if not error_type:
+            error_type = reported_failure[0]
+        if not error_message:
+            error_message = reported_failure[1]
+    _ = reminder_service.observe_tool_result(
+        ToolResultObservation(
+            session_id=ctx.deps.session_id,
+            run_id=ctx.deps.run_id,
+            trace_id=ctx.deps.trace_id,
+            task_id=ctx.deps.task_id,
+            instance_id=ctx.deps.instance_id,
+            role_id=ctx.deps.role_id,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            ok=observed_ok,
+            error_type=error_type,
+            error_message=error_message,
+            retryable=bool(error.get("retryable") is True),
+            meta=meta,
+        )
+    )
+
+
+def _reported_failure_from_success_envelope(
+    envelope: dict[str, JsonValue],
+) -> tuple[str, str] | None:
+    if envelope.get("ok") is not True:
+        return None
+    data_payload = envelope.get("data")
+    if not isinstance(data_payload, dict):
+        return None
+    data = cast(dict[str, JsonValue], data_payload)
+    if data.get("status") != "failed":
+        return None
+
+    message = _reported_failure_message(data)
+    return ("reported_failed_status", message)
+
+
+def _reported_failure_message(data: dict[str, JsonValue]) -> str:
+    output_excerpt = data.get("output_excerpt")
+    if isinstance(output_excerpt, str) and output_excerpt.strip():
+        return output_excerpt.strip()
+
+    recent_output = data.get("recent_output")
+    if isinstance(recent_output, list):
+        lines = [line for line in recent_output if isinstance(line, str)]
+        if lines:
+            return "\n".join(lines).strip()
+
+    command = data.get("command")
+    exit_code = data.get("exit_code")
+    if isinstance(command, str) and command.strip():
+        if type(exit_code) is int:
+            return f"Command failed with exit code {exit_code}: {command}"
+        return f"Command reported failed status: {command}"
+    return "The tool result reported failed status."
 
 
 async def _handle_tool_approval(

--- a/tests/integration_tests/api/test_http_run_flows.py
+++ b/tests/integration_tests/api/test_http_run_flows.py
@@ -124,8 +124,8 @@ def test_ai_run_persists_todo_snapshot_and_projects_it(
     assert isinstance(items, list)
     assert items == [
         {"content": "Inspect issue 399 requirements", "status": "completed"},
-        {"content": "Implement run todo persistence", "status": "in_progress"},
-        {"content": "Verify API and CLI output", "status": "pending"},
+        {"content": "Implement run todo persistence", "status": "completed"},
+        {"content": "Verify API and CLI output", "status": "completed"},
     ]
 
     round_response = api_client.get(f"/api/sessions/{session_id}/rounds/{run_id}")

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -2481,6 +2481,8 @@ def test_browser_round_todo_card_renders_and_collapses(
         1,
         timeout=_WAIT_TIMEOUT_MS,
     )
+    expect(todo_card).not_to_have_attribute("open", "", timeout=_WAIT_TIMEOUT_MS)
+    todo_card.locator(".round-todo-summary").click()
     expect(todo_card).to_have_attribute("open", "", timeout=_WAIT_TIMEOUT_MS)
     expect(todo_card.locator(".round-todo-item")).to_have_count(
         3,

--- a/tests/integration_tests/support/fake_llm_server.py
+++ b/tests/integration_tests/support/fake_llm_server.py
@@ -376,6 +376,39 @@ def _plan_todo_validation_response(
             "content": "[fake-llm] todo_write is not available for this role.",
         }
     attempt = _next_scenario_attempt(messages, marker="[todo-validation]")
+    if _messages_contain_user_text(
+        messages,
+        "run-scoped todos are still incomplete",
+    ):
+        last_tool_call_id = _extract_last_tool_call_id(messages)
+        if isinstance(last_tool_call_id, str) and last_tool_call_id.startswith(
+            "call-todo-validation-reminder"
+        ):
+            return {
+                "kind": "text",
+                "content": "todo validation completed",
+            }
+        return {
+            "kind": "tool_call",
+            "tool_name": "todo_write",
+            "tool_call_id": f"call-todo-validation-reminder-{attempt}",
+            "arguments": {
+                "items": [
+                    {
+                        "content": "Inspect issue 399 requirements",
+                        "status": "completed",
+                    },
+                    {
+                        "content": "Implement run todo persistence",
+                        "status": "completed",
+                    },
+                    {
+                        "content": "Verify API and CLI output",
+                        "status": "completed",
+                    },
+                ]
+            },
+        }
     if attempt == 1:
         return {
             "kind": "tool_call",
@@ -1191,6 +1224,8 @@ def _extract_last_user_text(messages: list[object]) -> str:
             continue
         content = message.get("content")
         if isinstance(content, str):
+            if _is_system_reminder_text(content):
+                continue
             return content
         if isinstance(content, list):
             parts: list[str] = []
@@ -1201,8 +1236,18 @@ def _extract_last_user_text(messages: list[object]) -> str:
                 if isinstance(text, str) and text:
                     parts.append(text)
             if parts:
-                return " ".join(parts)
+                combined = " ".join(parts)
+                if _is_system_reminder_text(combined):
+                    continue
+                return combined
     return ""
+
+
+def _is_system_reminder_text(text: str) -> bool:
+    stripped = text.strip()
+    return stripped.startswith("<system-reminder>") and stripped.endswith(
+        "</system-reminder>"
+    )
 
 
 def _messages_contain_user_text(messages: list[object], snippet: str) -> bool:

--- a/tests/unit_tests/agents/execution/agent_llm_session_test_support.py
+++ b/tests/unit_tests/agents/execution/agent_llm_session_test_support.py
@@ -142,6 +142,14 @@ class _FakeMessageRepo:
         self.requested_conversation_ids.append(conversation_id)
         return list(self._history)
 
+    def get_history_for_conversation_task(
+        self,
+        conversation_id: str,
+        task_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        _ = task_id
+        return self.get_history_for_conversation(conversation_id)
+
     def prune_conversation_history_to_safe_boundary(self, conversation_id: str) -> None:
         self.pruned_conversation_ids.append(conversation_id)
 

--- a/tests/unit_tests/agents/execution/session_prompt_core_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_prompt_core_test_cases.py
@@ -200,6 +200,63 @@ async def test_prepare_prompt_context_applies_microcompact_before_full_compactio
 
 
 @pytest.mark.asyncio
+async def test_prepare_prompt_context_protects_precommitted_current_prompt_from_compaction() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    current_prompt = ModelRequest(parts=[UserPromptPart(content="Current prompt")])
+    base_history = [
+        ModelRequest(parts=[UserPromptPart(content="Older prompt")]),
+        ModelResponse(parts=[]),
+        current_prompt,
+    ]
+    compacted_history = [
+        ModelRequest(parts=[UserPromptPart(content="Compacted carryover")])
+    ]
+    session._config = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        context_window=600,
+    )
+    session._message_repo = cast(MessageRepository, _FakeMessageRepo(base_history))
+    session._conversation_microcompact_service = None
+    compaction_service = _FakeCompactionService(
+        applied=True,
+        messages=tuple(compacted_history),
+    )
+    session._conversation_compaction_service = cast(
+        ConversationCompactionService,
+        compaction_service,
+    )
+    session._hook_service = None
+    session._reminder_service = None
+    session._run_event_hub = cast(Any, None)
+    session._run_intent_repo = cast(
+        RunIntentRepository,
+        _FakeRunIntentRepo("Current prompt"),
+    )
+    session._estimated_mcp_context_tokens = _zero_mcp_context_tokens
+    session._estimated_tool_context_tokens = lambda **_kwargs: 120
+
+    prepared = await AgentLlmSession._prepare_prompt_context(
+        session,
+        request=_build_request(user_prompt=None),
+        conversation_id="conv-1",
+        system_prompt="System prompt",
+        reserve_user_prompt_tokens=True,
+        allowed_tools=("shell",),
+        allowed_mcp_servers=(),
+        allowed_skills=(),
+    )
+
+    assert list(prepared.history) == [*compacted_history, current_prompt]
+    assert compaction_service.calls
+    assert compaction_service.calls[0]["history"] == base_history[:-1]
+    assert compaction_service.calls[0]["source_history"] == base_history[:-1]
+
+
+@pytest.mark.asyncio
 async def test_maybe_compact_history_emits_pre_and_post_compact_hooks() -> None:
     session = object.__new__(AgentLlmSession)
     history = [

--- a/tests/unit_tests/agents/execution/session_prompt_core_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_prompt_core_test_cases.py
@@ -254,6 +254,9 @@ async def test_prepare_prompt_context_protects_precommitted_current_prompt_from_
     assert compaction_service.calls
     assert compaction_service.calls[0]["history"] == base_history[:-1]
     assert compaction_service.calls[0]["source_history"] == base_history[:-1]
+    budget = compaction_service.calls[0]["budget"]
+    assert isinstance(budget, ConversationCompactionBudget)
+    assert budget.estimated_user_prompt_tokens > 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/session_prompt_core_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_prompt_core_test_cases.py
@@ -257,6 +257,83 @@ async def test_prepare_prompt_context_protects_precommitted_current_prompt_from_
 
 
 @pytest.mark.asyncio
+async def test_prepare_prompt_context_leaves_history_when_no_current_prompt_key() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    base_history: list[ModelRequest | ModelResponse] = [ModelResponse(parts=[])]
+    session._config = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        context_window=600,
+    )
+    session._message_repo = cast(MessageRepository, _FakeMessageRepo(base_history))
+    session._conversation_microcompact_service = None
+    session._conversation_compaction_service = None
+    session._estimated_mcp_context_tokens = _zero_mcp_context_tokens
+    session._estimated_tool_context_tokens = lambda **_kwargs: 120
+    session._run_intent_repo = cast(
+        RunIntentRepository,
+        _FakeRunIntentRepo("Continue without a prompt key."),
+    )
+
+    prepared = await AgentLlmSession._prepare_prompt_context(
+        session,
+        request=_build_request(user_prompt=None),
+        conversation_id="conv-1",
+        system_prompt="System prompt",
+        reserve_user_prompt_tokens=True,
+        allowed_tools=("shell",),
+        allowed_mcp_servers=(),
+        allowed_skills=(),
+    )
+
+    assert len(prepared.history) == 2
+    assert isinstance(prepared.history[0], ModelRequest)
+    assert prepared.history[1] == base_history[0]
+
+
+@pytest.mark.asyncio
+async def test_prepare_prompt_context_leaves_non_tail_current_prompt_in_history() -> (
+    None
+):
+    session = object.__new__(AgentLlmSession)
+    base_history = [
+        ModelRequest(parts=[UserPromptPart(content="Current prompt")]),
+        ModelResponse(parts=[]),
+    ]
+    session._config = ModelEndpointConfig(
+        model="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        context_window=600,
+    )
+    session._message_repo = cast(MessageRepository, _FakeMessageRepo(base_history))
+    session._conversation_microcompact_service = None
+    session._conversation_compaction_service = None
+    session._estimated_mcp_context_tokens = _zero_mcp_context_tokens
+    session._estimated_tool_context_tokens = lambda **_kwargs: 120
+    session._run_intent_repo = cast(
+        RunIntentRepository,
+        _FakeRunIntentRepo("Current prompt"),
+    )
+
+    prepared = await AgentLlmSession._prepare_prompt_context(
+        session,
+        request=_build_request(user_prompt=None),
+        conversation_id="conv-1",
+        system_prompt="System prompt",
+        reserve_user_prompt_tokens=True,
+        allowed_tools=("shell",),
+        allowed_mcp_servers=(),
+        allowed_skills=(),
+    )
+
+    assert list(prepared.history) == base_history
+
+
+@pytest.mark.asyncio
 async def test_maybe_compact_history_emits_pre_and_post_compact_hooks() -> None:
     session = object.__new__(AgentLlmSession)
     history = [

--- a/tests/unit_tests/agents/execution/test_conversation_compaction.py
+++ b/tests/unit_tests/agents/execution/test_conversation_compaction.py
@@ -300,6 +300,26 @@ def test_render_transcript_does_not_clip_first_tool_line_mid_token() -> None:
     assert transcript.startswith("User/Tool\nTool result [shell]:")
 
 
+def test_render_transcript_handles_empty_and_tiny_budget_cases() -> None:
+    assert compaction_module._render_transcript([], max_chars=32) == ""
+
+    single = compaction_module._render_transcript(
+        [ModelRequest(parts=[UserPromptPart(content="x" * 120)])],
+        max_chars=24,
+    )
+    assert single.startswith("User/Tool\nUser:")
+
+    tiny_multi = compaction_module._render_transcript(
+        [
+            ModelRequest(parts=[UserPromptPart(content="first compacted turn")]),
+            ModelRequest(parts=[UserPromptPart(content="second compacted turn")]),
+        ],
+        max_chars=32,
+    )
+    assert "transcript middle clipped" not in tiny_multi
+    assert tiny_multi.startswith("User/Tool\nUser:")
+
+
 def test_render_transcript_preserves_newest_compacted_turns_when_budget_clips() -> None:
     history = [
         ModelRequest(parts=[UserPromptPart(content="head objective")]),
@@ -331,6 +351,40 @@ def test_render_transcript_preserves_newest_compacted_turns_when_budget_clips() 
     assert "phase-5 anchor: nylon-orbit-508" in transcript
     assert "phase-5 checksum: CHK-P5-ER8" in transcript
     assert "transcript middle clipped" in transcript
+
+
+def test_render_transcript_omits_marker_when_suffix_has_no_safe_boundary() -> None:
+    transcript = compaction_module._render_transcript(
+        [
+            ModelRequest(parts=[UserPromptPart(content="head objective")]),
+            ModelRequest(parts=[UserPromptPart(content="x" * 1000)]),
+        ],
+        max_chars=600,
+    )
+
+    assert "head objective" in transcript
+    assert "transcript middle clipped" not in transcript
+
+
+def test_clip_rendered_message_suffix_uses_complete_tail_lines() -> None:
+    assert compaction_module._clip_rendered_message_suffix("", max_chars=8) == ""
+    assert compaction_module._clip_rendered_message_suffix("abcdef", max_chars=8) == (
+        "abcdef"
+    )
+    assert (
+        compaction_module._clip_rendered_message_suffix(
+            "abcdef",
+            max_chars=3,
+        )
+        == ""
+    )
+    assert (
+        compaction_module._clip_rendered_message_suffix(
+            "header\nline one\nline two",
+            max_chars=12,
+        )
+        == "line two"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/test_conversation_compaction.py
+++ b/tests/unit_tests/agents/execution/test_conversation_compaction.py
@@ -300,6 +300,39 @@ def test_render_transcript_does_not_clip_first_tool_line_mid_token() -> None:
     assert transcript.startswith("User/Tool\nTool result [shell]:")
 
 
+def test_render_transcript_preserves_newest_compacted_turns_when_budget_clips() -> None:
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="head objective")]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="shell",
+                    tool_call_id="call-1",
+                    content="\n".join(f"middle filler {index}" for index in range(80)),
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=(
+                        "Preserve exact facts.\n"
+                        "- phase-5 anchor: nylon-orbit-508\n"
+                        "- phase-5 checksum: CHK-P5-ER8"
+                    )
+                )
+            ]
+        ),
+    ]
+
+    transcript = compaction_module._render_transcript(history, max_chars=600)
+
+    assert "head objective" in transcript
+    assert "phase-5 anchor: nylon-orbit-508" in transcript
+    assert "phase-5 checksum: CHK-P5-ER8" in transcript
+    assert "transcript middle clipped" in transcript
+
+
 @pytest.mark.asyncio
 async def test_conversation_compaction_service_hides_messages_and_creates_marker(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/agents/execution/test_conversation_compaction.py
+++ b/tests/unit_tests/agents/execution/test_conversation_compaction.py
@@ -353,7 +353,7 @@ def test_render_transcript_preserves_newest_compacted_turns_when_budget_clips() 
     assert "transcript middle clipped" in transcript
 
 
-def test_render_transcript_omits_marker_when_suffix_has_no_safe_boundary() -> None:
+def test_render_transcript_preserves_single_line_suffix_when_clipped() -> None:
     transcript = compaction_module._render_transcript(
         [
             ModelRequest(parts=[UserPromptPart(content="head objective")]),
@@ -363,7 +363,8 @@ def test_render_transcript_omits_marker_when_suffix_has_no_safe_boundary() -> No
     )
 
     assert "head objective" in transcript
-    assert "transcript middle clipped" not in transcript
+    assert "transcript middle clipped" in transcript
+    assert "x" * 20 in transcript
 
 
 def test_clip_rendered_message_suffix_uses_complete_tail_lines() -> None:
@@ -376,7 +377,7 @@ def test_clip_rendered_message_suffix_uses_complete_tail_lines() -> None:
             "abcdef",
             max_chars=3,
         )
-        == ""
+        == "def"
     )
     assert (
         compaction_module._clip_rendered_message_suffix(

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -28,6 +28,7 @@ from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
+from relay_teams.sessions.runs.system_injection import SystemInjectionSink
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.sessions.runs.event_log import EventLog
@@ -35,6 +36,9 @@ from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.run_models import IntentInput, RunThinkingConfig
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
+from relay_teams.sessions.runs.todo_models import TodoItem, TodoStatus
+from relay_teams.sessions.runs.todo_repository import TodoRepository
+from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.sessions.runs.recoverable_pause import (
     RecoverableRunPauseError,
     RecoverableRunPausePayload,
@@ -45,6 +49,7 @@ from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeStatus,
 )
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.reminders import ReminderStateRepository, SystemReminderService
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.skills.skill_routing_service import SkillRuntimeService
@@ -83,6 +88,23 @@ class _CapturingProvider:
         self.thinking_enabled.append(getattr(thinking, "enabled", False) is True)
         self.thinking_efforts.append(getattr(thinking, "effort", None))
         return "ok"
+
+
+class _TodoCompletingProvider:
+    def __init__(self, todo_service: TodoService) -> None:
+        self.calls = 0
+        self._todo_service = todo_service
+
+    async def generate(self, request: object) -> str:
+        self.calls += 1
+        if self.calls == 2:
+            self._todo_service.clear_for_run(
+                run_id=str(getattr(request, "run_id")),
+                session_id=str(getattr(request, "session_id")),
+                updated_by_role_id=str(getattr(request, "role_id")),
+                updated_by_instance_id=str(getattr(request, "instance_id")),
+            )
+        return f"ok-{self.calls}"
 
 
 class _InterruptingProvider:
@@ -388,6 +410,71 @@ async def test_execute_omits_objective_when_task_history_exists(
 
     assert result.output == "ok"
     assert provider.prompts == [None]
+
+
+@pytest.mark.asyncio
+async def test_execute_retries_root_completion_when_todos_are_incomplete(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "task_execution_service_reminders.db"
+    todo_service = TodoService(repository=TodoRepository(db_path))
+    provider = _TodoCompletingProvider(todo_service)
+    service, task_repo, agent_repo, message_repo = _build_service(db_path, provider)
+    service.todo_service = todo_service
+    service.reminder_service = SystemReminderService(
+        state_repository=ReminderStateRepository(service.shared_store),
+        injection_sink=SystemInjectionSink(
+            injection_manager=RunInjectionManager(),
+            run_event_hub=RunEventHub(),
+            message_repo=message_repo,
+        ),
+    )
+    workspace_id = "default"
+    conversation_id = build_conversation_id("session-1", "time")
+    instance = create_subagent_instance(
+        "time",
+        workspace_id=workspace_id,
+        conversation_id=conversation_id,
+    )
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        objective="query time",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(task)
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id=instance.instance_id,
+        role_id="time",
+        workspace_id=instance.workspace_id,
+        conversation_id=instance.conversation_id,
+        status=InstanceStatus.IDLE,
+    )
+    todo_service.replace_for_run(
+        run_id="run-1",
+        session_id="session-1",
+        items=(TodoItem(content="finish verification", status=TodoStatus.PENDING),),
+    )
+
+    result = await service.execute(
+        instance_id=instance.instance_id,
+        role_id="time",
+        task=task,
+    )
+
+    refreshed = task_repo.get("task-1")
+    messages = message_repo.get_messages_for_instance("session-1", instance.instance_id)
+    serialized_messages = json.dumps(messages, ensure_ascii=False)
+    assert provider.calls == 2
+    assert result.output == "ok-2"
+    assert refreshed.status == TaskStatus.COMPLETED
+    assert "<system-reminder>" in serialized_messages
+    assert "finish verification" in serialized_messages
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -4,7 +4,21 @@ from pathlib import Path
 
 import pytest
 
+from relay_teams.secrets import AppSecretStore
+
 _UNIT_TESTS_ROOT = Path(__file__).resolve().parent
+
+
+class _UnitTestSecretStore(AppSecretStore):
+    def has_usable_keyring_backend(self) -> bool:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _disable_system_keyring_for_unit_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    import relay_teams.secrets.secret_store as secret_store
+
+    monkeypatch.setattr(secret_store, "_SECRET_STORE", _UnitTestSecretStore())
 
 
 def pytest_collection_modifyitems(

--- a/tests/unit_tests/reminders/__init__.py
+++ b/tests/unit_tests/reminders/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/unit_tests/reminders/test_policy.py
+++ b/tests/unit_tests/reminders/test_policy.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from relay_teams.reminders import (
+    CompletionAttemptObservation,
+    IncompleteTodoItem,
+    ReminderKind,
+    ReminderPolicyConfig,
+    SystemReminderPolicy,
+    ToolResultObservation,
+)
+from relay_teams.reminders.state import ReminderRunState, mark_issued
+
+
+def test_policy_reminds_after_read_only_streak_threshold() -> None:
+    policy = SystemReminderPolicy(ReminderPolicyConfig(read_only_streak_threshold=2))
+    state = ReminderRunState()
+
+    first, state = policy.evaluate_tool_result(
+        observation=_tool_result("read"),
+        state=state,
+    )
+    second, state = policy.evaluate_tool_result(
+        observation=_tool_result("grep"),
+        state=state,
+    )
+
+    assert first.issue is False
+    assert second.issue is True
+    assert second.kind == ReminderKind.READ_ONLY_STREAK
+    assert state.read_only_streak == 2
+
+
+def test_policy_resets_read_only_streak_after_mutating_tool() -> None:
+    policy = SystemReminderPolicy(ReminderPolicyConfig(read_only_streak_threshold=2))
+    state = ReminderRunState(read_only_streak=1)
+
+    decision, state = policy.evaluate_tool_result(
+        observation=_tool_result("write"),
+        state=state,
+    )
+
+    assert decision.issue is False
+    assert state.read_only_streak == 0
+
+
+def test_policy_dedupes_tool_failure_with_cooldown() -> None:
+    policy = SystemReminderPolicy()
+    state = ReminderRunState()
+    observation = _tool_result(
+        "read",
+        ok=False,
+        error_type="file_missing",
+        error_message="No such file",
+    )
+
+    first, state = policy.evaluate_tool_result(
+        observation=observation,
+        state=state,
+    )
+    state = mark_issued(state=state, issue_key=first.issue_key)
+    second, _ = policy.evaluate_tool_result(
+        observation=observation,
+        state=state,
+    )
+
+    assert first.issue is True
+    assert first.kind == ReminderKind.TOOL_FAILURE
+    assert second.issue is False
+
+
+def test_policy_fails_completion_after_retry_limit() -> None:
+    policy = SystemReminderPolicy(ReminderPolicyConfig(completion_max_retries=1))
+    observation = CompletionAttemptObservation(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        incomplete_todos=(
+            IncompleteTodoItem(content="finish tests", status="pending"),
+        ),
+    )
+    state = ReminderRunState()
+
+    first, state = policy.evaluate_completion_attempt(
+        observation=observation,
+        state=state,
+    )
+    second, state = policy.evaluate_completion_attempt(
+        observation=observation,
+        state=state,
+    )
+
+    assert first.retry_completion is True
+    assert second.fail_completion is True
+    assert state.completion_retry_count == 2
+
+
+def _tool_result(
+    tool_name: str,
+    *,
+    ok: bool = True,
+    error_type: str = "",
+    error_message: str = "",
+) -> ToolResultObservation:
+    return ToolResultObservation(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        tool_name=tool_name,
+        tool_call_id=f"call-{tool_name}",
+        ok=ok,
+        error_type=error_type,
+        error_message=error_message,
+    )

--- a/tests/unit_tests/reminders/test_renderer.py
+++ b/tests/unit_tests/reminders/test_renderer.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from relay_teams.reminders import render_system_reminder
+
+
+def test_render_system_reminder_wraps_content() -> None:
+    assert render_system_reminder(" Pay attention. ") == (
+        "<system-reminder>\nPay attention.\n</system-reminder>"
+    )
+
+
+def test_render_system_reminder_ignores_empty_content() -> None:
+    assert render_system_reminder("  ") == ""

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -6,7 +6,9 @@ from typing import cast
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.reminders import (
     CompletionAttemptObservation,
+    ContextPressureObservation,
     IncompleteTodoItem,
+    ReminderKind,
     ReminderPolicyConfig,
     ReminderStateRepository,
     SystemReminderPolicy,
@@ -92,6 +94,34 @@ def test_service_appends_completion_retry_reminder(tmp_path: Path) -> None:
     assert len(sink.appended) == 1
     assert sink.enqueued == []
     assert "finish tests" in sink.appended[0]
+
+
+def test_service_enqueues_context_pressure_reminder(tmp_path: Path) -> None:
+    sink = _CapturingSink()
+    service = _service(tmp_path, sink)
+
+    decision = service.observe_context_pressure(
+        ContextPressureObservation(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="role-1",
+            conversation_id="conversation-1",
+            kind=ReminderKind.POST_COMPACTION,
+            message_count_before=20,
+            message_count_after=8,
+            estimated_tokens_before=1000,
+            estimated_tokens_after=400,
+            threshold_tokens=800,
+            target_tokens=300,
+        )
+    )
+
+    assert decision.issue is True
+    assert len(sink.enqueued) == 1
+    assert "Conversation history was compacted" in sink.enqueued[0]
 
 
 def _service(

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -247,6 +247,37 @@ def test_service_preserves_completion_retry_limit_when_state_save_fails() -> Non
     assert len(sink.appended) == 1
 
 
+def test_service_preserves_completion_retry_limit_when_state_load_fails() -> None:
+    sink = _CapturingSink()
+    repository = _FailingStateRepository(fail_get=True)
+    service = SystemReminderService(
+        state_repository=repository,
+        injection_sink=cast(SystemInjectionSink, sink),
+        policy=SystemReminderPolicy(ReminderPolicyConfig(completion_max_retries=1)),
+    )
+    observation = CompletionAttemptObservation(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        incomplete_todos=(
+            IncompleteTodoItem(content="finish tests", status="pending"),
+        ),
+    )
+
+    first = service.evaluate_completion_attempt(observation)
+    second = service.evaluate_completion_attempt(observation)
+
+    assert first.retry_completion is True
+    assert second.fail_completion is True
+    assert len(sink.appended) == 1
+    assert [state.completion_retry_count for state in repository.saved_states] == [1, 2]
+
+
 def _service(
     tmp_path: Path,
     sink: _CapturingSink,

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import cast
+
+import pytest
 
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.reminders import (
@@ -10,6 +13,7 @@ from relay_teams.reminders import (
     IncompleteTodoItem,
     ReminderKind,
     ReminderPolicyConfig,
+    ReminderRunState,
     ReminderStateRepository,
     SystemReminderPolicy,
     SystemReminderService,
@@ -37,6 +41,31 @@ class _CapturingSink:
     def append_only(self, **kwargs: object) -> SystemInjectionResult:
         self.appended.append(str(kwargs["content"]))
         return SystemInjectionResult(appended=True)
+
+
+class _FailingStateRepository(ReminderStateRepository):
+    def __init__(self, *, fail_get: bool = False, fail_save: bool = False) -> None:
+        self._fail_get = fail_get
+        self._fail_save = fail_save
+        self.saved_states: list[ReminderRunState] = []
+
+    def get_run_state(self, *, session_id: str, run_id: str) -> ReminderRunState:
+        _ = (session_id, run_id)
+        if self._fail_get:
+            raise RuntimeError("state read failed")
+        return ReminderRunState()
+
+    def save_run_state(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        state: ReminderRunState,
+    ) -> None:
+        _ = (session_id, run_id)
+        if self._fail_save:
+            raise RuntimeError("state save failed")
+        self.saved_states.append(state)
 
 
 def test_service_enqueues_tool_failure_reminder_once(tmp_path: Path) -> None:
@@ -124,6 +153,71 @@ def test_service_enqueues_context_pressure_reminder(tmp_path: Path) -> None:
     assert "Conversation history was compacted" in sink.enqueued[0]
 
 
+def test_service_continues_when_reminder_state_load_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = _CapturingSink()
+    service = SystemReminderService(
+        state_repository=_FailingStateRepository(fail_get=True),
+        injection_sink=cast(SystemInjectionSink, sink),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="relay_teams.reminders.service"):
+        decision = service.observe_context_pressure(
+            ContextPressureObservation(
+                session_id="session-1",
+                run_id="run-1",
+                trace_id="run-1",
+                task_id="task-1",
+                instance_id="inst-1",
+                role_id="role-1",
+                conversation_id="conversation-1",
+                kind=ReminderKind.POST_COMPACTION,
+                message_count_before=20,
+                message_count_after=8,
+                estimated_tokens_before=1000,
+                estimated_tokens_after=400,
+                threshold_tokens=800,
+                target_tokens=300,
+            )
+        )
+
+    assert decision.issue is True
+    assert len(sink.enqueued) == 1
+    assert "reminders.state.load_failed" in _logged_events(caplog)
+
+
+def test_service_continues_when_reminder_state_save_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = _CapturingSink()
+    service = SystemReminderService(
+        state_repository=_FailingStateRepository(fail_save=True),
+        injection_sink=cast(SystemInjectionSink, sink),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="relay_teams.reminders.service"):
+        decision = service.observe_tool_result(
+            ToolResultObservation(
+                session_id="session-1",
+                run_id="run-1",
+                trace_id="run-1",
+                task_id="task-1",
+                instance_id="inst-1",
+                role_id="role-1",
+                tool_name="read",
+                tool_call_id="call-1",
+                ok=False,
+                error_type="file_missing",
+                error_message="No such file",
+            )
+        )
+
+    assert decision.issue is True
+    assert len(sink.enqueued) == 1
+    assert "reminders.state.save_failed" in _logged_events(caplog)
+
+
 def _service(
     tmp_path: Path,
     sink: _CapturingSink,
@@ -137,3 +231,12 @@ def _service(
         injection_sink=cast(SystemInjectionSink, sink),
         policy=policy,
     )
+
+
+def _logged_events(caplog: pytest.LogCaptureFixture) -> list[str]:
+    events: list[str] = []
+    for record in caplog.records:
+        event = getattr(record, "event", None)
+        if isinstance(event, str):
+            events.append(event)
+    return events

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.reminders import (
+    CompletionAttemptObservation,
+    IncompleteTodoItem,
+    ReminderPolicyConfig,
+    ReminderStateRepository,
+    SystemReminderPolicy,
+    SystemReminderService,
+    ToolResultObservation,
+)
+from relay_teams.sessions.runs.system_injection import (
+    SystemInjectionResult,
+    SystemInjectionSink,
+)
+
+
+class _CapturingSink:
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+        self.appended: list[str] = []
+
+    def enqueue_only(self, **kwargs: object) -> SystemInjectionResult:
+        self.enqueued.append(str(kwargs["content"]))
+        return SystemInjectionResult(enqueued=True)
+
+    def append_and_enqueue(self, **kwargs: object) -> SystemInjectionResult:
+        self.appended.append(str(kwargs["content"]))
+        return SystemInjectionResult(appended=True, enqueued=True)
+
+
+def test_service_enqueues_tool_failure_reminder_once(tmp_path: Path) -> None:
+    sink = _CapturingSink()
+    service = _service(tmp_path, sink)
+    observation = ToolResultObservation(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        tool_name="read",
+        tool_call_id="call-1",
+        ok=False,
+        error_type="file_missing",
+        error_message="No such file",
+    )
+
+    first = service.observe_tool_result(observation)
+    second = service.observe_tool_result(observation)
+
+    assert first.issue is True
+    assert second.issue is False
+    assert len(sink.enqueued) == 1
+    assert "<system-reminder>" in sink.enqueued[0]
+    assert "No such file" in sink.enqueued[0]
+
+
+def test_service_appends_completion_retry_reminder(tmp_path: Path) -> None:
+    sink = _CapturingSink()
+    service = _service(
+        tmp_path,
+        sink,
+        policy=SystemReminderPolicy(ReminderPolicyConfig(completion_max_retries=2)),
+    )
+
+    decision = service.evaluate_completion_attempt(
+        CompletionAttemptObservation(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="role-1",
+            workspace_id="workspace-1",
+            conversation_id="conversation-1",
+            incomplete_todos=(
+                IncompleteTodoItem(content="finish tests", status="pending"),
+            ),
+        )
+    )
+
+    assert decision.retry_completion is True
+    assert len(sink.appended) == 1
+    assert "finish tests" in sink.appended[0]
+
+
+def _service(
+    tmp_path: Path,
+    sink: _CapturingSink,
+    *,
+    policy: SystemReminderPolicy | None = None,
+) -> SystemReminderService:
+    return SystemReminderService(
+        state_repository=ReminderStateRepository(
+            SharedStateRepository(tmp_path / "state.db")
+        ),
+        injection_sink=cast(SystemInjectionSink, sink),
+        policy=policy,
+    )

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -32,6 +32,10 @@ class _CapturingSink:
         self.appended.append(str(kwargs["content"]))
         return SystemInjectionResult(appended=True, enqueued=True)
 
+    def append_only(self, **kwargs: object) -> SystemInjectionResult:
+        self.appended.append(str(kwargs["content"]))
+        return SystemInjectionResult(appended=True)
+
 
 def test_service_enqueues_tool_failure_reminder_once(tmp_path: Path) -> None:
     sink = _CapturingSink()
@@ -86,6 +90,7 @@ def test_service_appends_completion_retry_reminder(tmp_path: Path) -> None:
 
     assert decision.retry_completion is True
     assert len(sink.appended) == 1
+    assert sink.enqueued == []
     assert "finish tests" in sink.appended[0]
 
 

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -218,6 +218,35 @@ def test_service_continues_when_reminder_state_save_fails(
     assert "reminders.state.save_failed" in _logged_events(caplog)
 
 
+def test_service_preserves_completion_retry_limit_when_state_save_fails() -> None:
+    sink = _CapturingSink()
+    service = SystemReminderService(
+        state_repository=_FailingStateRepository(fail_save=True),
+        injection_sink=cast(SystemInjectionSink, sink),
+        policy=SystemReminderPolicy(ReminderPolicyConfig(completion_max_retries=1)),
+    )
+    observation = CompletionAttemptObservation(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        incomplete_todos=(
+            IncompleteTodoItem(content="finish tests", status="pending"),
+        ),
+    )
+
+    first = service.evaluate_completion_attempt(observation)
+    second = service.evaluate_completion_attempt(observation)
+
+    assert first.retry_completion is True
+    assert second.fail_completion is True
+    assert len(sink.appended) == 1
+
+
 def _service(
     tmp_path: Path,
     sink: _CapturingSink,

--- a/tests/unit_tests/reminders/test_state.py
+++ b/tests/unit_tests/reminders/test_state.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from json import dumps
+from pathlib import Path
+
+from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.reminders.state import (
+    ReminderRunState,
+    ReminderStateRepository,
+    can_issue,
+    mark_issued,
+)
+
+
+def test_state_repository_persists_run_state(tmp_path: Path) -> None:
+    repository = ReminderStateRepository(SharedStateRepository(tmp_path / "state.db"))
+    state = ReminderRunState(read_only_streak=3, completion_retry_count=1)
+
+    repository.save_run_state(session_id="session-1", run_id="run-1", state=state)
+
+    restored = repository.get_run_state(session_id="session-1", run_id="run-1")
+    assert restored == state
+
+
+def test_state_repository_ignores_invalid_persisted_state(tmp_path: Path) -> None:
+    shared = SharedStateRepository(tmp_path / "state.db")
+    shared.manage_state(
+        StateMutation(
+            scope=ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-1"),
+            key="system_reminders:run-1",
+            value_json=dumps({"read_only_streak": -1}),
+        )
+    )
+    repository = ReminderStateRepository(shared)
+
+    restored = repository.get_run_state(session_id="session-1", run_id="run-1")
+
+    assert restored == ReminderRunState()
+
+
+def test_can_issue_respects_cooldown() -> None:
+    now = datetime.now(tz=timezone.utc)
+    state = mark_issued(
+        state=ReminderRunState(),
+        issue_key="tool_failure:read:file_missing",
+        now=now,
+    )
+
+    assert (
+        can_issue(
+            state=state,
+            issue_key="tool_failure:read:file_missing",
+            cooldown_seconds=60,
+            now=now + timedelta(seconds=30),
+        )
+        is False
+    )
+    assert (
+        can_issue(
+            state=state,
+            issue_key="tool_failure:read:file_missing",
+            cooldown_seconds=60,
+            now=now + timedelta(seconds=61),
+        )
+        is True
+    )

--- a/tests/unit_tests/reminders/test_tool_effects.py
+++ b/tests/unit_tests/reminders/test_tool_effects.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from relay_teams.reminders import ToolEffect, classify_tool_effect
+
+
+def test_classify_tool_effect_treats_registered_orchestration_lists_as_read_only() -> (
+    None
+):
+    assert classify_tool_effect("orch_list_available_roles") == ToolEffect.READ_ONLY
+    assert classify_tool_effect("orch_list_delegated_tasks") == ToolEffect.READ_ONLY

--- a/tests/unit_tests/sessions/runs/test_system_injection_sink.py
+++ b/tests/unit_tests/sessions/runs/test_system_injection_sink.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
+from relay_teams.sessions.runs.enums import InjectionSource
 from relay_teams.sessions.runs.system_injection import SystemInjectionSink
 
 
@@ -99,3 +101,61 @@ def test_append_only_persists_without_queueing(tmp_path: Path) -> None:
     assert result.enqueued is False
     assert len(history) == 1
     assert injections == ()
+
+
+def test_append_only_without_message_repo_reports_not_appended() -> None:
+    sink = SystemInjectionSink(
+        injection_manager=RunInjectionManager(),
+        run_event_hub=RunEventHub(),
+        message_repo=None,
+    )
+
+    result = sink.append_only(
+        session_id="session-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        content="<system-reminder>\nCheck todos.\n</system-reminder>",
+    )
+
+    assert result.appended is False
+    assert result.enqueued is False
+
+
+def test_enqueue_only_degrades_when_active_run_disappears() -> None:
+    class _RaceyInjectionManager:
+        def is_active(self, run_id: str) -> bool:
+            _ = run_id
+            return True
+
+        def enqueue(
+            self,
+            *,
+            run_id: str,
+            recipient_instance_id: str,
+            source: InjectionSource,
+            content: object,
+        ) -> object:
+            _ = (run_id, recipient_instance_id, source, content)
+            raise KeyError("run disappeared")
+
+    sink = SystemInjectionSink(
+        injection_manager=cast(RunInjectionManager, _RaceyInjectionManager()),
+        run_event_hub=RunEventHub(),
+        message_repo=None,
+    )
+
+    result = sink.enqueue_only(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        content="<system-reminder>\nCheck todos.\n</system-reminder>",
+    )
+
+    assert result.enqueued is False

--- a/tests/unit_tests/sessions/runs/test_system_injection_sink.py
+++ b/tests/unit_tests/sessions/runs/test_system_injection_sink.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.injection_queue import RunInjectionManager
+from relay_teams.sessions.runs.system_injection import SystemInjectionSink
+
+
+def test_append_and_enqueue_persists_message_and_queues_injection(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "messages.db"
+    message_repo = MessageRepository(db_path)
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    sink = SystemInjectionSink(
+        injection_manager=injection_manager,
+        run_event_hub=RunEventHub(),
+        message_repo=message_repo,
+    )
+
+    result = sink.append_and_enqueue(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        content="<system-reminder>\nCheck todos.\n</system-reminder>",
+    )
+
+    history = message_repo.get_history_for_conversation("conversation-1")
+    injections = injection_manager.drain_at_boundary("run-1", "inst-1")
+    assert result.appended is True
+    assert result.enqueued is True
+    assert len(history) == 1
+    assert len(injections) == 1
+    assert (
+        injections[0].content == "<system-reminder>\nCheck todos.\n</system-reminder>"
+    )
+
+
+def test_append_and_enqueue_appends_even_when_run_is_inactive(tmp_path: Path) -> None:
+    db_path = tmp_path / "messages.db"
+    message_repo = MessageRepository(db_path)
+    sink = SystemInjectionSink(
+        injection_manager=RunInjectionManager(),
+        run_event_hub=RunEventHub(),
+        message_repo=message_repo,
+    )
+
+    result = sink.append_and_enqueue(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        content="<system-reminder>\nCheck todos.\n</system-reminder>",
+    )
+
+    history = message_repo.get_history_for_conversation("conversation-1")
+    assert result.appended is True
+    assert result.enqueued is False
+    assert len(history) == 1

--- a/tests/unit_tests/sessions/runs/test_system_injection_sink.py
+++ b/tests/unit_tests/sessions/runs/test_system_injection_sink.py
@@ -69,3 +69,33 @@ def test_append_and_enqueue_appends_even_when_run_is_inactive(tmp_path: Path) ->
     assert result.appended is True
     assert result.enqueued is False
     assert len(history) == 1
+
+
+def test_append_only_persists_without_queueing(tmp_path: Path) -> None:
+    db_path = tmp_path / "messages.db"
+    message_repo = MessageRepository(db_path)
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    sink = SystemInjectionSink(
+        injection_manager=injection_manager,
+        run_event_hub=RunEventHub(),
+        message_repo=message_repo,
+    )
+
+    result = sink.append_only(
+        session_id="session-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        content="<system-reminder>\nCheck todos.\n</system-reminder>",
+    )
+
+    history = message_repo.get_history_for_conversation("conversation-1")
+    injections = injection_manager.drain_at_boundary("run-1", "inst-1")
+    assert result.appended is True
+    assert result.enqueued is False
+    assert len(history) == 1
+    assert injections == ()

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -988,6 +988,76 @@ def test_execute_tool_ignores_domain_failed_status_for_successful_tools() -> Non
     assert observation.error_message == ""
 
 
+def test_reported_failure_helper_scopes_to_shell_failure_projections() -> None:
+    assert (
+        execution_module._reported_failure_from_success_envelope(
+            tool_name="shell",
+            envelope={"ok": False},
+        )
+        is None
+    )
+    assert (
+        execution_module._reported_failure_from_success_envelope(
+            tool_name="wait_background_task",
+            envelope={"ok": True, "data": {"status": "failed", "exit_code": 1}},
+        )
+        is None
+    )
+    assert (
+        execution_module._reported_failure_from_success_envelope(
+            tool_name="shell",
+            envelope={"ok": True, "data": "failed"},
+        )
+        is None
+    )
+    assert (
+        execution_module._reported_failure_from_success_envelope(
+            tool_name="shell",
+            envelope={"ok": True, "data": {"status": "completed", "exit_code": 1}},
+        )
+        is None
+    )
+    assert (
+        execution_module._reported_failure_from_success_envelope(
+            tool_name="shell",
+            envelope={"ok": True, "data": {"status": "failed", "exit_code": 0}},
+        )
+        is None
+    )
+    assert execution_module._reported_failure_from_success_envelope(
+        tool_name="shell",
+        envelope={
+            "ok": True,
+            "data": {
+                "status": "failed",
+                "exit_code": 2,
+                "recent_output": ["line one", "line two"],
+            },
+        },
+    ) == ("reported_failed_status", "line one\nline two")
+    assert execution_module._reported_failure_from_success_envelope(
+        tool_name="shell",
+        envelope={
+            "ok": True,
+            "data": {
+                "status": "failed",
+                "exit_code": 3,
+                "command": "cat missing.txt",
+            },
+        },
+    ) == ("reported_failed_status", "Command failed with exit code 3: cat missing.txt")
+    assert execution_module._reported_failure_from_success_envelope(
+        tool_name="shell",
+        envelope={
+            "ok": True,
+            "data": {
+                "status": "failed",
+                "exit_code": 1,
+            },
+        },
+    ) == ("reported_failed_status", "The tool result reported failed status.")
+
+
 def test_execute_tool_returns_tool_return_for_tool_content_parts() -> None:
     deps = _FakeDeps(
         manager=_FakeApprovalManager(wait_result=("approve", "")),

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -19,10 +19,12 @@ import relay_teams.tools.runtime.execution as execution_module
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.notifications import NotificationService, default_notification_config
+from relay_teams.reminders import ToolResultObservation
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.hooks import HookDecisionBundle, HookDecisionType, HookEventName
+from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.media import (
     MediaModality,
@@ -76,6 +78,12 @@ class _FakeInjectionRecord:
         self.source = source
         self.content = content
 
+    def model_dump_json(self) -> str:
+        return json.dumps(
+            {"source": self.source.value, "content": self.content},
+            ensure_ascii=False,
+        )
+
 
 class _FakeInjectionManager:
     def __init__(self) -> None:
@@ -97,6 +105,15 @@ class _FakeInjectionManager:
         record = _FakeInjectionRecord(source=source, content=content)
         self.records.append(record)
         return record
+
+
+class _FakeReminderService:
+    def __init__(self) -> None:
+        self.observations: list[ToolResultObservation] = []
+
+    def observe_tool_result(self, observation: ToolResultObservation) -> object:
+        self.observations.append(observation)
+        return None
 
 
 class _FakeApprovalManager:
@@ -167,9 +184,11 @@ class _FakeDeps:
         self.tool_approval_policy = policy
         self.notification_service = _build_notification_service(self.run_event_hub)
         self.hook_service: object | None = None
+        self.reminder_service: object | None = None
         self.hook_runtime_env: dict[str, str] = {}
         self.injection_manager = _FakeInjectionManager()
         self.media_asset_service: object | None = None
+        self.message_repo = MessageRepository(db_path)
         self.approval_ticket_repo = ApprovalTicketRepository(db_path)
         self.run_runtime_repo = RunRuntimeRepository(db_path)
         self.shared_store = SharedStateRepository(Path(mkdtemp()) / "state.db")
@@ -891,6 +910,45 @@ def test_execute_tool_supports_projection_with_separate_visible_and_internal_dat
         cast(dict[str, JsonValue], state.result_envelope)["internal_data"],
     )
     assert internal_data["stdout"] == "/tmp\n"
+
+
+def test_execute_tool_reports_failed_status_projection_to_reminders() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    reminder_service = _FakeReminderService()
+    deps.reminder_service = reminder_service
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-shell-failed-status"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="shell",
+            args_summary={"command": "cat missing.txt"},
+            action=lambda: ToolResultProjection(
+                visible_data={
+                    "status": "failed",
+                    "command": "cat missing.txt",
+                    "exit_code": 1,
+                    "output_excerpt": "cat: missing.txt: No such file or directory",
+                },
+                internal_data={
+                    "status": "failed",
+                    "command": "cat missing.txt",
+                    "exit_code": 1,
+                },
+            ),
+        )
+    )
+
+    assert result["ok"] is True
+    assert len(reminder_service.observations) == 1
+    observation = reminder_service.observations[0]
+    assert observation.ok is False
+    assert observation.error_type == "reported_failed_status"
+    assert observation.error_message == "cat: missing.txt: No such file or directory"
 
 
 def test_execute_tool_returns_tool_return_for_tool_content_parts() -> None:

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -951,6 +951,43 @@ def test_execute_tool_reports_failed_status_projection_to_reminders() -> None:
     assert observation.error_message == "cat: missing.txt: No such file or directory"
 
 
+def test_execute_tool_ignores_domain_failed_status_for_successful_tools() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    reminder_service = _FakeReminderService()
+    deps.reminder_service = reminder_service
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-background-status"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="wait_background_task",
+            args_summary={"background_task_id": "bg-1"},
+            action=lambda: ToolResultProjection(
+                visible_data={
+                    "status": "failed",
+                    "background_task_id": "bg-1",
+                    "output": "background task failed after the wait completed",
+                },
+                internal_data={
+                    "status": "failed",
+                    "background_task_id": "bg-1",
+                },
+            ),
+        )
+    )
+
+    assert result["ok"] is True
+    assert len(reminder_service.observations) == 1
+    observation = reminder_service.observations[0]
+    assert observation.ok is True
+    assert observation.error_type == ""
+    assert observation.error_message == ""
+
+
 def test_execute_tool_returns_tool_return_for_tool_content_parts() -> None:
     deps = _FakeDeps(
         manager=_FakeApprovalManager(wait_result=("approve", "")),


### PR DESCRIPTION
## Summary
- Add an event-driven system reminder module for tool failures, read-only streaks, post-compaction context pressure, and incomplete todo completion guards.
- Wire reminder injection through the shared run injection path for normal agent, external agent, and host tool flows.
- Document reminder boundaries and the relationship with runtime hooks.

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests`
- Browser real-LLM E2E covered read-only streak, tool failure, shell semantic failure, and incomplete todo guard paths.

Fixes #49
