### PR TITLE
Persist workspace read state by session

### DIFF
--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -86,6 +86,7 @@ from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.skills.skill_routing_service import SkillRuntimeService
 from relay_teams.tools.registry.registry import ToolRegistry, ToolResolutionContext
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from relay_teams.tools.workspace_tools.edit_state import READ_STATE_PREFIX
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.workspace import WorkspaceHandle, WorkspaceManager
 
@@ -1223,7 +1224,10 @@ class TaskExecutionService(BaseModel):
             ScopeRef(scope_type=ScopeType.ROLE, scope_id=f"{session_id}:{role_id}"),
             ScopeRef(scope_type=ScopeType.CONVERSATION, scope_id=conversation_id),
         )
-        return self.shared_store.snapshot_many(scopes)
+        return self.shared_store.snapshot_many(
+            scopes,
+            exclude_key_prefixes=(READ_STATE_PREFIX,),
+        )
 
     def _ensure_committed_task_prompt(
         self,

--- a/src/relay_teams/persistence/shared_state_repo.py
+++ b/src/relay_teams/persistence/shared_state_repo.py
@@ -92,10 +92,14 @@ class SharedStateRepository(SharedSqliteRepository):
     def snapshot_many(
         self,
         scopes: tuple[ScopeRef, ...],
+        *,
+        exclude_key_prefixes: tuple[str, ...] = (),
     ) -> tuple[tuple[str, str], ...]:
         merged: dict[str, str] = {}
         for scope in scopes:
             for key, value in self.snapshot(scope):
+                if key.startswith(exclude_key_prefixes):
+                    continue
                 merged[key] = value
         ordered_items = sorted(merged.items(), key=lambda item: item[0])
         return tuple((key, value) for key, value in ordered_items)
@@ -107,6 +111,24 @@ class SharedStateRepository(SharedSqliteRepository):
                 self._conn.execute(
                     "DELETE FROM shared_state WHERE expires_at IS NOT NULL AND expires_at <= CURRENT_TIMESTAMP"
                 ).rowcount
+            ),
+        )
+
+    def delete_by_scope_key_prefix(self, scope: ScopeRef, key_prefix: str) -> None:
+        self._run_write(
+            operation_name="delete_by_scope_key_prefix",
+            operation=lambda: self._conn.execute(
+                """
+                DELETE FROM shared_state
+                WHERE scope_type=? AND scope_id=?
+                  AND substr(state_key, 1, ?) = ?
+                """,
+                (
+                    scope.scope_type.value,
+                    scope.scope_id,
+                    len(key_prefix),
+                    key_prefix,
+                ),
             ),
         )
 

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -51,6 +51,7 @@ from relay_teams.sessions.runs.user_question_repository import UserQuestionRepos
 from relay_teams.sessions.external_session_binding_repository import (
     ExternalSessionBindingRepository,
 )
+from relay_teams.tools.workspace_tools.edit_state import READ_STATE_PREFIX
 from relay_teams.sessions.session_models import (
     ProjectKind,
     SessionMetadataPatch,
@@ -625,6 +626,10 @@ class SessionService:
                 ),
                 conversation_id=agent.conversation_id,
                 task_ids=task_ids,
+            )
+            self._shared_store.delete_by_scope_key_prefix(
+                ScopeRef(scope_type=ScopeType.SESSION, scope_id=session_id),
+                READ_STATE_PREFIX + agent.conversation_id + ":",
             )
         self._approval_ticket_repo.delete_by_run(agent.run_id)
         for background_task_record in background_task_records:
@@ -1526,7 +1531,10 @@ class SessionService:
             ScopeRef(scope_type=ScopeType.ROLE, scope_id=f"{session_id}:{role_id}"),
             ScopeRef(scope_type=ScopeType.CONVERSATION, scope_id=conversation_id),
         )
-        return self._shared_store.snapshot_many(scopes)
+        return self._shared_store.snapshot_many(
+            scopes,
+            exclude_key_prefixes=(READ_STATE_PREFIX,),
+        )
 
 
 def _history_marker_label(marker: SessionHistoryMarkerRecord) -> str:

--- a/src/relay_teams/tools/workspace_tools/edit.py
+++ b/src/relay_teams/tools/workspace_tools/edit.py
@@ -452,7 +452,8 @@ def apply_edit(
 def edit_file_with_guard(
     *,
     shared_store: SharedStateRepository,
-    task_id: str,
+    session_id: str,
+    conversation_id: str,
     file_path: Path,
     old_string: str,
     new_string: str,
@@ -466,7 +467,8 @@ def edit_file_with_guard(
     if old_string != "":
         assert_file_unchanged_since_read(
             shared_store=shared_store,
-            task_id=task_id,
+            session_id=session_id,
+            conversation_id=conversation_id,
             path=file_path,
         )
     result = apply_edit(
@@ -475,7 +477,12 @@ def edit_file_with_guard(
         new_string=new_string,
         replace_all=replace_all,
     )
-    record_file_read(shared_store=shared_store, task_id=task_id, path=file_path)
+    record_file_read(
+        shared_store=shared_store,
+        session_id=session_id,
+        conversation_id=conversation_id,
+        path=file_path,
+    )
     return result
 
 
@@ -507,7 +514,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             file_path = ctx.deps.workspace.resolve_path(path, write=True)
             result = edit_file_with_guard(
                 shared_store=ctx.deps.shared_store,
-                task_id=ctx.deps.task_id,
+                session_id=ctx.deps.session_id,
+                conversation_id=ctx.deps.conversation_id,
                 file_path=file_path,
                 old_string=old_string,
                 new_string=new_string,

--- a/src/relay_teams/tools/workspace_tools/edit_state.py
+++ b/src/relay_teams/tools/workspace_tools/edit_state.py
@@ -37,14 +37,15 @@ def fingerprint_file(path: Path) -> FileReadState:
 def record_file_read(
     *,
     shared_store: SharedStateRepository,
-    task_id: str,
+    session_id: str,
+    conversation_id: str,
     path: Path,
 ) -> FileReadState:
     state = fingerprint_file(path)
     shared_store.manage_state(
         StateMutation(
-            scope=_task_scope(task_id),
-            key=_state_key(path),
+            scope=_session_scope(session_id),
+            key=_state_key(conversation_id=conversation_id, path=path),
             value_json=state.model_dump_json(),
         )
     )
@@ -54,10 +55,14 @@ def record_file_read(
 def load_file_read_state(
     *,
     shared_store: SharedStateRepository,
-    task_id: str,
+    session_id: str,
+    conversation_id: str,
     path: Path,
 ) -> FileReadState | None:
-    raw = shared_store.get_state(_task_scope(task_id), _state_key(path))
+    raw = shared_store.get_state(
+        _session_scope(session_id),
+        _state_key(conversation_id=conversation_id, path=path),
+    )
     if raw is None:
         return None
     try:
@@ -75,10 +80,16 @@ def load_file_read_state(
 def assert_file_was_read(
     *,
     shared_store: SharedStateRepository,
-    task_id: str,
+    session_id: str,
+    conversation_id: str,
     path: Path,
 ) -> FileReadState:
-    state = load_file_read_state(shared_store=shared_store, task_id=task_id, path=path)
+    state = load_file_read_state(
+        shared_store=shared_store,
+        session_id=session_id,
+        conversation_id=conversation_id,
+        path=path,
+    )
     if state is None:
         raise ValueError("You must read file before editing it.")
     return state
@@ -87,19 +98,25 @@ def assert_file_was_read(
 def assert_file_unchanged_since_read(
     *,
     shared_store: SharedStateRepository,
-    task_id: str,
+    session_id: str,
+    conversation_id: str,
     path: Path,
 ) -> FileReadState:
-    state = assert_file_was_read(shared_store=shared_store, task_id=task_id, path=path)
+    state = assert_file_was_read(
+        shared_store=shared_store,
+        session_id=session_id,
+        conversation_id=conversation_id,
+        path=path,
+    )
     current = fingerprint_file(path)
     if current.mtime_ns != state.mtime_ns or current.size != state.size:
         raise ValueError("File has been modified since it was last read.")
     return state
 
 
-def _task_scope(task_id: str) -> ScopeRef:
-    return ScopeRef(scope_type=ScopeType.TASK, scope_id=task_id)
+def _session_scope(session_id: str) -> ScopeRef:
+    return ScopeRef(scope_type=ScopeType.SESSION, scope_id=session_id)
 
 
-def _state_key(path: Path) -> str:
-    return READ_STATE_PREFIX + normalize_resolved_path(path)
+def _state_key(*, conversation_id: str, path: Path) -> str:
+    return READ_STATE_PREFIX + conversation_id + ":" + normalize_resolved_path(path)

--- a/src/relay_teams/tools/workspace_tools/notebook.py
+++ b/src/relay_teams/tools/workspace_tools/notebook.py
@@ -428,7 +428,8 @@ def dump_notebook(
 def notebook_edit_file_with_guard(
     *,
     shared_store: SharedStateRepository,
-    task_id: str,
+    session_id: str,
+    conversation_id: str,
     file_path: Path,
     cell_id: str | None,
     new_source: str,
@@ -437,7 +438,8 @@ def notebook_edit_file_with_guard(
 ) -> dict[str, JsonValue]:
     assert_file_unchanged_since_read(
         shared_store=shared_store,
-        task_id=task_id,
+        session_id=session_id,
+        conversation_id=conversation_id,
         path=file_path,
     )
     notebook, original_content, newline = load_notebook(file_path)
@@ -454,7 +456,12 @@ def notebook_edit_file_with_guard(
         trailing_newline=original_content.endswith(("\n", "\r\n")),
     )
     atomic_write(file_path, updated_content, encoding="utf-8", newline="")
-    record_file_read(shared_store=shared_store, task_id=task_id, path=file_path)
+    record_file_read(
+        shared_store=shared_store,
+        session_id=session_id,
+        conversation_id=conversation_id,
+        path=file_path,
+    )
     diff_summary = format_diff_summary(original_content, updated_content)
     diff = generate_diff(str(file_path), original_content, updated_content)
     output = (

--- a/src/relay_teams/tools/workspace_tools/notebook_edit.py
+++ b/src/relay_teams/tools/workspace_tools/notebook_edit.py
@@ -45,7 +45,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             file_path = ctx.deps.workspace.resolve_path(path, write=True)
             result = notebook_edit_file_with_guard(
                 shared_store=ctx.deps.shared_store,
-                task_id=ctx.deps.task_id,
+                session_id=ctx.deps.session_id,
+                conversation_id=ctx.deps.conversation_id,
                 file_path=file_path,
                 cell_id=cell_id,
                 new_source=new_source,

--- a/src/relay_teams/tools/workspace_tools/office_read_markdown.py
+++ b/src/relay_teams/tools/workspace_tools/office_read_markdown.py
@@ -184,7 +184,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             output.append("</content>")
             record_file_read(
                 shared_store=ctx.deps.shared_store,
-                task_id=ctx.deps.task_id,
+                session_id=ctx.deps.session_id,
+                conversation_id=ctx.deps.conversation_id,
                 path=file_path,
             )
 

--- a/src/relay_teams/tools/workspace_tools/read.py
+++ b/src/relay_teams/tools/workspace_tools/read.py
@@ -293,7 +293,8 @@ def _project_image_read_result(
     media_part = media_content_part.model_dump(mode="json")
     record_file_read(
         shared_store=ctx.deps.shared_store,
-        task_id=ctx.deps.task_id,
+        session_id=ctx.deps.session_id,
+        conversation_id=ctx.deps.conversation_id,
         path=file_path,
     )
     output = "\n".join(
@@ -406,7 +407,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 output = _inject_instruction_sections(output, instruction_sections)
                 record_file_read(
                     shared_store=ctx.deps.shared_store,
-                    task_id=ctx.deps.task_id,
+                    session_id=ctx.deps.session_id,
+                    conversation_id=ctx.deps.conversation_id,
                     path=file_path,
                 )
                 return _project_read_result(
@@ -481,7 +483,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             output.append("</content>")
             record_file_read(
                 shared_store=ctx.deps.shared_store,
-                task_id=ctx.deps.task_id,
+                session_id=ctx.deps.session_id,
+                conversation_id=ctx.deps.conversation_id,
                 path=file_path,
             )
 

--- a/tests/unit_tests/persistence/test_shared_state_repo.py
+++ b/tests/unit_tests/persistence/test_shared_state_repo.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+
+
+def test_snapshot_many_can_exclude_internal_key_prefixes(tmp_path: Path) -> None:
+    repository = SharedStateRepository(tmp_path / "state.db")
+    scope = ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-1")
+    repository.manage_state(
+        StateMutation(
+            scope=scope,
+            key="workspace_read:/repo/file.py",
+            value_json='{"path": "/repo/file.py"}',
+        )
+    )
+    repository.manage_state(
+        StateMutation(
+            scope=scope,
+            key="ticket",
+            value_json='"BUG-123"',
+        )
+    )
+
+    assert repository.snapshot_many(
+        (scope,),
+        exclude_key_prefixes=("workspace_read:",),
+    ) == (("ticket", '"BUG-123"'),)
+
+
+def test_delete_by_scope_key_prefix_removes_only_matching_scope_and_prefix(
+    tmp_path: Path,
+) -> None:
+    repository = SharedStateRepository(tmp_path / "state.db")
+    session_scope = ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-1")
+    other_session_scope = ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-2")
+    for scope, key in (
+        (session_scope, "workspace_read:conversation-1:/repo/file.py"),
+        (session_scope, "workspace_read:conversation-2:/repo/file.py"),
+        (session_scope, "ticket"),
+        (other_session_scope, "workspace_read:conversation-1:/repo/file.py"),
+    ):
+        repository.manage_state(
+            StateMutation(
+                scope=scope,
+                key=key,
+                value_json='"value"',
+            )
+        )
+
+    repository.delete_by_scope_key_prefix(
+        session_scope,
+        "workspace_read:conversation-1:",
+    )
+
+    assert set(repository.snapshot(session_scope)) == {
+        ("workspace_read:conversation-2:/repo/file.py", '"value"'),
+        ("ticket", '"value"'),
+    }
+    assert repository.snapshot(other_session_scope) == (
+        ("workspace_read:conversation-1:/repo/file.py", '"value"'),
+    )

--- a/tests/unit_tests/sessions/test_session_delete_workspace_cleanup.py
+++ b/tests/unit_tests/sessions/test_session_delete_workspace_cleanup.py
@@ -28,6 +28,10 @@ from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.session_service import SessionService
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from relay_teams.tools.workspace_tools.edit_state import (
+    load_file_read_state,
+    record_file_read,
+)
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.run_runtime_repo import (
@@ -493,6 +497,21 @@ def test_delete_normal_mode_subagent_cleans_child_session_state(tmp_path: Path) 
             value_json='"conversation"',
         )
     )
+    read_state_path = project_root / "source.py"
+    read_state_path.write_text("print('hello')\n", encoding="utf-8")
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id=conversation_id,
+        path=read_state_path,
+    )
+    main_conversation_id = build_conversation_id("session-1", "MainAgent")
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id=main_conversation_id,
+        path=read_state_path,
+    )
 
     background_task_repository = BackgroundTaskRepository(db_path)
     workspace_manager = WorkspaceManager(
@@ -568,6 +587,24 @@ def test_delete_normal_mode_subagent_cleans_child_session_state(tmp_path: Path) 
             ScopeRef(scope_type=ScopeType.CONVERSATION, scope_id=conversation_id)
         )
         == ()
+    )
+    assert (
+        load_file_read_state(
+            shared_store=shared_store,
+            session_id="session-1",
+            conversation_id=conversation_id,
+            path=read_state_path,
+        )
+        is None
+    )
+    assert (
+        load_file_read_state(
+            shared_store=shared_store,
+            session_id="session-1",
+            conversation_id=main_conversation_id,
+            path=read_state_path,
+        )
+        is not None
     )
 
 

--- a/tests/unit_tests/tools/workspace_tools/test_edit.py
+++ b/tests/unit_tests/tools/workspace_tools/test_edit.py
@@ -101,7 +101,8 @@ def test_edit_file_with_guard_requires_read_first(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="You must read file"):
         edit_file_with_guard(
             shared_store=shared_store,
-            task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
             file_path=file_path,
             old_string="content",
             new_string="updated",
@@ -112,11 +113,17 @@ def test_edit_file_with_guard_succeeds_after_read(tmp_path: Path) -> None:
     shared_store = SharedStateRepository(tmp_path / "state.db")
     file_path = tmp_path / "file.txt"
     file_path.write_text("content", encoding="utf-8")
-    record_file_read(shared_store=shared_store, task_id="task-1", path=file_path)
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
 
     result = edit_file_with_guard(
         shared_store=shared_store,
-        task_id="task-1",
+        session_id="session-1",
+        conversation_id="conversation-1",
         file_path=file_path,
         old_string="content",
         new_string="updated",
@@ -125,9 +132,60 @@ def test_edit_file_with_guard_succeeds_after_read(tmp_path: Path) -> None:
     assert file_path.read_text(encoding="utf-8") == "updated"
     assert "Edit applied successfully." in result["output"]
     state = load_file_read_state(
-        shared_store=shared_store, task_id="task-1", path=file_path
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
     )
     assert state is not None
+
+
+def test_edit_file_with_guard_reuses_read_state_for_same_session(
+    tmp_path: Path,
+) -> None:
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content", encoding="utf-8")
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
+
+    result = edit_file_with_guard(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        file_path=file_path,
+        old_string="content",
+        new_string="updated",
+    )
+
+    assert file_path.read_text(encoding="utf-8") == "updated"
+    assert "Edit applied successfully." in result["output"]
+
+
+def test_file_read_state_does_not_leak_between_conversations(tmp_path: Path) -> None:
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content", encoding="utf-8")
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
+
+    assert (
+        load_file_read_state(
+            shared_store=shared_store,
+            session_id="session-1",
+            conversation_id="conversation-2",
+            path=file_path,
+        )
+        is None
+    )
 
 
 def test_edit_file_with_guard_rejects_external_change_after_read(
@@ -136,13 +194,19 @@ def test_edit_file_with_guard_rejects_external_change_after_read(
     shared_store = SharedStateRepository(tmp_path / "state.db")
     file_path = tmp_path / "file.txt"
     file_path.write_text("content", encoding="utf-8")
-    record_file_read(shared_store=shared_store, task_id="task-1", path=file_path)
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
     file_path.write_text("changed externally", encoding="utf-8")
 
     with pytest.raises(ValueError, match="modified since it was last read"):
         edit_file_with_guard(
             shared_store=shared_store,
-            task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
             file_path=file_path,
             old_string="changed externally",
             new_string="updated",
@@ -157,14 +221,20 @@ def test_edit_file_with_guard_allows_new_file_without_prior_read(
 
     edit_file_with_guard(
         shared_store=shared_store,
-        task_id="task-1",
+        session_id="session-1",
+        conversation_id="conversation-1",
         file_path=file_path,
         old_string="",
         new_string="created",
     )
 
     assert file_path.read_text(encoding="utf-8") == "created"
-    assert_file_was_read(shared_store=shared_store, task_id="task-1", path=file_path)
+    assert_file_was_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
 
 
 def test_project_edit_result_keeps_only_output_visible() -> None:

--- a/tests/unit_tests/tools/workspace_tools/test_notebook.py
+++ b/tests/unit_tests/tools/workspace_tools/test_notebook.py
@@ -186,7 +186,8 @@ def test_notebook_edit_file_requires_prior_read(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="read file before editing"):
         notebook_edit_file_with_guard(
             shared_store=shared_store,
-            task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
             file_path=file_path,
             cell_id="calc",
             new_source="print(2)\n",
@@ -197,13 +198,19 @@ def test_notebook_edit_file_rejects_external_change_after_read(tmp_path: Path) -
     file_path = tmp_path / "demo.ipynb"
     _write_notebook(file_path)
     shared_store = SharedStateRepository(tmp_path / "state.db")
-    record_file_read(shared_store=shared_store, task_id="task-1", path=file_path)
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
     _write_notebook(file_path, {**_notebook(), "metadata": {"changed": True}})
 
     with pytest.raises(ValueError, match="modified since it was last read"):
         notebook_edit_file_with_guard(
             shared_store=shared_store,
-            task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
             file_path=file_path,
             cell_id="calc",
             new_source="print(2)\n",
@@ -216,11 +223,17 @@ def test_notebook_edit_file_writes_cell_and_preserves_notebook_metadata(
     file_path = tmp_path / "demo.ipynb"
     _write_notebook(file_path)
     shared_store = SharedStateRepository(tmp_path / "state.db")
-    record_file_read(shared_store=shared_store, task_id="task-1", path=file_path)
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
 
     result = notebook_edit_file_with_guard(
         shared_store=shared_store,
-        task_id="task-1",
+        session_id="session-1",
+        conversation_id="conversation-1",
         file_path=file_path,
         cell_id="calc",
         new_source="print(2)\n",

--- a/tests/unit_tests/tools/workspace_tools/test_office_read_markdown.py
+++ b/tests/unit_tests/tools/workspace_tools/test_office_read_markdown.py
@@ -149,6 +149,8 @@ async def test_office_read_markdown_tool_converts_supported_pdf(
             workspace=_FakeWorkspace(tmp_path),
             shared_store=shared_store,
             task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
         )
     )
 
@@ -214,7 +216,8 @@ async def test_office_read_markdown_tool_converts_supported_pdf(
     assert (
         load_file_read_state(
             shared_store=shared_store,
-            task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
             path=file_path,
         )
         is not None
@@ -258,6 +261,8 @@ async def test_office_read_markdown_preserves_markdown_tables(
             workspace=_FakeWorkspace(tmp_path),
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
         )
     )
 
@@ -342,6 +347,8 @@ async def test_office_read_markdown_allows_explicit_line_numbers(
             workspace=_FakeWorkspace(tmp_path),
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
         )
     )
 
@@ -412,6 +419,8 @@ async def test_office_read_markdown_surfaces_office_ocr_error(
             workspace=_FakeWorkspace(tmp_path),
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
         )
     )
 
@@ -474,6 +483,8 @@ async def test_office_read_markdown_rejects_non_office_files(
             workspace=_FakeWorkspace(tmp_path),
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
         )
     )
 
@@ -529,6 +540,8 @@ async def test_office_read_markdown_rejects_non_positive_limit_before_conversion
             workspace=_FakeWorkspace(tmp_path),
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
         )
     )
 

--- a/tests/unit_tests/tools/workspace_tools/test_read.py
+++ b/tests/unit_tests/tools/workspace_tools/test_read.py
@@ -493,6 +493,8 @@ async def test_read_tool_reads_notebook_cell_without_outputs(
             workspace=_FakeWorkspace(tmp_path),
             shared_store=shared_store,
             task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
         )
     )
 
@@ -545,7 +547,8 @@ async def test_read_tool_reads_notebook_cell_without_outputs(
     assert (
         load_file_read_state(
             shared_store=shared_store,
-            task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
             path=file_path,
         )
         is not None
@@ -706,6 +709,7 @@ async def test_read_tool_projects_images_for_model_inspection(
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
             session_id="session-1",
+            conversation_id="conversation-1",
             workspace_id="workspace-1",
             run_id="run-1",
             instance_id="inst-1",
@@ -755,7 +759,8 @@ async def test_read_tool_projects_images_for_model_inspection(
     assert (
         load_file_read_state(
             shared_store=ctx.deps.shared_store,
-            task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
             path=file_path.resolve(),
         )
         is not None
@@ -786,6 +791,7 @@ async def test_read_tool_rejects_images_larger_than_limit(
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
             session_id="session-1",
+            conversation_id="conversation-1",
             workspace_id="workspace-1",
             run_id="run-1",
             instance_id="inst-1",
@@ -864,6 +870,7 @@ async def test_read_tool_rejects_images_without_model_image_input(
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
             session_id="session-1",
+            conversation_id="conversation-1",
             workspace_id="workspace-1",
             run_id="run-1",
             instance_id="inst-1",
@@ -929,6 +936,7 @@ async def test_read_tool_rejects_invalid_image_payloads(
             shared_store=SharedStateRepository(tmp_path / "state.db"),
             task_id="task-1",
             session_id="session-1",
+            conversation_id="conversation-1",
             workspace_id="workspace-1",
             run_id="run-1",
             instance_id="inst-1",


### PR DESCRIPTION
## Summary
- Persist workspace read-before-edit state at session scope instead of task scope
- Update edit, notebook edit, read, and office read paths to use session IDs
- Add regression coverage for same-session reuse and cross-session isolation

Fixes #505

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests