### PR TITLE
feat: add skill team role tools

### DIFF
--- a/docs/skill-routing-design.md
+++ b/docs/skill-routing-design.md
@@ -32,10 +32,13 @@ reuse or narrowing `load_skill` into a hard blocker.
 ## Non-Goals
 
 - Do not inline full skill bodies into any system prompt.
+- Do not inline skill-local role prompts into any system prompt.
 - Do not shrink the runtime tool catalog on every routing decision.
 - Do not change ACP wire protocol payloads.
 - Do not make execution fail when an existing role references a missing skill; runtime
   consumers must filter missing capabilities and log warnings.
+- Do not introduce a backend workflow engine for team skills. The model decides whether
+  to use skill-local roles after progressive discovery.
 
 ## Invariants
 
@@ -61,11 +64,19 @@ Document projection:
 
 - `document_id = skill_name`
 - `title = skill_name`
-- `body = description + instructions + scripts summary + resources summary`
+- `body = description + instructions + scripts summary + resources summary +
+  lightweight team-role signals`
 - `keywords = normalized tokens from skill name, scope, script names, and resource names`
 
 If both app and builtin scopes provide the same skill name, routing and prompt rendering
 use the app-scoped variant as the preferred document/source of truth.
+
+Team-role signals are intentionally small. When a skill contains `agents/` or `roles/`
+with role Markdown files, the index may include the directory names plus each role's
+`role_id`, `name`, and `description`. It must not include member role system prompts.
+Optional files such as `workflow.md`, `bind.md`, or `dependencies.yaml` may contribute
+their filenames as discovery signals, but their full content is not part of the
+retrieval document by default.
 
 The index is rebuilt at startup and on `skills:reload`.
 
@@ -133,6 +144,32 @@ relevant skills on each turn.
 
 This rule applies equally to local runtime tools and external ACP host tools.
 
+The same authorization boundary applies to skill-team tools. A role may list or
+activate skill-local roles only for skills already authorized by its capability set.
+
+## Skill-Team Role Tools
+
+Skill teams are discovered progressively by the model, not by a required manifest
+flag. The normal flow is:
+
+1. BM25 routing recommends candidate skills.
+2. The model uses `load_skill` to inspect the selected skill's lightweight manifest
+   and file index.
+3. If the skill appears to contain team members, the model uses the `skill-teams`
+   tool group to inspect and activate those members.
+
+The `skill-teams` group contains:
+
+- `list_skill_roles(skill_name)`: scans `agents/` and `roles/` under the skill
+  directory and returns role summaries only.
+- `activate_skill_roles(skill_name, role_ids)`: materializes selected skill-local
+  roles as run-scoped effective roles. Returned `effective_role_id` values may be
+  passed to existing `spawn_subagent` or `orch_dispatch_task`.
+
+These tools are registered in the default tool registry so role configuration and
+tool-group UI can expose them. They are not dynamic tools produced by
+`SkillRegistry.get_toolset_tools()`.
+
 ## Interface Changes
 
 ### `POST /api/prompts:preview`
@@ -194,4 +231,3 @@ Minimum coverage:
 - runtime stores routed skill candidates in user prompt history, not system prompt
 - external ACP packages skill candidates inside `User Prompt`
 - gateway ACP protocol behavior remains unchanged
-

--- a/docs/skill-routing-design.md
+++ b/docs/skill-routing-design.md
@@ -146,6 +146,9 @@ This rule applies equally to local runtime tools and external ACP host tools.
 
 The same authorization boundary applies to skill-team tools. A role may list or
 activate skill-local roles only for skills already authorized by its capability set.
+The built-in `MainAgent` and `Coordinator` roles both use the wildcard skill
+capability so normal and orchestration mode can activate team roles without
+manual role edits.
 
 ## Skill-Team Role Tools
 
@@ -160,8 +163,9 @@ flag. The normal flow is:
 
 The `skill-teams` group contains:
 
-- `list_skill_roles(skill_name)`: scans `agents/` and `roles/` under the skill
-  directory and returns role summaries only.
+- `list_skill_roles(skill_name)`: scans skill-local markdown files that expose role
+  front matter and returns role summaries only; directory and workflow file names
+  are not part of the contract.
 - `activate_skill_roles(skill_name, role_ids)`: materializes selected skill-local
   roles as run-scoped effective roles. Returned `effective_role_id` values may be
   passed to existing `spawn_subagent` or `orch_dispatch_task`.

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -290,6 +290,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 runtime_role_resolver=getattr(
                     self._task_execution_service, "runtime_role_resolver", None
                 ),
+                skill_registry=getattr(self, "_skill_registry", None),
                 mcp_registry=self._mcp_registry,
                 task_service=self._task_service,
                 task_execution_service=self._task_execution_service,

--- a/src/relay_teams/builtin/roles/coordinator.md
+++ b/src/relay_teams/builtin/roles/coordinator.md
@@ -5,6 +5,8 @@ description: Orchestrates delegated work across specialist roles.
 model_profile: default
 version: 1.0.0
 mode: primary
+skills:
+  - '*'
 tools:
   - orch_create_tasks
   - orch_create_temporary_role

--- a/src/relay_teams/builtin/roles/coordinator.md
+++ b/src/relay_teams/builtin/roles/coordinator.md
@@ -8,6 +8,8 @@ mode: primary
 tools:
   - orch_create_tasks
   - orch_create_temporary_role
+  - list_skill_roles
+  - activate_skill_roles
   - orch_update_task
   - orch_list_available_roles
   - orch_list_delegated_tasks

--- a/src/relay_teams/builtin/roles/main_agent.md
+++ b/src/relay_teams/builtin/roles/main_agent.md
@@ -20,6 +20,8 @@ tools:
   - shell
   - ask_question
   - spawn_subagent
+  - list_skill_roles
+  - activate_skill_roles
   - list_background_tasks
   - wait_background_task
   - stop_background_task

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -544,6 +544,10 @@ class ExternalAcpHostToolBridge:
             instance_id=request.instance_id,
             role_id=request.role_id,
             role_registry=self._get_role_registry(),
+            skill_registry=cast(
+                Callable[[], SkillRegistry | None],
+                getattr(self, "_get_skill_registry", lambda: None),
+            )(),
             mcp_registry=self._get_mcp_registry(),
             task_service=self._get_task_service(),
             task_execution_service=self._get_task_execution_service(),

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -45,6 +45,7 @@ from relay_teams.reminders import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
+from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
@@ -180,6 +181,7 @@ class ExternalAcpHostToolBridge:
         user_question_manager: UserQuestionManager | None,
         tool_approval_policy: ToolApprovalPolicy,
         get_notification_service: Callable[[], NotificationService | None],
+        runtime_role_resolver: RuntimeRoleResolver | None = None,
         resolve_model_config: (
             Callable[[RoleDefinition, LLMRequest], ModelEndpointConfig | None] | None
         ) = None,
@@ -218,6 +220,7 @@ class ExternalAcpHostToolBridge:
         self._user_question_manager = user_question_manager
         self._tool_approval_policy = tool_approval_policy
         self._get_notification_service = get_notification_service
+        self._runtime_role_resolver = runtime_role_resolver
         self._resolve_model_config = resolve_model_config
         self._metric_recorder = metric_recorder
         self._im_tool_service = im_tool_service
@@ -544,10 +547,8 @@ class ExternalAcpHostToolBridge:
             instance_id=request.instance_id,
             role_id=request.role_id,
             role_registry=self._get_role_registry(),
-            skill_registry=cast(
-                Callable[[], SkillRegistry | None],
-                getattr(self, "_get_skill_registry", lambda: None),
-            )(),
+            skill_registry=self._get_skill_registry(),
+            runtime_role_resolver=self._runtime_role_resolver,
             mcp_registry=self._get_mcp_registry(),
             task_service=self._get_task_service(),
             task_execution_service=self._get_task_execution_service(),

--- a/src/relay_teams/external_agents/provider.py
+++ b/src/relay_teams/external_agents/provider.py
@@ -52,6 +52,7 @@ from relay_teams.providers.openai_support import build_model_request_headers
 from relay_teams.providers.provider_contracts import LLMProvider, LLMRequest
 from relay_teams.reminders import SystemReminderService
 from relay_teams.roles.role_models import RoleDefinition
+from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.run_models import RunEvent
@@ -167,6 +168,7 @@ class ExternalAcpSessionManager:
         user_question_manager: UserQuestionManager | None,
         tool_approval_policy: ToolApprovalPolicy,
         get_notification_service: Callable[[], NotificationService | None],
+        runtime_role_resolver: RuntimeRoleResolver | None = None,
         shell_approval_repo: ShellApprovalRepository | None = None,
         resolve_model_config: (
             Callable[[RoleDefinition, LLMRequest], ModelEndpointConfig | None] | None
@@ -209,6 +211,7 @@ class ExternalAcpSessionManager:
         self._tool_approval_policy = tool_approval_policy
         self._shell_approval_repo = shell_approval_repo
         self._get_notification_service = get_notification_service
+        self._runtime_role_resolver = runtime_role_resolver
         self._resolve_model_config = resolve_model_config
         self._metric_recorder = metric_recorder
         self._im_tool_service = im_tool_service
@@ -969,6 +972,7 @@ class ExternalAcpSessionManager:
             tool_approval_manager=self._tool_approval_manager,
             user_question_manager=self._user_question_manager,
             tool_approval_policy=self._tool_approval_policy,
+            runtime_role_resolver=self._runtime_role_resolver,
             shell_approval_repo=self._shell_approval_repo,
             get_notification_service=self._get_notification_service,
             resolve_model_config=self._resolve_model_config,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -645,6 +645,7 @@ class ServerContainer:
             tool_approval_manager=self.tool_approval_manager,
             user_question_manager=self.user_question_manager,
             tool_approval_policy=self.tool_approval_policy,
+            runtime_role_resolver=self.runtime_role_resolver,
             shell_approval_repo=self.shell_approval_repo,
             get_notification_service=lambda: self.notification_service,
             resolve_model_config=self.resolve_external_agent_model_config,

--- a/src/relay_teams/interfaces/server/host_tool_stdio_server.py
+++ b/src/relay_teams/interfaces/server/host_tool_stdio_server.py
@@ -72,6 +72,7 @@ async def _run_stdio_server() -> None:
         tool_approval_manager=container.tool_approval_manager,
         user_question_manager=container.user_question_manager,
         tool_approval_policy=container.tool_approval_policy,
+        runtime_role_resolver=container.runtime_role_resolver,
         shell_approval_repo=container.shell_approval_repo,
         get_notification_service=lambda: container.notification_service,
         resolve_model_config=container.resolve_external_agent_model_config,

--- a/src/relay_teams/metrics/adapters/tool_metrics.py
+++ b/src/relay_teams/metrics/adapters/tool_metrics.py
@@ -24,6 +24,7 @@ class ToolSource(str, Enum):
 SKILL_TOOL_NAMES = frozenset(
     {
         "activate_skill_roles",
+        "list_skills",
         "list_skill_roles",
         "load_skill",
     }

--- a/src/relay_teams/metrics/adapters/tool_metrics.py
+++ b/src/relay_teams/metrics/adapters/tool_metrics.py
@@ -21,7 +21,13 @@ class ToolSource(str, Enum):
     MCP = "mcp"
 
 
-SKILL_TOOL_NAMES = frozenset({"load_skill"})
+SKILL_TOOL_NAMES = frozenset(
+    {
+        "activate_skill_roles",
+        "list_skill_roles",
+        "load_skill",
+    }
+)
 
 
 def record_tool_execution(

--- a/src/relay_teams/roles/runtime_role_resolver.py
+++ b/src/relay_teams/roles/runtime_role_resolver.py
@@ -36,6 +36,12 @@ class RuntimeRoleResolver:
                 return temp.role.to_role_definition()
         return self._role_registry.get(role_id)
 
+    def get_temporary_role(self, *, run_id: str | None, role_id: str) -> RoleDefinition:
+        if run_id is None:
+            raise KeyError(f"Unknown temporary role_id: {role_id}")
+        temp = self._temporary_role_repository.get(run_id=run_id, role_id=role_id)
+        return temp.role.to_role_definition()
+
     def list_effective_roles(self, *, run_id: str | None) -> tuple[RoleDefinition, ...]:
         static_roles = list(self._role_registry.list_roles())
         if run_id is None:

--- a/src/relay_teams/roles/temporary_role_models.py
+++ b/src/relay_teams/roles/temporary_role_models.py
@@ -15,6 +15,7 @@ from relay_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 class TemporaryRoleSource(str, Enum):
     META_AGENT_GENERATED = "meta_agent_generated"
+    SKILL_TEAM = "skill_team"
 
 
 class TemporaryRoleSpec(BaseModel):

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import datetime, timezone
 import logging
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Optional, Protocol, cast
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -20,6 +20,12 @@ from relay_teams.agents.tasks.ids import new_task_id
 from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
 from relay_teams.logger import get_logger, log_event
 from relay_teams.media import content_parts_from_text
+from relay_teams.roles.role_models import RoleDefinition, RoleMode
+from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
+from relay_teams.roles.temporary_role_models import (
+    TemporaryRoleSource,
+    TemporaryRoleSpec,
+)
 from relay_teams.sessions.runs.background_tasks.command_runtime import (
     normalize_timeout,
 )
@@ -348,6 +354,7 @@ class BackgroundTaskService:
         workspace_id: str,
         cwd: Path,
         subagent_role_id: str,
+        subagent_role: RoleDefinition | None = None,
         title: str,
         prompt: str,
     ) -> BackgroundTaskRecord:
@@ -359,6 +366,7 @@ class BackgroundTaskService:
             session_id=session_id,
             workspace_id=workspace_id,
             subagent_role_id=subagent_role_id,
+            subagent_role=subagent_role,
             title=title,
             prompt=prompt,
         )
@@ -453,6 +461,7 @@ class BackgroundTaskService:
         session_id: str,
         workspace_id: str,
         subagent_role_id: str,
+        subagent_role: RoleDefinition | None = None,
         title: str,
         prompt: str,
         suppress_hooks: bool = False,
@@ -464,6 +473,7 @@ class BackgroundTaskService:
             session_id=session_id,
             workspace_id=workspace_id,
             subagent_role_id=subagent_role_id,
+            subagent_role=subagent_role,
             title=title,
             prompt=prompt,
             suppress_hooks=suppress_hooks,
@@ -1033,6 +1043,7 @@ class BackgroundTaskService:
         session_id: str,
         workspace_id: str,
         subagent_role_id: str,
+        subagent_role: RoleDefinition | None = None,
         title: str,
         prompt: str,
         suppress_hooks: bool = False,
@@ -1103,6 +1114,11 @@ class BackgroundTaskService:
             subagent_role_id=subagent_role_id,
             prompt=normalized_prompt,
         )
+        self._clone_subagent_role_snapshot(
+            subagent_run_id=subagent_run_id,
+            session_id=session_id,
+            subagent_role=subagent_role,
+        )
         if self._run_runtime_repo is not None:
             _ = self._run_runtime_repo.ensure(
                 run_id=subagent_run_id,
@@ -1129,6 +1145,28 @@ class BackgroundTaskService:
             suppress_hooks=suppress_hooks,
             subagent_instance=subagent_instance,
             subagent_task=subagent_task,
+        )
+
+    def _clone_subagent_role_snapshot(
+        self,
+        *,
+        subagent_run_id: str,
+        session_id: str,
+        subagent_role: RoleDefinition | None,
+    ) -> None:
+        if subagent_role is None or self._task_execution_service is None:
+            return
+        runtime_role_resolver = cast(
+            RuntimeRoleResolver | None,
+            getattr(self._task_execution_service, "runtime_role_resolver", None),
+        )
+        if runtime_role_resolver is None:
+            return
+        runtime_role_resolver.create_temporary_role(
+            run_id=subagent_run_id,
+            session_id=session_id,
+            source=TemporaryRoleSource.SKILL_TEAM,
+            role=_temporary_role_spec_from_definition(subagent_role),
         )
 
     def _prime_subagent_hook_snapshot(self, *, subagent_run_id: str) -> None:
@@ -1324,6 +1362,24 @@ class BackgroundTaskService:
             active_subagent_instance_id=None,
             last_error=output or "Task failed",
         )
+
+
+def _temporary_role_spec_from_definition(role: RoleDefinition) -> TemporaryRoleSpec:
+    return TemporaryRoleSpec(
+        role_id=role.role_id,
+        name=role.name,
+        description=role.description,
+        version=role.version,
+        tools=role.tools,
+        mcp_servers=role.mcp_servers,
+        skills=role.skills,
+        model_profile=role.model_profile,
+        bound_agent_id=role.bound_agent_id,
+        execution_surface=role.execution_surface,
+        mode=RoleMode.SUBAGENT,
+        memory_profile=role.memory_profile,
+        system_prompt=role.system_prompt,
+    )
 
 
 def _default_subagent_title(*, role_id: str, prompt: str) -> str:

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -775,12 +775,16 @@ class BackgroundTaskService:
             output_text=summarized_output,
         )
         runtime = self._subagent_runtimes.pop(background_task_id, None)
-        if runtime is not None:
+        subagent_run_id = (
+            runtime.subagent_run_id if runtime is not None else record.subagent_run_id
+        )
+        if subagent_run_id:
             self._finalize_subagent_run_runtime(
-                subagent_run_id=runtime.subagent_run_id,
+                subagent_run_id=subagent_run_id,
                 status=status,
                 output=summarized_output,
             )
+        if runtime is not None:
             self._require_run_control_manager().unregister_run_task(
                 runtime.subagent_run_id
             )
@@ -1154,12 +1158,9 @@ class BackgroundTaskService:
         session_id: str,
         subagent_role: RoleDefinition | None,
     ) -> None:
-        if subagent_role is None or self._task_execution_service is None:
+        if subagent_role is None:
             return
-        runtime_role_resolver = cast(
-            RuntimeRoleResolver | None,
-            getattr(self._task_execution_service, "runtime_role_resolver", None),
-        )
+        runtime_role_resolver = self._get_runtime_role_resolver()
         if runtime_role_resolver is None:
             return
         runtime_role_resolver.create_temporary_role(
@@ -1167,6 +1168,14 @@ class BackgroundTaskService:
             session_id=session_id,
             source=TemporaryRoleSource.SKILL_TEAM,
             role=_temporary_role_spec_from_definition(subagent_role),
+        )
+
+    def _get_runtime_role_resolver(self) -> RuntimeRoleResolver | None:
+        if self._task_execution_service is None:
+            return None
+        return cast(
+            RuntimeRoleResolver | None,
+            getattr(self._task_execution_service, "runtime_role_resolver", None),
         )
 
     def _prime_subagent_hook_snapshot(self, *, subagent_run_id: str) -> None:
@@ -1322,6 +1331,9 @@ class BackgroundTaskService:
     ) -> None:
         if self._hook_service is not None:
             self._hook_service.clear_run(subagent_run_id)
+        runtime_role_resolver = self._get_runtime_role_resolver()
+        if runtime_role_resolver is not None:
+            runtime_role_resolver.cleanup_run(run_id=subagent_run_id)
         run_runtime_repo = self._run_runtime_repo
         if run_runtime_repo is None:
             return

--- a/src/relay_teams/skills/__init__.py
+++ b/src/relay_teams/skills/__init__.py
@@ -41,6 +41,10 @@ from relay_teams.skills.skill_routing_service import (
     SkillRoutingService,
     build_skill_routing_query_text,
 )
+from relay_teams.skills.skill_team_roles import (
+    SkillTeamRoleDefinition,
+    SkillTeamRoleSummary,
+)
 
 __all__ = [
     "Skill",
@@ -61,6 +65,8 @@ __all__ = [
     "SkillRoutingService",
     "SkillSource",
     "SkillScript",
+    "SkillTeamRoleDefinition",
+    "SkillTeamRoleSummary",
     "SkillSummaryEntry",
     "SkillsDirectory",
     "SkillRegistry",

--- a/src/relay_teams/skills/skill_registry.py
+++ b/src/relay_teams/skills/skill_registry.py
@@ -200,6 +200,20 @@ class SkillRegistry(BaseModel):
             if missing:
                 raise ValueError(f"Unknown skills: {list(missing)}")
 
+    def resolve_authorized_name_for_role(
+        self,
+        *,
+        role: object,
+        requested_name: str,
+        consumer: str | None = None,
+    ) -> str | None:
+        return _resolve_skill_name_for_role(
+            skill_registry=self,
+            role=role,
+            requested_name=requested_name,
+            consumer=consumer,
+        )
+
     def list_names(self) -> tuple[str, ...]:
         return tuple(skill.ref for skill in self.list_skill_definitions())
 
@@ -297,10 +311,10 @@ class SkillRegistry(BaseModel):
                     skill_registry=self,
                     ctx=ctx,
                 )
-                resolved_name = _resolve_skill_name_for_role(
-                    skill_registry=self,
+                resolved_name = self.resolve_authorized_name_for_role(
                     role=role,
                     requested_name=requested_name,
+                    consumer=f"skills.registry.load_skill.role:{getattr(role, 'role_id', '')}",
                 )
                 if resolved_name is None:
                     raise PermissionError(
@@ -560,6 +574,7 @@ def _raise_if_skill_unauthorized(
         skill_registry=skill_registry,
         role=role,
         requested_name=skill_name,
+        consumer=f"skills.registry.load_skill.role:{getattr(role, 'role_id', '')}",
     )
     if resolved_name is not None:
         return
@@ -591,6 +606,7 @@ def _resolve_skill_name_for_role(
     skill_registry: SkillRegistry,
     role: object,
     requested_name: str,
+    consumer: str | None = None,
 ) -> str | None:
     requested = requested_name.strip()
     if not requested:
@@ -607,7 +623,7 @@ def _resolve_skill_name_for_role(
         resolved_names = skill_registry.resolve_known(
             (requested,),
             strict=False,
-            consumer=f"skills.registry.load_skill.role:{getattr(role, 'role_id', '')}",
+            consumer=consumer,
         )
         if resolved_names:
             return resolved_names[0]

--- a/src/relay_teams/skills/skill_routing_service.py
+++ b/src/relay_teams/skills/skill_routing_service.py
@@ -23,6 +23,7 @@ from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.sessions.runs.run_models import RuntimePromptConversationContext
 from relay_teams.skills.skill_models import Skill, SkillInstructionEntry
 from relay_teams.skills.skill_registry import SkillRegistry
+from relay_teams.skills.skill_team_roles import build_skill_team_routing_signals
 from relay_teams.skills.skill_routing_models import (
     SkillPromptResult,
     SkillRouteCandidate,
@@ -474,6 +475,9 @@ def _build_skill_document_body(skill: Skill) -> str:
     ]
     if resource_lines:
         sections.append("Resources\n" + "\n".join(resource_lines))
+    team_role_lines = build_skill_team_routing_signals(skill)
+    if team_role_lines:
+        sections.append("Team Skill Signals\n" + "\n".join(team_role_lines))
     return "\n\n".join(sections)
 
 

--- a/src/relay_teams/skills/skill_team_roles.py
+++ b/src/relay_teams/skills/skill_team_roles.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 from pathlib import Path
 
+import yaml
 from pydantic import BaseModel, ConfigDict, Field
 
 from relay_teams.logger import get_logger, log_event
@@ -14,13 +15,6 @@ from relay_teams.roles.temporary_role_models import TemporaryRoleSpec
 from relay_teams.skills.skill_models import Skill
 
 LOGGER = get_logger(__name__)
-_ROLE_DIRECTORY_NAMES = ("agents", "roles")
-_TEAM_SIGNAL_FILENAMES = (
-    "workflow.md",
-    "bind.md",
-    "dependencies.yaml",
-    "dependencies.yml",
-)
 _MAX_IDENTIFIER_PART_LENGTH = 48
 
 
@@ -50,26 +44,26 @@ def list_skill_team_roles(skill: Skill) -> tuple[SkillTeamRoleDefinition, ...]:
     for role_path in _iter_skill_role_files(skill.directory):
         try:
             role = RoleLoader().load_one(role_path)
+            if role.role_id in roles_by_id:
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="skills.team_role.duplicate_ignored",
+                    message="Ignoring duplicate skill-local role id",
+                    payload={
+                        "skill_name": skill.metadata.name,
+                        "role_id": role.role_id,
+                        "source_path": _relative_skill_path(skill.directory, role_path),
+                    },
+                )
+                continue
+            roles_by_id[role.role_id] = SkillTeamRoleDefinition(
+                summary=summarize_skill_team_role(skill=skill, role=role),
+                role=role,
+            )
         except Exception as exc:
             _log_invalid_skill_role(skill=skill, role_path=role_path, error=exc)
             continue
-        if role.role_id in roles_by_id:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="skills.team_role.duplicate_ignored",
-                message="Ignoring duplicate skill-local role id",
-                payload={
-                    "skill_name": skill.metadata.name,
-                    "role_id": role.role_id,
-                    "source_path": _relative_skill_path(skill.directory, role_path),
-                },
-            )
-            continue
-        roles_by_id[role.role_id] = SkillTeamRoleDefinition(
-            summary=summarize_skill_team_role(skill=skill, role=role),
-            role=role,
-        )
     return tuple(
         sorted(
             roles_by_id.values(),
@@ -83,6 +77,8 @@ def summarize_skill_team_role(
     skill: Skill,
     role: RoleDefinition,
 ) -> SkillTeamRoleSummary:
+    role_spec = build_skill_team_role_spec(skill=skill, role=role)
+    effective_role = role_spec.to_role_definition()
     source_path = (
         _relative_skill_path(skill.directory, role.source_path)
         if role.source_path is not None
@@ -90,16 +86,13 @@ def summarize_skill_team_role(
     )
     return SkillTeamRoleSummary(
         role_id=role.role_id,
-        effective_role_id=build_skill_team_effective_role_id(
-            skill_name=skill.metadata.name,
-            role_id=role.role_id,
-        ),
-        name=role.name,
-        description=role.description,
-        tools=role.tools,
-        mcp_servers=role.mcp_servers,
-        skills=role.skills,
-        model_profile=role.model_profile,
+        effective_role_id=effective_role.role_id,
+        name=effective_role.name,
+        description=effective_role.description,
+        tools=effective_role.tools,
+        mcp_servers=effective_role.mcp_servers,
+        skills=effective_role.skills,
+        model_profile=effective_role.model_profile,
         source_path=source_path,
     )
 
@@ -140,14 +133,10 @@ def build_skill_team_effective_role_id(*, skill_name: str, role_id: str) -> str:
 
 def build_skill_team_routing_signals(skill: Skill) -> tuple[str, ...]:
     lines: list[str] = []
-    for filename in _TEAM_SIGNAL_FILENAMES:
-        if (skill.directory / filename).is_file():
-            lines.append(f"- Team file: {filename}")
-    for directory_name in _ROLE_DIRECTORY_NAMES:
-        directory = skill.directory / directory_name
-        if directory.is_dir():
-            lines.append(f"- Team role directory: {directory_name}")
-    for entry in list_skill_team_roles(skill):
+    role_entries = list_skill_team_roles(skill)
+    if role_entries:
+        lines.append(f"- Inferred skill team roles: {len(role_entries)}")
+    for entry in role_entries:
         summary = entry.summary
         lines.append(
             "- Role "
@@ -158,13 +147,37 @@ def build_skill_team_routing_signals(skill: Skill) -> tuple[str, ...]:
 
 
 def _iter_skill_role_files(skill_dir: Path) -> tuple[Path, ...]:
-    files: list[Path] = []
-    for directory_name in _ROLE_DIRECTORY_NAMES:
-        directory = skill_dir / directory_name
-        if not directory.is_dir():
-            continue
-        files.extend(sorted(directory.glob("*.md")))
-    return tuple(files)
+    return tuple(
+        path
+        for path in sorted(skill_dir.rglob("*.md"))
+        if path.name.casefold() != "skill.md" and _looks_like_role_file(path)
+    )
+
+
+def _looks_like_role_file(path: Path) -> bool:
+    try:
+        front_matter = _read_markdown_front_matter(path)
+        parsed = yaml.safe_load(front_matter)
+    except (OSError, ValueError, yaml.YAMLError):
+        return False
+    return isinstance(parsed, dict) and "role_id" in parsed
+
+
+def _read_markdown_front_matter(path: Path) -> str:
+    content = path.read_text(encoding="utf-8").lstrip("\ufeff")
+    if not content.startswith("---"):
+        raise ValueError("Markdown front matter is missing")
+    lines = content.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise ValueError("Markdown front matter is missing")
+    end_index: int | None = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            end_index = idx
+            break
+    if end_index is None:
+        raise ValueError("Markdown front matter is incomplete")
+    return "".join(lines[1:end_index])
 
 
 def _relative_skill_path(skill_dir: Path, path: Path) -> str:

--- a/src/relay_teams/skills/skill_team_roles.py
+++ b/src/relay_teams/skills/skill_team_roles.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.roles.role_models import RoleDefinition, RoleMode
+from relay_teams.roles.role_registry import RoleLoader
+from relay_teams.roles.temporary_role_models import TemporaryRoleSpec
+from relay_teams.skills.skill_models import Skill
+
+LOGGER = get_logger(__name__)
+_ROLE_DIRECTORY_NAMES = ("agents", "roles")
+_TEAM_SIGNAL_FILENAMES = (
+    "workflow.md",
+    "bind.md",
+    "dependencies.yaml",
+    "dependencies.yml",
+)
+_MAX_IDENTIFIER_PART_LENGTH = 48
+
+
+class SkillTeamRoleSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: str = Field(min_length=1)
+    effective_role_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    tools: tuple[str, ...] = ()
+    mcp_servers: tuple[str, ...] = ()
+    skills: tuple[str, ...] = ()
+    model_profile: str = Field(min_length=1)
+    source_path: str = Field(min_length=1)
+
+
+class SkillTeamRoleDefinition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    summary: SkillTeamRoleSummary
+    role: RoleDefinition
+
+
+def list_skill_team_roles(skill: Skill) -> tuple[SkillTeamRoleDefinition, ...]:
+    roles_by_id: dict[str, SkillTeamRoleDefinition] = {}
+    for role_path in _iter_skill_role_files(skill.directory):
+        try:
+            role = RoleLoader().load_one(role_path)
+        except Exception as exc:
+            _log_invalid_skill_role(skill=skill, role_path=role_path, error=exc)
+            continue
+        if role.role_id in roles_by_id:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="skills.team_role.duplicate_ignored",
+                message="Ignoring duplicate skill-local role id",
+                payload={
+                    "skill_name": skill.metadata.name,
+                    "role_id": role.role_id,
+                    "source_path": _relative_skill_path(skill.directory, role_path),
+                },
+            )
+            continue
+        roles_by_id[role.role_id] = SkillTeamRoleDefinition(
+            summary=summarize_skill_team_role(skill=skill, role=role),
+            role=role,
+        )
+    return tuple(
+        sorted(
+            roles_by_id.values(),
+            key=lambda item: (item.summary.name, item.summary.role_id),
+        )
+    )
+
+
+def summarize_skill_team_role(
+    *,
+    skill: Skill,
+    role: RoleDefinition,
+) -> SkillTeamRoleSummary:
+    source_path = (
+        _relative_skill_path(skill.directory, role.source_path)
+        if role.source_path is not None
+        else "."
+    )
+    return SkillTeamRoleSummary(
+        role_id=role.role_id,
+        effective_role_id=build_skill_team_effective_role_id(
+            skill_name=skill.metadata.name,
+            role_id=role.role_id,
+        ),
+        name=role.name,
+        description=role.description,
+        tools=role.tools,
+        mcp_servers=role.mcp_servers,
+        skills=role.skills,
+        model_profile=role.model_profile,
+        source_path=source_path,
+    )
+
+
+def build_skill_team_role_spec(
+    *,
+    skill: Skill,
+    role: RoleDefinition,
+) -> TemporaryRoleSpec:
+    return TemporaryRoleSpec(
+        role_id=build_skill_team_effective_role_id(
+            skill_name=skill.metadata.name,
+            role_id=role.role_id,
+        ),
+        name=role.name,
+        description=role.description,
+        version=role.version,
+        tools=role.tools,
+        mcp_servers=role.mcp_servers,
+        skills=role.skills,
+        model_profile=role.model_profile,
+        bound_agent_id=role.bound_agent_id,
+        execution_surface=role.execution_surface,
+        mode=RoleMode.SUBAGENT,
+        memory_profile=role.memory_profile,
+        system_prompt=role.system_prompt,
+    )
+
+
+def build_skill_team_effective_role_id(*, skill_name: str, role_id: str) -> str:
+    skill_part = _identifier_part(skill_name, fallback="skill")
+    role_part = _identifier_part(role_id, fallback="role")
+    digest = hashlib.sha256(
+        f"{skill_name.strip()}:{role_id.strip()}".encode("utf-8")
+    ).hexdigest()[:8]
+    return f"skill_team_{skill_part}_{role_part}_{digest}"
+
+
+def build_skill_team_routing_signals(skill: Skill) -> tuple[str, ...]:
+    lines: list[str] = []
+    for filename in _TEAM_SIGNAL_FILENAMES:
+        if (skill.directory / filename).is_file():
+            lines.append(f"- Team file: {filename}")
+    for directory_name in _ROLE_DIRECTORY_NAMES:
+        directory = skill.directory / directory_name
+        if directory.is_dir():
+            lines.append(f"- Team role directory: {directory_name}")
+    for entry in list_skill_team_roles(skill):
+        summary = entry.summary
+        lines.append(
+            "- Role "
+            f"{summary.role_id}: {summary.name} - {summary.description} "
+            f"({summary.source_path})"
+        )
+    return tuple(lines)
+
+
+def _iter_skill_role_files(skill_dir: Path) -> tuple[Path, ...]:
+    files: list[Path] = []
+    for directory_name in _ROLE_DIRECTORY_NAMES:
+        directory = skill_dir / directory_name
+        if not directory.is_dir():
+            continue
+        files.extend(sorted(directory.glob("*.md")))
+    return tuple(files)
+
+
+def _relative_skill_path(skill_dir: Path, path: Path) -> str:
+    try:
+        relative_path = path.resolve().relative_to(skill_dir.resolve())
+    except ValueError:
+        return path.resolve().as_posix()
+    return relative_path.as_posix()
+
+
+def _identifier_part(value: str, *, fallback: str) -> str:
+    chars: list[str] = []
+    for char in value.strip():
+        if char.isascii() and char.isalnum():
+            chars.append(char.lower())
+        elif char in {"-", "_"}:
+            chars.append("_")
+    result = "".join(chars).strip("_")
+    if not result:
+        result = fallback
+    return result[:_MAX_IDENTIFIER_PART_LENGTH]
+
+
+def _log_invalid_skill_role(
+    *,
+    skill: Skill,
+    role_path: Path,
+    error: Exception,
+) -> None:
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="skills.team_role.invalid_ignored",
+        message="Ignoring invalid skill-local role file",
+        payload={
+            "skill_name": skill.metadata.name,
+            "source_path": _relative_skill_path(skill.directory, role_path),
+            "error": str(error),
+        },
+    )

--- a/src/relay_teams/tools/registry/defaults.py
+++ b/src/relay_teams/tools/registry/defaults.py
@@ -5,6 +5,7 @@ from relay_teams.tools.computer_tools import TOOLS as COMPUTER_TOOLS
 from relay_teams.tools.im_tools.im_send import register as register_im_send
 from relay_teams.tools.orchestration_tools import TOOLS as ORCHESTRATION_TOOLS
 from relay_teams.tools.registry.registry import ToolRegistry
+from relay_teams.tools.skill_team_tools import TOOLS as SKILL_TEAM_TOOLS
 from relay_teams.tools.task_tools import TOOLS as TASK_TOOLS
 from relay_teams.tools.todo_tools import TOOLS as TODO_TOOLS
 from relay_teams.tools.web_tools import TOOLS as WEB_TOOLS
@@ -19,6 +20,7 @@ HIDDEN_FROM_ROLE_CONFIG: tuple[str, ...] = ("im_send",)
 def build_default_registry() -> ToolRegistry:
     tools = {
         **ORCHESTRATION_TOOLS,
+        **SKILL_TEAM_TOOLS,
         **TASK_TOOLS,
         **TODO_TOOLS,
         **WEB_TOOLS,

--- a/src/relay_teams/tools/registry/tool_groups.py
+++ b/src/relay_teams/tools/registry/tool_groups.py
@@ -80,6 +80,15 @@ DEFAULT_TOOL_GROUPS: tuple[ToolGroupDefinition, ...] = (
         ),
     ),
     ToolGroupDefinition(
+        group_id="skill-teams",
+        name="Skill Teams",
+        description="Skill-local role discovery and activation tools for team-style workflows.",
+        tools=(
+            "list_skill_roles",
+            "activate_skill_roles",
+        ),
+    ),
+    ToolGroupDefinition(
         group_id="task",
         name="Task",
         description="Task-adjacent tools for spawning subagents or asking the user questions.",

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -63,6 +63,18 @@ class ImToolServiceLike(Protocol):
     ) -> str: ...
 
 
+class SkillRegistryLike(Protocol):
+    def get_skill_definition(self, name: str) -> object | None: ...
+
+    def resolve_authorized_name_for_role(
+        self,
+        *,
+        role: object,
+        requested_name: str,
+        consumer: str | None = None,
+    ) -> str | None: ...
+
+
 class ToolDeps(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -97,6 +109,7 @@ class ToolDeps(BaseModel):
     role_id: str
     role_registry: SkipValidation[RoleRegistry]
     runtime_role_resolver: SkipValidation[RuntimeRoleResolver | None] = None
+    skill_registry: SkipValidation[SkillRegistryLike | None] = None
     mcp_registry: SkipValidation[McpRegistry]
     task_service: SkipValidation[TaskOrchestrationServiceLike]
     task_execution_service: SkipValidation[TaskExecutionServiceLike]

--- a/src/relay_teams/tools/skill_team_tools/__init__.py
+++ b/src/relay_teams/tools/skill_team_tools/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from relay_teams.tools.skill_team_tools.activate_skill_roles import (
+    register as register_activate_skill_roles,
+)
+from relay_teams.tools.skill_team_tools.list_skill_roles import (
+    register as register_list_skill_roles,
+)
+
+TOOLS = {
+    "activate_skill_roles": register_activate_skill_roles,
+    "list_skill_roles": register_list_skill_roles,
+}
+
+__all__ = [
+    "TOOLS",
+    "register_activate_skill_roles",
+    "register_list_skill_roles",
+]

--- a/src/relay_teams/tools/skill_team_tools/activate_skill_roles.py
+++ b/src/relay_teams/tools/skill_team_tools/activate_skill_roles.py
@@ -8,7 +8,6 @@ from relay_teams.roles.temporary_role_models import TemporaryRoleSource
 from relay_teams.skills.skill_team_roles import (
     build_skill_team_role_spec,
     list_skill_team_roles,
-    summarize_skill_team_role,
 )
 from relay_teams.tools._description_loader import load_tool_description
 from relay_teams.tools.runtime.context import ToolContext, ToolDeps
@@ -60,9 +59,16 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                         role=entry.role,
                     ),
                 )
-                summary = summarize_skill_team_role(skill=skill, role=entry.role)
-                summary = summary.model_copy(
-                    update={"effective_role_id": activated_role.role_id}
+                summary = entry.summary.model_copy(
+                    update={
+                        "effective_role_id": activated_role.role_id,
+                        "name": activated_role.name,
+                        "description": activated_role.description,
+                        "tools": activated_role.tools,
+                        "mcp_servers": activated_role.mcp_servers,
+                        "skills": activated_role.skills,
+                        "model_profile": activated_role.model_profile,
+                    }
                 )
                 activated_roles.append(skill_team_role_summary_to_json(summary))
             return {

--- a/src/relay_teams/tools/skill_team_tools/activate_skill_roles.py
+++ b/src/relay_teams/tools/skill_team_tools/activate_skill_roles.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pydantic import JsonValue
+from pydantic_ai import Agent
+
+from relay_teams.roles.temporary_role_models import TemporaryRoleSource
+from relay_teams.skills.skill_team_roles import (
+    build_skill_team_role_spec,
+    list_skill_team_roles,
+    summarize_skill_team_role,
+)
+from relay_teams.tools._description_loader import load_tool_description
+from relay_teams.tools.runtime.context import ToolContext, ToolDeps
+from relay_teams.tools.runtime.execution import execute_tool_call
+from relay_teams.tools.skill_team_tools.support import (
+    resolve_authorized_skill_for_tool,
+    skill_team_role_summary_to_json,
+)
+
+DESCRIPTION = load_tool_description(__file__)
+
+
+def register(agent: Agent[ToolDeps, str]) -> None:
+    @agent.tool(description=DESCRIPTION)
+    async def activate_skill_roles(
+        ctx: ToolContext,
+        skill_name: str,
+        role_ids: list[str],
+    ) -> dict[str, JsonValue]:
+        def _action(skill_name: str, role_ids: list[str]) -> dict[str, JsonValue]:
+            runtime_role_resolver = ctx.deps.runtime_role_resolver
+            if runtime_role_resolver is None:
+                raise RuntimeError("Temporary role activation is unavailable")
+            requested_role_ids = _normalize_requested_role_ids(role_ids)
+            skill = resolve_authorized_skill_for_tool(
+                ctx=ctx,
+                skill_name=skill_name,
+                tool_name="activate_skill_roles",
+            )
+            role_map = {
+                entry.summary.role_id: entry for entry in list_skill_team_roles(skill)
+            }
+            missing_role_ids = [
+                role_id for role_id in requested_role_ids if role_id not in role_map
+            ]
+            if missing_role_ids:
+                raise ValueError(
+                    f"Skill roles not found for {skill.metadata.name}: {missing_role_ids}"
+                )
+            activated_roles: list[JsonValue] = []
+            for requested_role_id in requested_role_ids:
+                entry = role_map[requested_role_id]
+                activated_role = runtime_role_resolver.create_temporary_role(
+                    run_id=ctx.deps.run_id,
+                    session_id=ctx.deps.session_id,
+                    source=TemporaryRoleSource.SKILL_TEAM,
+                    role=build_skill_team_role_spec(
+                        skill=skill,
+                        role=entry.role,
+                    ),
+                )
+                summary = summarize_skill_team_role(skill=skill, role=entry.role)
+                summary = summary.model_copy(
+                    update={"effective_role_id": activated_role.role_id}
+                )
+                activated_roles.append(skill_team_role_summary_to_json(summary))
+            return {
+                "skill": {
+                    "name": skill.metadata.name,
+                    "ref": skill.ref,
+                    "source": skill.source.value,
+                },
+                "activated_roles": activated_roles,
+            }
+
+        return await execute_tool_call(
+            ctx,
+            tool_name="activate_skill_roles",
+            args_summary={"skill_name": skill_name, "role_count": len(role_ids)},
+            action=_action,
+            raw_args=locals(),
+        )
+
+
+def _normalize_requested_role_ids(role_ids: list[str]) -> tuple[str, ...]:
+    normalized_role_ids: list[str] = []
+    for role_id in role_ids:
+        normalized = role_id.strip()
+        if not normalized:
+            continue
+        if normalized not in normalized_role_ids:
+            normalized_role_ids.append(normalized)
+    if not normalized_role_ids:
+        raise ValueError("role_ids must contain at least one role id")
+    return tuple(normalized_role_ids)

--- a/src/relay_teams/tools/skill_team_tools/activate_skill_roles.txt
+++ b/src/relay_teams/tools/skill_team_tools/activate_skill_roles.txt
@@ -1,0 +1,12 @@
+Activate one or more roles bundled inside an authorized skill as run-scoped temporary roles.
+
+Arguments:
+- `skill_name`: skill name that contains the roles.
+- `role_ids`: role ids returned by `list_skill_roles`.
+
+Returns activated role summaries. Use each returned `effective_role_id` with `spawn_subagent` in normal mode or `orch_dispatch_task` in orchestration mode.
+
+Usage rules:
+- Call `list_skill_roles` first so you can select only the roles needed for the current task.
+- Activate only the roles you intend to use in this run.
+- This tool does not load role system prompts into the current agent prompt; it stores the selected role definitions for later subagent/task execution.

--- a/src/relay_teams/tools/skill_team_tools/list_skill_roles.py
+++ b/src/relay_teams/tools/skill_team_tools/list_skill_roles.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pydantic import JsonValue
+from pydantic_ai import Agent
+
+from relay_teams.skills.skill_team_roles import list_skill_team_roles
+from relay_teams.tools._description_loader import load_tool_description
+from relay_teams.tools.runtime.context import ToolContext, ToolDeps
+from relay_teams.tools.runtime.execution import execute_tool_call
+from relay_teams.tools.skill_team_tools.support import (
+    resolve_authorized_skill_for_tool,
+    skill_team_role_summary_to_json,
+)
+
+DESCRIPTION = load_tool_description(__file__)
+
+
+def register(agent: Agent[ToolDeps, str]) -> None:
+    @agent.tool(description=DESCRIPTION)
+    async def list_skill_roles(
+        ctx: ToolContext,
+        skill_name: str,
+    ) -> dict[str, JsonValue]:
+        def _action(skill_name: str) -> dict[str, JsonValue]:
+            skill = resolve_authorized_skill_for_tool(
+                ctx=ctx,
+                skill_name=skill_name,
+                tool_name="list_skill_roles",
+            )
+            roles = list_skill_team_roles(skill)
+            role_payloads: list[JsonValue] = [
+                skill_team_role_summary_to_json(entry.summary) for entry in roles
+            ]
+            return {
+                "skill": {
+                    "name": skill.metadata.name,
+                    "ref": skill.ref,
+                    "source": skill.source.value,
+                },
+                "roles": role_payloads,
+            }
+
+        return await execute_tool_call(
+            ctx,
+            tool_name="list_skill_roles",
+            args_summary={"skill_name": skill_name},
+            action=_action,
+            raw_args=locals(),
+        )

--- a/src/relay_teams/tools/skill_team_tools/list_skill_roles.txt
+++ b/src/relay_teams/tools/skill_team_tools/list_skill_roles.txt
@@ -1,0 +1,11 @@
+List the lightweight role summaries bundled inside an authorized skill.
+
+Arguments:
+- `skill_name`: skill name to inspect.
+
+Returns role ids, effective role ids, names, descriptions, tools, MCP servers, skills, model profile, and skill-relative source paths. It does not return role system prompts.
+
+Usage rules:
+- Call this after `load_skill` or skill routing indicates a skill may contain a team workflow.
+- Use the returned `role_id` values with `activate_skill_roles`.
+- Use the returned `effective_role_id` values only after activation.

--- a/src/relay_teams/tools/skill_team_tools/support.py
+++ b/src/relay_teams/tools/skill_team_tools/support.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import cast
+
+from pydantic import JsonValue
+
+from relay_teams.roles.role_models import RoleDefinition
+from relay_teams.skills.skill_models import Skill
+from relay_teams.skills.skill_team_roles import SkillTeamRoleSummary
+from relay_teams.tools.runtime.context import (
+    SkillRegistryLike,
+    ToolContext,
+)
+
+
+def resolve_authorized_skill_for_tool(
+    *,
+    ctx: ToolContext,
+    skill_name: str,
+    tool_name: str,
+) -> Skill:
+    requested_name = skill_name.strip()
+    if not requested_name:
+        raise ValueError("skill_name must not be empty")
+    skill_registry = require_skill_registry(ctx)
+    role = get_effective_role_for_skill_tool(ctx)
+    resolved_name = skill_registry.resolve_authorized_name_for_role(
+        role=role,
+        requested_name=requested_name,
+        consumer=f"tools.{tool_name}.role:{role.role_id}",
+    )
+    if resolved_name is None:
+        raise PermissionError(
+            f"Role {role.role_id} is not authorized to load skill: {requested_name}"
+        )
+    skill = skill_registry.get_skill_definition(resolved_name)
+    if skill is None:
+        raise KeyError(f"Skill not found: {requested_name}")
+    return cast(Skill, skill)
+
+
+def require_skill_registry(ctx: ToolContext) -> SkillRegistryLike:
+    skill_registry = ctx.deps.skill_registry
+    if skill_registry is None:
+        raise RuntimeError("Skill registry is unavailable")
+    return skill_registry
+
+
+def get_effective_role_for_skill_tool(ctx: ToolContext) -> RoleDefinition:
+    runtime_role_resolver = ctx.deps.runtime_role_resolver
+    if runtime_role_resolver is not None:
+        try:
+            return runtime_role_resolver.get_effective_role(
+                run_id=ctx.deps.run_id,
+                role_id=ctx.deps.role_id,
+            )
+        except KeyError:
+            pass
+    return ctx.deps.role_registry.get(ctx.deps.role_id)
+
+
+def skill_team_role_summary_to_json(
+    summary: SkillTeamRoleSummary,
+) -> dict[str, JsonValue]:
+    return cast(dict[str, JsonValue], summary.model_dump(mode="json"))

--- a/src/relay_teams/tools/task_tools/spawn_subagent.py
+++ b/src/relay_teams/tools/task_tools/spawn_subagent.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from pydantic import JsonValue
 from pydantic_ai import Agent
 
+from relay_teams.roles.role_models import RoleDefinition, RoleMode
 from relay_teams.roles.role_registry import RoleRegistry
+from relay_teams.roles.role_registry import is_reserved_system_role_definition
 from relay_teams.tools._description_loader import load_tool_description
 from relay_teams.tools.runtime.context import (
     ToolContext,
@@ -39,7 +41,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             background: bool = False,
         ) -> ToolResultProjection:
             service = require_background_task_service(ctx)
-            resolved_role_id = ctx.deps.role_registry.resolve_subagent_role_id(role_id)
+            resolved_role_id, role_snapshot = _resolve_subagent_role(ctx, role_id)
             if background:
                 record = await service.start_subagent(
                     run_id=ctx.deps.run_id,
@@ -50,6 +52,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                     workspace_id=ctx.deps.workspace.ref.workspace_id,
                     cwd=ctx.deps.workspace.resolve_workdir(),
                     subagent_role_id=resolved_role_id,
+                    subagent_role=role_snapshot,
                     title=description,
                     prompt=prompt,
                 )
@@ -63,6 +66,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 session_id=ctx.deps.session_id,
                 workspace_id=ctx.deps.workspace.ref.workspace_id,
                 subagent_role_id=resolved_role_id,
+                subagent_role=role_snapshot,
                 title=description,
                 prompt=prompt,
             )
@@ -111,6 +115,50 @@ def _role_registry_from_agent(
     if isinstance(registry, RoleRegistry):
         return registry
     return None
+
+
+def _resolve_subagent_role(
+    ctx: ToolContext,
+    role_id: str,
+) -> tuple[str, RoleDefinition | None]:
+    normalized_role_id = role_id.strip()
+    if not normalized_role_id:
+        raise ValueError("role_id must not be empty")
+    runtime_role_resolver = ctx.deps.runtime_role_resolver
+    if runtime_role_resolver is not None:
+        try:
+            role = runtime_role_resolver.get_temporary_role(
+                run_id=ctx.deps.run_id,
+                role_id=normalized_role_id,
+            )
+        except KeyError:
+            pass
+        else:
+            _raise_if_role_unspawnable(ctx.deps.role_registry, role)
+            return role.role_id, role
+    return ctx.deps.role_registry.resolve_subagent_role_id(normalized_role_id), None
+
+
+def _raise_if_role_unspawnable(
+    role_registry: RoleRegistry,
+    role: RoleDefinition,
+) -> None:
+    if role_registry.is_coordinator_role(role.role_id):
+        raise ValueError(
+            f"Coordinator role cannot be used as a subagent: {role.role_id}"
+        )
+    if role_registry.is_main_agent_role(role.role_id):
+        raise ValueError(
+            f"Main agent role cannot be used as a subagent: {role.role_id}"
+        )
+    if is_reserved_system_role_definition(role):
+        raise ValueError(
+            f"Reserved system role cannot be used as a subagent: {role.role_id}"
+        )
+    if role.mode not in {RoleMode.SUBAGENT, RoleMode.ALL}:
+        raise ValueError(
+            f"Role cannot be used as a subagent: {role.role_id} (mode={role.mode.value})"
+        )
 
 
 def _build_subagent_capability_block(role_registry: RoleRegistry | None) -> str:

--- a/tests/unit_tests/external_agents/test_host_tool_bridge.py
+++ b/tests/unit_tests/external_agents/test_host_tool_bridge.py
@@ -161,6 +161,7 @@ def test_build_tool_deps_uses_resolved_model_capabilities() -> None:
         return resolved_config
 
     bridge = object.__new__(host_tool_bridge_module.ExternalAcpHostToolBridge)
+    runtime_role_resolver = object()
     role = RoleDefinition(
         role_id="main-agent",
         name="Main Agent",
@@ -201,9 +202,11 @@ def test_build_tool_deps_uses_resolved_model_capabilities() -> None:
             "_todo_service": None,
             "_run_intent_repo": _MissingRunIntentRepo(),
             "_get_role_registry": lambda: object(),
+            "_get_skill_registry": lambda: object(),
             "_get_mcp_registry": lambda: object(),
             "_get_task_service": lambda: object(),
             "_get_task_execution_service": lambda: object(),
+            "_runtime_role_resolver": runtime_role_resolver,
             "_run_control_manager": object(),
             "_tool_approval_manager": object(),
             "_user_question_manager": None,
@@ -221,6 +224,7 @@ def test_build_tool_deps_uses_resolved_model_capabilities() -> None:
 
     assert requested == [(role, request)]
     assert deps.model_capabilities == resolved_config.capabilities
+    assert deps.runtime_role_resolver is runtime_role_resolver
 
 
 def test_host_tool_bridge_init_stores_model_resolver(
@@ -263,6 +267,7 @@ def test_host_tool_bridge_init_stores_model_resolver(
         "user_question_manager": None,
         "tool_approval_policy": _FakeToolApprovalPolicy(),
         "get_notification_service": lambda: None,
+        "runtime_role_resolver": object(),
         "resolve_model_config": resolver,
     }
     bridge_ctor = cast(
@@ -273,6 +278,7 @@ def test_host_tool_bridge_init_stores_model_resolver(
     )
 
     assert bridge._resolve_model_config is resolver
+    assert bridge._runtime_role_resolver is kwargs["runtime_role_resolver"]
 
 
 def test_resolve_request_model_capabilities_defaults_when_resolution_is_unavailable() -> (

--- a/tests/unit_tests/feishu/test_inbound_runtime.py
+++ b/tests/unit_tests/feishu/test_inbound_runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from relay_teams.gateway.feishu.inbound_runtime import FeishuInboundRuntime
 from relay_teams.gateway.feishu.models import (
     FEISHU_METADATA_MESSAGE_ID_KEY,
@@ -201,6 +203,7 @@ def _build_message(
     )
 
 
+@pytest.mark.timeout(5)
 def test_start_run_creates_group_session_and_run(tmp_path: Path) -> None:
     session_service = _FakeSessionService()
     run_service = _FakeRunService()

--- a/tests/unit_tests/interfaces/server/test_host_tool_stdio_server.py
+++ b/tests/unit_tests/interfaces/server/test_host_tool_stdio_server.py
@@ -61,6 +61,7 @@ async def test_run_stdio_server_passes_todo_service_to_host_tool_bridge(
     fake_role = object()
     fake_todo_service = object()
     fake_resolve_model_config = object()
+    fake_runtime_role_resolver = object()
     fake_container = SimpleNamespace(
         role_registry=SimpleNamespace(get=lambda role_id: fake_role),
         task_repo=object(),
@@ -94,6 +95,7 @@ async def test_run_stdio_server_passes_todo_service_to_host_tool_bridge(
         metric_recorder=object(),
         im_tool_service=object(),
         computer_runtime=object(),
+        runtime_role_resolver=fake_runtime_role_resolver,
         resolve_external_agent_model_config=fake_resolve_model_config,
     )
 
@@ -122,6 +124,7 @@ async def test_run_stdio_server_passes_todo_service_to_host_tool_bridge(
     assert bridge is not None
     assert bridge.init_kwargs["todo_service"] is fake_todo_service
     assert bridge.init_kwargs["resolve_model_config"] is fake_resolve_model_config
+    assert bridge.init_kwargs["runtime_role_resolver"] is fake_runtime_role_resolver
     assert bridge.configure_calls[0]["role"] is fake_role
     assert bridge.configure_calls[0]["session_id"] == "session-1"
     assert len(bridge.bound_requests) == 1

--- a/tests/unit_tests/metrics/test_tool_metrics.py
+++ b/tests/unit_tests/metrics/test_tool_metrics.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+
+from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.metrics import DEFAULT_DEFINITIONS, MetricEvent, MetricRecorder
+from relay_teams.metrics.registry import MetricRegistry
+from relay_teams.metrics.adapters.tool_metrics import record_tool_execution
+
+
+class _CapturingSink:
+    def __init__(self) -> None:
+        self.events: list[MetricEvent] = []
+
+    def record(self, event: MetricEvent) -> None:
+        self.events.append(event)
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ("list_skills", "load_skill", "list_skill_roles", "activate_skill_roles"),
+)
+def test_skill_tools_are_recorded_as_skill_source(tool_name: str) -> None:
+    sink = _CapturingSink()
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(sink,),
+    )
+
+    record_tool_execution(
+        recorder,
+        mcp_registry=McpRegistry(),
+        workspace_id="workspace-1",
+        session_id="session-1",
+        run_id="run-1",
+        instance_id="instance-1",
+        role_id="MainAgent",
+        tool_name=tool_name,
+        duration_ms=12,
+        success=True,
+    )
+
+    assert {event.definition_name for event in sink.events} == {
+        "relay_teams.skill.calls",
+        "relay_teams.tool.calls",
+        "relay_teams.tool.duration_ms",
+    }
+    assert {event.tags.tool_source for event in sink.events} == {"skill"}

--- a/tests/unit_tests/roles/test_builtin_role_tools.py
+++ b/tests/unit_tests/roles/test_builtin_role_tools.py
@@ -60,6 +60,7 @@ def test_builtin_roles_mount_expected_write_tools() -> None:
     assert "webfetch" in main_agent.tools
     assert "websearch" in main_agent.tools
     assert main_agent.skills == ("*",)
+    assert coordinator.skills == ("*",)
     assert crafter.skills == ("*",)
     assert "office_read_markdown" in daily_ai_report.tools
     assert "todo_write" not in daily_ai_report.tools

--- a/tests/unit_tests/roles/test_builtin_role_tools.py
+++ b/tests/unit_tests/roles/test_builtin_role_tools.py
@@ -46,6 +46,10 @@ def test_builtin_roles_mount_expected_write_tools() -> None:
     assert background_task_tools.issubset(set(gater.tools))
     assert background_task_tools.issubset(set(main_agent.tools))
     assert "spawn_subagent" in main_agent.tools
+    assert "list_skill_roles" in main_agent.tools
+    assert "activate_skill_roles" in main_agent.tools
+    assert "list_skill_roles" in coordinator.tools
+    assert "activate_skill_roles" in coordinator.tools
     assert background_task_tools.issubset(set(daily_ai_report.tools))
     assert main_agent.mode == RoleMode.PRIMARY
     assert crafter.mode == RoleMode.SUBAGENT

--- a/tests/unit_tests/roles/test_coordinator_tools.py
+++ b/tests/unit_tests/roles/test_coordinator_tools.py
@@ -13,6 +13,8 @@ def test_coordinator_uses_task_tools_and_not_emit_event() -> None:
     assert tools == {
         "orch_create_tasks",
         "orch_create_temporary_role",
+        "list_skill_roles",
+        "activate_skill_roles",
         "orch_update_task",
         "orch_list_available_roles",
         "orch_list_delegated_tasks",

--- a/tests/unit_tests/roles/test_runtime_role_resolver.py
+++ b/tests/unit_tests/roles/test_runtime_role_resolver.py
@@ -68,6 +68,18 @@ def test_runtime_role_resolver_prefers_run_temporary_roles(tmp_path: Path) -> No
     assert role.tools == ("write", "office_read_markdown")
 
 
+def test_runtime_role_resolver_get_temporary_role_rejects_missing_run_id(
+    tmp_path: Path,
+) -> None:
+    resolver = RuntimeRoleResolver(
+        role_registry=_base_registry(),
+        temporary_role_repository=TemporaryRoleRepository(tmp_path / "roles.db"),
+    )
+
+    with pytest.raises(KeyError, match="Unknown temporary role_id"):
+        resolver.get_temporary_role(run_id=None, role_id="tmp_writer")
+
+
 def test_runtime_role_resolver_rejects_reserved_ids(tmp_path: Path) -> None:
     resolver = RuntimeRoleResolver(
         role_registry=_base_registry(),

--- a/tests/unit_tests/sessions/runs/background_tasks/test_service.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_service.py
@@ -43,6 +43,10 @@ from relay_teams.sessions.runs.run_runtime_repo import (
 )
 from relay_teams.hooks.hook_models import HookRuntimeSnapshot
 from relay_teams.hooks import HookService
+from relay_teams.roles.role_models import RoleDefinition, RoleMode
+from relay_teams.roles.role_registry import RoleRegistry
+from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
+from relay_teams.roles.temporary_role_repository import TemporaryRoleRepository
 from relay_teams.workspace import WorkspaceHandle
 
 
@@ -192,9 +196,11 @@ class _FakeTaskExecutionService:
         *,
         result: TaskExecutionResult,
         gate: asyncio.Event | None = None,
+        runtime_role_resolver: RuntimeRoleResolver | None = None,
     ) -> None:
         self._result = result
         self._gate = gate
+        self.runtime_role_resolver = runtime_role_resolver
         self.calls: list[dict[str, object]] = []
 
     async def execute(
@@ -754,6 +760,122 @@ async def test_background_task_service_start_subagent_completes_and_persists_res
     assert runtime is not None
     assert runtime.status == RunRuntimeStatus.COMPLETED
     assert runtime.phase == RunRuntimePhase.TERMINAL
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_clones_temporary_subagent_role(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-temp-role.db"
+    )
+    runtime_role_resolver = RuntimeRoleResolver(
+        role_registry=RoleRegistry(),
+        temporary_role_repository=TemporaryRoleRepository(
+            tmp_path / "temporary-roles.db"
+        ),
+    )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        ),
+        runtime_role_resolver=runtime_role_resolver,
+    )
+    role = RoleDefinition(
+        role_id="skill_team_review_analyst_12345678",
+        name="Analyst",
+        description="Collects evidence.",
+        version="1",
+        mode=RoleMode.SUBAGENT,
+        tools=("read",),
+        system_prompt="Analyze.",
+    )
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+    )
+
+    started = await service.start_subagent(
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="MainAgent",
+        tool_call_id="call-1",
+        workspace_id="workspace-1",
+        cwd=Path("C:/workspace"),
+        subagent_role_id=role.role_id,
+        subagent_role=role,
+        title="Investigate failures",
+        prompt="Inspect the failing tests and summarize the cause.",
+    )
+
+    assert started.subagent_run_id is not None
+    cloned_role = runtime_role_resolver.get_temporary_role(
+        run_id=started.subagent_run_id,
+        role_id=role.role_id,
+    )
+    assert cloned_role.role_id == role.role_id
+    assert cloned_role.system_prompt == "Analyze."
+    assert cloned_role.tools == ("read", "office_read_markdown")
+    _, completed = await service.wait_for_run(
+        run_id="run-1",
+        background_task_id=started.background_task_id,
+    )
+    assert completed is True
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_skips_role_clone_without_runtime_resolver(
+    tmp_path: Path,
+) -> None:
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=BackgroundTaskRepository(tmp_path / "background-tasks.db"),
+        task_execution_service=_FakeTaskExecutionService(
+            result=TaskExecutionResult(
+                output="analysis complete",
+                completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+            )
+        ),
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+    )
+    role = RoleDefinition(
+        role_id="skill_team_review_analyst_12345678",
+        name="Analyst",
+        description="Collects evidence.",
+        version="1",
+        mode=RoleMode.SUBAGENT,
+        tools=("read",),
+        system_prompt="Analyze.",
+    )
+
+    started = await service.start_subagent(
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="MainAgent",
+        tool_call_id="call-1",
+        workspace_id="workspace-1",
+        cwd=Path("C:/workspace"),
+        subagent_role_id=role.role_id,
+        subagent_role=role,
+        title="Investigate failures",
+        prompt="Inspect the failing tests and summarize the cause.",
+    )
+    _, completed = await service.wait_for_run(
+        run_id="run-1",
+        background_task_id=started.background_task_id,
+    )
+    assert completed is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/background_tasks/test_service.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_service.py
@@ -828,6 +828,11 @@ async def test_background_task_service_clones_temporary_subagent_role(
         background_task_id=started.background_task_id,
     )
     assert completed is True
+    with pytest.raises(KeyError, match="Unknown temporary role"):
+        runtime_role_resolver.get_temporary_role(
+            run_id=started.subagent_run_id,
+            role_id=role.role_id,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/skills/test_skill_routing_service.py
+++ b/tests/unit_tests/skills/test_skill_routing_service.py
@@ -69,10 +69,10 @@ def test_skill_index_documents_include_lightweight_team_role_signals(
     tmp_path: Path,
 ) -> None:
     skill_dir = tmp_path / "skills" / "team-review"
-    agents_dir = skill_dir / "agents"
-    agents_dir.mkdir(parents=True)
-    (skill_dir / "workflow.md").write_text("Full workflow text.\n", encoding="utf-8")
-    (agents_dir / "analyst.md").write_text(
+    contributors_dir = skill_dir / "contributors"
+    contributors_dir.mkdir(parents=True)
+    (skill_dir / "playbook.md").write_text("Full workflow text.\n", encoding="utf-8")
+    (contributors_dir / "analyst.md").write_text(
         "---\n"
         "role_id: analyst\n"
         "name: Research Analyst\n"
@@ -107,11 +107,11 @@ def test_skill_index_documents_include_lightweight_team_role_signals(
     assert len(documents) == 1
     document = documents[0]
     assert "Team Skill Signals" in document.body
-    assert "- Team file: workflow.md" in document.body
-    assert "- Team role directory: agents" in document.body
+    assert "- Inferred skill team roles: 1" in document.body
     assert "Role analyst: Research Analyst - Collects evidence for review." in (
         document.body
     )
+    assert "contributors/analyst.md" in document.body
     assert "SYSTEM PROMPT SHOULD NOT BE INDEXED" not in document.body
 
 

--- a/tests/unit_tests/skills/test_skill_routing_service.py
+++ b/tests/unit_tests/skills/test_skill_routing_service.py
@@ -65,6 +65,56 @@ def test_skill_index_documents_include_instruction_script_and_resource_summaries
     assert "builtin" not in document.keywords
 
 
+def test_skill_index_documents_include_lightweight_team_role_signals(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "skills" / "team-review"
+    agents_dir = skill_dir / "agents"
+    agents_dir.mkdir(parents=True)
+    (skill_dir / "workflow.md").write_text("Full workflow text.\n", encoding="utf-8")
+    (agents_dir / "analyst.md").write_text(
+        "---\n"
+        "role_id: analyst\n"
+        "name: Research Analyst\n"
+        "description: Collects evidence for review.\n"
+        "version: 1\n"
+        "mode: subagent\n"
+        "tools:\n"
+        "  - read\n"
+        "---\n"
+        "SYSTEM PROMPT SHOULD NOT BE INDEXED.\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: team-review\n"
+        "description: Coordinate a review team.\n"
+        "---\n"
+        "Use the review workflow.\n",
+        encoding="utf-8",
+    )
+    registry = SkillRegistry(
+        directory=SkillsDirectory(
+            sources=((SkillSource.USER_RELAY_TEAMS, tmp_path / "skills"),)
+        )
+    )
+    index_service = SkillIndexService(
+        retrieval_service=_build_retrieval_service(tmp_path)
+    )
+
+    documents = index_service.build_documents(skill_registry=registry)
+
+    assert len(documents) == 1
+    document = documents[0]
+    assert "Team Skill Signals" in document.body
+    assert "- Team file: workflow.md" in document.body
+    assert "- Team role directory: agents" in document.body
+    assert "Role analyst: Research Analyst - Collects evidence for review." in (
+        document.body
+    )
+    assert "SYSTEM PROMPT SHOULD NOT BE INDEXED" not in document.body
+
+
 def test_build_skill_routing_query_text_uses_stable_context_fields() -> None:
     query_text = build_skill_routing_query_text(
         SkillRoutingContext(

--- a/tests/unit_tests/skills/test_skill_team_roles.py
+++ b/tests/unit_tests/skills/test_skill_team_roles.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from relay_teams.roles.role_models import RoleMode
 from relay_teams.skills.discovery import SkillsDirectory
 from relay_teams.skills.skill_models import Skill
@@ -30,7 +32,7 @@ def test_list_skill_team_roles_summarizes_roles_without_system_prompt(
     assert summary.name == "Research Analyst"
     assert summary.description == "Collects evidence for review."
     assert summary.tools == ("read", "office_read_markdown")
-    assert summary.source_path == "agents/analyst.md"
+    assert summary.source_path == "contributors/analyst.md"
     assert "SYSTEM PROMPT" not in summary.model_dump_json()
 
 
@@ -46,13 +48,27 @@ def test_build_skill_team_role_spec_forces_subagent_mode(tmp_path: Path) -> None
     assert spec.tools == ("read", "office_read_markdown")
 
 
-def test_list_skill_team_roles_ignores_invalid_and_duplicate_roles(
+def test_list_skill_team_roles_reports_activation_effective_tools(
     tmp_path: Path,
 ) -> None:
+    skill = _write_team_skill(tmp_path, role_mode=RoleMode.PRIMARY)
+
+    role_entry = list_skill_team_roles(skill)[0]
+
+    assert "todo_write" in role_entry.role.tools
+    assert role_entry.summary.tools == ("read", "office_read_markdown")
+
+
+def test_list_skill_team_roles_ignores_invalid_and_duplicate_roles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     skill = _write_team_skill(tmp_path)
-    roles_dir = skill.directory / "roles"
-    roles_dir.mkdir()
-    (skill.directory / "agents" / "invalid.md").write_text(
+    invalid_dir = skill.directory / "notes"
+    duplicate_dir = skill.directory / "specialists"
+    invalid_dir.mkdir()
+    duplicate_dir.mkdir()
+    (invalid_dir / "invalid.md").write_text(
         "---\n"
         "role_id: invalid\n"
         "name: Invalid\n"
@@ -62,7 +78,37 @@ def test_list_skill_team_roles_ignores_invalid_and_duplicate_roles(
         "Invalid.\n",
         encoding="utf-8",
     )
-    (roles_dir / "duplicate.md").write_text(
+    (invalid_dir / "malformed.md").write_text(
+        "---\nrole_id: [malformed\n---\nMalformed YAML must not abort discovery.\n",
+        encoding="utf-8",
+    )
+    (invalid_dir / "invalid-summary.md").write_text(
+        "---\n"
+        "role_id: invalid_summary\n"
+        "name: Invalid Summary\n"
+        "description: Has role fields but invalid summary fields.\n"
+        "version: 1\n"
+        "model_profile: ''\n"
+        "tools:\n"
+        "  - read\n"
+        "---\n"
+        "Invalid summary must not abort discovery.\n",
+        encoding="utf-8",
+    )
+    unreadable_path = invalid_dir / "unreadable.md"
+    unreadable_path.write_text(
+        "---\n"
+        "role_id: unreadable\n"
+        "name: Unreadable\n"
+        "description: Simulates an I/O failure.\n"
+        "version: 1\n"
+        "tools:\n"
+        "  - read\n"
+        "---\n"
+        "Unreadable.\n",
+        encoding="utf-8",
+    )
+    (duplicate_dir / "duplicate.md").write_text(
         "---\n"
         "role_id: analyst\n"
         "name: Duplicate Analyst\n"
@@ -74,6 +120,22 @@ def test_list_skill_team_roles_ignores_invalid_and_duplicate_roles(
         "Duplicate.\n",
         encoding="utf-8",
     )
+    original_read_text = Path.read_text
+
+    def fake_read_text(
+        self: Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+    ) -> str:
+        if self == unreadable_path:
+            raise OSError("permission denied")
+        return original_read_text(
+            self,
+            encoding=encoding,
+            errors=errors,
+        )
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
 
     roles = list_skill_team_roles(skill)
 
@@ -97,10 +159,14 @@ def test_skill_team_effective_role_id_uses_fallback_fragments() -> None:
     assert role_id.startswith("skill_team_skill_role_")
 
 
-def _write_team_skill(tmp_path: Path) -> Skill:
+def _write_team_skill(
+    tmp_path: Path,
+    *,
+    role_mode: RoleMode = RoleMode.SUBAGENT,
+) -> Skill:
     skill_dir = tmp_path / "skills" / "team-review"
-    agents_dir = skill_dir / "agents"
-    agents_dir.mkdir(parents=True)
+    contributors_dir = skill_dir / "contributors"
+    contributors_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         "---\n"
         "name: team-review\n"
@@ -109,13 +175,13 @@ def _write_team_skill(tmp_path: Path) -> Skill:
         "Use the review workflow.\n",
         encoding="utf-8",
     )
-    (agents_dir / "analyst.md").write_text(
+    (contributors_dir / "analyst.md").write_text(
         "---\n"
         "role_id: analyst\n"
         "name: Research Analyst\n"
         "description: Collects evidence for review.\n"
         "version: 1\n"
-        "mode: subagent\n"
+        f"mode: {role_mode.value}\n"
         "tools:\n"
         "  - read\n"
         "---\n"

--- a/tests/unit_tests/skills/test_skill_team_roles.py
+++ b/tests/unit_tests/skills/test_skill_team_roles.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+from relay_teams.roles.role_models import RoleMode
+from relay_teams.skills.discovery import SkillsDirectory
+from relay_teams.skills.skill_models import Skill
+from relay_teams.skills.skill_models import SkillSource
+from relay_teams.skills.skill_registry import SkillRegistry
+from relay_teams.skills.skill_team_roles import (
+    build_skill_team_effective_role_id,
+    build_skill_team_role_spec,
+    list_skill_team_roles,
+    summarize_skill_team_role,
+)
+
+
+def test_list_skill_team_roles_summarizes_roles_without_system_prompt(
+    tmp_path: Path,
+) -> None:
+    skill = _write_team_skill(tmp_path)
+
+    roles = list_skill_team_roles(skill)
+
+    assert len(roles) == 1
+    summary = roles[0].summary
+    assert summary.role_id == "analyst"
+    assert summary.effective_role_id.startswith("skill_team_team_review_analyst_")
+    assert summary.name == "Research Analyst"
+    assert summary.description == "Collects evidence for review."
+    assert summary.tools == ("read", "office_read_markdown")
+    assert summary.source_path == "agents/analyst.md"
+    assert "SYSTEM PROMPT" not in summary.model_dump_json()
+
+
+def test_build_skill_team_role_spec_forces_subagent_mode(tmp_path: Path) -> None:
+    skill = _write_team_skill(tmp_path)
+    role_entry = list_skill_team_roles(skill)[0]
+
+    spec = build_skill_team_role_spec(skill=skill, role=role_entry.role)
+
+    assert spec.role_id == role_entry.summary.effective_role_id
+    assert spec.mode == RoleMode.SUBAGENT
+    assert spec.system_prompt == "SYSTEM PROMPT FOR ANALYST."
+    assert spec.tools == ("read", "office_read_markdown")
+
+
+def test_list_skill_team_roles_ignores_invalid_and_duplicate_roles(
+    tmp_path: Path,
+) -> None:
+    skill = _write_team_skill(tmp_path)
+    roles_dir = skill.directory / "roles"
+    roles_dir.mkdir()
+    (skill.directory / "agents" / "invalid.md").write_text(
+        "---\n"
+        "role_id: invalid\n"
+        "name: Invalid\n"
+        "description: Missing tools.\n"
+        "version: 1\n"
+        "---\n"
+        "Invalid.\n",
+        encoding="utf-8",
+    )
+    (roles_dir / "duplicate.md").write_text(
+        "---\n"
+        "role_id: analyst\n"
+        "name: Duplicate Analyst\n"
+        "description: Duplicate role id.\n"
+        "version: 1\n"
+        "tools:\n"
+        "  - read\n"
+        "---\n"
+        "Duplicate.\n",
+        encoding="utf-8",
+    )
+
+    roles = list_skill_team_roles(skill)
+
+    assert [entry.summary.name for entry in roles] == ["Research Analyst"]
+
+
+def test_skill_team_role_summary_handles_external_source_paths(tmp_path: Path) -> None:
+    skill = _write_team_skill(tmp_path)
+    role = list_skill_team_roles(skill)[0].role.model_copy(
+        update={"source_path": tmp_path / "external.md"}
+    )
+
+    summary = summarize_skill_team_role(skill=skill, role=role)
+
+    assert summary.source_path == (tmp_path / "external.md").resolve().as_posix()
+
+
+def test_skill_team_effective_role_id_uses_fallback_fragments() -> None:
+    role_id = build_skill_team_effective_role_id(skill_name="技能", role_id="角色")
+
+    assert role_id.startswith("skill_team_skill_role_")
+
+
+def _write_team_skill(tmp_path: Path) -> Skill:
+    skill_dir = tmp_path / "skills" / "team-review"
+    agents_dir = skill_dir / "agents"
+    agents_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: team-review\n"
+        "description: Coordinate a review team.\n"
+        "---\n"
+        "Use the review workflow.\n",
+        encoding="utf-8",
+    )
+    (agents_dir / "analyst.md").write_text(
+        "---\n"
+        "role_id: analyst\n"
+        "name: Research Analyst\n"
+        "description: Collects evidence for review.\n"
+        "version: 1\n"
+        "mode: subagent\n"
+        "tools:\n"
+        "  - read\n"
+        "---\n"
+        "SYSTEM PROMPT FOR ANALYST.\n",
+        encoding="utf-8",
+    )
+    registry = SkillRegistry(
+        directory=SkillsDirectory(
+            sources=((SkillSource.USER_RELAY_TEAMS, tmp_path / "skills"),)
+        )
+    )
+    skill = registry.get_skill_definition("team-review")
+    assert skill is not None
+    return skill

--- a/tests/unit_tests/tools/registry/test_defaults.py
+++ b/tests/unit_tests/tools/registry/test_defaults.py
@@ -15,6 +15,7 @@ def test_registry_rejects_unknown_tools() -> None:
 def test_registry_contains_registered_local_tools() -> None:
     registry = build_default_registry()
     assert registry.list_names() == (
+        "activate_skill_roles",
         "ask_question",
         "capture_screen",
         "click_at",
@@ -30,6 +31,7 @@ def test_registry_contains_registered_local_tools() -> None:
         "launch_app",
         "list_background_tasks",
         "list_monitors",
+        "list_skill_roles",
         "list_windows",
         "notebook_edit",
         "office_read_markdown",

--- a/tests/unit_tests/tools/registry/test_tool_groups.py
+++ b/tests/unit_tests/tools/registry/test_tool_groups.py
@@ -23,6 +23,7 @@ def test_default_tool_groups_include_expected_buckets() -> None:
         "web",
         "computer",
         "orchestration",
+        "skill-teams",
         "task",
         "todo",
     ]
@@ -37,6 +38,10 @@ def test_default_tool_groups_include_expected_buckets() -> None:
     )
     assert "orch_dispatch_task" in orchestration_group.tools
     assert "orch_create_tasks" in orchestration_group.tools
+    skill_teams_group = next(
+        group for group in groups if group.group_id == "skill-teams"
+    )
+    assert skill_teams_group.tools == ("list_skill_roles", "activate_skill_roles")
     task_group = next(group for group in groups if group.group_id == "task")
     assert task_group.tools == ("spawn_subagent", "ask_question")
     todo_group = next(group for group in groups if group.group_id == "todo")

--- a/tests/unit_tests/tools/skill_team_tools/__init__.py
+++ b/tests/unit_tests/tools/skill_team_tools/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/tests/unit_tests/tools/skill_team_tools/test_skill_team_tools.py
+++ b/tests/unit_tests/tools/skill_team_tools/test_skill_team_tools.py
@@ -219,6 +219,7 @@ async def test_activate_skill_roles_creates_run_scoped_temporary_roles(
     activated_roles = cast(list[dict[str, object]], result["activated_roles"])
     assert activated_roles[0]["role_id"] == "analyst"
     assert activated_roles[0]["effective_role_id"] == role_spec.role_id
+    assert activated_roles[0]["tools"] == ["read", "office_read_markdown"]
 
 
 def _build_role_registry() -> tuple[RoleRegistry, RoleDefinition]:

--- a/tests/unit_tests/tools/skill_team_tools/test_skill_team_tools.py
+++ b/tests/unit_tests/tools/skill_team_tools/test_skill_team_tools.py
@@ -1,0 +1,375 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pydantic import JsonValue
+from pydantic_ai import Agent
+
+from relay_teams.roles.role_models import RoleDefinition
+from relay_teams.roles.role_registry import RoleRegistry
+from relay_teams.roles.temporary_role_models import (
+    TemporaryRoleSource,
+    TemporaryRoleSpec,
+)
+from relay_teams.skills.discovery import SkillsDirectory
+from relay_teams.skills.skill_models import SkillSource
+from relay_teams.skills.skill_registry import SkillRegistry
+from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.skill_team_tools.activate_skill_roles import (
+    _normalize_requested_role_ids,
+    register as register_activate_skill_roles,
+)
+from relay_teams.tools.skill_team_tools.list_skill_roles import (
+    register as register_list_skill_roles,
+)
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., object]] = {}
+
+    def tool(
+        self, *, description: str
+    ) -> Callable[[Callable[..., object]], Callable[..., object]]:
+        def decorator(func: Callable[..., object]) -> Callable[..., object]:
+            _ = description
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+
+class _CapturingRuntimeRoleResolver:
+    def __init__(self, current_role: RoleDefinition) -> None:
+        self._current_role = current_role
+        self.calls: list[dict[str, object]] = []
+
+    def get_effective_role(self, *, run_id: str | None, role_id: str) -> RoleDefinition:
+        _ = run_id
+        if role_id == self._current_role.role_id:
+            return self._current_role
+        raise KeyError(f"Unknown role_id: {role_id}")
+
+    def create_temporary_role(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        role: TemporaryRoleSpec,
+        source: TemporaryRoleSource = TemporaryRoleSource.META_AGENT_GENERATED,
+    ) -> RoleDefinition:
+        self.calls.append(
+            {
+                "run_id": run_id,
+                "session_id": session_id,
+                "role": role,
+                "source": source,
+            }
+        )
+        return role.to_role_definition()
+
+
+async def _invoke_tool_action(
+    action: Callable[..., object],
+    raw_args: dict[str, object] | None,
+) -> dict[str, JsonValue]:
+    resolved_raw_args = {} if raw_args is None else raw_args
+    tool_args = {
+        name: resolved_raw_args[name]
+        for name in inspect.signature(action).parameters
+        if name in resolved_raw_args
+    }
+    result = action(**tool_args)
+    if inspect.isawaitable(result):
+        return cast(dict[str, JsonValue], await result)
+    return cast(dict[str, JsonValue], result)
+
+
+@pytest.mark.asyncio
+async def test_list_skill_roles_returns_lightweight_role_summaries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_list_skill_roles(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, JsonValue]]],
+        fake_agent.tools["list_skill_roles"],
+    )
+    registry = _build_skill_registry(tmp_path)
+    role_registry, current_role = _build_role_registry()
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            skill_registry=registry,
+            role_registry=role_registry,
+            runtime_role_resolver=None,
+            run_id="run-1",
+            session_id="session-1",
+            role_id=current_role.role_id,
+        ),
+    )
+
+    from relay_teams.tools.skill_team_tools import (
+        list_skill_roles as list_skill_roles_module,
+    )
+
+    async def _fake_execute_tool_call(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, JsonValue],
+        action: Callable[..., object],
+        raw_args: dict[str, object] | None = None,
+        **_: object,
+    ) -> dict[str, JsonValue]:
+        del ctx, tool_name, args_summary
+        return await _invoke_tool_action(action, raw_args)
+
+    monkeypatch.setattr(
+        list_skill_roles_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
+
+    result = await tool(cast(object, ctx), skill_name="team-review")
+
+    assert result["skill"] == {
+        "name": "team-review",
+        "ref": "team-review",
+        "source": "user_relay_teams",
+    }
+    roles = cast(list[dict[str, object]], result["roles"])
+    assert roles[0]["role_id"] == "analyst"
+    assert cast(str, roles[0]["effective_role_id"]).startswith(
+        "skill_team_team_review_analyst_"
+    )
+    assert roles[0]["source_path"] == "agents/analyst.md"
+    assert "system_prompt" not in roles[0]
+
+
+@pytest.mark.asyncio
+async def test_activate_skill_roles_creates_run_scoped_temporary_roles(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_activate_skill_roles(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, JsonValue]]],
+        fake_agent.tools["activate_skill_roles"],
+    )
+    registry = _build_skill_registry(tmp_path)
+    role_registry, current_role = _build_role_registry()
+    runtime_role_resolver = _CapturingRuntimeRoleResolver(current_role)
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            skill_registry=registry,
+            role_registry=role_registry,
+            runtime_role_resolver=runtime_role_resolver,
+            run_id="run-1",
+            session_id="session-1",
+            role_id=current_role.role_id,
+        ),
+    )
+
+    from relay_teams.tools.skill_team_tools import (
+        activate_skill_roles as activate_skill_roles_module,
+    )
+
+    async def _fake_execute_tool_call(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, JsonValue],
+        action: Callable[..., object],
+        raw_args: dict[str, object] | None = None,
+        **_: object,
+    ) -> dict[str, JsonValue]:
+        del ctx, tool_name, args_summary
+        return await _invoke_tool_action(action, raw_args)
+
+    monkeypatch.setattr(
+        activate_skill_roles_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
+
+    result = await tool(
+        cast(object, ctx),
+        skill_name="team-review",
+        role_ids=[" analyst ", "analyst"],
+    )
+
+    assert len(runtime_role_resolver.calls) == 1
+    created = runtime_role_resolver.calls[0]
+    assert created["run_id"] == "run-1"
+    assert created["session_id"] == "session-1"
+    assert created["source"] == TemporaryRoleSource.SKILL_TEAM
+    role_spec = cast(TemporaryRoleSpec, created["role"])
+    assert role_spec.role_id.startswith("skill_team_team_review_analyst_")
+    assert role_spec.system_prompt == "SYSTEM PROMPT FOR ANALYST."
+    activated_roles = cast(list[dict[str, object]], result["activated_roles"])
+    assert activated_roles[0]["role_id"] == "analyst"
+    assert activated_roles[0]["effective_role_id"] == role_spec.role_id
+
+
+def _build_role_registry() -> tuple[RoleRegistry, RoleDefinition]:
+    current_role = RoleDefinition(
+        role_id="MainAgent",
+        name="Main Agent",
+        description="Handles normal-mode runs.",
+        version="1",
+        tools=(),
+        skills=("team-review",),
+        system_prompt="Handle the run.",
+    )
+    registry = RoleRegistry()
+    registry.register(current_role)
+    return registry, current_role
+
+
+def _build_skill_registry(tmp_path: Path) -> SkillRegistry:
+    skill_dir = tmp_path / "skills" / "team-review"
+    agents_dir = skill_dir / "agents"
+    agents_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: team-review\n"
+        "description: Coordinate a review team.\n"
+        "---\n"
+        "Use the review workflow.\n",
+        encoding="utf-8",
+    )
+    (agents_dir / "analyst.md").write_text(
+        "---\n"
+        "role_id: analyst\n"
+        "name: Research Analyst\n"
+        "description: Collects evidence for review.\n"
+        "version: 1\n"
+        "mode: subagent\n"
+        "tools:\n"
+        "  - read\n"
+        "---\n"
+        "SYSTEM PROMPT FOR ANALYST.\n",
+        encoding="utf-8",
+    )
+    return SkillRegistry(
+        directory=SkillsDirectory(
+            sources=((SkillSource.USER_RELAY_TEAMS, tmp_path / "skills"),)
+        )
+    )
+
+
+def test_normalize_requested_role_ids_rejects_blank_values() -> None:
+    with pytest.raises(ValueError, match="role_ids must contain"):
+        _normalize_requested_role_ids(["  "])
+
+
+@pytest.mark.asyncio
+async def test_activate_skill_roles_requires_runtime_role_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_activate_skill_roles(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, JsonValue]]],
+        fake_agent.tools["activate_skill_roles"],
+    )
+    registry = _build_skill_registry(tmp_path)
+    role_registry, current_role = _build_role_registry()
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            skill_registry=registry,
+            role_registry=role_registry,
+            runtime_role_resolver=None,
+            run_id="run-1",
+            session_id="session-1",
+            role_id=current_role.role_id,
+        ),
+    )
+
+    from relay_teams.tools.skill_team_tools import (
+        activate_skill_roles as activate_skill_roles_module,
+    )
+
+    async def _fake_execute_tool_call(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, JsonValue],
+        action: Callable[..., object],
+        raw_args: dict[str, object] | None = None,
+        **_: object,
+    ) -> dict[str, JsonValue]:
+        del ctx, tool_name, args_summary
+        return await _invoke_tool_action(action, raw_args)
+
+    monkeypatch.setattr(
+        activate_skill_roles_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
+
+    with pytest.raises(RuntimeError, match="Temporary role activation"):
+        await tool(cast(object, ctx), skill_name="team-review", role_ids=["analyst"])
+
+
+@pytest.mark.asyncio
+async def test_activate_skill_roles_rejects_unknown_skill_role(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_activate_skill_roles(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, JsonValue]]],
+        fake_agent.tools["activate_skill_roles"],
+    )
+    registry = _build_skill_registry(tmp_path)
+    role_registry, current_role = _build_role_registry()
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            skill_registry=registry,
+            role_registry=role_registry,
+            runtime_role_resolver=_CapturingRuntimeRoleResolver(current_role),
+            run_id="run-1",
+            session_id="session-1",
+            role_id=current_role.role_id,
+        ),
+    )
+
+    from relay_teams.tools.skill_team_tools import (
+        activate_skill_roles as activate_skill_roles_module,
+    )
+
+    async def _fake_execute_tool_call(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, JsonValue],
+        action: Callable[..., object],
+        raw_args: dict[str, object] | None = None,
+        **_: object,
+    ) -> dict[str, JsonValue]:
+        del ctx, tool_name, args_summary
+        return await _invoke_tool_action(action, raw_args)
+
+    monkeypatch.setattr(
+        activate_skill_roles_module,
+        "execute_tool_call",
+        _fake_execute_tool_call,
+    )
+
+    with pytest.raises(ValueError, match="Skill roles not found"):
+        await tool(cast(object, ctx), skill_name="team-review", role_ids=["missing"])

--- a/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
+++ b/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
@@ -155,6 +155,26 @@ class _CapturingBackgroundTaskService:
         )
 
 
+class _RuntimeRoleResolverWithTemporaryRole:
+    def __init__(self, role: RoleDefinition) -> None:
+        self._role = role
+
+    def get_temporary_role(self, *, run_id: str | None, role_id: str) -> RoleDefinition:
+        _ = run_id
+        if role_id == self._role.role_id:
+            return self._role
+        raise KeyError(f"Unknown temporary role: {role_id}")
+
+
+class _RuntimeRoleResolverWithoutTemporaryRole:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def get_temporary_role(self, *, run_id: str | None, role_id: str) -> RoleDefinition:
+        self.calls.append({"run_id": run_id, "role_id": role_id})
+        raise KeyError(f"Unknown temporary role: {role_id}")
+
+
 @pytest.mark.asyncio
 async def test_shell_passes_none_tool_call_id_without_validation_error(
     monkeypatch: pytest.MonkeyPatch,
@@ -227,6 +247,7 @@ async def test_spawn_subagent_runs_synchronously_by_default(
             background_task_service=service,
             workspace=workspace,
             role_registry=role_registry,
+            runtime_role_resolver=None,
             run_id="run-1",
             session_id="session-1",
             instance_id="inst-1",
@@ -265,6 +286,7 @@ async def test_spawn_subagent_runs_synchronously_by_default(
         "session_id": "session-1",
         "workspace_id": "workspace-1",
         "subagent_role_id": "Crafter",
+        "subagent_role": None,
         "title": "Investigate test failures",
         "prompt": "Inspect the failing tests and summarize the root cause.",
     }
@@ -272,6 +294,205 @@ async def test_spawn_subagent_runs_synchronously_by_default(
         "completed": True,
         "output": "root cause found",
     }
+
+
+@pytest.mark.asyncio
+async def test_spawn_subagent_falls_back_to_static_role_when_temp_role_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_spawn_subagent(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["spawn_subagent"],
+    )
+    service = _CapturingBackgroundTaskService()
+    workspace = _FakeWorkspace(tmp_path)
+    runtime_role_resolver = _RuntimeRoleResolverWithoutTemporaryRole()
+    role_registry = SimpleNamespace(resolve_subagent_role_id=lambda role_id: role_id)
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            background_task_service=service,
+            workspace=workspace,
+            role_registry=role_registry,
+            runtime_role_resolver=runtime_role_resolver,
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+        ),
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[ToolResultProjection]],
+        raw_args: dict[str, object] | None = None,
+        approval_request=None,
+        approval_request_factory=None,
+        **_: object,
+    ) -> dict[str, object]:
+        del ctx, tool_name, approval_request, approval_request_factory
+        projected = await _invoke_tool_action(action, raw_args)
+        return cast(dict[str, object], projected.visible_data)
+
+    from relay_teams.tools.task_tools import spawn_subagent as spawn_subagent_module
+
+    monkeypatch.setattr(spawn_subagent_module, "execute_tool_call", _fake_execute_tool)
+
+    result = await tool(
+        ctx,
+        role_id="Crafter",
+        description="Investigate test failures",
+        prompt="Inspect the failing tests and summarize the root cause.",
+    )
+
+    assert runtime_role_resolver.calls == [{"run_id": "run-1", "role_id": "Crafter"}]
+    assert service.calls[0]["subagent_role_id"] == "Crafter"
+    assert service.calls[0]["subagent_role"] is None
+    assert result["output"] == "root cause found"
+
+
+@pytest.mark.asyncio
+async def test_spawn_subagent_passes_temporary_role_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_spawn_subagent(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["spawn_subagent"],
+    )
+    service = _CapturingBackgroundTaskService()
+    workspace = _FakeWorkspace(tmp_path)
+    role = RoleDefinition(
+        role_id="skill_team_review_analyst_12345678",
+        name="Analyst",
+        description="Collects evidence.",
+        version="1",
+        mode=RoleMode.SUBAGENT,
+        tools=(),
+        system_prompt="Analyze.",
+    )
+    role_registry = SimpleNamespace(
+        is_coordinator_role=lambda role_id: False,
+        is_main_agent_role=lambda role_id: False,
+    )
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            background_task_service=service,
+            workspace=workspace,
+            role_registry=role_registry,
+            runtime_role_resolver=_RuntimeRoleResolverWithTemporaryRole(role),
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+        ),
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[ToolResultProjection]],
+        raw_args: dict[str, object] | None = None,
+        approval_request=None,
+        approval_request_factory=None,
+        **_: object,
+    ) -> dict[str, object]:
+        del ctx, tool_name, approval_request, approval_request_factory
+        projected = await _invoke_tool_action(action, raw_args)
+        return cast(dict[str, object], projected.visible_data)
+
+    from relay_teams.tools.task_tools import spawn_subagent as spawn_subagent_module
+
+    monkeypatch.setattr(spawn_subagent_module, "execute_tool_call", _fake_execute_tool)
+
+    result = await tool(
+        ctx,
+        role_id=role.role_id,
+        description="Investigate test failures",
+        prompt="Inspect the failing tests and summarize the root cause.",
+    )
+
+    assert service.calls[0]["subagent_role_id"] == role.role_id
+    assert service.calls[0]["subagent_role"] == role
+    assert result["output"] == "root cause found"
+
+
+@pytest.mark.asyncio
+async def test_spawn_subagent_rejects_unspawnable_temporary_role(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_agent = _FakeAgent()
+    register_spawn_subagent(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["spawn_subagent"],
+    )
+    workspace = _FakeWorkspace(tmp_path)
+    role = RoleDefinition(
+        role_id="skill_team_review_analyst_12345678",
+        name="Analyst",
+        description="Collects evidence.",
+        version="1",
+        mode=RoleMode.PRIMARY,
+        tools=(),
+        system_prompt="Analyze.",
+    )
+    role_registry = SimpleNamespace(
+        is_coordinator_role=lambda role_id: False,
+        is_main_agent_role=lambda role_id: False,
+    )
+    ctx = SimpleNamespace(
+        tool_call_id="call-1",
+        deps=SimpleNamespace(
+            background_task_service=_CapturingBackgroundTaskService(),
+            workspace=workspace,
+            role_registry=role_registry,
+            runtime_role_resolver=_RuntimeRoleResolverWithTemporaryRole(role),
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+        ),
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[ToolResultProjection]],
+        raw_args: dict[str, object] | None = None,
+        approval_request=None,
+        approval_request_factory=None,
+        **_: object,
+    ) -> dict[str, object]:
+        del ctx, tool_name, approval_request, approval_request_factory
+        projected = await _invoke_tool_action(action, raw_args)
+        return cast(dict[str, object], projected.visible_data)
+
+    from relay_teams.tools.task_tools import spawn_subagent as spawn_subagent_module
+
+    monkeypatch.setattr(spawn_subagent_module, "execute_tool_call", _fake_execute_tool)
+
+    with pytest.raises(ValueError, match="Role cannot be used as a subagent"):
+        await tool(
+            ctx,
+            role_id=role.role_id,
+            description="Investigate test failures",
+            prompt="Inspect the failing tests and summarize the root cause.",
+        )
 
 
 @pytest.mark.asyncio
@@ -294,6 +515,7 @@ async def test_spawn_subagent_starts_background_subagent_task_when_requested(
             background_task_service=service,
             workspace=workspace,
             role_registry=role_registry,
+            runtime_role_resolver=None,
             run_id="run-1",
             session_id="session-1",
             instance_id="inst-1",


### PR DESCRIPTION
## Summary
- add progressive skill-team role discovery and activation tools under the skill-teams tool group
- extend BM25 skill routing documents with lightweight team-role signals without indexing role system prompts
- allow activated run-scoped skill roles to be used by spawn_subagent and orchestration dispatch
- update docs and built-in Coordinator/MainAgent tool capabilities

Closes #500

## Tests
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests