### PR TITLE
fix: accept stringified skill team role ids

### DIFF
--- a/src/relay_teams/tools/skill_team_tools/activate_skill_roles.py
+++ b/src/relay_teams/tools/skill_team_tools/activate_skill_roles.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import ast
+import json
+
 from pydantic import JsonValue
 from pydantic_ai import Agent
 
@@ -25,9 +28,12 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     async def activate_skill_roles(
         ctx: ToolContext,
         skill_name: str,
-        role_ids: list[str],
+        role_ids: list[str] | str,
     ) -> dict[str, JsonValue]:
-        def _action(skill_name: str, role_ids: list[str]) -> dict[str, JsonValue]:
+        def _action(
+            skill_name: str,
+            role_ids: list[str] | str,
+        ) -> dict[str, JsonValue]:
             runtime_role_resolver = ctx.deps.runtime_role_resolver
             if runtime_role_resolver is None:
                 raise RuntimeError("Temporary role activation is unavailable")
@@ -83,15 +89,19 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         return await execute_tool_call(
             ctx,
             tool_name="activate_skill_roles",
-            args_summary={"skill_name": skill_name, "role_count": len(role_ids)},
+            args_summary={
+                "skill_name": skill_name,
+                "role_count": len(_coerce_requested_role_ids(role_ids)),
+            },
             action=_action,
             raw_args=locals(),
         )
 
 
-def _normalize_requested_role_ids(role_ids: list[str]) -> tuple[str, ...]:
+def _normalize_requested_role_ids(role_ids: list[str] | str) -> tuple[str, ...]:
+    raw_role_ids = _coerce_requested_role_ids(role_ids)
     normalized_role_ids: list[str] = []
-    for role_id in role_ids:
+    for role_id in raw_role_ids:
         normalized = role_id.strip()
         if not normalized:
             continue
@@ -100,3 +110,47 @@ def _normalize_requested_role_ids(role_ids: list[str]) -> tuple[str, ...]:
     if not normalized_role_ids:
         raise ValueError("role_ids must contain at least one role id")
     return tuple(normalized_role_ids)
+
+
+def _coerce_requested_role_ids(role_ids: list[str] | str) -> tuple[str, ...]:
+    if isinstance(role_ids, str):
+        normalized = role_ids.strip()
+        if not normalized:
+            return ()
+        parsed = _parse_role_ids_text(normalized)
+        if parsed is not None:
+            return parsed
+        return (normalized,)
+    return tuple(role_ids)
+
+
+def _parse_role_ids_text(value: str) -> tuple[str, ...] | None:
+    json_parsed = _parse_role_ids_json(value)
+    if json_parsed is not None:
+        return json_parsed
+    try:
+        literal = ast.literal_eval(value)
+    except (SyntaxError, ValueError):
+        return None
+    return _role_ids_from_parsed_value(literal)
+
+
+def _parse_role_ids_json(value: str) -> tuple[str, ...] | None:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return _role_ids_from_parsed_value(parsed)
+
+
+def _role_ids_from_parsed_value(value: object) -> tuple[str, ...] | None:
+    if isinstance(value, str):
+        return (value,)
+    if not isinstance(value, list | tuple):
+        return None
+    parsed_role_ids: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None
+        parsed_role_ids.append(item)
+    return tuple(parsed_role_ids)

--- a/tests/unit_tests/tools/skill_team_tools/test_skill_team_tools.py
+++ b/tests/unit_tests/tools/skill_team_tools/test_skill_team_tools.py
@@ -274,6 +274,22 @@ def test_normalize_requested_role_ids_rejects_blank_values() -> None:
         _normalize_requested_role_ids(["  "])
 
 
+@pytest.mark.parametrize(
+    ("raw_role_ids", "expected"),
+    [
+        ([" analyst ", "analyst"], ("analyst",)),
+        ('[" analyst ", "analyst"]', ("analyst",)),
+        ("[' analyst ', 'analyst']", ("analyst",)),
+        ("analyst", ("analyst",)),
+    ],
+)
+def test_normalize_requested_role_ids_accepts_provider_string_forms(
+    raw_role_ids: list[str] | str,
+    expected: tuple[str, ...],
+) -> None:
+    assert _normalize_requested_role_ids(raw_role_ids) == expected
+
+
 @pytest.mark.asyncio
 async def test_activate_skill_roles_requires_runtime_role_resolver(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- accept provider string forms for `activate_skill_roles.role_ids`, including JSON and Python-list-style strings
- keep normal list input behavior unchanged and dedupe role ids after parsing
- add regression coverage for provider string forms observed during real LLM E2E validation

Closes #513

## Validation
- real LLM E2E with `bigmodel/glm-5`: `load_skill -> list_skill_roles -> activate_skill_roles -> spawn_subagent` completed successfully
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests` (one browser visibility flake, rerun of the failed case passed)
- `uv run --extra dev pytest -q tests/integration_tests/browser/test_browser_smoke.py::test_browser_shell_settings_and_session_management`