### PR TITLE
feat: migrate SQLite repositories to async paths

### DIFF
--- a/src/relay_teams/agents/execution/event_publishing.py
+++ b/src/relay_teams/agents/execution/event_publishing.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Sequence
-from typing import Protocol, cast
+from collections.abc import Awaitable, Callable, Sequence
+from typing import cast
 
 from pydantic import JsonValue
 from pydantic_ai.messages import (
@@ -19,18 +19,19 @@ from relay_teams.agents.tasks.task_status_sanitizer import (
 )
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_stream import (
+    AsyncRunEventPublisher,
+    SyncRunEventPublisher,
+    publish_run_event_async,
+)
 from relay_teams.sessions.runs.run_models import RunEvent
-
-
-class RunEventPublisher(Protocol):
-    def publish(self, event: RunEvent) -> None: ...
 
 
 class EventPublishingService:
     def __init__(
         self,
         *,
-        run_event_hub: RunEventPublisher | None,
+        run_event_hub: AsyncRunEventPublisher | SyncRunEventPublisher | None,
     ) -> None:
         self._run_event_hub = run_event_hub
 
@@ -50,6 +51,22 @@ class EventPublishingService:
             },
         )
 
+    async def publish_text_delta_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        text: str,
+    ) -> None:
+        await self._publish_run_event_async(
+            request=request,
+            event_type=RunEventType.TEXT_DELTA,
+            payload={
+                "text": text,
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+        )
+
     def publish_thinking_started_event(
         self,
         *,
@@ -57,6 +74,22 @@ class EventPublishingService:
         part_index: int,
     ) -> None:
         self._publish_run_event(
+            request=request,
+            event_type=RunEventType.THINKING_STARTED,
+            payload={
+                "part_index": part_index,
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+        )
+
+    async def publish_thinking_started_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+    ) -> None:
+        await self._publish_run_event_async(
             request=request,
             event_type=RunEventType.THINKING_STARTED,
             payload={
@@ -84,6 +117,24 @@ class EventPublishingService:
             },
         )
 
+    async def publish_thinking_delta_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+        text: str,
+    ) -> None:
+        await self._publish_run_event_async(
+            request=request,
+            event_type=RunEventType.THINKING_DELTA,
+            payload={
+                "part_index": part_index,
+                "text": text,
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+        )
+
     def publish_thinking_finished_event(
         self,
         *,
@@ -91,6 +142,22 @@ class EventPublishingService:
         part_index: int,
     ) -> None:
         self._publish_run_event(
+            request=request,
+            event_type=RunEventType.THINKING_FINISHED,
+            payload={
+                "part_index": part_index,
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+        )
+
+    async def publish_thinking_finished_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+    ) -> None:
+        await self._publish_run_event_async(
             request=request,
             event_type=RunEventType.THINKING_FINISHED,
             payload={
@@ -133,6 +200,39 @@ class EventPublishingService:
                 emitted = True
         return emitted
 
+    async def publish_tool_call_events_from_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        messages: Sequence[ModelResponse | ModelRequest],
+        published_tool_call_ids: set[str] | None = None,
+    ) -> bool:
+        emitted = False
+        for msg in messages:
+            if not isinstance(msg, ModelResponse):
+                continue
+            for part in msg.parts:
+                if not isinstance(part, ToolCallPart):
+                    continue
+                tool_call_id = str(part.tool_call_id or "").strip()
+                if tool_call_id and published_tool_call_ids is not None:
+                    if tool_call_id in published_tool_call_ids:
+                        continue
+                    published_tool_call_ids.add(tool_call_id)
+                await self._publish_run_event_async(
+                    request=request,
+                    event_type=RunEventType.TOOL_CALL,
+                    payload={
+                        "tool_name": part.tool_name,
+                        "tool_call_id": tool_call_id,
+                        "args": part.args,
+                        "role_id": request.role_id,
+                        "instance_id": request.instance_id,
+                    },
+                )
+                emitted = True
+        return emitted
+
     def publish_committed_tool_outcome_events_from_messages(
         self,
         *,
@@ -156,9 +256,7 @@ class EventPublishingService:
                         continue
                     result_payload = cast(
                         JsonValue,
-                        sanitize_task_status_payload(
-                            to_json_compatible(cast(object, part.content))
-                        ),
+                        sanitize_task_status_payload(to_json_compatible(part.content)),
                     )
                     result_payload = maybe_enrich_tool_result_payload(
                         tool_name=str(part.tool_name),
@@ -166,8 +264,7 @@ class EventPublishingService:
                     )
                     is_error = False
                     if isinstance(result_payload, dict):
-                        payload_map = cast(dict[str, object], result_payload)
-                        is_error = payload_map.get("ok") is False
+                        is_error = result_payload.get("ok") is False
                     self._publish_run_event(
                         request=request,
                         event_type=RunEventType.TOOL_RESULT,
@@ -195,6 +292,68 @@ class EventPublishingService:
                         },
                     )
 
+    async def publish_committed_tool_outcome_events_from_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        messages: Sequence[ModelResponse | ModelRequest],
+        to_json_compatible: Callable[[object], JsonValue],
+        maybe_enrich_tool_result_payload: Callable[..., JsonValue],
+        tool_result_already_emitted_from_runtime: Callable[..., Awaitable[bool]],
+    ) -> None:
+        for msg in messages:
+            if isinstance(msg, ModelResponse):
+                continue
+            for part in msg.parts:
+                if isinstance(part, ToolReturnPart):
+                    tool_call_id = str(part.tool_call_id or "").strip()
+                    already_emitted = await tool_result_already_emitted_from_runtime(
+                        request=request,
+                        tool_name=str(part.tool_name),
+                        tool_call_id=tool_call_id,
+                    )
+                    if already_emitted:
+                        continue
+                    result_payload = cast(
+                        JsonValue,
+                        sanitize_task_status_payload(
+                            to_json_compatible(cast(object, part.content))
+                        ),
+                    )
+                    result_payload = maybe_enrich_tool_result_payload(
+                        tool_name=str(part.tool_name),
+                        result_payload=result_payload,
+                    )
+                    is_error = False
+                    if isinstance(result_payload, dict):
+                        is_error = result_payload.get("ok") is False
+                    await self._publish_run_event_async(
+                        request=request,
+                        event_type=RunEventType.TOOL_RESULT,
+                        payload={
+                            "tool_name": str(part.tool_name),
+                            "tool_call_id": tool_call_id,
+                            "result": result_payload,
+                            "error": is_error,
+                            "role_id": request.role_id,
+                            "instance_id": request.instance_id,
+                        },
+                    )
+                    continue
+                if isinstance(part, RetryPromptPart) and part.tool_name:
+                    await self._publish_run_event_async(
+                        request=request,
+                        event_type=RunEventType.TOOL_INPUT_VALIDATION_FAILED,
+                        payload={
+                            "tool_name": part.tool_name,
+                            "tool_call_id": part.tool_call_id,
+                            "reason": "Input validation failed before tool execution.",
+                            "details": part.content,
+                            "role_id": request.role_id,
+                            "instance_id": request.instance_id,
+                        },
+                    )
+
     def _publish_run_event(
         self,
         *,
@@ -203,6 +362,8 @@ class EventPublishingService:
         payload: dict[str, object],
     ) -> None:
         if self._run_event_hub is None:
+            return
+        if not isinstance(self._run_event_hub, SyncRunEventPublisher):
             return
         self._run_event_hub.publish(
             RunEvent(
@@ -215,6 +376,29 @@ class EventPublishingService:
                 event_type=event_type,
                 payload_json=self._to_json(payload),
             )
+        )
+
+    async def _publish_run_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        event_type: RunEventType,
+        payload: dict[str, object],
+    ) -> None:
+        if self._run_event_hub is None:
+            return
+        await publish_run_event_async(
+            self._run_event_hub,
+            RunEvent(
+                session_id=request.session_id,
+                run_id=request.run_id,
+                trace_id=request.trace_id,
+                task_id=request.task_id,
+                instance_id=request.instance_id,
+                role_id=request.role_id,
+                event_type=event_type,
+                payload_json=self._to_json(payload),
+            ),
         )
 
     def _to_json(self, obj: object) -> str:

--- a/src/relay_teams/agents/execution/llm_transport_scope.py
+++ b/src/relay_teams/agents/execution/llm_transport_scope.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from relay_teams.providers.provider_contracts import LLMRequest
+
+
+def llm_http_client_cache_scope_for_request(request: LLMRequest) -> str:
+    return ":".join(
+        (
+            request.run_id,
+            request.session_id,
+            request.task_id,
+            request.instance_id,
+            request.role_id,
+        )
+    )

--- a/src/relay_teams/agents/execution/message_commit.py
+++ b/src/relay_teams/agents/execution/message_commit.py
@@ -32,12 +32,14 @@ class CommitMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
-    ) -> None: ...
+    ) -> None:
+        pass
 
     def get_history_for_conversation(
         self,
         conversation_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
     async def append_async(
         self,
@@ -50,12 +52,14 @@ class CommitMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def get_history_for_conversation_async(
         self,
         conversation_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -71,12 +75,14 @@ class AsyncCommitMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def get_history_for_conversation_async(
         self,
         conversation_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
 
 class NormalizeCommittableMessages(Protocol):
@@ -85,7 +91,8 @@ class NormalizeCommittableMessages(Protocol):
         *,
         request: LLMRequest,
         messages: Sequence[ModelRequest | ModelResponse],
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
 
 class MessageCommitService:

--- a/src/relay_teams/agents/execution/message_commit.py
+++ b/src/relay_teams/agents/execution/message_commit.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
-from typing import Protocol
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Protocol, runtime_checkable
 
 from pydantic_ai.messages import (
     ModelRequest,
@@ -39,6 +39,45 @@ class CommitMessageRepository(Protocol):
         conversation_id: str,
     ) -> list[ModelRequest | ModelResponse]: ...
 
+    async def append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None: ...
+
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]: ...
+
+
+@runtime_checkable
+class AsyncCommitMessageRepository(Protocol):
+    async def append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None: ...
+
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]: ...
+
 
 class NormalizeCommittableMessages(Protocol):
     def __call__(
@@ -56,6 +95,51 @@ class MessageCommitService:
         message_repo: CommitMessageRepository,
     ) -> None:
         self._message_repo = message_repo
+
+    async def _append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None:
+        if isinstance(self._message_repo, AsyncCommitMessageRepository):
+            await self._message_repo.append_async(
+                session_id=session_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                agent_role_id=agent_role_id,
+                instance_id=instance_id,
+                task_id=task_id,
+                trace_id=trace_id,
+                messages=messages,
+            )
+            return
+        self._message_repo.append(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            messages=messages,
+        )
+
+    async def _get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        if isinstance(self._message_repo, AsyncCommitMessageRepository):
+            return await self._message_repo.get_history_for_conversation_async(
+                conversation_id
+            )
+        return self._message_repo.get_history_for_conversation(conversation_id)
 
     def commit_ready_messages(
         self,
@@ -122,6 +206,75 @@ class MessageCommitService:
             committed_tool_validation_failures,
         )
 
+    async def commit_ready_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+        last_committable_index: Callable[
+            [Sequence[ModelRequest | ModelResponse]],
+            int,
+        ],
+        has_tool_input_validation_failures: Callable[
+            [Sequence[ModelRequest | ModelResponse]],
+            bool,
+        ],
+        normalize_committable_messages: NormalizeCommittableMessages,
+        workspace_id: Callable[[LLMRequest], str],
+        conversation_id: Callable[[LLMRequest], str],
+        publish_committed_tool_outcome_events_from_messages: Callable[
+            ...,
+            Awaitable[None],
+        ],
+        filter_model_messages: Callable[
+            [Sequence[ModelRequest | ModelResponse]],
+            list[ModelRequest | ModelResponse],
+        ],
+        has_tool_side_effect_messages: Callable[
+            [Sequence[ModelRequest | ModelResponse]],
+            bool,
+        ],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        bool,
+        bool,
+    ]:
+        _ = history
+        safe_index = last_committable_index(pending_messages)
+        if safe_index <= 0:
+            return history, pending_messages, False, False
+        raw_ready = pending_messages[:safe_index]
+        committed_tool_validation_failures = has_tool_input_validation_failures(
+            raw_ready
+        )
+        ready = normalize_committable_messages(request=request, messages=raw_ready)
+        resolved_conversation_id = conversation_id(request)
+        await self._append_async(
+            session_id=request.session_id,
+            workspace_id=workspace_id(request),
+            conversation_id=resolved_conversation_id,
+            agent_role_id=request.role_id,
+            instance_id=request.instance_id,
+            task_id=request.task_id,
+            trace_id=request.trace_id,
+            messages=ready,
+        )
+        await publish_committed_tool_outcome_events_from_messages(
+            request=request,
+            messages=ready,
+        )
+        next_history = filter_model_messages(
+            await self._get_history_for_conversation_async(resolved_conversation_id)
+        )
+        return (
+            next_history,
+            pending_messages[safe_index:],
+            has_tool_side_effect_messages(ready),
+            committed_tool_validation_failures,
+        )
+
     def commit_all_safe_messages(
         self,
         *,
@@ -161,6 +314,63 @@ class MessageCommitService:
                 committed_tool_events_published,
                 committed_tool_validation_failures,
             ) = commit_ready_messages(
+                request=request,
+                history=next_history,
+                pending_messages=remaining,
+            )
+            if committed_tool_events_published:
+                tool_events_published = True
+            if committed_tool_validation_failures:
+                tool_validation_failures_committed = True
+        return (
+            next_history,
+            remaining,
+            tool_events_published,
+            tool_validation_failures_committed,
+        )
+
+    # noinspection PyMethodMayBeStatic
+    async def commit_all_safe_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+        commit_ready_messages: Callable[
+            ...,
+            Awaitable[
+                tuple[
+                    list[ModelRequest | ModelResponse],
+                    list[ModelRequest | ModelResponse],
+                    bool,
+                    bool,
+                ]
+            ],
+        ],
+        last_committable_index: Callable[
+            [Sequence[ModelRequest | ModelResponse]],
+            int,
+        ],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        bool,
+        bool,
+    ]:
+        next_history = history
+        remaining = list(pending_messages)
+        tool_events_published = False
+        tool_validation_failures_committed = False
+        while remaining:
+            safe_index = last_committable_index(remaining)
+            if safe_index <= 0:
+                break
+            (
+                next_history,
+                remaining,
+                committed_tool_events_published,
+                committed_tool_validation_failures,
+            ) = await commit_ready_messages(
                 request=request,
                 history=next_history,
                 pending_messages=remaining,

--- a/src/relay_teams/agents/execution/message_repository.py
+++ b/src/relay_teams/agents/execution/message_repository.py
@@ -298,6 +298,20 @@ class MessageRepository(SharedSqliteRepository):
             )
         return _dedupe_duplicate_objective_messages(results)
 
+    async def get_user_messages_by_session_async(
+        self,
+        session_id: str,
+        *,
+        include_cleared: bool = False,
+        include_hidden_from_context: bool = False,
+    ) -> list[dict[str, JsonValue]]:
+        return await self._call_sync_async(
+            self.get_user_messages_by_session,
+            session_id,
+            include_cleared=include_cleared,
+            include_hidden_from_context=include_hidden_from_context,
+        )
+
     async def get_messages_by_session_async(
         self,
         session_id: str,

--- a/src/relay_teams/agents/execution/message_repository.py
+++ b/src/relay_teams/agents/execution/message_repository.py
@@ -9,7 +9,6 @@ from collections.abc import Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic_ai.messages import (
     ModelMessage,
@@ -18,7 +17,8 @@ from pydantic_ai.messages import (
     ToolCallPart,
 )
 
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.agents.execution.tool_args_repair import repair_tool_args
 from relay_teams.agents.execution.tool_call_history import (
     collect_safe_row_ids,
@@ -36,7 +36,7 @@ from relay_teams.sessions.session_history_marker_repository import (
 )
 
 
-class MessageRepository:
+class MessageRepository(SharedSqliteRepository):
     """Persists conversation-safe LLM message history."""
 
     def __init__(
@@ -45,10 +45,7 @@ class MessageRepository:
         *,
         session_history_marker_repo: SessionHistoryMarkerRepository | None = None,
     ) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._session_history_marker_repo = session_history_marker_repo
         self._init_tables()
 
@@ -169,16 +166,50 @@ class MessageRepository:
             operation_name="append",
         )
 
+    async def append_async(
+        self,
+        *,
+        session_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: Sequence[ModelMessage],
+        workspace_id: str,
+        conversation_id: str | None = None,
+        agent_role_id: str | None = None,
+    ) -> None:
+        return await self._call_sync_async(
+            self.append,
+            session_id=session_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            messages=messages,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+        )
+
     def get_history(self, instance_id: str) -> list[ModelMessage]:
         return self._read_history(
             "SELECT session_id, message_json, created_at, hidden_from_context FROM messages WHERE instance_id=? ORDER BY id ASC",
             (instance_id,),
         )
 
+    async def get_history_async(self, instance_id: str) -> list[ModelMessage]:
+        return await self._call_sync_async(self.get_history, instance_id)
+
     def get_history_for_conversation(self, conversation_id: str) -> list[ModelMessage]:
         return self._read_history(
             "SELECT session_id, message_json, created_at, hidden_from_context FROM messages WHERE conversation_id=? ORDER BY id ASC",
             (conversation_id,),
+        )
+
+    async def get_history_for_conversation_async(
+        self, conversation_id: str
+    ) -> list[ModelMessage]:
+        return await self._call_sync_async(
+            self.get_history_for_conversation, conversation_id
         )
 
     def get_messages_by_session(
@@ -267,6 +298,20 @@ class MessageRepository:
             )
         return _dedupe_duplicate_objective_messages(results)
 
+    async def get_messages_by_session_async(
+        self,
+        session_id: str,
+        *,
+        include_cleared: bool = False,
+        include_hidden_from_context: bool = False,
+    ) -> list[dict[str, JsonValue]]:
+        return await self._call_sync_async(
+            self.get_messages_by_session,
+            session_id,
+            include_cleared=include_cleared,
+            include_hidden_from_context=include_hidden_from_context,
+        )
+
     def get_messages_for_instance(
         self,
         session_id: str,
@@ -311,6 +356,22 @@ class MessageRepository:
             )
         return _dedupe_duplicate_objective_messages(results)
 
+    async def get_messages_for_instance_async(
+        self,
+        session_id: str,
+        instance_id: str,
+        *,
+        include_cleared: bool = False,
+        include_hidden_from_context: bool = False,
+    ) -> list[dict[str, JsonValue]]:
+        return await self._call_sync_async(
+            self.get_messages_for_instance,
+            session_id,
+            instance_id,
+            include_cleared=include_cleared,
+            include_hidden_from_context=include_hidden_from_context,
+        )
+
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -322,6 +383,9 @@ class MessageRepository:
             repository_name="MessageRepository",
             operation_name="delete_by_session",
         )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_session, session_id)
 
     def delete_by_instance(self, instance_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -336,16 +400,31 @@ class MessageRepository:
             operation_name="delete_by_instance",
         )
 
+    async def delete_by_instance_async(self, instance_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_instance, instance_id)
+
     def prune_history_to_safe_boundary(self, instance_id: str) -> None:
         self._prune_to_safe_boundary(
             "SELECT id, session_id, message_json, created_at, hidden_from_context FROM messages WHERE instance_id=? ORDER BY id ASC",
             (instance_id,),
         )
 
+    async def prune_history_to_safe_boundary_async(self, instance_id: str) -> None:
+        return await self._call_sync_async(
+            self.prune_history_to_safe_boundary, instance_id
+        )
+
     def prune_conversation_history_to_safe_boundary(self, conversation_id: str) -> None:
         self._prune_to_safe_boundary(
             "SELECT id, session_id, message_json, created_at, hidden_from_context FROM messages WHERE conversation_id=? ORDER BY id ASC",
             (conversation_id,),
+        )
+
+    async def prune_conversation_history_to_safe_boundary_async(
+        self, conversation_id: str
+    ) -> None:
+        return await self._call_sync_async(
+            self.prune_conversation_history_to_safe_boundary, conversation_id
         )
 
     def compact_conversation_history(
@@ -391,6 +470,22 @@ class MessageRepository:
             lock=self._lock,
             repository_name="MessageRepository",
             operation_name="compact_conversation_history",
+        )
+
+    async def compact_conversation_history_async(
+        self,
+        conversation_id: str,
+        *,
+        keep_message_count: int,
+        hidden_reason: str = "compaction",
+        hidden_marker_id: str = "",
+    ) -> None:
+        return await self._call_sync_async(
+            self.compact_conversation_history,
+            conversation_id,
+            keep_message_count=keep_message_count,
+            hidden_reason=hidden_reason,
+            hidden_marker_id=hidden_marker_id,
         )
 
     def replace_pending_user_prompt(
@@ -466,6 +561,30 @@ class MessageRepository:
             lock=self._lock,
             repository_name="MessageRepository",
             operation_name="replace_pending_user_prompt",
+        )
+
+    async def replace_pending_user_prompt_async(
+        self,
+        *,
+        session_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: UserPromptContent,
+        workspace_id: str,
+        conversation_id: str | None = None,
+        agent_role_id: str | None = None,
+    ) -> bool:
+        return await self._call_sync_async(
+            self.replace_pending_user_prompt,
+            session_id=session_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
         )
 
     def append_user_prompt_if_missing(
@@ -549,6 +668,30 @@ class MessageRepository:
             operation_name="append_user_prompt_if_missing",
         )
 
+    async def append_user_prompt_if_missing_async(
+        self,
+        *,
+        session_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: UserPromptContent,
+        workspace_id: str,
+        conversation_id: str | None = None,
+        agent_role_id: str | None = None,
+    ) -> bool:
+        return await self._call_sync_async(
+            self.append_user_prompt_if_missing,
+            session_id=session_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+        )
+
     def append_system_prompt_if_missing(
         self,
         *,
@@ -608,6 +751,30 @@ class MessageRepository:
             operation_name="append_system_prompt_if_missing",
         )
 
+    async def append_system_prompt_if_missing_async(
+        self,
+        *,
+        session_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: str,
+        workspace_id: str,
+        conversation_id: str | None = None,
+        agent_role_id: str | None = None,
+    ) -> bool:
+        return await self._call_sync_async(
+            self.append_system_prompt_if_missing,
+            session_id=session_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+        )
+
     def get_history_for_task(
         self, instance_id: str, task_id: str
     ) -> list[ModelMessage]:
@@ -616,12 +783,26 @@ class MessageRepository:
             (instance_id, task_id),
         )
 
+    async def get_history_for_task_async(
+        self, instance_id: str, task_id: str
+    ) -> list[ModelMessage]:
+        return await self._call_sync_async(
+            self.get_history_for_task, instance_id, task_id
+        )
+
     def get_history_for_conversation_task(
         self, conversation_id: str, task_id: str
     ) -> list[ModelMessage]:
         return self._read_history(
             "SELECT session_id, message_json, created_at, hidden_from_context FROM messages WHERE conversation_id=? AND task_id=? ORDER BY id ASC",
             (conversation_id, task_id),
+        )
+
+    async def get_history_for_conversation_task_async(
+        self, conversation_id: str, task_id: str
+    ) -> list[ModelMessage]:
+        return await self._call_sync_async(
+            self.get_history_for_conversation_task, conversation_id, task_id
         )
 
     def _read_history(
@@ -726,6 +907,16 @@ class MessageRepository:
             lock=self._lock,
             repository_name="MessageRepository",
             operation_name="hide_conversation_messages_for_compaction",
+        )
+
+    async def hide_conversation_messages_for_compaction_async(
+        self, *, conversation_id: str, hide_message_count: int, hidden_marker_id: str
+    ) -> int:
+        return await self._call_sync_async(
+            self.hide_conversation_messages_for_compaction,
+            conversation_id=conversation_id,
+            hide_message_count=hide_message_count,
+            hidden_marker_id=hidden_marker_id,
         )
 
     def _append_rows(

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -93,7 +93,7 @@ class PromptContentPersistenceService(Protocol):
             ...,
         ],
     ) -> UserPromptContent:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 @runtime_checkable
@@ -103,7 +103,7 @@ class PromptContentHydrationService(Protocol):
         *,
         content: UserPromptContent,
     ) -> UserPromptContent:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 @runtime_checkable
@@ -116,7 +116,7 @@ class PromptContentProviderService(Protocol):
             ...,
         ],
     ) -> UserPromptContent:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 # noinspection PyShadowingNames
@@ -125,20 +125,20 @@ class PromptHistoryMessageRepository(Protocol):
         self,
         conversation_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def get_history_for_conversation_task(
         self,
         conversation_id: str,
         task_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def prune_conversation_history_to_safe_boundary(
         self,
         conversation_id: str,
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     def append(
         self,
@@ -152,7 +152,7 @@ class PromptHistoryMessageRepository(Protocol):
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     def append_system_prompt_if_missing(
         self,
@@ -166,7 +166,7 @@ class PromptHistoryMessageRepository(Protocol):
         trace_id: str,
         content: str,
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     def replace_pending_user_prompt(
         self,
@@ -180,26 +180,26 @@ class PromptHistoryMessageRepository(Protocol):
         trace_id: str,
         content: UserPromptContent,
     ) -> bool:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     async def get_history_for_conversation_async(
         self,
         conversation_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     async def get_history_for_conversation_task_async(
         self,
         conversation_id: str,
         task_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     async def prune_conversation_history_to_safe_boundary_async(
         self,
         conversation_id: str,
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     async def append_async(
         self,
@@ -213,7 +213,7 @@ class PromptHistoryMessageRepository(Protocol):
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     async def append_system_prompt_if_missing_async(
         self,
@@ -227,7 +227,7 @@ class PromptHistoryMessageRepository(Protocol):
         trace_id: str,
         content: str,
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     async def replace_pending_user_prompt_async(
         self,
@@ -241,7 +241,7 @@ class PromptHistoryMessageRepository(Protocol):
         trace_id: str,
         content: UserPromptContent,
     ) -> bool:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 # noinspection PyShadowingNames
@@ -251,20 +251,20 @@ class AsyncPromptHistoryMessageRepository(Protocol):
         self,
         conversation_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     async def get_history_for_conversation_task_async(
         self,
         conversation_id: str,
         task_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     async def prune_conversation_history_to_safe_boundary_async(
         self,
         conversation_id: str,
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     async def append_async(
         self,
@@ -278,7 +278,7 @@ class AsyncPromptHistoryMessageRepository(Protocol):
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     async def append_system_prompt_if_missing_async(
         self,
@@ -292,7 +292,7 @@ class AsyncPromptHistoryMessageRepository(Protocol):
         trace_id: str,
         content: str,
     ) -> None:
-        pass
+        pass  # pragma: no cover
 
     async def replace_pending_user_prompt_async(
         self,
@@ -306,7 +306,7 @@ class AsyncPromptHistoryMessageRepository(Protocol):
         trace_id: str,
         content: UserPromptContent,
     ) -> bool:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 @runtime_checkable
@@ -317,7 +317,7 @@ class AsyncRunIntentRepository(Protocol):
         *,
         fallback_session_id: str | None = None,
     ) -> object:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 @runtime_checkable
@@ -328,7 +328,7 @@ class PromptHookService(Protocol):
         event_input: UserPromptSubmitInput | PreCompactInput | PostCompactInput,
         run_event_hub: object,
     ) -> HookDecisionBundle:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 class PreparedPromptContext(BaseModel):

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Protocol, cast, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict
@@ -116,6 +116,7 @@ class PromptContentProviderService(Protocol):
     ) -> UserPromptContent: ...
 
 
+# noinspection PyShadowingNames
 class PromptHistoryMessageRepository(Protocol):
     def get_history_for_conversation(
         self,
@@ -172,6 +173,130 @@ class PromptHistoryMessageRepository(Protocol):
         content: UserPromptContent,
     ) -> bool: ...
 
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]: ...
+
+    async def get_history_for_conversation_task_async(
+        self,
+        conversation_id: str,
+        task_id: str,
+    ) -> list[ModelRequest | ModelResponse]: ...
+
+    async def prune_conversation_history_to_safe_boundary_async(
+        self,
+        conversation_id: str,
+    ) -> None: ...
+
+    async def append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None: ...
+
+    async def append_system_prompt_if_missing_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: str,
+    ) -> None: ...
+
+    async def replace_pending_user_prompt_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: UserPromptContent,
+    ) -> bool: ...
+
+
+# noinspection PyShadowingNames
+@runtime_checkable
+class AsyncPromptHistoryMessageRepository(Protocol):
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]: ...
+
+    async def get_history_for_conversation_task_async(
+        self,
+        conversation_id: str,
+        task_id: str,
+    ) -> list[ModelRequest | ModelResponse]: ...
+
+    async def prune_conversation_history_to_safe_boundary_async(
+        self,
+        conversation_id: str,
+    ) -> None: ...
+
+    async def append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None: ...
+
+    async def append_system_prompt_if_missing_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: str,
+    ) -> None: ...
+
+    async def replace_pending_user_prompt_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: UserPromptContent,
+    ) -> bool: ...
+
+
+@runtime_checkable
+class AsyncRunIntentRepository(Protocol):
+    async def get_async(
+        self,
+        run_id: str,
+        *,
+        fallback_session_id: str | None = None,
+    ) -> object: ...
+
 
 @runtime_checkable
 class PromptHookService(Protocol):
@@ -199,6 +324,7 @@ class PreparedPromptContext(BaseModel):
     microcompact_compacted_part_count: int = 0
 
 
+# noinspection PyShadowingNames
 class PromptHistoryService:
     def __init__(
         self,
@@ -217,6 +343,10 @@ class PromptHistoryService:
         load_safe_history_for_conversation: Callable[
             [str], list[ModelRequest | ModelResponse]
         ],
+        load_safe_history_for_conversation_async: Callable[
+            [str], Awaitable[list[ModelRequest | ModelResponse]]
+        ]
+        | None = None,
     ) -> None:
         self._config = config
         self._run_intent_repo = run_intent_repo
@@ -230,12 +360,155 @@ class PromptHistoryService:
         self._reminder_service = reminder_service
         self._run_event_hub = run_event_hub
         self._load_safe_history_for_conversation = load_safe_history_for_conversation
+        self._load_safe_history_for_conversation_async = (
+            load_safe_history_for_conversation_async
+        )
 
     def _prompt_budgeting_service(self) -> PromptBudgetingService:
         return PromptBudgetingService(
             config=self._config,
             mcp_registry=self._mcp_registry,
             mcp_tool_context_token_cache=self._mcp_tool_context_token_cache,
+        )
+
+    async def _get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
+            return await self._message_repo.get_history_for_conversation_async(
+                conversation_id
+            )
+        return self._message_repo.get_history_for_conversation(conversation_id)
+
+    async def _get_history_for_conversation_task_async(
+        self,
+        conversation_id: str,
+        task_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
+            return await self._message_repo.get_history_for_conversation_task_async(
+                conversation_id,
+                task_id,
+            )
+        return self._message_repo.get_history_for_conversation_task(
+            conversation_id,
+            task_id,
+        )
+
+    async def _prune_conversation_history_to_safe_boundary_async(
+        self,
+        conversation_id: str,
+    ) -> None:
+        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
+            await self._message_repo.prune_conversation_history_to_safe_boundary_async(
+                conversation_id
+            )
+            return
+        self._message_repo.prune_conversation_history_to_safe_boundary(conversation_id)
+
+    async def _append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None:
+        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
+            await self._message_repo.append_async(
+                session_id=session_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                agent_role_id=agent_role_id,
+                instance_id=instance_id,
+                task_id=task_id,
+                trace_id=trace_id,
+                messages=messages,
+            )
+            return
+        self._message_repo.append(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            messages=messages,
+        )
+
+    async def _append_system_prompt_if_missing_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: str,
+    ) -> None:
+        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
+            await self._message_repo.append_system_prompt_if_missing_async(
+                session_id=session_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                agent_role_id=agent_role_id,
+                instance_id=instance_id,
+                task_id=task_id,
+                trace_id=trace_id,
+                content=content,
+            )
+            return
+        self._message_repo.append_system_prompt_if_missing(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
+        )
+
+    async def _replace_pending_user_prompt_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: UserPromptContent,
+    ) -> bool:
+        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
+            return await self._message_repo.replace_pending_user_prompt_async(
+                session_id=session_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                agent_role_id=agent_role_id,
+                instance_id=instance_id,
+                task_id=task_id,
+                trace_id=trace_id,
+                content=content,
+            )
+        return self._message_repo.replace_pending_user_prompt(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
         )
 
     async def prepare_prompt_context(
@@ -249,8 +522,16 @@ class PromptHistoryService:
         allowed_mcp_servers: tuple[str, ...],
         allowed_skills: tuple[str, ...],
     ) -> PreparedPromptContext:
-        history = self._load_safe_history_for_conversation(conversation_id)
-        history, protected_current_prompt = self._split_protected_current_prompt(
+        if self._load_safe_history_for_conversation_async is not None:
+            history = await self._load_safe_history_for_conversation_async(
+                conversation_id
+            )
+        else:
+            history = self._load_safe_history_for_conversation(conversation_id)
+        (
+            history,
+            protected_current_prompt,
+        ) = await self._split_protected_current_prompt_async(
             request=request,
             conversation_id=conversation_id,
             history=history,
@@ -300,7 +581,7 @@ class PromptHistoryService:
             estimated_tokens_before_microcompact=estimated_before_microcompact,
             estimated_tokens_after_microcompact=estimated_after_microcompact,
         )
-        history = self.coerce_history_to_provider_safe_sequence(
+        history = await self.coerce_history_to_provider_safe_sequence_async(
             request=request,
             history=history,
         )
@@ -357,6 +638,33 @@ class PromptHistoryService:
             return candidate_history, None
         return candidate_history, protected_prompt
 
+    async def _split_protected_current_prompt_async(
+        self,
+        *,
+        request: LLMRequest,
+        conversation_id: str,
+        history: Sequence[ModelRequest | ModelResponse],
+        reserve_user_prompt_tokens: bool,
+    ) -> tuple[list[ModelRequest | ModelResponse], ModelRequest | None]:
+        candidate_history = list(history)
+        if not reserve_user_prompt_tokens:
+            return candidate_history, None
+        current_keys = await self._current_request_prompt_keys_async(
+            request=request,
+            conversation_id=conversation_id,
+        )
+        if not current_keys:
+            return candidate_history, None
+        if not any(
+            history_ends_with_user_prompt(candidate_history, current_key)
+            for current_key in current_keys
+        ):
+            return candidate_history, None
+        protected_prompt = candidate_history.pop()
+        if not isinstance(protected_prompt, ModelRequest):
+            return candidate_history, None
+        return candidate_history, protected_prompt
+
     def _current_request_prompt_keys(
         self,
         *,
@@ -370,6 +678,32 @@ class PromptHistoryService:
             if current_key and current_key not in keys:
                 keys.append(current_key)
         task_history = self._message_repo.get_history_for_conversation_task(
+            conversation_id,
+            request.task_id,
+        )
+        for message in reversed(task_history):
+            if not isinstance(message, ModelRequest):
+                continue
+            current_key = user_prompt_parts_key(parts=message.parts)
+            if current_key:
+                if current_key not in keys:
+                    keys.append(current_key)
+                break
+        return tuple(keys)
+
+    async def _current_request_prompt_keys_async(
+        self,
+        *,
+        request: LLMRequest,
+        conversation_id: str,
+    ) -> tuple[str, ...]:
+        keys: list[str] = []
+        current_content = self.current_request_prompt_content(request)
+        if current_content is not None:
+            current_key = user_prompt_content_key(current_content)
+            if current_key and current_key not in keys:
+                keys.append(current_key)
+        task_history = await self._get_history_for_conversation_task_async(
             conversation_id,
             request.task_id,
         )
@@ -480,6 +814,94 @@ class PromptHistoryService:
             return [bridge_message]
         return []
 
+    async def coerce_history_to_provider_safe_sequence_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: Sequence[ModelRequest | ModelResponse],
+    ) -> list[ModelRequest | ModelResponse]:
+        candidate_history = list(history)
+        if is_replayable_history(candidate_history):
+            return candidate_history
+        replayable_start = self.first_tool_replayable_history_index(candidate_history)
+        if replayable_start > 0:
+            candidate_history = candidate_history[replayable_start:]
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="llm.history.replayable_prefix.dropped",
+                message=(
+                    "Dropped a non-replayable history prefix before sending the "
+                    "provider request"
+                ),
+                payload={
+                    "role_id": request.role_id,
+                    "instance_id": request.instance_id,
+                    "dropped_message_count": replayable_start,
+                },
+            )
+        if candidate_history and is_replayable_history(candidate_history):
+            return candidate_history
+        if (
+            candidate_history
+            and not request_has_prompt_content(request)
+            and history_has_valid_tool_replay(candidate_history)
+        ):
+            bridge_message = await self.build_history_replay_bridge_message_async(
+                request=request
+            )
+            if bridge_message is not None:
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="llm.history.replay_bridge.inserted",
+                    message=(
+                        "Inserted a synthetic user bridge before replaying "
+                        "assistant/tool-only history"
+                    ),
+                    payload={
+                        "role_id": request.role_id,
+                        "instance_id": request.instance_id,
+                        "message_count": len(candidate_history),
+                    },
+                )
+                return [bridge_message, *candidate_history]
+        if request_has_prompt_content(request):
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="llm.history.invalid_suffix.dropped",
+                message=(
+                    "Dropped non-replayable history and relied on the current user "
+                    "prompt to restart the provider request"
+                ),
+                payload={
+                    "role_id": request.role_id,
+                    "instance_id": request.instance_id,
+                    "message_count": len(candidate_history),
+                },
+            )
+            return []
+        bridge_message = await self.build_history_replay_bridge_message_async(
+            request=request
+        )
+        if bridge_message is not None:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="llm.history.replay_bridge.synthetic_only",
+                message=(
+                    "Fell back to a synthetic user bridge because no replayable "
+                    "history suffix remained"
+                ),
+                payload={
+                    "role_id": request.role_id,
+                    "instance_id": request.instance_id,
+                },
+            )
+            return [bridge_message]
+        return []
+
     def first_tool_replayable_history_index(
         self,
         history: Sequence[ModelRequest | ModelResponse],
@@ -501,6 +923,16 @@ class PromptHistoryService:
             return None
         return ModelRequest(parts=[UserPromptPart(content=prompt)])
 
+    async def build_history_replay_bridge_message_async(
+        self,
+        *,
+        request: LLMRequest,
+    ) -> ModelRequest | None:
+        prompt = await self.build_history_replay_bridge_prompt_async(request=request)
+        if not prompt:
+            return None
+        return ModelRequest(parts=[UserPromptPart(content=prompt)])
+
     def build_history_replay_bridge_prompt(
         self,
         *,
@@ -512,6 +944,39 @@ class PromptHistoryService:
                 request.run_id,
                 fallback_session_id=request.session_id,
             ).intent.strip()
+        except KeyError:
+            intent_text = ""
+        lines = [
+            "Continue the existing task using the compacted summary and preserved execution history.",
+            "Resume from the latest in-progress state without discarding prior decisions or artifacts.",
+        ]
+        if intent_text:
+            lines.extend(
+                [
+                    "",
+                    "Original task intent:",
+                    intent_text,
+                ]
+            )
+        return "\n".join(lines).strip()
+
+    async def build_history_replay_bridge_prompt_async(
+        self,
+        *,
+        request: LLMRequest,
+    ) -> str:
+        try:
+            if isinstance(self._run_intent_repo, AsyncRunIntentRepository):
+                record = await self._run_intent_repo.get_async(
+                    request.run_id,
+                    fallback_session_id=request.session_id,
+                )
+            else:
+                record = self._run_intent_repo.get(
+                    request.run_id,
+                    fallback_session_id=request.session_id,
+                )
+            intent_text = str(getattr(record, "intent", "")).strip()
         except KeyError:
             intent_text = ""
         lines = [
@@ -696,7 +1161,7 @@ class PromptHistoryService:
                 run_event_hub=self._run_event_hub,
             )
         if compacted_result.applied and self._reminder_service is not None:
-            _ = self._reminder_service.observe_context_pressure(
+            _ = await self._reminder_service.observe_context_pressure_async(
                 ContextPressureObservation(
                     session_id=request.session_id,
                     run_id=request.run_id,
@@ -741,7 +1206,7 @@ class PromptHistoryService:
     ) -> tuple[LLMRequest, tuple[str, ...]]:
         if not isinstance(self._hook_service, PromptHookService):
             return request, ()
-        prompt_text = self.resolve_hook_prompt_text(request)
+        prompt_text = await self.resolve_hook_prompt_text_async(request)
         if not prompt_text:
             return request, ()
         bundle = await self._hook_service.execute(
@@ -801,6 +1266,21 @@ class PromptHistoryService:
                 return resolved
         return ""
 
+    async def resolve_hook_prompt_text_async(self, request: LLMRequest) -> str:
+        prompt_text = request.prompt_text.strip()
+        if prompt_text:
+            return prompt_text
+        history = await self._get_history_for_conversation_async(
+            conversation_id(request)
+        )
+        for message in reversed(history):
+            if not isinstance(message, ModelRequest):
+                continue
+            resolved = extract_user_prompt_text(message)
+            if resolved:
+                return resolved
+        return ""
+
     def persist_hook_system_context_if_needed(
         self,
         *,
@@ -813,6 +1293,28 @@ class PromptHistoryService:
             if not text:
                 continue
             self._message_repo.append_system_prompt_if_missing(
+                session_id=request.session_id,
+                workspace_id=request.workspace_id,
+                conversation_id=resolved_conversation_id,
+                agent_role_id=request.role_id,
+                instance_id=request.instance_id,
+                task_id=request.task_id,
+                trace_id=request.trace_id,
+                content=text,
+            )
+
+    async def persist_hook_system_context_if_needed_async(
+        self,
+        *,
+        request: LLMRequest,
+        contexts: tuple[str, ...],
+    ) -> None:
+        resolved_conversation_id = conversation_id(request)
+        for context in contexts:
+            text = str(context).strip()
+            if not text:
+                continue
+            await self._append_system_prompt_if_missing_async(
                 session_id=request.session_id,
                 workspace_id=request.workspace_id,
                 conversation_id=resolved_conversation_id,
@@ -867,6 +1369,63 @@ class PromptHistoryService:
                 True,
             )
         self._message_repo.append(
+            session_id=request.session_id,
+            workspace_id=request.workspace_id,
+            conversation_id=resolved_conversation_id,
+            agent_role_id=request.role_id,
+            instance_id=request.instance_id,
+            task_id=request.task_id,
+            trace_id=request.trace_id,
+            messages=[prompt_message],
+        )
+        next_history = list(history)
+        next_history.append(prompt_message)
+        return next_history, False
+
+    async def persist_user_prompt_if_needed_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        content: UserPromptContent | None,
+        filter_model_messages: Callable[
+            [Sequence[ModelRequest | ModelResponse]],
+            list[ModelRequest | ModelResponse],
+        ],
+    ) -> tuple[list[ModelRequest | ModelResponse], bool]:
+        if content is None:
+            return history, False
+        prompt_text = user_prompt_content_to_text(content)
+        if not prompt_text:
+            return history, False
+        prompt_key = user_prompt_content_key(content)
+        if history_ends_with_user_prompt(history, prompt_key):
+            return history, False
+        resolved_conversation_id = conversation_id(request)
+        await self._prune_conversation_history_to_safe_boundary_async(
+            resolved_conversation_id
+        )
+        replaced = await self._replace_pending_user_prompt_async(
+            session_id=request.session_id,
+            workspace_id=request.workspace_id,
+            conversation_id=resolved_conversation_id,
+            agent_role_id=request.role_id,
+            instance_id=request.instance_id,
+            task_id=request.task_id,
+            trace_id=request.trace_id,
+            content=content,
+        )
+        prompt_message = ModelRequest(parts=[UserPromptPart(content=content)])
+        if replaced:
+            return (
+                filter_model_messages(
+                    await self._get_history_for_conversation_async(
+                        resolved_conversation_id
+                    )
+                ),
+                True,
+            )
+        await self._append_async(
             session_id=request.session_id,
             workspace_id=request.workspace_id,
             conversation_id=resolved_conversation_id,

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -92,7 +92,8 @@ class PromptContentPersistenceService(Protocol):
             TextContentPart | MediaRefContentPart | InlineMediaContentPart,
             ...,
         ],
-    ) -> UserPromptContent: ...
+    ) -> UserPromptContent:
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -101,7 +102,8 @@ class PromptContentHydrationService(Protocol):
         self,
         *,
         content: UserPromptContent,
-    ) -> UserPromptContent: ...
+    ) -> UserPromptContent:
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -113,7 +115,8 @@ class PromptContentProviderService(Protocol):
             TextContentPart | MediaRefContentPart | InlineMediaContentPart,
             ...,
         ],
-    ) -> UserPromptContent: ...
+    ) -> UserPromptContent:
+        raise NotImplementedError
 
 
 # noinspection PyShadowingNames
@@ -121,18 +124,21 @@ class PromptHistoryMessageRepository(Protocol):
     def get_history_for_conversation(
         self,
         conversation_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
     def get_history_for_conversation_task(
         self,
         conversation_id: str,
         task_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
     def prune_conversation_history_to_safe_boundary(
         self,
         conversation_id: str,
-    ) -> None: ...
+    ) -> None:
+        pass
 
     def append(
         self,
@@ -145,7 +151,8 @@ class PromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
-    ) -> None: ...
+    ) -> None:
+        pass
 
     def append_system_prompt_if_missing(
         self,
@@ -158,7 +165,8 @@ class PromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None: ...
+    ) -> None:
+        pass
 
     def replace_pending_user_prompt(
         self,
@@ -171,23 +179,27 @@ class PromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: UserPromptContent,
-    ) -> bool: ...
+    ) -> bool:
+        raise NotImplementedError
 
     async def get_history_for_conversation_async(
         self,
         conversation_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
     async def get_history_for_conversation_task_async(
         self,
         conversation_id: str,
         task_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
     async def prune_conversation_history_to_safe_boundary_async(
         self,
         conversation_id: str,
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def append_async(
         self,
@@ -200,7 +212,8 @@ class PromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def append_system_prompt_if_missing_async(
         self,
@@ -213,7 +226,8 @@ class PromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def replace_pending_user_prompt_async(
         self,
@@ -226,7 +240,8 @@ class PromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: UserPromptContent,
-    ) -> bool: ...
+    ) -> bool:
+        raise NotImplementedError
 
 
 # noinspection PyShadowingNames
@@ -235,18 +250,21 @@ class AsyncPromptHistoryMessageRepository(Protocol):
     async def get_history_for_conversation_async(
         self,
         conversation_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
     async def get_history_for_conversation_task_async(
         self,
         conversation_id: str,
         task_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError
 
     async def prune_conversation_history_to_safe_boundary_async(
         self,
         conversation_id: str,
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def append_async(
         self,
@@ -259,7 +277,8 @@ class AsyncPromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def append_system_prompt_if_missing_async(
         self,
@@ -272,7 +291,8 @@ class AsyncPromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None: ...
+    ) -> None:
+        pass
 
     async def replace_pending_user_prompt_async(
         self,
@@ -285,7 +305,8 @@ class AsyncPromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: UserPromptContent,
-    ) -> bool: ...
+    ) -> bool:
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -295,7 +316,8 @@ class AsyncRunIntentRepository(Protocol):
         run_id: str,
         *,
         fallback_session_id: str | None = None,
-    ) -> object: ...
+    ) -> object:
+        raise NotImplementedError
 
 
 @runtime_checkable
@@ -305,7 +327,8 @@ class PromptHookService(Protocol):
         *,
         event_input: UserPromptSubmitInput | PreCompactInput | PostCompactInput,
         run_event_hub: object,
-    ) -> HookDecisionBundle: ...
+    ) -> HookDecisionBundle:
+        raise NotImplementedError
 
 
 class PreparedPromptContext(BaseModel):

--- a/src/relay_teams/agents/execution/prompt_instruction_state.py
+++ b/src/relay_teams/agents/execution/prompt_instruction_state.py
@@ -33,6 +33,22 @@ def record_prompt_instruction_loaded(
     )
 
 
+async def record_prompt_instruction_loaded_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    path: Path,
+) -> None:
+    resolved_path = path.expanduser().resolve()
+    await shared_store.manage_state_async(
+        StateMutation(
+            scope=_task_scope(task_id),
+            key=_state_key(resolved_path),
+            value_json='"loaded"',
+        )
+    )
+
+
 def record_prompt_instruction_paths_loaded(
     *,
     shared_store: SharedStateRepository,
@@ -47,6 +63,20 @@ def record_prompt_instruction_paths_loaded(
         )
 
 
+async def record_prompt_instruction_paths_loaded_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    paths: tuple[Path, ...],
+) -> None:
+    for path in paths:
+        await record_prompt_instruction_loaded_async(
+            shared_store=shared_store,
+            task_id=task_id,
+            path=path,
+        )
+
+
 def is_prompt_instruction_loaded(
     *,
     shared_store: SharedStateRepository,
@@ -54,6 +84,18 @@ def is_prompt_instruction_loaded(
     path: Path,
 ) -> bool:
     return shared_store.get_state(_task_scope(task_id), _state_key(path)) is not None
+
+
+async def is_prompt_instruction_loaded_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    path: Path,
+) -> bool:
+    return (
+        await shared_store.get_state_async(_task_scope(task_id), _state_key(path))
+        is not None
+    )
 
 
 def filter_unloaded_prompt_instruction_paths(
@@ -71,6 +113,23 @@ def filter_unloaded_prompt_instruction_paths(
             path=path,
         )
     )
+
+
+async def filter_unloaded_prompt_instruction_paths_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    paths: tuple[Path, ...],
+) -> tuple[Path, ...]:
+    unloaded: list[Path] = []
+    for path in paths:
+        if not await is_prompt_instruction_loaded_async(
+            shared_store=shared_store,
+            task_id=task_id,
+            path=path,
+        ):
+            unloaded.append(path)
+    return tuple(unloaded)
 
 
 def _task_scope(task_id: str) -> ScopeRef:

--- a/src/relay_teams/agents/execution/recovery_flow.py
+++ b/src/relay_teams/agents/execution/recovery_flow.py
@@ -10,6 +10,9 @@ from typing import Protocol, cast
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_ai.messages import ModelRequest, ModelResponse, ToolReturnPart
 
+from relay_teams.agents.execution.llm_transport_scope import (
+    llm_http_client_cache_scope_for_request,
+)
 from relay_teams.logger import get_logger, log_event
 from relay_teams.net.llm_client import reset_llm_http_client_cache_entry
 from relay_teams.providers.llm_retry import (
@@ -255,7 +258,7 @@ class AttemptRecoveryService:
         await reset_llm_http_client_cache_entry(
             ssl_verify=self._config.ssl_verify,
             connect_timeout_seconds=self._config.connect_timeout_seconds,
-            cache_scope=request.run_id,
+            cache_scope=llm_http_client_cache_scope_for_request(request),
         )
 
     async def close_run_scoped_llm_http_client(
@@ -266,7 +269,7 @@ class AttemptRecoveryService:
         await reset_llm_http_client_cache_entry(
             ssl_verify=self._config.ssl_verify,
             connect_timeout_seconds=self._config.connect_timeout_seconds,
-            cache_scope=request.run_id,
+            cache_scope=llm_http_client_cache_scope_for_request(request),
         )
 
     def should_retry_request(

--- a/src/relay_teams/agents/execution/session_mixin_base.py
+++ b/src/relay_teams/agents/execution/session_mixin_base.py
@@ -160,7 +160,24 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
     ) -> None:
         raise NotImplementedError
 
+    async def _persist_hook_system_context_if_needed_async(
+        self,
+        *,
+        request: LLMRequest,
+        contexts: tuple[str, ...],
+    ) -> None:
+        raise NotImplementedError
+
     def _persist_user_prompt_if_needed(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        content: UserPromptContent | None,
+    ) -> tuple[list[ModelRequest | ModelResponse], bool]:
+        raise NotImplementedError
+
+    async def _persist_user_prompt_if_needed_async(
         self,
         *,
         request: LLMRequest,
@@ -251,6 +268,19 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
     ) -> bool:
         raise NotImplementedError
 
+    async def _handle_model_stream_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        stream_event: object,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+    ) -> bool:
+        raise NotImplementedError
+
     def _apply_streamed_text_fallback(
         self,
         messages: list[ModelRequest | ModelResponse],
@@ -260,6 +290,14 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
         raise NotImplementedError
 
     def _publish_text_delta_event(
+        self,
+        *,
+        request: LLMRequest,
+        text: str,
+    ) -> None:
+        raise NotImplementedError
+
+    async def _publish_text_delta_event_async(
         self,
         *,
         request: LLMRequest,
@@ -287,7 +325,24 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
     ) -> bool:
         raise NotImplementedError
 
+    async def _publish_tool_call_events_from_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        messages: Sequence[ModelResponse | ModelRequest],
+        published_tool_call_ids: set[str] | None = None,
+    ) -> bool:
+        raise NotImplementedError
+
     def _publish_committed_tool_outcome_events_from_messages(
+        self,
+        *,
+        request: LLMRequest,
+        messages: Sequence[ModelResponse | ModelRequest],
+    ) -> None:
+        raise NotImplementedError
+
+    async def _publish_committed_tool_outcome_events_from_messages_async(
         self,
         *,
         request: LLMRequest,
@@ -315,7 +370,35 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
     ]:
         raise NotImplementedError
 
+    async def _commit_ready_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        bool,
+        bool,
+    ]:
+        raise NotImplementedError
+
     def _commit_all_safe_messages(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        bool,
+        bool,
+    ]:
+        raise NotImplementedError
+
+    async def _commit_all_safe_messages_async(
         self,
         *,
         request: LLMRequest,

--- a/src/relay_teams/agents/execution/session_prompt.py
+++ b/src/relay_teams/agents/execution/session_prompt.py
@@ -26,6 +26,9 @@ from relay_teams.agents.execution.message_commit import MessageCommitService
 from relay_teams.agents.execution.prompt_history import (
     PreparedPromptContext,
 )
+from relay_teams.agents.execution.llm_transport_scope import (
+    llm_http_client_cache_scope_for_request,
+)
 from relay_teams.agents.execution.session_mixin_base import AgentLlmSessionMixinBase
 from relay_teams.agents.execution.tool_args_repair import repair_tool_args
 from relay_teams.computer import (
@@ -40,7 +43,10 @@ from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.providers.openai_model_profiles import (
     resolve_openai_chat_model_profile,
 )
-from relay_teams.tools.runtime.persisted_state import load_tool_call_state
+from relay_teams.tools.runtime.persisted_state import (
+    load_tool_call_state,
+    load_tool_call_state_async,
+)
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.workspace import build_conversation_id
 
@@ -110,6 +116,35 @@ class _NullCommitMessageRepo:
     ) -> list[ModelRequest | ModelResponse]:
         _ = conversation_id
         return []
+
+    async def append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None:
+        self.append(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            messages=messages,
+        )
+
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        return self.get_history_for_conversation(conversation_id)
 
 
 class SessionPromptMixin(AgentLlmSessionMixinBase):
@@ -197,7 +232,9 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
                 )
                 else None
             ),
-            llm_http_client_cache_scope=request.run_id,
+            llm_http_client_cache_scope=llm_http_client_cache_scope_for_request(
+                request
+            ),
             allowed_mcp_servers=allowed_mcp_servers,
             allowed_skills=allowed_skills,
             tool_registry=self._tool_registry,
@@ -415,6 +452,19 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             contexts=contexts,
         )
 
+    async def _persist_hook_system_context_if_needed_async(
+        self,
+        *,
+        request: LLMRequest,
+        contexts: tuple[str, ...],
+    ) -> None:
+        await (
+            self._prompt_history_service().persist_hook_system_context_if_needed_async(
+                request=request,
+                contexts=contexts,
+            )
+        )
+
     def _persist_user_prompt_if_needed(
         self,
         *,
@@ -423,6 +473,20 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
         content: UserPromptContent | None,
     ) -> tuple[list[ModelRequest | ModelResponse], bool]:
         return self._prompt_history_service().persist_user_prompt_if_needed(
+            request=request,
+            history=history,
+            content=content,
+            filter_model_messages=self._filter_model_messages,
+        )
+
+    async def _persist_user_prompt_if_needed_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        content: UserPromptContent | None,
+    ) -> tuple[list[ModelRequest | ModelResponse], bool]:
+        return await self._prompt_history_service().persist_user_prompt_if_needed_async(
             request=request,
             history=history,
             content=content,
@@ -602,6 +666,36 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             has_tool_side_effect_messages=self._has_tool_side_effect_messages,
         )
 
+    async def _commit_ready_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        bool,
+        bool,
+    ]:
+        return await self._message_commit_service().commit_ready_messages_async(
+            request=request,
+            history=history,
+            pending_messages=pending_messages,
+            last_committable_index=self._last_committable_index,
+            has_tool_input_validation_failures=(
+                self._has_tool_input_validation_failures
+            ),
+            normalize_committable_messages=self._normalize_committable_messages,
+            workspace_id=self._workspace_id,
+            conversation_id=self._conversation_id,
+            publish_committed_tool_outcome_events_from_messages=(
+                self._publish_committed_tool_outcome_events_from_messages_async
+            ),
+            filter_model_messages=self._filter_model_messages,
+            has_tool_side_effect_messages=self._has_tool_side_effect_messages,
+        )
+
     def _commit_all_safe_messages(
         self,
         *,
@@ -619,6 +713,26 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             history=history,
             pending_messages=pending_messages,
             commit_ready_messages=self._commit_ready_messages,
+            last_committable_index=self._last_committable_index,
+        )
+
+    async def _commit_all_safe_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        bool,
+        bool,
+    ]:
+        return await self._message_commit_service().commit_all_safe_messages_async(
+            request=request,
+            history=history,
+            pending_messages=pending_messages,
+            commit_ready_messages=self._commit_ready_messages_async,
             last_committable_index=self._last_committable_index,
         )
 
@@ -758,6 +872,19 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             published_tool_call_ids=published_tool_call_ids,
         )
 
+    async def _publish_tool_call_events_from_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        messages: Sequence[ModelResponse | ModelRequest],
+        published_tool_call_ids: set[str] | None = None,
+    ) -> bool:
+        return await self._event_publishing_service().publish_tool_call_events_from_messages_async(
+            request=request,
+            messages=messages,
+            published_tool_call_ids=published_tool_call_ids,
+        )
+
     def _publish_committed_tool_outcome_events_from_messages(
         self,
         *,
@@ -771,6 +898,22 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             maybe_enrich_tool_result_payload=self._maybe_enrich_tool_result_payload,
             tool_result_already_emitted_from_runtime=(
                 self._tool_result_already_emitted_from_runtime
+            ),
+        )
+
+    async def _publish_committed_tool_outcome_events_from_messages_async(
+        self,
+        *,
+        request: LLMRequest,
+        messages: Sequence[ModelResponse | ModelRequest],
+    ) -> None:
+        await self._event_publishing_service().publish_committed_tool_outcome_events_from_messages_async(
+            request=request,
+            messages=messages,
+            to_json_compatible=self._to_json_compatible,
+            maybe_enrich_tool_result_payload=self._maybe_enrich_tool_result_payload,
+            tool_result_already_emitted_from_runtime=(
+                self._tool_result_already_emitted_from_runtime_async
             ),
         )
 
@@ -789,6 +932,21 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
                 shared_store=self._shared_store,
                 load_tool_call_state=load_tool_call_state,
             )
+        )
+
+    async def _tool_result_already_emitted_from_runtime_async(
+        self,
+        *,
+        request: LLMRequest,
+        tool_name: str,
+        tool_call_id: str,
+    ) -> bool:
+        return await self._tool_result_state_service().tool_result_already_emitted_from_runtime_async(
+            request=request,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            shared_store=self._shared_store,
+            load_tool_call_state=load_tool_call_state_async,
         )
 
     def _to_json(self, obj: object) -> str:

--- a/src/relay_teams/agents/execution/session_recovery.py
+++ b/src/relay_teams/agents/execution/session_recovery.py
@@ -33,6 +33,7 @@ from relay_teams.providers.model_fallback import (
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.sessions.runs.assistant_errors import build_tool_error_result
 from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_stream import publish_run_event_async
 from relay_teams.sessions.runs.recoverable_pause import RecoverableRunPauseError
 from relay_teams.sessions.runs.run_models import RunEvent
 
@@ -60,12 +61,13 @@ class SessionRecoveryMixin(AgentLlmSessionMixinBase):
             "error_message": schedule.error.message,
             "status_code": schedule.error.status_code,
         }
-        self._run_event_hub.publish(
+        await publish_run_event_async(
+            self._run_event_hub,
             self._build_run_event(
                 request=request,
                 event_type="LLM_RETRY_SCHEDULED",
                 payload=payload,
-            )
+            ),
         )
         log_event(
             LOGGER,

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -28,10 +28,14 @@ from relay_teams.logger import (
     log_model_output,
     log_model_stream_chunk,
 )
-from relay_teams.metrics.adapters import record_session_step, record_token_usage
+from relay_teams.metrics.adapters import (
+    record_session_step_async,
+    record_token_usage_async,
+)
 from relay_teams.providers.llm_retry import extract_retry_error_info
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_stream import publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
 from relay_teams.tools.runtime.context import ToolDeps
@@ -200,13 +204,13 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
         if not skip_initial_user_prompt_persist:
             request, hook_system_contexts = await self._apply_user_prompt_hooks(request)
             if hook_system_contexts:
-                self._persist_hook_system_context_if_needed(
+                await self._persist_hook_system_context_if_needed_async(
                     request=request,
                     contexts=hook_system_contexts,
                 )
         self._validate_request_input_capabilities(request)
         if self._metric_recorder is not None:
-            record_session_step(
+            await record_session_step_async(
                 self._metric_recorder,
                 workspace_id=resolved_workspace_id,
                 session_id=request.session_id,
@@ -219,7 +223,8 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
             self._allowed_tools,
             session_id=request.session_id,
         )
-        self._run_event_hub.publish(
+        await publish_run_event_async(
+            self._run_event_hub,
             RunEvent(
                 session_id=request.session_id,
                 run_id=request.run_id,
@@ -234,7 +239,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                         instance_id=request.instance_id,
                     )
                 ),
-            )
+            ),
         )
         try:
             (
@@ -346,12 +351,13 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 },
             )
             if not skip_initial_user_prompt_persist:
-                persisted_history, rebuild_context = (
-                    self._persist_user_prompt_if_needed(
-                        request=request,
-                        history=history,
-                        content=self._current_request_prompt_content(request),
-                    )
+                (
+                    persisted_history,
+                    rebuild_context,
+                ) = await self._persist_user_prompt_if_needed_async(
+                    request=request,
+                    history=history,
+                    content=self._current_request_prompt_content(request),
                 )
                 if rebuild_context:
                     (
@@ -422,7 +428,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                         started_thinking_parts: set[int] = set()
                                         async for stream_event in stream:
                                             control_ctx.raise_if_cancelled()
-                                            text_emitted = self._handle_model_stream_event(
+                                            text_emitted = await self._handle_model_stream_event_async(
                                                 request=request,
                                                 stream_event=stream_event,
                                                 emitted_text_chunks=emitted_text_chunks,
@@ -451,7 +457,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                                 if active_retry_number > 0:
                                                     active_retry_number = 0
                                                 emitted_text_chunks.append(text_delta)
-                                                self._publish_text_delta_event(
+                                                await self._publish_text_delta_event_async(
                                                     request=request,
                                                     text=text_delta,
                                                 )
@@ -506,12 +512,10 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                             if new_to_process:
                                 if active_retry_number > 0:
                                     active_retry_number = 0
-                                tool_call_events_emitted = (
-                                    self._publish_tool_call_events_from_messages(
-                                        request=request,
-                                        messages=new_to_process,
-                                        published_tool_call_ids=published_tool_call_ids,
-                                    )
+                                tool_call_events_emitted = await self._publish_tool_call_events_from_messages_async(
+                                    request=request,
+                                    messages=new_to_process,
+                                    published_tool_call_ids=published_tool_call_ids,
                                 )
                                 if tool_call_events_emitted:
                                     attempt_tool_call_event_emitted = True
@@ -525,7 +529,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                     buffered_messages,
                                     committed_tool_events_published,
                                     committed_tool_validation_failures,
-                                ) = self._commit_ready_messages(
+                                ) = await self._commit_ready_messages_async(
                                     request=request,
                                     history=history,
                                     pending_messages=buffered_messages,
@@ -575,7 +579,8 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                             )
                             if injections:
                                 for msg in injections:
-                                    self._run_event_hub.publish(
+                                    await publish_run_event_async(
+                                        self._run_event_hub,
                                         RunEvent(
                                             session_id=request.session_id,
                                             run_id=request.run_id,
@@ -585,9 +590,9 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                             role_id=request.role_id,
                                             event_type=RunEventType.INJECTION_APPLIED,
                                             payload_json=msg.model_dump_json(),
-                                        )
+                                        ),
                                     )
-                                    self._message_repo.append_user_prompt_if_missing(
+                                    await self._message_repo.append_user_prompt_if_missing_async(
                                         session_id=request.session_id,
                                         workspace_id=resolved_workspace_id,
                                         conversation_id=resolved_conversation_id,
@@ -635,12 +640,10 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                             streamed_text=latest_streamed_text,
                         )
                         if to_save:
-                            tool_call_events_emitted = (
-                                self._publish_tool_call_events_from_messages(
-                                    request=request,
-                                    messages=to_save,
-                                    published_tool_call_ids=published_tool_call_ids,
-                                )
+                            tool_call_events_emitted = await self._publish_tool_call_events_from_messages_async(
+                                request=request,
+                                messages=to_save,
+                                published_tool_call_ids=published_tool_call_ids,
                             )
                             if tool_call_events_emitted:
                                 attempt_tool_call_event_emitted = True
@@ -652,7 +655,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                             buffered_messages,
                             committed_tool_events_published,
                             _committed_tool_validation_failures,
-                        ) = self._commit_all_safe_messages(
+                        ) = await self._commit_all_safe_messages_async(
                             request=request,
                             history=history,
                             pending_messages=buffered_messages,
@@ -681,7 +684,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                             requests = self._usage_field_int(usage, "requests")
                         tool_calls = self._usage_field_int(usage, "tool_calls")
                         if self._token_usage_repo is not None:
-                            self._token_usage_repo.record(
+                            await self._token_usage_repo.record_async(
                                 session_id=request.session_id,
                                 run_id=request.run_id,
                                 instance_id=request.instance_id,
@@ -693,7 +696,8 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                 requests=requests,
                                 tool_calls=tool_calls,
                             )
-                        self._run_event_hub.publish(
+                        await publish_run_event_async(
+                            self._run_event_hub,
                             RunEvent(
                                 session_id=request.session_id,
                                 run_id=request.run_id,
@@ -715,10 +719,10 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                         "instance_id": request.instance_id,
                                     }
                                 ),
-                            )
+                            ),
                         )
                         if self._metric_recorder is not None:
-                            record_token_usage(
+                            await record_token_usage_async(
                                 self._metric_recorder,
                                 workspace_id=resolved_workspace_id,
                                 session_id=request.session_id,
@@ -828,7 +832,8 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
             if not text and emitted_text_chunks:
                 text = "".join(emitted_text_chunks)
             elif text and not emitted_text_chunks:
-                self._run_event_hub.publish(
+                await publish_run_event_async(
+                    self._run_event_hub,
                     RunEvent(
                         session_id=request.session_id,
                         run_id=request.run_id,
@@ -844,11 +849,12 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                 "instance_id": request.instance_id,
                             }
                         ),
-                    )
+                    ),
                 )
             if text and not printed_any:
                 log_model_output(request.role_id, text)
-            self._run_event_hub.publish(
+            await publish_run_event_async(
+                self._run_event_hub,
                 RunEvent(
                     session_id=request.session_id,
                     run_id=request.run_id,
@@ -864,7 +870,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                             prepared_prompt=prepared_prompt,
                         )
                     ),
-                )
+                ),
             )
             log_event(
                 LOGGER,

--- a/src/relay_teams/agents/execution/session_support.py
+++ b/src/relay_teams/agents/execution/session_support.py
@@ -7,7 +7,7 @@ import logging
 import json
 from collections.abc import Sequence
 from dataclasses import replace
-from typing import cast
+from typing import Protocol, cast, runtime_checkable
 
 from pydantic import JsonValue
 from pydantic_ai.exceptions import ModelAPIError
@@ -58,6 +58,14 @@ _RECOVERED_SUBAGENT_DESCRIPTION = "Recovered spawn_subagent call"
 _RECOVERED_SUBAGENT_PROMPT = "Recovered spawn_subagent prompt unavailable."
 
 
+@runtime_checkable
+class _AsyncConversationHistoryRepo(Protocol):
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]: ...
+
+
 class _NullPromptHistoryMessageRepo:
     def get_history_for_conversation(
         self,
@@ -65,6 +73,12 @@ class _NullPromptHistoryMessageRepo:
     ) -> list[ModelRequest | ModelResponse]:
         _ = conversation_id
         return []
+
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        return self.get_history_for_conversation(conversation_id)
 
     def get_history_for_conversation_task(
         self,
@@ -74,11 +88,24 @@ class _NullPromptHistoryMessageRepo:
         _ = (conversation_id, task_id)
         return []
 
+    async def get_history_for_conversation_task_async(
+        self,
+        conversation_id: str,
+        task_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        return self.get_history_for_conversation_task(conversation_id, task_id)
+
     def prune_conversation_history_to_safe_boundary(
         self,
         conversation_id: str,
     ) -> None:
         _ = conversation_id
+
+    async def prune_conversation_history_to_safe_boundary_async(
+        self,
+        conversation_id: str,
+    ) -> None:
+        self.prune_conversation_history_to_safe_boundary(conversation_id)
 
     def append(
         self,
@@ -103,6 +130,29 @@ class _NullPromptHistoryMessageRepo:
             messages,
         )
 
+    async def append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None:
+        self.append(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            messages=messages,
+        )
+
     def append_system_prompt_if_missing(
         self,
         *,
@@ -124,6 +174,29 @@ class _NullPromptHistoryMessageRepo:
             task_id,
             trace_id,
             content,
+        )
+
+    async def append_system_prompt_if_missing_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: str,
+    ) -> None:
+        self.append_system_prompt_if_missing(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
         )
 
     def replace_pending_user_prompt(
@@ -150,11 +223,39 @@ class _NullPromptHistoryMessageRepo:
         )
         return False
 
+    async def replace_pending_user_prompt_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: object,
+    ) -> bool:
+        return self.replace_pending_user_prompt(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
+        )
+
 
 class _NullRunIntentRepo:
     def get(self, run_id: str, *, fallback_session_id: str | None = None) -> object:
         _ = (run_id, fallback_session_id)
         return type("_Intent", (), {"intent": ""})()
+
+    async def get_async(
+        self, run_id: str, *, fallback_session_id: str | None = None
+    ) -> object:
+        return self.get(run_id, fallback_session_id=fallback_session_id)
 
 
 def _tool_result_error_code(result: dict[str, JsonValue]) -> str:
@@ -387,6 +488,30 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             handle_part_end_event=self._handle_part_end_event,
         )
 
+    async def _handle_model_stream_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        stream_event: object,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+    ) -> bool:
+        return await self._stream_event_service().handle_model_stream_event_async(
+            request=request,
+            stream_event=stream_event,
+            emitted_text_chunks=emitted_text_chunks,
+            text_lengths=text_lengths,
+            thinking_lengths=thinking_lengths,
+            started_thinking_parts=started_thinking_parts,
+            streamed_tool_calls=streamed_tool_calls,
+            handle_part_start_event=self._handle_part_start_event_async,
+            handle_part_delta_event=self._handle_part_delta_event_async,
+            handle_part_end_event=self._handle_part_end_event_async,
+        )
+
     def _handle_part_start_event(
         self,
         *,
@@ -409,6 +534,30 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             emit_text_suffix_for_part=self._emit_text_suffix_for_part,
             emit_thinking_suffix_for_part=self._emit_thinking_suffix_for_part,
             publish_thinking_started_event=self._publish_thinking_started_event,
+        )
+
+    async def _handle_part_start_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        event: PartStartEvent,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+    ) -> bool:
+        return await self._stream_event_service().handle_part_start_event_async(
+            request=request,
+            event=event,
+            emitted_text_chunks=emitted_text_chunks,
+            text_lengths=text_lengths,
+            thinking_lengths=thinking_lengths,
+            started_thinking_parts=started_thinking_parts,
+            streamed_tool_calls=streamed_tool_calls,
+            emit_text_suffix_for_part=self._emit_text_suffix_for_part_async,
+            emit_thinking_suffix_for_part=self._emit_thinking_suffix_for_part_async,
+            publish_thinking_started_event=self._publish_thinking_started_event_async,
         )
 
     def _handle_part_delta_event(
@@ -436,6 +585,31 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             publish_thinking_delta_event=self._publish_thinking_delta_event,
         )
 
+    async def _handle_part_delta_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        event: PartDeltaEvent,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+    ) -> bool:
+        return await self._stream_event_service().handle_part_delta_event_async(
+            request=request,
+            event=event,
+            emitted_text_chunks=emitted_text_chunks,
+            text_lengths=text_lengths,
+            thinking_lengths=thinking_lengths,
+            started_thinking_parts=started_thinking_parts,
+            streamed_tool_calls=streamed_tool_calls,
+            log_model_stream_chunk=log_model_stream_chunk,
+            publish_text_delta_event=self._publish_text_delta_event_async,
+            publish_thinking_started_event=self._publish_thinking_started_event_async,
+            publish_thinking_delta_event=self._publish_thinking_delta_event_async,
+        )
+
     def _handle_part_end_event(
         self,
         *,
@@ -461,6 +635,31 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             publish_thinking_finished_event=self._publish_thinking_finished_event,
         )
 
+    async def _handle_part_end_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        event: PartEndEvent,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+    ) -> bool:
+        return await self._stream_event_service().handle_part_end_event_async(
+            request=request,
+            event=event,
+            emitted_text_chunks=emitted_text_chunks,
+            text_lengths=text_lengths,
+            thinking_lengths=thinking_lengths,
+            started_thinking_parts=started_thinking_parts,
+            streamed_tool_calls=streamed_tool_calls,
+            emit_text_suffix_for_part=self._emit_text_suffix_for_part_async,
+            emit_thinking_suffix_for_part=self._emit_thinking_suffix_for_part_async,
+            publish_thinking_started_event=self._publish_thinking_started_event_async,
+            publish_thinking_finished_event=self._publish_thinking_finished_event_async,
+        )
+
     def _emit_text_suffix_for_part(
         self,
         *,
@@ -480,6 +679,25 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             publish_text_delta_event=self._publish_text_delta_event,
         )
 
+    async def _emit_text_suffix_for_part_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+        content: str,
+        emitted_text_chunks: list[str],
+        emitted_lengths: dict[int, int],
+    ) -> bool:
+        return await self._stream_event_service().emit_text_suffix_for_part_async(
+            request=request,
+            part_index=part_index,
+            content=content,
+            emitted_text_chunks=emitted_text_chunks,
+            emitted_lengths=emitted_lengths,
+            log_model_stream_chunk=log_model_stream_chunk,
+            publish_text_delta_event=self._publish_text_delta_event_async,
+        )
+
     def _emit_thinking_suffix_for_part(
         self,
         *,
@@ -496,6 +714,22 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             publish_thinking_delta_event=self._publish_thinking_delta_event,
         )
 
+    async def _emit_thinking_suffix_for_part_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+        content: str,
+        emitted_lengths: dict[int, int],
+    ) -> bool:
+        return await self._stream_event_service().emit_thinking_suffix_for_part_async(
+            request=request,
+            part_index=part_index,
+            content=content,
+            emitted_lengths=emitted_lengths,
+            publish_thinking_delta_event=self._publish_thinking_delta_event_async,
+        )
+
     def _publish_text_delta_event(
         self,
         *,
@@ -507,6 +741,17 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             text=text,
         )
 
+    async def _publish_text_delta_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        text: str,
+    ) -> None:
+        await self._event_publishing_service().publish_text_delta_event_async(
+            request=request,
+            text=text,
+        )
+
     def _publish_thinking_started_event(
         self,
         *,
@@ -514,6 +759,17 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         part_index: int,
     ) -> None:
         self._event_publishing_service().publish_thinking_started_event(
+            request=request,
+            part_index=part_index,
+        )
+
+    async def _publish_thinking_started_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+    ) -> None:
+        await self._event_publishing_service().publish_thinking_started_event_async(
             request=request,
             part_index=part_index,
         )
@@ -531,6 +787,19 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             text=text,
         )
 
+    async def _publish_thinking_delta_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+        text: str,
+    ) -> None:
+        await self._event_publishing_service().publish_thinking_delta_event_async(
+            request=request,
+            part_index=part_index,
+            text=text,
+        )
+
     def _publish_thinking_finished_event(
         self,
         *,
@@ -538,6 +807,17 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         part_index: int,
     ) -> None:
         self._event_publishing_service().publish_thinking_finished_event(
+            request=request,
+            part_index=part_index,
+        )
+
+    async def _publish_thinking_finished_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+    ) -> None:
+        await self._event_publishing_service().publish_thinking_finished_event_async(
             request=request,
             part_index=part_index,
         )
@@ -1046,6 +1326,20 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             )
         )
 
+    async def _load_safe_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        if isinstance(self._message_repo, _AsyncConversationHistoryRepo):
+            history = await self._message_repo.get_history_for_conversation_async(
+                conversation_id
+            )
+        else:
+            history = self._message_repo.get_history_for_conversation(conversation_id)
+        return self._truncate_history_to_safe_boundary(
+            self._filter_model_messages(history)
+        )
+
     def _prompt_history_service(self) -> PromptHistoryService:
         mcp_tool_context_token_cache = getattr(
             self,
@@ -1094,6 +1388,11 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
                 self,
                 "_load_safe_history_for_conversation",
                 lambda _conversation_id: [],
+            ),
+            load_safe_history_for_conversation_async=getattr(
+                self,
+                "_load_safe_history_for_conversation_async",
+                None,
             ),
         )
 

--- a/src/relay_teams/agents/execution/session_support.py
+++ b/src/relay_teams/agents/execution/session_support.py
@@ -63,7 +63,8 @@ class _AsyncConversationHistoryRepo(Protocol):
     async def get_history_for_conversation_async(
         self,
         conversation_id: str,
-    ) -> list[ModelRequest | ModelResponse]: ...
+    ) -> list[ModelRequest | ModelResponse]:
+        raise NotImplementedError  # pragma: no cover
 
 
 class _NullPromptHistoryMessageRepo:

--- a/src/relay_teams/agents/execution/stream_events.py
+++ b/src/relay_teams/agents/execution/stream_events.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from pydantic_ai.messages import (
     PartDeltaEvent,
@@ -124,6 +124,53 @@ class StreamEventService:
             )
         return False
 
+    # noinspection PyMethodMayBeStatic
+    async def handle_model_stream_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        stream_event: object,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+        handle_part_start_event: Callable[..., Awaitable[bool]],
+        handle_part_delta_event: Callable[..., Awaitable[bool]],
+        handle_part_end_event: Callable[..., Awaitable[bool]],
+    ) -> bool:
+        if isinstance(stream_event, PartStartEvent):
+            return await handle_part_start_event(
+                request=request,
+                event=stream_event,
+                emitted_text_chunks=emitted_text_chunks,
+                text_lengths=text_lengths,
+                thinking_lengths=thinking_lengths,
+                started_thinking_parts=started_thinking_parts,
+                streamed_tool_calls=streamed_tool_calls,
+            )
+        if isinstance(stream_event, PartDeltaEvent):
+            return await handle_part_delta_event(
+                request=request,
+                event=stream_event,
+                emitted_text_chunks=emitted_text_chunks,
+                text_lengths=text_lengths,
+                thinking_lengths=thinking_lengths,
+                started_thinking_parts=started_thinking_parts,
+                streamed_tool_calls=streamed_tool_calls,
+            )
+        if isinstance(stream_event, PartEndEvent):
+            return await handle_part_end_event(
+                request=request,
+                event=stream_event,
+                emitted_text_chunks=emitted_text_chunks,
+                text_lengths=text_lengths,
+                thinking_lengths=thinking_lengths,
+                started_thinking_parts=started_thinking_parts,
+                streamed_tool_calls=streamed_tool_calls,
+            )
+        return False
+
     def handle_part_start_event(
         self,
         *,
@@ -157,6 +204,49 @@ class StreamEventService:
                 started_thinking_parts.add(event.index)
             thinking_lengths.setdefault(event.index, 0)
             return emit_thinking_suffix_for_part(
+                request=request,
+                part_index=event.index,
+                content=part.content,
+                emitted_lengths=thinking_lengths,
+            )
+        if isinstance(part, ToolCallPart):
+            streamed_tool_calls[event.index] = part
+        return False
+
+    # noinspection PyMethodMayBeStatic
+    async def handle_part_start_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        event: PartStartEvent,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+        emit_text_suffix_for_part: Callable[..., Awaitable[bool]],
+        emit_thinking_suffix_for_part: Callable[..., Awaitable[bool]],
+        publish_thinking_started_event: Callable[..., Awaitable[None]],
+    ) -> bool:
+        part = event.part
+        if isinstance(part, TextPart):
+            text_lengths.setdefault(event.index, 0)
+            return await emit_text_suffix_for_part(
+                request=request,
+                part_index=event.index,
+                content=part.content,
+                emitted_text_chunks=emitted_text_chunks,
+                emitted_lengths=text_lengths,
+            )
+        if isinstance(part, ThinkingPart):
+            if event.index not in started_thinking_parts:
+                await publish_thinking_started_event(
+                    request=request,
+                    part_index=event.index,
+                )
+                started_thinking_parts.add(event.index)
+            thinking_lengths.setdefault(event.index, 0)
+            return await emit_thinking_suffix_for_part(
                 request=request,
                 part_index=event.index,
                 content=part.content,
@@ -223,6 +313,64 @@ class StreamEventService:
                     streamed_tool_calls[event.index] = updated
         return False
 
+    # noinspection PyMethodMayBeStatic
+    async def handle_part_delta_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        event: PartDeltaEvent,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+        log_model_stream_chunk: Callable[[str, str], None],
+        publish_text_delta_event: Callable[..., Awaitable[None]],
+        publish_thinking_started_event: Callable[..., Awaitable[None]],
+        publish_thinking_delta_event: Callable[..., Awaitable[None]],
+    ) -> bool:
+        delta = event.delta
+        if isinstance(delta, TextPartDelta):
+            text = str(delta.content_delta or "")
+            if not text:
+                return False
+            text_lengths[event.index] = text_lengths.get(event.index, 0) + len(text)
+            emitted_text_chunks.append(text)
+            log_model_stream_chunk(request.role_id, text)
+            await publish_text_delta_event(request=request, text=text)
+            return True
+        if isinstance(delta, ThinkingPartDelta):
+            if event.index not in started_thinking_parts:
+                await publish_thinking_started_event(
+                    request=request,
+                    part_index=event.index,
+                )
+                started_thinking_parts.add(event.index)
+            text = str(delta.content_delta or "")
+            if not text:
+                return False
+            thinking_lengths[event.index] = thinking_lengths.get(event.index, 0) + len(
+                text
+            )
+            await publish_thinking_delta_event(
+                request=request,
+                part_index=event.index,
+                text=text,
+            )
+            return False
+        if isinstance(delta, ToolCallPartDelta):
+            existing = streamed_tool_calls.get(event.index)
+            if existing is None:
+                as_part = delta.as_part()
+                streamed_tool_calls[event.index] = (
+                    as_part if as_part is not None else delta
+                )
+            else:
+                updated = delta.apply(existing)
+                if isinstance(updated, (ToolCallPart, ToolCallPartDelta)):
+                    streamed_tool_calls[event.index] = updated
+        return False
+
     def handle_part_end_event(
         self,
         *,
@@ -268,6 +416,52 @@ class StreamEventService:
             streamed_tool_calls[event.index] = part
         return False
 
+    # noinspection PyMethodMayBeStatic
+    async def handle_part_end_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        event: PartEndEvent,
+        emitted_text_chunks: list[str],
+        text_lengths: dict[int, int],
+        thinking_lengths: dict[int, int],
+        started_thinking_parts: set[int],
+        streamed_tool_calls: dict[int, ToolCallPart | ToolCallPartDelta],
+        emit_text_suffix_for_part: Callable[..., Awaitable[bool]],
+        emit_thinking_suffix_for_part: Callable[..., Awaitable[bool]],
+        publish_thinking_started_event: Callable[..., Awaitable[None]],
+        publish_thinking_finished_event: Callable[..., Awaitable[None]],
+    ) -> bool:
+        part = event.part
+        if isinstance(part, TextPart):
+            return await emit_text_suffix_for_part(
+                request=request,
+                part_index=event.index,
+                content=part.content,
+                emitted_text_chunks=emitted_text_chunks,
+                emitted_lengths=text_lengths,
+            )
+        if isinstance(part, ThinkingPart):
+            if event.index not in started_thinking_parts:
+                await publish_thinking_started_event(
+                    request=request,
+                    part_index=event.index,
+                )
+                started_thinking_parts.add(event.index)
+            _ = await emit_thinking_suffix_for_part(
+                request=request,
+                part_index=event.index,
+                content=part.content,
+                emitted_lengths=thinking_lengths,
+            )
+            await publish_thinking_finished_event(
+                request=request,
+                part_index=event.index,
+            )
+        if isinstance(part, ToolCallPart):
+            streamed_tool_calls[event.index] = part
+        return False
+
     def emit_text_suffix_for_part(
         self,
         *,
@@ -289,6 +483,28 @@ class StreamEventService:
         publish_text_delta_event(request=request, text=suffix)
         return True
 
+    # noinspection PyMethodMayBeStatic
+    async def emit_text_suffix_for_part_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+        content: str,
+        emitted_text_chunks: list[str],
+        emitted_lengths: dict[int, int],
+        log_model_stream_chunk: Callable[[str, str], None],
+        publish_text_delta_event: Callable[..., Awaitable[None]],
+    ) -> bool:
+        previous_length = emitted_lengths.get(part_index, 0)
+        suffix = content[previous_length:]
+        emitted_lengths[part_index] = len(content)
+        if not suffix:
+            return False
+        emitted_text_chunks.append(suffix)
+        log_model_stream_chunk(request.role_id, suffix)
+        await publish_text_delta_event(request=request, text=suffix)
+        return True
+
     def emit_thinking_suffix_for_part(
         self,
         *,
@@ -304,6 +520,28 @@ class StreamEventService:
         if not suffix:
             return False
         publish_thinking_delta_event(
+            request=request,
+            part_index=part_index,
+            text=suffix,
+        )
+        return False
+
+    # noinspection PyMethodMayBeStatic
+    async def emit_thinking_suffix_for_part_async(
+        self,
+        *,
+        request: LLMRequest,
+        part_index: int,
+        content: str,
+        emitted_lengths: dict[int, int],
+        publish_thinking_delta_event: Callable[..., Awaitable[None]],
+    ) -> bool:
+        previous_length = emitted_lengths.get(part_index, 0)
+        suffix = content[previous_length:]
+        emitted_lengths[part_index] = len(content)
+        if not suffix:
+            return False
+        await publish_thinking_delta_event(
             request=request,
             part_index=part_index,
             text=suffix,

--- a/src/relay_teams/agents/execution/tool_result_state.py
+++ b/src/relay_teams/agents/execution/tool_result_state.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import cast
 
 from pydantic import JsonValue
@@ -89,6 +89,41 @@ class ToolResultStateService:
         if not tool_call_id:
             return False
         state = load_tool_call_state(
+            shared_store=shared_store,
+            task_id=request.task_id,
+            tool_call_id=tool_call_id,
+        )
+        if state is None or state.tool_name != tool_name:
+            return False
+        if state.execution_status not in (
+            ToolExecutionStatus.COMPLETED,
+            ToolExecutionStatus.FAILED,
+        ):
+            return False
+        result_envelope = state.result_envelope
+        if not isinstance(result_envelope, dict):
+            return False
+        visible_result = self.visible_tool_result_from_envelope(result_envelope)
+        return self.tool_result_event_was_published(
+            result_envelope=result_envelope,
+            visible_result=visible_result,
+        )
+
+    async def tool_result_already_emitted_from_runtime_async(
+        self,
+        *,
+        request: LLMRequest,
+        tool_name: str,
+        tool_call_id: str,
+        shared_store: object,
+        load_tool_call_state: Callable[
+            ...,
+            Awaitable[PersistedToolCallState | None],
+        ],
+    ) -> bool:
+        if not tool_call_id:
+            return False
+        state = await load_tool_call_state(
             shared_store=shared_store,
             task_id=request.task_id,
             tool_call_id=tool_call_id,

--- a/src/relay_teams/agents/instances/instance_repository.py
+++ b/src/relay_teams/agents/instances/instance_repository.py
@@ -4,23 +4,20 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 from typing import Optional
 
 from relay_teams.agents.instances.enums import InstanceLifecycle, InstanceStatus
 from relay_teams.agents.instances.models import AgentRuntimeRecord
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.workspace import build_conversation_id
 
 _SQLITE_SAFE_VARIABLE_LIMIT = 900
 
 
-class AgentInstanceRepository:
+class AgentInstanceRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -159,6 +156,34 @@ class AgentInstanceRepository:
             operation_name="upsert_instance",
         )
 
+    async def upsert_instance_async(
+        self,
+        *,
+        run_id: str,
+        trace_id: str,
+        session_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str | None = None,
+        status: InstanceStatus,
+        lifecycle: Optional[InstanceLifecycle] = None,
+        parent_instance_id: Optional[str] = None,
+    ) -> None:
+        return await self._call_sync_async(
+            self.upsert_instance,
+            run_id=run_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            status=status,
+            lifecycle=lifecycle,
+            parent_instance_id=parent_instance_id,
+        )
+
     def update_runtime_snapshot(
         self,
         instance_id: str,
@@ -183,6 +208,16 @@ class AgentInstanceRepository:
             operation_name="update_runtime_snapshot",
         )
 
+    async def update_runtime_snapshot_async(
+        self, instance_id: str, *, runtime_system_prompt: str, runtime_tools_json: str
+    ) -> None:
+        return await self._call_sync_async(
+            self.update_runtime_snapshot,
+            instance_id,
+            runtime_system_prompt=runtime_system_prompt,
+            runtime_tools_json=runtime_tools_json,
+        )
+
     def mark_status(self, instance_id: str, status: InstanceStatus) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
         run_sqlite_write_with_retry(
@@ -196,6 +231,9 @@ class AgentInstanceRepository:
             repository_name="AgentInstanceRepository",
             operation_name="mark_status",
         )
+
+    async def mark_status_async(self, instance_id: str, status: InstanceStatus) -> None:
+        return await self._call_sync_async(self.mark_status, instance_id, status)
 
     def update_session_workspace(self, session_id: str, *, workspace_id: str) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
@@ -213,6 +251,13 @@ class AgentInstanceRepository:
             lock=self._lock,
             repository_name="AgentInstanceRepository",
             operation_name="update_session_workspace",
+        )
+
+    async def update_session_workspace_async(
+        self, session_id: str, *, workspace_id: str
+    ) -> None:
+        return await self._call_sync_async(
+            self.update_session_workspace, session_id, workspace_id=workspace_id
         )
 
     def mark_running_instances_failed(self) -> tuple[str, ...]:
@@ -238,12 +283,18 @@ class AgentInstanceRepository:
         )
         return instance_ids
 
+    async def mark_running_instances_failed_async(self) -> tuple[str, ...]:
+        return await self._call_sync_async(self.mark_running_instances_failed)
+
     def list_all(self) -> tuple[AgentRuntimeRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
                 "SELECT * FROM agent_instances ORDER BY created_at ASC",
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_all_async(self) -> tuple[AgentRuntimeRecord, ...]:
+        return await self._call_sync_async(self.list_all)
 
     def list_running(self, run_id: str) -> tuple[AgentRuntimeRecord, ...]:
         with self._lock:
@@ -253,6 +304,9 @@ class AgentInstanceRepository:
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
 
+    async def list_running_async(self, run_id: str) -> tuple[AgentRuntimeRecord, ...]:
+        return await self._call_sync_async(self.list_running, run_id)
+
     def list_by_run(self, run_id: str) -> tuple[AgentRuntimeRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -261,6 +315,9 @@ class AgentInstanceRepository:
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
 
+    async def list_by_run_async(self, run_id: str) -> tuple[AgentRuntimeRecord, ...]:
+        return await self._call_sync_async(self.list_by_run, run_id)
+
     def list_by_session(self, session_id: str) -> tuple[AgentRuntimeRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -268,6 +325,11 @@ class AgentInstanceRepository:
                 (session_id,),
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_by_session_async(
+        self, session_id: str
+    ) -> tuple[AgentRuntimeRecord, ...]:
+        return await self._call_sync_async(self.list_by_session, session_id)
 
     def count_normal_mode_subagents_by_session_ids(
         self,
@@ -296,6 +358,13 @@ class AgentInstanceRepository:
                     subagent_counts[str(row["session_id"])] = int(row["subagent_count"])
         return subagent_counts
 
+    async def count_normal_mode_subagents_by_session_ids_async(
+        self, session_ids: tuple[str, ...]
+    ) -> dict[str, int]:
+        return await self._call_sync_async(
+            self.count_normal_mode_subagents_by_session_ids, session_ids
+        )
+
     def list_session_role_instances(
         self, session_id: str
     ) -> tuple[AgentRuntimeRecord, ...]:
@@ -317,6 +386,11 @@ class AgentInstanceRepository:
             latest_by_role[role_id] for role_id in sorted(latest_by_role.keys())
         )
 
+    async def list_session_role_instances_async(
+        self, session_id: str
+    ) -> tuple[AgentRuntimeRecord, ...]:
+        return await self._call_sync_async(self.list_session_role_instances, session_id)
+
     def get_instance(self, instance_id: str) -> AgentRuntimeRecord:
         with self._lock:
             row = self._conn.execute(
@@ -326,6 +400,9 @@ class AgentInstanceRepository:
         if row is None:
             raise KeyError(f"Unknown instance_id: {instance_id}")
         return self._to_record(row)
+
+    async def get_instance_async(self, instance_id: str) -> AgentRuntimeRecord:
+        return await self._call_sync_async(self.get_instance, instance_id)
 
     def get_session_role_instance(
         self, session_id: str, role_id: str
@@ -345,9 +422,23 @@ class AgentInstanceRepository:
             return None
         return self._to_record(row)
 
+    async def get_session_role_instance_async(
+        self, session_id: str, role_id: str
+    ) -> AgentRuntimeRecord | None:
+        return await self._call_sync_async(
+            self.get_session_role_instance, session_id, role_id
+        )
+
     def get_session_role_instance_id(self, session_id: str, role_id: str) -> str | None:
         record = self.get_session_role_instance(session_id, role_id)
         return record.instance_id if record is not None else None
+
+    async def get_session_role_instance_id_async(
+        self, session_id: str, role_id: str
+    ) -> str | None:
+        return await self._call_sync_async(
+            self.get_session_role_instance_id, session_id, role_id
+        )
 
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -361,6 +452,9 @@ class AgentInstanceRepository:
             operation_name="delete_by_session",
         )
 
+    async def delete_by_session_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_session, session_id)
+
     def delete_instance(self, instance_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -373,6 +467,9 @@ class AgentInstanceRepository:
             repository_name="AgentInstanceRepository",
             operation_name="delete_instance",
         )
+
+    async def delete_instance_async(self, instance_id: str) -> None:
+        return await self._call_sync_async(self.delete_instance, instance_id)
 
     def _to_record(self, row: sqlite3.Row) -> AgentRuntimeRecord:
         return AgentRuntimeRecord(

--- a/src/relay_teams/agents/orchestration/task_contracts.py
+++ b/src/relay_teams/agents/orchestration/task_contracts.py
@@ -55,6 +55,14 @@ class TaskOrchestrationServiceLike(Protocol):
         update: TaskUpdate,
     ) -> Dict[str, JsonValue]: ...
 
+    async def update_task_async(
+        self,
+        *,
+        run_id: Optional[str],
+        task_id: str,
+        update: TaskUpdate,
+    ) -> Dict[str, JsonValue]: ...
+
     def list_delegated_tasks(
         self,
         *,
@@ -62,7 +70,21 @@ class TaskOrchestrationServiceLike(Protocol):
         include_root: bool = False,
     ) -> Dict[str, JsonValue]: ...
 
+    async def list_delegated_tasks_async(
+        self,
+        *,
+        run_id: str,
+        include_root: bool = False,
+    ) -> Dict[str, JsonValue]: ...
+
     def list_run_tasks(
+        self,
+        *,
+        run_id: str,
+        include_root: bool = False,
+    ) -> Dict[str, JsonValue]: ...
+
+    async def list_run_tasks_async(
         self,
         *,
         run_id: str,

--- a/src/relay_teams/agents/orchestration/task_contracts.py
+++ b/src/relay_teams/agents/orchestration/task_contracts.py
@@ -45,7 +45,8 @@ class TaskOrchestrationServiceLike(Protocol):
         *,
         run_id: str,
         tasks: List[TaskDraft],
-    ) -> Dict[str, JsonValue]: ...
+    ) -> Dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
 
     def update_task(
         self,
@@ -53,7 +54,8 @@ class TaskOrchestrationServiceLike(Protocol):
         run_id: Optional[str],
         task_id: str,
         update: TaskUpdate,
-    ) -> Dict[str, JsonValue]: ...
+    ) -> Dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
 
     async def update_task_async(
         self,
@@ -61,35 +63,40 @@ class TaskOrchestrationServiceLike(Protocol):
         run_id: Optional[str],
         task_id: str,
         update: TaskUpdate,
-    ) -> Dict[str, JsonValue]: ...
+    ) -> Dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
 
     def list_delegated_tasks(
         self,
         *,
         run_id: str,
         include_root: bool = False,
-    ) -> Dict[str, JsonValue]: ...
+    ) -> Dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
 
     async def list_delegated_tasks_async(
         self,
         *,
         run_id: str,
         include_root: bool = False,
-    ) -> Dict[str, JsonValue]: ...
+    ) -> Dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
 
     def list_run_tasks(
         self,
         *,
         run_id: str,
         include_root: bool = False,
-    ) -> Dict[str, JsonValue]: ...
+    ) -> Dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
 
     async def list_run_tasks_async(
         self,
         *,
         run_id: str,
         include_root: bool = False,
-    ) -> Dict[str, JsonValue]: ...
+    ) -> Dict[str, JsonValue]:
+        raise NotImplementedError  # pragma: no cover
 
     def dispatch_task(
         self,
@@ -98,7 +105,8 @@ class TaskOrchestrationServiceLike(Protocol):
         task_id: str,
         role_id: str,
         prompt: str = "",
-    ) -> Awaitable[Dict[str, JsonValue]]: ...
+    ) -> Awaitable[Dict[str, JsonValue]]:
+        raise NotImplementedError  # pragma: no cover
 
 
 class TaskExecutionServiceLike(Protocol):
@@ -109,4 +117,5 @@ class TaskExecutionServiceLike(Protocol):
         role_id: str,
         task: TaskEnvelope,
         user_prompt_override: Optional[str] = None,
-    ) -> object: ...
+    ) -> object:
+        raise NotImplementedError  # pragma: no cover

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -14,7 +14,7 @@ from pydantic_ai.messages import ModelRequest, UserContent, UserPromptPart
 
 from relay_teams.agents.execution.subagent_runner import SubAgentRunner
 from relay_teams.agents.execution.prompt_instruction_state import (
-    record_prompt_instruction_paths_loaded,
+    record_prompt_instruction_paths_loaded_async,
 )
 from relay_teams.agents.execution.system_prompts import (
     PromptBuildInput,
@@ -178,9 +178,9 @@ class TaskExecutionService(BaseModel):
                 "role_id": role_id,
             },
         )
-        _ = self.agent_repo.mark_status(instance_id, InstanceStatus.RUNNING)
-        _ = self.task_repo.update_status(task.task_id, TaskStatus.RUNNING)
-        self.run_runtime_repo.ensure(
+        await self.agent_repo.mark_status_async(instance_id, InstanceStatus.RUNNING)
+        _ = await self.task_repo.update_status_async(task.task_id, TaskStatus.RUNNING)
+        await self.run_runtime_repo.ensure_async(
             run_id=task.trace_id,
             session_id=task.session_id,
             root_task_id=task.parent_task_id or task.task_id,
@@ -191,7 +191,7 @@ class TaskExecutionService(BaseModel):
                 else RunRuntimePhase.SUBAGENT_RUNNING
             ),
         )
-        self.run_runtime_repo.update(
+        await self.run_runtime_repo.update_async(
             task.trace_id,
             status=RunRuntimeStatus.RUNNING,
             phase=(
@@ -205,7 +205,7 @@ class TaskExecutionService(BaseModel):
             active_subagent_instance_id=(None if is_coordinator else instance_id),
             last_error=None,
         )
-        self.event_bus.emit(
+        await self.event_bus.emit_async(
             EventEnvelope(
                 event_type=EventType.TASK_STARTED,
                 trace_id=task.trace_id,
@@ -217,13 +217,13 @@ class TaskExecutionService(BaseModel):
         )
 
         if self.runtime_role_resolver is not None:
-            role = self.runtime_role_resolver.get_effective_role(
+            role = await self.runtime_role_resolver.get_effective_role_async(
                 run_id=task.trace_id,
                 role_id=role_id,
             )
         else:
             role = self.role_registry.get(role_id)
-        instance_record = self.agent_repo.get_instance(instance_id)
+        instance_record = await self.agent_repo.get_instance_async(instance_id)
         workspace = self.workspace_manager.resolve(
             session_id=task.session_id,
             role_id=role_id,
@@ -241,7 +241,7 @@ class TaskExecutionService(BaseModel):
             prompt_builder=self.prompt_builder,
             provider=self.provider_factory(role_for_run, task.session_id),
         )
-        snapshot = self._shared_state_snapshot(
+        snapshot = await self._shared_state_snapshot_async(
             session_id=task.session_id,
             role_id=role_id,
             conversation_id=workspace.ref.conversation_id,
@@ -259,7 +259,7 @@ class TaskExecutionService(BaseModel):
                     user_prompt_override=user_prompt_override,
                 ),
             )
-            self._ensure_committed_task_prompt(
+            await self._ensure_committed_task_prompt_async(
                 role_id=role_id,
                 workspace_id=workspace.ref.workspace_id,
                 conversation_id=workspace.ref.conversation_id,
@@ -275,7 +275,7 @@ class TaskExecutionService(BaseModel):
                 runtime_prompt_sections=runtime_prompt_sections,
                 skill_instructions=prepared_runtime_snapshot.skill_instructions,
             )
-            self.agent_repo.update_runtime_snapshot(
+            await self.agent_repo.update_runtime_snapshot_async(
                 instance_id,
                 runtime_system_prompt=runtime_system_prompt,
                 runtime_tools_json=runtime_tools_json,
@@ -298,15 +298,17 @@ class TaskExecutionService(BaseModel):
             if isinstance(guarded_result, TaskExecutionResult):
                 return guarded_result
             result = guarded_result
-            self.task_repo.update_status(
+            await self.task_repo.update_status_async(
                 task.task_id, TaskStatus.COMPLETED, result=result
             )
-            _ = self.agent_repo.mark_status(instance_id, InstanceStatus.COMPLETED)
-            self._mark_runtime_idle_after_success(
+            await self.agent_repo.mark_status_async(
+                instance_id, InstanceStatus.COMPLETED
+            )
+            await self._mark_runtime_idle_after_success_async(
                 run_id=task.trace_id,
                 completed_task_id=task.task_id,
             )
-            self.event_bus.emit(
+            await self.event_bus.emit_async(
                 EventEnvelope(
                     event_type=EventType.TASK_COMPLETED,
                     trace_id=task.trace_id,
@@ -322,7 +324,7 @@ class TaskExecutionService(BaseModel):
                 role_id=role_id,
                 output_text=result,
             )
-            self._record_memory_if_needed(
+            await self._record_memory_if_needed_async(
                 role_id=role_id,
                 workspace_id=workspace.ref.workspace_id,
                 task=task,
@@ -367,13 +369,15 @@ class TaskExecutionService(BaseModel):
                 )
             else:
                 stopped = False
-                self.task_repo.update_status(
+                await self.task_repo.update_status_async(
                     task.task_id,
                     TaskStatus.FAILED,
                     error_message="Task cancelled",
                 )
-                self.agent_repo.mark_status(instance_id, InstanceStatus.FAILED)
-                self.event_bus.emit(
+                await self.agent_repo.mark_status_async(
+                    instance_id, InstanceStatus.FAILED
+                )
+                await self.event_bus.emit_async(
                     EventEnvelope(
                         event_type=EventType.TASK_FAILED,
                         trace_id=task.trace_id,
@@ -385,12 +389,12 @@ class TaskExecutionService(BaseModel):
                 )
             last_error = "Task stopped by user" if stopped else "Task cancelled"
             if paused_subagent:
-                if not self._promote_running_runtime_lane(
+                if not await self._promote_running_runtime_lane_async(
                     run_id=task.trace_id,
                     terminal_task_id=task.task_id,
                     last_error=last_error,
                 ):
-                    self.run_runtime_repo.update(
+                    await self.run_runtime_repo.update_async(
                         task.trace_id,
                         status=RunRuntimeStatus.STOPPED,
                         phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
@@ -401,7 +405,7 @@ class TaskExecutionService(BaseModel):
                         last_error=last_error,
                     )
             else:
-                self._mark_runtime_after_terminal_task_update(
+                await self._mark_runtime_after_terminal_task_update_async(
                     run_id=task.trace_id,
                     terminal_task_id=task.task_id,
                     status=(
@@ -430,7 +434,7 @@ class TaskExecutionService(BaseModel):
             )
             raise
         except AssistantRunError as exc:
-            return self._complete_with_assistant_error(
+            return await self._complete_with_assistant_error_async(
                 task=task,
                 instance_id=instance_id,
                 role_id=role_id,
@@ -443,14 +447,14 @@ class TaskExecutionService(BaseModel):
             )
         except RecoverableRunPauseError as exc:
             payload = exc.payload
-            _ = self.task_repo.update_status(
+            _ = await self.task_repo.update_status_async(
                 task.task_id,
                 TaskStatus.STOPPED,
                 assigned_instance_id=instance_id,
                 error_message=payload.error_message,
             )
-            _ = self.agent_repo.mark_status(instance_id, InstanceStatus.IDLE)
-            self.run_runtime_repo.update(
+            await self.agent_repo.mark_status_async(instance_id, InstanceStatus.IDLE)
+            await self.run_runtime_repo.update_async(
                 task.trace_id,
                 status=RunRuntimeStatus.PAUSED,
                 phase=RunRuntimePhase.AWAITING_RECOVERY,
@@ -462,7 +466,7 @@ class TaskExecutionService(BaseModel):
                 ),
                 last_error=payload.error_message,
             )
-            self.event_bus.emit(
+            await self.event_bus.emit_async(
                 EventEnvelope(
                     event_type=EventType.TASK_STOPPED,
                     trace_id=task.trace_id,
@@ -486,7 +490,7 @@ class TaskExecutionService(BaseModel):
             )
             raise
         except TimeoutError:
-            return self._complete_with_assistant_error(
+            return await self._complete_with_assistant_error_async(
                 task=task,
                 instance_id=instance_id,
                 role_id=role_id,
@@ -500,7 +504,7 @@ class TaskExecutionService(BaseModel):
                 error_message="Task timeout",
             )
         except Exception as exc:
-            return self._complete_with_assistant_error(
+            return await self._complete_with_assistant_error_async(
                 task=task,
                 instance_id=instance_id,
                 role_id=role_id,
@@ -536,7 +540,7 @@ class TaskExecutionService(BaseModel):
             system_prompt_override=system_prompt_override,
         )
         while True:
-            decision = self._evaluate_completion_guard(
+            decision = await self._evaluate_completion_guard_async(
                 task=task,
                 instance_id=instance_id,
                 role_id=role_id,
@@ -574,7 +578,7 @@ class TaskExecutionService(BaseModel):
                     error_code="incomplete_todos",
                     error_message=decision.content,
                 )
-                return self._complete_with_assistant_error(
+                return await self._complete_with_assistant_error_async(
                     task=task,
                     instance_id=instance_id,
                     role_id=role_id,
@@ -604,10 +608,56 @@ class TaskExecutionService(BaseModel):
             working_directory=workspace.resolve_workdir(),
             conversation_id=conversation_id,
             shared_state_snapshot=shared_state_snapshot,
-            thinking=self._thinking_for_run(task.trace_id),
+            thinking=await self._thinking_for_run_async(task.trace_id),
             system_prompt_override=system_prompt_override,
             user_prompt=None,
         )
+
+    async def _evaluate_completion_guard_async(
+        self,
+        *,
+        task: TaskEnvelope,
+        instance_id: str,
+        role_id: str,
+        workspace: WorkspaceHandle,
+        conversation_id: str,
+        output_text: str,
+    ) -> ReminderDecision:
+        if self.reminder_service is None or self.todo_service is None:
+            return ReminderDecision()
+        if task.parent_task_id is not None:
+            return ReminderDecision()
+        snapshot = await self.todo_service.get_for_run_async(
+            run_id=task.trace_id,
+            session_id=task.session_id,
+        )
+        incomplete = tuple(
+            IncompleteTodoItem(content=item.content, status=item.status.value)
+            for item in snapshot.items
+            if item.status != TodoStatus.COMPLETED
+        )
+        return await self.reminder_service.evaluate_completion_attempt_async(
+            CompletionAttemptObservation(
+                session_id=task.session_id,
+                run_id=task.trace_id,
+                trace_id=task.trace_id,
+                task_id=task.task_id,
+                instance_id=instance_id,
+                role_id=role_id,
+                workspace_id=workspace.ref.workspace_id,
+                conversation_id=conversation_id,
+                output_text=output_text,
+                incomplete_todos=incomplete,
+            )
+        )
+
+    async def _thinking_for_run_async(self, run_id: str) -> RunThinkingConfig:
+        if self.run_intent_repo is None:
+            return RunThinkingConfig()
+        try:
+            return (await self.run_intent_repo.get_async(run_id)).thinking
+        except KeyError:
+            return RunThinkingConfig()
 
     def _evaluate_completion_guard(
         self,
@@ -758,6 +808,81 @@ class TaskExecutionService(BaseModel):
             error_message=error_message or assistant_message,
         )
 
+    async def _complete_with_assistant_error_async(
+        self,
+        *,
+        task: TaskEnvelope,
+        instance_id: str,
+        role_id: str,
+        conversation_id: str,
+        workspace_id: str,
+        assistant_message: str,
+        error_code: str,
+        error_message: str,
+        append_message: bool = True,
+    ) -> TaskExecutionResult:
+        if append_message:
+            await self.message_repo.prune_conversation_history_to_safe_boundary_async(
+                conversation_id
+            )
+            await self.message_repo.append_async(
+                session_id=task.session_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                agent_role_id=role_id,
+                instance_id=instance_id,
+                task_id=task.task_id,
+                trace_id=task.trace_id,
+                messages=[build_assistant_error_response(assistant_message)],
+            )
+        await self.task_repo.update_status_async(
+            task.task_id,
+            TaskStatus.FAILED,
+            assigned_instance_id=instance_id,
+            result=assistant_message,
+            error_message=error_message or assistant_message,
+        )
+        await self.agent_repo.mark_status_async(instance_id, InstanceStatus.FAILED)
+        await self._mark_runtime_after_terminal_task_update_async(
+            run_id=task.trace_id,
+            terminal_task_id=task.task_id,
+            status=RunRuntimeStatus.RUNNING,
+            phase=RunRuntimePhase.IDLE,
+            active_instance_id=None,
+            active_task_id=None,
+            active_role_id=None,
+            active_subagent_instance_id=None,
+            last_error=error_message or assistant_message,
+        )
+        await self.event_bus.emit_async(
+            EventEnvelope(
+                event_type=EventType.TASK_FAILED,
+                trace_id=task.trace_id,
+                session_id=task.session_id,
+                task_id=task.task_id,
+                instance_id=instance_id,
+                payload_json="{}",
+            )
+        )
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="task.execution.failed_with_assistant_error",
+            message="Task execution failed after assistant error message was persisted",
+            payload={
+                "task_id": task.task_id,
+                "instance_id": instance_id,
+                "role_id": role_id,
+                "error_code": error_code,
+            },
+        )
+        return TaskExecutionResult(
+            output=assistant_message,
+            completion_reason=RunCompletionReason.ASSISTANT_ERROR,
+            error_code=error_code,
+            error_message=error_message or assistant_message,
+        )
+
     def _topology_for_run(self, run_id: str) -> RunTopologySnapshot | None:
         if self.run_intent_repo is None:
             return None
@@ -774,6 +899,25 @@ class TaskExecutionService(BaseModel):
             return None
         try:
             return self.run_intent_repo.get(run_id).conversation_context
+        except KeyError:
+            return None
+
+    async def _topology_for_run_async(self, run_id: str) -> RunTopologySnapshot | None:
+        if self.run_intent_repo is None:
+            return None
+        try:
+            return (await self.run_intent_repo.get_async(run_id)).topology
+        except KeyError:
+            return None
+
+    async def _conversation_context_for_run_async(
+        self,
+        run_id: str,
+    ) -> RuntimePromptConversationContext | None:
+        if self.run_intent_repo is None:
+            return None
+        try:
+            return (await self.run_intent_repo.get_async(run_id)).conversation_context
         except KeyError:
             return None
 
@@ -803,8 +947,10 @@ class TaskExecutionService(BaseModel):
         shared_state_snapshot: tuple[tuple[str, str], ...],
         objective: str,
     ) -> PreparedRuntimeSnapshot:
-        topology = self._topology_for_run(task.trace_id)
-        conversation_context = self._conversation_context_for_run(task.trace_id)
+        topology = await self._topology_for_run_async(task.trace_id)
+        conversation_context = await self._conversation_context_for_run_async(
+            task.trace_id
+        )
         runtime_tools = await self._build_runtime_tools_snapshot(role=role, task=task)
         prompt_sections = await self.prompt_builder.build_sections(
             PromptBuildInput(
@@ -833,7 +979,7 @@ class TaskExecutionService(BaseModel):
                 runtime_tools=runtime_tools,
             )
         )
-        record_prompt_instruction_paths_loaded(
+        await record_prompt_instruction_paths_loaded_async(
             shared_store=self.shared_store,
             task_id=task.task_id,
             paths=prompt_sections.local_instruction_paths,
@@ -1057,6 +1203,52 @@ class TaskExecutionService(BaseModel):
                 exc_info=True,
             )
 
+    async def _record_memory_if_needed_async(
+        self,
+        *,
+        role_id: str,
+        workspace_id: str,
+        task: TaskEnvelope,
+        conversation_id: str,
+        instance_id: str,
+        lifecycle: str,
+        result: str,
+    ) -> None:
+        payload: dict[str, JsonValue] = {
+            "task_id": task.task_id,
+            "title": task.title or "",
+            "objective": task.objective[:500],
+            "role_id": role_id,
+            "workspace_id": workspace_id,
+            "conversation_id": conversation_id,
+            "instance_id": instance_id,
+            "lifecycle": lifecycle,
+            "result_excerpt": _truncate_task_memory_result(result),
+            "completed_at": datetime.now(tz=timezone.utc).isoformat(),
+        }
+        # noinspection PyBroadException
+        try:
+            await self.shared_store.manage_state_async(
+                StateMutation(
+                    scope=ScopeRef(
+                        scope_type=ScopeType.ROLE,
+                        scope_id=f"{task.session_id}:{role_id}",
+                    ),
+                    key=f"task_result:{task.task_id}",
+                    value_json=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                )
+            )
+        except Exception:
+            LOGGER.warning(
+                "Failed to persist completed task memory",
+                extra={
+                    "task_id": task.task_id,
+                    "role_id": role_id,
+                    "instance_id": instance_id,
+                },
+                exc_info=True,
+            )
+
     def _mark_runtime_idle_after_success(
         self,
         *,
@@ -1064,6 +1256,24 @@ class TaskExecutionService(BaseModel):
         completed_task_id: str,
     ) -> None:
         self._mark_runtime_after_terminal_task_update(
+            run_id=run_id,
+            terminal_task_id=completed_task_id,
+            status=RunRuntimeStatus.RUNNING,
+            phase=RunRuntimePhase.IDLE,
+            active_instance_id=None,
+            active_task_id=None,
+            active_role_id=None,
+            active_subagent_instance_id=None,
+            last_error=None,
+        )
+
+    async def _mark_runtime_idle_after_success_async(
+        self,
+        *,
+        run_id: str,
+        completed_task_id: str,
+    ) -> None:
+        await self._mark_runtime_after_terminal_task_update_async(
             run_id=run_id,
             terminal_task_id=completed_task_id,
             status=RunRuntimeStatus.RUNNING,
@@ -1119,6 +1329,50 @@ class TaskExecutionService(BaseModel):
             last_error=last_error,
         )
 
+    async def _mark_runtime_after_terminal_task_update_async(
+        self,
+        *,
+        run_id: str,
+        terminal_task_id: str,
+        status: RunRuntimeStatus,
+        phase: RunRuntimePhase,
+        active_instance_id: Optional[str],
+        active_task_id: Optional[str],
+        active_role_id: Optional[str],
+        active_subagent_instance_id: Optional[str],
+        last_error: Optional[str],
+    ) -> None:
+        current = await self.run_runtime_repo.get_async(run_id)
+        if current is not None and current.active_task_id not in {
+            None,
+            terminal_task_id,
+        }:
+            if last_error is not None:
+                await self.run_runtime_repo.update_async(run_id, last_error=last_error)
+            return
+        if await self._promote_running_runtime_lane_async(
+            run_id=run_id,
+            terminal_task_id=terminal_task_id,
+            last_error=last_error,
+        ):
+            return
+        if await self._promote_paused_runtime_lane_async(
+            run_id=run_id,
+            terminal_task_id=terminal_task_id,
+            last_error=last_error,
+        ):
+            return
+        await self.run_runtime_repo.update_async(
+            run_id,
+            status=status,
+            phase=phase,
+            active_instance_id=active_instance_id,
+            active_task_id=active_task_id,
+            active_role_id=active_role_id,
+            active_subagent_instance_id=active_subagent_instance_id,
+            last_error=last_error,
+        )
+
     def _promote_running_runtime_lane(
         self,
         *,
@@ -1151,6 +1405,53 @@ class TaskExecutionService(BaseModel):
             return False
         is_coordinator = task.parent_task_id is None
         self.run_runtime_repo.update(
+            run_id,
+            status=RunRuntimeStatus.RUNNING,
+            phase=(
+                RunRuntimePhase.COORDINATOR_RUNNING
+                if is_coordinator
+                else RunRuntimePhase.SUBAGENT_RUNNING
+            ),
+            active_instance_id=instance_id,
+            active_task_id=task.task_id,
+            active_role_id=task.role_id,
+            active_subagent_instance_id=(None if is_coordinator else instance_id),
+            last_error=last_error,
+        )
+        return True
+
+    async def _promote_running_runtime_lane_async(
+        self,
+        *,
+        run_id: str,
+        terminal_task_id: str,
+        last_error: Optional[str],
+    ) -> bool:
+        coordinator_record: Optional[TaskRecord] = None
+        promoted_record: Optional[TaskRecord] = None
+        for record in await self.task_repo.list_by_trace_async(run_id):
+            task = record.envelope
+            if task.task_id == terminal_task_id:
+                continue
+            if record.status != TaskStatus.RUNNING:
+                continue
+            if not record.assigned_instance_id:
+                continue
+            if task.parent_task_id is not None:
+                promoted_record = record
+                break
+            if coordinator_record is None:
+                coordinator_record = record
+        if promoted_record is None:
+            promoted_record = coordinator_record
+        if promoted_record is None:
+            return False
+        task = promoted_record.envelope
+        instance_id = promoted_record.assigned_instance_id
+        if not instance_id:
+            return False
+        is_coordinator = task.parent_task_id is None
+        await self.run_runtime_repo.update_async(
             run_id,
             status=RunRuntimeStatus.RUNNING,
             phase=(
@@ -1212,6 +1513,52 @@ class TaskExecutionService(BaseModel):
             return True
         return False
 
+    async def _promote_paused_runtime_lane_async(
+        self,
+        *,
+        run_id: str,
+        terminal_task_id: str,
+        last_error: Optional[str],
+    ) -> bool:
+        if self.run_control_manager is None:
+            return False
+        if self.run_control_manager.is_run_stop_requested(run_id):
+            return False
+        for record in await self.task_repo.list_by_trace_async(run_id):
+            task = record.envelope
+            instance_id = record.assigned_instance_id
+            if task.task_id == terminal_task_id:
+                continue
+            if task.parent_task_id is None:
+                continue
+            if record.status != TaskStatus.STOPPED:
+                continue
+            if not instance_id:
+                continue
+            if not (
+                self.run_control_manager.is_subagent_stop_requested(
+                    run_id=run_id,
+                    instance_id=instance_id,
+                )
+                or self.run_control_manager.is_subagent_paused(
+                    session_id=task.session_id,
+                    instance_id=instance_id,
+                )
+            ):
+                continue
+            await self.run_runtime_repo.update_async(
+                run_id,
+                status=RunRuntimeStatus.STOPPED,
+                phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
+                active_instance_id=None,
+                active_task_id=task.task_id,
+                active_role_id=task.role_id,
+                active_subagent_instance_id=instance_id,
+                last_error=last_error or record.error_message or "Task stopped by user",
+            )
+            return True
+        return False
+
     def _shared_state_snapshot(
         self,
         *,
@@ -1225,6 +1572,23 @@ class TaskExecutionService(BaseModel):
             ScopeRef(scope_type=ScopeType.CONVERSATION, scope_id=conversation_id),
         )
         return self.shared_store.snapshot_many(
+            scopes,
+            exclude_key_prefixes=(READ_STATE_PREFIX,),
+        )
+
+    async def _shared_state_snapshot_async(
+        self,
+        *,
+        session_id: str,
+        role_id: str,
+        conversation_id: str,
+    ) -> tuple[tuple[str, str], ...]:
+        scopes = (
+            ScopeRef(scope_type=ScopeType.SESSION, scope_id=session_id),
+            ScopeRef(scope_type=ScopeType.ROLE, scope_id=f"{session_id}:{role_id}"),
+            ScopeRef(scope_type=ScopeType.CONVERSATION, scope_id=conversation_id),
+        )
+        return await self.shared_store.snapshot_many_async(
             scopes,
             exclude_key_prefixes=(READ_STATE_PREFIX,),
         )
@@ -1311,6 +1675,100 @@ class TaskExecutionService(BaseModel):
             )
             return
         self.message_repo.append_user_prompt_if_missing(
+            session_id=task.session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=role_id,
+            instance_id=instance_id,
+            task_id=task.task_id,
+            trace_id=task.trace_id,
+            content=task.objective,
+        )
+
+    async def _ensure_committed_task_prompt_async(
+        self,
+        *,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        instance_id: str,
+        task: TaskEnvelope,
+        user_prompt_text: str,
+        user_prompt_override: str | None,
+    ) -> None:
+        prompt = user_prompt_text.strip()
+        override_prompt = str(user_prompt_override or "").strip()
+        if override_prompt:
+            await self.message_repo.append_user_prompt_if_missing_async(
+                session_id=task.session_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                agent_role_id=role_id,
+                instance_id=instance_id,
+                task_id=task.task_id,
+                trace_id=task.trace_id,
+                content=override_prompt,
+            )
+            return
+
+        task_history = await self.message_repo.get_history_for_conversation_task_async(
+            conversation_id,
+            task.task_id,
+        )
+        if task_history:
+            return
+        if (
+            task.parent_task_id is None
+            and self.run_intent_repo is not None
+            and self.media_asset_service is not None
+        ):
+            try:
+                run_intent = await self.run_intent_repo.get_async(task.trace_id)
+            except KeyError:
+                run_intent = None
+            if run_intent is not None and run_intent.input:
+                provider_content = (
+                    self.media_asset_service.to_persisted_user_prompt_content(
+                        parts=run_intent.input
+                    )
+                )
+                merged_provider_content = self._merge_provider_prompt_content(
+                    provider_content=provider_content,
+                    user_prompt_text=prompt,
+                )
+                await (
+                    self.message_repo.prune_conversation_history_to_safe_boundary_async(
+                        conversation_id
+                    )
+                )
+                await self.message_repo.append_async(
+                    session_id=task.session_id,
+                    workspace_id=workspace_id,
+                    conversation_id=conversation_id,
+                    agent_role_id=role_id,
+                    instance_id=instance_id,
+                    task_id=task.task_id,
+                    trace_id=task.trace_id,
+                    messages=[
+                        ModelRequest(
+                            parts=[UserPromptPart(content=merged_provider_content)]
+                        )
+                    ],
+                )
+                return
+        if prompt:
+            await self.message_repo.append_user_prompt_if_missing_async(
+                session_id=task.session_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                agent_role_id=role_id,
+                instance_id=instance_id,
+                task_id=task.task_id,
+                trace_id=task.trace_id,
+                content=prompt,
+            )
+            return
+        await self.message_repo.append_user_prompt_if_missing_async(
             session_id=task.session_id,
             workspace_id=workspace_id,
             conversation_id=conversation_id,

--- a/src/relay_teams/agents/orchestration/task_orchestration_service.py
+++ b/src/relay_teams/agents/orchestration/task_orchestration_service.py
@@ -72,10 +72,10 @@ class TaskOrchestrationService:
         if not tasks:
             raise ValueError("tasks must contain at least one task")
 
-        root = self._get_root_task(run_id)
+        root = await self._get_root_task_async(run_id)
         created_records: list[TaskRecord] = []
         for draft in tasks:
-            record = self._task_repo.create(
+            record = await self._task_repo.create_async(
                 TaskEnvelope(
                     task_id=new_task_id().value,
                     session_id=root.envelope.session_id,
@@ -177,6 +177,70 @@ class TaskOrchestrationService:
     ) -> dict[str, JsonValue]:
         return self.list_delegated_tasks(run_id=run_id, include_root=include_root)
 
+    async def update_task_async(
+        self,
+        *,
+        run_id: str | None,
+        task_id: str,
+        update: TaskUpdate,
+    ) -> dict[str, JsonValue]:
+        record = await self.get_task_async(task_id=task_id, run_id=run_id)
+        if record.envelope.parent_task_id is None:
+            raise ValueError("root coordinator task cannot be updated via task APIs")
+        if record.status != TaskStatus.CREATED:
+            raise ValueError("only created tasks can be updated")
+
+        current = record.envelope
+        next_objective = (
+            str(update.objective).strip()
+            if update.objective is not None
+            else current.objective
+        )
+        if not next_objective:
+            raise ValueError("objective must not be empty")
+
+        next_title = (
+            _resolved_title(update.title, next_objective)
+            if update.title is not None
+            else current.title or _resolved_title(None, next_objective)
+        )
+        updated = await self._task_repo.update_envelope_async(
+            task_id,
+            current.model_copy(
+                update={
+                    "objective": next_objective,
+                    "title": next_title,
+                }
+            ),
+        )
+        return {"task": _task_projection(updated)}
+
+    async def list_delegated_tasks_async(
+        self,
+        *,
+        run_id: str,
+        include_root: bool = False,
+    ) -> dict[str, JsonValue]:
+        records = [
+            record
+            for record in await self._task_repo.list_by_trace_async(run_id)
+            if include_root or record.envelope.parent_task_id is not None
+        ]
+        return {
+            "tasks": [_task_projection(record) for record in records],
+        }
+
+    async def list_run_tasks_async(
+        self,
+        *,
+        run_id: str,
+        include_root: bool = False,
+    ) -> dict[str, JsonValue]:
+        return await self.list_delegated_tasks_async(
+            run_id=run_id,
+            include_root=include_root,
+        )
+
     def list_tasks(self) -> tuple[TaskRecord, ...]:
         return self._task_repo.list_all()
 
@@ -188,7 +252,7 @@ class TaskOrchestrationService:
         role_id: str,
         prompt: str = "",
     ) -> dict[str, JsonValue]:
-        record = self.get_task(task_id=task_id, run_id=run_id)
+        record = await self.get_task_async(task_id=task_id, run_id=run_id)
         resolved_run_id = run_id or record.envelope.trace_id
         if record.envelope.parent_task_id is None:
             raise ValueError("root coordinator task cannot be dispatched via task APIs")
@@ -199,7 +263,7 @@ class TaskOrchestrationService:
         if not normalized_role_id:
             raise ValueError("role_id must not be empty")
         if self._runtime_role_resolver is not None:
-            self._runtime_role_resolver.get_effective_role(
+            await self._runtime_role_resolver.get_effective_role_async(
                 run_id=resolved_run_id,
                 role_id=normalized_role_id,
             )
@@ -216,7 +280,7 @@ class TaskOrchestrationService:
                 role_id=normalized_role_id,
             ) as assignment_lock:
                 async with assignment_lock:
-                    record = self._task_repo.get(task_id)
+                    record = await self._task_repo.get_async(task_id)
                     bound_role_id = str(record.envelope.role_id or "").strip()
                     if record.status == TaskStatus.CREATED:
                         if bound_role_id and bound_role_id != normalized_role_id:
@@ -224,25 +288,25 @@ class TaskOrchestrationService:
                                 f"Task is already bound to role {bound_role_id}; create a replacement task to change roles."
                             )
                         if not bound_role_id:
-                            record = self._task_repo.update_envelope(
+                            record = await self._task_repo.update_envelope_async(
                                 task_id,
                                 record.envelope.model_copy(
                                     update={"role_id": normalized_role_id}
                                 ),
                             )
                             bound_role_id = normalized_role_id
-                        instance_id = self._ensure_execution_instance(
+                        instance_id = await self._ensure_execution_instance_async(
                             session_id=record.envelope.session_id,
                             run_id=resolved_run_id,
                             role_id=bound_role_id,
                             task_id=task_id,
                         )
-                        self._task_repo.update_status(
+                        await self._task_repo.update_status_async(
                             task_id=task_id,
                             status=TaskStatus.ASSIGNED,
                             assigned_instance_id=instance_id,
                         )
-                        record = self._task_repo.get(task_id)
+                        record = await self._task_repo.get_async(task_id)
                     else:
                         if not bound_role_id:
                             raise ValueError(
@@ -280,7 +344,9 @@ class TaskOrchestrationService:
         if not instance_id:
             raise ValueError("task has no bound instance to dispatch")
 
-        self._assert_instance_available(task=record, instance_id=instance_id)
+        await self._assert_instance_available_async(
+            task=record, instance_id=instance_id
+        )
 
         effective_prompt = (
             normalized_prompt
@@ -294,7 +360,7 @@ class TaskOrchestrationService:
                 task=record.envelope,
                 user_prompt_override=effective_prompt,
             )
-        refreshed = self._task_repo.get(task_id)
+        refreshed = await self._task_repo.get_async(task_id)
         return {
             "task": _task_projection(refreshed),
         }
@@ -429,6 +495,70 @@ class TaskOrchestrationService:
         )
         return instance.instance_id
 
+    async def _ensure_execution_instance_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        role_id: str,
+        task_id: str,
+    ) -> str:
+        existing = await self._agent_repo.get_session_role_instance_async(
+            session_id, role_id
+        )
+        if existing is not None:
+            if await self._instance_has_blocking_task_async(
+                session_id=session_id,
+                instance_id=existing.instance_id,
+                task_id=task_id,
+            ):
+                return await self._create_ephemeral_role_clone_async(
+                    session_id=session_id,
+                    run_id=run_id,
+                    role_id=role_id,
+                    workspace_id=existing.workspace_id,
+                    parent_instance_id=existing.instance_id,
+                )
+            await self._agent_repo.upsert_instance_async(
+                run_id=run_id,
+                trace_id=run_id,
+                session_id=session_id,
+                instance_id=existing.instance_id,
+                role_id=existing.role_id,
+                workspace_id=existing.workspace_id,
+                conversation_id=existing.conversation_id,
+                status=existing.status,
+                lifecycle=InstanceLifecycle.REUSABLE,
+            )
+            return existing.instance_id
+
+        session = (
+            await self._session_repo.get_async(session_id)
+            if self._session_repo
+            else None
+        )
+        if session is None:
+            raise RuntimeError(
+                "TaskOrchestrationService requires session_repo to resolve workspace"
+            )
+        instance = create_subagent_instance(
+            role_id,
+            session_id=session_id,
+            workspace_id=session.workspace_id,
+        )
+        await self._agent_repo.upsert_instance_async(
+            run_id=run_id,
+            trace_id=run_id,
+            session_id=session_id,
+            instance_id=instance.instance_id,
+            role_id=instance.role_id,
+            workspace_id=instance.workspace_id,
+            conversation_id=instance.conversation_id,
+            status=InstanceStatus.IDLE,
+            lifecycle=InstanceLifecycle.REUSABLE,
+        )
+        return instance.instance_id
+
     def _create_ephemeral_role_clone(
         self,
         *,
@@ -444,6 +574,34 @@ class TaskOrchestrationService:
             workspace_id=workspace_id,
         )
         self._agent_repo.upsert_instance(
+            run_id=run_id,
+            trace_id=run_id,
+            session_id=session_id,
+            instance_id=instance.instance_id,
+            role_id=instance.role_id,
+            workspace_id=instance.workspace_id,
+            conversation_id=instance.conversation_id,
+            status=InstanceStatus.IDLE,
+            lifecycle=InstanceLifecycle.EPHEMERAL,
+            parent_instance_id=parent_instance_id,
+        )
+        return instance.instance_id
+
+    async def _create_ephemeral_role_clone_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        role_id: str,
+        workspace_id: str,
+        parent_instance_id: str,
+    ) -> str:
+        instance = create_subagent_instance(
+            role_id,
+            session_id=session_id,
+            workspace_id=workspace_id,
+        )
+        await self._agent_repo.upsert_instance_async(
             run_id=run_id,
             trace_id=run_id,
             session_id=session_id,
@@ -478,6 +636,27 @@ class TaskOrchestrationService:
                 return True
         return False
 
+    async def _instance_has_blocking_task_async(
+        self,
+        *,
+        session_id: str,
+        instance_id: str,
+        task_id: str,
+    ) -> bool:
+        blocking_statuses = {
+            TaskStatus.ASSIGNED,
+            TaskStatus.RUNNING,
+            TaskStatus.STOPPED,
+        }
+        for candidate in await self._task_repo.list_by_session_async(session_id):
+            if candidate.envelope.task_id == task_id:
+                continue
+            if candidate.assigned_instance_id != instance_id:
+                continue
+            if candidate.status in blocking_statuses:
+                return True
+        return False
+
     def _assert_instance_available(self, *, task: TaskRecord, instance_id: str) -> None:
         blocking_statuses = {
             TaskStatus.ASSIGNED,
@@ -497,14 +676,51 @@ class TaskOrchestrationService:
                 f"Wait for it to complete or use a different role."
             )
 
+    async def _assert_instance_available_async(
+        self, *, task: TaskRecord, instance_id: str
+    ) -> None:
+        blocking_statuses = {
+            TaskStatus.ASSIGNED,
+            TaskStatus.RUNNING,
+            TaskStatus.STOPPED,
+        }
+        for candidate in await self._task_repo.list_by_session_async(
+            task.envelope.session_id
+        ):
+            if candidate.envelope.task_id == task.envelope.task_id:
+                continue
+            if candidate.assigned_instance_id != instance_id:
+                continue
+            if candidate.status not in blocking_statuses:
+                continue
+            raise ValueError(
+                f"Role {candidate.envelope.role_id or 'unassigned'} is busy with task "
+                f"'{candidate.envelope.title}' (status={candidate.status.value}). "
+                f"Wait for it to complete or use a different role."
+            )
+
     def _get_root_task(self, run_id: str) -> TaskRecord:
         for record in self._task_repo.list_by_trace(run_id):
             if record.envelope.parent_task_id is None:
                 return record
         raise KeyError(f"No root task found for run_id={run_id}")
 
+    async def _get_root_task_async(self, run_id: str) -> TaskRecord:
+        for record in await self._task_repo.list_by_trace_async(run_id):
+            if record.envelope.parent_task_id is None:
+                return record
+        raise KeyError(f"No root task found for run_id={run_id}")
+
     def get_task(self, *, task_id: str, run_id: str | None = None) -> TaskRecord:
         record = self._task_repo.get(task_id)
+        if run_id is not None and record.envelope.trace_id != run_id:
+            raise KeyError(f"Task {task_id} does not belong to run {run_id}")
+        return record
+
+    async def get_task_async(
+        self, *, task_id: str, run_id: str | None = None
+    ) -> TaskRecord:
+        record = await self._task_repo.get_async(task_id)
         if run_id is not None and record.envelope.trace_id != run_id:
             raise KeyError(f"Task {task_id} does not belong to run {run_id}")
         return record

--- a/src/relay_teams/agents/tasks/task_repository.py
+++ b/src/relay_teams/agents/tasks/task_repository.py
@@ -4,19 +4,16 @@ import sqlite3
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
 from relay_teams.agents.tasks.enums import TaskStatus
 from relay_teams.agents.tasks.models import TaskEnvelope, TaskRecord
+from relay_teams.persistence import async_fetchall, async_fetchone
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 
-class TaskRepository:
+class TaskRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -45,21 +42,48 @@ class TaskRepository:
                 "CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id)"
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="TaskRepository",
+        self._run_write(
             operation_name="init_tables",
+            operation=operation,
+        )
+
+    async def _init_tables_async(self) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    task_id              TEXT PRIMARY KEY,
+                    trace_id             TEXT NOT NULL,
+                    session_id           TEXT NOT NULL,
+                    parent_task_id       TEXT,
+                    envelope_json        TEXT NOT NULL,
+                    status               TEXT NOT NULL,
+                    assigned_instance_id TEXT,
+                    result               TEXT,
+                    error_message        TEXT,
+                    created_at           TEXT NOT NULL,
+                    updated_at           TEXT NOT NULL
+                )
+                """
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tasks_trace ON tasks(trace_id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id)"
+            )
+
+        await self._run_async_write(
+            operation_name="init_tables_async",
+            operation=lambda _conn: operation(),
         )
 
     def create(self, envelope: TaskEnvelope) -> TaskRecord:
         now = datetime.now(tz=timezone.utc).isoformat()
         record = TaskRecord(envelope=envelope)
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="create",
             operation=lambda: self._conn.execute(
                 """
                 INSERT INTO tasks(task_id, trace_id, session_id, parent_task_id, envelope_json, status,
@@ -80,17 +104,47 @@ class TaskRepository:
                     now,
                 ),
             ),
-            lock=self._lock,
-            repository_name="TaskRepository",
-            operation_name="create",
+        )
+        return record
+
+    async def create_async(self, envelope: TaskEnvelope) -> TaskRecord:
+        now = datetime.now(tz=timezone.utc).isoformat()
+        record = TaskRecord(envelope=envelope)
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO tasks(task_id, trace_id, session_id, parent_task_id, envelope_json, status,
+                                  assigned_instance_id, result, error_message, created_at, updated_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    envelope.task_id,
+                    envelope.trace_id,
+                    envelope.session_id,
+                    envelope.parent_task_id,
+                    envelope.model_dump_json(),
+                    TaskStatus.CREATED.value,
+                    None,
+                    None,
+                    None,
+                    now,
+                    now,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="create_async",
+            operation=lambda _conn: operation(),
         )
         return record
 
     def update_envelope(self, task_id: str, envelope: TaskEnvelope) -> TaskRecord:
         now = datetime.now(tz=timezone.utc).isoformat()
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="update_envelope",
             operation=lambda: self._conn.execute(
                 """
                 UPDATE tasks
@@ -106,11 +160,38 @@ class TaskRepository:
                     task_id,
                 ),
             ),
-            lock=self._lock,
-            repository_name="TaskRepository",
-            operation_name="update_envelope",
         )
         return self.get(task_id)
+
+    async def update_envelope_async(
+        self, task_id: str, envelope: TaskEnvelope
+    ) -> TaskRecord:
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                UPDATE tasks
+                SET trace_id=?, session_id=?, parent_task_id=?, envelope_json=?, updated_at=?
+                WHERE task_id=?
+                """,
+                (
+                    envelope.trace_id,
+                    envelope.session_id,
+                    envelope.parent_task_id,
+                    envelope.model_dump_json(),
+                    now,
+                    task_id,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="update_envelope_async",
+            operation=lambda _conn: operation(),
+        )
+        return await self.get_async(task_id)
 
     def update_status(
         self,
@@ -177,13 +258,82 @@ class TaskRepository:
                 ),
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="TaskRepository",
+        self._run_write(
             operation_name="update_status",
+            operation=operation,
+        )
+
+    async def update_status_async(
+        self,
+        task_id: str,
+        status: TaskStatus,
+        assigned_instance_id: str | None = None,
+        result: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            row = await async_fetchone(
+                conn,
+                "SELECT assigned_instance_id, result, error_message FROM tasks WHERE task_id=?",
+                (task_id,),
+            )
+            if row is None:
+                raise KeyError(f"Unknown task_id: {task_id}")
+
+            next_assigned_instance_id = (
+                assigned_instance_id
+                if assigned_instance_id is not None
+                else (
+                    str(row["assigned_instance_id"])
+                    if row["assigned_instance_id"]
+                    else None
+                )
+            )
+
+            if result is not None:
+                next_result = result
+            elif status == TaskStatus.COMPLETED:
+                next_result = str(row["result"]) if row["result"] else None
+            else:
+                next_result = None
+
+            if error_message is not None:
+                next_error_message = error_message
+            elif status in {
+                TaskStatus.CREATED,
+                TaskStatus.ASSIGNED,
+                TaskStatus.RUNNING,
+                TaskStatus.COMPLETED,
+            }:
+                next_error_message = None
+            else:
+                next_error_message = (
+                    str(row["error_message"]) if row["error_message"] else None
+                )
+
+            cursor = await conn.execute(
+                """
+                UPDATE tasks
+                SET status=?, assigned_instance_id=?, result=?, error_message=?, updated_at=?
+                WHERE task_id=?
+                """,
+                (
+                    status.value,
+                    next_assigned_instance_id,
+                    next_result,
+                    next_error_message,
+                    now,
+                    task_id,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="update_status_async",
+            operation=lambda _conn: operation(),
         )
 
     def get(self, task_id: str) -> TaskRecord:
@@ -195,11 +345,32 @@ class TaskRepository:
             raise KeyError(f"Unknown task_id: {task_id}")
         return self._to_record(row)
 
+    async def get_async(self, task_id: str) -> TaskRecord:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT * FROM tasks WHERE task_id=?",
+                (task_id,),
+            )
+        )
+        if row is None:
+            raise KeyError(f"Unknown task_id: {task_id}")
+        return self._to_record(row)
+
     def list_all(self) -> tuple[TaskRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
                 "SELECT * FROM tasks ORDER BY created_at ASC"
             ).fetchall()
+        return tuple(self._to_record(row) for row in rows)
+
+    async def list_all_async(self) -> tuple[TaskRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM tasks ORDER BY created_at ASC",
+            )
+        )
         return tuple(self._to_record(row) for row in rows)
 
     def list_by_trace(self, trace_id: str) -> tuple[TaskRecord, ...]:
@@ -210,6 +381,16 @@ class TaskRepository:
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
 
+    async def list_by_trace_async(self, trace_id: str) -> tuple[TaskRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM tasks WHERE trace_id=? ORDER BY created_at ASC",
+                (trace_id,),
+            )
+        )
+        return tuple(self._to_record(row) for row in rows)
+
     def list_by_session(self, session_id: str) -> tuple[TaskRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -218,29 +399,58 @@ class TaskRepository:
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
 
+    async def list_by_session_async(self, session_id: str) -> tuple[TaskRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM tasks WHERE session_id=? ORDER BY created_at ASC",
+                (session_id,),
+            )
+        )
+        return tuple(self._to_record(row) for row in rows)
+
     def delete_by_session(self, session_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_session",
             operation=lambda: self._conn.execute(
                 "DELETE FROM tasks WHERE session_id=?", (session_id,)
             ),
-            lock=self._lock,
-            repository_name="TaskRepository",
-            operation_name="delete_by_session",
+        )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM tasks WHERE session_id=?", (session_id,)
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_session_async",
+            operation=lambda _conn: operation(),
         )
 
     def delete(self, task_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete",
             operation=lambda: self._conn.execute(
                 "DELETE FROM tasks WHERE task_id=?",
                 (task_id,),
             ),
-            lock=self._lock,
-            repository_name="TaskRepository",
-            operation_name="delete",
+        )
+
+    async def delete_async(self, task_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM tasks WHERE task_id=?",
+                (task_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_async",
+            operation=lambda _conn: operation(),
         )
 
     def _to_record(self, row: sqlite3.Row) -> TaskRecord:

--- a/src/relay_teams/automation/automation_bound_session_queue_repository.py
+++ b/src/relay_teams/automation/automation_bound_session_queue_repository.py
@@ -5,7 +5,6 @@ import json
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from threading import RLock
 
 from relay_teams.automation.automation_models import (
     AutomationBoundSessionQueueRecord,
@@ -15,7 +14,8 @@ from relay_teams.automation.automation_models import (
     AutomationFeishuBinding,
     AutomationRunConfig,
 )
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 _NON_TERMINAL_QUEUE_STATUSES = (
     AutomationBoundSessionQueueStatus.QUEUED.value,
@@ -24,12 +24,9 @@ _NON_TERMINAL_QUEUE_STATUSES = (
 )
 
 
-class AutomationBoundSessionQueueRepository:
+class AutomationBoundSessionQueueRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -179,6 +176,11 @@ class AutomationBoundSessionQueueRepository:
             )
         return stored
 
+    async def create_async(
+        self, record: AutomationBoundSessionQueueRecord
+    ) -> AutomationBoundSessionQueueRecord:
+        return await self._call_sync_async(self.create, record)
+
     def update(
         self,
         record: AutomationBoundSessionQueueRecord,
@@ -248,6 +250,11 @@ class AutomationBoundSessionQueueRepository:
             raise RuntimeError("Failed to reload automation bound session queue record")
         return stored
 
+    async def update_async(
+        self, record: AutomationBoundSessionQueueRecord
+    ) -> AutomationBoundSessionQueueRecord:
+        return await self._call_sync_async(self.update, record)
+
     def get(self, automation_queue_id: str) -> AutomationBoundSessionQueueRecord | None:
         with self._lock:
             row = self._conn.execute(
@@ -261,6 +268,11 @@ class AutomationBoundSessionQueueRepository:
         if row is None:
             return None
         return self._to_record(row)
+
+    async def get_async(
+        self, automation_queue_id: str
+    ) -> AutomationBoundSessionQueueRecord | None:
+        return await self._call_sync_async(self.get, automation_queue_id)
 
     def has_non_terminal_item_for_run(self, run_id: str) -> bool:
         if not str(run_id).strip():
@@ -278,6 +290,9 @@ class AutomationBoundSessionQueueRepository:
             ).fetchone()
         return row is not None
 
+    async def has_non_terminal_item_for_run_async(self, run_id: str) -> bool:
+        return await self._call_sync_async(self.has_non_terminal_item_for_run, run_id)
+
     def count_non_terminal_by_session(self, session_id: str) -> int:
         with self._lock:
             row = self._conn.execute(
@@ -290,6 +305,11 @@ class AutomationBoundSessionQueueRepository:
                 (session_id, *_NON_TERMINAL_QUEUE_STATUSES),
             ).fetchone()
         return int(row["total"]) if row is not None else 0
+
+    async def count_non_terminal_by_session_async(self, session_id: str) -> int:
+        return await self._call_sync_async(
+            self.count_non_terminal_by_session, session_id
+        )
 
     def count_non_terminal_ahead(self, automation_queue_id: str) -> int:
         with self._lock:
@@ -306,6 +326,11 @@ class AutomationBoundSessionQueueRepository:
                 (automation_queue_id, *_NON_TERMINAL_QUEUE_STATUSES),
             ).fetchone()
         return int(row["total"]) if row is not None else 0
+
+    async def count_non_terminal_ahead_async(self, automation_queue_id: str) -> int:
+        return await self._call_sync_async(
+            self.count_non_terminal_ahead, automation_queue_id
+        )
 
     def list_ready_to_start(
         self,
@@ -332,6 +357,13 @@ class AutomationBoundSessionQueueRepository:
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
 
+    async def list_ready_to_start_async(
+        self, *, ready_at: datetime, limit: int = 20
+    ) -> tuple[AutomationBoundSessionQueueRecord, ...]:
+        return await self._call_sync_async(
+            self.list_ready_to_start, ready_at=ready_at, limit=limit
+        )
+
     def list_waiting_for_result(
         self,
         *,
@@ -353,6 +385,11 @@ class AutomationBoundSessionQueueRepository:
                 ),
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_waiting_for_result_async(
+        self, *, limit: int = 20
+    ) -> tuple[AutomationBoundSessionQueueRecord, ...]:
+        return await self._call_sync_async(self.list_waiting_for_result, limit=limit)
 
     def claim_starting(
         self,
@@ -394,6 +431,15 @@ class AutomationBoundSessionQueueRepository:
             return None
         return self.get(automation_queue_id)
 
+    async def claim_starting_async(
+        self, *, automation_queue_id: str, stale_before: datetime
+    ) -> AutomationBoundSessionQueueRecord | None:
+        return await self._call_sync_async(
+            self.claim_starting,
+            automation_queue_id=automation_queue_id,
+            stale_before=stale_before,
+        )
+
     def list_pending_queue_cleanup(
         self,
         *,
@@ -432,6 +478,13 @@ class AutomationBoundSessionQueueRepository:
                     ),
                 ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_pending_queue_cleanup_async(
+        self, *, limit: int = 20, stale_before: datetime | None = None
+    ) -> tuple[AutomationBoundSessionQueueRecord, ...]:
+        return await self._call_sync_async(
+            self.list_pending_queue_cleanup, limit=limit, stale_before=stale_before
+        )
 
     def claim_queue_cleanup(
         self,
@@ -473,6 +526,15 @@ class AutomationBoundSessionQueueRepository:
             return None
         return self.get(automation_queue_id)
 
+    async def claim_queue_cleanup_async(
+        self, *, automation_queue_id: str, stale_before: datetime
+    ) -> AutomationBoundSessionQueueRecord | None:
+        return await self._call_sync_async(
+            self.claim_queue_cleanup,
+            automation_queue_id=automation_queue_id,
+            stale_before=stale_before,
+        )
+
     def has_project_records(self, automation_project_id: str) -> bool:
         with self._lock:
             row = self._conn.execute(
@@ -480,6 +542,11 @@ class AutomationBoundSessionQueueRepository:
                 (automation_project_id,),
             ).fetchone()
         return row is not None
+
+    async def has_project_records_async(self, automation_project_id: str) -> bool:
+        return await self._call_sync_async(
+            self.has_project_records, automation_project_id
+        )
 
     def delete_by_project(self, automation_project_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -495,6 +562,11 @@ class AutomationBoundSessionQueueRepository:
             lock=self._lock,
             repository_name="AutomationBoundSessionQueueRepository",
             operation_name="delete_by_project",
+        )
+
+    async def delete_by_project_async(self, automation_project_id: str) -> None:
+        return await self._call_sync_async(
+            self.delete_by_project, automation_project_id
         )
 
     def _to_row(self, record: AutomationBoundSessionQueueRecord) -> tuple[object, ...]:

--- a/src/relay_teams/automation/automation_delivery_repository.py
+++ b/src/relay_teams/automation/automation_delivery_repository.py
@@ -5,7 +5,6 @@ import json
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from threading import RLock
 
 from relay_teams.automation.automation_models import (
     AutomationDeliveryBinding,
@@ -15,15 +14,13 @@ from relay_teams.automation.automation_models import (
     AutomationRunDeliveryRecord,
     validate_automation_delivery_binding,
 )
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 
-class AutomationDeliveryRepository:
+class AutomationDeliveryRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -170,6 +167,11 @@ class AutomationDeliveryRepository:
         )
         return self.get_by_run_id(record.run_id)
 
+    async def create_async(
+        self, record: AutomationRunDeliveryRecord
+    ) -> AutomationRunDeliveryRecord:
+        return await self._call_sync_async(self.create, record)
+
     def update(
         self, record: AutomationRunDeliveryRecord
     ) -> AutomationRunDeliveryRecord:
@@ -239,6 +241,11 @@ class AutomationDeliveryRepository:
         )
         return self.get_by_run_id(record.run_id)
 
+    async def update_async(
+        self, record: AutomationRunDeliveryRecord
+    ) -> AutomationRunDeliveryRecord:
+        return await self._call_sync_async(self.update, record)
+
     def get_by_run_id(self, run_id: str) -> AutomationRunDeliveryRecord:
         row = self._conn.execute(
             "SELECT * FROM automation_deliveries WHERE run_id=?",
@@ -247,6 +254,9 @@ class AutomationDeliveryRepository:
         if row is None:
             raise KeyError(f"Unknown automation delivery run_id: {run_id}")
         return self._to_record(row)
+
+    async def get_by_run_id_async(self, run_id: str) -> AutomationRunDeliveryRecord:
+        return await self._call_sync_async(self.get_by_run_id, run_id)
 
     def list_pending_started(
         self,
@@ -284,6 +294,13 @@ class AutomationDeliveryRepository:
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
 
+    async def list_pending_started_async(
+        self, *, limit: int = 20, stale_before: datetime | None = None
+    ) -> tuple[AutomationRunDeliveryRecord, ...]:
+        return await self._call_sync_async(
+            self.list_pending_started, limit=limit, stale_before=stale_before
+        )
+
     def list_pending_terminal(
         self,
         *,
@@ -319,6 +336,13 @@ class AutomationDeliveryRepository:
                 ),
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_pending_terminal_async(
+        self, *, limit: int = 20, stale_before: datetime | None = None
+    ) -> tuple[AutomationRunDeliveryRecord, ...]:
+        return await self._call_sync_async(
+            self.list_pending_terminal, limit=limit, stale_before=stale_before
+        )
 
     def claim_started(
         self,
@@ -367,6 +391,15 @@ class AutomationDeliveryRepository:
             return None
         return self._to_record(row)
 
+    async def claim_started_async(
+        self, *, automation_delivery_id: str, stale_before: datetime
+    ) -> AutomationRunDeliveryRecord | None:
+        return await self._call_sync_async(
+            self.claim_started,
+            automation_delivery_id=automation_delivery_id,
+            stale_before=stale_before,
+        )
+
     def claim_terminal(
         self,
         *,
@@ -414,6 +447,15 @@ class AutomationDeliveryRepository:
             return None
         return self._to_record(row)
 
+    async def claim_terminal_async(
+        self, *, automation_delivery_id: str, stale_before: datetime
+    ) -> AutomationRunDeliveryRecord | None:
+        return await self._call_sync_async(
+            self.claim_terminal,
+            automation_delivery_id=automation_delivery_id,
+            stale_before=stale_before,
+        )
+
     def list_pending_started_cleanup(
         self,
         *,
@@ -449,6 +491,13 @@ class AutomationDeliveryRepository:
                 ),
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_pending_started_cleanup_async(
+        self, *, limit: int = 20, stale_before: datetime | None = None
+    ) -> tuple[AutomationRunDeliveryRecord, ...]:
+        return await self._call_sync_async(
+            self.list_pending_started_cleanup, limit=limit, stale_before=stale_before
+        )
 
     def claim_started_cleanup(
         self,
@@ -497,6 +546,15 @@ class AutomationDeliveryRepository:
             return None
         return self._to_record(row)
 
+    async def claim_started_cleanup_async(
+        self, *, automation_delivery_id: str, stale_before: datetime
+    ) -> AutomationRunDeliveryRecord | None:
+        return await self._call_sync_async(
+            self.claim_started_cleanup,
+            automation_delivery_id=automation_delivery_id,
+            stale_before=stale_before,
+        )
+
     def has_project_records(self, automation_project_id: str) -> bool:
         with self._lock:
             row = self._conn.execute(
@@ -504,6 +562,11 @@ class AutomationDeliveryRepository:
                 (automation_project_id,),
             ).fetchone()
         return row is not None
+
+    async def has_project_records_async(self, automation_project_id: str) -> bool:
+        return await self._call_sync_async(
+            self.has_project_records, automation_project_id
+        )
 
     def delete_by_project(self, automation_project_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -516,6 +579,11 @@ class AutomationDeliveryRepository:
             lock=self._lock,
             repository_name="AutomationDeliveryRepository",
             operation_name="delete_by_project",
+        )
+
+    async def delete_by_project_async(self, automation_project_id: str) -> None:
+        return await self._call_sync_async(
+            self.delete_by_project, automation_project_id
         )
 
     def _to_row(self, record: AutomationRunDeliveryRecord) -> tuple[object, ...]:

--- a/src/relay_teams/automation/automation_event_repository.py
+++ b/src/relay_teams/automation/automation_event_repository.py
@@ -95,5 +95,10 @@ class AutomationEventRepository(SharedSqliteRepository):
         )
         return record
 
+    async def create_event_async(
+        self, record: AutomationExecutionEventRecord
+    ) -> AutomationExecutionEventRecord:
+        return await self._call_sync_async(self.create_event, record)
+
 
 __all__ = ["AutomationEventRepository", "AutomationExecutionEventRecord"]

--- a/src/relay_teams/automation/automation_repository.py
+++ b/src/relay_teams/automation/automation_repository.py
@@ -120,6 +120,11 @@ class AutomationProjectRepository(SharedSqliteRepository):
             raise
         return record
 
+    async def create_async(
+        self, record: AutomationProjectRecord
+    ) -> AutomationProjectRecord:
+        return await self._call_sync_async(self.create, record)
+
     def update(self, record: AutomationProjectRecord) -> AutomationProjectRecord:
         try:
             self._run_write(
@@ -178,6 +183,11 @@ class AutomationProjectRepository(SharedSqliteRepository):
             raise
         return record
 
+    async def update_async(
+        self, record: AutomationProjectRecord
+    ) -> AutomationProjectRecord:
+        return await self._call_sync_async(self.update, record)
+
     def get(self, automation_project_id: str) -> AutomationProjectRecord:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -198,6 +208,9 @@ class AutomationProjectRepository(SharedSqliteRepository):
                 f"Unknown automation_project_id: {automation_project_id}"
             ) from exc
 
+    async def get_async(self, automation_project_id: str) -> AutomationProjectRecord:
+        return await self._call_sync_async(self.get, automation_project_id)
+
     def list_all(self) -> Tuple[AutomationProjectRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -210,6 +223,9 @@ class AutomationProjectRepository(SharedSqliteRepository):
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
+
+    async def list_all_async(self) -> Tuple[AutomationProjectRecord, ...]:
+        return await self._call_sync_async(self.list_all)
 
     def list_due(self, now: datetime) -> Tuple[AutomationProjectRecord, ...]:
         rows = self._run_read(
@@ -229,6 +245,11 @@ class AutomationProjectRepository(SharedSqliteRepository):
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
+    async def list_due_async(
+        self, now: datetime
+    ) -> Tuple[AutomationProjectRecord, ...]:
+        return await self._call_sync_async(self.list_due, now)
+
     def delete(self, automation_project_id: str) -> None:
         self._run_write(
             operation_name="delete",
@@ -240,6 +261,9 @@ class AutomationProjectRepository(SharedSqliteRepository):
                 (automation_project_id,),
             ),
         )
+
+    async def delete_async(self, automation_project_id: str) -> None:
+        return await self._call_sync_async(self.delete, automation_project_id)
 
     def _to_row(self, record: AutomationProjectRecord) -> Tuple[object, ...]:
         return (

--- a/src/relay_teams/external_agents/provider.py
+++ b/src/relay_teams/external_agents/provider.py
@@ -54,7 +54,7 @@ from relay_teams.reminders import SystemReminderService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.sessions.runs.enums import RunEventType
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.workspace import WorkspaceManager
 
@@ -256,7 +256,8 @@ class ExternalAcpSessionManager:
             state = _ActivePromptState(request=request)
             handle.active_prompt = state
             handle.host_tool_bridge.bind_active_request(request)
-            self._run_event_hub.publish(
+            await publish_run_event_async(
+                self._run_event_hub,
                 RunEvent(
                     session_id=request.session_id,
                     run_id=request.run_id,
@@ -272,7 +273,7 @@ class ExternalAcpSessionManager:
                         },
                         ensure_ascii=False,
                     ),
-                )
+                ),
             )
             output = ""
             try:
@@ -288,7 +289,8 @@ class ExternalAcpSessionManager:
                 raise
             finally:
                 if state.thinking_started:
-                    self._run_event_hub.publish(
+                    await publish_run_event_async(
+                        self._run_event_hub,
                         RunEvent(
                             session_id=request.session_id,
                             run_id=request.run_id,
@@ -305,9 +307,10 @@ class ExternalAcpSessionManager:
                                 },
                                 ensure_ascii=False,
                             ),
-                        )
+                        ),
                     )
-                self._run_event_hub.publish(
+                await publish_run_event_async(
+                    self._run_event_hub,
                     RunEvent(
                         session_id=request.session_id,
                         run_id=request.run_id,
@@ -323,7 +326,7 @@ class ExternalAcpSessionManager:
                             },
                             ensure_ascii=False,
                         ),
-                    )
+                    ),
                 )
                 handle.active_prompt = None
                 handle.host_tool_bridge.clear_active_request()
@@ -491,7 +494,10 @@ class ExternalAcpSessionManager:
                 },
             )
             state.text_chunks.append(fallback_output)
-            self._publish_text_delta(request=state.request, text=fallback_output)
+            await self._publish_text_delta(
+                request=state.request,
+                text=fallback_output,
+            )
             return
         log_event(
             LOGGER,
@@ -738,7 +744,7 @@ class ExternalAcpSessionManager:
         if method == "initialized":
             return {}
         if method == "session/update":
-            self._handle_session_update(
+            await self._handle_session_update(
                 key=key,
                 params=params,
             )
@@ -784,7 +790,7 @@ class ExternalAcpSessionManager:
                 raise AcpProtocolError(-32602, str(exc)) from exc
         raise AcpProtocolError(-32601, f"Method not found: {method}")
 
-    def _handle_session_update(
+    async def _handle_session_update(
         self,
         *,
         key: str,
@@ -802,7 +808,7 @@ class ExternalAcpSessionManager:
             if not text:
                 return
             handle.active_prompt.text_chunks.append(text)
-            self._publish_text_delta(request=request, text=text)
+            await self._publish_text_delta(request=request, text=text)
             return
         if update_name == "agent_thought_chunk":
             text = _extract_content_text(update.get("content"))
@@ -810,7 +816,8 @@ class ExternalAcpSessionManager:
                 return
             if not handle.active_prompt.thinking_started:
                 handle.active_prompt.thinking_started = True
-                self._run_event_hub.publish(
+                await publish_run_event_async(
+                    self._run_event_hub,
                     RunEvent(
                         session_id=request.session_id,
                         run_id=request.run_id,
@@ -827,9 +834,10 @@ class ExternalAcpSessionManager:
                             },
                             ensure_ascii=False,
                         ),
-                    )
+                    ),
                 )
-            self._run_event_hub.publish(
+            await publish_run_event_async(
+                self._run_event_hub,
                 RunEvent(
                     session_id=request.session_id,
                     run_id=request.run_id,
@@ -847,7 +855,7 @@ class ExternalAcpSessionManager:
                         },
                         ensure_ascii=False,
                     ),
-                )
+                ),
             )
             return
         if update_name == "tool_call":
@@ -858,7 +866,8 @@ class ExternalAcpSessionManager:
             raw_input = update.get("rawInput")
             if raw_input is not None:
                 payload["args"] = raw_input
-            self._run_event_hub.publish(
+            await publish_run_event_async(
+                self._run_event_hub,
                 RunEvent(
                     session_id=request.session_id,
                     run_id=request.run_id,
@@ -868,7 +877,7 @@ class ExternalAcpSessionManager:
                     role_id=request.role_id,
                     event_type=RunEventType.TOOL_CALL,
                     payload_json=json.dumps(payload, ensure_ascii=False, default=str),
-                )
+                ),
             )
             return
         if update_name == "tool_call_update":
@@ -879,7 +888,8 @@ class ExternalAcpSessionManager:
                 tool_result=tool_result,
             )
             handle.active_prompt.note_tool_result(tool_result)
-            self._run_event_hub.publish(
+            await publish_run_event_async(
+                self._run_event_hub,
                 RunEvent(
                     session_id=request.session_id,
                     run_id=request.run_id,
@@ -898,7 +908,7 @@ class ExternalAcpSessionManager:
                         ensure_ascii=False,
                         default=str,
                     ),
-                )
+                ),
             )
 
     def _resolve_workspace(self, request: LLMRequest):
@@ -1015,8 +1025,9 @@ class ExternalAcpSessionManager:
             {"sessionId": handle.external_session_id},
         )
 
-    def _publish_text_delta(self, *, request: LLMRequest, text: str) -> None:
-        self._run_event_hub.publish(
+    async def _publish_text_delta(self, *, request: LLMRequest, text: str) -> None:
+        await publish_run_event_async(
+            self._run_event_hub,
             RunEvent(
                 session_id=request.session_id,
                 run_id=request.run_id,
@@ -1033,7 +1044,7 @@ class ExternalAcpSessionManager:
                     },
                     ensure_ascii=False,
                 ),
-            )
+            ),
         )
 
     def _append_assistant_message(

--- a/src/relay_teams/external_agents/session_repository.py
+++ b/src/relay_teams/external_agents/session_repository.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
-import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from relay_teams.external_agents.models import ExternalAgentSessionRecord
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 
-class ExternalAgentSessionRepository:
+class ExternalAgentSessionRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -63,6 +59,13 @@ class ExternalAgentSessionRepository:
         if row is None:
             return None
         return ExternalAgentSessionRecord.model_validate(dict(row))
+
+    async def get_async(
+        self, *, session_id: str, role_id: str, agent_id: str
+    ) -> ExternalAgentSessionRecord | None:
+        return await self._call_sync_async(
+            self.get, session_id=session_id, role_id=role_id, agent_id=agent_id
+        )
 
     def upsert(self, record: ExternalAgentSessionRecord) -> ExternalAgentSessionRecord:
         next_record = record.model_copy(
@@ -119,6 +122,11 @@ class ExternalAgentSessionRepository:
             raise RuntimeError("Failed to persist external agent session")
         return persisted
 
+    async def upsert_async(
+        self, record: ExternalAgentSessionRecord
+    ) -> ExternalAgentSessionRecord:
+        return await self._call_sync_async(self.upsert, record)
+
     def delete(self, *, session_id: str, role_id: str, agent_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -133,4 +141,11 @@ class ExternalAgentSessionRepository:
             lock=self._lock,
             repository_name="ExternalAgentSessionRepository",
             operation_name="delete",
+        )
+
+    async def delete_async(
+        self, *, session_id: str, role_id: str, agent_id: str
+    ) -> None:
+        return await self._call_sync_async(
+            self.delete, session_id=session_id, role_id=role_id, agent_id=agent_id
         )

--- a/src/relay_teams/gateway/feishu/account_repository.py
+++ b/src/relay_teams/gateway/feishu/account_repository.py
@@ -6,7 +6,6 @@ import logging
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
-from threading import RLock
 
 from pydantic import JsonValue, ValidationError
 
@@ -17,7 +16,8 @@ from relay_teams.gateway.feishu.models import (
     FeishuGatewayAccountStatus,
 )
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.validation import (
     normalize_persisted_text,
     parse_persisted_datetime_or_none,
@@ -27,12 +27,9 @@ from relay_teams.validation import (
 LOGGER = get_logger(__name__)
 
 
-class FeishuAccountRepository:
+class FeishuAccountRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -167,6 +164,11 @@ class FeishuAccountRepository:
             raise
         return record
 
+    async def create_account_async(
+        self, record: FeishuGatewayAccountRecord
+    ) -> FeishuGatewayAccountRecord:
+        return await self._call_sync_async(self.create_account, record)
+
     def update_account(
         self,
         record: FeishuGatewayAccountRecord,
@@ -210,6 +212,11 @@ class FeishuAccountRepository:
             raise
         return record
 
+    async def update_account_async(
+        self, record: FeishuGatewayAccountRecord
+    ) -> FeishuGatewayAccountRecord:
+        return await self._call_sync_async(self.update_account, record)
+
     def get_account(self, account_id: str) -> FeishuGatewayAccountRecord:
         row = self._conn.execute(
             """
@@ -227,6 +234,9 @@ class FeishuAccountRepository:
             _log_invalid_feishu_account_row(row=row, error=exc)
             raise KeyError(f"Unknown Feishu account: {account_id}") from exc
 
+    async def get_account_async(self, account_id: str) -> FeishuGatewayAccountRecord:
+        return await self._call_sync_async(self.get_account, account_id)
+
     def list_accounts(self) -> tuple[FeishuGatewayAccountRecord, ...]:
         rows = self._conn.execute(
             """
@@ -243,6 +253,9 @@ class FeishuAccountRepository:
                 _log_invalid_feishu_account_row(row=row, error=exc)
         return tuple(records)
 
+    async def list_accounts_async(self) -> tuple[FeishuGatewayAccountRecord, ...]:
+        return await self._call_sync_async(self.list_accounts)
+
     def delete_account(self, account_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -255,6 +268,9 @@ class FeishuAccountRepository:
             repository_name="FeishuAccountRepository",
             operation_name="delete_account",
         )
+
+    async def delete_account_async(self, account_id: str) -> None:
+        return await self._call_sync_async(self.delete_account, account_id)
 
     @staticmethod
     def _row_to_record(row: sqlite3.Row) -> FeishuGatewayAccountRecord:

--- a/src/relay_teams/gateway/feishu/message_pool_repository.py
+++ b/src/relay_teams/gateway/feishu/message_pool_repository.py
@@ -6,7 +6,6 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic import JsonValue, ValidationError
 
@@ -16,7 +15,8 @@ from relay_teams.gateway.feishu.models import (
     FeishuMessageProcessingStatus,
 )
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.validation import (
     normalize_persisted_text,
     parse_persisted_datetime_or_none,
@@ -52,12 +52,9 @@ class FeishuMessageDuplicateError(ValueError):
         self.message_key = message_key
 
 
-class FeishuMessagePoolRepository:
+class FeishuMessagePoolRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -179,6 +176,11 @@ class FeishuMessagePoolRepository:
             return updated, False
         return created, True
 
+    async def create_or_get_async(
+        self, record: FeishuMessagePoolRecord
+    ) -> tuple[FeishuMessagePoolRecord, bool]:
+        return await self._call_sync_async(self.create_or_get, record)
+
     def _create(self, record: FeishuMessagePoolRecord) -> FeishuMessagePoolRecord:
         def operation() -> None:
             self._conn.execute(
@@ -276,6 +278,9 @@ class FeishuMessagePoolRepository:
             return None
         return self._record_or_none(row)
 
+    async def get_async(self, message_pool_id: str) -> FeishuMessagePoolRecord | None:
+        return await self._call_sync_async(self.get, message_pool_id)
+
     def get_by_message_key(
         self,
         *,
@@ -306,6 +311,16 @@ class FeishuMessagePoolRepository:
             f"trigger_id={trigger_id}, tenant_key={tenant_key}, message_key={message_key}"
         )
 
+    async def get_by_message_key_async(
+        self, *, trigger_id: str, tenant_key: str, message_key: str
+    ) -> FeishuMessagePoolRecord:
+        return await self._call_sync_async(
+            self.get_by_message_key,
+            trigger_id=trigger_id,
+            tenant_key=tenant_key,
+            message_key=message_key,
+        )
+
     def get_latest_by_run_id(self, run_id: str) -> FeishuMessagePoolRecord | None:
         with self._lock:
             rows = self._conn.execute(
@@ -321,6 +336,11 @@ class FeishuMessagePoolRepository:
             if (record := self._record_or_none(row)) is not None:
                 return record
         return None
+
+    async def get_latest_by_run_id_async(
+        self, run_id: str
+    ) -> FeishuMessagePoolRecord | None:
+        return await self._call_sync_async(self.get_latest_by_run_id, run_id)
 
     def update(
         self,
@@ -431,6 +451,11 @@ class FeishuMessagePoolRepository:
             )
         return stored
 
+    async def update_async(
+        self, message_pool_id: str, **changes: object
+    ) -> FeishuMessagePoolRecord:
+        return await self._call_sync_async(self.update, message_pool_id, **changes)
+
     def count_active_chat_messages_ahead(self, message_pool_id: str) -> int:
         with self._lock:
             row = self._conn.execute(
@@ -448,6 +473,11 @@ class FeishuMessagePoolRepository:
                 (message_pool_id, *_ACTIVE_PROCESSING_STATUSES),
             ).fetchone()
         return int(row["total"]) if row is not None else 0
+
+    async def count_active_chat_messages_ahead_async(self, message_pool_id: str) -> int:
+        return await self._call_sync_async(
+            self.count_active_chat_messages_ahead, message_pool_id
+        )
 
     def list_ready_for_processing(
         self,
@@ -488,6 +518,13 @@ class FeishuMessagePoolRepository:
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
+    async def list_ready_for_processing_async(
+        self, *, ready_at: datetime, limit: int = 20
+    ) -> tuple[FeishuMessagePoolRecord, ...]:
+        return await self._call_sync_async(
+            self.list_ready_for_processing, ready_at=ready_at, limit=limit
+        )
+
     def list_waiting_for_result(
         self,
         *,
@@ -512,6 +549,11 @@ class FeishuMessagePoolRepository:
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
+    async def list_waiting_for_result_async(
+        self, *, limit: int = 20
+    ) -> tuple[FeishuMessagePoolRecord, ...]:
+        return await self._call_sync_async(self.list_waiting_for_result, limit=limit)
+
     def list_pending_acknowledgements(
         self,
         *,
@@ -534,6 +576,13 @@ class FeishuMessagePoolRepository:
             ).fetchall()
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
+        )
+
+    async def list_pending_acknowledgements_async(
+        self, *, limit: int = 20
+    ) -> tuple[FeishuMessagePoolRecord, ...]:
+        return await self._call_sync_async(
+            self.list_pending_acknowledgements, limit=limit
         )
 
     def list_pending_reactions(
@@ -560,6 +609,11 @@ class FeishuMessagePoolRepository:
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
+    async def list_pending_reactions_async(
+        self, *, limit: int = 20
+    ) -> tuple[FeishuMessagePoolRecord, ...]:
+        return await self._call_sync_async(self.list_pending_reactions, limit=limit)
+
     def list_active_chat_messages(
         self,
         *,
@@ -582,6 +636,16 @@ class FeishuMessagePoolRepository:
             ).fetchall()
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
+        )
+
+    async def list_active_chat_messages_async(
+        self, *, trigger_id: str, tenant_key: str, chat_id: str
+    ) -> tuple[FeishuMessagePoolRecord, ...]:
+        return await self._call_sync_async(
+            self.list_active_chat_messages,
+            trigger_id=trigger_id,
+            tenant_key=tenant_key,
+            chat_id=chat_id,
         )
 
     def get_chat_status_counts(
@@ -619,6 +683,16 @@ class FeishuMessagePoolRepository:
             status = FeishuMessageProcessingStatus(str(row["processing_status"]))
             counts[status] = int(row["total"])
         return counts
+
+    async def get_chat_status_counts_async(
+        self, *, trigger_id: str, tenant_key: str, chat_id: str
+    ) -> dict[FeishuMessageProcessingStatus, int]:
+        return await self._call_sync_async(
+            self.get_chat_status_counts,
+            trigger_id=trigger_id,
+            tenant_key=tenant_key,
+            chat_id=chat_id,
+        )
 
     def cancel_active_chat_messages(
         self,
@@ -676,6 +750,17 @@ class FeishuMessagePoolRepository:
         )
         return affected
 
+    async def cancel_active_chat_messages_async(
+        self, *, trigger_id: str, tenant_key: str, chat_id: str, cancelled_at: datetime
+    ) -> int:
+        return await self._call_sync_async(
+            self.cancel_active_chat_messages,
+            trigger_id=trigger_id,
+            tenant_key=tenant_key,
+            chat_id=chat_id,
+            cancelled_at=cancelled_at,
+        )
+
     def recover_stale_claims(self, *, claimed_before: datetime) -> int:
         affected = 0
 
@@ -710,6 +795,11 @@ class FeishuMessagePoolRepository:
             operation_name="recover_stale_claims",
         )
         return affected
+
+    async def recover_stale_claims_async(self, *, claimed_before: datetime) -> int:
+        return await self._call_sync_async(
+            self.recover_stale_claims, claimed_before=claimed_before
+        )
 
     def _row_to_record(self, row: sqlite3.Row) -> FeishuMessagePoolRecord:
         message_pool_id = require_persisted_identifier(

--- a/src/relay_teams/gateway/gateway_session_repository.py
+++ b/src/relay_teams/gateway/gateway_session_repository.py
@@ -123,6 +123,9 @@ class GatewaySessionRepository(SharedSqliteRepository):
         )
         return record
 
+    async def create_async(self, record: GatewaySessionRecord) -> GatewaySessionRecord:
+        return await self._call_sync_async(self.create, record)
+
     def get(self, gateway_session_id: str) -> GatewaySessionRecord:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -137,6 +140,9 @@ class GatewaySessionRepository(SharedSqliteRepository):
         except (ValidationError, ValueError, json.JSONDecodeError) as exc:
             _log_invalid_gateway_session_row(row=row, error=exc)
             raise KeyError(f"Unknown gateway_session_id: {gateway_session_id}") from exc
+
+    async def get_async(self, gateway_session_id: str) -> GatewaySessionRecord:
+        return await self._call_sync_async(self.get, gateway_session_id)
 
     def get_by_external(
         self,
@@ -157,6 +163,15 @@ class GatewaySessionRepository(SharedSqliteRepository):
             return None
         return self._record_or_none(row, fallback_invalid_timestamps=True)
 
+    async def get_by_external_async(
+        self, *, channel_type: GatewayChannelType, external_session_id: str
+    ) -> GatewaySessionRecord | None:
+        return await self._call_sync_async(
+            self.get_by_external,
+            channel_type=channel_type,
+            external_session_id=external_session_id,
+        )
+
     def get_by_internal_session_id(
         self,
         internal_session_id: str,
@@ -176,6 +191,13 @@ class GatewaySessionRepository(SharedSqliteRepository):
             if record is not None:
                 return record
         return None
+
+    async def get_by_internal_session_id_async(
+        self, internal_session_id: str
+    ) -> GatewaySessionRecord | None:
+        return await self._call_sync_async(
+            self.get_by_internal_session_id, internal_session_id
+        )
 
     def update(self, record: GatewaySessionRecord) -> GatewaySessionRecord:
         rowcount = self._run_write(
@@ -230,6 +252,9 @@ class GatewaySessionRepository(SharedSqliteRepository):
             raise KeyError(f"Unknown gateway_session_id: {record.gateway_session_id}")
         return record
 
+    async def update_async(self, record: GatewaySessionRecord) -> GatewaySessionRecord:
+        return await self._call_sync_async(self.update, record)
+
     def list_all(self) -> tuple[GatewaySessionRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -239,6 +264,9 @@ class GatewaySessionRepository(SharedSqliteRepository):
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
+
+    async def list_all_async(self) -> tuple[GatewaySessionRecord, ...]:
+        return await self._call_sync_async(self.list_all)
 
     def _to_record(
         self,

--- a/src/relay_teams/gateway/wechat/account_repository.py
+++ b/src/relay_teams/gateway/wechat/account_repository.py
@@ -6,12 +6,12 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic import JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.gateway.wechat.models import (
     WeChatAccountRecord,
     WeChatAccountStatus,
@@ -25,12 +25,9 @@ from relay_teams.validation import (
 LOGGER = get_logger(__name__)
 
 
-class WeChatAccountRepository:
+class WeChatAccountRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -80,6 +77,9 @@ class WeChatAccountRepository:
                 _log_invalid_wechat_account_row(row=row, error=exc)
         return tuple(records)
 
+    async def list_accounts_async(self) -> tuple[WeChatAccountRecord, ...]:
+        return await self._call_sync_async(self.list_accounts)
+
     def get_account(self, account_id: str) -> WeChatAccountRecord:
         row = self._conn.execute(
             "SELECT * FROM wechat_accounts WHERE account_id=?",
@@ -92,6 +92,9 @@ class WeChatAccountRepository:
         except (ValidationError, ValueError, json.JSONDecodeError) as exc:
             _log_invalid_wechat_account_row(row=row, error=exc)
             raise KeyError(f"Unknown account_id: {account_id}") from exc
+
+    async def get_account_async(self, account_id: str) -> WeChatAccountRecord:
+        return await self._call_sync_async(self.get_account, account_id)
 
     def upsert_account(self, record: WeChatAccountRecord) -> WeChatAccountRecord:
         run_sqlite_write_with_retry(
@@ -166,6 +169,11 @@ class WeChatAccountRepository:
         )
         return self.get_account(record.account_id)
 
+    async def upsert_account_async(
+        self, record: WeChatAccountRecord
+    ) -> WeChatAccountRecord:
+        return await self._call_sync_async(self.upsert_account, record)
+
     def delete_account(self, account_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -178,6 +186,9 @@ class WeChatAccountRepository:
             repository_name="WeChatAccountRepository",
             operation_name="delete_account",
         )
+
+    async def delete_account_async(self, account_id: str) -> None:
+        return await self._call_sync_async(self.delete_account, account_id)
 
     def _to_record(
         self,

--- a/src/relay_teams/gateway/wechat/inbound_queue_repository.py
+++ b/src/relay_teams/gateway/wechat/inbound_queue_repository.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from relay_teams.gateway.wechat.models import (
     WeChatInboundQueueRecord,
     WeChatInboundQueueStatus,
 )
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 _NON_TERMINAL_QUEUE_STATUSES = (
     WeChatInboundQueueStatus.QUEUED.value,
@@ -30,12 +30,9 @@ class WeChatInboundQueueDuplicateError(ValueError):
         )
 
 
-class WeChatInboundQueueRepository:
+class WeChatInboundQueueRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -104,6 +101,11 @@ class WeChatInboundQueueRepository:
                 ),
                 False,
             )
+
+    async def create_or_get_async(
+        self, record: WeChatInboundQueueRecord
+    ) -> tuple[WeChatInboundQueueRecord, bool]:
+        return await self._call_sync_async(self.create_or_get, record)
 
     def _create(
         self,
@@ -225,6 +227,11 @@ class WeChatInboundQueueRepository:
             )
         return stored
 
+    async def update_async(
+        self, record: WeChatInboundQueueRecord
+    ) -> WeChatInboundQueueRecord:
+        return await self._call_sync_async(self.update, record)
+
     def get(self, inbound_queue_id: str) -> WeChatInboundQueueRecord | None:
         with self._lock:
             row = self._conn.execute(
@@ -238,6 +245,9 @@ class WeChatInboundQueueRepository:
         if row is None:
             return None
         return self._to_record(row)
+
+    async def get_async(self, inbound_queue_id: str) -> WeChatInboundQueueRecord | None:
+        return await self._call_sync_async(self.get, inbound_queue_id)
 
     def get_by_message_key(
         self,
@@ -265,6 +275,16 @@ class WeChatInboundQueueRepository:
             )
         return self._to_record(row)
 
+    async def get_by_message_key_async(
+        self, *, account_id: str, peer_user_id: str, message_key: str
+    ) -> WeChatInboundQueueRecord:
+        return await self._call_sync_async(
+            self.get_by_message_key,
+            account_id=account_id,
+            peer_user_id=peer_user_id,
+            message_key=message_key,
+        )
+
     def get_latest_by_run_id(self, run_id: str) -> WeChatInboundQueueRecord | None:
         if not str(run_id).strip():
             return None
@@ -283,6 +303,11 @@ class WeChatInboundQueueRepository:
             return None
         return self._to_record(row)
 
+    async def get_latest_by_run_id_async(
+        self, run_id: str
+    ) -> WeChatInboundQueueRecord | None:
+        return await self._call_sync_async(self.get_latest_by_run_id, run_id)
+
     def has_non_terminal_item_for_run(self, run_id: str) -> bool:
         if not str(run_id).strip():
             return False
@@ -299,6 +324,9 @@ class WeChatInboundQueueRepository:
             ).fetchone()
         return row is not None
 
+    async def has_non_terminal_item_for_run_async(self, run_id: str) -> bool:
+        return await self._call_sync_async(self.has_non_terminal_item_for_run, run_id)
+
     def count_non_terminal_by_session(self, session_id: str) -> int:
         with self._lock:
             row = self._conn.execute(
@@ -311,6 +339,11 @@ class WeChatInboundQueueRepository:
                 (session_id, *_NON_TERMINAL_QUEUE_STATUSES),
             ).fetchone()
         return int(row["total"]) if row is not None else 0
+
+    async def count_non_terminal_by_session_async(self, session_id: str) -> int:
+        return await self._call_sync_async(
+            self.count_non_terminal_by_session, session_id
+        )
 
     def count_non_terminal_ahead(self, inbound_queue_id: str) -> int:
         with self._lock:
@@ -327,6 +360,11 @@ class WeChatInboundQueueRepository:
                 (inbound_queue_id, *_NON_TERMINAL_QUEUE_STATUSES),
             ).fetchone()
         return int(row["total"]) if row is not None else 0
+
+    async def count_non_terminal_ahead_async(self, inbound_queue_id: str) -> int:
+        return await self._call_sync_async(
+            self.count_non_terminal_ahead, inbound_queue_id
+        )
 
     def list_ready_to_start(
         self,
@@ -368,6 +406,13 @@ class WeChatInboundQueueRepository:
                     ),
                 ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_ready_to_start_async(
+        self, *, limit: int = 20, stale_before: datetime | None = None
+    ) -> tuple[WeChatInboundQueueRecord, ...]:
+        return await self._call_sync_async(
+            self.list_ready_to_start, limit=limit, stale_before=stale_before
+        )
 
     def claim_starting(
         self,
@@ -412,6 +457,15 @@ class WeChatInboundQueueRepository:
             return None
         return self.get(inbound_queue_id)
 
+    async def claim_starting_async(
+        self, *, inbound_queue_id: str, stale_before: datetime
+    ) -> WeChatInboundQueueRecord | None:
+        return await self._call_sync_async(
+            self.claim_starting,
+            inbound_queue_id=inbound_queue_id,
+            stale_before=stale_before,
+        )
+
     def requeue_if_starting(
         self,
         *,
@@ -452,6 +506,15 @@ class WeChatInboundQueueRepository:
         if updated <= 0:
             return None
         return self.get(inbound_queue_id)
+
+    async def requeue_if_starting_async(
+        self, *, inbound_queue_id: str, last_error: str | None = None
+    ) -> WeChatInboundQueueRecord | None:
+        return await self._call_sync_async(
+            self.requeue_if_starting,
+            inbound_queue_id=inbound_queue_id,
+            last_error=last_error,
+        )
 
     def _to_record(self, row: sqlite3.Row) -> WeChatInboundQueueRecord:
         return WeChatInboundQueueRecord(

--- a/src/relay_teams/gateway/xiaoluban/account_repository.py
+++ b/src/relay_teams/gateway/xiaoluban/account_repository.py
@@ -6,7 +6,6 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 from typing import Dict, List, Tuple
 
 from pydantic import JsonValue, ValidationError
@@ -16,7 +15,8 @@ from relay_teams.gateway.xiaoluban.models import (
     XiaolubanAccountStatus,
 )
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.validation import (
     normalize_identifier_tuple,
     parse_persisted_datetime_or_none,
@@ -26,12 +26,9 @@ from relay_teams.validation import (
 LOGGER = get_logger(__name__)
 
 
-class XiaolubanAccountRepository:
+class XiaolubanAccountRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -89,6 +86,9 @@ class XiaolubanAccountRepository:
                 _log_invalid_row(row=row, error=exc)
         return tuple(records)
 
+    async def list_accounts_async(self) -> Tuple[XiaolubanAccountRecord, ...]:
+        return await self._call_sync_async(self.list_accounts)
+
     def get_account(self, account_id: str) -> XiaolubanAccountRecord:
         row = self._conn.execute(
             "SELECT * FROM xiaoluban_accounts WHERE account_id=?",
@@ -101,6 +101,9 @@ class XiaolubanAccountRepository:
         except (ValidationError, ValueError) as exc:
             _log_invalid_row(row=row, error=exc)
             raise KeyError(f"Unknown Xiaoluban account_id: {account_id}") from exc
+
+    async def get_account_async(self, account_id: str) -> XiaolubanAccountRecord:
+        return await self._call_sync_async(self.get_account, account_id)
 
     def upsert_account(self, record: XiaolubanAccountRecord) -> XiaolubanAccountRecord:
         run_sqlite_write_with_retry(
@@ -147,6 +150,11 @@ class XiaolubanAccountRepository:
         )
         return self.get_account(record.account_id)
 
+    async def upsert_account_async(
+        self, record: XiaolubanAccountRecord
+    ) -> XiaolubanAccountRecord:
+        return await self._call_sync_async(self.upsert_account, record)
+
     def delete_account(self, account_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -159,6 +167,9 @@ class XiaolubanAccountRepository:
             repository_name="XiaolubanAccountRepository",
             operation_name="delete_account",
         )
+
+    async def delete_account_async(self, account_id: str) -> None:
+        return await self._call_sync_async(self.delete_account, account_id)
 
     @staticmethod
     def _to_record(row: sqlite3.Row) -> XiaolubanAccountRecord:

--- a/src/relay_teams/interfaces/server/async_call.py
+++ b/src/relay_teams/interfaces/server/async_call.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import ParamSpec, TypeVar
+
+ParamT = ParamSpec("ParamT")
+ResultT = TypeVar("ResultT")
+
+
+async def call_maybe_async(
+    function: Callable[ParamT, ResultT | Awaitable[ResultT]],
+    /,
+    *args: ParamT.args,
+    **kwargs: ParamT.kwargs,
+) -> ResultT:
+    if inspect.iscoroutinefunction(function):
+        result = function(*args, **kwargs)
+    else:
+        result = await asyncio.to_thread(function, *args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from pathlib import Path
-from typing import FrozenSet, List, Optional, Tuple
+from typing import FrozenSet, List, Optional, Protocol, Tuple
 
 from relay_teams.agents.execution.prompt_instructions import PromptInstructionResolver
 from relay_teams.automation.automation_bound_session_queue_repository import (
@@ -122,7 +122,10 @@ from relay_teams.providers.model_fallback_config_manager import (
     ModelFallbackConfigManager,
 )
 from relay_teams.providers.model_fallback import LlmFallbackMiddleware
-from relay_teams.net.llm_client import clear_llm_http_client_cache
+from relay_teams.net import (
+    clear_llm_http_client_cache,
+    clear_llm_http_client_cache_async,
+)
 from relay_teams.net.clawhub_connectivity import ClawHubConnectivityProbeService
 from relay_teams.net.github_connectivity import (
     GitHubConnectivityProbeService,
@@ -236,6 +239,10 @@ from relay_teams.workspace import (
 
 
 LOGGER = get_logger(__name__)
+
+
+class AsyncCloseableRepository(Protocol):
+    async def close_async(self) -> None: ...
 
 
 class ServerContainer:
@@ -978,6 +985,45 @@ class ServerContainer:
             config_dir=app_config_dir,
             on_skill_mutated=self._reload_skills_config,
         )
+        self._async_closeables: tuple[AsyncCloseableRepository, ...] = (
+            self.task_repo,
+            self.shared_store,
+            self.workspace_repo,
+            self.ssh_profile_repo,
+            self.media_asset_repo,
+            self.event_log,
+            self.agent_repo,
+            self.session_history_marker_repo,
+            self.message_repo,
+            self.approval_ticket_repo,
+            self.user_question_repo,
+            self.shell_approval_repo,
+            self.run_runtime_repo,
+            self.run_intent_repo,
+            self.background_task_repository,
+            self.todo_repository,
+            self.run_state_repo,
+            self.trigger_repository,
+            self.session_repo,
+            self.external_session_binding_repo,
+            self.external_agent_session_repo,
+            self.gateway_session_repository,
+            self.token_usage_repo,
+            self.metrics_store,
+            self.retrieval_store,
+            self.feishu_message_pool_repo,
+            self.feishu_account_repository,
+            self.automation_repo,
+            self.automation_event_repo,
+            self.automation_delivery_repo,
+            self.automation_bound_session_queue_repo,
+            self.role_memory_repo,
+            self.temporary_role_repo,
+            self.monitor_repository,
+            self.xiaoluban_account_repository,
+            self.wechat_account_repository,
+            self.wechat_inbound_queue_repo,
+        )
 
     def _build_runtime_services(self) -> None:
         def get_task_execution_service() -> TaskExecutionService:
@@ -1163,7 +1209,20 @@ class ServerContainer:
         self.localhost_run_tunnel_service.stop()
         await self.external_acp_session_manager.close()
         await self.background_task_manager.close()
+        await self._close_async_repositories()
+        await clear_llm_http_client_cache_async()
         return None
+
+    async def _close_async_repositories(self) -> None:
+        for repository in reversed(self._async_closeables):
+            # noinspection PyBroadException
+            try:
+                await repository.close_async()
+            except Exception:
+                LOGGER.warning(
+                    "Failed to close async SQLite repository connection",
+                    exc_info=True,
+                )
 
     def _sanitize_role_registry(self, role_registry: RoleRegistry) -> RoleRegistry:
         sanitized_registry = RoleRegistry()

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -242,7 +242,8 @@ LOGGER = get_logger(__name__)
 
 
 class AsyncCloseableRepository(Protocol):
-    async def close_async(self) -> None: ...
+    async def close_async(self) -> None:
+        pass
 
 
 class ServerContainer:

--- a/src/relay_teams/interfaces/server/routers/automation.py
+++ b/src/relay_teams/interfaces/server/routers/automation.py
@@ -4,8 +4,8 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import JsonValue
-from starlette.concurrency import run_in_threadpool
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.automation import (
     AutomationDeliveryBindingCandidate,
     AutomationFeishuBindingCandidate,
@@ -31,7 +31,7 @@ router = APIRouter(prefix="/automation", tags=["Automation"])
 async def list_delivery_bindings(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> list[AutomationDeliveryBindingCandidate]:
-    bindings = await run_in_threadpool(service.list_delivery_bindings)
+    bindings = await call_maybe_async(service.list_delivery_bindings)
     return list(bindings)
 
 
@@ -39,7 +39,7 @@ async def list_delivery_bindings(
 async def list_feishu_bindings(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> list[AutomationFeishuBindingCandidate]:
-    bindings = await run_in_threadpool(service.list_feishu_bindings)
+    bindings = await call_maybe_async(service.list_feishu_bindings)
     return list(bindings)
 
 
@@ -49,7 +49,7 @@ async def create_project(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
     try:
-        return await run_in_threadpool(service.create_project, req)
+        return await call_maybe_async(service.create_project, req)
     except (AutomationProjectNameConflictError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -61,7 +61,7 @@ async def create_project(
 async def list_projects(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> list[AutomationProjectRecord]:
-    projects = await run_in_threadpool(service.list_projects)
+    projects = await call_maybe_async(service.list_projects)
     return list(projects)
 
 
@@ -71,7 +71,7 @@ async def get_project(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
     try:
-        return await run_in_threadpool(service.get_project, automation_project_id)
+        return await call_maybe_async(service.get_project, automation_project_id)
     except KeyError as exc:
         raise http_exception_for(exc) from exc
 
@@ -85,7 +85,7 @@ async def update_project(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             service.update_project,
             automation_project_id,
             req,
@@ -104,7 +104,7 @@ async def delete_project(
     req: DeleteRequest | None = Body(default=None),
 ) -> dict[str, JsonValue]:
     try:
-        await run_in_threadpool(
+        await call_maybe_async(
             service.delete_project,
             automation_project_id,
             force=req.force if req is not None else False,
@@ -124,7 +124,7 @@ async def run_project(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> dict[str, JsonValue]:
     try:
-        return await run_in_threadpool(service.run_now, automation_project_id)
+        return await call_maybe_async(service.run_now, automation_project_id)
     except (KeyError, RuntimeError) as exc:
         raise http_exception_for(
             exc,
@@ -140,7 +140,7 @@ async def enable_project(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             service.set_project_status,
             automation_project_id,
             AutomationProjectStatus.ENABLED,
@@ -161,7 +161,7 @@ async def disable_project(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> AutomationProjectRecord:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             service.set_project_status,
             automation_project_id,
             AutomationProjectStatus.DISABLED,
@@ -176,7 +176,7 @@ async def list_project_sessions(
     service: Annotated[AutomationService, Depends(get_automation_service)],
 ) -> list[dict[str, object]]:
     try:
-        sessions = await run_in_threadpool(
+        sessions = await call_maybe_async(
             service.list_project_sessions,
             automation_project_id,
         )

--- a/src/relay_teams/interfaces/server/routers/feishu_gateway.py
+++ b/src/relay_teams/interfaces/server/routers/feishu_gateway.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException
-from starlette.concurrency import run_in_threadpool
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.gateway.feishu.errors import FeishuAccountNameConflictError
 from relay_teams.gateway.feishu.gateway_service import FeishuGatewayService
 from relay_teams.gateway.feishu.models import (
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/gateway/feishu", tags=["Gateway"])
 async def list_feishu_accounts(
     service: Annotated[FeishuGatewayService, Depends(get_feishu_gateway_service)],
 ) -> list[FeishuGatewayAccountRecord]:
-    accounts = await run_in_threadpool(service.list_accounts)
+    accounts = await call_maybe_async(service.list_accounts)
     return list(accounts)
 
 
@@ -49,7 +49,7 @@ async def create_feishu_account(
             subscription_service.reload()
             return created
 
-        return await run_in_threadpool(_create_feishu_account)
+        return await call_maybe_async(_create_feishu_account)
     except (FeishuAccountNameConflictError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -80,7 +80,7 @@ async def update_feishu_account(
                 subscription_service.reload()
             return updated
 
-        return await run_in_threadpool(_update_feishu_account)
+        return await call_maybe_async(_update_feishu_account)
     except (KeyError, FeishuAccountNameConflictError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -104,7 +104,7 @@ async def enable_feishu_account(
             subscription_service.reload()
             return updated
 
-        return await run_in_threadpool(_enable_feishu_account)
+        return await call_maybe_async(_enable_feishu_account)
     except (KeyError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -130,7 +130,7 @@ async def disable_feishu_account(
             subscription_service.reload()
             return updated
 
-        return await run_in_threadpool(_disable_feishu_account)
+        return await call_maybe_async(_disable_feishu_account)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -154,7 +154,7 @@ async def delete_feishu_account(
             )
             subscription_service.reload()
 
-        await run_in_threadpool(_delete_feishu_account)
+        await call_maybe_async(_delete_feishu_account)
         return {"status": "ok"}
     except (KeyError, RuntimeError) as exc:
         raise http_exception_for(
@@ -170,5 +170,5 @@ async def reload_feishu_gateway(
         Depends(get_feishu_subscription_service),
     ],
 ) -> dict[str, str]:
-    await run_in_threadpool(subscription_service.reload)
+    await call_maybe_async(subscription_service.reload)
     return {"status": "ok"}

--- a/src/relay_teams/interfaces/server/routers/gateway.py
+++ b/src/relay_teams/interfaces/server/routers/gateway.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.gateway.wechat.models import (
     WeChatAccountRecord,
     WeChatAccountUpdateInput,
@@ -35,7 +35,7 @@ router = APIRouter(prefix="/gateway", tags=["Gateway"])
 async def list_wechat_accounts(
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> list[WeChatAccountRecord]:
-    accounts = await asyncio.to_thread(service.list_accounts)
+    accounts = await call_maybe_async(service.list_accounts)
     return list(accounts)
 
 
@@ -43,7 +43,7 @@ async def list_wechat_accounts(
 async def list_xiaoluban_accounts(
     service: Annotated[XiaolubanGatewayService, Depends(get_xiaoluban_gateway_service)],
 ) -> list[XiaolubanAccountRecord]:
-    accounts = await asyncio.to_thread(service.list_accounts)
+    accounts = await call_maybe_async(service.list_accounts)
     return list(accounts)
 
 
@@ -53,7 +53,7 @@ async def create_xiaoluban_account(
     service: Annotated[XiaolubanGatewayService, Depends(get_xiaoluban_gateway_service)],
 ) -> XiaolubanAccountRecord:
     try:
-        return await asyncio.to_thread(service.create_account, req)
+        return await call_maybe_async(service.create_account, req)
     except ValueError as exc:
         raise http_exception_for(exc, mappings=((ValueError, 422),)) from exc
 
@@ -65,7 +65,7 @@ async def update_xiaoluban_account(
     service: Annotated[XiaolubanGatewayService, Depends(get_xiaoluban_gateway_service)],
 ) -> XiaolubanAccountRecord:
     try:
-        return await asyncio.to_thread(service.update_account, account_id, req)
+        return await call_maybe_async(service.update_account, account_id, req)
     except (KeyError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -82,7 +82,7 @@ async def enable_xiaoluban_account(
     service: Annotated[XiaolubanGatewayService, Depends(get_xiaoluban_gateway_service)],
 ) -> XiaolubanAccountRecord:
     try:
-        return await asyncio.to_thread(service.set_account_enabled, account_id, True)
+        return await call_maybe_async(service.set_account_enabled, account_id, True)
     except (KeyError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -99,7 +99,7 @@ async def disable_xiaoluban_account(
     service: Annotated[XiaolubanGatewayService, Depends(get_xiaoluban_gateway_service)],
 ) -> XiaolubanAccountRecord:
     try:
-        return await asyncio.to_thread(service.set_account_enabled, account_id, False)
+        return await call_maybe_async(service.set_account_enabled, account_id, False)
     except (KeyError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -114,7 +114,7 @@ async def delete_xiaoluban_account(
     req: DeleteRequest | None = Body(default=None),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(
+        await call_maybe_async(
             service.delete_account,
             account_id,
             force=req.force if req is not None else False,
@@ -132,7 +132,7 @@ async def start_wechat_login(
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> WeChatLoginStartResponse:
     try:
-        return await asyncio.to_thread(service.start_login, req)
+        return await call_maybe_async(service.start_login, req)
     except RuntimeError as exc:
         raise http_exception_for(exc, mappings=((RuntimeError, 400),)) from exc
 
@@ -143,7 +143,7 @@ async def wait_wechat_login(
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> WeChatLoginWaitResponse:
     try:
-        return await asyncio.to_thread(service.wait_login, req)
+        return await call_maybe_async(service.wait_login, req)
     except (KeyError, RuntimeError) as exc:
         raise http_exception_for(
             exc,
@@ -158,7 +158,7 @@ async def update_wechat_account(
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> WeChatAccountRecord:
     try:
-        return await asyncio.to_thread(service.update_account, account_id, req)
+        return await call_maybe_async(service.update_account, account_id, req)
     except (KeyError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -172,7 +172,7 @@ async def enable_wechat_account(
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> WeChatAccountRecord:
     try:
-        return await asyncio.to_thread(service.set_account_enabled, account_id, True)
+        return await call_maybe_async(service.set_account_enabled, account_id, True)
     except (KeyError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -188,7 +188,7 @@ async def disable_wechat_account(
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> WeChatAccountRecord:
     try:
-        return await asyncio.to_thread(service.set_account_enabled, account_id, False)
+        return await call_maybe_async(service.set_account_enabled, account_id, False)
     except (KeyError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -203,7 +203,7 @@ async def delete_wechat_account(
     req: DeleteRequest | None = Body(default=None),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(
+        await call_maybe_async(
             service.delete_account,
             account_id,
             force=req.force if req is not None else False,
@@ -219,5 +219,5 @@ async def delete_wechat_account(
 async def reload_wechat_gateway(
     service: Annotated[WeChatGatewayService, Depends(get_wechat_gateway_service)],
 ) -> dict[str, str]:
-    await asyncio.to_thread(service.reload)
+    await call_maybe_async(service.reload)
     return {"status": "ok"}

--- a/src/relay_teams/interfaces/server/routers/logs.py
+++ b/src/relay_teams/interfaces/server/routers/logs.py
@@ -6,8 +6,8 @@ from typing import ClassVar
 
 from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
-from starlette.concurrency import run_in_threadpool
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.logger import get_logger, log_event
 from relay_teams.trace import bind_trace_context, generate_trace_id
 from relay_teams.validation import OptionalIdentifierStr
@@ -45,7 +45,7 @@ class FrontendLogBatchRequest(BaseModel):
 
 @router.post("/frontend")
 async def ingest_frontend_logs(req: FrontendLogBatchRequest) -> dict[str, int]:
-    return await run_in_threadpool(_ingest_frontend_logs, req)
+    return await call_maybe_async(_ingest_frontend_logs, req)
 
 
 def _ingest_frontend_logs(req: FrontendLogBatchRequest) -> dict[str, int]:

--- a/src/relay_teams/interfaces/server/routers/observability.py
+++ b/src/relay_teams/interfaces/server/routers/observability.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.interfaces.server.deps import get_metrics_service
 from relay_teams.metrics import MetricScope, MetricsService
 
@@ -19,7 +19,7 @@ async def get_observability_overview(
 ) -> dict[str, object]:
     if scope != MetricScope.GLOBAL and not scope_id.strip():
         raise HTTPException(status_code=422, detail="scope_id is required")
-    overview = await asyncio.to_thread(
+    overview = await call_maybe_async(
         service.get_overview,
         scope=scope,
         scope_id=scope_id,
@@ -37,7 +37,7 @@ async def get_observability_breakdowns(
 ) -> dict[str, object]:
     if scope != MetricScope.GLOBAL and not scope_id.strip():
         raise HTTPException(status_code=422, detail="scope_id is required")
-    breakdown = await asyncio.to_thread(
+    breakdown = await call_maybe_async(
         service.get_breakdowns,
         scope=scope,
         scope_id=scope_id,

--- a/src/relay_teams/interfaces/server/routers/roles.py
+++ b/src/relay_teams/interfaces/server/routers/roles.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
-from starlette.concurrency import run_in_threadpool
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.computer import ExecutionSurface
 from relay_teams.builtin import get_builtin_roles_dir
 from relay_teams.interfaces.server.deps import (
@@ -71,7 +71,7 @@ async def get_role_config_options(
     ),
 ) -> RoleConfigOptions:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             _build_role_config_options,
             role_registry=role_registry,
             model_config_service=model_config_service,
@@ -161,7 +161,7 @@ def _build_role_config_options(
 async def list_role_configs(
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> tuple[RoleDocumentSummary, ...]:
-    return await run_in_threadpool(service.list_role_documents)
+    return await call_maybe_async(service.list_role_documents)
 
 
 @router.get(
@@ -174,7 +174,7 @@ async def get_role_config(
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> RoleDocumentRecord:
     try:
-        return await run_in_threadpool(service.get_role_document, role_id)
+        return await call_maybe_async(service.get_role_document, role_id)
     except ValueError as exc:
         raise http_exception_for(exc, mappings=((ValueError, 404),)) from exc
 
@@ -190,7 +190,7 @@ async def save_role_config(
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> RoleDocumentRecord:
     try:
-        return await run_in_threadpool(service.save_role_document, role_id, draft)
+        return await call_maybe_async(service.save_role_document, role_id, draft)
     except ValueError as exc:
         raise http_exception_for(exc, mappings=((ValueError, 400),)) from exc
 
@@ -201,7 +201,7 @@ async def delete_role_config(
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> dict[str, str]:
     try:
-        await run_in_threadpool(service.delete_role_document, role_id)
+        await call_maybe_async(service.delete_role_document, role_id)
         return {"status": "ok"}
     except ValueError as exc:
         if str(exc).startswith("Role not found:"):
@@ -214,7 +214,7 @@ async def validate_roles(
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> dict[str, int | bool]:
     try:
-        return await run_in_threadpool(service.validate_all_roles)
+        return await call_maybe_async(service.validate_all_roles)
     except (SystemRolesUnavailableError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -232,7 +232,7 @@ async def validate_role_config(
     service: RoleSettingsService = Depends(get_role_settings_service),
 ) -> RoleValidationResult:
     try:
-        return await run_in_threadpool(service.validate_role_document, draft)
+        return await call_maybe_async(service.validate_role_document, draft)
     except ValueError as exc:
         raise http_exception_for(exc, mappings=((ValueError, 400),)) from exc
 

--- a/src/relay_teams/interfaces/server/routers/runs.py
+++ b/src/relay_teams/interfaces/server/routers/runs.py
@@ -42,6 +42,40 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/runs", tags=["Runs"])
 
 
+async def _create_and_start_run(
+    service: SessionRunService,
+    intent_input: IntentInput,
+) -> tuple[str, str]:
+    async def operation() -> tuple[str, str]:
+        run_id, session_id = await service.create_run_async(intent_input)
+        await service.ensure_run_started_async(run_id)
+        return run_id, session_id
+
+    task = asyncio.create_task(operation())
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
+
+
+async def _resume_and_start_run(
+    service: SessionRunService,
+    run_id: str,
+) -> str:
+    async def operation() -> str:
+        session_id = await service.resume_run_async(run_id)
+        await service.ensure_run_started_async(run_id)
+        return session_id
+
+    task = asyncio.create_task(operation())
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
+
+
 def _reuse_normalized_inline_media_refs(
     *,
     raw_input: tuple[ContentPart, ...],
@@ -258,12 +292,7 @@ async def create_run(
             skills=resolved_skills,
         )
 
-        def create_and_start_run() -> tuple[str, str]:
-            created_run_id, created_session_id = service.create_run(intent_input)
-            service.ensure_run_started(created_run_id)
-            return created_run_id, created_session_id
-
-        run_id, session_id = await asyncio.to_thread(create_and_start_run)
+        run_id, session_id = await _create_and_start_run(service, intent_input)
         elapsed_ms = int((time.perf_counter() - started) * 1000)
         with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
             log_event(
@@ -359,7 +388,7 @@ async def list_monitors(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> dict[str, object]:
     try:
-        monitors = await asyncio.to_thread(service.list_monitors, run_id)
+        monitors = await service.list_monitors_async(run_id)
         return {"items": list(monitors)}
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -375,8 +404,7 @@ async def create_monitor(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> MonitorResponse:
     try:
-        monitor = await asyncio.to_thread(
-            service.create_monitor,
+        monitor = await service.create_monitor_async(
             run_id=run_id,
             source_kind=req.source_kind,
             source_key=req.source_key,
@@ -407,8 +435,7 @@ async def stop_monitor(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> MonitorResponse:
     try:
-        monitor = await asyncio.to_thread(
-            service.stop_monitor,
+        monitor = await service.stop_monitor_async(
             run_id=run_id,
             monitor_id=monitor_id,
         )
@@ -427,8 +454,7 @@ async def inject_message(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> dict[str, object]:
     try:
-        result = await asyncio.to_thread(
-            service.inject_message,
+        result = await service.inject_message_async(
             run_id=run_id,
             source=req.source,
             content=req.content,
@@ -455,7 +481,7 @@ async def list_tool_approvals(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> list[dict[str, str]]:
     with bind_trace_context(trace_id=run_id, run_id=run_id):
-        result = await asyncio.to_thread(service.list_open_tool_approvals, run_id)
+        result = await service.list_open_tool_approvals_async(run_id)
         log_event(
             logger,
             logging.INFO,
@@ -472,7 +498,7 @@ async def list_user_questions(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> list[dict[str, object]]:
     try:
-        questions = await asyncio.to_thread(service.list_user_questions, run_id)
+        questions = await service.list_user_questions_async(run_id)
         return cast(list[dict[str, object]], questions)
     except KeyError as exc:
         raise http_exception_for(exc) from exc
@@ -489,8 +515,7 @@ async def answer_user_question(
         submission = UserQuestionAnswerSubmission.model_validate(
             {"answers": list(req.answers)}
         )
-        result = await asyncio.to_thread(
-            service.answer_user_question,
+        result = await service.answer_user_question_async(
             run_id=run_id,
             question_id=question_id,
             answers=submission,
@@ -523,9 +548,7 @@ async def list_background_tasks(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> dict[str, object]:
     try:
-        background_tasks = await asyncio.to_thread(
-            service.list_background_tasks, run_id
-        )
+        background_tasks = await service.list_background_tasks_async(run_id)
         return {"items": list(background_tasks)}
     except KeyError as exc:
         raise http_exception_for(exc) from exc
@@ -537,7 +560,7 @@ async def get_todo(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> dict[str, object]:
     try:
-        todo = await asyncio.to_thread(service.get_todo, run_id)
+        todo = await service.get_todo_async(run_id)
         return {"todo": todo}
     except KeyError as exc:
         raise http_exception_for(exc) from exc
@@ -550,8 +573,7 @@ async def get_background_task(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> dict[str, object]:
     try:
-        background_task = await asyncio.to_thread(
-            service.get_background_task,
+        background_task = await service.get_background_task_async(
             run_id=run_id,
             background_task_id=background_task_id,
         )
@@ -587,8 +609,7 @@ async def resolve_tool_approval(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(
-            service.resolve_tool_approval,
+        await service.resolve_tool_approval_async(
             run_id=run_id,
             tool_call_id=tool_call_id,
             action=req.action,
@@ -619,7 +640,7 @@ async def stop_run(
 ) -> dict[str, str]:
     try:
         if req.scope == "main":
-            await asyncio.to_thread(service.stop_run, run_id)
+            await service.stop_run_async(run_id)
             with bind_trace_context(trace_id=run_id, run_id=run_id):
                 log_event(
                     logger,
@@ -633,11 +654,7 @@ async def stop_run(
                 status_code=422,
                 detail="instance_id is required when scope is subagent",
             )
-        payload = await asyncio.to_thread(
-            service.stop_subagent,
-            run_id,
-            req.instance_id,
-        )
+        payload = await service.stop_subagent_async(run_id, req.instance_id)
         with bind_trace_context(
             trace_id=run_id, run_id=run_id, instance_id=req.instance_id
         ):
@@ -665,13 +682,7 @@ async def resume_run(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> dict[str, str]:
     try:
-
-        def resume_and_start_run() -> str:
-            resumed_session_id = service.resume_run(run_id)
-            service.ensure_run_started(run_id)
-            return resumed_session_id
-
-        session_id = await asyncio.to_thread(resume_and_start_run)
+        session_id = await _resume_and_start_run(service, run_id)
         with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
             log_event(
                 logger,
@@ -695,8 +706,7 @@ async def inject_subagent(
     service: Annotated[SessionRunService, Depends(get_run_service)],
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(
-            service.inject_subagent_message,
+        await service.inject_subagent_message_async(
             run_id=run_id,
             instance_id=instance_id,
             content=req.content,

--- a/src/relay_teams/interfaces/server/routers/runs.py
+++ b/src/relay_teams/interfaces/server/routers/runs.py
@@ -55,7 +55,7 @@ async def _create_and_start_run(
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError:
-        await task
+        _ = await task
         raise
 
 
@@ -72,7 +72,7 @@ async def _resume_and_start_run(
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError:
-        await task
+        _ = await task
         raise
 
 

--- a/src/relay_teams/interfaces/server/routers/session_media.py
+++ b/src/relay_teams/interfaces/server/routers/session_media.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse, RedirectResponse
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.interfaces.server.deps import (
     get_media_asset_service,
     get_session_service,
@@ -30,10 +30,10 @@ async def list_session_media(
     media_asset_service: Annotated[MediaAssetService, Depends(get_media_asset_service)],
 ) -> list[MediaRefContentPart]:
     try:
-        await asyncio.to_thread(session_service.get_session, session_id)
+        await call_maybe_async(session_service.get_session, session_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Session not found") from exc
-    records = await asyncio.to_thread(
+    records = await call_maybe_async(
         media_asset_service.list_session_assets,
         session_id,
     )
@@ -49,7 +49,7 @@ async def upload_session_media(
     modality: Annotated[MediaModality | None, Form()] = None,
 ) -> MediaRefContentPart:
     try:
-        session = await asyncio.to_thread(session_service.get_session, session_id)
+        session = await call_maybe_async(session_service.get_session, session_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Session not found") from exc
 
@@ -73,7 +73,7 @@ async def upload_session_media(
     if not content_type:
         content_type = _default_mime_type(resolved_modality)
 
-    record = await asyncio.to_thread(
+    record = await call_maybe_async(
         media_asset_service.store_bytes,
         session_id=session_id,
         workspace_id=session.workspace_id,
@@ -95,8 +95,8 @@ async def get_session_media(
     media_asset_service: Annotated[MediaAssetService, Depends(get_media_asset_service)],
 ) -> MediaRefContentPart:
     try:
-        await asyncio.to_thread(session_service.get_session, session_id)
-        record = await asyncio.to_thread(media_asset_service.get_asset, asset_id)
+        await call_maybe_async(session_service.get_session, session_id)
+        record = await call_maybe_async(media_asset_service.get_asset, asset_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     if record.session_id != session_id:
@@ -112,8 +112,8 @@ async def get_session_media_file(
     media_asset_service: Annotated[MediaAssetService, Depends(get_media_asset_service)],
 ) -> FileResponse | RedirectResponse:
     try:
-        await asyncio.to_thread(session_service.get_session, session_id)
-        record = await asyncio.to_thread(media_asset_service.get_asset, asset_id)
+        await call_maybe_async(session_service.get_session, session_id)
+        record = await call_maybe_async(media_asset_service.get_asset, asset_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     if record.session_id != session_id:
@@ -121,7 +121,7 @@ async def get_session_media_file(
     if record.external_url is not None and record.external_url.strip():
         return RedirectResponse(url=record.external_url.strip())
     try:
-        file_path, media_type = await asyncio.to_thread(
+        file_path, media_type = await call_maybe_async(
             media_asset_service.get_asset_file,
             session_id=session_id,
             asset_id=asset_id,

--- a/src/relay_teams/interfaces/server/routers/sessions.py
+++ b/src/relay_teams/interfaces/server/routers/sessions.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, field_validator
-from starlette.concurrency import run_in_threadpool
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.interfaces.server.deps import get_session_service
 from relay_teams.interfaces.server.router_error_mapping import http_exception_for
 from relay_teams.interfaces.server.write_models import DeleteRequest
@@ -64,7 +64,7 @@ async def create_session(
                 ),
             )
 
-        return await run_in_threadpool(_create_session)
+        return await call_maybe_async(_create_session)
     except (SystemRolesUnavailableError, ValueError) as exc:
         raise http_exception_for(
             exc,
@@ -79,7 +79,7 @@ async def list_sessions(
     def _list_sessions() -> tuple[SessionRecord, ...]:
         return service.list_sessions()
 
-    records = await run_in_threadpool(_list_sessions)
+    records = await call_maybe_async(_list_sessions)
     return list(records)
 
 
@@ -89,7 +89,7 @@ async def get_session(
     service: SessionService = Depends(get_session_service),
 ) -> SessionRecord:
     try:
-        return await run_in_threadpool(service.get_session, session_id)
+        return await call_maybe_async(service.get_session, session_id)
     except KeyError as exc:
         raise http_exception_for(exc, key_error_detail="Session not found") from exc
 
@@ -101,7 +101,7 @@ async def update_session(
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, str]:
     try:
-        await run_in_threadpool(service.update_session, session_id, req)
+        await call_maybe_async(service.update_session, session_id, req)
         return {"status": "ok"}
     except KeyError as exc:
         raise http_exception_for(exc, key_error_detail="Session not found") from exc
@@ -125,7 +125,7 @@ async def update_session_topology(
                 orchestration_preset_id=req.orchestration_preset_id,
             )
 
-        return await run_in_threadpool(_update_session_topology)
+        return await call_maybe_async(_update_session_topology)
     except KeyError as exc:
         raise http_exception_for(exc, key_error_detail="Session not found") from exc
     except SystemRolesUnavailableError as exc:
@@ -154,7 +154,7 @@ async def delete_session(
                 cascade=req.cascade if req is not None else False,
             )
 
-        await run_in_threadpool(_delete_session)
+        await call_maybe_async(_delete_session)
         return {"status": "ok"}
     except KeyError as exc:
         raise http_exception_for(exc, key_error_detail="Session not found") from exc
@@ -178,7 +178,7 @@ async def get_session_rounds(
             timeline=timeline,
         )
 
-    return await run_in_threadpool(_get_session_rounds)
+    return await call_maybe_async(_get_session_rounds)
 
 
 @router.get("/{session_id}/recovery")
@@ -187,7 +187,7 @@ async def get_session_recovery(
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
-        return await run_in_threadpool(service.get_recovery_snapshot, session_id)
+        return await call_maybe_async(service.get_recovery_snapshot, session_id)
     except KeyError as exc:
         raise http_exception_for(exc, key_error_detail="Session not found") from exc
 
@@ -199,7 +199,7 @@ async def get_round(
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
-        return await run_in_threadpool(service.get_round, session_id, run_id)
+        return await call_maybe_async(service.get_round, session_id, run_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -210,7 +210,7 @@ async def list_session_agents(
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
     try:
-        agents = await run_in_threadpool(service.list_agents_in_session, session_id)
+        agents = await call_maybe_async(service.list_agents_in_session, session_id)
         return list(agents)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Session not found") from exc
@@ -222,7 +222,7 @@ async def list_session_subagents(
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
     try:
-        subagents = await run_in_threadpool(
+        subagents = await call_maybe_async(
             service.list_normal_mode_subagents,
             session_id,
         )
@@ -238,7 +238,7 @@ async def delete_session_subagent(
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, str]:
     try:
-        await run_in_threadpool(
+        await call_maybe_async(
             service.delete_normal_mode_subagent,
             session_id,
             instance_id,
@@ -257,7 +257,7 @@ async def get_agent_reflection(
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             service.get_agent_reflection,
             session_id,
             instance_id,
@@ -296,7 +296,7 @@ async def update_agent_reflection(
                 summary=req.summary,
             )
 
-        return await run_in_threadpool(_update_agent_reflection)
+        return await call_maybe_async(_update_agent_reflection)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Agent not found") from exc
     except RuntimeError as exc:
@@ -310,7 +310,7 @@ async def delete_agent_reflection(
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             service.delete_agent_reflection,
             session_id,
             instance_id,
@@ -326,7 +326,7 @@ async def get_session_events(
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
-    return await run_in_threadpool(service.get_global_events, session_id)
+    return await call_maybe_async(service.get_global_events, session_id)
 
 
 @router.get("/{session_id}/messages")
@@ -334,7 +334,7 @@ async def get_session_messages(
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
-    return await run_in_threadpool(service.get_session_messages, session_id)
+    return await call_maybe_async(service.get_session_messages, session_id)
 
 
 @router.get("/{session_id}/agents/{instance_id}/messages")
@@ -343,7 +343,7 @@ async def get_agent_messages(
     instance_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
-    return await run_in_threadpool(
+    return await call_maybe_async(
         service.get_agent_messages,
         session_id,
         instance_id,
@@ -355,7 +355,7 @@ async def get_session_tasks(
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> list[dict[str, object]]:
-    return await run_in_threadpool(service.get_session_tasks, session_id)
+    return await call_maybe_async(service.get_session_tasks, session_id)
 
 
 @router.get("/{session_id}/token-usage")
@@ -363,7 +363,7 @@ async def get_session_token_usage(
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
-    summary = await run_in_threadpool(service.get_token_usage_by_session, session_id)
+    summary = await call_maybe_async(service.get_token_usage_by_session, session_id)
     return {
         "session_id": summary.session_id,
         "total_input_tokens": summary.total_input_tokens,
@@ -396,7 +396,7 @@ async def get_run_token_usage(
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     _ = session_id
-    usage = await run_in_threadpool(service.get_token_usage_by_run, run_id)
+    usage = await call_maybe_async(service.get_token_usage_by_run, run_id)
     return {
         "run_id": usage.run_id,
         "total_input_tokens": usage.total_input_tokens,

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import asyncio
 from typing import NoReturn
 
 import httpx
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, JsonValue
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.env.clawhub_config_models import ClawHubConfig
 from relay_teams.env.clawhub_config_service import ClawHubConfigService
 from relay_teams.net.clawhub_connectivity import (
@@ -209,8 +209,8 @@ def _raise_system_http_error(
 async def health_check(request: Request) -> ServerHealthPayload:
     container = getattr(request.app.state, "container", None)
     if container is None:
-        return await asyncio.to_thread(build_server_health_payload)
-    return await asyncio.to_thread(
+        return await call_maybe_async(build_server_health_payload)
+    return await call_maybe_async(
         build_server_health_payload,
         config_dir=container.config_dir,
         role_registry=container.role_registry,
@@ -223,14 +223,14 @@ async def health_check(request: Request) -> ServerHealthPayload:
 async def get_config_status(
     service: ConfigStatusService = Depends(get_config_status_service),
 ) -> dict[str, JsonValue]:
-    return await asyncio.to_thread(service.get_config_status)
+    return await call_maybe_async(service.get_config_status)
 
 
 @router.get("/configs/workspace/ssh-profiles")
 async def list_ssh_profiles(
     service: SshProfileService = Depends(get_ssh_profile_service),
 ) -> list[SshProfileRecord]:
-    return list(await asyncio.to_thread(service.list_profiles))
+    return list(await call_maybe_async(service.list_profiles))
 
 
 @router.get("/configs/workspace/ssh-profiles/{ssh_profile_id}")
@@ -239,7 +239,7 @@ async def get_ssh_profile(
     service: SshProfileService = Depends(get_ssh_profile_service),
 ) -> SshProfileRecord:
     try:
-        return await asyncio.to_thread(service.get_profile, ssh_profile_id)
+        return await call_maybe_async(service.get_profile, ssh_profile_id)
     except Exception as exc:
         _raise_system_http_error(
             exc,
@@ -255,7 +255,7 @@ async def reveal_ssh_profile_password(
     service: SshProfileService = Depends(get_ssh_profile_service),
 ) -> SshProfilePasswordRevealView:
     try:
-        return await asyncio.to_thread(service.reveal_password, ssh_profile_id)
+        return await call_maybe_async(service.reveal_password, ssh_profile_id)
     except Exception as exc:
         _raise_system_http_error(
             exc,
@@ -271,7 +271,7 @@ async def probe_ssh_profile_connectivity(
     service: SshProfileService = Depends(get_ssh_profile_service),
 ) -> SshProfileConnectivityProbeResult:
     try:
-        return await asyncio.to_thread(service.probe_connectivity, req)
+        return await call_maybe_async(service.probe_connectivity, req)
     except Exception as exc:
         _raise_system_http_error(
             exc,
@@ -288,7 +288,7 @@ async def save_ssh_profile(
     service: SshProfileService = Depends(get_ssh_profile_service),
 ) -> SshProfileRecord:
     try:
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.save_profile,
             ssh_profile_id=ssh_profile_id,
             config=req.config,
@@ -306,7 +306,7 @@ async def delete_ssh_profile(
     service: SshProfileService = Depends(get_ssh_profile_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.delete_profile, ssh_profile_id)
+        await call_maybe_async(service.delete_profile, ssh_profile_id)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(
@@ -321,7 +321,7 @@ async def delete_ssh_profile(
 async def get_ui_language_settings(
     service: UiLanguageSettingsService = Depends(get_ui_language_settings_service),
 ) -> UiLanguageSettings:
-    return await asyncio.to_thread(service.get_ui_language_settings)
+    return await call_maybe_async(service.get_ui_language_settings)
 
 
 @router.put("/configs/ui-language")
@@ -330,7 +330,7 @@ async def save_ui_language_settings(
     service: UiLanguageSettingsService = Depends(get_ui_language_settings_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.save_ui_language_settings, req)
+        await call_maybe_async(service.save_ui_language_settings, req)
         return {"status": "ok"}
     except OSError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -340,21 +340,21 @@ async def save_ui_language_settings(
 async def get_model_config(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> dict[str, JsonValue]:
-    return await asyncio.to_thread(service.get_model_config)
+    return await call_maybe_async(service.get_model_config)
 
 
 @router.get("/configs/model/profiles")
 async def get_model_profiles(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> dict[str, dict[str, JsonValue]]:
-    return await asyncio.to_thread(service.get_model_profiles)
+    return await call_maybe_async(service.get_model_profiles)
 
 
 @router.get("/configs/model-fallback")
 async def get_model_fallback_config(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelFallbackConfig:
-    return await asyncio.to_thread(service.get_model_fallback_config)
+    return await call_maybe_async(service.get_model_fallback_config)
 
 
 @router.get("/configs/model/catalog")
@@ -362,14 +362,14 @@ async def get_model_catalog(
     refresh: bool = Query(default=False),
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelCatalogResult:
-    return await asyncio.to_thread(service.get_model_catalog, refresh=refresh)
+    return await call_maybe_async(service.get_model_catalog, refresh=refresh)
 
 
 @router.post("/configs/model/catalog:refresh")
 async def refresh_model_catalog(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelCatalogResult:
-    return await asyncio.to_thread(service.get_model_catalog, refresh=True)
+    return await call_maybe_async(service.get_model_catalog, refresh=True)
 
 
 class ModelProfileRequest(ModelProfileConfigPayload):
@@ -450,7 +450,7 @@ async def save_model_profile(
             profile["maas_auth"] = req.maas_auth.model_dump(mode="json")
         if req.codeagent_auth is not None:
             profile["codeagent_auth"] = req.codeagent_auth.model_dump(mode="json")
-        await asyncio.to_thread(
+        await call_maybe_async(
             service.save_model_profile,
             name,
             profile,
@@ -561,7 +561,7 @@ async def get_provider_models(
 ) -> list[dict[str, JsonValue]]:
     return [
         model.model_dump(mode="json")
-        for model in await asyncio.to_thread(
+        for model in await call_maybe_async(
             service.get_provider_models,
             provider=provider,
         )
@@ -574,7 +574,7 @@ async def delete_model_profile(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.delete_model_profile, name)
+        await call_maybe_async(service.delete_model_profile, name)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(
@@ -591,7 +591,7 @@ async def save_model_config(
 ) -> dict[str, str]:
     try:
         config = req.config if isinstance(req, ModelConfigRequest) else req
-        await asyncio.to_thread(service.save_model_config, config)
+        await call_maybe_async(service.save_model_config, config)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(exc, value_error_status=400)
@@ -604,7 +604,7 @@ async def save_model_fallback_config(
 ) -> dict[str, str]:
     try:
         config = req.config if isinstance(req, ModelFallbackConfigRequest) else req
-        await asyncio.to_thread(service.save_model_fallback_config, config)
+        await call_maybe_async(service.save_model_fallback_config, config)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(exc, value_error_status=400)
@@ -616,7 +616,7 @@ async def probe_model_connectivity(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelConnectivityProbeResult:
     try:
-        return await asyncio.to_thread(service.probe_connectivity, req)
+        return await call_maybe_async(service.probe_connectivity, req)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -627,7 +627,7 @@ async def discover_model_catalog(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelDiscoveryResult:
     try:
-        return await asyncio.to_thread(service.discover_models, req)
+        return await call_maybe_async(service.discover_models, req)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -636,7 +636,7 @@ async def discover_model_catalog(
 async def get_notification_config(
     service: NotificationSettingsService = Depends(get_notification_settings_service),
 ) -> NotificationConfig:
-    return await asyncio.to_thread(service.get_notification_config)
+    return await call_maybe_async(service.get_notification_config)
 
 
 @router.get("/configs/environment-variables")
@@ -644,7 +644,7 @@ async def get_environment_variables(
     service: EnvironmentVariableService = Depends(get_environment_variable_service),
 ) -> EnvironmentVariableCatalog:
     try:
-        return await asyncio.to_thread(service.list_environment_variables)
+        return await call_maybe_async(service.list_environment_variables)
     except RuntimeError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -657,7 +657,7 @@ async def save_environment_variable(
     service: EnvironmentVariableService = Depends(get_environment_variable_service),
 ) -> EnvironmentVariableRecord:
     try:
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.save_environment_variable,
             scope=scope,
             key=key,
@@ -679,7 +679,7 @@ async def delete_environment_variable(
     service: EnvironmentVariableService = Depends(get_environment_variable_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(
+        await call_maybe_async(
             service.delete_environment_variable,
             scope=scope,
             key=key,
@@ -698,7 +698,7 @@ async def delete_environment_variable(
 async def get_proxy_config(
     service: ProxyConfigService = Depends(get_proxy_config_service),
 ) -> ProxyEnvInput:
-    return await asyncio.to_thread(service.get_saved_proxy_config)
+    return await call_maybe_async(service.get_saved_proxy_config)
 
 
 @router.put("/configs/proxy")
@@ -707,7 +707,7 @@ async def save_proxy_config(
     service: ProxyConfigService = Depends(get_proxy_config_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.save_proxy_config, req)
+        await call_maybe_async(service.save_proxy_config, req)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(
@@ -721,7 +721,7 @@ async def save_proxy_config(
 async def get_web_config(
     service: WebConfigService = Depends(get_web_config_service),
 ) -> WebConfig:
-    return await asyncio.to_thread(service.get_web_config)
+    return await call_maybe_async(service.get_web_config)
 
 
 @router.put("/configs/web")
@@ -730,7 +730,7 @@ async def save_web_config(
     service: WebConfigService = Depends(get_web_config_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.save_web_config, req)
+        await call_maybe_async(service.save_web_config, req)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(
@@ -744,7 +744,7 @@ async def save_web_config(
 async def list_external_agents(
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> tuple[ExternalAgentSummary, ...]:
-    return await asyncio.to_thread(service.list_agents)
+    return await call_maybe_async(service.list_agents)
 
 
 @router.get("/configs/agents/{agent_id}", response_model=ExternalAgentConfig)
@@ -753,7 +753,7 @@ async def get_external_agent(
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> ExternalAgentConfig:
     try:
-        return await asyncio.to_thread(service.get_agent, agent_id)
+        return await call_maybe_async(service.get_agent, agent_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -765,7 +765,7 @@ async def save_external_agent(
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> ExternalAgentConfig:
     try:
-        return await asyncio.to_thread(service.save_agent, agent_id, req)
+        return await call_maybe_async(service.save_agent, agent_id, req)
     except (KeyError, ValueError, RuntimeError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -776,7 +776,7 @@ async def delete_external_agent(
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.delete_agent, agent_id)
+        await call_maybe_async(service.delete_agent, agent_id)
         return {"status": "ok"}
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -788,7 +788,7 @@ async def test_external_agent(
     service: ExternalAgentConfigService = Depends(get_external_agent_config_service),
 ) -> ExternalAgentTestResult:
     try:
-        config = await asyncio.to_thread(service.resolve_runtime_agent, agent_id)
+        config = await call_maybe_async(service.resolve_runtime_agent, agent_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     result = await probe_acp_agent(config)
@@ -801,14 +801,14 @@ async def test_external_agent(
 async def get_github_config(
     service: GitHubConfigService = Depends(get_github_config_service),
 ) -> GitHubConfigView:
-    return await asyncio.to_thread(service.get_github_config_view)
+    return await call_maybe_async(service.get_github_config_view)
 
 
 @router.post("/configs/github:reveal")
 async def reveal_github_token(
     service: GitHubConfigService = Depends(get_github_config_service),
 ) -> GitHubTokenRevealView:
-    return await asyncio.to_thread(service.reveal_github_token)
+    return await call_maybe_async(service.reveal_github_token)
 
 
 @router.put("/configs/github")
@@ -826,7 +826,7 @@ async def save_github_config(
                 previous_webhook_base_url=previous_config.webhook_base_url
             )
 
-        await asyncio.to_thread(_save_github_config)
+        await call_maybe_async(_save_github_config)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(
@@ -840,7 +840,7 @@ async def save_github_config(
 async def get_clawhub_config(
     service: ClawHubConfigService = Depends(get_clawhub_config_service),
 ) -> ClawHubConfig:
-    return await asyncio.to_thread(service.get_clawhub_config)
+    return await call_maybe_async(service.get_clawhub_config)
 
 
 @router.put("/configs/clawhub")
@@ -849,7 +849,7 @@ async def save_clawhub_config(
     service: ClawHubConfigService = Depends(get_clawhub_config_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.save_clawhub_config, req)
+        await call_maybe_async(service.save_clawhub_config, req)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(
@@ -867,7 +867,7 @@ async def probe_clawhub_connectivity(
     ),
 ) -> ClawHubConnectivityProbeResult:
     try:
-        return await asyncio.to_thread(service.probe, req)
+        return await call_maybe_async(service.probe, req)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -879,7 +879,7 @@ async def probe_clawhub_connectivity(
 async def list_clawhub_skills(
     service: ClawHubSkillService = Depends(get_clawhub_skill_service),
 ) -> tuple[ClawHubSkillSummary, ...]:
-    return await asyncio.to_thread(service.list_skills)
+    return await call_maybe_async(service.list_skills)
 
 
 @router.get(
@@ -891,7 +891,7 @@ async def get_clawhub_skill(
     service: ClawHubSkillService = Depends(get_clawhub_skill_service),
 ) -> ClawHubSkillDetail:
     try:
-        return await asyncio.to_thread(service.get_skill, skill_id)
+        return await call_maybe_async(service.get_skill, skill_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
@@ -908,7 +908,7 @@ async def save_clawhub_skill(
     service: ClawHubSkillService = Depends(get_clawhub_skill_service),
 ) -> ClawHubSkillDetail:
     try:
-        return await asyncio.to_thread(service.save_skill, skill_id, req)
+        return await call_maybe_async(service.save_skill, skill_id, req)
     except (KeyError, ValueError, RuntimeError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -919,7 +919,7 @@ async def delete_clawhub_skill(
     service: ClawHubSkillService = Depends(get_clawhub_skill_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.delete_skill, skill_id)
+        await call_maybe_async(service.delete_skill, skill_id)
         return {"status": "ok"}
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -934,7 +934,7 @@ async def save_notification_config(
 ) -> dict[str, str]:
     try:
         config = req.config if isinstance(req, NotificationConfigRequest) else req
-        await asyncio.to_thread(service.save_notification_config, config)
+        await call_maybe_async(service.save_notification_config, config)
         return {"status": "ok"}
     except OSError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -944,7 +944,7 @@ async def save_notification_config(
 async def get_orchestration_config(
     service: OrchestrationSettingsService = Depends(get_orchestration_settings_service),
 ) -> OrchestrationSettings:
-    return await asyncio.to_thread(service.get_orchestration_config)
+    return await call_maybe_async(service.get_orchestration_config)
 
 
 @router.put("/configs/orchestration")
@@ -954,7 +954,7 @@ async def save_orchestration_config(
 ) -> dict[str, str]:
     try:
         config = req.config if isinstance(req, OrchestrationConfigRequest) else req
-        await asyncio.to_thread(service.save_orchestration_config, config)
+        await call_maybe_async(service.save_orchestration_config, config)
         return {"status": "ok"}
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -965,7 +965,7 @@ async def reload_model_config(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.reload_model_config)
+        await call_maybe_async(service.reload_model_config)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(
@@ -980,7 +980,7 @@ async def reload_proxy_config(
     service: ProxyConfigService = Depends(get_proxy_config_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.reload_proxy_config)
+        await call_maybe_async(service.reload_proxy_config)
         return {"status": "ok"}
     except Exception as exc:
         _raise_system_http_error(
@@ -1022,7 +1022,7 @@ async def probe_github_webhook_connectivity(
     ),
 ) -> GitHubWebhookConnectivityProbeResult:
     try:
-        return await asyncio.to_thread(service.probe, req)
+        return await call_maybe_async(service.probe, req)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -1031,7 +1031,7 @@ async def probe_github_webhook_connectivity(
 async def get_github_webhook_tunnel_status(
     service: LocalhostRunTunnelService = Depends(get_localhost_run_tunnel_service),
 ) -> LocalhostRunTunnelStatus:
-    return await asyncio.to_thread(service.get_status)
+    return await call_maybe_async(service.get_status)
 
 
 @router.post("/configs/github/webhook/tunnel:start")
@@ -1063,7 +1063,7 @@ async def start_github_webhook_tunnel(
                 )
             return status
 
-        return await asyncio.to_thread(_start_tunnel)
+        return await call_maybe_async(_start_tunnel)
     except Exception as exc:
         _raise_system_http_error(
             exc,
@@ -1097,7 +1097,7 @@ async def stop_github_webhook_tunnel(
                     )
             return status
 
-        return await asyncio.to_thread(_stop_tunnel)
+        return await call_maybe_async(_stop_tunnel)
     except Exception as exc:
         _raise_system_http_error(
             exc,
@@ -1111,7 +1111,7 @@ async def reload_mcp_config(
     service: McpConfigReloadService = Depends(get_mcp_config_reload_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.reload_mcp_config)
+        await call_maybe_async(service.reload_mcp_config)
         return {"status": "ok"}
     except (ValueError, RuntimeError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1124,7 +1124,7 @@ async def reload_skills_config(
     service: SkillsConfigReloadService = Depends(get_skills_config_reload_service),
 ) -> dict[str, str]:
     try:
-        await asyncio.to_thread(service.reload_skills_config)
+        await call_maybe_async(service.reload_skills_config)
         return {"status": "ok"}
     except (ValueError, RuntimeError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1136,14 +1136,14 @@ async def reload_skills_config(
 async def get_hooks_config(
     service: HookService = Depends(get_hook_service),
 ) -> HooksConfig:
-    return await asyncio.to_thread(service.get_user_config)
+    return await call_maybe_async(service.get_user_config)
 
 
 @router.get("/configs/hooks/runtime")
 async def get_hooks_runtime_view(
     service: HookService = Depends(get_hook_service),
 ) -> HookRuntimeView:
-    return await asyncio.to_thread(service.get_runtime_view)
+    return await call_maybe_async(service.get_runtime_view)
 
 
 @router.put("/configs/hooks")
@@ -1152,7 +1152,7 @@ async def save_hooks_config(
     service: HookService = Depends(get_hook_service),
 ) -> HooksConfig:
     try:
-        return await asyncio.to_thread(service.save_user_config, req)
+        return await call_maybe_async(service.save_user_config, req)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -1163,7 +1163,7 @@ async def validate_hooks_config(
     service: HookService = Depends(get_hook_service),
 ) -> dict[str, str]:
     try:
-        _ = await asyncio.to_thread(service.validate_config, req)
+        _ = await call_maybe_async(service.validate_config, req)
         return {"status": "ok"}
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/src/relay_teams/interfaces/server/routers/tasks.py
+++ b/src/relay_teams/interfaces/server/routers/tasks.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import asyncio
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.agents.orchestration.task_orchestration_service import (
     TaskOrchestrationService,
 )
@@ -36,7 +36,7 @@ class UpdateTaskRequest(BaseModel):
 async def list_tasks(
     service: TaskOrchestrationService = Depends(get_task_service),
 ) -> list[TaskRecord]:
-    return list(await asyncio.to_thread(service.list_tasks))
+    return list(await call_maybe_async(service.list_tasks))
 
 
 @router.post("/runs/{run_id}")
@@ -64,7 +64,7 @@ async def list_tasks_for_run(
     service: TaskOrchestrationService = Depends(get_task_service),
 ) -> dict[str, JsonValue]:
     try:
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.list_delegated_tasks,
             run_id=run_id,
             include_root=include_root,
@@ -79,7 +79,7 @@ async def get_task(
     service: TaskOrchestrationService = Depends(get_task_service),
 ) -> TaskRecord:
     try:
-        return await asyncio.to_thread(service.get_task, task_id=task_id)
+        return await call_maybe_async(service.get_task, task_id=task_id)
     except KeyError as exc:
         raise http_exception_for(exc, key_error_detail="Task not found") from exc
 
@@ -91,7 +91,7 @@ async def update_task_by_id(
     service: TaskOrchestrationService = Depends(get_task_service),
 ) -> dict[str, JsonValue]:
     try:
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.update_task,
             run_id=None,
             task_id=task_id,

--- a/src/relay_teams/interfaces/server/routers/triggers.py
+++ b/src/relay_teams/interfaces/server/routers/triggers.py
@@ -5,8 +5,8 @@ from typing import Annotated, NoReturn
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import JsonValue
-from starlette.concurrency import run_in_threadpool
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.env.github_config_service import GitHubConfigService
 from relay_teams.env.public_webhook_url import (
     build_public_base_url_path,
@@ -64,7 +64,7 @@ def _github_delivery_callback_url(
 async def list_github_accounts(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> list[GitHubTriggerAccountRecord]:
-    accounts = await run_in_threadpool(service.list_accounts)
+    accounts = await call_maybe_async(service.list_accounts)
     return list(accounts)
 
 
@@ -74,7 +74,7 @@ async def create_github_account(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> GitHubTriggerAccountRecord:
     try:
-        return await run_in_threadpool(service.create_account, req)
+        return await call_maybe_async(service.create_account, req)
     except GitHubTriggerAccountNameConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except GitHubApiError as exc:
@@ -92,7 +92,7 @@ async def update_github_account(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> GitHubTriggerAccountRecord:
     try:
-        return await run_in_threadpool(service.update_account, account_id, req)
+        return await call_maybe_async(service.update_account, account_id, req)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except GitHubTriggerAccountNameConflictError as exc:
@@ -109,7 +109,7 @@ async def delete_github_account(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> dict[str, JsonValue]:
     try:
-        await run_in_threadpool(service.delete_account, account_id)
+        await call_maybe_async(service.delete_account, account_id)
         return {"status": "ok"}
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -123,7 +123,7 @@ async def enable_github_account(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> GitHubTriggerAccountRecord:
     try:
-        return await run_in_threadpool(service.enable_account, account_id)
+        return await call_maybe_async(service.enable_account, account_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except GitHubApiError as exc:
@@ -140,7 +140,7 @@ async def disable_github_account(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> GitHubTriggerAccountRecord:
     try:
-        return await run_in_threadpool(service.disable_account, account_id)
+        return await call_maybe_async(service.disable_account, account_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except GitHubApiError as exc:
@@ -153,7 +153,7 @@ async def disable_github_account(
 async def list_github_repo_subscriptions(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> list[GitHubRepoSubscriptionRecord]:
-    subscriptions = await run_in_threadpool(service.list_repo_subscriptions)
+    subscriptions = await call_maybe_async(service.list_repo_subscriptions)
     return list(subscriptions)
 
 
@@ -173,7 +173,7 @@ async def list_github_available_repositories(
         ]:
             return service.list_available_repositories(account_id, query=query)
 
-        repositories = await run_in_threadpool(_list_available_repositories)
+        repositories = await call_maybe_async(_list_available_repositories)
         return list(repositories)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -198,7 +198,7 @@ async def create_github_repo_subscription(
             callback_url = _github_delivery_callback_url(request, github_config_service)
             if callback_url is not None:
                 resolved_req = req.model_copy(update={"callback_url": callback_url})
-        return await run_in_threadpool(service.create_repo_subscription, resolved_req)
+        return await call_maybe_async(service.create_repo_subscription, resolved_req)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except GitHubRepoSubscriptionConflictError as exc:
@@ -219,7 +219,7 @@ async def update_github_repo_subscription(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> GitHubRepoSubscriptionRecord:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             service.update_repo_subscription,
             repo_subscription_id,
             req,
@@ -240,7 +240,7 @@ async def delete_github_repo_subscription(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> dict[str, JsonValue]:
     try:
-        await run_in_threadpool(service.delete_repo_subscription, repo_subscription_id)
+        await call_maybe_async(service.delete_repo_subscription, repo_subscription_id)
         return {"status": "ok"}
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -255,7 +255,7 @@ async def enable_github_repo_subscription(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> GitHubRepoSubscriptionRecord:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             service.enable_repo_subscription,
             repo_subscription_id,
         )
@@ -276,7 +276,7 @@ async def disable_github_repo_subscription(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> GitHubRepoSubscriptionRecord:
     try:
-        return await run_in_threadpool(
+        return await call_maybe_async(
             service.disable_repo_subscription,
             repo_subscription_id,
         )
@@ -292,7 +292,7 @@ async def disable_github_repo_subscription(
 async def list_github_rules(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> list[TriggerRuleRecord]:
-    rules = await run_in_threadpool(service.list_rules)
+    rules = await call_maybe_async(service.list_rules)
     return list(rules)
 
 
@@ -302,7 +302,7 @@ async def create_github_rule(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> TriggerRuleRecord:
     try:
-        return await run_in_threadpool(service.create_rule, req)
+        return await call_maybe_async(service.create_rule, req)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except TriggerRuleNameConflictError as exc:
@@ -320,7 +320,7 @@ async def update_github_rule(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> TriggerRuleRecord:
     try:
-        return await run_in_threadpool(service.update_rule, trigger_rule_id, req)
+        return await call_maybe_async(service.update_rule, trigger_rule_id, req)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except TriggerRuleNameConflictError as exc:
@@ -337,7 +337,7 @@ async def delete_github_rule(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> dict[str, JsonValue]:
     try:
-        await run_in_threadpool(service.delete_rule, trigger_rule_id)
+        await call_maybe_async(service.delete_rule, trigger_rule_id)
         return {"status": "ok"}
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -349,7 +349,7 @@ async def enable_github_rule(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> TriggerRuleRecord:
     try:
-        return await run_in_threadpool(service.enable_rule, trigger_rule_id)
+        return await call_maybe_async(service.enable_rule, trigger_rule_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except GitHubApiError as exc:
@@ -366,7 +366,7 @@ async def disable_github_rule(
     service: Annotated[GitHubTriggerService, Depends(get_github_trigger_service)],
 ) -> TriggerRuleRecord:
     try:
-        return await run_in_threadpool(service.disable_rule, trigger_rule_id)
+        return await call_maybe_async(service.disable_rule, trigger_rule_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except GitHubApiError as exc:
@@ -382,7 +382,7 @@ async def handle_github_delivery(
 ) -> dict[str, JsonValue]:
     body = await request.body()
     headers = {str(key): str(value) for key, value in request.headers.items()}
-    return await run_in_threadpool(
+    return await call_maybe_async(
         service.handle_inbound_github_delivery,
         headers=headers,
         body=body,

--- a/src/relay_teams/interfaces/server/routers/workspaces.py
+++ b/src/relay_teams/interfaces/server/routers/workspaces.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from typing import Annotated
 
@@ -10,6 +9,7 @@ from fastapi.responses import FileResponse
 from urllib.parse import unquote
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from relay_teams.interfaces.server.async_call import call_maybe_async
 from relay_teams.validation import require_force_delete
 from relay_teams.interfaces.server.deps import get_workspace_service
 from relay_teams.interfaces.server.write_models import DeleteRequest
@@ -87,7 +87,7 @@ async def create_workspace(
                 default_mount_name=req.default_mount_name,
             )
 
-        return await asyncio.to_thread(_create_workspace)
+        return await call_maybe_async(_create_workspace)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -107,7 +107,7 @@ async def pick_workspace(
         return service.create_workspace_for_root(root_path=selected_root)
 
     try:
-        workspace = await asyncio.to_thread(_pick_workspace_for_request)
+        workspace = await call_maybe_async(_pick_workspace_for_request)
         if workspace is None:
             return PickWorkspaceResponse(workspace=None)
     except ValueError as exc:
@@ -121,7 +121,7 @@ async def pick_workspace(
 async def list_workspaces(
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> list[WorkspaceRecord]:
-    records = await asyncio.to_thread(service.list_workspaces)
+    records = await call_maybe_async(service.list_workspaces)
     return list(records)
 
 
@@ -131,7 +131,7 @@ async def get_workspace(
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceRecord:
     try:
-        return await asyncio.to_thread(service.get_workspace, workspace_id)
+        return await call_maybe_async(service.get_workspace, workspace_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Workspace not found") from exc
 
@@ -143,7 +143,7 @@ async def update_workspace(
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceRecord:
     try:
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.update_workspace,
             workspace_id,
             mounts=req.mounts,
@@ -163,9 +163,9 @@ async def open_workspace_root(
 ) -> dict[str, str]:
     try:
         if mount is None:
-            _ = await asyncio.to_thread(service.open_workspace_root, workspace_id)
+            _ = await call_maybe_async(service.open_workspace_root, workspace_id)
         else:
-            _ = await asyncio.to_thread(
+            _ = await call_maybe_async(
                 service.open_workspace_root,
                 workspace_id,
                 mount_name=mount,
@@ -185,7 +185,7 @@ async def get_workspace_snapshot(
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceSnapshot:
     try:
-        return await asyncio.to_thread(service.get_workspace_snapshot, workspace_id)
+        return await call_maybe_async(service.get_workspace_snapshot, workspace_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Workspace not found") from exc
     except ValueError as exc:
@@ -201,12 +201,12 @@ async def get_workspace_tree_listing(
 ) -> WorkspaceTreeListing:
     try:
         if mount is None:
-            return await asyncio.to_thread(
+            return await call_maybe_async(
                 service.get_workspace_tree_listing,
                 workspace_id,
                 directory_path=path,
             )
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.get_workspace_tree_listing,
             workspace_id,
             directory_path=path,
@@ -227,7 +227,7 @@ async def search_workspace_paths(
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceSearchResponse:
     try:
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.search_workspace_paths,
             workspace_id,
             query=query,
@@ -248,8 +248,8 @@ async def get_workspace_diffs(
 ) -> WorkspaceDiffListing:
     try:
         if mount is None:
-            return await asyncio.to_thread(service.get_workspace_diffs, workspace_id)
-        return await asyncio.to_thread(
+            return await call_maybe_async(service.get_workspace_diffs, workspace_id)
+        return await call_maybe_async(
             service.get_workspace_diffs,
             workspace_id,
             mount_name=mount,
@@ -269,12 +269,12 @@ async def get_workspace_diff_file(
 ) -> WorkspaceDiffFile:
     try:
         if mount is None:
-            return await asyncio.to_thread(
+            return await call_maybe_async(
                 service.get_workspace_diff_file,
                 workspace_id,
                 path=unquote(path),
             )
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.get_workspace_diff_file,
             workspace_id,
             path=unquote(path),
@@ -295,13 +295,13 @@ async def get_workspace_preview_file(
 ) -> FileResponse:
     try:
         if mount is None:
-            resolved_path, media_type = await asyncio.to_thread(
+            resolved_path, media_type = await call_maybe_async(
                 service.get_workspace_image_preview_file,
                 workspace_id,
                 path=unquote(path),
             )
         else:
-            resolved_path, media_type = await asyncio.to_thread(
+            resolved_path, media_type = await call_maybe_async(
                 service.get_workspace_image_preview_file,
                 workspace_id,
                 path=unquote(path),
@@ -337,7 +337,7 @@ async def delete_workspace(
                 message="Cannot remove workspace directory without force",
             )
 
-        await asyncio.to_thread(
+        await call_maybe_async(
             service.delete_workspace_with_options,
             workspace_id=workspace_id,
             remove_directory=should_remove_directory,
@@ -358,7 +358,7 @@ async def fork_workspace(
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> WorkspaceRecord:
     try:
-        return await asyncio.to_thread(
+        return await call_maybe_async(
             service.fork_workspace,
             source_workspace_id=workspace_id,
             name=req.name,

--- a/src/relay_teams/media/asset_repository.py
+++ b/src/relay_teams/media/asset_repository.py
@@ -3,22 +3,19 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from relay_teams.media.models import (
     MediaAssetRecord,
     MediaAssetStorageKind,
     MediaModality,
 )
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 
-class MediaAssetRepository:
+class MediaAssetRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -132,6 +129,9 @@ class MediaAssetRepository:
         )
         return self.get(record.asset_id)
 
+    async def upsert_async(self, record: MediaAssetRecord) -> MediaAssetRecord:
+        return await self._call_sync_async(self.upsert, record)
+
     def get(self, asset_id: str) -> MediaAssetRecord:
         with self._lock:
             row = self._conn.execute(
@@ -142,6 +142,9 @@ class MediaAssetRepository:
             raise KeyError(f"Unknown asset_id: {asset_id}")
         return self._to_record(row)
 
+    async def get_async(self, asset_id: str) -> MediaAssetRecord:
+        return await self._call_sync_async(self.get, asset_id)
+
     def list_by_session(self, session_id: str) -> tuple[MediaAssetRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -149,6 +152,11 @@ class MediaAssetRepository:
                 (session_id,),
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_by_session_async(
+        self, session_id: str
+    ) -> tuple[MediaAssetRecord, ...]:
+        return await self._call_sync_async(self.list_by_session, session_id)
 
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -162,6 +170,9 @@ class MediaAssetRepository:
             repository_name="MediaAssetRepository",
             operation_name="delete_by_session",
         )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_session, session_id)
 
     def _to_record(self, row: sqlite3.Row) -> MediaAssetRecord:
         return MediaAssetRecord(

--- a/src/relay_teams/metrics/__init__.py
+++ b/src/relay_teams/metrics/__init__.py
@@ -23,6 +23,7 @@ from relay_teams.metrics.registry import MetricRegistry
 from relay_teams.metrics.service import MetricsService
 from relay_teams.metrics.sinks import (
     AggregateStoreSink,
+    AsyncMetricsSink,
     GrafanaExporterSink,
     MetricsSink,
     PrettyLogSink,
@@ -31,6 +32,7 @@ from relay_teams.metrics.stores import MetricPointRecord, SqliteMetricAggregateS
 
 __all__ = [
     "AggregateStoreSink",
+    "AsyncMetricsSink",
     "DEFAULT_DEFINITIONS",
     "GrafanaExporterSink",
     "MetricDefinition",

--- a/src/relay_teams/metrics/adapters/__init__.py
+++ b/src/relay_teams/metrics/adapters/__init__.py
@@ -2,14 +2,24 @@
 from __future__ import annotations
 
 from relay_teams.metrics.adapters.gateway_metrics import record_gateway_operation
-from relay_teams.metrics.adapters.llm_metrics import record_token_usage
+from relay_teams.metrics.adapters.llm_metrics import (
+    record_token_usage,
+    record_token_usage_async,
+)
 from relay_teams.metrics.adapters.retrieval_metrics import (
     record_retrieval_document_count,
     record_retrieval_rebuild,
     record_retrieval_search,
 )
-from relay_teams.metrics.adapters.session_metrics import record_session_step
-from relay_teams.metrics.adapters.tool_metrics import ToolSource, record_tool_execution
+from relay_teams.metrics.adapters.session_metrics import (
+    record_session_step,
+    record_session_step_async,
+)
+from relay_teams.metrics.adapters.tool_metrics import (
+    ToolSource,
+    record_tool_execution,
+    record_tool_execution_async,
+)
 
 __all__ = [
     "record_gateway_operation",
@@ -18,6 +28,9 @@ __all__ = [
     "record_retrieval_rebuild",
     "record_retrieval_search",
     "record_session_step",
+    "record_session_step_async",
     "record_token_usage",
+    "record_token_usage_async",
     "record_tool_execution",
+    "record_tool_execution_async",
 ]

--- a/src/relay_teams/metrics/adapters/llm_metrics.py
+++ b/src/relay_teams/metrics/adapters/llm_metrics.py
@@ -47,3 +47,42 @@ def record_token_usage(
             value=output_tokens,
             tags=tags,
         )
+
+
+async def record_token_usage_async(
+    recorder: MetricRecorder,
+    *,
+    workspace_id: str,
+    session_id: str,
+    run_id: str,
+    instance_id: str,
+    role_id: str,
+    input_tokens: int,
+    cached_input_tokens: int,
+    output_tokens: int,
+) -> None:
+    tags = MetricTagSet(
+        workspace_id=workspace_id,
+        session_id=session_id,
+        run_id=run_id,
+        instance_id=instance_id,
+        role_id=role_id,
+    )
+    if input_tokens > 0:
+        await recorder.emit_async(
+            definition_name=LLM_INPUT_TOKENS.name,
+            value=input_tokens,
+            tags=tags,
+        )
+    if cached_input_tokens > 0:
+        await recorder.emit_async(
+            definition_name=LLM_CACHED_INPUT_TOKENS.name,
+            value=cached_input_tokens,
+            tags=tags,
+        )
+    if output_tokens > 0:
+        await recorder.emit_async(
+            definition_name=LLM_OUTPUT_TOKENS.name,
+            value=output_tokens,
+            tags=tags,
+        )

--- a/src/relay_teams/metrics/adapters/session_metrics.py
+++ b/src/relay_teams/metrics/adapters/session_metrics.py
@@ -26,3 +26,25 @@ def record_session_step(
             role_id=role_id,
         ),
     )
+
+
+async def record_session_step_async(
+    recorder: MetricRecorder,
+    *,
+    workspace_id: str,
+    session_id: str,
+    run_id: str,
+    instance_id: str,
+    role_id: str,
+) -> None:
+    await recorder.emit_async(
+        definition_name=SESSION_STEPS.name,
+        value=1,
+        tags=MetricTagSet(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            run_id=run_id,
+            instance_id=instance_id,
+            role_id=role_id,
+        ),
+    )

--- a/src/relay_teams/metrics/adapters/tool_metrics.py
+++ b/src/relay_teams/metrics/adapters/tool_metrics.py
@@ -68,6 +68,51 @@ def record_tool_execution(
         recorder.emit(definition_name=MCP_CALLS.name, value=1, tags=tags)
 
 
+async def record_tool_execution_async(
+    recorder: MetricRecorder,
+    *,
+    mcp_registry: McpRegistry,
+    workspace_id: str,
+    session_id: str,
+    run_id: str,
+    instance_id: str,
+    role_id: str,
+    tool_name: str,
+    duration_ms: int,
+    success: bool,
+) -> None:
+    source, mcp_server = _resolve_tool_source(
+        tool_name=tool_name, mcp_registry=mcp_registry
+    )
+    tags = MetricTagSet(
+        workspace_id=workspace_id,
+        session_id=session_id,
+        run_id=run_id,
+        instance_id=instance_id,
+        role_id=role_id,
+        tool_name=tool_name,
+        tool_source=source.value,
+        mcp_server=mcp_server,
+        status="success" if success else "failure",
+    )
+    await recorder.emit_async(definition_name=TOOL_CALLS.name, value=1, tags=tags)
+    await recorder.emit_async(
+        definition_name=TOOL_DURATION_MS.name,
+        value=duration_ms,
+        tags=tags,
+    )
+    if not success:
+        await recorder.emit_async(
+            definition_name=TOOL_FAILURES.name,
+            value=1,
+            tags=tags,
+        )
+    if source == ToolSource.SKILL:
+        await recorder.emit_async(definition_name=SKILL_CALLS.name, value=1, tags=tags)
+    if source == ToolSource.MCP:
+        await recorder.emit_async(definition_name=MCP_CALLS.name, value=1, tags=tags)
+
+
 def _resolve_tool_source(
     *,
     tool_name: str,

--- a/src/relay_teams/metrics/recorder.py
+++ b/src/relay_teams/metrics/recorder.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 
 from relay_teams.metrics.models import MetricEvent, MetricTagSet
 from relay_teams.metrics.registry import MetricRegistry
-from relay_teams.metrics.sinks.base import MetricsSink
+from relay_teams.metrics.sinks.base import AsyncMetricsSink, MetricsSink
 
 
 class MetricRecorder:
@@ -35,7 +36,33 @@ class MetricRecorder:
             occurred_at=occurred_at or datetime.now(tz=timezone.utc),
         )
         for sink in self._sinks:
+            # noinspection PyBroadException
             try:
                 sink.record(event)
+            except Exception:
+                continue
+
+    async def emit_async(
+        self,
+        *,
+        definition_name: str,
+        value: float,
+        tags: MetricTagSet,
+        occurred_at: datetime | None = None,
+    ) -> None:
+        definition = self._registry.get(definition_name)
+        event = MetricEvent(
+            definition_name=definition.name,
+            kind=definition.kind,
+            value=float(value),
+            tags=tags,
+            occurred_at=occurred_at or datetime.now(tz=timezone.utc),
+        )
+        for sink in self._sinks:
+            try:
+                if isinstance(sink, AsyncMetricsSink):
+                    await sink.record_async(event)
+                else:
+                    await asyncio.to_thread(sink.record, event)
             except Exception:
                 continue

--- a/src/relay_teams/metrics/sinks/__init__.py
+++ b/src/relay_teams/metrics/sinks/__init__.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from relay_teams.metrics.sinks.base import MetricsSink
+from relay_teams.metrics.sinks.base import AsyncMetricsSink, MetricsSink
 from relay_teams.metrics.sinks.grafana_exporter import GrafanaExporterSink
 from relay_teams.metrics.sinks.pretty_log import PrettyLogSink
 from relay_teams.metrics.sinks.store_sink import AggregateStoreSink
 
 __all__ = [
     "AggregateStoreSink",
+    "AsyncMetricsSink",
     "GrafanaExporterSink",
     "MetricsSink",
     "PrettyLogSink",

--- a/src/relay_teams/metrics/sinks/base.py
+++ b/src/relay_teams/metrics/sinks/base.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from relay_teams.metrics.models import MetricEvent
 
 
 class MetricsSink(Protocol):
     def record(self, event: MetricEvent) -> None: ...
+
+
+@runtime_checkable
+class AsyncMetricsSink(Protocol):
+    async def record_async(self, event: MetricEvent) -> None: ...

--- a/src/relay_teams/metrics/sinks/base.py
+++ b/src/relay_teams/metrics/sinks/base.py
@@ -7,9 +7,11 @@ from relay_teams.metrics.models import MetricEvent
 
 
 class MetricsSink(Protocol):
-    def record(self, event: MetricEvent) -> None: ...
+    def record(self, event: MetricEvent) -> None:
+        pass
 
 
 @runtime_checkable
 class AsyncMetricsSink(Protocol):
-    async def record_async(self, event: MetricEvent) -> None: ...
+    async def record_async(self, event: MetricEvent) -> None:
+        pass

--- a/src/relay_teams/metrics/sinks/store_sink.py
+++ b/src/relay_teams/metrics/sinks/store_sink.py
@@ -11,3 +11,6 @@ class AggregateStoreSink:
 
     def record(self, event: MetricEvent) -> None:
         self._store.record(event)
+
+    async def record_async(self, event: MetricEvent) -> None:
+        await self._store.record_async(event)

--- a/src/relay_teams/metrics/stores/sqlite.py
+++ b/src/relay_teams/metrics/stores/sqlite.py
@@ -9,7 +9,11 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict, Field
 
 from relay_teams.metrics.models import MetricEvent, MetricScope
-from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
+from relay_teams.persistence.sqlite_repository import (
+    SharedSqliteRepository,
+    async_fetchall,
+    async_fetchone,
+)
 
 
 class MetricPointRecord(BaseModel):
@@ -98,6 +102,47 @@ class SqliteMetricAggregateStore(SharedSqliteRepository):
 
         self._run_write(operation_name="record", operation=operation)
 
+    async def record_async(self, event: MetricEvent) -> None:
+        bucket_start = event.occurred_at.astimezone(timezone.utc).replace(
+            second=0,
+            microsecond=0,
+        )
+        tags_json = json.dumps(dict(event.tags.normalized_items()), sort_keys=True)
+        recorded_at = event.occurred_at.astimezone(timezone.utc).isoformat()
+        scopes = (
+            (MetricScope.GLOBAL, "global"),
+            (MetricScope.SESSION, event.tags.session_id),
+            (MetricScope.RUN, event.tags.run_id),
+        )
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            for scope, scope_id in scopes:
+                if not scope_id:
+                    continue
+                await conn.execute(
+                    """
+                    INSERT INTO metric_points(
+                        scope, scope_id, metric_name, bucket_start,
+                        tags_json, value, recorded_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        scope.value,
+                        scope_id,
+                        event.definition_name,
+                        bucket_start.isoformat(),
+                        tags_json,
+                        event.value,
+                        recorded_at,
+                    ),
+                )
+
+        await self._run_async_write(
+            operation_name="record", operation=lambda _: operation()
+        )
+
     def query_points(
         self,
         *,
@@ -126,6 +171,34 @@ class SqliteMetricAggregateStore(SharedSqliteRepository):
         )
         return tuple(self._row_to_record(row) for row in rows)
 
+    async def query_points_async(
+        self, *, scope: MetricScope, scope_id: str, time_window_minutes: int
+    ) -> tuple[MetricPointRecord, ...]:
+        threshold = datetime.now(tz=timezone.utc) - timedelta(
+            minutes=time_window_minutes
+        )
+
+        async def operation() -> list[sqlite3.Row]:
+            conn = await self._get_async_conn()
+            return await async_fetchall(
+                conn,
+                """
+                SELECT scope, scope_id, metric_name, bucket_start,
+                       tags_json, value, recorded_at
+                FROM metric_points
+                WHERE scope=? AND scope_id=? AND bucket_start>=?
+                ORDER BY bucket_start ASC, id ASC
+                """,
+                (
+                    scope.value,
+                    scope_id,
+                    threshold.replace(second=0, microsecond=0).isoformat(),
+                ),
+            )
+
+        rows = await self._run_async_read(lambda _: operation())
+        return tuple(self._row_to_record(row) for row in rows)
+
     def latest_recorded_at(
         self,
         *,
@@ -142,6 +215,29 @@ class SqliteMetricAggregateStore(SharedSqliteRepository):
                 (scope.value, scope_id),
             ).fetchone()
         )
+        if row is None:
+            return None
+        value = row["recorded_at"]
+        if value is None:
+            return None
+        return str(value)
+
+    async def latest_recorded_at_async(
+        self, *, scope: MetricScope, scope_id: str
+    ) -> str | None:
+        async def operation() -> sqlite3.Row | None:
+            conn = await self._get_async_conn()
+            return await async_fetchone(
+                conn,
+                """
+                SELECT MAX(recorded_at) AS recorded_at
+                FROM metric_points
+                WHERE scope=? AND scope_id=?
+                """,
+                (scope.value, scope_id),
+            )
+
+        row = await self._run_async_read(lambda _: operation())
         if row is None:
             return None
         value = row["recorded_at"]
@@ -171,6 +267,33 @@ class SqliteMetricAggregateStore(SharedSqliteRepository):
             )
 
         self._run_write(operation_name="delete_by_session", operation=operation)
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            await conn.execute(
+                "DELETE FROM metric_points WHERE scope=? AND scope_id=?",
+                (MetricScope.SESSION.value, session_id),
+            )
+            await conn.execute(
+                """
+                DELETE FROM metric_points
+                WHERE scope=? AND tags_json LIKE ?
+                """,
+                (MetricScope.GLOBAL.value, f'%"session_id": "{session_id}"%'),
+            )
+            await conn.execute(
+                """
+                DELETE FROM metric_points
+                WHERE scope=? AND tags_json LIKE ?
+                """,
+                (MetricScope.RUN.value, f'%"session_id": "{session_id}"%'),
+            )
+
+        await self._run_async_write(
+            operation_name="delete_by_session",
+            operation=lambda _: operation(),
+        )
 
     def _row_to_record(self, row: sqlite3.Row) -> MetricPointRecord:
         return MetricPointRecord(

--- a/src/relay_teams/monitors/repository.py
+++ b/src/relay_teams/monitors/repository.py
@@ -147,6 +147,11 @@ class MonitorRepository(SharedSqliteRepository):
         )
         return record
 
+    async def create_subscription_async(
+        self, record: MonitorSubscriptionRecord
+    ) -> MonitorSubscriptionRecord:
+        return await self._call_sync_async(self.create_subscription, record)
+
     def update_subscription(
         self,
         record: MonitorSubscriptionRecord,
@@ -198,6 +203,11 @@ class MonitorRepository(SharedSqliteRepository):
         )
         return record
 
+    async def update_subscription_async(
+        self, record: MonitorSubscriptionRecord
+    ) -> MonitorSubscriptionRecord:
+        return await self._call_sync_async(self.update_subscription, record)
+
     def get_subscription(self, monitor_id: str) -> MonitorSubscriptionRecord:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -212,6 +222,11 @@ class MonitorRepository(SharedSqliteRepository):
             raise KeyError(f"Unknown monitor: {monitor_id}")
         return _subscription_from_row(row)
 
+    async def get_subscription_async(
+        self, monitor_id: str
+    ) -> MonitorSubscriptionRecord:
+        return await self._call_sync_async(self.get_subscription, monitor_id)
+
     def list_for_run(self, run_id: str) -> tuple[MonitorSubscriptionRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -224,6 +239,11 @@ class MonitorRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(_subscription_from_row(row) for row in rows)
+
+    async def list_for_run_async(
+        self, run_id: str
+    ) -> tuple[MonitorSubscriptionRecord, ...]:
+        return await self._call_sync_async(self.list_for_run, run_id)
 
     def delete_by_run(self, run_id: str) -> None:
         self._run_write(
@@ -240,6 +260,9 @@ class MonitorRepository(SharedSqliteRepository):
             ),
         )
 
+    async def delete_by_run_async(self, run_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_run, run_id)
+
     def delete_by_session(self, session_id: str) -> None:
         self._run_write(
             operation_name="delete_by_session",
@@ -254,6 +277,9 @@ class MonitorRepository(SharedSqliteRepository):
                 ),
             ),
         )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_session, session_id)
 
     def list_active_for_source(
         self,
@@ -276,6 +302,13 @@ class MonitorRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(_subscription_from_row(row) for row in rows)
+
+    async def list_active_for_source_async(
+        self, *, source_kind: str, source_key: str
+    ) -> tuple[MonitorSubscriptionRecord, ...]:
+        return await self._call_sync_async(
+            self.list_active_for_source, source_kind=source_kind, source_key=source_key
+        )
 
     def create_trigger(self, record: MonitorTriggerRecord) -> MonitorTriggerRecord:
         self._run_write(
@@ -319,6 +352,11 @@ class MonitorRepository(SharedSqliteRepository):
             ),
         )
         return record
+
+    async def create_trigger_async(
+        self, record: MonitorTriggerRecord
+    ) -> MonitorTriggerRecord:
+        return await self._call_sync_async(self.create_trigger, record)
 
     def record_matching_trigger(
         self,
@@ -465,6 +503,13 @@ class MonitorRepository(SharedSqliteRepository):
             operation=operation,
         )
 
+    async def record_matching_trigger_async(
+        self, *, monitor_id: str, envelope: MonitorEventEnvelope
+    ) -> tuple[MonitorSubscriptionRecord, MonitorTriggerRecord] | None:
+        return await self._call_sync_async(
+            self.record_matching_trigger, monitor_id=monitor_id, envelope=envelope
+        )
+
     def has_trigger_dedupe_key(self, *, monitor_id: str, dedupe_key: str) -> bool:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -478,6 +523,13 @@ class MonitorRepository(SharedSqliteRepository):
             ).fetchone()
         )
         return row is not None
+
+    async def has_trigger_dedupe_key_async(
+        self, *, monitor_id: str, dedupe_key: str
+    ) -> bool:
+        return await self._call_sync_async(
+            self.has_trigger_dedupe_key, monitor_id=monitor_id, dedupe_key=dedupe_key
+        )
 
     def list_triggers_for_monitor(
         self, monitor_id: str
@@ -493,6 +545,11 @@ class MonitorRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(_trigger_from_row(row) for row in rows)
+
+    async def list_triggers_for_monitor_async(
+        self, monitor_id: str
+    ) -> tuple[MonitorTriggerRecord, ...]:
+        return await self._call_sync_async(self.list_triggers_for_monitor, monitor_id)
 
 
 def _subscription_from_row(row: sqlite3.Row) -> MonitorSubscriptionRecord:

--- a/src/relay_teams/monitors/service.py
+++ b/src/relay_teams/monitors/service.py
@@ -25,7 +25,7 @@ from relay_teams.notifications import (
     NotificationType,
 )
 from relay_teams.sessions.runs.enums import RunEventType
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 
 LOGGER = get_logger(__name__)
@@ -76,21 +76,16 @@ class MonitorService:
         created_by_role_id: str | None,
         tool_call_id: str | None,
     ) -> MonitorSubscriptionRecord:
-        now = _utc_now()
-        record = MonitorSubscriptionRecord(
-            monitor_id=f"mon_{uuid4().hex[:12]}",
+        record = self._build_monitor_record(
             run_id=run_id,
             session_id=session_id,
             source_kind=source_kind,
-            source_key=source_key.strip(),
-            created_by_instance_id=_normalize_optional_text(created_by_instance_id),
-            created_by_role_id=_normalize_optional_text(created_by_role_id),
-            tool_call_id=_normalize_optional_text(tool_call_id),
-            status=MonitorSubscriptionStatus.ACTIVE,
             rule=rule,
             action=action,
-            created_at=now,
-            updated_at=now,
+            source_key=source_key,
+            created_by_instance_id=created_by_instance_id,
+            created_by_role_id=created_by_role_id,
+            tool_call_id=tool_call_id,
         )
         created = self._repository.create_subscription(record)
         self._publish_monitor_event(
@@ -105,8 +100,50 @@ class MonitorService:
         )
         return created
 
+    async def create_monitor_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        source_kind: MonitorSourceKind,
+        source_key: str,
+        rule: MonitorRule,
+        action: MonitorAction,
+        created_by_instance_id: str | None,
+        created_by_role_id: str | None,
+        tool_call_id: str | None,
+    ) -> MonitorSubscriptionRecord:
+        record = self._build_monitor_record(
+            run_id=run_id,
+            session_id=session_id,
+            source_kind=source_kind,
+            rule=rule,
+            action=action,
+            source_key=source_key,
+            created_by_instance_id=created_by_instance_id,
+            created_by_role_id=created_by_role_id,
+            tool_call_id=tool_call_id,
+        )
+        created = await self._repository.create_subscription_async(record)
+        await self._publish_monitor_event_async(
+            record=created,
+            event_type=RunEventType.MONITOR_CREATED,
+            payload={
+                "monitor_id": created.monitor_id,
+                "source_kind": created.source_kind.value,
+                "source_key": created.source_key,
+                "action_type": created.action.action_type.value,
+            },
+        )
+        return created
+
     def list_for_run(self, run_id: str) -> tuple[MonitorSubscriptionRecord, ...]:
         return self._repository.list_for_run(run_id)
+
+    async def list_for_run_async(
+        self, run_id: str
+    ) -> tuple[MonitorSubscriptionRecord, ...]:
+        return await self._repository.list_for_run_async(run_id)
 
     def stop_for_run(
         self,
@@ -130,6 +167,34 @@ class MonitorService:
             )
         )
         self._publish_monitor_event(
+            record=updated,
+            event_type=RunEventType.MONITOR_STOPPED,
+            payload={"monitor_id": updated.monitor_id},
+        )
+        return updated
+
+    async def stop_for_run_async(
+        self,
+        *,
+        run_id: str,
+        monitor_id: str,
+    ) -> MonitorSubscriptionRecord:
+        record = await self._repository.get_subscription_async(monitor_id)
+        if record.run_id != run_id:
+            raise KeyError(f"Monitor {monitor_id} does not belong to run {run_id}")
+        if record.status == MonitorSubscriptionStatus.STOPPED:
+            return record
+        now = _utc_now()
+        updated = await self._repository.update_subscription_async(
+            record.model_copy(
+                update={
+                    "status": MonitorSubscriptionStatus.STOPPED,
+                    "updated_at": now,
+                    "stopped_at": now,
+                }
+            )
+        )
+        await self._publish_monitor_event_async(
             record=updated,
             event_type=RunEventType.MONITOR_STOPPED,
             payload={"monitor_id": updated.monitor_id},
@@ -167,6 +232,46 @@ class MonitorService:
             self._dispatch_action(updated, envelope)
             if updated.status == MonitorSubscriptionStatus.STOPPED:
                 self._publish_monitor_event(
+                    record=updated,
+                    event_type=RunEventType.MONITOR_STOPPED,
+                    payload={"monitor_id": updated.monitor_id},
+                )
+            triggered.append(trigger)
+        return tuple(triggered)
+
+    async def emit_async(
+        self, envelope: MonitorEventEnvelope
+    ) -> tuple[MonitorTriggerRecord, ...]:
+        triggered: list[MonitorTriggerRecord] = []
+        subscriptions = await self._repository.list_active_for_source_async(
+            source_kind=envelope.source_kind.value,
+            source_key=envelope.source_key,
+        )
+        for subscription in subscriptions:
+            if not _rule_matches(subscription.rule, envelope):
+                continue
+            recorded = await self._repository.record_matching_trigger_async(
+                monitor_id=subscription.monitor_id,
+                envelope=envelope,
+            )
+            if recorded is None:
+                continue
+            updated, trigger = recorded
+            await self._publish_monitor_event_async(
+                record=updated,
+                event_type=RunEventType.MONITOR_TRIGGERED,
+                payload={
+                    "monitor_id": updated.monitor_id,
+                    "monitor_trigger_id": trigger.monitor_trigger_id,
+                    "event_name": envelope.event_name,
+                    "source_kind": envelope.source_kind.value,
+                    "source_key": envelope.source_key,
+                    "action_type": updated.action.action_type.value,
+                },
+            )
+            self._dispatch_action(updated, envelope)
+            if updated.status == MonitorSubscriptionStatus.STOPPED:
+                await self._publish_monitor_event_async(
                     record=updated,
                     event_type=RunEventType.MONITOR_STOPPED,
                     payload={"monitor_id": updated.monitor_id},
@@ -265,6 +370,56 @@ class MonitorService:
                 event_type=event_type,
                 payload_json=json.dumps(payload, ensure_ascii=False),
             )
+        )
+
+    async def _publish_monitor_event_async(
+        self,
+        *,
+        record: MonitorSubscriptionRecord,
+        event_type: RunEventType,
+        payload: dict[str, str],
+    ) -> None:
+        await publish_run_event_async(
+            self._run_event_hub,
+            RunEvent(
+                session_id=record.session_id,
+                run_id=record.run_id,
+                trace_id=record.run_id,
+                instance_id=record.created_by_instance_id,
+                role_id=record.created_by_role_id,
+                event_type=event_type,
+                payload_json=json.dumps(payload, ensure_ascii=False),
+            ),
+        )
+
+    @staticmethod
+    def _build_monitor_record(
+        *,
+        run_id: str,
+        session_id: str,
+        source_kind: MonitorSourceKind,
+        source_key: str,
+        rule: MonitorRule,
+        action: MonitorAction,
+        created_by_instance_id: str | None,
+        created_by_role_id: str | None,
+        tool_call_id: str | None,
+    ) -> MonitorSubscriptionRecord:
+        now = _utc_now()
+        return MonitorSubscriptionRecord(
+            monitor_id=f"mon_{uuid4().hex[:12]}",
+            run_id=run_id,
+            session_id=session_id,
+            source_kind=source_kind,
+            source_key=source_key.strip(),
+            created_by_instance_id=_normalize_optional_text(created_by_instance_id),
+            created_by_role_id=_normalize_optional_text(created_by_role_id),
+            tool_call_id=_normalize_optional_text(tool_call_id),
+            status=MonitorSubscriptionStatus.ACTIVE,
+            rule=rule,
+            action=action,
+            created_at=now,
+            updated_at=now,
         )
 
 

--- a/src/relay_teams/net/__init__.py
+++ b/src/relay_teams/net/__init__.py
@@ -15,6 +15,7 @@ from relay_teams.net.github_cli import (
 from relay_teams.net.llm_client import (
     build_llm_http_client,
     clear_llm_http_client_cache,
+    clear_llm_http_client_cache_async,
     reset_llm_http_client_cache_entry,
 )
 from relay_teams.net.websocket import (
@@ -27,6 +28,7 @@ __all__ = [
     "build_llm_http_client",
     "build_websocket_ssl_context",
     "clear_llm_http_client_cache",
+    "clear_llm_http_client_cache_async",
     "reset_llm_http_client_cache_entry",
     "create_async_http_client",
     "create_runtime_sync_http_client",

--- a/src/relay_teams/net/llm_client.py
+++ b/src/relay_teams/net/llm_client.py
@@ -18,6 +18,7 @@ from relay_teams.net.constants import DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
 __all__ = [
     "build_llm_http_client",
     "clear_llm_http_client_cache",
+    "clear_llm_http_client_cache_async",
     "reset_llm_http_client_cache_entry",
 ]
 
@@ -84,6 +85,15 @@ def clear_llm_http_client_cache() -> None:
     _SHARED_LLM_HTTP_CLIENT_CACHE.clear()
     _SCOPED_LLM_HTTP_CLIENT_CACHE.clear()
     _close_llm_http_clients(clients)
+
+
+async def clear_llm_http_client_cache_async() -> None:
+    clients = tuple(_SHARED_LLM_HTTP_CLIENT_CACHE.values()) + tuple(
+        _SCOPED_LLM_HTTP_CLIENT_CACHE.values()
+    )
+    _SHARED_LLM_HTTP_CLIENT_CACHE.clear()
+    _SCOPED_LLM_HTTP_CLIENT_CACHE.clear()
+    await _close_llm_http_clients_async(clients)
 
 
 async def reset_llm_http_client_cache_entry(

--- a/src/relay_teams/notifications/notification_service.py
+++ b/src/relay_teams/notifications/notification_service.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from json import dumps
 import logging
@@ -14,7 +15,7 @@ from relay_teams.notifications.models import (
     NotificationType,
 )
 from relay_teams.sessions.runs.enums import RunEventType
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 
 logger = get_logger(__name__)
@@ -74,6 +75,62 @@ class NotificationService:
         for dispatcher in self._dispatchers:
             try:
                 dispatcher.dispatch(request)
+            except Exception as exc:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event="notification.dispatch.failed",
+                    message="Notification dispatcher failed",
+                    payload={
+                        "dispatcher": type(dispatcher).__name__,
+                        "notification_type": request.notification_type.value,
+                        "run_id": request.context.run_id,
+                        "session_id": request.context.session_id,
+                    },
+                    exc_info=exc,
+                )
+                continue
+        return True
+
+    async def emit_async(
+        self,
+        *,
+        notification_type: NotificationType,
+        title: str,
+        body: str,
+        context: NotificationContext,
+        dedupe_key: str | None = None,
+    ) -> bool:
+        config = self._get_config()
+        rule = config.rule_for(notification_type)
+        if not rule.enabled or not rule.channels:
+            return False
+
+        request = NotificationRequest(
+            notification_type=notification_type,
+            title=title,
+            body=body,
+            channels=rule.channels,
+            feishu_format=rule.feishu_format,
+            dedupe_key=dedupe_key or self._build_dedupe_key(notification_type, context),
+            context=context,
+        )
+        await publish_run_event_async(
+            self._run_event_hub,
+            RunEvent(
+                session_id=context.session_id,
+                run_id=context.run_id,
+                trace_id=context.trace_id,
+                task_id=context.task_id,
+                instance_id=context.instance_id,
+                role_id=context.role_id,
+                event_type=RunEventType.NOTIFICATION_REQUESTED,
+                payload_json=dumps(request.model_dump(mode="json"), ensure_ascii=False),
+            ),
+        )
+        for dispatcher in self._dispatchers:
+            try:
+                await asyncio.to_thread(dispatcher.dispatch, request)
             except Exception as exc:
                 log_event(
                     logger,

--- a/src/relay_teams/persistence/__init__.py
+++ b/src/relay_teams/persistence/__init__.py
@@ -20,6 +20,8 @@ from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutat
 from relay_teams.persistence.sqlite_repository import (
     AsyncSharedSqliteRepository,
     SharedSqliteRepository,
+    async_fetchall,
+    async_fetchone,
 )
 from relay_teams.persistence.shared_state_repo import (
     SharedStateRepository,
@@ -37,6 +39,8 @@ __all__ = [
     "SharedSqliteRepository",
     "SharedStateRepository",
     "StateMutation",
+    "async_fetchall",
+    "async_fetchone",
     "async_sqlite_compile_options",
     "async_sqlite_supports_fts5",
     "build_global_scope_ref",

--- a/src/relay_teams/persistence/db.py
+++ b/src/relay_teams/persistence/db.py
@@ -5,8 +5,9 @@ import logging
 import sqlite3
 import time
 from pathlib import Path
-from threading import RLock
+from threading import Condition, RLock, get_ident
 from typing import Awaitable, Callable, Optional, TypeVar
+from weakref import WeakKeyDictionary
 
 import aiosqlite
 
@@ -20,11 +21,78 @@ SQLITE_WRITE_RETRY_INITIAL_DELAY_SECONDS = 0.01
 SQLITE_WRITE_RETRY_MAX_DELAY_SECONDS = 0.2
 
 LOGGER = get_logger(__name__)
+type _WriteOwnerToken = tuple[str, int]
+_CROSS_WRITE_COORDINATORS: dict[str, CrossModeWriteCoordinator] = {}
 _WRITE_COORDINATORS: dict[str, RLock] = {}
 _WRITE_COORDINATORS_LOCK = RLock()
-_ASYNC_WRITE_COORDINATORS: dict[str, asyncio.Lock] = {}
+_ASYNC_WRITE_COORDINATORS: dict[
+    str, WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]
+] = {}
 _RESOLVED_DB_PATH_KEYS: dict[str, str] = {}
 ResultT = TypeVar("ResultT")
+
+
+class CrossModeWriteCoordinator:
+    def __init__(self) -> None:
+        self._condition = Condition()
+        self._owner: _WriteOwnerToken | None = None
+        self._depth = 0
+
+    def acquire_sync(self) -> _WriteOwnerToken:
+        token = ("thread", get_ident())
+        with self._condition:
+            while self._owner is not None and self._owner != token:
+                self._condition.wait()
+            self._owner = token
+            self._depth += 1
+        return token
+
+    async def acquire_async(self) -> _WriteOwnerToken:
+        task = asyncio.current_task()
+        token = (
+            "async",
+            id(task) if task is not None else id(asyncio.get_running_loop()),
+        )
+        initial_depth = self._owned_depth(token)
+        try:
+            while not await asyncio.to_thread(self._try_acquire, token):
+                await asyncio.sleep(0.001)
+        except asyncio.CancelledError:
+            self._release_cancelled_acquire(token, initial_depth)
+            raise
+        return token
+
+    def release(self, token: _WriteOwnerToken) -> None:
+        with self._condition:
+            if self._owner != token:
+                raise RuntimeError("SQLite write coordinator released by non-owner")
+            self._depth -= 1
+            if self._depth > 0:
+                return
+            self._owner = None
+            self._condition.notify_all()
+
+    def _try_acquire(self, token: _WriteOwnerToken) -> bool:
+        with self._condition:
+            if self._owner is not None and self._owner != token:
+                return False
+            self._owner = token
+            self._depth += 1
+            return True
+
+    def _owned_depth(self, token: _WriteOwnerToken) -> int:
+        with self._condition:
+            if self._owner != token:
+                return 0
+            return self._depth
+
+    def _release_cancelled_acquire(
+        self, token: _WriteOwnerToken, initial_depth: int
+    ) -> None:
+        with self._condition:
+            if self._owner != token or self._depth <= initial_depth:
+                return
+        self.release(token)
 
 
 def _configure_connection(
@@ -156,18 +224,26 @@ async def run_async_sqlite_write_with_retry(
     max_retries: int = SQLITE_WRITE_RETRY_ATTEMPTS,
 ) -> ResultT:
     delay = SQLITE_WRITE_RETRY_INITIAL_DELAY_SECONDS
+    cross_write_lock = _cross_write_coordinator_for(db_path)
     write_lock = _async_write_coordinator_for(db_path)
     for attempt in range(max_retries + 1):
+        operation_started = False
         try:
-            async with write_lock:
-                if lock is not None:
-                    async with lock:
-                        result = await operation()
-                        await conn.commit()
-                        return result
-                result = await operation()
-                await conn.commit()
-                return result
+            cross_write_token = await cross_write_lock.acquire_async()
+            try:
+                async with write_lock:
+                    if lock is not None:
+                        async with lock:
+                            operation_started = True
+                            result = await operation()
+                            await conn.commit()
+                            return result
+                    operation_started = True
+                    result = await operation()
+                    await conn.commit()
+                    return result
+            finally:
+                cross_write_lock.release(cross_write_token)
         except sqlite3.OperationalError as exc:
             await _async_rollback_quietly(conn)
             if not is_retryable_sqlite_error(exc) or attempt >= max_retries:
@@ -187,6 +263,10 @@ async def run_async_sqlite_write_with_retry(
             )
             await asyncio.sleep(delay)
             delay = min(delay * 2, SQLITE_WRITE_RETRY_MAX_DELAY_SECONDS)
+        except BaseException:
+            if operation_started:
+                await _async_rollback_quietly(conn)
+            raise
     raise RuntimeError(
         f"SQLite write helper exhausted retries for {repository_name}.{operation_name}"
     )
@@ -204,18 +284,26 @@ def run_sqlite_write_with_retry(
     max_retries: int = SQLITE_WRITE_RETRY_ATTEMPTS,
 ) -> ResultT:
     delay = SQLITE_WRITE_RETRY_INITIAL_DELAY_SECONDS
+    cross_write_lock = _cross_write_coordinator_for(db_path)
     write_lock = _write_coordinator_for(db_path)
     for attempt in range(max_retries + 1):
+        operation_started = False
         try:
-            with write_lock:
-                if lock is not None:
-                    with lock:
-                        result = operation()
-                        conn.commit()
-                        return result
-                result = operation()
-                conn.commit()
-                return result
+            cross_write_token = cross_write_lock.acquire_sync()
+            try:
+                with write_lock:
+                    if lock is not None:
+                        with lock:
+                            operation_started = True
+                            result = operation()
+                            conn.commit()
+                            return result
+                    operation_started = True
+                    result = operation()
+                    conn.commit()
+                    return result
+            finally:
+                cross_write_lock.release(cross_write_token)
         except sqlite3.OperationalError as exc:
             _rollback_quietly(conn)
             if not is_retryable_sqlite_error(exc) or attempt >= max_retries:
@@ -235,6 +323,10 @@ def run_sqlite_write_with_retry(
             )
             time.sleep(delay)
             delay = min(delay * 2, SQLITE_WRITE_RETRY_MAX_DELAY_SECONDS)
+        except BaseException:
+            if operation_started:
+                _rollback_quietly(conn)
+            raise
     raise RuntimeError(
         f"SQLite write helper exhausted retries for {repository_name}.{operation_name}"
     )
@@ -268,12 +360,28 @@ def _write_coordinator_for(db_path: Path) -> RLock:
     return coordinator
 
 
+def _cross_write_coordinator_for(db_path: Path) -> CrossModeWriteCoordinator:
+    key = _resolved_db_path_key(db_path)
+    with _WRITE_COORDINATORS_LOCK:
+        coordinator = _CROSS_WRITE_COORDINATORS.get(key)
+        if coordinator is None:
+            coordinator = CrossModeWriteCoordinator()
+            _CROSS_WRITE_COORDINATORS[key] = coordinator
+    return coordinator
+
+
 def _async_write_coordinator_for(db_path: Path) -> asyncio.Lock:
     key = _resolved_db_path_key(db_path)
-    coordinator = _ASYNC_WRITE_COORDINATORS.get(key)
-    if coordinator is None:
-        coordinator = asyncio.Lock()
-        _ASYNC_WRITE_COORDINATORS[key] = coordinator
+    loop = asyncio.get_running_loop()
+    with _WRITE_COORDINATORS_LOCK:
+        locks_by_loop = _ASYNC_WRITE_COORDINATORS.get(key)
+        if locks_by_loop is None:
+            locks_by_loop = WeakKeyDictionary()
+            _ASYNC_WRITE_COORDINATORS[key] = locks_by_loop
+        coordinator = locks_by_loop.get(loop)
+        if coordinator is None:
+            coordinator = asyncio.Lock()
+            locks_by_loop[loop] = coordinator
     return coordinator
 
 

--- a/src/relay_teams/persistence/shared_state_repo.py
+++ b/src/relay_teams/persistence/shared_state_repo.py
@@ -5,7 +5,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
-from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
+from relay_teams.persistence.sqlite_repository import (
+    SharedSqliteRepository,
+    async_fetchall,
+    async_fetchone,
+)
 
 
 class SharedStateRepository(SharedSqliteRepository):
@@ -61,6 +65,39 @@ class SharedStateRepository(SharedSqliteRepository):
             ),
         )
 
+    async def manage_state_async(
+        self, mutation: StateMutation, ttl_seconds: int | None = None
+    ) -> None:
+        expires_at: str | None = None
+        if ttl_seconds is not None:
+            expires_at = (
+                datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
+            ).isoformat()
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            await conn.execute(
+                """
+                INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
+                VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
+                ON CONFLICT(scope_type, scope_id, state_key)
+                DO UPDATE SET value_json=excluded.value_json, updated_at=CURRENT_TIMESTAMP,
+                              expires_at=COALESCE(excluded.expires_at, expires_at)
+                """,
+                (
+                    mutation.scope.scope_type.value,
+                    mutation.scope.scope_id,
+                    mutation.key,
+                    mutation.value_json,
+                    expires_at,
+                ),
+            )
+
+        await self._run_async_write(
+            operation_name="manage_state",
+            operation=lambda _conn: operation(),
+        )
+
     def get_state(self, scope: ScopeRef, key: str) -> str | None:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -71,6 +108,22 @@ class SharedStateRepository(SharedSqliteRepository):
                 """,
                 (scope.scope_type.value, scope.scope_id, key),
             ).fetchone()
+        )
+        if row is None:
+            return None
+        return str(row["value_json"])
+
+    async def get_state_async(self, scope: ScopeRef, key: str) -> str | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                """
+                SELECT value_json FROM shared_state
+                WHERE scope_type=? AND scope_id=? AND state_key=?
+                  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                """,
+                (scope.scope_type.value, scope.scope_id, key),
+            )
         )
         if row is None:
             return None
@@ -89,6 +142,20 @@ class SharedStateRepository(SharedSqliteRepository):
         )
         return tuple((str(row["state_key"]), str(row["value_json"])) for row in rows)
 
+    async def snapshot_async(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT state_key, value_json FROM shared_state
+                WHERE scope_type=? AND scope_id=?
+                  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                """,
+                (scope.scope_type.value, scope.scope_id),
+            )
+        )
+        return tuple((str(row["state_key"]), str(row["value_json"])) for row in rows)
+
     def snapshot_many(
         self,
         scopes: tuple[ScopeRef, ...],
@@ -104,6 +171,21 @@ class SharedStateRepository(SharedSqliteRepository):
         ordered_items = sorted(merged.items(), key=lambda item: item[0])
         return tuple((key, value) for key, value in ordered_items)
 
+    async def snapshot_many_async(
+        self,
+        scopes: tuple[ScopeRef, ...],
+        *,
+        exclude_key_prefixes: tuple[str, ...] = (),
+    ) -> tuple[tuple[str, str], ...]:
+        merged: dict[str, str] = {}
+        for scope in scopes:
+            for key, value in await self.snapshot_async(scope):
+                if key.startswith(exclude_key_prefixes):
+                    continue
+                merged[key] = value
+        ordered_items = sorted(merged.items(), key=lambda item: item[0])
+        return tuple((key, value) for key, value in ordered_items)
+
     def cleanup_expired(self) -> int:
         return self._run_write(
             operation_name="cleanup_expired",
@@ -112,6 +194,22 @@ class SharedStateRepository(SharedSqliteRepository):
                     "DELETE FROM shared_state WHERE expires_at IS NOT NULL AND expires_at <= CURRENT_TIMESTAMP"
                 ).rowcount
             ),
+        )
+
+    async def cleanup_expired_async(self) -> int:
+        async def operation() -> int:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM shared_state WHERE expires_at IS NOT NULL AND expires_at <= CURRENT_TIMESTAMP"
+            )
+            try:
+                return cursor.rowcount
+            finally:
+                await cursor.close()
+
+        return await self._run_async_write(
+            operation_name="cleanup_expired",
+            operation=lambda _conn: operation(),
         )
 
     def delete_by_scope_key_prefix(self, scope: ScopeRef, key_prefix: str) -> None:
@@ -130,6 +228,30 @@ class SharedStateRepository(SharedSqliteRepository):
                     key_prefix,
                 ),
             ),
+        )
+
+    async def delete_by_scope_key_prefix_async(
+        self, scope: ScopeRef, key_prefix: str
+    ) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            await conn.execute(
+                """
+                DELETE FROM shared_state
+                WHERE scope_type=? AND scope_id=?
+                  AND substr(state_key, 1, ?) = ?
+                """,
+                (
+                    scope.scope_type.value,
+                    scope.scope_id,
+                    len(key_prefix),
+                    key_prefix,
+                ),
+            )
+
+        await self._run_async_write(
+            operation_name="delete_by_scope_key_prefix",
+            operation=lambda _conn: operation(),
         )
 
     def delete_by_session(
@@ -189,6 +311,67 @@ class SharedStateRepository(SharedSqliteRepository):
             ),
         )
 
+    async def delete_by_session_async(
+        self,
+        session_id: str,
+        task_ids: list[str],
+        instance_ids: list[str],
+        role_scope_ids: list[str] | None = None,
+        session_scope_ids: list[str] | None = None,
+        conversation_ids: list[str] | None = None,
+        workspace_ids: list[str] | None = None,
+    ) -> None:
+        if not task_ids:
+            task_ids = ["__dummy_id__"]
+        if not instance_ids:
+            instance_ids = ["__dummy_id__"]
+        session_scope_values = list(
+            dict.fromkeys([session_id, *(session_scope_ids or [])])
+        )
+        role_scope_values = role_scope_ids or ["__dummy_id__"]
+        conversation_values = conversation_ids or ["__dummy_id__"]
+        workspace_values = workspace_ids or ["__dummy_id__"]
+
+        session_placeholders = ",".join("?" * len(session_scope_values))
+        task_placeholders = ",".join("?" * len(task_ids))
+        instance_placeholders = ",".join("?" * len(instance_ids))
+        role_placeholders = ",".join("?" * len(role_scope_values))
+        conversation_placeholders = ",".join("?" * len(conversation_values))
+        workspace_placeholders = ",".join("?" * len(workspace_values))
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            await conn.execute(
+                f"""
+                DELETE FROM shared_state WHERE
+                (scope_type=? AND scope_id IN ({session_placeholders})) OR
+                (scope_type=? AND scope_id IN ({task_placeholders})) OR
+                (scope_type=? AND scope_id IN ({instance_placeholders})) OR
+                (scope_type=? AND scope_id IN ({role_placeholders})) OR
+                (scope_type=? AND scope_id IN ({conversation_placeholders})) OR
+                (scope_type=? AND scope_id IN ({workspace_placeholders}))
+                """,
+                (
+                    ScopeType.SESSION.value,
+                    *session_scope_values,
+                    ScopeType.TASK.value,
+                    *task_ids,
+                    ScopeType.INSTANCE.value,
+                    *instance_ids,
+                    ScopeType.ROLE.value,
+                    *role_scope_values,
+                    ScopeType.CONVERSATION.value,
+                    *conversation_values,
+                    ScopeType.WORKSPACE.value,
+                    *workspace_values,
+                ),
+            )
+
+        await self._run_async_write(
+            operation_name="delete_by_session",
+            operation=lambda _conn: operation(),
+        )
+
     def delete_for_subagent(
         self,
         *,
@@ -226,6 +409,50 @@ class SharedStateRepository(SharedSqliteRepository):
                     *task_values,
                 ),
             ),
+        )
+
+    async def delete_for_subagent_async(
+        self,
+        *,
+        instance_id: str,
+        session_scope_id: str,
+        role_scope_id: str,
+        conversation_id: str,
+        task_ids: list[str] | None = None,
+    ) -> None:
+        task_values = task_ids or ["__dummy_id__"]
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            await conn.execute(
+                """
+                DELETE FROM shared_state WHERE
+                (scope_type=? AND scope_id=?) OR
+                (scope_type=? AND scope_id=?) OR
+                (scope_type=? AND scope_id=?) OR
+                (scope_type=? AND scope_id=?) OR
+                (scope_type=? AND scope_id IN ({task_placeholders}))
+                """.replace(
+                    "{task_placeholders}",
+                    ",".join("?" for _ in task_values),
+                ),
+                (
+                    ScopeType.INSTANCE.value,
+                    instance_id,
+                    ScopeType.SESSION.value,
+                    session_scope_id,
+                    ScopeType.ROLE.value,
+                    role_scope_id,
+                    ScopeType.CONVERSATION.value,
+                    conversation_id,
+                    ScopeType.TASK.value,
+                    *task_values,
+                ),
+            )
+
+        await self._run_async_write(
+            operation_name="delete_for_subagent",
+            operation=lambda _conn: operation(),
         )
 
 

--- a/src/relay_teams/persistence/sqlite_repository.py
+++ b/src/relay_teams/persistence/sqlite_repository.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from collections.abc import Sequence
 from pathlib import Path
 from threading import RLock
-from typing import Awaitable, Callable, Optional, Self, TypeVar
+from typing import Awaitable, Callable, Optional, ParamSpec, Self, TypeVar
 
 import aiosqlite
 
@@ -17,6 +18,33 @@ from relay_teams.persistence.db import (
 )
 
 ResultT = TypeVar("ResultT")
+ParamT = ParamSpec("ParamT")
+SqliteParameters = Sequence[object]
+
+
+async def async_fetchone(
+    conn: aiosqlite.Connection,
+    sql: str,
+    parameters: SqliteParameters = (),
+) -> sqlite3.Row | None:
+    cursor = await conn.execute(sql, tuple(parameters))
+    try:
+        return await cursor.fetchone()
+    finally:
+        await cursor.close()
+
+
+async def async_fetchall(
+    conn: aiosqlite.Connection,
+    sql: str,
+    parameters: SqliteParameters = (),
+) -> list[sqlite3.Row]:
+    cursor = await conn.execute(sql, tuple(parameters))
+    try:
+        rows = await cursor.fetchall()
+    finally:
+        await cursor.close()
+    return list(rows)
 
 
 class SharedSqliteRepository:
@@ -30,6 +58,9 @@ class SharedSqliteRepository:
         self._conn = open_sqlite(self._db_path)
         self._conn.row_factory = sqlite3.Row
         self._lock = RLock()
+        self._async_conn: aiosqlite.Connection | None = None
+        self._async_conn_lock = asyncio.Lock()
+        self._async_lock = asyncio.Lock()
         self._repository_name = repository_name or type(self).__name__
 
     # noinspection PyTypeHints
@@ -52,6 +83,56 @@ class SharedSqliteRepository:
             repository_name=self._repository_name,
             operation_name=operation_name,
         )
+
+    async def close_async(self) -> None:
+        async with self._async_conn_lock:
+            if self._async_conn is None:
+                return
+            await self._async_conn.close()
+            self._async_conn = None
+
+    async def _get_async_conn(self) -> aiosqlite.Connection:
+        async with self._async_conn_lock:
+            if self._async_conn is None:
+                self._async_conn = await open_async_sqlite(self._db_path)
+                self._async_conn.row_factory = sqlite3.Row
+            return self._async_conn
+
+    # noinspection PyTypeHints
+    async def _run_async_read(
+        self,
+        operation: Callable[[aiosqlite.Connection], Awaitable[ResultT]],
+    ) -> ResultT:
+        conn = await self._get_async_conn()
+        async with self._async_lock:
+            return await operation(conn)
+
+    # noinspection PyTypeHints
+    async def _run_async_write(
+        self,
+        *,
+        operation_name: str,
+        operation: Callable[[aiosqlite.Connection], Awaitable[ResultT]],
+    ) -> ResultT:
+        conn = await self._get_async_conn()
+        return await run_async_sqlite_write_with_retry(
+            conn=conn,
+            db_path=self._db_path,
+            operation=lambda: operation(conn),
+            lock=self._async_lock,
+            repository_name=self._repository_name,
+            operation_name=operation_name,
+        )
+
+    # noinspection PyMethodMayBeStatic
+    async def _call_sync_async(
+        self,
+        function: Callable[ParamT, ResultT],
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
+    ) -> ResultT:
+        return await asyncio.to_thread(function, *args, **kwargs)
 
 
 class AsyncSharedSqliteRepository:

--- a/src/relay_teams/providers/token_usage_repo.py
+++ b/src/relay_teams/providers/token_usage_repo.py
@@ -191,6 +191,34 @@ class TokenUsageRepository(SharedSqliteRepository):
 
         self._run_write(operation_name="record", operation=operation)
 
+    async def record_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        instance_id: str,
+        role_id: str,
+        input_tokens: int = 0,
+        cached_input_tokens: int = 0,
+        output_tokens: int = 0,
+        reasoning_output_tokens: int = 0,
+        requests: int = 0,
+        tool_calls: int = 0,
+    ) -> None:
+        return await self._call_sync_async(
+            self.record,
+            session_id=session_id,
+            run_id=run_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            input_tokens=input_tokens,
+            cached_input_tokens=cached_input_tokens,
+            output_tokens=output_tokens,
+            reasoning_output_tokens=reasoning_output_tokens,
+            requests=requests,
+            tool_calls=tool_calls,
+        )
+
     def get_by_run(self, run_id: str) -> RunTokenUsage:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -254,6 +282,9 @@ class TokenUsageRepository(SharedSqliteRepository):
             total_tool_calls=sum(agent.tool_calls for agent in agents),
             by_agent=agents,
         )
+
+    async def get_by_run_async(self, run_id: str) -> RunTokenUsage:
+        return await self._call_sync_async(self.get_by_run, run_id)
 
     def get_by_session(
         self,
@@ -332,6 +363,13 @@ class TokenUsageRepository(SharedSqliteRepository):
             by_role=by_role,
         )
 
+    async def get_by_session_async(
+        self, session_id: str, *, include_cleared: bool = False
+    ) -> SessionTokenUsage:
+        return await self._call_sync_async(
+            self.get_by_session, session_id, include_cleared=include_cleared
+        )
+
     def delete_by_session(self, session_id: str) -> None:
         self._run_write(
             operation_name="delete_by_session",
@@ -339,6 +377,9 @@ class TokenUsageRepository(SharedSqliteRepository):
                 "DELETE FROM token_usage WHERE session_id=?", (session_id,)
             ),
         )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_session, session_id)
 
     def delete_by_run(self, run_id: str) -> None:
         self._run_write(
@@ -348,6 +389,9 @@ class TokenUsageRepository(SharedSqliteRepository):
                 (run_id,),
             ),
         )
+
+    async def delete_by_run_async(self, run_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_run, run_id)
 
     def _latest_clear_cutoff(self, session_id: str) -> str | None:
         if self._session_history_marker_repo is None:

--- a/src/relay_teams/reminders/service.py
+++ b/src/relay_teams/reminders/service.py
@@ -72,6 +72,38 @@ class SystemReminderService:
         )
         return decision
 
+    async def observe_tool_result_async(
+        self,
+        observation: ToolResultObservation,
+    ) -> ReminderDecision:
+        state = await self._load_state_async(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        )
+        decision, next_state = self._policy.evaluate_tool_result(
+            observation=observation,
+            state=state,
+        )
+        if decision.issue:
+            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+            content = render_system_reminder(decision.content)
+            if content:
+                _ = await self._injection_sink.enqueue_only_async(
+                    session_id=observation.session_id,
+                    run_id=observation.run_id,
+                    trace_id=observation.trace_id,
+                    task_id=observation.task_id,
+                    instance_id=observation.instance_id,
+                    role_id=observation.role_id,
+                    content=content,
+                )
+        await self._save_state_async(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+            state=next_state,
+        )
+        return decision
+
     def evaluate_completion_attempt(
         self,
         observation: CompletionAttemptObservation,
@@ -99,6 +131,39 @@ class SystemReminderService:
                     content=content,
                 )
         self._save_state(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+            state=next_state,
+        )
+        return decision
+
+    async def evaluate_completion_attempt_async(
+        self,
+        observation: CompletionAttemptObservation,
+    ) -> ReminderDecision:
+        state = await self._load_state_async(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        )
+        decision, next_state = self._policy.evaluate_completion_attempt(
+            observation=observation,
+            state=state,
+        )
+        if decision.issue and decision.retry_completion:
+            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+            content = render_system_reminder(decision.content)
+            if content:
+                _ = await self._injection_sink.append_only_async(
+                    session_id=observation.session_id,
+                    trace_id=observation.trace_id,
+                    task_id=observation.task_id,
+                    instance_id=observation.instance_id,
+                    role_id=observation.role_id,
+                    workspace_id=observation.workspace_id,
+                    conversation_id=observation.conversation_id,
+                    content=content,
+                )
+        await self._save_state_async(
             session_id=observation.session_id,
             run_id=observation.run_id,
             state=next_state,
@@ -137,6 +202,38 @@ class SystemReminderService:
         )
         return decision
 
+    async def observe_context_pressure_async(
+        self,
+        observation: ContextPressureObservation,
+    ) -> ReminderDecision:
+        state = await self._load_state_async(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        )
+        decision, next_state = self._policy.evaluate_context_pressure(
+            observation=observation,
+            state=state,
+        )
+        if decision.issue:
+            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+            content = render_system_reminder(decision.content)
+            if content:
+                _ = await self._injection_sink.enqueue_only_async(
+                    session_id=observation.session_id,
+                    run_id=observation.run_id,
+                    trace_id=observation.trace_id,
+                    task_id=observation.task_id,
+                    instance_id=observation.instance_id,
+                    role_id=observation.role_id,
+                    content=content,
+                )
+        await self._save_state_async(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+            state=next_state,
+        )
+        return decision
+
     def _load_state(self, *, session_id: str, run_id: str) -> ReminderRunState:
         key = _state_cache_key(session_id=session_id, run_id=run_id)
         if key in self._write_degraded_keys:
@@ -145,6 +242,38 @@ class SystemReminderService:
                 return fallback_state
         try:
             state = self._state_repository.get_run_state(
+                session_id=session_id,
+                run_id=run_id,
+            )
+            self._read_degraded_keys.discard(key)
+            self._fallback_states.pop(key, None)
+            return state
+        except Exception as exc:
+            fallback_state = self._fallback_states.get(key)
+            if fallback_state is None:
+                fallback_state = ReminderRunState()
+                self._fallback_states[key] = fallback_state
+            self._read_degraded_keys.add(key)
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="reminders.state.load_failed",
+                message="Falling back to in-memory reminder state",
+                payload={"session_id": session_id, "run_id": run_id},
+                exc_info=exc,
+            )
+            return fallback_state
+
+    async def _load_state_async(
+        self, *, session_id: str, run_id: str
+    ) -> ReminderRunState:
+        key = _state_cache_key(session_id=session_id, run_id=run_id)
+        if key in self._write_degraded_keys:
+            fallback_state = self._fallback_states.get(key)
+            if fallback_state is not None:
+                return fallback_state
+        try:
+            state = await self._state_repository.get_run_state_async(
                 session_id=session_id,
                 run_id=run_id,
             )
@@ -177,6 +306,37 @@ class SystemReminderService:
         key = _state_cache_key(session_id=session_id, run_id=run_id)
         try:
             self._state_repository.save_run_state(
+                session_id=session_id,
+                run_id=run_id,
+                state=state,
+            )
+            self._write_degraded_keys.discard(key)
+            if key in self._read_degraded_keys:
+                self._fallback_states[key] = state
+            else:
+                self._fallback_states.pop(key, None)
+        except Exception as exc:
+            self._fallback_states[key] = state
+            self._write_degraded_keys.add(key)
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="reminders.state.save_failed",
+                message="Ignoring reminder state persistence failure",
+                payload={"session_id": session_id, "run_id": run_id},
+                exc_info=exc,
+            )
+
+    async def _save_state_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        state: ReminderRunState,
+    ) -> None:
+        key = _state_cache_key(session_id=session_id, run_id=run_id)
+        try:
+            await self._state_repository.save_run_state_async(
                 session_id=session_id,
                 run_id=run_id,
                 state=state,

--- a/src/relay_teams/reminders/state.py
+++ b/src/relay_teams/reminders/state.py
@@ -29,20 +29,15 @@ class ReminderStateRepository:
 
     def get_run_state(self, *, session_id: str, run_id: str) -> ReminderRunState:
         raw = self._repository.get_state(_scope(session_id), _state_key(run_id))
-        if raw is None:
-            return ReminderRunState()
-        try:
-            return ReminderRunState.model_validate_json(raw)
-        except ValidationError as exc:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="reminders.state.invalid",
-                message="Ignoring invalid persisted reminder state",
-                payload={"session_id": session_id, "run_id": run_id},
-                exc_info=exc,
-            )
-            return ReminderRunState()
+        return _parse_run_state(raw, session_id=session_id, run_id=run_id)
+
+    async def get_run_state_async(
+        self, *, session_id: str, run_id: str
+    ) -> ReminderRunState:
+        raw = await self._repository.get_state_async(
+            _scope(session_id), _state_key(run_id)
+        )
+        return _parse_run_state(raw, session_id=session_id, run_id=run_id)
 
     def save_run_state(
         self,
@@ -52,12 +47,54 @@ class ReminderStateRepository:
         state: ReminderRunState,
     ) -> None:
         self._repository.manage_state(
-            StateMutation(
-                scope=_scope(session_id),
-                key=_state_key(run_id),
-                value_json=dumps(state.model_dump(mode="json"), ensure_ascii=False),
-            )
+            _run_state_mutation(session_id=session_id, run_id=run_id, state=state)
         )
+
+    async def save_run_state_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        state: ReminderRunState,
+    ) -> None:
+        await self._repository.manage_state_async(
+            _run_state_mutation(session_id=session_id, run_id=run_id, state=state)
+        )
+
+
+def _parse_run_state(
+    raw: str | None,
+    *,
+    session_id: str,
+    run_id: str,
+) -> ReminderRunState:
+    if raw is None:
+        return ReminderRunState()
+    try:
+        return ReminderRunState.model_validate_json(raw)
+    except ValidationError as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="reminders.state.invalid",
+            message="Ignoring invalid persisted reminder state",
+            payload={"session_id": session_id, "run_id": run_id},
+            exc_info=exc,
+        )
+        return ReminderRunState()
+
+
+def _run_state_mutation(
+    *,
+    session_id: str,
+    run_id: str,
+    state: ReminderRunState,
+) -> StateMutation:
+    return StateMutation(
+        scope=_scope(session_id),
+        key=_state_key(run_id),
+        value_json=dumps(state.model_dump(mode="json"), ensure_ascii=False),
+    )
 
 
 def can_issue(

--- a/src/relay_teams/retrieval/sqlite_store.py
+++ b/src/relay_teams/retrieval/sqlite_store.py
@@ -24,8 +24,9 @@ from relay_teams.retrieval.retrieval_models import (
 from relay_teams.trace import trace_span
 
 LOGGER = get_logger(__name__)
-_UNICODE61_SPLIT_PATTERN = re.compile(r"[^\w]+", re.UNICODE)
+_UNICODE61_SPLIT_PATTERN = re.compile(r"(?:[^\w]+|_+)", re.UNICODE)
 _MATCH_SANITIZE_PATTERN = re.compile(r'["\'`(){}\[\]:^*]+')
+_CJK_CHARACTER_PATTERN = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
 
 
 class SqliteFts5RetrievalStore(SharedSqliteRepository):
@@ -823,13 +824,32 @@ def _build_match_expression(
     if tokenizer == RetrievalTokenizer.TRIGRAM:
         return _build_trigram_match_expression(sanitized)
     tokens = tuple(
-        token.lower()
+        expanded_token
         for token in _UNICODE61_SPLIT_PATTERN.split(sanitized)
-        if token.strip()
+        for expanded_token in _expand_unicode61_match_terms(token)
     )
     if not tokens:
         return ""
-    return " OR ".join(f'"{token}"' for token in tokens)
+    return " OR ".join(tokens)
+
+
+def _expand_unicode61_match_terms(token: str) -> tuple[str, ...]:
+    cleaned = token.strip().lower()
+    if not cleaned:
+        return ()
+    terms: list[str] = []
+    current_word: list[str] = []
+    for char in cleaned:
+        if _CJK_CHARACTER_PATTERN.fullmatch(char):
+            if current_word:
+                terms.append("".join(current_word))
+                current_word.clear()
+            terms.append(char)
+            continue
+        current_word.append(char)
+    if current_word:
+        terms.append("".join(current_word))
+    return tuple(terms)
 
 
 def _build_trigram_match_expression(raw_query: str) -> str:

--- a/src/relay_teams/retrieval/sqlite_store.py
+++ b/src/relay_teams/retrieval/sqlite_store.py
@@ -24,7 +24,7 @@ from relay_teams.retrieval.retrieval_models import (
 from relay_teams.trace import trace_span
 
 LOGGER = get_logger(__name__)
-_UNICODE61_SPLIT_PATTERN = re.compile(r"(?:[^\w]+|_+)", re.UNICODE)
+_UNICODE61_SPLIT_PATTERN = re.compile(r"[\W_]+", re.UNICODE)
 _MATCH_SANITIZE_PATTERN = re.compile(r'["\'`(){}\[\]:^*]+')
 _CJK_CHARACTER_PATTERN = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
 

--- a/src/relay_teams/retrieval/sqlite_store.py
+++ b/src/relay_teams/retrieval/sqlite_store.py
@@ -65,6 +65,13 @@ class SqliteFts5RetrievalStore(SharedSqliteRepository):
             )
         return self.stats(scope_kind=config.scope_kind, scope_id=config.scope_id)
 
+    async def replace_scope_async(
+        self, *, config: RetrievalScopeConfig, documents: tuple[RetrievalDocument, ...]
+    ) -> RetrievalStats:
+        return await self._call_sync_async(
+            self.replace_scope, config=config, documents=documents
+        )
+
     def upsert_documents(
         self,
         *,
@@ -91,6 +98,13 @@ class SqliteFts5RetrievalStore(SharedSqliteRepository):
                 ),
             )
         return self.stats(scope_kind=config.scope_kind, scope_id=config.scope_id)
+
+    async def upsert_documents_async(
+        self, *, config: RetrievalScopeConfig, documents: tuple[RetrievalDocument, ...]
+    ) -> RetrievalStats:
+        return await self._call_sync_async(
+            self.upsert_documents, config=config, documents=documents
+        )
 
     def delete_documents(
         self,
@@ -119,6 +133,20 @@ class SqliteFts5RetrievalStore(SharedSqliteRepository):
                 ),
             )
         return self.stats(scope_kind=scope_kind, scope_id=scope_id)
+
+    async def delete_documents_async(
+        self,
+        *,
+        scope_kind: RetrievalScopeKind,
+        scope_id: str,
+        document_ids: tuple[str, ...],
+    ) -> RetrievalStats:
+        return await self._call_sync_async(
+            self.delete_documents,
+            scope_kind=scope_kind,
+            scope_id=scope_id,
+            document_ids=document_ids,
+        )
 
     def search(
         self,
@@ -191,6 +219,9 @@ class SqliteFts5RetrievalStore(SharedSqliteRepository):
                 for index, row in enumerate(rows, start=1)
             )
 
+    async def search_async(self, *, query: RetrievalQuery) -> tuple[RetrievalHit, ...]:
+        return await self._call_sync_async(self.search, query=query)
+
     def rebuild_scope(
         self,
         *,
@@ -214,6 +245,13 @@ class SqliteFts5RetrievalStore(SharedSqliteRepository):
                 ),
             )
         return self.stats(scope_kind=scope_kind, scope_id=scope_id)
+
+    async def rebuild_scope_async(
+        self, *, scope_kind: RetrievalScopeKind, scope_id: str
+    ) -> RetrievalStats:
+        return await self._call_sync_async(
+            self.rebuild_scope, scope_kind=scope_kind, scope_id=scope_id
+        )
 
     def stats(
         self,
@@ -266,6 +304,13 @@ class SqliteFts5RetrievalStore(SharedSqliteRepository):
                 ),
                 updated_at=updated_at,
             )
+
+    async def stats_async(
+        self, *, scope_kind: RetrievalScopeKind, scope_id: str
+    ) -> RetrievalStats:
+        return await self._call_sync_async(
+            self.stats, scope_kind=scope_kind, scope_id=scope_id
+        )
 
     def _require_fts5(self) -> None:
         if self._run_read(lambda: sqlite_supports_fts5(self._conn)):

--- a/src/relay_teams/roles/memory_repository.py
+++ b/src/relay_teams/roles/memory_repository.py
@@ -42,6 +42,13 @@ class RoleMemoryRepository(SharedSqliteRepository):
             updated_at=datetime.fromisoformat(str(row["updated_at"])),
         )
 
+    async def read_role_memory_async(
+        self, *, role_id: str, workspace_id: str
+    ) -> RoleMemoryRecord:
+        return await self._call_sync_async(
+            self.read_role_memory, role_id=role_id, workspace_id=workspace_id
+        )
+
     def write_role_memory(
         self,
         *,
@@ -64,6 +71,16 @@ class RoleMemoryRepository(SharedSqliteRepository):
             ),
         )
 
+    async def write_role_memory_async(
+        self, *, role_id: str, workspace_id: str, content_markdown: str
+    ) -> None:
+        return await self._call_sync_async(
+            self.write_role_memory,
+            role_id=role_id,
+            workspace_id=workspace_id,
+            content_markdown=content_markdown,
+        )
+
     def delete_role_memory(self, *, role_id: str, workspace_id: str) -> None:
         self._run_write(
             operation_name="delete_role_memory",
@@ -71,6 +88,13 @@ class RoleMemoryRepository(SharedSqliteRepository):
                 "DELETE FROM role_memories WHERE role_id=? AND workspace_id=?",
                 (role_id, workspace_id),
             ),
+        )
+
+    async def delete_role_memory_async(
+        self, *, role_id: str, workspace_id: str
+    ) -> None:
+        return await self._call_sync_async(
+            self.delete_role_memory, role_id=role_id, workspace_id=workspace_id
         )
 
     def _ensure_role_memories_schema(self) -> None:

--- a/src/relay_teams/roles/runtime_role_resolver.py
+++ b/src/relay_teams/roles/runtime_role_resolver.py
@@ -36,6 +36,20 @@ class RuntimeRoleResolver:
                 return temp.role.to_role_definition()
         return self._role_registry.get(role_id)
 
+    async def get_effective_role_async(
+        self, *, run_id: str | None, role_id: str
+    ) -> RoleDefinition:
+        if run_id is not None:
+            try:
+                temp = await self._temporary_role_repository.get_async(
+                    run_id=run_id, role_id=role_id
+                )
+            except KeyError:
+                pass
+            else:
+                return temp.role.to_role_definition()
+        return self._role_registry.get(role_id)
+
     def get_temporary_role(self, *, run_id: str | None, role_id: str) -> RoleDefinition:
         if run_id is None:
             raise KeyError(f"Unknown temporary role_id: {role_id}")
@@ -49,6 +63,20 @@ class RuntimeRoleResolver:
         temp_roles = [
             record.role.to_role_definition()
             for record in self._temporary_role_repository.list_by_run(run_id)
+        ]
+        return tuple(static_roles + temp_roles)
+
+    async def list_effective_roles_async(
+        self, *, run_id: str | None
+    ) -> tuple[RoleDefinition, ...]:
+        static_roles = list(self._role_registry.list_roles())
+        if run_id is None:
+            return tuple(static_roles)
+        temp_roles = [
+            record.role.to_role_definition()
+            for record in await self._temporary_role_repository.list_by_run_async(
+                run_id
+            )
         ]
         return tuple(static_roles + temp_roles)
 

--- a/src/relay_teams/roles/temporary_role_repository.py
+++ b/src/relay_teams/roles/temporary_role_repository.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from relay_teams.computer import ExecutionSurface
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.roles.memory_models import MemoryProfile
 from relay_teams.roles.temporary_role_models import (
     TemporaryRoleRecord,
@@ -16,12 +16,9 @@ from relay_teams.roles.temporary_role_models import (
 )
 
 
-class TemporaryRoleRepository:
+class TemporaryRoleRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -135,6 +132,9 @@ class TemporaryRoleRepository:
         )
         return self.get(run_id=record.run_id, role_id=record.role.role_id)
 
+    async def upsert_async(self, record: TemporaryRoleRecord) -> TemporaryRoleRecord:
+        return await self._call_sync_async(self.upsert, record)
+
     def get(self, *, run_id: str, role_id: str) -> TemporaryRoleRecord:
         with self._lock:
             row = self._conn.execute(
@@ -147,6 +147,9 @@ class TemporaryRoleRepository:
             )
         return self._to_record(row)
 
+    async def get_async(self, *, run_id: str, role_id: str) -> TemporaryRoleRecord:
+        return await self._call_sync_async(self.get, run_id=run_id, role_id=role_id)
+
     def list_by_run(self, run_id: str) -> tuple[TemporaryRoleRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -154,6 +157,9 @@ class TemporaryRoleRepository:
                 (run_id,),
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    async def list_by_run_async(self, run_id: str) -> tuple[TemporaryRoleRecord, ...]:
+        return await self._call_sync_async(self.list_by_run, run_id)
 
     def delete_by_run(self, run_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -166,6 +172,9 @@ class TemporaryRoleRepository:
             repository_name="TemporaryRoleRepository",
             operation_name="delete_by_run",
         )
+
+    async def delete_by_run_async(self, run_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_run, run_id)
 
     def _to_record(self, row: sqlite3.Row) -> TemporaryRoleRecord:
         return TemporaryRoleRecord(

--- a/src/relay_teams/sessions/external_session_binding_repository.py
+++ b/src/relay_teams/sessions/external_session_binding_repository.py
@@ -5,12 +5,12 @@ import sqlite3
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic import JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.external_session_binding_models import (
     ExternalSessionBinding,
 )
@@ -22,12 +22,9 @@ from relay_teams.validation import (
 LOGGER = get_logger(__name__)
 
 
-class ExternalSessionBindingRepository:
+class ExternalSessionBindingRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -110,6 +107,17 @@ class ExternalSessionBindingRepository:
             return None
         return self._record_or_none(row, fallback_invalid_timestamps=True)
 
+    async def get_binding_async(
+        self, *, platform: str, trigger_id: str, tenant_key: str, external_chat_id: str
+    ) -> ExternalSessionBinding | None:
+        return await self._call_sync_async(
+            self.get_binding,
+            platform=platform,
+            trigger_id=trigger_id,
+            tenant_key=tenant_key,
+            external_chat_id=external_chat_id,
+        )
+
     def upsert_binding(
         self,
         *,
@@ -164,6 +172,24 @@ class ExternalSessionBindingRepository:
             raise RuntimeError("Failed to load upserted external session binding")
         return binding
 
+    async def upsert_binding_async(
+        self,
+        *,
+        platform: str,
+        trigger_id: str,
+        tenant_key: str,
+        external_chat_id: str,
+        session_id: str,
+    ) -> ExternalSessionBinding:
+        return await self._call_sync_async(
+            self.upsert_binding,
+            platform=platform,
+            trigger_id=trigger_id,
+            tenant_key=tenant_key,
+            external_chat_id=external_chat_id,
+            session_id=session_id,
+        )
+
     def list_by_platform(self, platform: str) -> tuple[ExternalSessionBinding, ...]:
         rows = self._conn.execute(
             """
@@ -177,6 +203,11 @@ class ExternalSessionBindingRepository:
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
+
+    async def list_by_platform_async(
+        self, platform: str
+    ) -> tuple[ExternalSessionBinding, ...]:
+        return await self._call_sync_async(self.list_by_platform, platform)
 
     def exists(
         self,
@@ -196,6 +227,17 @@ class ExternalSessionBindingRepository:
             is not None
         )
 
+    async def exists_async(
+        self, *, platform: str, trigger_id: str, tenant_key: str, external_chat_id: str
+    ) -> bool:
+        return await self._call_sync_async(
+            self.exists,
+            platform=platform,
+            trigger_id=trigger_id,
+            tenant_key=tenant_key,
+            external_chat_id=external_chat_id,
+        )
+
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -209,6 +251,9 @@ class ExternalSessionBindingRepository:
             operation_name="delete_by_session",
         )
 
+    async def delete_by_session_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_session, session_id)
+
     def delete_by_trigger(self, trigger_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -221,6 +266,9 @@ class ExternalSessionBindingRepository:
             repository_name="ExternalSessionBindingRepository",
             operation_name="delete_by_trigger",
         )
+
+    async def delete_by_trigger_async(self, trigger_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_trigger, trigger_id)
 
     @staticmethod
     def _to_record(

--- a/src/relay_teams/sessions/runs/background_tasks/manager.py
+++ b/src/relay_teams/sessions/runs/background_tasks/manager.py
@@ -584,6 +584,9 @@ class BackgroundTaskManager:
     def list_for_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
         return self._repository.list_by_run(run_id)
 
+    async def list_for_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        return await self._repository.list_by_run_async(run_id)
+
     def get_for_run(
         self,
         *,
@@ -591,6 +594,19 @@ class BackgroundTaskManager:
         background_task_id: str,
     ) -> BackgroundTaskRecord:
         record = self._get_record(background_task_id)
+        if record.run_id != run_id:
+            raise KeyError(
+                f"Background task {background_task_id} does not belong to run {run_id}"
+            )
+        return record
+
+    async def get_for_run_async(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        record = await self._get_record_async(background_task_id)
         if record.run_id != run_id:
             raise KeyError(
                 f"Background task {background_task_id} does not belong to run {run_id}"
@@ -1602,6 +1618,12 @@ class BackgroundTaskManager:
 
     def _get_record(self, background_task_id: str) -> BackgroundTaskRecord:
         record = self._repository.get(background_task_id)
+        if record is None:
+            raise KeyError(f"Unknown background task: {background_task_id}")
+        return record
+
+    async def _get_record_async(self, background_task_id: str) -> BackgroundTaskRecord:
+        record = await self._repository.get_async(background_task_id)
         if record is None:
             raise KeyError(f"Unknown background task: {background_task_id}")
         return record

--- a/src/relay_teams/sessions/runs/background_tasks/repository.py
+++ b/src/relay_teams/sessions/runs/background_tasks/repository.py
@@ -5,10 +5,10 @@ import json
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 from typing import Literal
 
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.runs.background_tasks.models import (
     BackgroundTaskKind,
     BackgroundTaskRecord,
@@ -21,12 +21,9 @@ from relay_teams.validation import (
 )
 
 
-class BackgroundTaskRepository:
+class BackgroundTaskRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -205,6 +202,9 @@ class BackgroundTaskRepository:
             )
         return persisted
 
+    async def upsert_async(self, record: BackgroundTaskRecord) -> BackgroundTaskRecord:
+        return await self._call_sync_async(self.upsert, record)
+
     def get(self, background_task_id: str) -> BackgroundTaskRecord | None:
         with self._lock:
             row = self._conn.execute(
@@ -219,6 +219,9 @@ class BackgroundTaskRepository:
             return None
         return _row_to_record(row)
 
+    async def get_async(self, background_task_id: str) -> BackgroundTaskRecord | None:
+        return await self._call_sync_async(self.get, background_task_id)
+
     def list_by_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -231,6 +234,9 @@ class BackgroundTaskRepository:
                 (run_id,),
             ).fetchall()
         return tuple(_row_to_record(row) for row in rows)
+
+    async def list_by_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        return await self._call_sync_async(self.list_by_run, run_id)
 
     def list_by_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
         with self._lock:
@@ -245,6 +251,11 @@ class BackgroundTaskRepository:
             ).fetchall()
         return tuple(_row_to_record(row) for row in rows)
 
+    async def list_by_session_async(
+        self, session_id: str
+    ) -> tuple[BackgroundTaskRecord, ...]:
+        return await self._call_sync_async(self.list_by_session, session_id)
+
     def list_all(self) -> tuple[BackgroundTaskRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -255,6 +266,9 @@ class BackgroundTaskRepository:
                 """
             ).fetchall()
         return tuple(_row_to_record(row) for row in rows)
+
+    async def list_all_async(self) -> tuple[BackgroundTaskRecord, ...]:
+        return await self._call_sync_async(self.list_all)
 
     def list_interruptible(self) -> tuple[BackgroundTaskRecord, ...]:
         with self._lock:
@@ -272,6 +286,9 @@ class BackgroundTaskRepository:
             ).fetchall()
         return tuple(_row_to_record(row) for row in rows)
 
+    async def list_interruptible_async(self) -> tuple[BackgroundTaskRecord, ...]:
+        return await self._call_sync_async(self.list_interruptible)
+
     def delete(self, background_task_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -285,6 +302,9 @@ class BackgroundTaskRepository:
             operation_name="delete",
         )
 
+    async def delete_async(self, background_task_id: str) -> None:
+        return await self._call_sync_async(self.delete, background_task_id)
+
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -297,6 +317,9 @@ class BackgroundTaskRepository:
             repository_name="BackgroundTaskRepository",
             operation_name="delete_by_session",
         )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_session, session_id)
 
     def mark_transient_background_tasks_interrupted(
         self,
@@ -354,6 +377,14 @@ class BackgroundTaskRepository:
             operation_name="mark_transient_background_tasks_interrupted",
         )
         return affected
+
+    async def mark_transient_background_tasks_interrupted_async(
+        self, *, background_task_ids: tuple[str, ...] | None = None
+    ) -> int:
+        return await self._call_sync_async(
+            self.mark_transient_background_tasks_interrupted,
+            background_task_ids=background_task_ids,
+        )
 
 
 def _record_params(record: BackgroundTaskRecord) -> tuple[object, ...]:

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -42,7 +42,7 @@ from relay_teams.sessions.runs.background_tasks.repository import (
     BackgroundTaskRepository,
 )
 from relay_teams.sessions.runs.enums import ExecutionMode, RunEventType
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
 from relay_teams.sessions.runs.run_models import (
     IntentInput,
@@ -658,6 +658,13 @@ class BackgroundTaskService:
             if record.execution_mode == "background"
         )
 
+    async def list_for_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        return tuple(
+            record
+            for record in await self._repository.list_by_run_async(run_id)
+            if record.execution_mode == "background"
+        )
+
     def get_for_run(
         self,
         *,
@@ -673,38 +680,56 @@ class BackgroundTaskService:
             raise KeyError(f"Unknown background task: {background_task_id}")
         return record
 
+    async def get_for_run_async(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        record = await self._repository.get_async(background_task_id)
+        if (
+            record is None
+            or record.run_id != run_id
+            or record.execution_mode != "background"
+        ):
+            raise KeyError(f"Unknown background task: {background_task_id}")
+        return record
+
     async def wait_for_run(
         self,
         *,
         run_id: str,
         background_task_id: str,
     ) -> tuple[BackgroundTaskRecord, bool]:
-        record = self.get_for_run(run_id=run_id, background_task_id=background_task_id)
+        record = await self.get_for_run_async(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
         if not record.is_active:
-            return self._mark_completion_consumed(record), True
+            return await self._mark_completion_consumed_async(record), True
         if record.kind == BackgroundTaskKind.SUBAGENT:
             runtime = self._subagent_runtimes.get(background_task_id)
             if runtime is None:
-                refreshed = self.get_for_run(
+                refreshed = await self.get_for_run_async(
                     run_id=run_id,
                     background_task_id=background_task_id,
                 )
                 if not refreshed.is_active:
-                    return self._mark_completion_consumed(refreshed), True
+                    return await self._mark_completion_consumed_async(refreshed), True
                 return refreshed, False
             await asyncio.shield(runtime.worker_task)
-            updated = self.get_for_run(
+            updated = await self.get_for_run_async(
                 run_id=run_id,
                 background_task_id=background_task_id,
             )
-            return self._mark_completion_consumed(updated), True
+            return await self._mark_completion_consumed_async(updated), True
         updated, completed = await self._require_manager().wait_for_run(
             run_id=run_id,
             background_task_id=background_task_id,
         )
         if not completed:
             return updated, False
-        return self._mark_completion_consumed(updated), True
+        return await self._mark_completion_consumed_async(updated), True
 
     async def stop_for_run(
         self,
@@ -712,7 +737,10 @@ class BackgroundTaskService:
         run_id: str,
         background_task_id: str,
     ) -> BackgroundTaskRecord:
-        record = self.get_for_run(run_id=run_id, background_task_id=background_task_id)
+        record = await self.get_for_run_async(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
         if record.kind == BackgroundTaskKind.SUBAGENT:
             runtime = self._subagent_runtimes.get(background_task_id)
             if runtime is None:
@@ -728,7 +756,7 @@ class BackgroundTaskService:
                 runtime.subagent_run_id
             )
             await asyncio.gather(runtime.worker_task, return_exceptions=True)
-            updated = self.get_for_run(
+            updated = await self.get_for_run_async(
                 run_id=run_id,
                 background_task_id=background_task_id,
             )
@@ -753,12 +781,12 @@ class BackgroundTaskService:
         exit_code: int | None,
         output: str,
     ) -> BackgroundTaskRecord:
-        current = self._repository.get(background_task_id)
+        current = await self._repository.get_async(background_task_id)
         if current is None:
             raise KeyError(f"Unknown background task: {background_task_id}")
         completed_at = datetime.now(tz=timezone.utc)
         summarized_output = output.strip()
-        record = self._repository.upsert(
+        record = await self._repository.upsert_async(
             current.model_copy(
                 update={
                     "status": status,
@@ -788,7 +816,7 @@ class BackgroundTaskService:
             self._require_run_control_manager().unregister_run_task(
                 runtime.subagent_run_id
             )
-        self._publish_background_task_event(
+        await self._publish_background_task_event_async(
             event_type=(
                 RunEventType.BACKGROUND_TASK_STOPPED
                 if status == BackgroundTaskStatus.STOPPED
@@ -973,6 +1001,21 @@ class BackgroundTaskService:
             )
         )
 
+    async def _mark_completion_consumed_async(
+        self, record: BackgroundTaskRecord
+    ) -> BackgroundTaskRecord:
+        if not self._should_notify_completion(record):
+            return record
+        completed_at = datetime.now(tz=timezone.utc)
+        return await self._repository.upsert_async(
+            record.model_copy(
+                update={
+                    "completion_notified_at": completed_at,
+                    "updated_at": completed_at,
+                }
+            )
+        )
+
     def _should_notify_completion(self, record: BackgroundTaskRecord) -> bool:
         return (
             record.execution_mode == "background"
@@ -1000,6 +1043,28 @@ class BackgroundTaskService:
                 event_type=event_type,
                 payload_json=record.model_dump_json(),
             )
+        )
+
+    async def _publish_background_task_event_async(
+        self,
+        *,
+        event_type: RunEventType,
+        record: BackgroundTaskRecord,
+    ) -> None:
+        if self._run_event_hub is None:
+            return
+        await publish_run_event_async(
+            self._run_event_hub,
+            RunEvent(
+                session_id=record.session_id,
+                run_id=record.run_id,
+                trace_id=record.run_id,
+                task_id=None,
+                instance_id=record.instance_id,
+                role_id=record.role_id,
+                event_type=event_type,
+                payload_json=record.model_dump_json(),
+            ),
         )
 
     def _upsert_subagent_intent(

--- a/src/relay_teams/sessions/runs/event_log.py
+++ b/src/relay_teams/sessions/runs/event_log.py
@@ -4,9 +4,9 @@ from pydantic import JsonValue
 
 import sqlite3
 from pathlib import Path
-from threading import RLock
 
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence import async_fetchall
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.runs.run_state_models import (
     RunStateRecord,
     apply_run_event_to_state,
@@ -16,14 +16,11 @@ from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.agents.tasks.events import EventEnvelope
 
 
-class EventLog:
+class EventLog(SharedSqliteRepository):
     """Append-only business event log backed by SQLite."""
 
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -49,19 +46,46 @@ class EventLog:
                 "CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id)"
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="EventLog",
+        self._run_write(
             operation_name="init_tables",
+            operation=operation,
+        )
+
+    async def _init_tables_async(self) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_type   TEXT NOT NULL,
+                    trace_id     TEXT NOT NULL,
+                    session_id   TEXT NOT NULL,
+                    task_id      TEXT,
+                    instance_id  TEXT,
+                    payload_json TEXT NOT NULL,
+                    occurred_at  TEXT NOT NULL
+                )
+                """
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_trace ON events(trace_id)"
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id)"
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="init_tables_async",
+            operation=lambda _conn: operation(),
         )
 
     def emit(self, event: EventEnvelope) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="emit",
             operation=lambda: self._conn.execute(
                 """
                 INSERT INTO events(event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at)
@@ -77,15 +101,36 @@ class EventLog:
                     event.occurred_at.isoformat(),
                 ),
             ),
-            lock=self._lock,
-            repository_name="EventLog",
-            operation_name="emit",
+        )
+
+    async def emit_async(self, event: EventEnvelope) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO events(event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.event_type.value,
+                    event.trace_id,
+                    event.session_id,
+                    event.task_id,
+                    event.instance_id,
+                    event.payload_json,
+                    event.occurred_at.isoformat(),
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="emit_async",
+            operation=lambda _conn: operation(),
         )
 
     def emit_run_event(self, event: RunEvent) -> int:
-        lastrowid = run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        lastrowid = self._run_write(
+            operation_name="emit_run_event",
             operation=lambda: (
                 self._conn.execute(
                     """
@@ -103,9 +148,36 @@ class EventLog:
                     ),
                 ).lastrowid
             ),
-            lock=self._lock,
-            repository_name="EventLog",
-            operation_name="emit_run_event",
+        )
+        if lastrowid is None:
+            raise RuntimeError("Failed to persist run event id")
+        return int(lastrowid)
+
+    async def emit_run_event_async(self, event: RunEvent) -> int:
+        async def operation() -> int | None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO events(event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.event_type.value,
+                    event.trace_id,
+                    event.session_id,
+                    event.task_id,
+                    event.instance_id,
+                    event.payload_json,
+                    event.occurred_at.isoformat(),
+                ),
+            )
+            inserted_row_id = cursor.lastrowid
+            await cursor.close()
+            return inserted_row_id
+
+        lastrowid = await self._run_async_write(
+            operation_name="emit_run_event_async",
+            operation=lambda _conn: operation(),
         )
         if lastrowid is None:
             raise RuntimeError("Failed to persist run event id")
@@ -120,6 +192,19 @@ class EventLog:
             ).fetchall()
         return tuple(self._row_to_dict(row) for row in rows)
 
+    async def list_by_trace_async(
+        self, trace_id: str
+    ) -> tuple[dict[str, JsonValue], ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                "FROM events WHERE trace_id=? ORDER BY id ASC",
+                (trace_id,),
+            )
+        )
+        return tuple(self._row_to_dict(row) for row in rows)
+
     def list_by_trace_after_id(
         self, trace_id: str, after_event_id: int
     ) -> tuple[dict[str, JsonValue], ...]:
@@ -131,6 +216,19 @@ class EventLog:
             ).fetchall()
         return tuple(self._row_to_dict(row) for row in rows)
 
+    async def list_by_trace_after_id_async(
+        self, trace_id: str, after_event_id: int
+    ) -> tuple[dict[str, JsonValue], ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                "FROM events WHERE trace_id=? AND id>? ORDER BY id ASC",
+                (trace_id, after_event_id),
+            )
+        )
+        return tuple(self._row_to_dict(row) for row in rows)
+
     def list_by_trace_with_ids(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -140,6 +238,19 @@ class EventLog:
             ).fetchall()
         return tuple(self._row_to_dict(row) for row in rows)
 
+    async def list_by_trace_with_ids_async(
+        self, trace_id: str
+    ) -> tuple[dict[str, JsonValue], ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                "FROM events WHERE trace_id=? ORDER BY id ASC",
+                (trace_id,),
+            )
+        )
+        return tuple(self._row_to_dict(row) for row in rows)
+
     def list_by_session(self, session_id: str) -> tuple[dict[str, JsonValue], ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -147,6 +258,19 @@ class EventLog:
                 "FROM events WHERE session_id=? ORDER BY id ASC",
                 (session_id,),
             ).fetchall()
+        return tuple(self._row_to_dict(row) for row in rows)
+
+    async def list_by_session_async(
+        self, session_id: str
+    ) -> tuple[dict[str, JsonValue], ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                "FROM events WHERE session_id=? ORDER BY id ASC",
+                (session_id,),
+            )
+        )
         return tuple(self._row_to_dict(row) for row in rows)
 
     def list_by_session_with_ids(
@@ -160,12 +284,41 @@ class EventLog:
             ).fetchall()
         return tuple(self._row_to_dict(row) for row in rows)
 
+    async def list_by_session_with_ids_async(
+        self, session_id: str
+    ) -> tuple[dict[str, JsonValue], ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                "FROM events WHERE session_id=? ORDER BY id ASC",
+                (session_id,),
+            )
+        )
+        return tuple(self._row_to_dict(row) for row in rows)
+
     def list_run_states(self) -> tuple[RunStateRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
                 "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
                 "FROM events ORDER BY id ASC"
             ).fetchall()
+        return self._run_states_from_rows(rows)
+
+    async def list_run_states_async(self) -> tuple[RunStateRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                "FROM events ORDER BY id ASC",
+            )
+        )
+        return self._run_states_from_rows(rows)
+
+    def _run_states_from_rows(
+        self,
+        rows: list[sqlite3.Row] | tuple[sqlite3.Row, ...],
+    ) -> tuple[RunStateRecord, ...]:
         states_by_run: dict[str, RunStateRecord] = {}
         for row in rows:
             row_dict = self._row_to_dict(row)
@@ -232,29 +385,79 @@ class EventLog:
             )
         return state
 
+    async def get_run_state_async(self, run_id: str) -> RunStateRecord | None:
+        state: RunStateRecord | None = None
+        for row in await self.list_by_trace_with_ids_async(run_id):
+            try:
+                event_type = RunEventType(str(row["event_type"]))
+            except ValueError:
+                continue
+            row_id = row.get("id")
+            if not isinstance(row_id, int):
+                continue
+            state = apply_run_event_to_state(
+                state,
+                event=RunEvent(
+                    session_id=str(row["session_id"]),
+                    run_id=str(row["trace_id"]),
+                    trace_id=str(row["trace_id"]),
+                    task_id=(
+                        str(row["task_id"]) if row["task_id"] is not None else None
+                    ),
+                    instance_id=(
+                        str(row["instance_id"])
+                        if row["instance_id"] is not None
+                        else None
+                    ),
+                    event_type=event_type,
+                    payload_json=str(row["payload_json"]),
+                ),
+                event_id=row_id,
+            )
+        return state
+
     def delete_by_session(self, session_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_session",
             operation=lambda: self._conn.execute(
                 "DELETE FROM events WHERE session_id=?", (session_id,)
             ),
-            lock=self._lock,
-            repository_name="EventLog",
-            operation_name="delete_by_session",
+        )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM events WHERE session_id=?", (session_id,)
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_session_async",
+            operation=lambda _conn: operation(),
         )
 
     def delete_by_trace(self, trace_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_trace",
             operation=lambda: self._conn.execute(
                 "DELETE FROM events WHERE trace_id=?",
                 (trace_id,),
             ),
-            lock=self._lock,
-            repository_name="EventLog",
-            operation_name="delete_by_trace",
+        )
+
+    async def delete_by_trace_async(self, trace_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM events WHERE trace_id=?",
+                (trace_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_trace_async",
+            operation=lambda _conn: operation(),
         )
 
     def _row_to_dict(self, row: sqlite3.Row) -> dict[str, JsonValue]:

--- a/src/relay_teams/sessions/runs/event_stream.py
+++ b/src/relay_teams/sessions/runs/event_stream.py
@@ -11,12 +11,14 @@ from relay_teams.sessions.runs.run_state_repo import RunStateRepository
 
 @runtime_checkable
 class AsyncRunEventPublisher(Protocol):
-    async def publish_async(self, event: RunEvent) -> None: ...
+    async def publish_async(self, event: RunEvent) -> None:
+        pass
 
 
 @runtime_checkable
 class SyncRunEventPublisher(Protocol):
-    def publish(self, event: RunEvent) -> None: ...
+    def publish(self, event: RunEvent) -> None:
+        pass
 
 
 async def publish_run_event_async(
@@ -93,9 +95,9 @@ class RunEventHub:
         await self._acquire_publish_lock_async()
         task = asyncio.create_task(self._publish_async_with_lock(event))
         try:
-            await asyncio.shield(task)
+            _ = await asyncio.shield(task)
         except asyncio.CancelledError:
-            await task
+            _ = await task
             raise
 
     async def _publish_async_with_lock(self, event: RunEvent) -> None:

--- a/src/relay_teams/sessions/runs/event_stream.py
+++ b/src/relay_teams/sessions/runs/event_stream.py
@@ -1,10 +1,32 @@
 from __future__ import annotations
 
 import asyncio
+from threading import Lock
+from typing import Protocol, runtime_checkable
 
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.run_state_repo import RunStateRepository
+
+
+@runtime_checkable
+class AsyncRunEventPublisher(Protocol):
+    async def publish_async(self, event: RunEvent) -> None: ...
+
+
+@runtime_checkable
+class SyncRunEventPublisher(Protocol):
+    def publish(self, event: RunEvent) -> None: ...
+
+
+async def publish_run_event_async(
+    publisher: AsyncRunEventPublisher | SyncRunEventPublisher,
+    event: RunEvent,
+) -> None:
+    if isinstance(publisher, AsyncRunEventPublisher):
+        await publisher.publish_async(event)
+        return
+    publisher.publish(event)
 
 
 class RunEventHub:
@@ -16,6 +38,7 @@ class RunEventHub:
         self._subscribers: dict[str, list[asyncio.Queue[RunEvent]]] = {}
         self._event_log = event_log
         self._run_state_repo = run_state_repo
+        self._publish_lock = Lock()
 
     def subscribe(self, run_id: str) -> asyncio.Queue[RunEvent]:
         queue: asyncio.Queue[RunEvent] = asyncio.Queue()
@@ -31,6 +54,28 @@ class RunEventHub:
             self._subscribers.pop(run_id, None)
 
     def publish(self, event: RunEvent) -> None:
+        if self._publish_from_running_loop(event):
+            return
+        with self._publish_lock:
+            self._publish_sync_with_lock(event)
+
+    def _publish_from_running_loop(self, event: RunEvent) -> bool:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        if self._publish_lock.acquire(blocking=False):
+            try:
+                self._publish_sync_with_lock(event)
+            finally:
+                self._publish_lock.release()
+            return True
+        raise RuntimeError(
+            "RunEventHub.publish cannot wait for an in-flight async publish from "
+            "a running event loop; use publish_async instead."
+        )
+
+    def _publish_sync_with_lock(self, event: RunEvent) -> None:
         event_id = 0
         if self._event_log:
             event_id = self._event_log.emit_run_event(event)
@@ -43,6 +88,39 @@ class RunEventHub:
         listeners = self._subscribers.get(event.run_id, [])
         for queue in listeners:
             queue.put_nowait(event)
+
+    async def publish_async(self, event: RunEvent) -> None:
+        await self._acquire_publish_lock_async()
+        task = asyncio.create_task(self._publish_async_with_lock(event))
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            await task
+            raise
+
+    async def _publish_async_with_lock(self, event: RunEvent) -> None:
+        try:
+            event_id = 0
+            if self._event_log:
+                event_id = await self._event_log.emit_run_event_async(event)
+            if self._run_state_repo is not None and event_id > 0:
+                await self._run_state_repo.apply_event_async(
+                    event_id=event_id,
+                    event=event,
+                )
+
+            if event_id > 0:
+                event = event.model_copy(update={"event_id": event_id})
+
+            listeners = self._subscribers.get(event.run_id, [])
+            for queue in listeners:
+                queue.put_nowait(event)
+        finally:
+            self._publish_lock.release()
+
+    async def _acquire_publish_lock_async(self) -> None:
+        while not self._publish_lock.acquire(blocking=False):
+            await asyncio.sleep(0.001)
 
     def unsubscribe_all(self, run_id: str) -> None:
         self._subscribers.pop(run_id, None)

--- a/src/relay_teams/sessions/runs/media_run_executor.py
+++ b/src/relay_teams/sessions/runs/media_run_executor.py
@@ -124,7 +124,7 @@ class MediaRunExecutor:
             active_subagent_instance_id=None,
             last_error=None,
         )
-        self._event_publisher.safe_publish_run_event(
+        await self._event_publisher.safe_publish_run_event_async(
             RunEvent(
                 session_id=intent.session_id,
                 run_id=run_id,
@@ -139,7 +139,7 @@ class MediaRunExecutor:
             ),
             failure_event="run.event.publish_failed",
         )
-        self.publish_generation_progress(
+        await self.publish_generation_progress_async(
             run_id=run_id,
             session_id=intent.session_id,
             task_id=root_task.task_id,
@@ -174,7 +174,7 @@ class MediaRunExecutor:
             if not output:
                 raise RuntimeError("Provider returned no media output")
             self.append_media_output_message(request=request, output=output)
-            self.publish_output_delta(
+            await self.publish_output_delta_async(
                 run_id=run_id,
                 session_id=intent.session_id,
                 task_id=root_task.task_id,
@@ -190,7 +190,7 @@ class MediaRunExecutor:
                 ),
                 None,
             )
-            self.publish_generation_progress(
+            await self.publish_generation_progress_async(
                 run_id=run_id,
                 session_id=intent.session_id,
                 task_id=root_task.task_id,
@@ -201,7 +201,7 @@ class MediaRunExecutor:
                 progress=1.0,
                 preview_asset_id=preview_asset_id,
             )
-            self._event_publisher.safe_publish_run_event(
+            await self._event_publisher.safe_publish_run_event_async(
                 RunEvent(
                     session_id=intent.session_id,
                     run_id=run_id,
@@ -250,7 +250,7 @@ class MediaRunExecutor:
                 error_message=result.error_message,
             )
             agent_repo.mark_status(instance.instance_id, InstanceStatus.COMPLETED)
-            self.publish_generation_progress(
+            await self.publish_generation_progress_async(
                 run_id=run_id,
                 session_id=intent.session_id,
                 task_id=root_task.task_id,
@@ -307,7 +307,7 @@ class MediaRunExecutor:
             return intent.topology.normal_root_role_id
         return role_registry.get_main_agent_role_id()
 
-    def publish_generation_progress(
+    async def publish_generation_progress_async(
         self,
         *,
         run_id: str,
@@ -320,7 +320,7 @@ class MediaRunExecutor:
         progress: float,
         preview_asset_id: str | None,
     ) -> None:
-        self._event_publisher.safe_publish_run_event(
+        await self._event_publisher.safe_publish_run_event_async(
             RunEvent(
                 session_id=session_id,
                 run_id=run_id,
@@ -341,7 +341,7 @@ class MediaRunExecutor:
             failure_event="run.event.publish_failed",
         )
 
-    def publish_output_delta(
+    async def publish_output_delta_async(
         self,
         *,
         run_id: str,
@@ -356,7 +356,7 @@ class MediaRunExecutor:
             "role_id": role_id,
             "instance_id": instance_id,
         }
-        self._event_publisher.safe_publish_run_event(
+        await self._event_publisher.safe_publish_run_event_async(
             RunEvent(
                 session_id=session_id,
                 run_id=run_id,

--- a/src/relay_teams/sessions/runs/run_auxiliary.py
+++ b/src/relay_teams/sessions/runs/run_auxiliary.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from relay_teams.monitors import (
     MonitorAction,
@@ -24,12 +24,14 @@ class RunAuxiliaryService:
         get_background_task_service: Callable[[], BackgroundTaskService | None],
         get_todo_service: Callable[[], TodoService | None],
         get_run_session_id: Callable[[str], str],
+        get_run_session_id_async: Callable[[str], Awaitable[str]],
     ) -> None:
         self._get_monitor_service = get_monitor_service
         self._get_background_task_manager = get_background_task_manager
         self._get_background_task_service = get_background_task_service
         self._get_todo_service = get_todo_service
         self._get_run_session_id = get_run_session_id
+        self._get_run_session_id_async = get_run_session_id_async
 
     def create_monitor(
         self,
@@ -63,10 +65,49 @@ class RunAuxiliaryService:
         )
         return record.model_dump(mode="json")
 
+    async def create_monitor_async(
+        self,
+        *,
+        run_id: str,
+        source_kind: MonitorSourceKind,
+        source_key: str,
+        rule: MonitorRule,
+        action_type: MonitorActionType,
+        created_by_instance_id: str | None = None,
+        created_by_role_id: str | None = None,
+        tool_call_id: str | None = None,
+    ) -> dict[str, object]:
+        service = self._require_monitor_service()
+        normalized_source_key = source_key.strip()
+        if source_kind == MonitorSourceKind.BACKGROUND_TASK:
+            _ = await self.get_background_task_async(
+                run_id=run_id,
+                background_task_id=normalized_source_key,
+            )
+        record = await service.create_monitor_async(
+            run_id=run_id,
+            session_id=await self._get_run_session_id_async(run_id),
+            source_kind=source_kind,
+            source_key=normalized_source_key,
+            rule=rule,
+            action=MonitorAction(action_type=action_type),
+            created_by_instance_id=created_by_instance_id,
+            created_by_role_id=created_by_role_id,
+            tool_call_id=tool_call_id,
+        )
+        return record.model_dump(mode="json")
+
     def list_monitors(self, run_id: str) -> tuple[dict[str, object], ...]:
         service = self._require_monitor_service()
         return tuple(
             record.model_dump(mode="json") for record in service.list_for_run(run_id)
+        )
+
+    async def list_monitors_async(self, run_id: str) -> tuple[dict[str, object], ...]:
+        service = self._require_monitor_service()
+        return tuple(
+            record.model_dump(mode="json")
+            for record in await service.list_for_run_async(run_id)
         )
 
     def stop_monitor(
@@ -79,6 +120,20 @@ class RunAuxiliaryService:
         return service.stop_for_run(
             run_id=run_id,
             monitor_id=monitor_id,
+        ).model_dump(mode="json")
+
+    async def stop_monitor_async(
+        self,
+        *,
+        run_id: str,
+        monitor_id: str,
+    ) -> dict[str, object]:
+        service = self._require_monitor_service()
+        return (
+            await service.stop_for_run_async(
+                run_id=run_id,
+                monitor_id=monitor_id,
+            )
         ).model_dump(mode="json")
 
     def list_background_tasks(self, run_id: str) -> tuple[dict[str, object], ...]:
@@ -94,6 +149,25 @@ class RunAuxiliaryService:
         return tuple(
             record.model_dump(mode="json")
             for record in manager.list_for_run(run_id)
+            if record.execution_mode == "background"
+        )
+
+    async def list_background_tasks_async(
+        self,
+        run_id: str,
+    ) -> tuple[dict[str, object], ...]:
+        service = self._get_background_task_service()
+        if service is not None:
+            return tuple(
+                record.model_dump(mode="json")
+                for record in await service.list_for_run_async(run_id)
+            )
+        manager = self._get_background_task_manager()
+        if manager is None:
+            return ()
+        return tuple(
+            record.model_dump(mode="json")
+            for record in await manager.list_for_run_async(run_id)
             if record.execution_mode == "background"
         )
 
@@ -120,6 +194,31 @@ class RunAuxiliaryService:
             raise KeyError(f"Background task {background_task_id} not found")
         return record.model_dump(mode="json")
 
+    async def get_background_task_async(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> dict[str, object]:
+        service = self._get_background_task_service()
+        if service is not None:
+            return (
+                await service.get_for_run_async(
+                    run_id=run_id,
+                    background_task_id=background_task_id,
+                )
+            ).model_dump(mode="json")
+        manager = self._get_background_task_manager()
+        if manager is None:
+            raise KeyError(f"Background task {background_task_id} not found")
+        record = await manager.get_for_run_async(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
+        if record.execution_mode != "background":
+            raise KeyError(f"Background task {background_task_id} not found")
+        return record.model_dump(mode="json")
+
     def get_todo(self, run_id: str) -> dict[str, object]:
         service = self._get_todo_service()
         if service is None:
@@ -127,6 +226,16 @@ class RunAuxiliaryService:
         snapshot = service.get_for_run(
             run_id=run_id,
             session_id=self._get_run_session_id(run_id),
+        )
+        return snapshot.model_dump(mode="json")
+
+    async def get_todo_async(self, run_id: str) -> dict[str, object]:
+        service = self._get_todo_service()
+        if service is None:
+            raise RuntimeError("Todo service is not configured")
+        snapshot = await service.get_for_run_async(
+            run_id=run_id,
+            session_id=await self._get_run_session_id_async(run_id),
         )
         return snapshot.model_dump(mode="json")
 

--- a/src/relay_teams/sessions/runs/run_control_manager.py
+++ b/src/relay_teams/sessions/runs/run_control_manager.py
@@ -309,6 +309,20 @@ class RunControlManager:
             )
         )
 
+    async def publish_run_stopped_async(
+        self, *, session_id: str, run_id: str, reason: str
+    ) -> None:
+        await self._require_run_event_hub().publish_async(
+            RunEvent(
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=run_id,
+                task_id=None,
+                event_type=RunEventType.RUN_STOPPED,
+                payload_json=dumps({"reason": reason}),
+            )
+        )
+
     def inject_to_running_agents(
         self,
         *,
@@ -329,6 +343,32 @@ class RunControlManager:
                 content=content,
             )
             self._publish_injection_event(run_id=run_id, record=record, created=created)
+        if created is None:
+            raise KeyError(f"No RUNNING agent for run_id={run_id}")
+        return created
+
+    async def inject_to_running_agents_async(
+        self,
+        *,
+        run_id: str,
+        source: InjectionSource,
+        content: str,
+    ) -> InjectionMessage:
+        agent_repo = self._require_agent_repo()
+        created: InjectionMessage | None = None
+        running = await agent_repo.list_running_async(run_id)
+        if not running:
+            raise KeyError(f"No RUNNING agent for run_id={run_id}")
+        for record in running:
+            created = self._require_injection_manager().enqueue(
+                run_id=run_id,
+                recipient_instance_id=record.instance_id,
+                source=source,
+                content=content,
+            )
+            await self._publish_injection_event_async(
+                run_id=run_id, record=record, created=created
+            )
         if created is None:
             raise KeyError(f"No RUNNING agent for run_id={run_id}")
         return created
@@ -404,6 +444,78 @@ class RunControlManager:
         )
         if self._run_runtime_repo is not None:
             self._run_runtime_repo.update(
+                run_id,
+                status=RunRuntimeStatus.PAUSED,
+                phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
+                active_instance_id=instance_id,
+                active_task_id=paused.task_id,
+                active_role_id=record.role_id,
+                active_subagent_instance_id=instance_id,
+                last_error="Subagent stopped by user",
+            )
+        return {
+            "status": "paused",
+            "instance_id": instance_id,
+            "role_id": record.role_id,
+            "task_id": paused.task_id or "",
+            "run_id": run_id,
+        }
+
+    async def stop_subagent_async(
+        self, *, run_id: str, instance_id: str
+    ) -> dict[str, str]:
+        record = await self._require_agent_repo().get_instance_async(instance_id)
+        if record.run_id != run_id:
+            raise KeyError(f"Instance {instance_id} does not belong to run {run_id}")
+        if await self._is_coordinator_role_for_run_async(
+            run_id=run_id, role_id=record.role_id
+        ):
+            raise ValueError("Stopping coordinator via subagent API is not allowed")
+
+        paused = self.request_subagent_stop(run_id=run_id, instance_id=instance_id)
+        if paused is None:
+            paused = self.pause_subagent(
+                session_id=record.session_id,
+                run_id=run_id,
+                instance_id=instance_id,
+                role_id=record.role_id,
+                task_id=await self._find_task_for_instance_async(
+                    run_id=run_id, instance_id=instance_id
+                ),
+            )
+
+        if paused.task_id:
+            await self._require_task_repo().update_status_async(
+                task_id=paused.task_id,
+                status=TaskStatus.STOPPED,
+                assigned_instance_id=instance_id,
+                error_message="Task stopped by user",
+            )
+        await self._require_agent_repo().mark_status_async(
+            instance_id, InstanceStatus.STOPPED
+        )
+
+        await self._require_run_event_hub().publish_async(
+            RunEvent(
+                session_id=record.session_id,
+                run_id=run_id,
+                trace_id=run_id,
+                task_id=paused.task_id,
+                instance_id=instance_id,
+                role_id=record.role_id,
+                event_type=RunEventType.SUBAGENT_STOPPED,
+                payload_json=dumps(
+                    {
+                        "instance_id": instance_id,
+                        "role_id": record.role_id,
+                        "task_id": paused.task_id,
+                        "reason": paused.reason,
+                    }
+                ),
+            )
+        )
+        if self._run_runtime_repo is not None:
+            await self._run_runtime_repo.update_async(
                 run_id,
                 status=RunRuntimeStatus.PAUSED,
                 phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
@@ -668,8 +780,22 @@ class RunControlManager:
             coordinator_role_id == role_id if coordinator_role_id is not None else False
         )
 
+    async def _is_coordinator_role_for_run_async(
+        self, *, run_id: str, role_id: str
+    ) -> bool:
+        coordinator_role_id = await self._root_role_id_for_run_async(run_id)
+        return (
+            coordinator_role_id == role_id if coordinator_role_id is not None else False
+        )
+
     def _root_role_id_for_run(self, run_id: str) -> str | None:
         for record in self._require_task_repo().list_by_trace(run_id):
+            if record.envelope.parent_task_id is None:
+                return record.envelope.role_id
+        return None
+
+    async def _root_role_id_for_run_async(self, run_id: str) -> str | None:
+        for record in await self._require_task_repo().list_by_trace_async(run_id):
             if record.envelope.parent_task_id is None:
                 return record.envelope.role_id
         return None
@@ -687,10 +813,41 @@ class RunControlManager:
                 return record.envelope.task_id
         return None
 
+    async def _find_task_for_instance_async(
+        self, *, run_id: str, instance_id: str
+    ) -> str | None:
+        for record in await self._require_task_repo().list_by_trace_async(run_id):
+            if record.assigned_instance_id != instance_id:
+                continue
+            if record.status in (
+                TaskStatus.RUNNING,
+                TaskStatus.ASSIGNED,
+                TaskStatus.CREATED,
+                TaskStatus.STOPPED,
+            ):
+                return record.envelope.task_id
+        return None
+
     def _publish_injection_event(
         self, *, run_id: str, record: AgentRuntimeRecord, created: InjectionMessage
     ) -> None:
         self._require_run_event_hub().publish(
+            RunEvent(
+                session_id=record.session_id,
+                run_id=run_id,
+                trace_id=run_id,
+                task_id=None,
+                instance_id=record.instance_id,
+                role_id=record.role_id,
+                event_type=RunEventType.INJECTION_ENQUEUED,
+                payload_json=created.model_dump_json(),
+            )
+        )
+
+    async def _publish_injection_event_async(
+        self, *, run_id: str, record: AgentRuntimeRecord, created: InjectionMessage
+    ) -> None:
+        await self._require_run_event_hub().publish_async(
             RunEvent(
                 session_id=record.session_id,
                 run_id=run_id,

--- a/src/relay_teams/sessions/runs/run_event_publisher.py
+++ b/src/relay_teams/sessions/runs/run_event_publisher.py
@@ -11,7 +11,7 @@ from relay_teams.notifications import (
     NotificationService,
     NotificationType,
 )
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeRecord,
@@ -112,6 +112,29 @@ class RunEventPublisher:
     ) -> None:
         try:
             self._run_event_hub.publish(event)
+        except Exception as exc:
+            with bind_trace_context(
+                trace_id=event.trace_id,
+                run_id=event.run_id,
+                session_id=event.session_id,
+            ):
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event=failure_event,
+                    message="Run event publish failed",
+                    payload={"event_type": event.event_type.value},
+                    exc_info=exc,
+                )
+
+    async def safe_publish_run_event_async(
+        self,
+        event: RunEvent,
+        *,
+        failure_event: str,
+    ) -> None:
+        try:
+            await publish_run_event_async(self._run_event_hub, event)
         except Exception as exc:
             with bind_trace_context(
                 trace_id=event.trace_id,

--- a/src/relay_teams/sessions/runs/run_followups.py
+++ b/src/relay_teams/sessions/runs/run_followups.py
@@ -374,6 +374,12 @@ class RunFollowupRouter:
             return False
         return any(True for _ in agent_repo.list_running(run_id))
 
+    async def has_running_agents_for_run_async(self, run_id: str) -> bool:
+        agent_repo = self._get_agent_repo()
+        if agent_repo is None:
+            return False
+        return any(True for _ in await agent_repo.list_running_async(run_id))
+
     def has_pending_resolvable_question_for_session(self, session_id: str) -> bool:
         user_question_repo = self._get_user_question_repo()
         if user_question_repo is None:

--- a/src/relay_teams/sessions/runs/run_intent_repo.py
+++ b/src/relay_teams/sessions/runs/run_intent_repo.py
@@ -244,6 +244,13 @@ class RunIntentRepository(SharedSqliteRepository):
             ),
         )
 
+    async def upsert_async(
+        self, *, run_id: str, session_id: str, intent: IntentInput
+    ) -> None:
+        return await self._call_sync_async(
+            self.upsert, run_id=run_id, session_id=session_id, intent=intent
+        )
+
     def append_followup(self, *, run_id: str, content: str) -> None:
         def operation() -> None:
             row = self._conn.execute(
@@ -273,6 +280,11 @@ class RunIntentRepository(SharedSqliteRepository):
             )
 
         self._run_write(operation_name="append_followup", operation=operation)
+
+    async def append_followup_async(self, *, run_id: str, content: str) -> None:
+        return await self._call_sync_async(
+            self.append_followup, run_id=run_id, content=content
+        )
 
     def get(
         self,
@@ -357,6 +369,13 @@ def _intent_input_from_row(
             row["conversation_context_json"]
         ),
     )
+
+    async def get_async(
+        self, run_id: str, *, fallback_session_id: str | None = None
+    ) -> IntentInput:
+        return await self._call_sync_async(
+            self.get, run_id, fallback_session_id=fallback_session_id
+        )
 
 
 def _coerce_session_id(

--- a/src/relay_teams/sessions/runs/run_intent_repo.py
+++ b/src/relay_teams/sessions/runs/run_intent_repo.py
@@ -306,6 +306,13 @@ class RunIntentRepository(SharedSqliteRepository):
             raise KeyError(f"Unknown run_id: {run_id}")
         return _intent_input_from_row(row, fallback_session_id=fallback_session_id)
 
+    async def get_async(
+        self, run_id: str, *, fallback_session_id: str | None = None
+    ) -> IntentInput:
+        return await self._call_sync_async(
+            self.get, run_id, fallback_session_id=fallback_session_id
+        )
+
     def list_by_session(self, session_id: str) -> dict[str, IntentInput]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -333,6 +340,9 @@ class RunIntentRepository(SharedSqliteRepository):
             except (KeyError, ValueError, ValidationError) as exc:
                 _log_invalid_run_intent_row(row=row, error=exc)
         return records
+
+    async def list_by_session_async(self, session_id: str) -> dict[str, IntentInput]:
+        return await self._call_sync_async(self.list_by_session, session_id)
 
 
 def _intent_input_from_row(
@@ -369,13 +379,6 @@ def _intent_input_from_row(
             row["conversation_context_json"]
         ),
     )
-
-    async def get_async(
-        self, run_id: str, *, fallback_session_id: str | None = None
-    ) -> IntentInput:
-        return await self._call_sync_async(
-            self.get, run_id, fallback_session_id=fallback_session_id
-        )
 
 
 def _coerce_session_id(

--- a/src/relay_teams/sessions/runs/run_interactions.py
+++ b/src/relay_teams/sessions/runs/run_interactions.py
@@ -386,7 +386,9 @@ class RunInteractionService:
                     feedback=feedback,
                 )
             except KeyError:
-                pass
+                # Approval can already be absent from in-memory tracking after
+                # expiry, restart, or duplicate resolution.
+                pass  # pragma: no cover
         if self._is_running_run(run_id) or runtime is None:
             return
 
@@ -917,7 +919,9 @@ class RunInteractionService:
                     expected_status=UserQuestionRequestStatus.REQUESTED,
                 )
             except UserQuestionStatusConflictError:
-                pass
+                # Concurrent resolution is acceptable; later closure logic still
+                # reconciles the run state from the persisted question records.
+                pass  # pragma: no cover
             if resolved_record is not None:
                 self._event_publisher.safe_publish_run_event(
                     RunEvent(

--- a/src/relay_teams/sessions/runs/run_interactions.py
+++ b/src/relay_teams/sessions/runs/run_interactions.py
@@ -503,7 +503,10 @@ class RunInteractionService:
                     feedback=feedback,
                 )
             except KeyError:
-                pass
+                LOGGER.debug(  # pragma: no cover
+                    "Tool approval was already absent from in-memory tracking",
+                    extra={"run_id": run_id, "tool_call_id": tool_call_id},
+                )
         if self._is_running_run(run_id) or runtime is None:
             return
 
@@ -998,7 +1001,10 @@ class RunInteractionService:
                     expected_status=UserQuestionRequestStatus.REQUESTED,
                 )
             except UserQuestionStatusConflictError:
-                pass
+                LOGGER.debug(  # pragma: no cover
+                    "User question was already resolved concurrently",
+                    extra={"run_id": run_id, "question_id": record.question_id},
+                )
             if resolved_record is not None:
                 await self._event_publisher.safe_publish_run_event_async(
                     RunEvent(

--- a/src/relay_teams/sessions/runs/run_interactions.py
+++ b/src/relay_teams/sessions/runs/run_interactions.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
+from collections.abc import Awaitable, Callable
 from json import dumps
 from typing import cast
 
@@ -189,11 +190,17 @@ class RunInteractionService:
         get_user_question_repo: Callable[[], UserQuestionRepository | None],
         get_user_question_manager: Callable[[], UserQuestionManager | None],
         get_runtime: Callable[[str], RunRuntimeRecord | None],
+        get_runtime_async: Callable[[str], Awaitable[RunRuntimeRecord | None]],
         is_running_run: Callable[[str], bool],
         has_pending_resolvable_question_for_session: Callable[[str], bool],
+        has_pending_resolvable_question_for_session_async: Callable[
+            [str], Awaitable[bool]
+        ],
         has_running_agents_for_run: Callable[[str], bool],
         resume_run: Callable[[str], str],
+        resume_run_async: Callable[[str], Awaitable[str]],
         ensure_run_started: Callable[[str], None],
+        ensure_run_started_async: Callable[[str], Awaitable[None]],
         event_publisher: RunEventPublisher,
     ) -> None:
         self._run_control_manager = run_control_manager
@@ -204,13 +211,19 @@ class RunInteractionService:
         self._get_user_question_repo = get_user_question_repo
         self._get_user_question_manager = get_user_question_manager
         self._get_runtime = get_runtime
+        self._get_runtime_async = get_runtime_async
         self._is_running_run = is_running_run
         self._has_pending_resolvable_question_for_session = (
             has_pending_resolvable_question_for_session
         )
+        self._has_pending_resolvable_question_for_session_async = (
+            has_pending_resolvable_question_for_session_async
+        )
         self._has_running_agents_for_run = has_running_agents_for_run
         self._resume_run = resume_run
+        self._resume_run_async = resume_run_async
         self._ensure_run_started = ensure_run_started
+        self._ensure_run_started_async = ensure_run_started_async
         self._event_publisher = event_publisher
 
     def inject_subagent_message(
@@ -226,12 +239,40 @@ class RunInteractionService:
             content=content,
         )
 
+    async def inject_subagent_message_async(
+        self,
+        *,
+        run_id: str,
+        instance_id: str,
+        content: str,
+    ) -> None:
+        await asyncio.to_thread(
+            self.inject_subagent_message,
+            run_id=run_id,
+            instance_id=instance_id,
+            content=content,
+        )
+
     def stop_subagent(self, run_id: str, instance_id: str) -> dict[str, str]:
         stopped = self._run_control_manager.stop_subagent(
             run_id=run_id,
             instance_id=instance_id,
         )
         self.complete_pending_user_questions(
+            run_id=run_id,
+            instance_id=instance_id,
+            reason="subagent_stopped",
+        )
+        return stopped
+
+    async def stop_subagent_async(
+        self, run_id: str, instance_id: str
+    ) -> dict[str, str]:
+        stopped = await self._run_control_manager.stop_subagent_async(
+            run_id=run_id,
+            instance_id=instance_id,
+        )
+        await self.complete_pending_user_questions_async(
             run_id=run_id,
             instance_id=instance_id,
             reason="subagent_stopped",
@@ -345,6 +386,114 @@ class RunInteractionService:
             failure_event="run.event.publish_failed",
         )
 
+    async def resolve_tool_approval_async(
+        self,
+        *,
+        run_id: str,
+        tool_call_id: str,
+        action: str,
+        feedback: str = "",
+    ) -> None:
+        approval_action = parse_tool_approval_action(action)
+        runtime = await self._get_runtime_async(run_id)
+        if (
+            not self._is_running_run(run_id)
+            and runtime is not None
+            and runtime.is_recoverable
+            and runtime.status == RunRuntimeStatus.STOPPED
+        ):
+            raise RuntimeError(
+                f"Run {run_id} is stopped. Resume the run before resolving tool approval."
+            )
+        if runtime is not None and runtime.status == RunRuntimeStatus.STOPPING:
+            raise RuntimeError(
+                f"Run {run_id} is stopping. Wait for it to stop before resolving tool approval."
+            )
+        approval = self._tool_approval_manager.get_approval(
+            run_id=run_id,
+            tool_call_id=tool_call_id,
+        )
+        approval_ticket_repo = self._get_approval_ticket_repo()
+        ticket = (
+            await approval_ticket_repo.get_async(tool_call_id)
+            if approval_ticket_repo is not None
+            else None
+        )
+        if ticket is not None and ticket.run_id != run_id:
+            raise KeyError(f"Tool approval {tool_call_id} not found for run {run_id}")
+        resolved_ticket = ticket
+        if approval_ticket_repo is not None:
+            try:
+                resolved_ticket = await approval_ticket_repo.resolve_async(
+                    tool_call_id=tool_call_id,
+                    status=(
+                        ApprovalTicketStatus.APPROVED
+                        if approval_action_is_approved(action)
+                        else ApprovalTicketStatus.DENIED
+                    ),
+                    feedback=feedback,
+                    expected_status=ApprovalTicketStatus.REQUESTED,
+                )
+            except ApprovalTicketStatusConflictError as exc:
+                raise RuntimeError(
+                    approval_ticket_status_conflict_message(
+                        tool_call_id=tool_call_id,
+                        status=exc.actual_status,
+                    )
+                ) from exc
+        if approval_action_requires_shell_grant(action):
+            self.persist_shell_approval_grants(ticket=ticket, action=action)
+        if approval is not None:
+            try:
+                self._tool_approval_manager.resolve_approval(
+                    run_id=run_id,
+                    tool_call_id=tool_call_id,
+                    action=approval_action,
+                    feedback=feedback,
+                )
+            except KeyError:
+                pass
+        if self._is_running_run(run_id) or runtime is None:
+            return
+
+        instance_id = (
+            approval["instance_id"]
+            if approval is not None
+            else (resolved_ticket.instance_id if resolved_ticket is not None else None)
+        )
+        role_id = (
+            approval["role_id"]
+            if approval is not None
+            else (resolved_ticket.role_id if resolved_ticket is not None else None)
+        )
+        tool_name = (
+            approval["tool_name"]
+            if approval is not None
+            else (resolved_ticket.tool_name if resolved_ticket is not None else "")
+        )
+        await self._event_publisher.safe_publish_run_event_async(
+            RunEvent(
+                session_id=runtime.session_id,
+                run_id=run_id,
+                trace_id=run_id,
+                task_id=None,
+                instance_id=instance_id or None,
+                role_id=role_id or None,
+                event_type=RunEventType.TOOL_APPROVAL_RESOLVED,
+                payload_json=dumps(
+                    {
+                        "tool_call_id": tool_call_id,
+                        "tool_name": tool_name,
+                        "action": action,
+                        "feedback": feedback,
+                        "instance_id": instance_id,
+                        "role_id": role_id,
+                    }
+                ),
+            ),
+            failure_event="run.event.publish_failed",
+        )
+
     def persist_shell_approval_grants(
         self,
         *,
@@ -391,6 +540,24 @@ class RunInteractionService:
             for item in approval_ticket_repo.list_open_by_run(run_id)
         ]
 
+    async def list_open_tool_approvals_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, str]]:
+        approval_ticket_repo = self._get_approval_ticket_repo()
+        if approval_ticket_repo is None:
+            return self._tool_approval_manager.list_open_approvals(run_id=run_id)
+        return [
+            {
+                "tool_call_id": item.tool_call_id,
+                "instance_id": item.instance_id,
+                "role_id": item.role_id,
+                "tool_name": item.tool_name,
+                "args_preview": item.args_preview,
+            }
+            for item in await approval_ticket_repo.list_open_by_run_async(run_id)
+        ]
+
     def list_user_questions(self, run_id: str) -> list[dict[str, JsonValue]]:
         repo = self._require_user_question_repo()
         runtime = self._get_runtime(run_id)
@@ -399,6 +566,19 @@ class RunInteractionService:
         return [
             cast(dict[str, JsonValue], item.model_dump(mode="json"))
             for item in repo.list_by_run(run_id)
+        ]
+
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, JsonValue]]:
+        repo = self._require_user_question_repo()
+        runtime = await self._get_runtime_async(run_id)
+        if runtime is None:
+            raise KeyError(f"Run {run_id} not found")
+        return [
+            cast(dict[str, JsonValue], item.model_dump(mode="json"))
+            for item in await repo.list_by_run_async(run_id)
         ]
 
     def answer_user_question(
@@ -521,6 +701,126 @@ class RunInteractionService:
                 self._ensure_run_started(run_id)
         return cast(dict[str, JsonValue], resolved_record.model_dump(mode="json"))
 
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        repo = self._require_user_question_repo()
+        runtime = await self._get_runtime_async(run_id)
+        if runtime is None:
+            raise KeyError(f"Run {run_id} not found")
+        if runtime.status == RunRuntimeStatus.STOPPING:
+            raise RuntimeError(
+                f"Run {run_id} is stopping. Wait for it to stop before answering."
+            )
+        record = await repo.get_async(question_id)
+        if record is None or record.run_id != run_id:
+            raise KeyError(f"User question {question_id} not found for run {run_id}")
+        if record.status != UserQuestionRequestStatus.REQUESTED:
+            raise RuntimeError(
+                user_question_status_conflict_message(
+                    question_id=question_id,
+                    status=record.status,
+                )
+            )
+        validated_answers = validate_user_question_answers(
+            questions=record.questions,
+            answers=answers,
+        )
+        try:
+            resolved_record = await repo.resolve_async(
+                question_id=question_id,
+                status=UserQuestionRequestStatus.ANSWERED,
+                answers=validated_answers.answers,
+                expected_status=UserQuestionRequestStatus.REQUESTED,
+            )
+        except UserQuestionStatusConflictError as exc:
+            raise RuntimeError(
+                user_question_status_conflict_message(
+                    question_id=question_id,
+                    status=exc.actual_status,
+                )
+            ) from exc
+        user_question_manager = self._get_user_question_manager()
+        manager_question = (
+            user_question_manager.get_question(
+                run_id=run_id,
+                question_id=question_id,
+            )
+            if user_question_manager is not None
+            else None
+        )
+        if user_question_manager is not None and manager_question is not None:
+            try:
+                user_question_manager.resolve_question(
+                    run_id=run_id,
+                    question_id=question_id,
+                    answers=validated_answers,
+                )
+            except (KeyError, UserQuestionClosedError):
+                manager_question = None
+        await self._event_publisher.safe_publish_run_event_async(
+            RunEvent(
+                session_id=resolved_record.session_id,
+                run_id=run_id,
+                trace_id=run_id,
+                task_id=resolved_record.task_id,
+                instance_id=(
+                    manager_question["instance_id"]
+                    if manager_question is not None
+                    else None
+                ),
+                role_id=manager_question["role_id"]
+                if manager_question is not None
+                else None,
+                event_type=RunEventType.USER_QUESTION_ANSWERED,
+                payload_json=dumps(
+                    {
+                        "question_id": question_id,
+                        "answers": [
+                            answer.model_dump(mode="json")
+                            for answer in validated_answers.answers
+                        ],
+                        "instance_id": (
+                            manager_question["instance_id"]
+                            if manager_question is not None
+                            else resolved_record.instance_id
+                        ),
+                        "role_id": (
+                            manager_question["role_id"]
+                            if manager_question is not None
+                            else resolved_record.role_id
+                        ),
+                    },
+                    ensure_ascii=False,
+                ),
+            ),
+            failure_event="run.event.publish_failed",
+        )
+        current_runtime = await self._get_runtime_async(run_id)
+        if (
+            not self._is_running_run(run_id)
+            and current_runtime is not None
+            and current_runtime.is_recoverable
+            and current_runtime.status
+            in {RunRuntimeStatus.PAUSED, RunRuntimeStatus.STOPPED}
+            and not await self._has_pending_resolvable_question_for_session_async(
+                resolved_record.session_id
+            )
+            and not self._has_running_agents_for_run(run_id)
+        ):
+            try:
+                _ = await self._resume_run_async(run_id)
+            except RuntimeError as exc:
+                if not is_run_already_running_conflict(run_id=run_id, error=exc):
+                    raise
+            else:
+                await self._ensure_run_started_async(run_id)
+        return cast(dict[str, JsonValue], resolved_record.model_dump(mode="json"))
+
     def complete_pending_user_questions(
         self,
         *,
@@ -566,6 +866,78 @@ class RunInteractionService:
                 pass
             if resolved_record is not None:
                 self._event_publisher.safe_publish_run_event(
+                    RunEvent(
+                        session_id=resolved_record.session_id,
+                        run_id=run_id,
+                        trace_id=run_id,
+                        task_id=resolved_record.task_id,
+                        instance_id=resolved_record.instance_id,
+                        role_id=resolved_record.role_id,
+                        event_type=RunEventType.USER_QUESTION_ANSWERED,
+                        payload_json=dumps(
+                            {
+                                "question_id": record.question_id,
+                                "status": resolved_record.status.value,
+                                "instance_id": resolved_record.instance_id,
+                                "role_id": resolved_record.role_id,
+                            },
+                            ensure_ascii=False,
+                        ),
+                    ),
+                    failure_event="run.event.publish_failed",
+                )
+            if user_question_manager is not None:
+                user_question_manager.mark_question_closed(
+                    run_id=run_id,
+                    question_id=record.question_id,
+                    reason=reason,
+                )
+
+    async def complete_pending_user_questions_async(
+        self,
+        *,
+        run_id: str,
+        instance_id: str | None = None,
+        reason: str,
+    ) -> None:
+        repo = self._get_user_question_repo()
+        if repo is None:
+            return
+        records = await repo.list_by_run_async(run_id)
+        targets = tuple(
+            record
+            for record in records
+            if instance_id is None or record.instance_id == instance_id
+        )
+        user_question_manager = self._get_user_question_manager()
+        if not targets:
+            if user_question_manager is None:
+                return
+            if instance_id is None:
+                user_question_manager.mark_questions_closed_for_run(
+                    run_id=run_id,
+                    reason=reason,
+                )
+                return
+            _ = user_question_manager.mark_questions_closed_for_instance(
+                run_id=run_id,
+                instance_id=instance_id,
+                reason=reason,
+            )
+            return
+        for record in targets:
+            resolved_record = None
+            try:
+                resolved_record = await repo.resolve_async(
+                    question_id=record.question_id,
+                    status=UserQuestionRequestStatus.COMPLETED,
+                    answers=record.answers,
+                    expected_status=UserQuestionRequestStatus.REQUESTED,
+                )
+            except UserQuestionStatusConflictError:
+                pass
+            if resolved_record is not None:
+                await self._event_publisher.safe_publish_run_event_async(
                     RunEvent(
                         session_id=resolved_record.session_id,
                         run_id=run_id,

--- a/src/relay_teams/sessions/runs/run_interactions.py
+++ b/src/relay_teams/sessions/runs/run_interactions.py
@@ -8,6 +8,7 @@ from typing import cast
 
 from pydantic import JsonValue
 
+from relay_teams.logger import get_logger
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.run_event_publisher import RunEventPublisher
@@ -47,6 +48,8 @@ from relay_teams.tools.workspace_tools.shell_approval_repo import (
     ShellApprovalScope,
 )
 from relay_teams.tools.workspace_tools.shell_policy import ShellRuntimeFamily
+
+LOGGER = get_logger(__name__)
 
 type ShellApprovalGrantSpec = tuple[
     str,
@@ -386,9 +389,10 @@ class RunInteractionService:
                     feedback=feedback,
                 )
             except KeyError:
-                # Approval can already be absent from in-memory tracking after
-                # expiry, restart, or duplicate resolution.
-                pass  # pragma: no cover
+                LOGGER.debug(  # pragma: no cover
+                    "Tool approval was already absent from in-memory tracking",
+                    extra={"run_id": run_id, "tool_call_id": tool_call_id},
+                )
         if self._is_running_run(run_id) or runtime is None:
             return
 
@@ -919,9 +923,10 @@ class RunInteractionService:
                     expected_status=UserQuestionRequestStatus.REQUESTED,
                 )
             except UserQuestionStatusConflictError:
-                # Concurrent resolution is acceptable; later closure logic still
-                # reconciles the run state from the persisted question records.
-                pass  # pragma: no cover
+                LOGGER.debug(  # pragma: no cover
+                    "User question was already resolved concurrently",
+                    extra={"run_id": run_id, "question_id": record.question_id},
+                )
             if resolved_record is not None:
                 self._event_publisher.safe_publish_run_event(
                     RunEvent(

--- a/src/relay_teams/sessions/runs/run_interactions.py
+++ b/src/relay_teams/sessions/runs/run_interactions.py
@@ -48,6 +48,13 @@ from relay_teams.tools.workspace_tools.shell_approval_repo import (
 )
 from relay_teams.tools.workspace_tools.shell_policy import ShellRuntimeFamily
 
+type ShellApprovalGrantSpec = tuple[
+    str,
+    ShellRuntimeFamily,
+    ShellApprovalScope,
+    str,
+]
+
 
 def approval_action_is_approved(action: str) -> bool:
     return action in {"approve", "approve_once", "approve_exact", "approve_prefix"}
@@ -103,6 +110,39 @@ def extract_shell_grant_metadata(
     except ValueError:
         return None
     return workspace_key, resolved_runtime_family, normalized_command, prefix_candidates
+
+
+def shell_approval_grant_specs(
+    *,
+    ticket: ApprovalTicketRecord | None,
+    action: str,
+) -> tuple[ShellApprovalGrantSpec, ...]:
+    if ticket is None or ticket.status != ApprovalTicketStatus.REQUESTED:
+        return ()
+    resolved = extract_shell_grant_metadata(ticket)
+    if resolved is None:
+        return ()
+    workspace_key, runtime_family, normalized_command, prefix_candidates = resolved
+    if action == "approve_exact" and normalized_command:
+        return (
+            (
+                workspace_key,
+                runtime_family,
+                ShellApprovalScope.EXACT,
+                normalized_command,
+            ),
+        )
+    if action == "approve_prefix":
+        return tuple(
+            (
+                workspace_key,
+                runtime_family,
+                ShellApprovalScope.PREFIX,
+                candidate,
+            )
+            for candidate in prefix_candidates
+        )
+    return ()
 
 
 def validate_user_question_answers(
@@ -444,7 +484,10 @@ class RunInteractionService:
                     )
                 ) from exc
         if approval_action_requires_shell_grant(action):
-            self.persist_shell_approval_grants(ticket=ticket, action=action)
+            await self.persist_shell_approval_grants_async(
+                ticket=ticket,
+                action=action,
+            )
         if approval is not None:
             try:
                 self._tool_approval_manager.resolve_approval(
@@ -503,29 +546,38 @@ class RunInteractionService:
         action: str,
     ) -> None:
         shell_approval_repo = self._get_shell_approval_repo()
-        if ticket is None or shell_approval_repo is None:
+        if shell_approval_repo is None:
             return
-        if ticket.status != ApprovalTicketStatus.REQUESTED:
-            return
-        resolved = extract_shell_grant_metadata(ticket)
-        if resolved is None:
-            return
-        workspace_key, runtime_family, normalized_command, prefix_candidates = resolved
-        if action == "approve_exact" and normalized_command:
+        for workspace_key, runtime_family, scope, value in shell_approval_grant_specs(
+            ticket=ticket,
+            action=action,
+        ):
             shell_approval_repo.grant(
                 workspace_key=workspace_key,
                 runtime_family=runtime_family,
-                scope=ShellApprovalScope.EXACT,
-                value=normalized_command,
+                scope=scope,
+                value=value,
             )
-        if action == "approve_prefix":
-            for candidate in prefix_candidates:
-                shell_approval_repo.grant(
-                    workspace_key=workspace_key,
-                    runtime_family=runtime_family,
-                    scope=ShellApprovalScope.PREFIX,
-                    value=candidate,
-                )
+
+    async def persist_shell_approval_grants_async(
+        self,
+        *,
+        ticket: ApprovalTicketRecord | None,
+        action: str,
+    ) -> None:
+        shell_approval_repo = self._get_shell_approval_repo()
+        if shell_approval_repo is None:
+            return
+        for workspace_key, runtime_family, scope, value in shell_approval_grant_specs(
+            ticket=ticket,
+            action=action,
+        ):
+            await shell_approval_repo.grant_async(
+                workspace_key=workspace_key,
+                runtime_family=runtime_family,
+                scope=scope,
+                value=value,
+            )
 
     def list_open_tool_approvals(self, run_id: str) -> list[dict[str, str]]:
         approval_ticket_repo = self._get_approval_ticket_repo()

--- a/src/relay_teams/sessions/runs/run_interactions.py
+++ b/src/relay_teams/sessions/runs/run_interactions.py
@@ -197,6 +197,7 @@ class RunInteractionService:
             [str], Awaitable[bool]
         ],
         has_running_agents_for_run: Callable[[str], bool],
+        has_running_agents_for_run_async: Callable[[str], Awaitable[bool]],
         resume_run: Callable[[str], str],
         resume_run_async: Callable[[str], Awaitable[str]],
         ensure_run_started: Callable[[str], None],
@@ -220,6 +221,7 @@ class RunInteractionService:
             has_pending_resolvable_question_for_session_async
         )
         self._has_running_agents_for_run = has_running_agents_for_run
+        self._has_running_agents_for_run_async = has_running_agents_for_run_async
         self._resume_run = resume_run
         self._resume_run_async = resume_run_async
         self._ensure_run_started = ensure_run_started
@@ -810,7 +812,7 @@ class RunInteractionService:
             and not await self._has_pending_resolvable_question_for_session_async(
                 resolved_record.session_id
             )
-            and not self._has_running_agents_for_run(run_id)
+            and not await self._has_running_agents_for_run_async(run_id)
         ):
             try:
                 _ = await self._resume_run_async(run_id)

--- a/src/relay_teams/sessions/runs/run_runtime_repo.py
+++ b/src/relay_teams/sessions/runs/run_runtime_repo.py
@@ -5,12 +5,14 @@ import logging
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from threading import RLock
 
+import aiosqlite
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence import async_fetchall, async_fetchone
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.validation import (
     OptionalIdentifierStr,
     RequiredIdentifierStr,
@@ -70,12 +72,9 @@ class RunRuntimeRecord(BaseModel):
         }
 
 
-class RunRuntimeRepository:
+class RunRuntimeRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -171,6 +170,79 @@ class RunRuntimeRepository:
             raise RuntimeError(f"Failed to persist run runtime {record.run_id}")
         return next_record
 
+    async def upsert_async(self, record: RunRuntimeRecord) -> RunRuntimeRecord:
+        async def operation(conn: aiosqlite.Connection) -> RunRuntimeRecord:
+            row = await async_fetchone(
+                conn,
+                "SELECT * FROM run_runtime WHERE run_id=?",
+                (record.run_id,),
+            )
+            existing = (
+                self._record_or_none(row, fallback_invalid_timestamps=True)
+                if row is not None
+                else None
+            )
+            created_at = (
+                existing.created_at.isoformat()
+                if existing is not None
+                else record.created_at.isoformat()
+            )
+            updated_at = record.updated_at.isoformat()
+            cursor = await conn.execute(
+                """
+                INSERT INTO run_runtime(run_id, session_id, root_task_id, status, phase, active_instance_id,
+                                        active_task_id, active_role_id, active_subagent_instance_id,
+                                        last_error, created_at, updated_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    root_task_id=excluded.root_task_id,
+                    status=excluded.status,
+                    phase=excluded.phase,
+                    active_instance_id=excluded.active_instance_id,
+                    active_task_id=excluded.active_task_id,
+                    active_role_id=excluded.active_role_id,
+                    active_subagent_instance_id=excluded.active_subagent_instance_id,
+                    last_error=excluded.last_error,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    record.run_id,
+                    record.session_id,
+                    record.root_task_id,
+                    record.status.value,
+                    record.phase.value,
+                    record.active_instance_id,
+                    record.active_task_id,
+                    record.active_role_id,
+                    record.active_subagent_instance_id,
+                    record.last_error,
+                    created_at,
+                    updated_at,
+                ),
+            )
+            await cursor.close()
+            next_row = await async_fetchone(
+                conn,
+                "SELECT * FROM run_runtime WHERE run_id=?",
+                (record.run_id,),
+            )
+            if next_row is None:
+                raise RuntimeError(f"Failed to persist run runtime {record.run_id}")
+            next_record = self._record_or_none(
+                next_row,
+                fallback_invalid_timestamps=True,
+            )
+            if next_record is None:
+                raise RuntimeError(f"Failed to load run runtime {record.run_id}")
+            return next_record
+
+        return await self._run_async_write(
+            operation_name="upsert_async",
+            operation=operation,
+        )
+
     def ensure(
         self,
         *,
@@ -198,6 +270,33 @@ class RunRuntimeRepository:
             )
         )
 
+    async def ensure_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        root_task_id: str | None = None,
+        status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
+        phase: RunRuntimePhase = RunRuntimePhase.IDLE,
+    ) -> RunRuntimeRecord:
+        existing = await self.get_async(run_id)
+        if existing is not None:
+            update: dict[str, object] = {}
+            if root_task_id and not existing.root_task_id:
+                update["root_task_id"] = root_task_id
+            if update:
+                return await self.update_async(run_id, **update)
+            return existing
+        return await self.upsert_async(
+            RunRuntimeRecord(
+                run_id=run_id,
+                session_id=session_id,
+                root_task_id=root_task_id,
+                status=status,
+                phase=phase,
+            )
+        )
+
     def update(self, run_id: str, **changes: object) -> RunRuntimeRecord:
         current = self.get(run_id)
         if current is None:
@@ -206,6 +305,15 @@ class RunRuntimeRepository:
         update["updated_at"] = datetime.now(tz=timezone.utc)
         next_record = current.model_copy(update=update)
         return self.upsert(next_record)
+
+    async def update_async(self, run_id: str, **changes: object) -> RunRuntimeRecord:
+        current = await self.get_async(run_id)
+        if current is None:
+            raise KeyError(f"Unknown run_id: {run_id}")
+        update = dict(changes)
+        update["updated_at"] = datetime.now(tz=timezone.utc)
+        next_record = current.model_copy(update=update)
+        return await self.upsert_async(next_record)
 
     def get(self, run_id: str) -> RunRuntimeRecord | None:
         with self._lock:
@@ -216,6 +324,18 @@ class RunRuntimeRepository:
             if row is None:
                 return None
             return self._record_or_none(row, fallback_invalid_timestamps=True)
+
+    async def get_async(self, run_id: str) -> RunRuntimeRecord | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT * FROM run_runtime WHERE run_id=?",
+                (run_id,),
+            )
+        )
+        if row is None:
+            return None
+        return self._record_or_none(row, fallback_invalid_timestamps=True)
 
     def list_by_session(self, session_id: str) -> tuple[RunRuntimeRecord, ...]:
         with self._lock:
@@ -228,6 +348,20 @@ class RunRuntimeRepository:
                 for row in rows
                 if (record := self._record_or_none(row)) is not None
             )
+
+    async def list_by_session_async(
+        self, session_id: str
+    ) -> tuple[RunRuntimeRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM run_runtime WHERE session_id=? ORDER BY updated_at DESC",
+                (session_id,),
+            )
+        )
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
 
     def list_recoverable(self) -> tuple[RunRuntimeRecord, ...]:
         with self._lock:
@@ -249,6 +383,27 @@ class RunRuntimeRepository:
                 for row in rows
                 if (record := self._record_or_none(row)) is not None
             )
+
+    async def list_recoverable_async(self) -> tuple[RunRuntimeRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT * FROM run_runtime
+                WHERE status IN (?, ?, ?, ?)
+                ORDER BY updated_at DESC
+                """,
+                (
+                    RunRuntimeStatus.QUEUED.value,
+                    RunRuntimeStatus.RUNNING.value,
+                    RunRuntimeStatus.PAUSED.value,
+                    RunRuntimeStatus.STOPPED.value,
+                ),
+            )
+        )
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
 
     def mark_transient_runs_interrupted(self) -> int:
         affected = 0
@@ -291,6 +446,41 @@ class RunRuntimeRepository:
         )
         return affected
 
+    async def mark_transient_runs_interrupted_async(self) -> int:
+        async def operation(conn: aiosqlite.Connection) -> int:
+            updated_at = datetime.now(tz=timezone.utc).isoformat()
+            cursor = await conn.execute(
+                """
+                UPDATE run_runtime
+                SET
+                    status=?,
+                    phase=?,
+                    active_instance_id=NULL,
+                    active_task_id=NULL,
+                    active_role_id=NULL,
+                    active_subagent_instance_id=NULL,
+                    last_error=?,
+                    updated_at=?
+                WHERE status IN (?, ?)
+                """,
+                (
+                    RunRuntimeStatus.STOPPED.value,
+                    RunRuntimePhase.IDLE.value,
+                    "interrupted_by_process_restart",
+                    updated_at,
+                    RunRuntimeStatus.QUEUED.value,
+                    RunRuntimeStatus.RUNNING.value,
+                ),
+            )
+            affected = int(cursor.rowcount or 0)
+            await cursor.close()
+            return affected
+
+        return await self._run_async_write(
+            operation_name="mark_transient_runs_interrupted_async",
+            operation=operation,
+        )
+
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -301,6 +491,19 @@ class RunRuntimeRepository:
             lock=self._lock,
             repository_name="RunRuntimeRepository",
             operation_name="delete_by_session",
+        )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                "DELETE FROM run_runtime WHERE session_id=?",
+                (session_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_session_async",
+            operation=operation,
         )
 
     def delete(self, run_id: str) -> None:
@@ -314,6 +517,19 @@ class RunRuntimeRepository:
             lock=self._lock,
             repository_name="RunRuntimeRepository",
             operation_name="delete",
+        )
+
+    async def delete_async(self, run_id: str) -> None:
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                "DELETE FROM run_runtime WHERE run_id=?",
+                (run_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_async",
+            operation=operation,
         )
 
     def _to_record(

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -271,6 +271,7 @@ class SessionRunService:
                 self._has_pending_resolvable_question_for_session_async
             ),
             has_running_agents_for_run=self._has_running_agents_for_run,
+            has_running_agents_for_run_async=self._has_running_agents_for_run_async,
             resume_run=lambda run_id: self.resume_run(run_id),
             resume_run_async=lambda run_id: self.resume_run_async(run_id),
             ensure_run_started=lambda run_id: self.ensure_run_started(run_id),
@@ -2169,6 +2170,9 @@ class SessionRunService:
 
     def _has_running_agents_for_run(self, run_id: str) -> bool:
         return self._followup_router.has_running_agents_for_run(run_id)
+
+    async def _has_running_agents_for_run_async(self, run_id: str) -> bool:
+        return await self._followup_router.has_running_agents_for_run_async(run_id)
 
     def _has_pending_resolvable_question_for_session(self, session_id: str) -> bool:
         return self._followup_router.has_pending_resolvable_question_for_session(

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -178,6 +178,7 @@ class SessionRunService:
             get_background_task_service=lambda: self._background_task_service,
             get_todo_service=lambda: self._todo_service,
             get_run_session_id=self._run_session_id,
+            get_run_session_id_async=self._run_session_id_async,
         )
         self._recovery_service = RunRecoveryService(
             get_event_log=lambda: self._event_log,
@@ -261,18 +262,27 @@ class SessionRunService:
             get_user_question_repo=lambda: self._user_question_repo,
             get_user_question_manager=lambda: self._user_question_manager,
             get_runtime=lambda run_id: self._runtime_for_run(run_id),
+            get_runtime_async=lambda run_id: self._runtime_for_run_async(run_id),
             is_running_run=lambda run_id: run_id in self._running_run_ids,
             has_pending_resolvable_question_for_session=(
                 self._has_pending_resolvable_question_for_session
             ),
+            has_pending_resolvable_question_for_session_async=(
+                self._has_pending_resolvable_question_for_session_async
+            ),
             has_running_agents_for_run=self._has_running_agents_for_run,
             resume_run=lambda run_id: self.resume_run(run_id),
+            resume_run_async=lambda run_id: self.resume_run_async(run_id),
             ensure_run_started=lambda run_id: self.ensure_run_started(run_id),
+            ensure_run_started_async=lambda run_id: self.ensure_run_started_async(
+                run_id
+            ),
             event_publisher=self._event_publisher,
         )
         self._pending_runs: dict[str, IntentInput] = {}
         self._running_run_ids: set[str] = set()
         self._resume_requested_runs: set[str] = set()
+        self._run_creation_lock = asyncio.Lock()
         self._event_loop: asyncio.AbstractEventLoop | None = None
         self._scheduler = RunScheduler(
             meta_agent=self._meta_agent,
@@ -414,8 +424,35 @@ class SessionRunService:
         _ = self._session_repo.get(session_id)
         return session_id
 
+    async def _ensure_session_async(self, session_id: str) -> str:
+        _ = await self._session_repo.get_async(session_id)
+        return session_id
+
     def _prepare_intent(self, intent: IntentInput) -> IntentInput:
         session = self._session_repo.get(intent.session_id)
+        target_role_id = str(intent.target_role_id or "").strip() or None
+        skills = tuple(str(skill or "").strip() for skill in (intent.skills or ()))
+        skills = tuple(skill for skill in skills if skill) or None
+        if self._orchestration_settings_service is None:
+            return intent.model_copy(
+                update={
+                    "session_mode": session.session_mode,
+                    "target_role_id": target_role_id,
+                    "skills": skills,
+                }
+            )
+        topology = self._orchestration_settings_service.resolve_run_topology(session)
+        return intent.model_copy(
+            update={
+                "session_mode": session.session_mode,
+                "target_role_id": target_role_id,
+                "skills": skills,
+                "topology": topology,
+            }
+        )
+
+    async def _prepare_intent_async(self, intent: IntentInput) -> IntentInput:
+        session = await self._session_repo.get_async(intent.session_id)
         target_role_id = str(intent.target_role_id or "").strip() or None
         skills = tuple(str(skill or "").strip() for skill in (intent.skills or ()))
         skills = tuple(skill for skill in skills if skill) or None
@@ -444,6 +481,13 @@ class SessionRunService:
                 return runtime
         return None
 
+    async def _runtime_for_run_async(self, run_id: str) -> RunRuntimeRecord | None:
+        if self._run_runtime_repo is not None:
+            runtime = await self._run_runtime_repo.get_async(run_id)
+            if runtime is not None:
+                return runtime
+        return None
+
     def _active_recoverable_run(
         self, session_id: str
     ) -> tuple[str, RunRuntimeRecord | None] | None:
@@ -451,6 +495,14 @@ class SessionRunService:
         if not run_id:
             return None
         return run_id, self._runtime_for_run(run_id)
+
+    async def _active_recoverable_run_async(
+        self, session_id: str
+    ) -> tuple[str, RunRuntimeRecord | None] | None:
+        run_id = self._active_run_registry.get_active_run_id(session_id)
+        if not run_id:
+            return None
+        return run_id, await self._runtime_for_run_async(run_id)
 
     def _remember_active_run(self, session_id: str, run_id: str) -> None:
         self._active_run_registry.remember_active_run(
@@ -606,8 +658,39 @@ class SessionRunService:
     ) -> tuple[str, str]:
         return self._scheduler.create_run(intent, source=source)
 
+    async def create_run_async(
+        self,
+        intent: IntentInput,
+        *,
+        source: InjectionSource = InjectionSource.USER,
+    ) -> tuple[str, str]:
+        if self._should_delegate_to_bound_loop():
+            delegated_intent = intent.model_copy(deep=True)
+            return await self._call_in_bound_loop_async(
+                lambda: self.create_run(delegated_intent, source=source)
+            )
+        delegated_intent = intent.model_copy(deep=True)
+        return await self._create_run_local_async(
+            delegated_intent,
+            allow_active_run_attach=True,
+            source=source,
+        )
+
     def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
         return self._scheduler.create_detached_run(intent)
+
+    async def create_detached_run_async(self, intent: IntentInput) -> tuple[str, str]:
+        if self._should_delegate_to_bound_loop():
+            delegated_intent = intent.model_copy(deep=True)
+            return await self._call_in_bound_loop_async(
+                lambda: self.create_detached_run(delegated_intent)
+            )
+        delegated_intent = intent.model_copy(deep=True)
+        return await self._create_run_local_async(
+            delegated_intent,
+            allow_active_run_attach=False,
+            source=InjectionSource.USER,
+        )
 
     def _create_run_local(
         self,
@@ -622,6 +705,127 @@ class SessionRunService:
             source=source,
         )
 
+    async def _create_run_local_async(
+        self,
+        intent: IntentInput,
+        *,
+        allow_active_run_attach: bool,
+        source: InjectionSource,
+    ) -> tuple[str, str]:
+        async with self._run_creation_lock:
+            session_id = await self._ensure_session_async(intent.session_id)
+            intent.session_id = session_id
+            intent = await self._prepare_intent_async(intent)
+            self._run_control_manager.assert_session_allows_main_input(session_id)
+            _ = await self._session_repo.mark_started_async(session_id)
+
+            existing = await self._active_recoverable_run_async(session_id)
+            if existing is not None:
+                active_run_id, runtime = existing
+                if not allow_active_run_attach:
+                    raise RuntimeError(
+                        f"Session {session_id} already has active run {active_run_id}"
+                    )
+                if not await self._run_accepts_followups_async(active_run_id, intent):
+                    raise RuntimeError(
+                        f"Run {active_run_id} is active and does not accept follow-up input"
+                    )
+                await self._assert_auto_attach_allowed_async(active_run_id, runtime)
+                if (
+                    active_run_id in self._pending_runs
+                    and active_run_id not in self._running_run_ids
+                ):
+                    pending = self._pending_runs[active_run_id]
+                    pending.intent = self._merge_intent(pending.intent, intent.intent)
+                    existing_skills = pending.skills or ()
+                    next_skills = intent.skills or ()
+                    merged_skills = tuple(
+                        dict.fromkeys((*existing_skills, *next_skills))
+                    )
+                    pending.skills = merged_skills or None
+                    pending.yolo = intent.yolo
+                    run_intent_repo = self._run_intent_repo
+                    if run_intent_repo is not None:
+                        await run_intent_repo.upsert_async(
+                            run_id=active_run_id,
+                            session_id=session_id,
+                            intent=pending,
+                        )
+                    with bind_trace_context(
+                        trace_id=active_run_id,
+                        run_id=active_run_id,
+                        session_id=session_id,
+                    ):
+                        log_event(
+                            logger,
+                            logging.INFO,
+                            event="run.followup.attached",
+                            message="Follow-up merged into pending run",
+                            payload={"mode": "pending_merge"},
+                        )
+                    return active_run_id, session_id
+                if (
+                    active_run_id in self._running_run_ids
+                    or self._injection_manager.is_active(active_run_id)
+                ):
+                    await self._update_run_yolo_async(
+                        run_id=active_run_id,
+                        session_id=session_id,
+                        yolo=intent.yolo,
+                    )
+                    self._append_followup_to_coordinator(
+                        active_run_id,
+                        intent.intent,
+                        enqueue=True,
+                        source=source,
+                    )
+                    with bind_trace_context(
+                        trace_id=active_run_id,
+                        run_id=active_run_id,
+                        session_id=session_id,
+                    ):
+                        log_event(
+                            logger,
+                            logging.INFO,
+                            event="run.followup.attached",
+                            message="Follow-up enqueued to active coordinator",
+                            payload={"mode": "active_enqueue"},
+                        )
+                    return active_run_id, session_id
+                if (
+                    runtime is not None
+                    and runtime.is_recoverable
+                    and runtime.status
+                    in {RunRuntimeStatus.PAUSED, RunRuntimeStatus.STOPPED}
+                ):
+                    self._append_followup_to_coordinator(
+                        active_run_id,
+                        intent.intent,
+                        enqueue=False,
+                        source=InjectionSource.USER,
+                    )
+                    await self._update_run_yolo_async(
+                        run_id=active_run_id,
+                        session_id=session_id,
+                        yolo=intent.yolo,
+                    )
+                    self._resume_requested_runs.add(active_run_id)
+                    with bind_trace_context(
+                        trace_id=active_run_id,
+                        run_id=active_run_id,
+                        session_id=session_id,
+                    ):
+                        log_event(
+                            logger,
+                            logging.INFO,
+                            event="run.followup.attached",
+                            message="Follow-up queued for recoverable run",
+                            payload={"mode": "recoverable_resume"},
+                        )
+                    return active_run_id, session_id
+
+            return await self._queue_new_run_async(session_id=session_id, intent=intent)
+
     def _queue_new_run(
         self,
         *,
@@ -630,17 +834,304 @@ class SessionRunService:
     ) -> tuple[str, str]:
         return self._scheduler.queue_new_run(session_id=session_id, intent=intent)
 
+    async def _queue_new_run_async(
+        self,
+        *,
+        session_id: str,
+        intent: IntentInput,
+    ) -> tuple[str, str]:
+        run_id = new_trace_id().value
+        if self._hook_service is not None:
+            self._hook_service.snapshot_run(run_id)
+        self._pending_runs[run_id] = intent
+        run_runtime_repo = self._run_runtime_repo
+        if run_runtime_repo is not None:
+            await run_runtime_repo.ensure_async(
+                run_id=run_id,
+                session_id=session_id,
+                status=RunRuntimeStatus.QUEUED,
+                phase=RunRuntimePhase.IDLE,
+            )
+        run_intent_repo = self._run_intent_repo
+        if run_intent_repo is not None:
+            await run_intent_repo.upsert_async(
+                run_id=run_id,
+                session_id=session_id,
+                intent=intent,
+            )
+        self._remember_active_run(session_id, run_id)
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.INFO,
+                event="run.queued",
+                message="Run queued for streaming execution",
+            )
+        return run_id, session_id
+
     def ensure_run_started(self, run_id: str) -> None:
         self._scheduler.ensure_run_started(run_id)
+
+    async def ensure_run_started_async(self, run_id: str) -> None:
+        if self._should_delegate_to_bound_loop():
+            await self._call_in_bound_loop_async(
+                lambda: self.ensure_run_started(run_id)
+            )
+            return
+        await self._ensure_run_started_local_async(run_id)
 
     def _ensure_run_started_local(self, run_id: str) -> None:
         self._scheduler.ensure_run_started_local(run_id)
 
+    async def _ensure_run_started_local_async(self, run_id: str) -> None:
+        if run_id in self._running_run_ids:
+            return
+        if run_id in self._pending_runs:
+            await self._start_new_run_worker_async(run_id)
+            return
+        if run_id in self._resume_requested_runs:
+            runtime = await self._runtime_for_run_async(run_id)
+            if runtime is None:
+                raise KeyError(f"Run {run_id} not found")
+            if runtime.status not in {
+                RunRuntimeStatus.QUEUED,
+                RunRuntimeStatus.PAUSED,
+                RunRuntimeStatus.STOPPED,
+            }:
+                raise RuntimeError(
+                    f"Run {run_id} cannot be resumed from status {runtime.status.value}"
+                )
+            await self._start_resume_worker_async(run_id)
+            return
+        raise KeyError(f"Run {run_id} not found")
+
     def _start_new_run_worker(self, run_id: str) -> None:
         self._scheduler.start_new_run_worker(run_id)
 
+    def _register_startup_gated_worker(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        runner: Callable[[], Awaitable[RunResult]],
+    ) -> tuple[asyncio.Event, asyncio.Event, asyncio.Event, asyncio.Task[None]]:
+        startup_ready = asyncio.Event()
+        startup_done = asyncio.Event()
+        startup_failed = asyncio.Event()
+
+        async def _run_after_startup() -> None:
+            try:
+                await startup_ready.wait()
+            except asyncio.CancelledError:
+                await startup_done.wait()
+                if not startup_failed.is_set():
+                    await self._handle_startup_cancelled_async(
+                        run_id=run_id,
+                        session_id=session_id,
+                    )
+                return
+            await self._worker(run_id=run_id, session_id=session_id, runner=runner)
+
+        task = asyncio.create_task(_run_after_startup())
+        self._run_control_manager.register_run_task(
+            run_id=run_id,
+            session_id=session_id,
+            task=task,
+        )
+        return startup_ready, startup_done, startup_failed, task
+
+    async def _handle_startup_cancelled_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+    ) -> None:
+        run_runtime_repo = self._run_runtime_repo
+        if run_runtime_repo is not None:
+            await run_runtime_repo.update_async(
+                run_id,
+                status=RunRuntimeStatus.STOPPED,
+                phase=RunRuntimePhase.IDLE,
+                active_instance_id=None,
+                active_task_id=None,
+                active_role_id=None,
+                active_subagent_instance_id=None,
+                last_error="stopped_by_user",
+            )
+        await self._run_control_manager.publish_run_stopped_async(
+            session_id=session_id,
+            run_id=run_id,
+            reason="stopped_by_user",
+        )
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.WARNING,
+                event="run.stopped",
+                message="Run cancelled during startup",
+                payload={"reason": "stopped_by_user"},
+            )
+        self._emit_notification(
+            notification_type=NotificationType.RUN_STOPPED,
+            session_id=session_id,
+            run_id=run_id,
+            trace_id=run_id,
+            title="Run Stopped",
+            body=f"Run {run_id} was stopped by user.",
+        )
+        await self._hook_pipeline.execute_session_end_hooks(
+            run_id=run_id,
+            session_id=session_id,
+            status="stopped",
+            completion_reason="stopped_by_user",
+            output_text="",
+        )
+        self._safe_finalize_run(run_id=run_id, session_id=session_id)
+
+    async def _start_new_run_worker_async(self, run_id: str) -> None:
+        intent = self._pending_runs.get(run_id)
+        if intent is None:
+            raise KeyError(f"Run {run_id} not found")
+        session_id = intent.session_id
+        if session_id is None:
+            raise RuntimeError(f"Run {run_id} is missing session id")
+        self._running_run_ids.add(run_id)
+        self._injection_manager.activate(run_id)
+        runner = (
+            (
+                lambda: self._media_executor.run_media_generation(
+                    run_id=run_id,
+                    intent=intent,
+                )
+            )
+            if intent.run_kind != RunKind.CONVERSATION
+            else (lambda: self._meta_agent.handle_intent(intent, trace_id=run_id))
+        )
+        startup_ready, startup_done, startup_failed, task = (
+            self._register_startup_gated_worker(
+                run_id=run_id,
+                session_id=session_id,
+                runner=runner,
+            )
+        )
+        run_runtime_repo = self._run_runtime_repo
+        try:
+            if run_runtime_repo is not None:
+                await run_runtime_repo.ensure_async(
+                    run_id=run_id,
+                    session_id=session_id,
+                    status=RunRuntimeStatus.RUNNING,
+                    phase=RunRuntimePhase.COORDINATOR_RUNNING,
+                )
+                await run_runtime_repo.update_async(
+                    run_id,
+                    status=RunRuntimeStatus.RUNNING,
+                    phase=RunRuntimePhase.COORDINATOR_RUNNING,
+                    last_error=None,
+                )
+            await self._run_event_hub.publish_async(
+                RunEvent(
+                    session_id=session_id,
+                    run_id=run_id,
+                    trace_id=run_id,
+                    task_id=None,
+                    event_type=RunEventType.RUN_STARTED,
+                    payload_json=dumps({"session_id": session_id}),
+                )
+            )
+        except BaseException:
+            startup_failed.set()
+            startup_done.set()
+            task.cancel()
+            self._run_control_manager.unregister_run_task(run_id)
+            raise
+        startup_done.set()
+        if self._run_control_manager.is_run_stop_requested(run_id) or task.done():
+            return
+        startup_ready.set()
+
     def _start_resume_worker(self, run_id: str) -> None:
         self._scheduler.start_resume_worker(run_id)
+
+    async def _start_resume_worker_async(self, run_id: str) -> None:
+        runtime = await self._runtime_for_run_async(run_id)
+        if runtime is None:
+            raise KeyError(f"Run {run_id} not found")
+        session_id = runtime.session_id
+        self._running_run_ids.add(run_id)
+        self._resume_requested_runs.discard(run_id)
+        self._injection_manager.activate(run_id)
+        startup_ready, startup_done, startup_failed, task = (
+            self._register_startup_gated_worker(
+                run_id=run_id,
+                session_id=session_id,
+                runner=lambda: self._resume_existing_run(run_id),
+            )
+        )
+        try:
+            resume_payload = await self._transition_run_to_resumed_async(
+                run_id=run_id,
+                session_id=session_id,
+                reason="resume",
+            )
+            with bind_trace_context(
+                trace_id=run_id,
+                run_id=run_id,
+                session_id=session_id,
+            ):
+                log_event(
+                    logger,
+                    logging.INFO,
+                    event="run.resumed",
+                    message="Recoverable run resumed",
+                    payload=resume_payload,
+                )
+        except BaseException:
+            startup_failed.set()
+            startup_done.set()
+            task.cancel()
+            self._run_control_manager.unregister_run_task(run_id)
+            raise
+        startup_done.set()
+        if self._run_control_manager.is_run_stop_requested(run_id) or task.done():
+            return
+        startup_ready.set()
+
+    async def _transition_run_to_resumed_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        reason: str,
+    ) -> dict[str, JsonValue]:
+        runtime = await self._runtime_for_run_async(run_id)
+        phase = RunRuntimePhase.COORDINATOR_RUNNING
+        if runtime is not None and runtime.phase != RunRuntimePhase.TERMINAL:
+            phase = runtime.phase
+        run_runtime_repo = self._run_runtime_repo
+        if run_runtime_repo is not None:
+            await run_runtime_repo.update_async(
+                run_id,
+                status=RunRuntimeStatus.RUNNING,
+                phase=phase,
+                last_error=None,
+            )
+        payload: dict[str, JsonValue] = {
+            "session_id": session_id,
+            "reason": reason,
+        }
+        await self._event_publisher.safe_publish_run_event_async(
+            RunEvent(
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=run_id,
+                task_id=None,
+                event_type=RunEventType.RUN_RESUMED,
+                payload_json=dumps(payload),
+            ),
+            failure_event="run.event.publish_failed",
+        )
+        return payload
 
     async def _resume_existing_run(self, run_id: str) -> RunResult:
         try:
@@ -733,7 +1224,7 @@ class SessionRunService:
                 active_subagent_instance_id=None,
                 last_error=((result.error_message or output_text) if failed else None),
             )
-            self._safe_publish_run_event(
+            await self._safe_publish_run_event_async(
                 RunEvent(
                     session_id=session_id,
                     run_id=run_id,
@@ -788,7 +1279,7 @@ class SessionRunService:
                 active_subagent_instance_id=None,
                 last_error=payload.error_message,
             )
-            self._safe_publish_run_event(
+            await self._safe_publish_run_event_async(
                 RunEvent(
                     session_id=session_id,
                     run_id=run_id,
@@ -822,7 +1313,7 @@ class SessionRunService:
                 active_subagent_instance_id=None,
                 last_error="stopped_by_user",
             )
-            self._run_control_manager.publish_run_stopped(
+            await self._run_control_manager.publish_run_stopped_async(
                 session_id=session_id,
                 run_id=run_id,
                 reason="stopped_by_user",
@@ -878,7 +1369,7 @@ class SessionRunService:
                 active_subagent_instance_id=None,
                 last_error=((result.error_message or output_text) if failed else None),
             )
-            self._safe_publish_run_event(
+            await self._safe_publish_run_event_async(
                 RunEvent(
                     session_id=session_id,
                     run_id=run_id,
@@ -1069,6 +1560,27 @@ class SessionRunService:
             content=content,
         )
 
+    async def inject_message_async(
+        self,
+        *,
+        run_id: str,
+        source: InjectionSource,
+        content: str,
+    ):
+        if self._should_delegate_to_bound_loop():
+            return await self._call_in_bound_loop_async(
+                lambda: self.inject_message(
+                    run_id=run_id,
+                    source=source,
+                    content=content,
+                )
+            )
+        return await self._run_control_manager.inject_to_running_agents_async(
+            run_id=run_id,
+            source=source,
+            content=content,
+        )
+
     def handle_background_task_completion(
         self,
         *,
@@ -1113,8 +1625,89 @@ class SessionRunService:
     def stop_run(self, run_id: str) -> None:
         self._scheduler.stop_run(run_id)
 
+    async def stop_run_async(self, run_id: str) -> None:
+        if self._should_delegate_to_bound_loop():
+            await self._call_in_bound_loop_async(lambda: self.stop_run(run_id))
+            return
+        await self._stop_run_local_async(run_id)
+
     def _stop_run_local(self, run_id: str) -> None:
         self._scheduler.stop_run_local(run_id)
+
+    async def _stop_run_local_async(self, run_id: str) -> None:
+        self._run_control_manager.clear_paused_subagent_for_run(run_id)
+        if run_id in self._pending_runs and run_id not in self._running_run_ids:
+            await self._interaction_service.complete_pending_user_questions_async(
+                run_id=run_id,
+                reason="run_stopped",
+            )
+            intent = self._pending_runs.pop(run_id)
+            session_id = intent.session_id
+            if session_id is None:
+                raise RuntimeError(f"Run {run_id} is missing session id")
+            run_runtime_repo = self._run_runtime_repo
+            if run_runtime_repo is not None:
+                await run_runtime_repo.update_async(
+                    run_id,
+                    status=RunRuntimeStatus.STOPPED,
+                    phase=RunRuntimePhase.IDLE,
+                    active_instance_id=None,
+                    active_task_id=None,
+                    active_role_id=None,
+                    active_subagent_instance_id=None,
+                    last_error="stopped_before_start",
+                )
+            await self._run_control_manager.publish_run_stopped_async(
+                session_id=session_id,
+                run_id=run_id,
+                reason="stopped_before_start",
+            )
+            self._emit_notification(
+                notification_type=NotificationType.RUN_STOPPED,
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=run_id,
+                title="Run Stopped",
+                body=f"Run {run_id} was stopped before start.",
+            )
+            with bind_trace_context(
+                trace_id=run_id, run_id=run_id, session_id=session_id
+            ):
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    event="run.stopped",
+                    message="Pending run stopped before worker start",
+                    payload={"reason": "stopped_before_start"},
+                )
+            return
+
+        requested = self._run_control_manager.request_run_stop(run_id)
+        if not requested and run_id not in self._running_run_ids:
+            raise KeyError(f"Run {run_id} not found")
+        if requested:
+            await self._interaction_service.complete_pending_user_questions_async(
+                run_id=run_id,
+                reason="run_stopped",
+            )
+        run_runtime_repo = self._run_runtime_repo
+        if run_runtime_repo is not None and requested:
+            runtime = await run_runtime_repo.get_async(run_id)
+            if runtime is not None:
+                await run_runtime_repo.update_async(
+                    run_id,
+                    status=RunRuntimeStatus.STOPPING,
+                    phase=runtime.phase,
+                    last_error="stop_requested",
+                )
+        with bind_trace_context(trace_id=run_id, run_id=run_id):
+            log_event(
+                logger,
+                logging.WARNING,
+                event="run.stop.requested",
+                message="Run stop requested",
+                payload={"was_running": requested},
+            )
 
     def _handle_background_task_completion_local(
         self,
@@ -1164,11 +1757,90 @@ class SessionRunService:
         loop.call_soon_threadsafe(runner)
         return result.result(timeout=30)
 
+    async def _call_in_bound_loop_async(self, callback: Callable[[], _T]) -> _T:
+        loop = self._event_loop
+        if loop is None:
+            return callback()
+        result: ThreadFuture[_T] = ThreadFuture()
+
+        def runner() -> None:
+            try:
+                result.set_result(callback())
+            except Exception as exc:
+                result.set_exception(exc)
+
+        loop.call_soon_threadsafe(runner)
+        return await asyncio.wait_for(asyncio.wrap_future(result), timeout=30)
+
     def resume_run(self, run_id: str) -> str:
         return self._scheduler.resume_run(run_id)
 
+    async def resume_run_async(self, run_id: str) -> str:
+        if self._should_delegate_to_bound_loop():
+            return await self._call_in_bound_loop_async(lambda: self.resume_run(run_id))
+        return await self._resume_run_local_async(run_id)
+
+    async def _resume_run_local_async(self, run_id: str) -> str:
+        if run_id in self._running_run_ids:
+            raise RuntimeError(f"Run {run_id} is already running")
+        if run_id in self._pending_runs:
+            pending = self._pending_runs[run_id]
+            if pending.session_id is None:
+                raise RuntimeError(f"Run {run_id} is missing session id")
+            if run_id in self._resume_requested_runs:
+                return pending.session_id
+            self._resume_requested_runs.add(run_id)
+            self._remember_active_run(pending.session_id, run_id)
+            with bind_trace_context(
+                trace_id=run_id, run_id=run_id, session_id=pending.session_id
+            ):
+                log_event(
+                    logger,
+                    logging.INFO,
+                    event="run.resume.requested",
+                    message="Resume requested for pending run",
+                )
+            return pending.session_id
+
+        runtime = await self._runtime_for_run_async(run_id)
+        if runtime is None:
+            raise KeyError(f"Run {run_id} not found")
+        if runtime.status == RunRuntimeStatus.RUNNING:
+            raise RuntimeError(f"Run {run_id} is already running")
+        if runtime.status == RunRuntimeStatus.STOPPING:
+            raise RuntimeError(
+                f"Run {run_id} is stopping. Wait for it to stop before resuming."
+            )
+        if not runtime.is_recoverable:
+            raise RuntimeError(f"Run {run_id} is not recoverable")
+        if run_id in self._resume_requested_runs:
+            return runtime.session_id
+        self._resume_requested_runs.add(run_id)
+        self._remember_active_run(runtime.session_id, run_id)
+        with bind_trace_context(
+            trace_id=run_id, run_id=run_id, session_id=runtime.session_id
+        ):
+            log_event(
+                logger,
+                logging.INFO,
+                event="run.resume.requested",
+                message="Resume requested for recoverable run",
+            )
+        return runtime.session_id
+
     def stop_subagent(self, run_id: str, instance_id: str) -> dict[str, str]:
         return self._interaction_service.stop_subagent(run_id, instance_id)
+
+    async def stop_subagent_async(
+        self,
+        run_id: str,
+        instance_id: str,
+    ) -> dict[str, str]:
+        if self._should_delegate_to_bound_loop():
+            return await self._call_in_bound_loop_async(
+                lambda: self.stop_subagent(run_id, instance_id)
+            )
+        return await self._interaction_service.stop_subagent_async(run_id, instance_id)
 
     def _complete_pending_user_questions(
         self,
@@ -1206,8 +1878,34 @@ class SessionRunService:
             tool_call_id=tool_call_id,
         )
 
+    async def create_monitor_async(
+        self,
+        *,
+        run_id: str,
+        source_kind: MonitorSourceKind,
+        source_key: str,
+        rule: MonitorRule,
+        action_type: MonitorActionType,
+        created_by_instance_id: str | None = None,
+        created_by_role_id: str | None = None,
+        tool_call_id: str | None = None,
+    ) -> dict[str, object]:
+        return await self._auxiliary_service.create_monitor_async(
+            run_id=run_id,
+            source_kind=source_kind,
+            source_key=source_key,
+            rule=rule,
+            action_type=action_type,
+            created_by_instance_id=created_by_instance_id,
+            created_by_role_id=created_by_role_id,
+            tool_call_id=tool_call_id,
+        )
+
     def list_monitors(self, run_id: str) -> tuple[dict[str, object], ...]:
         return self._auxiliary_service.list_monitors(run_id)
+
+    async def list_monitors_async(self, run_id: str) -> tuple[dict[str, object], ...]:
+        return await self._auxiliary_service.list_monitors_async(run_id)
 
     def stop_monitor(
         self,
@@ -1220,8 +1918,25 @@ class SessionRunService:
             monitor_id=monitor_id,
         )
 
+    async def stop_monitor_async(
+        self,
+        *,
+        run_id: str,
+        monitor_id: str,
+    ) -> dict[str, object]:
+        return await self._auxiliary_service.stop_monitor_async(
+            run_id=run_id,
+            monitor_id=monitor_id,
+        )
+
     def list_background_tasks(self, run_id: str) -> tuple[dict[str, object], ...]:
         return self._auxiliary_service.list_background_tasks(run_id)
+
+    async def list_background_tasks_async(
+        self,
+        run_id: str,
+    ) -> tuple[dict[str, object], ...]:
+        return await self._auxiliary_service.list_background_tasks_async(run_id)
 
     def get_background_task(
         self,
@@ -1234,8 +1949,22 @@ class SessionRunService:
             background_task_id=background_task_id,
         )
 
+    async def get_background_task_async(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> dict[str, object]:
+        return await self._auxiliary_service.get_background_task_async(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
+
     def get_todo(self, run_id: str) -> dict[str, object]:
         return self._auxiliary_service.get_todo(run_id)
+
+    async def get_todo_async(self, run_id: str) -> dict[str, object]:
+        return await self._auxiliary_service.get_todo_async(run_id)
 
     async def stop_background_task(
         self,
@@ -1259,6 +1988,17 @@ class SessionRunService:
                 pass
         raise KeyError(f"Run {run_id} not found")
 
+    async def _run_session_id_async(self, run_id: str) -> str:
+        runtime = await self._runtime_for_run_async(run_id)
+        if runtime is not None:
+            return runtime.session_id
+        if self._run_intent_repo is not None:
+            try:
+                return (await self._run_intent_repo.get_async(run_id)).session_id
+            except KeyError:
+                pass
+        raise KeyError(f"Run {run_id} not found")
+
     def inject_subagent_message(
         self,
         *,
@@ -1267,6 +2007,19 @@ class SessionRunService:
         content: str,
     ) -> None:
         self._interaction_service.inject_subagent_message(
+            run_id=run_id,
+            instance_id=instance_id,
+            content=content,
+        )
+
+    async def inject_subagent_message_async(
+        self,
+        *,
+        run_id: str,
+        instance_id: str,
+        content: str,
+    ) -> None:
+        await self._interaction_service.inject_subagent_message_async(
             run_id=run_id,
             instance_id=instance_id,
             content=content,
@@ -1286,6 +2039,31 @@ class SessionRunService:
             feedback,
         )
 
+    async def resolve_tool_approval_async(
+        self,
+        *,
+        run_id: str,
+        tool_call_id: str,
+        action: str,
+        feedback: str = "",
+    ) -> None:
+        if self._should_delegate_to_bound_loop():
+            await self._call_in_bound_loop_async(
+                lambda: self.resolve_tool_approval(
+                    run_id=run_id,
+                    tool_call_id=tool_call_id,
+                    action=action,
+                    feedback=feedback,
+                )
+            )
+            return
+        await self._interaction_service.resolve_tool_approval_async(
+            run_id=run_id,
+            tool_call_id=tool_call_id,
+            action=action,
+            feedback=feedback,
+        )
+
     def _persist_shell_approval_grants(
         self,
         *,
@@ -1300,8 +2078,16 @@ class SessionRunService:
     def list_open_tool_approvals(self, run_id: str) -> list[dict[str, str]]:
         return self._interaction_service.list_open_tool_approvals(run_id)
 
+    async def list_open_tool_approvals_async(self, run_id: str) -> list[dict[str, str]]:
+        return await self._interaction_service.list_open_tool_approvals_async(run_id)
+
     def list_user_questions(self, run_id: str) -> list[dict[str, JsonValue]]:
         return self._interaction_service.list_user_questions(run_id)
+
+    async def list_user_questions_async(
+        self, run_id: str
+    ) -> list[dict[str, JsonValue]]:
+        return await self._interaction_service.list_user_questions_async(run_id)
 
     def answer_user_question(
         self,
@@ -1316,6 +2102,19 @@ class SessionRunService:
             answers=answers,
         )
 
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers: UserQuestionAnswerSubmission,
+    ) -> dict[str, JsonValue]:
+        return await self._interaction_service.answer_user_question_async(
+            run_id=run_id,
+            question_id=question_id,
+            answers=answers,
+        )
+
     @staticmethod
     def _merge_intent(current: str, followup: str) -> str:
         return f"{current}\n\n{followup}" if current.strip() else followup
@@ -1324,6 +2123,46 @@ class SessionRunService:
         self, run_id: str, runtime: RunRuntimeRecord | None
     ) -> None:
         self._followup_router.assert_auto_attach_allowed(run_id, runtime)
+
+    async def _assert_auto_attach_allowed_async(
+        self, run_id: str, runtime: RunRuntimeRecord | None
+    ) -> None:
+        if runtime is None:
+            return
+        if (
+            self._approval_ticket_repo is not None
+            and await self._approval_ticket_repo.list_open_by_run_async(run_id)
+        ):
+            raise RuntimeError(
+                f"Run {run_id} is waiting for tool approval. Resolve the pending approval before continuing."
+            )
+        if await self._has_pending_resolvable_question_for_session_async(
+            runtime.session_id
+        ):
+            raise RuntimeError(
+                f"Run {run_id} is waiting for manual action. Answer the pending question before continuing."
+            )
+        if runtime.status == RunRuntimeStatus.STOPPING:
+            raise RuntimeError(
+                f"Run {run_id} is stopping. Wait for it to stop before continuing."
+            )
+        if (
+            runtime.phase == RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP
+            and runtime.active_subagent_instance_id
+        ):
+            instance_id = runtime.active_subagent_instance_id
+            role_id = instance_id
+            agent_repo = self._agent_repo
+            if agent_repo is not None:
+                try:
+                    record = await agent_repo.get_instance_async(instance_id)
+                    role_id = record.role_id
+                except KeyError:
+                    role_id = instance_id
+            raise RuntimeError(
+                f"Subagent {role_id} ({instance_id}) is paused in run {run_id}. "
+                "Please send a follow-up message to that subagent first."
+            )
 
     def _root_task_for_run(self, run_id: str) -> TaskRecord:
         return self._followup_router.root_task_for_run(run_id)
@@ -1335,6 +2174,16 @@ class SessionRunService:
         return self._followup_router.has_pending_resolvable_question_for_session(
             session_id
         )
+
+    async def _has_pending_resolvable_question_for_session_async(
+        self, session_id: str
+    ) -> bool:
+        if self._user_question_repo is None:
+            return False
+        for record in await self._user_question_repo.list_by_session_async(session_id):
+            if await self._runtime_for_run_async(record.run_id) is not None:
+                return True
+        return False
 
     def _append_followup_to_instance(
         self,
@@ -1370,6 +2219,33 @@ class SessionRunService:
             source=source,
         )
 
+    async def _update_run_yolo_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        yolo: bool,
+    ) -> None:
+        run_intent_repo = self._run_intent_repo
+        if run_intent_repo is None:
+            return
+        try:
+            intent = await run_intent_repo.get_async(
+                run_id,
+                fallback_session_id=session_id,
+            )
+        except KeyError:
+            return
+        if intent.yolo == yolo:
+            return
+        intent.session_id = session_id
+        intent.yolo = yolo
+        await run_intent_repo.upsert_async(
+            run_id=run_id,
+            session_id=session_id,
+            intent=intent,
+        )
+
     def _run_accepts_followups(self, run_id: str, next_intent: IntentInput) -> bool:
         if next_intent.run_kind != RunKind.CONVERSATION:
             return False
@@ -1379,6 +2255,27 @@ class SessionRunService:
                 runtime_repo = self._run_runtime_repo
                 runtime = runtime_repo.get(run_id) if runtime_repo is not None else None
                 current_intent = self._run_intent_repo.get(
+                    run_id,
+                    fallback_session_id=(
+                        runtime.session_id if runtime is not None else None
+                    ),
+                )
+            except KeyError:
+                current_intent = None
+        if current_intent is None:
+            return True
+        return current_intent.run_kind == RunKind.CONVERSATION
+
+    async def _run_accepts_followups_async(
+        self, run_id: str, next_intent: IntentInput
+    ) -> bool:
+        if next_intent.run_kind != RunKind.CONVERSATION:
+            return False
+        current_intent = self._pending_runs.get(run_id)
+        if current_intent is None and self._run_intent_repo is not None:
+            try:
+                runtime = await self._runtime_for_run_async(run_id)
+                current_intent = await self._run_intent_repo.get_async(
                     run_id,
                     fallback_session_id=(
                         runtime.session_id if runtime is not None else None
@@ -1446,6 +2343,17 @@ class SessionRunService:
         failure_event: str,
     ) -> None:
         self._event_publisher.safe_publish_run_event(
+            event,
+            failure_event=failure_event,
+        )
+
+    async def _safe_publish_run_event_async(
+        self,
+        event: RunEvent,
+        *,
+        failure_event: str,
+    ) -> None:
+        await self._event_publisher.safe_publish_run_event_async(
             event,
             failure_event=failure_event,
         )

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -275,9 +275,7 @@ class SessionRunService:
             resume_run=lambda run_id: self.resume_run(run_id),
             resume_run_async=self.resume_run_async,
             ensure_run_started=lambda run_id: self.ensure_run_started(run_id),
-            ensure_run_started_async=lambda run_id: self.ensure_run_started_async(
-                run_id
-            ),
+            ensure_run_started_async=self._ensure_run_started_for_interaction_async,
             event_publisher=self._event_publisher,
         )
         self._pending_runs: dict[str, IntentInput] = {}
@@ -488,6 +486,9 @@ class SessionRunService:
             if runtime is not None:
                 return runtime
         return None
+
+    async def _ensure_run_started_for_interaction_async(self, run_id: str) -> None:
+        await self.ensure_run_started_async(run_id)
 
     def _active_recoverable_run(
         self, session_id: str

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -262,7 +262,7 @@ class SessionRunService:
             get_user_question_repo=lambda: self._user_question_repo,
             get_user_question_manager=lambda: self._user_question_manager,
             get_runtime=lambda run_id: self._runtime_for_run(run_id),
-            get_runtime_async=lambda run_id: self._runtime_for_run_async(run_id),
+            get_runtime_async=self._runtime_for_run_async,
             is_running_run=lambda run_id: run_id in self._running_run_ids,
             has_pending_resolvable_question_for_session=(
                 self._has_pending_resolvable_question_for_session
@@ -273,7 +273,7 @@ class SessionRunService:
             has_running_agents_for_run=self._has_running_agents_for_run,
             has_running_agents_for_run_async=self._has_running_agents_for_run_async,
             resume_run=lambda run_id: self.resume_run(run_id),
-            resume_run_async=lambda run_id: self.resume_run_async(run_id),
+            resume_run_async=self.resume_run_async,
             ensure_run_started=lambda run_id: self.ensure_run_started(run_id),
             ensure_run_started_async=lambda run_id: self.ensure_run_started_async(
                 run_id

--- a/src/relay_teams/sessions/runs/run_state_repo.py
+++ b/src/relay_teams/sessions/runs/run_state_repo.py
@@ -4,11 +4,11 @@ import json
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from threading import RLock
 
+from relay_teams.persistence import async_fetchall, async_fetchone
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_models import RunEvent
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
 from relay_teams.sessions.runs.run_state_models import (
     RunSnapshotRecord,
     RunStateRecord,
@@ -31,12 +31,9 @@ _SNAPSHOT_EVENT_TYPES = {
 }
 
 
-class RunStateRepository:
+class RunStateRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -70,13 +67,50 @@ class RunStateRepository:
                 "CREATE INDEX IF NOT EXISTS idx_run_snapshots_session ON run_snapshots(session_id, created_at DESC)"
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="RunStateRepository",
+        self._run_write(
             operation_name="init_tables",
+            operation=operation,
+        )
+
+    async def _init_tables_async(self) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS run_states (
+                    run_id      TEXT PRIMARY KEY,
+                    session_id  TEXT NOT NULL,
+                    state_json  TEXT NOT NULL,
+                    updated_at  TEXT NOT NULL
+                )
+                """
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_run_states_session ON run_states(session_id, updated_at DESC)"
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS run_snapshots (
+                    run_id               TEXT NOT NULL,
+                    session_id           TEXT NOT NULL,
+                    checkpoint_event_id  INTEGER NOT NULL,
+                    state_json           TEXT NOT NULL,
+                    created_at           TEXT NOT NULL,
+                    PRIMARY KEY (run_id, checkpoint_event_id)
+                )
+                """
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_run_snapshots_session ON run_snapshots(session_id, created_at DESC)"
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="init_tables_async",
+            operation=lambda _conn: operation(),
         )
 
     def apply_event(self, *, event_id: int, event: RunEvent) -> RunStateRecord:
@@ -131,20 +165,78 @@ class RunStateRepository:
                     ),
                 )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="RunStateRepository",
+        self._run_write(
             operation_name="apply_event",
+            operation=operation,
+        )
+        return next_state
+
+    async def apply_event_async(
+        self, *, event_id: int, event: RunEvent
+    ) -> RunStateRecord:
+        previous = await self.get_run_state_async(event.run_id)
+        next_state = apply_run_event_to_state(previous, event=event, event_id=event_id)
+        snapshot = (
+            RunSnapshotRecord(
+                run_id=next_state.run_id,
+                session_id=next_state.session_id,
+                checkpoint_event_id=next_state.checkpoint_event_id,
+                state=next_state,
+                created_at=next_state.updated_at,
+            )
+            if event.event_type in _SNAPSHOT_EVENT_TYPES
+            else None
+        )
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO run_states(run_id, session_id, state_json, updated_at)
+                VALUES(?, ?, ?, ?)
+                ON CONFLICT(run_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    state_json=excluded.state_json,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    next_state.run_id,
+                    next_state.session_id,
+                    next_state.model_dump_json(),
+                    next_state.updated_at.isoformat(),
+                ),
+            )
+            await cursor.close()
+            if snapshot is not None:
+                cursor = await conn.execute(
+                    """
+                    INSERT INTO run_snapshots(run_id, session_id, checkpoint_event_id, state_json, created_at)
+                    VALUES(?, ?, ?, ?, ?)
+                    ON CONFLICT(run_id, checkpoint_event_id)
+                    DO UPDATE SET
+                        state_json=excluded.state_json,
+                        created_at=excluded.created_at
+                    """,
+                    (
+                        snapshot.run_id,
+                        snapshot.session_id,
+                        snapshot.checkpoint_event_id,
+                        json.dumps(snapshot.state.model_dump(mode="json")),
+                        snapshot.created_at.isoformat(),
+                    ),
+                )
+                await cursor.close()
+
+        await self._run_async_write(
+            operation_name="apply_event_async",
+            operation=lambda _conn: operation(),
         )
         return next_state
 
     def upsert(self, state: RunStateRecord) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="upsert",
             operation=lambda: self._conn.execute(
                 """
                 INSERT INTO run_states(run_id, session_id, state_json, updated_at)
@@ -162,9 +254,33 @@ class RunStateRepository:
                     state.updated_at.isoformat(),
                 ),
             ),
-            lock=self._lock,
-            repository_name="RunStateRepository",
-            operation_name="upsert",
+        )
+
+    async def upsert_async(self, state: RunStateRecord) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO run_states(run_id, session_id, state_json, updated_at)
+                VALUES(?, ?, ?, ?)
+                ON CONFLICT(run_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    state_json=excluded.state_json,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    state.run_id,
+                    state.session_id,
+                    state.model_dump_json(),
+                    state.updated_at.isoformat(),
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="upsert_async",
+            operation=lambda _conn: operation(),
         )
 
     def get_run_state(self, run_id: str) -> RunStateRecord | None:
@@ -173,6 +289,18 @@ class RunStateRepository:
                 "SELECT state_json FROM run_states WHERE run_id=?",
                 (run_id,),
             ).fetchone()
+        if row is None:
+            return None
+        return RunStateRecord.model_validate_json(str(row["state_json"]))
+
+    async def get_run_state_async(self, run_id: str) -> RunStateRecord | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT state_json FROM run_states WHERE run_id=?",
+                (run_id,),
+            )
+        )
         if row is None:
             return None
         return RunStateRecord.model_validate_json(str(row["state_json"]))
@@ -199,6 +327,30 @@ class RunStateRepository:
             created_at=datetime.fromisoformat(str(row["created_at"])),
         )
 
+    async def get_latest_snapshot_async(self, run_id: str) -> RunSnapshotRecord | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                """
+                SELECT checkpoint_event_id, state_json, session_id, created_at
+                FROM run_snapshots
+                WHERE run_id=?
+                ORDER BY checkpoint_event_id DESC
+                LIMIT 1
+                """,
+                (run_id,),
+            )
+        )
+        if row is None:
+            return None
+        return RunSnapshotRecord(
+            run_id=run_id,
+            session_id=str(row["session_id"]),
+            checkpoint_event_id=int(row["checkpoint_event_id"]),
+            state=RunStateRecord.model_validate_json(str(row["state_json"])),
+            created_at=datetime.fromisoformat(str(row["created_at"])),
+        )
+
     def list_by_session(self, session_id: str) -> tuple[RunStateRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -214,21 +366,39 @@ class RunStateRepository:
             RunStateRecord.model_validate_json(str(row["state_json"])) for row in rows
         )
 
+    async def list_by_session_async(
+        self, session_id: str
+    ) -> tuple[RunStateRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT state_json
+                FROM run_states
+                WHERE session_id=?
+                ORDER BY updated_at DESC
+                """,
+                (session_id,),
+            )
+        )
+        return tuple(
+            RunStateRecord.model_validate_json(str(row["state_json"])) for row in rows
+        )
+
     def list_recoverable(self) -> tuple[RunStateRecord, ...]:
         with self._lock:
             rows = self._conn.execute("SELECT state_json FROM run_states").fetchall()
-        result: list[RunStateRecord] = []
-        for row in rows:
-            state = RunStateRecord.model_validate_json(str(row["state_json"]))
-            if state.recoverable:
-                result.append(state)
-        result.sort(key=lambda item: item.updated_at, reverse=True)
-        return tuple(result)
+        return _recoverable_states_from_rows(rows)
+
+    async def list_recoverable_async(self) -> tuple[RunStateRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(conn, "SELECT state_json FROM run_states")
+        )
+        return _recoverable_states_from_rows(rows)
 
     def delete(self, run_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete",
             operation=lambda: (
                 self._conn.execute(
                     "DELETE FROM run_states WHERE run_id=?",
@@ -239,15 +409,30 @@ class RunStateRepository:
                     (run_id,),
                 ),
             ),
-            lock=self._lock,
-            repository_name="RunStateRepository",
-            operation_name="delete",
+        )
+
+    async def delete_async(self, run_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM run_states WHERE run_id=?",
+                (run_id,),
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "DELETE FROM run_snapshots WHERE run_id=?",
+                (run_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_async",
+            operation=lambda _conn: operation(),
         )
 
     def _upsert_snapshot(self, snapshot: RunSnapshotRecord) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="upsert_snapshot",
             operation=lambda: self._conn.execute(
                 """
                 INSERT INTO run_snapshots(run_id, session_id, checkpoint_event_id, state_json, created_at)
@@ -265,7 +450,43 @@ class RunStateRepository:
                     snapshot.created_at.isoformat(),
                 ),
             ),
-            lock=self._lock,
-            repository_name="RunStateRepository",
-            operation_name="upsert_snapshot",
         )
+
+    async def _upsert_snapshot_async(self, snapshot: RunSnapshotRecord) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO run_snapshots(run_id, session_id, checkpoint_event_id, state_json, created_at)
+                VALUES(?, ?, ?, ?, ?)
+                ON CONFLICT(run_id, checkpoint_event_id)
+                DO UPDATE SET
+                    state_json=excluded.state_json,
+                    created_at=excluded.created_at
+                """,
+                (
+                    snapshot.run_id,
+                    snapshot.session_id,
+                    snapshot.checkpoint_event_id,
+                    json.dumps(snapshot.state.model_dump(mode="json")),
+                    snapshot.created_at.isoformat(),
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="upsert_snapshot_async",
+            operation=lambda _conn: operation(),
+        )
+
+
+def _recoverable_states_from_rows(
+    rows: list[sqlite3.Row] | tuple[sqlite3.Row, ...],
+) -> tuple[RunStateRecord, ...]:
+    result: list[RunStateRecord] = []
+    for row in rows:
+        state = RunStateRecord.model_validate_json(str(row["state_json"]))
+        if state.recoverable:
+            result.append(state)
+    result.sort(key=lambda item: item.updated_at, reverse=True)
+    return tuple(result)

--- a/src/relay_teams/sessions/runs/system_injection.py
+++ b/src/relay_teams/sessions/runs/system_injection.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict
 
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_models import InjectionMessage, RunEvent
 
@@ -54,6 +54,30 @@ class SystemInjectionSink:
         )
         return SystemInjectionResult(enqueued=record is not None)
 
+    async def enqueue_only_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: Optional[str],
+        instance_id: str,
+        role_id: str,
+        content: str,
+        source: InjectionSource = InjectionSource.SYSTEM,
+    ) -> SystemInjectionResult:
+        record = await self._enqueue_async(
+            session_id=session_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            content=content,
+            source=source,
+        )
+        return SystemInjectionResult(enqueued=record is not None)
+
     def append_and_enqueue(
         self,
         *,
@@ -90,6 +114,42 @@ class SystemInjectionSink:
         )
         return SystemInjectionResult(appended=appended, enqueued=record is not None)
 
+    async def append_and_enqueue_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        content: str,
+        source: InjectionSource = InjectionSource.SYSTEM,
+    ) -> SystemInjectionResult:
+        appended = await self._append_async(
+            session_id=session_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            content=content,
+        )
+        record = await self._enqueue_async(
+            session_id=session_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            content=content,
+            source=source,
+        )
+        return SystemInjectionResult(appended=appended, enqueued=record is not None)
+
     def append_only(
         self,
         *,
@@ -103,6 +163,30 @@ class SystemInjectionSink:
         content: str,
     ) -> SystemInjectionResult:
         appended = self._append(
+            session_id=session_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            content=content,
+        )
+        return SystemInjectionResult(appended=appended)
+
+    async def append_only_async(
+        self,
+        *,
+        session_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        content: str,
+    ) -> SystemInjectionResult:
+        appended = await self._append_async(
             session_id=session_id,
             trace_id=trace_id,
             task_id=task_id,
@@ -129,6 +213,31 @@ class SystemInjectionSink:
         if self._message_repo is None:
             return False
         return self._message_repo.append_user_prompt_if_missing(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            content=content,
+        )
+
+    async def _append_async(
+        self,
+        *,
+        session_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        content: str,
+    ) -> bool:
+        if self._message_repo is None:
+            return False
+        return await self._message_repo.append_user_prompt_if_missing_async(
             session_id=session_id,
             workspace_id=workspace_id,
             conversation_id=conversation_id,
@@ -173,5 +282,43 @@ class SystemInjectionSink:
                 event_type=RunEventType.INJECTION_ENQUEUED,
                 payload_json=record.model_dump_json(),
             )
+        )
+        return record
+
+    async def _enqueue_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: Optional[str],
+        instance_id: str,
+        role_id: str,
+        content: str,
+        source: InjectionSource,
+    ) -> Optional[InjectionMessage]:
+        if not self._injection_manager.is_active(run_id):
+            return None
+        try:
+            record = self._injection_manager.enqueue(
+                run_id=run_id,
+                recipient_instance_id=instance_id,
+                source=source,
+                content=content,
+            )
+        except KeyError:
+            return None
+        await publish_run_event_async(
+            self._run_event_hub,
+            RunEvent(
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=trace_id,
+                task_id=task_id,
+                instance_id=instance_id,
+                role_id=role_id,
+                event_type=RunEventType.INJECTION_ENQUEUED,
+                payload_json=record.model_dump_json(),
+            ),
         )
         return record

--- a/src/relay_teams/sessions/runs/todo_repository.py
+++ b/src/relay_teams/sessions/runs/todo_repository.py
@@ -5,12 +5,12 @@ import json
 import logging
 import sqlite3
 from pathlib import Path
-from threading import RLock
 
 from pydantic import JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence import async_fetchall, async_fetchone
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.runs.todo_models import TodoItem, TodoSnapshot
 from relay_teams.validation import (
     normalize_persisted_text,
@@ -21,12 +21,9 @@ from relay_teams.validation import (
 LOGGER = get_logger(__name__)
 
 
-class TodoRepository:
+class TodoRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -63,13 +60,51 @@ class TodoRepository:
                 """
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="TodoRepository",
+        self._run_write(
             operation_name="init_tables",
+            operation=operation,
+        )
+
+    async def _init_tables_async(self) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS run_todos (
+                    run_id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    items_json TEXT NOT NULL,
+                    version INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    updated_by_role_id TEXT,
+                    updated_by_instance_id TEXT
+                )
+                """
+            )
+            await cursor.close()
+            rows = await async_fetchall(conn, "PRAGMA table_info(run_todos)")
+            columns = {str(row["name"]) for row in rows}
+            if "updated_by_role_id" not in columns:
+                cursor = await conn.execute(
+                    "ALTER TABLE run_todos ADD COLUMN updated_by_role_id TEXT"
+                )
+                await cursor.close()
+            if "updated_by_instance_id" not in columns:
+                cursor = await conn.execute(
+                    "ALTER TABLE run_todos ADD COLUMN updated_by_instance_id TEXT"
+                )
+                await cursor.close()
+            cursor = await conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_run_todos_session
+                ON run_todos(session_id, updated_at DESC)
+                """
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="init_tables_async",
+            operation=lambda _conn: operation(),
         )
 
     def upsert(self, snapshot: TodoSnapshot) -> TodoSnapshot:
@@ -100,15 +135,52 @@ class TodoRepository:
                 _snapshot_params(snapshot),
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="TodoRepository",
+        self._run_write(
             operation_name="upsert",
+            operation=operation,
         )
         persisted = self.get(snapshot.run_id)
+        if persisted is None:
+            raise RuntimeError(
+                f"Failed to persist todo snapshot for run {snapshot.run_id}"
+            )
+        return persisted
+
+    async def upsert_async(self, snapshot: TodoSnapshot) -> TodoSnapshot:
+        async def operation() -> None:
+            if snapshot.updated_at is None:
+                raise ValueError("Todo snapshot updated_at is required for persistence")
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO run_todos(
+                    run_id,
+                    session_id,
+                    items_json,
+                    version,
+                    updated_at,
+                    updated_by_role_id,
+                    updated_by_instance_id
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    items_json=excluded.items_json,
+                    version=excluded.version,
+                    updated_at=excluded.updated_at,
+                    updated_by_role_id=excluded.updated_by_role_id,
+                    updated_by_instance_id=excluded.updated_by_instance_id
+                """,
+                _snapshot_params(snapshot),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="upsert_async",
+            operation=lambda _conn: operation(),
+        )
+        persisted = await self.get_async(snapshot.run_id)
         if persisted is None:
             raise RuntimeError(
                 f"Failed to persist todo snapshot for run {snapshot.run_id}"
@@ -125,6 +197,22 @@ class TodoRepository:
                 """,
                 (run_id,),
             ).fetchone()
+        if row is None:
+            return None
+        return _row_to_snapshot_or_none(row)
+
+    async def get_async(self, run_id: str) -> TodoSnapshot | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                """
+                SELECT *
+                FROM run_todos
+                WHERE run_id=?
+                """,
+                (run_id,),
+            )
+        )
         if row is None:
             return None
         return _row_to_snapshot_or_none(row)
@@ -147,30 +235,73 @@ class TodoRepository:
                 snapshots.append(snapshot)
         return tuple(snapshots)
 
+    async def list_by_session_async(
+        self,
+        session_id: str,
+    ) -> tuple[TodoSnapshot, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT *
+                FROM run_todos
+                WHERE session_id=?
+                ORDER BY updated_at DESC
+                """,
+                (session_id,),
+            )
+        )
+        snapshots: list[TodoSnapshot] = []
+        for row in rows:
+            snapshot = _row_to_snapshot_or_none(row)
+            if snapshot is not None:
+                snapshots.append(snapshot)
+        return tuple(snapshots)
+
     def delete_by_session(self, session_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_session",
             operation=lambda: self._conn.execute(
                 "DELETE FROM run_todos WHERE session_id=?",
                 (session_id,),
             ),
-            lock=self._lock,
-            repository_name="TodoRepository",
-            operation_name="delete_by_session",
+        )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM run_todos WHERE session_id=?",
+                (session_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_session_async",
+            operation=lambda _conn: operation(),
         )
 
     def delete_by_run(self, run_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_run",
             operation=lambda: self._conn.execute(
                 "DELETE FROM run_todos WHERE run_id=?",
                 (run_id,),
             ),
-            lock=self._lock,
-            repository_name="TodoRepository",
-            operation_name="delete_by_run",
+        )
+
+    async def delete_by_run_async(self, run_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM run_todos WHERE run_id=?",
+                (run_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_run_async",
+            operation=lambda _conn: operation(),
         )
 
 

--- a/src/relay_teams/sessions/runs/todo_service.py
+++ b/src/relay_teams/sessions/runs/todo_service.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from json import dumps
 
 from relay_teams.sessions.runs.enums import RunEventType
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.todo_models import (
     TodoItem,
@@ -41,14 +41,34 @@ class TodoService:
             return snapshot
         return empty_todo_snapshot(run_id=run_id, session_id=session_id)
 
+    async def get_for_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+    ) -> TodoSnapshot:
+        snapshot = await self._repository.get_async(run_id)
+        if snapshot is not None:
+            return snapshot
+        return empty_todo_snapshot(run_id=run_id, session_id=session_id)
+
     def list_for_session(self, session_id: str) -> tuple[TodoSnapshot, ...]:
         return self._repository.list_by_session(session_id)
+
+    async def list_for_session_async(self, session_id: str) -> tuple[TodoSnapshot, ...]:
+        return await self._repository.list_by_session_async(session_id)
 
     def delete_for_session(self, session_id: str) -> None:
         self._repository.delete_by_session(session_id)
 
+    async def delete_for_session_async(self, session_id: str) -> None:
+        await self._repository.delete_by_session_async(session_id)
+
     def delete_for_run(self, run_id: str) -> None:
         self._repository.delete_by_run(run_id)
+
+    async def delete_for_run_async(self, run_id: str) -> None:
+        await self._repository.delete_by_run_async(run_id)
 
     def replace_for_run(
         self,
@@ -75,6 +95,31 @@ class TodoService:
         self._publish_todo_updated_event(persisted)
         return persisted
 
+    async def replace_for_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        items: Sequence[TodoItem],
+        updated_by_role_id: str | None = None,
+        updated_by_instance_id: str | None = None,
+    ) -> TodoSnapshot:
+        normalized_items = tuple(items)
+        _validate_items(normalized_items)
+        previous = await self._repository.get_async(run_id)
+        next_version = 1 if previous is None else previous.version + 1
+        snapshot = build_todo_snapshot(
+            run_id=run_id,
+            session_id=session_id,
+            items=normalized_items,
+            version=next_version,
+            updated_by_role_id=updated_by_role_id,
+            updated_by_instance_id=updated_by_instance_id,
+        )
+        persisted = await self._repository.upsert_async(snapshot)
+        await self._publish_todo_updated_event_async(persisted)
+        return persisted
+
     def clear_for_run(
         self,
         *,
@@ -84,6 +129,22 @@ class TodoService:
         updated_by_instance_id: str | None = None,
     ) -> TodoSnapshot:
         return self.replace_for_run(
+            run_id=run_id,
+            session_id=session_id,
+            items=(),
+            updated_by_role_id=updated_by_role_id,
+            updated_by_instance_id=updated_by_instance_id,
+        )
+
+    async def clear_for_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        updated_by_role_id: str | None = None,
+        updated_by_instance_id: str | None = None,
+    ) -> TodoSnapshot:
+        return await self.replace_for_run_async(
             run_id=run_id,
             session_id=session_id,
             items=(),
@@ -106,6 +167,24 @@ class TodoService:
                     snapshot.model_dump(mode="json"), ensure_ascii=False
                 ),
             )
+        )
+
+    async def _publish_todo_updated_event_async(self, snapshot: TodoSnapshot) -> None:
+        if self._run_event_hub is None:
+            return
+        await publish_run_event_async(
+            self._run_event_hub,
+            RunEvent(
+                session_id=snapshot.session_id,
+                run_id=snapshot.run_id,
+                trace_id=snapshot.run_id,
+                instance_id=snapshot.updated_by_instance_id,
+                role_id=snapshot.updated_by_role_id,
+                event_type=RunEventType.TODO_UPDATED,
+                payload_json=dumps(
+                    snapshot.model_dump(mode="json"), ensure_ascii=False
+                ),
+            ),
         )
 
 

--- a/src/relay_teams/sessions/runs/user_question_repository.py
+++ b/src/relay_teams/sessions/runs/user_question_repository.py
@@ -6,12 +6,13 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
+import aiosqlite
 from pydantic import JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence import async_fetchall, async_fetchone
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.runs.user_question_models import (
     UserQuestionAnswer,
     UserQuestionPrompt,
@@ -45,12 +46,9 @@ class UserQuestionStatusConflictError(RuntimeError):
         self.actual_status = actual_status
 
 
-class UserQuestionRepository:
+class UserQuestionRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -81,13 +79,46 @@ class UserQuestionRepository:
                 "CREATE INDEX IF NOT EXISTS idx_user_questions_session_status ON user_questions(session_id, status, created_at ASC)"
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="UserQuestionRepository",
+        self._run_write(
             operation_name="init_tables",
+            operation=operation,
+        )
+
+    async def _init_tables_async(self) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS user_questions (
+                    question_id    TEXT PRIMARY KEY,
+                    run_id         TEXT NOT NULL,
+                    session_id     TEXT NOT NULL,
+                    task_id        TEXT NOT NULL,
+                    instance_id    TEXT NOT NULL,
+                    role_id        TEXT NOT NULL,
+                    tool_name      TEXT NOT NULL,
+                    questions_json TEXT NOT NULL,
+                    status         TEXT NOT NULL,
+                    answers_json   TEXT NOT NULL DEFAULT '[]',
+                    created_at     TEXT NOT NULL,
+                    updated_at     TEXT NOT NULL,
+                    resolved_at    TEXT
+                )
+                """
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_user_questions_run_status ON user_questions(run_id, status, created_at ASC)"
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_user_questions_session_status ON user_questions(session_id, status, created_at ASC)"
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="init_tables_async",
+            operation=lambda _conn: operation(),
         )
 
     def upsert_requested(
@@ -150,15 +181,80 @@ class UserQuestionRepository:
                 ),
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="UserQuestionRepository",
+        self._run_write(
             operation_name="upsert_requested",
+            operation=operation,
         )
         record = self.get(question_id)
+        if record is None:
+            raise RuntimeError(f"Failed to persist user question {question_id}")
+        return record
+
+    async def upsert_requested_async(
+        self,
+        *,
+        question_id: str,
+        run_id: str,
+        session_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        tool_name: str,
+        questions: tuple[UserQuestionPrompt, ...],
+    ) -> UserQuestionRequestRecord:
+        now = datetime.now(tz=timezone.utc).isoformat()
+        questions_json = json.dumps(
+            [question.model_dump(mode="json") for question in questions],
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        existing = await self.get_async(question_id)
+        created_at = existing.created_at.isoformat() if existing is not None else now
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO user_questions(question_id, run_id, session_id, task_id, instance_id, role_id,
+                                           tool_name, questions_json, status, answers_json, created_at, updated_at, resolved_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(question_id)
+                DO UPDATE SET
+                    run_id=excluded.run_id,
+                    session_id=excluded.session_id,
+                    task_id=excluded.task_id,
+                    instance_id=excluded.instance_id,
+                    role_id=excluded.role_id,
+                    tool_name=excluded.tool_name,
+                    questions_json=excluded.questions_json,
+                    status=excluded.status,
+                    answers_json=excluded.answers_json,
+                    updated_at=excluded.updated_at,
+                    resolved_at=excluded.resolved_at
+                """,
+                (
+                    question_id,
+                    run_id,
+                    session_id,
+                    task_id,
+                    instance_id,
+                    role_id,
+                    tool_name,
+                    questions_json,
+                    UserQuestionRequestStatus.REQUESTED.value,
+                    "[]",
+                    created_at,
+                    now,
+                    None,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="upsert_requested_async",
+            operation=lambda _conn: operation(),
+        )
+        record = await self.get_async(question_id)
         if record is None:
             raise RuntimeError(f"Failed to persist user question {question_id}")
         return record
@@ -178,9 +274,8 @@ class UserQuestionRepository:
             sort_keys=True,
         )
         resolved_at = now if status != UserQuestionRequestStatus.REQUESTED else None
-        rowcount = run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        rowcount = self._run_write(
+            operation_name="resolve",
             operation=lambda: self._resolve_row(
                 question_id=question_id,
                 status=status,
@@ -189,11 +284,46 @@ class UserQuestionRepository:
                 resolved_at=resolved_at,
                 expected_status=expected_status,
             ),
-            lock=self._lock,
-            repository_name="UserQuestionRepository",
-            operation_name="resolve",
         )
         record = self.get(question_id)
+        if record is None:
+            raise KeyError(f"Unknown user question: {question_id}")
+        if rowcount == 0 and expected_status is not None:
+            raise UserQuestionStatusConflictError(
+                question_id=question_id,
+                expected_status=expected_status,
+                actual_status=record.status,
+            )
+        return record
+
+    async def resolve_async(
+        self,
+        *,
+        question_id: str,
+        status: UserQuestionRequestStatus,
+        answers: tuple[UserQuestionAnswer, ...] = (),
+        expected_status: UserQuestionRequestStatus | None = None,
+    ) -> UserQuestionRequestRecord:
+        now = datetime.now(tz=timezone.utc).isoformat()
+        answers_json = json.dumps(
+            [answer.model_dump(mode="json") for answer in answers],
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        resolved_at = now if status != UserQuestionRequestStatus.REQUESTED else None
+        rowcount = await self._run_async_write(
+            operation_name="resolve_async",
+            operation=lambda conn: self._resolve_row_async(
+                conn=conn,
+                question_id=question_id,
+                status=status,
+                answers_json=answers_json,
+                updated_at=now,
+                resolved_at=resolved_at,
+                expected_status=expected_status,
+            ),
+        )
+        record = await self.get_async(question_id)
         if record is None:
             raise KeyError(f"Unknown user question: {question_id}")
         if rowcount == 0 and expected_status is not None:
@@ -214,12 +344,36 @@ class UserQuestionRepository:
             answers=record.answers,
         )
 
+    async def mark_completed_async(
+        self, question_id: str
+    ) -> UserQuestionRequestRecord | None:
+        record = await self.get_async(question_id)
+        if record is None:
+            return None
+        return await self.resolve_async(
+            question_id=question_id,
+            status=UserQuestionRequestStatus.COMPLETED,
+            answers=record.answers,
+        )
+
     def get(self, question_id: str) -> UserQuestionRequestRecord | None:
         with self._lock:
             row = self._conn.execute(
                 "SELECT * FROM user_questions WHERE question_id=?",
                 (question_id,),
             ).fetchone()
+        if row is None:
+            return None
+        return self._record_or_none(row, fallback_invalid_timestamps=True)
+
+    async def get_async(self, question_id: str) -> UserQuestionRequestRecord | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT * FROM user_questions WHERE question_id=?",
+                (question_id,),
+            )
+        )
         if row is None:
             return None
         return self._record_or_none(row, fallback_invalid_timestamps=True)
@@ -249,6 +403,32 @@ class UserQuestionRepository:
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
+    async def list_by_run_async(
+        self,
+        run_id: str,
+        *,
+        include_resolved: bool = False,
+    ) -> tuple[UserQuestionRequestRecord, ...]:
+        query = (
+            "SELECT * FROM user_questions WHERE run_id=? ORDER BY created_at ASC"
+            if include_resolved
+            else (
+                "SELECT * FROM user_questions WHERE run_id=? AND status=? "
+                "ORDER BY created_at ASC"
+            )
+        )
+        params: tuple[object, ...] = (
+            (run_id,)
+            if include_resolved
+            else (run_id, UserQuestionRequestStatus.REQUESTED.value)
+        )
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(conn, query, params)
+        )
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
+
     def list_by_session(
         self,
         session_id: str,
@@ -274,17 +454,53 @@ class UserQuestionRepository:
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
+    async def list_by_session_async(
+        self,
+        session_id: str,
+        *,
+        include_resolved: bool = False,
+    ) -> tuple[UserQuestionRequestRecord, ...]:
+        query = (
+            "SELECT * FROM user_questions WHERE session_id=? ORDER BY created_at ASC"
+            if include_resolved
+            else (
+                "SELECT * FROM user_questions WHERE session_id=? AND status=? "
+                "ORDER BY created_at ASC"
+            )
+        )
+        params: tuple[object, ...] = (
+            (session_id,)
+            if include_resolved
+            else (session_id, UserQuestionRequestStatus.REQUESTED.value)
+        )
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(conn, query, params)
+        )
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
+
     def delete_by_session(self, session_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_session",
             operation=lambda: self._conn.execute(
                 "DELETE FROM user_questions WHERE session_id=?",
                 (session_id,),
             ),
-            lock=self._lock,
-            repository_name="UserQuestionRepository",
-            operation_name="delete_by_session",
+        )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM user_questions WHERE session_id=?",
+                (session_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_session_async",
+            operation=lambda _conn: operation(),
         )
 
     def _resolve_row(
@@ -324,17 +540,70 @@ class UserQuestionRepository:
         )
         return int(cursor.rowcount or 0)
 
+    # noinspection PyMethodMayBeStatic
+    async def _resolve_row_async(
+        self,
+        *,
+        conn: aiosqlite.Connection,
+        question_id: str,
+        status: UserQuestionRequestStatus,
+        answers_json: str,
+        updated_at: str,
+        resolved_at: str | None,
+        expected_status: UserQuestionRequestStatus | None,
+    ) -> int:
+        if expected_status is None:
+            cursor = await conn.execute(
+                """
+                UPDATE user_questions
+                SET status=?, answers_json=?, updated_at=?, resolved_at=?
+                WHERE question_id=?
+                """,
+                (status.value, answers_json, updated_at, resolved_at, question_id),
+            )
+            rowcount = int(cursor.rowcount or 0)
+            await cursor.close()
+            return rowcount
+        cursor = await conn.execute(
+            """
+            UPDATE user_questions
+            SET status=?, answers_json=?, updated_at=?, resolved_at=?
+            WHERE question_id=? AND status=?
+            """,
+            (
+                status.value,
+                answers_json,
+                updated_at,
+                resolved_at,
+                question_id,
+                expected_status.value,
+            ),
+        )
+        rowcount = int(cursor.rowcount or 0)
+        await cursor.close()
+        return rowcount
+
     def delete_by_run(self, run_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_run",
             operation=lambda: self._conn.execute(
                 "DELETE FROM user_questions WHERE run_id=?",
                 (run_id,),
             ),
-            lock=self._lock,
-            repository_name="UserQuestionRepository",
-            operation_name="delete_by_run",
+        )
+
+    async def delete_by_run_async(self, run_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM user_questions WHERE run_id=?",
+                (run_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_run_async",
+            operation=lambda _conn: operation(),
         )
 
     def _to_record(

--- a/src/relay_teams/sessions/session_history_marker_repository.py
+++ b/src/relay_teams/sessions/session_history_marker_repository.py
@@ -7,12 +7,12 @@ import sqlite3
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic import JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.session_history_marker_models import (
     SessionHistoryMarkerRecord,
     SessionHistoryMarkerType,
@@ -25,12 +25,9 @@ from relay_teams.validation import (
 LOGGER = get_logger(__name__)
 
 
-class SessionHistoryMarkerRepository:
+class SessionHistoryMarkerRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -106,11 +103,30 @@ class SessionHistoryMarkerRepository:
         )
         return record
 
+    async def create_async(
+        self,
+        *,
+        session_id: str,
+        marker_type: SessionHistoryMarkerType,
+        metadata: dict[str, str] | None = None,
+    ) -> SessionHistoryMarkerRecord:
+        return await self._call_sync_async(
+            self.create,
+            session_id=session_id,
+            marker_type=marker_type,
+            metadata=metadata,
+        )
+
     def create_clear_marker(self, session_id: str) -> SessionHistoryMarkerRecord:
         return self.create(
             session_id=session_id,
             marker_type=SessionHistoryMarkerType.CLEAR,
         )
+
+    async def create_clear_marker_async(
+        self, session_id: str
+    ) -> SessionHistoryMarkerRecord:
+        return await self._call_sync_async(self.create_clear_marker, session_id)
 
     def list_by_session(
         self,
@@ -129,6 +145,11 @@ class SessionHistoryMarkerRepository:
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
+
+    async def list_by_session_async(
+        self, session_id: str
+    ) -> tuple[SessionHistoryMarkerRecord, ...]:
+        return await self._call_sync_async(self.list_by_session, session_id)
 
     def get_latest(
         self,
@@ -156,6 +177,13 @@ class SessionHistoryMarkerRepository:
                 return record
         return None
 
+    async def get_latest_async(
+        self, session_id: str, *, marker_type: SessionHistoryMarkerType | None = None
+    ) -> SessionHistoryMarkerRecord | None:
+        return await self._call_sync_async(
+            self.get_latest, session_id, marker_type=marker_type
+        )
+
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
             conn=self._conn,
@@ -168,6 +196,9 @@ class SessionHistoryMarkerRepository:
             repository_name="SessionHistoryMarkerRepository",
             operation_name="delete_by_session",
         )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete_by_session, session_id)
 
     def delete_by_conversation(self, session_id: str, conversation_id: str) -> None:
         def operation() -> None:
@@ -203,6 +234,13 @@ class SessionHistoryMarkerRepository:
             lock=self._lock,
             repository_name="SessionHistoryMarkerRepository",
             operation_name="delete_by_conversation",
+        )
+
+    async def delete_by_conversation_async(
+        self, session_id: str, conversation_id: str
+    ) -> None:
+        return await self._call_sync_async(
+            self.delete_by_conversation, session_id, conversation_id
         )
 
     @staticmethod

--- a/src/relay_teams/sessions/session_repository.py
+++ b/src/relay_teams/sessions/session_repository.py
@@ -151,6 +151,30 @@ class SessionRepository(SharedSqliteRepository):
         )
         return record
 
+    async def create_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        metadata: dict[str, str] | None = None,
+        project_kind: ProjectKind = ProjectKind.WORKSPACE,
+        project_id: str | None = None,
+        session_mode: SessionMode = SessionMode.NORMAL,
+        normal_root_role_id: str | None = None,
+        orchestration_preset_id: str | None = None,
+    ) -> SessionRecord:
+        return await self._call_sync_async(
+            self.create,
+            session_id=session_id,
+            workspace_id=workspace_id,
+            metadata=metadata,
+            project_kind=project_kind,
+            project_id=project_id,
+            session_mode=session_mode,
+            normal_root_role_id=normal_root_role_id,
+            orchestration_preset_id=orchestration_preset_id,
+        )
+
     def update_topology(
         self,
         session_id: str,
@@ -185,6 +209,22 @@ class SessionRepository(SharedSqliteRepository):
                 raise RuntimeError("Session mode can no longer be changed")
             raise KeyError(f"Unknown session_id: {session_id}")
 
+    async def update_topology_async(
+        self,
+        session_id: str,
+        *,
+        session_mode: SessionMode,
+        normal_root_role_id: str | None,
+        orchestration_preset_id: str | None,
+    ) -> None:
+        return await self._call_sync_async(
+            self.update_topology,
+            session_id,
+            session_mode=session_mode,
+            normal_root_role_id=normal_root_role_id,
+            orchestration_preset_id=orchestration_preset_id,
+        )
+
     def update_metadata(self, session_id: str, metadata: dict[str, str]) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
         rowcount = self._run_write(
@@ -202,6 +242,11 @@ class SessionRepository(SharedSqliteRepository):
         )
         if rowcount == 0:
             raise KeyError(f"Unknown session_id: {session_id}")
+
+    async def update_metadata_async(
+        self, session_id: str, metadata: dict[str, str]
+    ) -> None:
+        return await self._call_sync_async(self.update_metadata, session_id, metadata)
 
     def update_workspace(
         self,
@@ -227,6 +272,16 @@ class SessionRepository(SharedSqliteRepository):
         if rowcount == 0:
             raise KeyError(f"Unknown session_id: {session_id}")
 
+    async def update_workspace_async(
+        self, session_id: str, *, workspace_id: str, project_id: str
+    ) -> None:
+        return await self._call_sync_async(
+            self.update_workspace,
+            session_id,
+            workspace_id=workspace_id,
+            project_id=project_id,
+        )
+
     def mark_started(self, session_id: str) -> SessionRecord:
         now = datetime.now(tz=timezone.utc).isoformat()
         rowcount = self._run_write(
@@ -245,6 +300,9 @@ class SessionRepository(SharedSqliteRepository):
         if rowcount == 0:
             raise KeyError(f"Unknown session_id: {session_id}")
         return self.get(session_id)
+
+    async def mark_started_async(self, session_id: str) -> SessionRecord:
+        return await self._call_sync_async(self.mark_started, session_id)
 
     def reconcile_orchestration_presets(
         self,
@@ -298,6 +356,15 @@ class SessionRepository(SharedSqliteRepository):
                     orchestration_preset_id=next_preset_id,
                 )
 
+    async def reconcile_orchestration_presets_async(
+        self, *, valid_preset_ids: tuple[str, ...], default_preset_id: str | None
+    ) -> None:
+        return await self._call_sync_async(
+            self.reconcile_orchestration_presets,
+            valid_preset_ids=valid_preset_ids,
+            default_preset_id=default_preset_id,
+        )
+
     def get(self, session_id: str) -> SessionRecord:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -311,6 +378,9 @@ class SessionRepository(SharedSqliteRepository):
         except (ValidationError, ValueError) as exc:
             _log_invalid_session_row(row=row, error=exc)
             raise KeyError(f"Unknown session_id: {session_id}") from exc
+
+    async def get_async(self, session_id: str) -> SessionRecord:
+        return await self._call_sync_async(self.get, session_id)
 
     def list_all(self) -> tuple[SessionRecord, ...]:
         rows = self._run_read(
@@ -326,6 +396,9 @@ class SessionRepository(SharedSqliteRepository):
                 _log_invalid_session_row(row=row, error=exc)
         return tuple(records)
 
+    async def list_all_async(self) -> tuple[SessionRecord, ...]:
+        return await self._call_sync_async(self.list_all)
+
     def delete(self, session_id: str) -> None:
         self._run_write(
             operation_name="delete",
@@ -333,6 +406,9 @@ class SessionRepository(SharedSqliteRepository):
                 "DELETE FROM sessions WHERE session_id=?", (session_id,)
             ),
         )
+
+    async def delete_async(self, session_id: str) -> None:
+        return await self._call_sync_async(self.delete, session_id)
 
     def _to_record(self, row: sqlite3.Row) -> SessionRecord:
         session_id = require_persisted_identifier(

--- a/src/relay_teams/tools/orchestration_tools/list_delegated_tasks.py
+++ b/src/relay_teams/tools/orchestration_tools/list_delegated_tasks.py
@@ -22,8 +22,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     ) -> dict[str, JsonValue]:
         """List delegated tasks associated with the current run."""
 
-        def _action() -> dict[str, JsonValue]:
-            return ctx.deps.task_service.list_delegated_tasks(
+        async def _action() -> dict[str, JsonValue]:
+            return await ctx.deps.task_service.list_delegated_tasks_async(
                 run_id=ctx.deps.run_id,
                 include_root=include_root,
             )

--- a/src/relay_teams/tools/orchestration_tools/list_run_tasks.py
+++ b/src/relay_teams/tools/orchestration_tools/list_run_tasks.py
@@ -23,8 +23,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     ) -> dict[str, JsonValue]:
         """List tasks associated with the current run."""
 
-        def _action() -> dict[str, JsonValue]:
-            return ctx.deps.task_service.list_run_tasks(
+        async def _action() -> dict[str, JsonValue]:
+            return await ctx.deps.task_service.list_run_tasks_async(
                 run_id=ctx.deps.run_id,
                 include_root=include_root,
             )

--- a/src/relay_teams/tools/orchestration_tools/update_task.py
+++ b/src/relay_teams/tools/orchestration_tools/update_task.py
@@ -27,12 +27,12 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     ) -> dict[str, JsonValue]:
         """Update a task contract that is still in the created state."""
 
-        def _action(
+        async def _action(
             task_id: str,
             objective: str | None = None,
             title: str | None = None,
         ) -> dict[str, JsonValue]:
-            return ctx.deps.task_service.update_task(
+            return await ctx.deps.task_service.update_task_async(
                 run_id=ctx.deps.run_id,
                 task_id=task_id,
                 update=TaskUpdate(

--- a/src/relay_teams/tools/runtime/approval_ticket_repo.py
+++ b/src/relay_teams/tools/runtime/approval_ticket_repo.py
@@ -7,12 +7,13 @@ import logging
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from threading import RLock
 
+import aiosqlite
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence import async_fetchall, async_fetchone
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.validation import (
     RequiredIdentifierStr,
     normalize_persisted_text,
@@ -93,12 +94,9 @@ def approval_signature_key(
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
-class ApprovalTicketRepository:
+class ApprovalTicketRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -145,13 +143,60 @@ class ApprovalTicketRepository:
                 "CREATE INDEX IF NOT EXISTS idx_approval_tickets_signature ON approval_tickets(signature_key, updated_at DESC)"
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="ApprovalTicketRepository",
+        self._run_write(
             operation_name="init_tables",
+            operation=operation,
+        )
+
+    async def _init_tables_async(self) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS approval_tickets (
+                    tool_call_id   TEXT PRIMARY KEY,
+                    signature_key  TEXT NOT NULL,
+                    run_id         TEXT NOT NULL,
+                    session_id     TEXT NOT NULL,
+                    task_id        TEXT NOT NULL,
+                    instance_id    TEXT NOT NULL,
+                    role_id        TEXT NOT NULL,
+                    tool_name      TEXT NOT NULL,
+                    args_preview   TEXT NOT NULL DEFAULT '',
+                    metadata_json  TEXT NOT NULL DEFAULT '{}',
+                    status         TEXT NOT NULL,
+                    feedback       TEXT NOT NULL DEFAULT '',
+                    created_at     TEXT NOT NULL,
+                    updated_at     TEXT NOT NULL,
+                    resolved_at    TEXT
+                )
+                """
+            )
+            await cursor.close()
+            rows = await async_fetchall(conn, "PRAGMA table_info(approval_tickets)")
+            columns = {str(row["name"]) for row in rows}
+            if "metadata_json" not in columns:
+                cursor = await conn.execute(
+                    "ALTER TABLE approval_tickets "
+                    "ADD COLUMN metadata_json TEXT NOT NULL DEFAULT '{}'"
+                )
+                await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_approval_tickets_run_status ON approval_tickets(run_id, status, created_at ASC)"
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_approval_tickets_session_status ON approval_tickets(session_id, status, created_at ASC)"
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_approval_tickets_signature ON approval_tickets(signature_key, updated_at DESC)"
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="init_tables_async",
+            operation=lambda _conn: operation(),
         )
 
     def upsert_requested(
@@ -237,15 +282,103 @@ class ApprovalTicketRepository:
                 ),
             )
 
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name="ApprovalTicketRepository",
+        self._run_write(
             operation_name="upsert_requested",
+            operation=operation,
         )
         record = self.get(tool_call_id)
+        if record is None:
+            raise RuntimeError(f"Failed to persist approval ticket {tool_call_id}")
+        return record
+
+    async def upsert_requested_async(
+        self,
+        *,
+        tool_call_id: str,
+        run_id: str,
+        session_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        tool_name: str,
+        args_preview: str,
+        metadata: dict[str, JsonValue] | None = None,
+        cache_key: str = "",
+        signature_args_preview: str | None = None,
+    ) -> ApprovalTicketRecord:
+        now = datetime.now(tz=timezone.utc).isoformat()
+        metadata_json = json.dumps(
+            {} if metadata is None else metadata,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        signature_key = approval_signature_key(
+            run_id=run_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            tool_name=tool_name,
+            args_preview=(
+                args_preview
+                if signature_args_preview is None
+                else signature_args_preview
+            ),
+            cache_key=cache_key,
+        )
+        existing = await self.get_async(tool_call_id)
+        created_at = existing.created_at.isoformat() if existing is not None else now
+        resolved_at = (
+            existing.resolved_at.isoformat()
+            if existing and existing.resolved_at
+            else None
+        )
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO approval_tickets(tool_call_id, signature_key, run_id, session_id, task_id, instance_id,
+                                             role_id, tool_name, args_preview, metadata_json, status, feedback, created_at, updated_at, resolved_at)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(tool_call_id)
+                DO UPDATE SET
+                    signature_key=excluded.signature_key,
+                    run_id=excluded.run_id,
+                    session_id=excluded.session_id,
+                    task_id=excluded.task_id,
+                    instance_id=excluded.instance_id,
+                    role_id=excluded.role_id,
+                    tool_name=excluded.tool_name,
+                    args_preview=excluded.args_preview,
+                    metadata_json=excluded.metadata_json,
+                    status=excluded.status,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    tool_call_id,
+                    signature_key,
+                    run_id,
+                    session_id,
+                    task_id,
+                    instance_id,
+                    role_id,
+                    tool_name,
+                    args_preview,
+                    metadata_json,
+                    ApprovalTicketStatus.REQUESTED.value,
+                    "",
+                    created_at,
+                    now,
+                    resolved_at,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="upsert_requested_async",
+            operation=lambda _conn: operation(),
+        )
+        record = await self.get_async(tool_call_id)
         if record is None:
             raise RuntimeError(f"Failed to persist approval ticket {tool_call_id}")
         return record
@@ -260,9 +393,8 @@ class ApprovalTicketRepository:
     ) -> ApprovalTicketRecord:
         now = datetime.now(tz=timezone.utc).isoformat()
         resolved_at = now if status != ApprovalTicketStatus.REQUESTED else None
-        rowcount = run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        rowcount = self._run_write(
+            operation_name="resolve",
             operation=lambda: self._resolve_row(
                 tool_call_id=tool_call_id,
                 status=status,
@@ -271,11 +403,41 @@ class ApprovalTicketRepository:
                 resolved_at=resolved_at,
                 expected_status=expected_status,
             ),
-            lock=self._lock,
-            repository_name="ApprovalTicketRepository",
-            operation_name="resolve",
         )
         record = self.get(tool_call_id)
+        if record is None:
+            raise KeyError(f"Unknown approval ticket: {tool_call_id}")
+        if rowcount == 0 and expected_status is not None:
+            raise ApprovalTicketStatusConflictError(
+                tool_call_id=tool_call_id,
+                expected_status=expected_status,
+                actual_status=record.status,
+            )
+        return record
+
+    async def resolve_async(
+        self,
+        *,
+        tool_call_id: str,
+        status: ApprovalTicketStatus,
+        feedback: str = "",
+        expected_status: ApprovalTicketStatus | None = None,
+    ) -> ApprovalTicketRecord:
+        now = datetime.now(tz=timezone.utc).isoformat()
+        resolved_at = now if status != ApprovalTicketStatus.REQUESTED else None
+        rowcount = await self._run_async_write(
+            operation_name="resolve_async",
+            operation=lambda conn: self._resolve_row_async(
+                conn=conn,
+                tool_call_id=tool_call_id,
+                status=status,
+                feedback=feedback,
+                updated_at=now,
+                resolved_at=resolved_at,
+                expected_status=expected_status,
+            ),
+        )
+        record = await self.get_async(tool_call_id)
         if record is None:
             raise KeyError(f"Unknown approval ticket: {tool_call_id}")
         if rowcount == 0 and expected_status is not None:
@@ -296,12 +458,36 @@ class ApprovalTicketRepository:
             feedback=record.feedback,
         )
 
+    async def mark_completed_async(
+        self, tool_call_id: str
+    ) -> ApprovalTicketRecord | None:
+        record = await self.get_async(tool_call_id)
+        if record is None:
+            return None
+        return await self.resolve_async(
+            tool_call_id=tool_call_id,
+            status=ApprovalTicketStatus.COMPLETED,
+            feedback=record.feedback,
+        )
+
     def get(self, tool_call_id: str) -> ApprovalTicketRecord | None:
         with self._lock:
             row = self._conn.execute(
                 "SELECT * FROM approval_tickets WHERE tool_call_id=?",
                 (tool_call_id,),
             ).fetchone()
+        if row is None:
+            return None
+        return self._record_or_none(row, fallback_invalid_timestamps=True)
+
+    async def get_async(self, tool_call_id: str) -> ApprovalTicketRecord | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT * FROM approval_tickets WHERE tool_call_id=?",
+                (tool_call_id,),
+            )
+        )
         if row is None:
             return None
         return self._record_or_none(row, fallback_invalid_timestamps=True)
@@ -316,12 +502,40 @@ class ApprovalTicketRepository:
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
 
+    async def list_open_by_run_async(
+        self, run_id: str
+    ) -> tuple[ApprovalTicketRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM approval_tickets WHERE run_id=? AND status=? ORDER BY created_at ASC",
+                (run_id, ApprovalTicketStatus.REQUESTED.value),
+            )
+        )
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
+
     def list_open_by_session(self, session_id: str) -> tuple[ApprovalTicketRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
                 "SELECT * FROM approval_tickets WHERE session_id=? AND status=? ORDER BY created_at ASC",
                 (session_id, ApprovalTicketStatus.REQUESTED.value),
             ).fetchall()
+        return tuple(
+            record for row in rows if (record := self._record_or_none(row)) is not None
+        )
+
+    async def list_open_by_session_async(
+        self, session_id: str
+    ) -> tuple[ApprovalTicketRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM approval_tickets WHERE session_id=? AND status=? ORDER BY created_at ASC",
+                (session_id, ApprovalTicketStatus.REQUESTED.value),
+            )
+        )
         return tuple(
             record for row in rows if (record := self._record_or_none(row)) is not None
         )
@@ -371,29 +585,95 @@ class ApprovalTicketRepository:
                 return record
         return None
 
+    async def find_reusable_async(
+        self,
+        *,
+        run_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        tool_name: str,
+        args_preview: str,
+        cache_key: str = "",
+        signature_args_preview: str | None = None,
+    ) -> ApprovalTicketRecord | None:
+        signature_key = approval_signature_key(
+            run_id=run_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            tool_name=tool_name,
+            args_preview=(
+                args_preview
+                if signature_args_preview is None
+                else signature_args_preview
+            ),
+            cache_key=cache_key,
+        )
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT * FROM approval_tickets
+                WHERE signature_key=?
+                  AND status IN (?, ?)
+                ORDER BY updated_at DESC
+                """,
+                (
+                    signature_key,
+                    ApprovalTicketStatus.REQUESTED.value,
+                    ApprovalTicketStatus.APPROVED.value,
+                ),
+            )
+        )
+        for row in rows:
+            record = self._record_or_none(row, fallback_invalid_timestamps=True)
+            if record is not None:
+                return record
+        return None
+
     def delete_by_session(self, session_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_session",
             operation=lambda: self._conn.execute(
                 "DELETE FROM approval_tickets WHERE session_id=?", (session_id,)
             ),
-            lock=self._lock,
-            repository_name="ApprovalTicketRepository",
-            operation_name="delete_by_session",
+        )
+
+    async def delete_by_session_async(self, session_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM approval_tickets WHERE session_id=?", (session_id,)
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_session_async",
+            operation=lambda _conn: operation(),
         )
 
     def delete_by_run(self, run_id: str) -> None:
-        run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
+        self._run_write(
+            operation_name="delete_by_run",
             operation=lambda: self._conn.execute(
                 "DELETE FROM approval_tickets WHERE run_id=?",
                 (run_id,),
             ),
-            lock=self._lock,
-            repository_name="ApprovalTicketRepository",
-            operation_name="delete_by_run",
+        )
+
+    async def delete_by_run_async(self, run_id: str) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM approval_tickets WHERE run_id=?",
+                (run_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_run_async",
+            operation=lambda _conn: operation(),
         )
 
     def _resolve_row(
@@ -432,6 +712,49 @@ class ApprovalTicketRepository:
             ),
         )
         return int(cursor.rowcount or 0)
+
+    # noinspection PyMethodMayBeStatic
+    async def _resolve_row_async(
+        self,
+        *,
+        conn: aiosqlite.Connection,
+        tool_call_id: str,
+        status: ApprovalTicketStatus,
+        feedback: str,
+        updated_at: str,
+        resolved_at: str | None,
+        expected_status: ApprovalTicketStatus | None,
+    ) -> int:
+        if expected_status is None:
+            cursor = await conn.execute(
+                """
+                UPDATE approval_tickets
+                SET status=?, feedback=?, updated_at=?, resolved_at=?
+                WHERE tool_call_id=?
+                """,
+                (status.value, feedback, updated_at, resolved_at, tool_call_id),
+            )
+            rowcount = int(cursor.rowcount or 0)
+            await cursor.close()
+            return rowcount
+        cursor = await conn.execute(
+            """
+            UPDATE approval_tickets
+            SET status=?, feedback=?, updated_at=?, resolved_at=?
+            WHERE tool_call_id=? AND status=?
+            """,
+            (
+                status.value,
+                feedback,
+                updated_at,
+                resolved_at,
+                tool_call_id,
+                expected_status.value,
+            ),
+        )
+        rowcount = int(cursor.rowcount or 0)
+        await cursor.close()
+        return rowcount
 
     def _to_record(
         self,

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -86,7 +86,8 @@ LOGGER = get_logger(__name__)
 class _AsyncToolResultReminderService(Protocol):
     async def observe_tool_result_async(
         self, observation: ToolResultObservation
-    ) -> object: ...
+    ) -> object:
+        pass
 
 
 @runtime_checkable
@@ -99,9 +100,11 @@ class _AsyncRunRuntimeRepository(Protocol):
         root_task_id: str | None = None,
         status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
         phase: RunRuntimePhase = RunRuntimePhase.IDLE,
-    ) -> object: ...
+    ) -> object:
+        pass
 
-    async def update_async(self, run_id: str, **changes: object) -> object: ...
+    async def update_async(self, run_id: str, **changes: object) -> object:
+        pass
 
 
 # noinspection PyUnusedLocal,PyTypeHints
@@ -2034,7 +2037,8 @@ def _evaluate_tool_approval_policy(
 class _RequiresApprovalPolicy(Protocol):
     timeout_seconds: float
 
-    def requires_approval(self, tool_name: str) -> bool: ...
+    def requires_approval(self, tool_name: str) -> bool:
+        raise NotImplementedError
 
 
 # noinspection PyTypeHints

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -22,12 +22,13 @@ from typing import (
     get_origin,
     get_type_hints,
     overload,
+    runtime_checkable,
 )
 from uuid import uuid4
 
 from relay_teams.logger import get_logger, log_event, log_tool_error
 from relay_teams.media import ContentPart, TextContentPart, UserPromptContent
-from relay_teams.metrics.adapters import record_tool_execution
+from relay_teams.metrics.adapters import record_tool_execution_async
 from relay_teams.notifications import NotificationContext, NotificationType
 from relay_teams.persistence import is_retryable_sqlite_error
 from relay_teams.agents.tasks.task_status_sanitizer import (
@@ -35,6 +36,7 @@ from relay_teams.agents.tasks.task_status_sanitizer import (
 )
 from relay_teams.reminders import ToolResultObservation
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
+from relay_teams.sessions.runs.event_stream import publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.system_injection import SystemInjectionSink
 
@@ -60,8 +62,8 @@ from relay_teams.tools.runtime.persisted_state import (
     ToolApprovalMode,
     ToolApprovalStatus,
     ToolExecutionStatus,
-    load_tool_call_state,
-    merge_tool_call_state,
+    load_tool_call_state_async,
+    merge_tool_call_state_async,
 )
 from relay_teams.env.hook_runtime_env import (
     reset_tool_hook_runtime_env,
@@ -78,6 +80,28 @@ from relay_teams.hooks import (
 )
 
 LOGGER = get_logger(__name__)
+
+
+@runtime_checkable
+class _AsyncToolResultReminderService(Protocol):
+    async def observe_tool_result_async(
+        self, observation: ToolResultObservation
+    ) -> object: ...
+
+
+@runtime_checkable
+class _AsyncRunRuntimeRepository(Protocol):
+    async def ensure_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        root_task_id: str | None = None,
+        status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
+        phase: RunRuntimePhase = RunRuntimePhase.IDLE,
+    ) -> object: ...
+
+    async def update_async(self, run_id: str, **changes: object) -> object: ...
 
 
 # noinspection PyUnusedLocal,PyTypeHints
@@ -198,7 +222,7 @@ async def execute_tool(
             tool_input=effective_tool_input,
         )
         args_summary = dict(effective_tool_input)
-        reusable_result = _reusable_tool_result(
+        reusable_result = await _reusable_tool_result_async(
             ctx=ctx,
             args_preview=_safe_json(args_summary),
             tool_call_id=tool_call_id,
@@ -252,13 +276,13 @@ async def execute_tool(
                 error=approval_error,
                 meta=meta,
             )
-            _observe_tool_result_reminders(
+            await _observe_tool_result_reminders_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            _persist_tool_record(
+            await _persist_tool_record_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
@@ -268,13 +292,13 @@ async def execute_tool(
                 runtime_meta=meta,
                 execution_status=ToolExecutionStatus.FAILED,
             )
-            _record_tool_metrics(
+            await _record_tool_metrics_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=False,
             )
-            _publish_tool_result_event(
+            await _publish_tool_result_event_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
@@ -282,13 +306,9 @@ async def execute_tool(
             )
             return envelope
 
-        ctx.deps.run_runtime_repo.ensure(
-            run_id=ctx.deps.run_id,
-            session_id=ctx.deps.session_id,
-            root_task_id=ctx.deps.task_id,
-        )
-        ctx.deps.run_runtime_repo.update(
-            ctx.deps.run_id,
+        await _ensure_run_runtime_async(ctx=ctx)
+        await _update_run_runtime_async(
+            ctx=ctx,
             status=RunRuntimeStatus.RUNNING,
             phase=RunRuntimePhase.COORDINATOR_RUNNING
             if ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id)
@@ -359,13 +379,13 @@ async def execute_tool(
                 args_summary=args_summary,
                 envelope=envelope,
             )
-            _observe_tool_result_reminders(
+            await _observe_tool_result_reminders_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            _persist_tool_record(
+            await _persist_tool_record_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
@@ -376,20 +396,22 @@ async def execute_tool(
                 execution_status=ToolExecutionStatus.COMPLETED,
                 tool_content_parts=tool_content_parts,
             )
-            _record_tool_metrics(
+            await _record_tool_metrics_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=True,
             )
-            _publish_tool_result_event(
+            await _publish_tool_result_event_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
                 visible_envelope=envelope,
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
-                ctx.deps.approval_ticket_repo.mark_completed(approval_ticket_id)
+                await ctx.deps.approval_ticket_repo.mark_completed_async(
+                    approval_ticket_id
+                )
             if tool_return_content is not None:
                 return ToolReturn(
                     return_value=envelope,
@@ -439,13 +461,13 @@ async def execute_tool(
                 args_summary=args_summary,
                 envelope=envelope,
             )
-            _observe_tool_result_reminders(
+            await _observe_tool_result_reminders_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            _persist_tool_record(
+            await _persist_tool_record_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
@@ -455,20 +477,22 @@ async def execute_tool(
                 runtime_meta=meta,
                 execution_status=ToolExecutionStatus.FAILED,
             )
-            _record_tool_metrics(
+            await _record_tool_metrics_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=False,
             )
-            _publish_tool_result_event(
+            await _publish_tool_result_event_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
                 visible_envelope=envelope,
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
-                ctx.deps.approval_ticket_repo.mark_completed(approval_ticket_id)
+                await ctx.deps.approval_ticket_repo.mark_completed_async(
+                    approval_ticket_id
+                )
             return envelope
 
 
@@ -579,7 +603,7 @@ async def execute_tool_call(
     )
 
 
-def _reusable_tool_result(
+async def _reusable_tool_result_async(
     *,
     ctx: ToolContext,
     args_preview: str,
@@ -587,7 +611,7 @@ def _reusable_tool_result(
     tool_name: str,
     allow_tool_return: bool,
 ) -> Optional[ToolReturn | dict[str, JsonValue]]:
-    state = load_tool_call_state(
+    state = await load_tool_call_state_async(
         shared_store=ctx.deps.shared_store,
         task_id=ctx.deps.task_id,
         tool_call_id=tool_call_id,
@@ -646,7 +670,7 @@ def _state_matches_runtime_scope(
     return not state_run_id or state_run_id == ctx.deps.run_id
 
 
-def _record_tool_metrics(
+async def _record_tool_metrics_async(
     *,
     ctx: ToolContext,
     tool_name: str,
@@ -657,7 +681,7 @@ def _record_tool_metrics(
     mcp_registry = getattr(ctx.deps, "mcp_registry", None)
     if metric_recorder is None or mcp_registry is None:
         return
-    record_tool_execution(
+    await record_tool_execution_async(
         metric_recorder,
         mcp_registry=mcp_registry,
         workspace_id=ctx.deps.workspace_id,
@@ -671,7 +695,47 @@ def _record_tool_metrics(
     )
 
 
-def _publish_tool_result_event(
+async def _ensure_run_runtime_async(
+    *,
+    ctx: ToolContext,
+    status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
+    phase: RunRuntimePhase = RunRuntimePhase.IDLE,
+) -> None:
+    repository = ctx.deps.run_runtime_repo
+    if isinstance(repository, _AsyncRunRuntimeRepository):
+        _ = await repository.ensure_async(
+            run_id=ctx.deps.run_id,
+            session_id=ctx.deps.session_id,
+            root_task_id=ctx.deps.task_id,
+            status=status,
+            phase=phase,
+        )
+        return
+    ensure_kwargs: dict[str, object] = {
+        "run_id": ctx.deps.run_id,
+        "session_id": ctx.deps.session_id,
+        "root_task_id": ctx.deps.task_id,
+    }
+    if status != RunRuntimeStatus.QUEUED:
+        ensure_kwargs["status"] = status
+    if phase != RunRuntimePhase.IDLE:
+        ensure_kwargs["phase"] = phase
+    _ = await asyncio.to_thread(repository.ensure, **ensure_kwargs)
+
+
+async def _update_run_runtime_async(
+    *,
+    ctx: ToolContext,
+    **changes: object,
+) -> None:
+    repository = ctx.deps.run_runtime_repo
+    if isinstance(repository, _AsyncRunRuntimeRepository):
+        _ = await repository.update_async(ctx.deps.run_id, **changes)
+        return
+    _ = await asyncio.to_thread(repository.update, ctx.deps.run_id, **changes)
+
+
+async def _publish_tool_result_event_async(
     *,
     ctx: ToolContext,
     tool_call_id: str,
@@ -683,7 +747,8 @@ def _publish_tool_result_event(
         sanitize_task_status_payload(visible_envelope),
     )
     is_error = bool(visible_envelope.get("ok") is False)
-    ctx.deps.run_event_hub.publish(
+    await publish_run_event_async(
+        ctx.deps.run_event_hub,
         RunEvent(
             session_id=ctx.deps.session_id,
             run_id=ctx.deps.run_id,
@@ -702,7 +767,7 @@ def _publish_tool_result_event(
                     "instance_id": ctx.deps.instance_id,
                 }
             ),
-        )
+        ),
     )
 
 
@@ -1230,7 +1295,7 @@ async def _apply_post_tool_hooks(
         ),
         run_event_hub=ctx.deps.run_event_hub,
     )
-    return _apply_post_hook_bundle_to_envelope(
+    return await _apply_post_hook_bundle_to_envelope_async(
         ctx=ctx,
         hook_event=HookEventName.POST_TOOL_USE,
         tool_name=tool_name,
@@ -1273,7 +1338,7 @@ async def _apply_post_tool_failure_hooks(
         ),
         run_event_hub=ctx.deps.run_event_hub,
     )
-    return _apply_post_hook_bundle_to_envelope(
+    return await _apply_post_hook_bundle_to_envelope_async(
         ctx=ctx,
         hook_event=HookEventName.POST_TOOL_USE_FAILURE,
         tool_name=tool_name,
@@ -1283,7 +1348,7 @@ async def _apply_post_tool_failure_hooks(
     )
 
 
-def _apply_post_hook_bundle_to_envelope(
+async def _apply_post_hook_bundle_to_envelope_async(
     *,
     ctx: ToolContext,
     hook_event: HookEventName,
@@ -1296,7 +1361,7 @@ def _apply_post_hook_bundle_to_envelope(
     runtime_meta = cast(dict[str, JsonValue], meta) if isinstance(meta, dict) else {}
     if bundle.additional_context:
         runtime_meta["hook_additional_context"] = list(bundle.additional_context)
-        _enqueue_system_followup(
+        await _enqueue_system_followup_async(
             ctx=ctx,
             content="\n\n".join(
                 str(context).strip()
@@ -1306,7 +1371,7 @@ def _apply_post_hook_bundle_to_envelope(
         )
     if bundle.deferred_action:
         runtime_meta["hook_deferred_action"] = bundle.deferred_action
-        _enqueue_deferred_followup(
+        await _enqueue_deferred_followup_async(
             ctx=ctx,
             hook_event=hook_event,
             tool_name=tool_name,
@@ -1317,14 +1382,14 @@ def _apply_post_hook_bundle_to_envelope(
     return envelope
 
 
-def _enqueue_system_followup(
+async def _enqueue_system_followup_async(
     *,
     ctx: ToolContext,
     content: str,
 ) -> bool:
     if not content:
         return False
-    result = _system_injection_sink(ctx).enqueue_only(
+    result = await _system_injection_sink(ctx).enqueue_only_async(
         session_id=ctx.deps.session_id,
         run_id=ctx.deps.run_id,
         trace_id=ctx.deps.trace_id,
@@ -1337,7 +1402,7 @@ def _enqueue_system_followup(
     return result.enqueued
 
 
-def _enqueue_deferred_followup(
+async def _enqueue_deferred_followup_async(
     *,
     ctx: ToolContext,
     hook_event: HookEventName,
@@ -1345,9 +1410,10 @@ def _enqueue_deferred_followup(
     tool_call_id: str,
     deferred_action: str,
 ) -> None:
-    if not _enqueue_system_followup(ctx=ctx, content=deferred_action):
+    if not await _enqueue_system_followup_async(ctx=ctx, content=deferred_action):
         return
-    ctx.deps.run_event_hub.publish(
+    await publish_run_event_async(
+        ctx.deps.run_event_hub,
         RunEvent(
             session_id=ctx.deps.session_id,
             run_id=ctx.deps.run_id,
@@ -1365,7 +1431,7 @@ def _enqueue_deferred_followup(
                 },
                 ensure_ascii=False,
             ),
-        )
+        ),
     )
 
 
@@ -1378,7 +1444,7 @@ def _system_injection_sink(ctx: ToolContext) -> SystemInjectionSink:
 
 
 # noinspection PyTypeHints
-def _observe_tool_result_reminders(
+async def _observe_tool_result_reminders_async(
     *,
     ctx: ToolContext,
     tool_name: str,
@@ -1413,23 +1479,25 @@ def _observe_tool_result_reminders(
             error_type = reported_failure[0]
         if not error_message:
             error_message = reported_failure[1]
-    _ = reminder_service.observe_tool_result(
-        ToolResultObservation(
-            session_id=ctx.deps.session_id,
-            run_id=ctx.deps.run_id,
-            trace_id=ctx.deps.trace_id,
-            task_id=ctx.deps.task_id,
-            instance_id=ctx.deps.instance_id,
-            role_id=ctx.deps.role_id,
-            tool_name=tool_name,
-            tool_call_id=tool_call_id,
-            ok=observed_ok,
-            error_type=error_type,
-            error_message=error_message,
-            retryable=bool(error.get("retryable") is True),
-            meta=meta,
-        )
+    observation = ToolResultObservation(
+        session_id=ctx.deps.session_id,
+        run_id=ctx.deps.run_id,
+        trace_id=ctx.deps.trace_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        ok=observed_ok,
+        error_type=error_type,
+        error_message=error_message,
+        retryable=bool(error.get("retryable") is True),
+        meta=meta,
     )
+    if isinstance(reminder_service, _AsyncToolResultReminderService):
+        _ = await reminder_service.observe_tool_result_async(observation)
+        return
+    _ = await asyncio.to_thread(reminder_service.observe_tool_result, observation)
 
 
 def _reported_failure_from_success_envelope(
@@ -1535,7 +1603,7 @@ async def _handle_tool_approval(
         meta["approval_status"] = "not_required"
         return None, None
 
-    reusable_ticket = ctx.deps.approval_ticket_repo.find_reusable(
+    reusable_ticket = await ctx.deps.approval_ticket_repo.find_reusable_async(
         run_id=ctx.deps.run_id,
         task_id=ctx.deps.task_id,
         instance_id=ctx.deps.instance_id,
@@ -1576,7 +1644,7 @@ async def _handle_tool_approval(
                 message="Tool approval timed out.",
                 retryable=True,
             )
-    ticket = ctx.deps.approval_ticket_repo.upsert_requested(
+    ticket = await ctx.deps.approval_ticket_repo.upsert_requested_async(
         tool_call_id=tool_call_id,
         run_id=ctx.deps.run_id,
         session_id=ctx.deps.session_id,
@@ -1628,13 +1696,9 @@ async def _wait_for_ticket_resolution(
         )
         publish_request = True
 
-    ctx.deps.run_runtime_repo.ensure(
-        run_id=ctx.deps.run_id,
-        session_id=ctx.deps.session_id,
-        root_task_id=ctx.deps.task_id,
-    )
-    ctx.deps.run_runtime_repo.update(
-        ctx.deps.run_id,
+    await _ensure_run_runtime_async(ctx=ctx)
+    await _update_run_runtime_async(
+        ctx=ctx,
         status=RunRuntimeStatus.PAUSED,
         phase=RunRuntimePhase.AWAITING_TOOL_APPROVAL,
         active_instance_id=ctx.deps.instance_id,
@@ -1654,7 +1718,7 @@ async def _wait_for_ticket_resolution(
                 "tool_call_id": ticket_id,
             },
         )
-        _publish_tool_approval_event(
+        await _publish_tool_approval_event_async(
             ctx=ctx,
             event_type=RunEventType.TOOL_APPROVAL_REQUESTED,
             payload={
@@ -1682,7 +1746,7 @@ async def _wait_for_ticket_resolution(
                 ),
             },
         )
-        _publish_tool_approval_notification(
+        await _publish_tool_approval_notification_async(
             ctx=ctx,
             tool_call_id=ticket_id,
             tool_name=tool_name,
@@ -1701,13 +1765,13 @@ async def _wait_for_ticket_resolution(
             tool_call_id=ticket_id,
         )
         try:
-            resolved_ticket = ctx.deps.approval_ticket_repo.resolve(
+            resolved_ticket = await ctx.deps.approval_ticket_repo.resolve_async(
                 tool_call_id=ticket_id,
                 status=ApprovalTicketStatus.TIMED_OUT,
                 expected_status=ApprovalTicketStatus.REQUESTED,
             )
         except ApprovalTicketStatusConflictError:
-            resolved_ticket = ctx.deps.approval_ticket_repo.get(ticket_id)
+            resolved_ticket = await ctx.deps.approval_ticket_repo.get_async(ticket_id)
             if resolved_ticket is None:
                 raise KeyError(f"Unknown approval ticket: {ticket_id}") from None
         resolved_action, resolved_error = _approval_resolution_from_ticket(
@@ -1715,8 +1779,8 @@ async def _wait_for_ticket_resolution(
             meta=meta,
         )
         if resolved_action == "timeout":
-            ctx.deps.run_runtime_repo.update(
-                ctx.deps.run_id,
+            await _update_run_runtime_async(
+                ctx=ctx,
                 status=RunRuntimeStatus.PAUSED,
                 phase=RunRuntimePhase.AWAITING_TOOL_APPROVAL,
                 active_instance_id=ctx.deps.instance_id,
@@ -1726,8 +1790,8 @@ async def _wait_for_ticket_resolution(
                 last_error="Tool approval timed out",
             )
         elif resolved_action == "deny":
-            ctx.deps.run_runtime_repo.update(
-                ctx.deps.run_id,
+            await _update_run_runtime_async(
+                ctx=ctx,
                 status=RunRuntimeStatus.PAUSED,
                 phase=RunRuntimePhase.AWAITING_TOOL_APPROVAL,
                 active_instance_id=ctx.deps.instance_id,
@@ -1751,7 +1815,7 @@ async def _wait_for_ticket_resolution(
                 "action": resolved_action,
             },
         )
-        _publish_tool_approval_event(
+        await _publish_tool_approval_event_async(
             ctx=ctx,
             event_type=RunEventType.TOOL_APPROVAL_RESOLVED,
             payload={
@@ -1775,14 +1839,14 @@ async def _wait_for_ticket_resolution(
         else ApprovalTicketStatus.DENIED
     )
     try:
-        resolved_ticket = ctx.deps.approval_ticket_repo.resolve(
+        resolved_ticket = await ctx.deps.approval_ticket_repo.resolve_async(
             tool_call_id=ticket_id,
             status=resolved_status,
             feedback=feedback,
             expected_status=ApprovalTicketStatus.REQUESTED,
         )
     except ApprovalTicketStatusConflictError:
-        resolved_ticket = ctx.deps.approval_ticket_repo.get(ticket_id)
+        resolved_ticket = await ctx.deps.approval_ticket_repo.get_async(ticket_id)
         if resolved_ticket is None:
             raise KeyError(f"Unknown approval ticket: {ticket_id}") from None
     resolved_action, resolved_error = _approval_resolution_from_ticket(
@@ -1800,7 +1864,7 @@ async def _wait_for_ticket_resolution(
             "action": resolved_action,
         },
     )
-    _publish_tool_approval_event(
+    await _publish_tool_approval_event_async(
         ctx=ctx,
         event_type=RunEventType.TOOL_APPROVAL_RESOLVED,
         payload={
@@ -1813,8 +1877,8 @@ async def _wait_for_ticket_resolution(
         },
     )
     if resolved_action == "deny":
-        ctx.deps.run_runtime_repo.update(
-            ctx.deps.run_id,
+        await _update_run_runtime_async(
+            ctx=ctx,
             status=RunRuntimeStatus.PAUSED,
             phase=RunRuntimePhase.AWAITING_TOOL_APPROVAL,
             active_instance_id=ctx.deps.instance_id,
@@ -1825,8 +1889,8 @@ async def _wait_for_ticket_resolution(
         )
         return ticket_id, resolved_error
     if resolved_action == "timeout":
-        ctx.deps.run_runtime_repo.update(
-            ctx.deps.run_id,
+        await _update_run_runtime_async(
+            ctx=ctx,
             status=RunRuntimeStatus.PAUSED,
             phase=RunRuntimePhase.AWAITING_TOOL_APPROVAL,
             active_instance_id=ctx.deps.instance_id,
@@ -1872,7 +1936,7 @@ def _approval_resolution_from_ticket(
     )
 
 
-def _publish_tool_approval_notification(
+async def _publish_tool_approval_notification_async(
     *,
     ctx: ToolContext,
     tool_call_id: str,
@@ -1884,7 +1948,7 @@ def _publish_tool_approval_notification(
 
     role_label = ctx.deps.role_id or "An agent"
     body = f"{role_label} requests approval for {tool_name}."
-    _ = notification_service.emit(
+    _ = await notification_service.emit_async(
         notification_type=NotificationType.TOOL_APPROVAL_REQUESTED,
         title="Approval Required",
         body=body,
@@ -1902,13 +1966,14 @@ def _publish_tool_approval_notification(
     )
 
 
-def _publish_tool_approval_event(
+async def _publish_tool_approval_event_async(
     *,
     ctx: ToolContext,
     event_type: RunEventType,
     payload: dict[str, JsonValue],
 ) -> None:
-    ctx.deps.run_event_hub.publish(
+    await publish_run_event_async(
+        ctx.deps.run_event_hub,
         RunEvent(
             session_id=ctx.deps.session_id,
             run_id=ctx.deps.run_id,
@@ -1918,7 +1983,7 @@ def _publish_tool_approval_event(
             role_id=ctx.deps.role_id,
             event_type=event_type,
             payload_json=dumps(payload, ensure_ascii=False),
-        )
+        ),
     )
 
 
@@ -1991,7 +2056,7 @@ def _internal_record(
     return cast(dict[str, JsonValue], record.model_dump(mode="json"))
 
 
-def _persist_tool_record(
+async def _persist_tool_record_async(
     *,
     ctx: ToolContext,
     tool_call_id: str,
@@ -2012,7 +2077,7 @@ def _persist_tool_record(
         runtime_meta=runtime_meta,
         tool_content_parts=tool_content_parts,
     )
-    current_state = load_tool_call_state(
+    current_state = await load_tool_call_state_async(
         shared_store=ctx.deps.shared_store,
         task_id=ctx.deps.task_id,
         tool_call_id=tool_call_id,
@@ -2020,7 +2085,7 @@ def _persist_tool_record(
     existing_call_state = (
         dict(current_state.call_state) if current_state is not None else {}
     )
-    merge_tool_call_state(
+    await merge_tool_call_state_async(
         shared_store=ctx.deps.shared_store,
         task_id=ctx.deps.task_id,
         tool_call_id=tool_call_id,

--- a/src/relay_teams/tools/runtime/persisted_state.py
+++ b/src/relay_teams/tools/runtime/persisted_state.py
@@ -80,6 +80,23 @@ def load_tool_call_state(
         return None
 
 
+async def load_tool_call_state_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    tool_call_id: str,
+) -> PersistedToolCallState | None:
+    raw = await shared_store.get_state_async(
+        _task_scope(task_id), _state_key(tool_call_id)
+    )
+    if raw is None:
+        return None
+    try:
+        return PersistedToolCallState.model_validate_json(raw)
+    except Exception:
+        return None
+
+
 def merge_tool_call_state(
     *,
     shared_store: SharedStateRepository,
@@ -148,6 +165,83 @@ def merge_tool_call_state(
         update["call_state"] = call_state
     next_state = current.model_copy(update=update)
     shared_store.manage_state(
+        StateMutation(
+            scope=_task_scope(task_id),
+            key=_state_key(tool_call_id),
+            value_json=next_state.model_dump_json(),
+        )
+    )
+    return next_state
+
+
+async def merge_tool_call_state_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    tool_call_id: str,
+    tool_name: str,
+    run_id: str | None = None,
+    session_id: str | None = None,
+    instance_id: str,
+    role_id: str,
+    args_preview: str | None = None,
+    run_yolo: bool | None = None,
+    approval_mode: ToolApprovalMode | None = None,
+    approval_status: ToolApprovalStatus | None = None,
+    approval_feedback: str | None = None,
+    execution_status: ToolExecutionStatus | None = None,
+    result_envelope: dict[str, JsonValue] | None = None,
+    call_state: dict[str, JsonValue] | None = None,
+) -> PersistedToolCallState:
+    current = await load_tool_call_state_async(
+        shared_store=shared_store,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+    )
+    now = datetime.now(tz=timezone.utc).isoformat()
+    if current is None:
+        current = PersistedToolCallState(
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            run_id=run_id or "",
+            session_id=session_id or "",
+            instance_id=instance_id,
+            role_id=role_id,
+            args_preview=args_preview or "",
+            run_yolo=False if run_yolo is None else run_yolo,
+            approval_mode=(
+                ToolApprovalMode.UNKNOWN if approval_mode is None else approval_mode
+            ),
+            updated_at=now,
+        )
+    update: dict[str, object] = {
+        "tool_name": tool_name,
+        "instance_id": instance_id,
+        "role_id": role_id,
+        "updated_at": now,
+    }
+    if run_id is not None:
+        update["run_id"] = run_id
+    if session_id is not None:
+        update["session_id"] = session_id
+    if args_preview is not None:
+        update["args_preview"] = args_preview
+    if run_yolo is not None:
+        update["run_yolo"] = run_yolo
+    if approval_mode is not None:
+        update["approval_mode"] = approval_mode
+    if approval_status is not None:
+        update["approval_status"] = approval_status
+    if approval_feedback is not None:
+        update["approval_feedback"] = approval_feedback
+    if execution_status is not None:
+        update["execution_status"] = execution_status
+    if result_envelope is not None:
+        update["result_envelope"] = result_envelope
+    if call_state is not None:
+        update["call_state"] = call_state
+    next_state = current.model_copy(update=update)
+    await shared_store.manage_state_async(
         StateMutation(
             scope=_task_scope(task_id),
             key=_state_key(tool_call_id),

--- a/src/relay_teams/tools/task_tools/ask_question.py
+++ b/src/relay_teams/tools/task_tools/ask_question.py
@@ -11,6 +11,7 @@ from pydantic_ai import Agent
 
 from relay_teams.logger import get_logger, log_event
 from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_stream import publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
@@ -86,7 +87,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 role_id=ctx.deps.role_id,
             )
             try:
-                _ = repo.upsert_requested(
+                _ = await repo.upsert_requested_async(
                     question_id=question_id,
                     run_id=ctx.deps.run_id,
                     session_id=ctx.deps.session_id,
@@ -110,15 +111,17 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 )
                 is None
             ):
-                return _build_question_result(
+                return await _build_question_result_async(
                     ctx=ctx,
-                    record=_resolve_closed_question(
+                    record=await _resolve_closed_question(
                         repo=repo,
                         question_id=question_id,
                     ),
                 )
-            _set_runtime_phase(ctx, phase=RunRuntimePhase.AWAITING_MANUAL_ACTION)
-            _publish_user_question_event(
+            await _set_runtime_phase_async(
+                ctx, phase=RunRuntimePhase.AWAITING_MANUAL_ACTION
+            )
+            await _publish_user_question_event(
                 ctx=ctx,
                 event_type=RunEventType.USER_QUESTION_REQUESTED,
                 payload={
@@ -156,19 +159,19 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                     reason="timed_out",
                 )
                 try:
-                    resolved_record = repo.resolve(
+                    resolved_record = await repo.resolve_async(
                         question_id=question_id,
                         status=UserQuestionRequestStatus.TIMED_OUT,
                         expected_status=UserQuestionRequestStatus.REQUESTED,
                     )
                 except UserQuestionStatusConflictError:
-                    resolved_record = repo.get(question_id)
+                    resolved_record = await repo.get_async(question_id)
                     if resolved_record is None:
                         raise KeyError(
                             f"Unknown user question: {question_id}"
                         ) from None
                 if resolved_record.status == UserQuestionRequestStatus.TIMED_OUT:
-                    _publish_user_question_event(
+                    await _publish_user_question_event(
                         ctx=ctx,
                         event_type=RunEventType.USER_QUESTION_ANSWERED,
                         payload={
@@ -178,7 +181,9 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                             "role_id": ctx.deps.role_id,
                         },
                     )
-                return _build_question_result(ctx=ctx, record=resolved_record)
+                return await _build_question_result_async(
+                    ctx=ctx, record=resolved_record
+                )
             except UserQuestionClosedError:
                 manager.close_question(
                     run_id=ctx.deps.run_id,
@@ -199,10 +204,10 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 question_id=question_id,
                 reason="answered",
             )
-            completed_record = repo.mark_completed(question_id)
+            completed_record = await repo.mark_completed_async(question_id)
             if completed_record is None:
                 raise KeyError(f"Unknown user question: {question_id}")
-            return _build_question_result(
+            return await _build_question_result_async(
                 ctx=ctx,
                 record=completed_record.model_copy(
                     update={
@@ -221,13 +226,14 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         )
 
 
-def _publish_user_question_event(
+async def _publish_user_question_event(
     *,
     ctx: ToolContext,
     event_type: RunEventType,
     payload: dict[str, JsonValue],
 ) -> None:
-    ctx.deps.run_event_hub.publish(
+    await publish_run_event_async(
+        ctx.deps.run_event_hub,
         RunEvent(
             session_id=ctx.deps.session_id,
             run_id=ctx.deps.run_id,
@@ -237,7 +243,38 @@ def _publish_user_question_event(
             role_id=ctx.deps.role_id,
             event_type=event_type,
             payload_json=dumps(payload, ensure_ascii=False),
-        )
+        ),
+    )
+
+
+async def _set_runtime_phase_async(ctx: ToolContext, *, phase: RunRuntimePhase) -> None:
+    runtime = await ctx.deps.run_runtime_repo.ensure_async(
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        root_task_id=ctx.deps.task_id,
+    )
+    if runtime.status in {
+        RunRuntimeStatus.STOPPING,
+        RunRuntimeStatus.STOPPED,
+    }:
+        return
+    await ctx.deps.run_runtime_repo.update_async(
+        ctx.deps.run_id,
+        status=(
+            RunRuntimeStatus.PAUSED
+            if phase == RunRuntimePhase.AWAITING_MANUAL_ACTION
+            else RunRuntimeStatus.RUNNING
+        ),
+        phase=phase,
+        active_instance_id=ctx.deps.instance_id,
+        active_task_id=ctx.deps.task_id,
+        active_role_id=ctx.deps.role_id,
+        active_subagent_instance_id=(
+            None
+            if ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id)
+            else ctx.deps.instance_id
+        ),
+        last_error=None,
     )
 
 
@@ -278,13 +315,13 @@ def _running_phase(ctx: ToolContext) -> RunRuntimePhase:
     return RunRuntimePhase.SUBAGENT_RUNNING
 
 
-def _build_question_result(
+async def _build_question_result_async(
     *,
     ctx: ToolContext,
     record: UserQuestionRequestRecord,
 ) -> ToolResultProjection:
     if record.status == UserQuestionRequestStatus.ANSWERED:
-        _set_runtime_phase(ctx, phase=_running_phase(ctx))
+        await _set_runtime_phase_async(ctx, phase=_running_phase(ctx))
         answers_payload: list[JsonValue] = [
             answer.model_dump(mode="json") for answer in record.answers
         ]
@@ -298,7 +335,7 @@ def _build_question_result(
             internal_data=payload,
         )
     if record.status == UserQuestionRequestStatus.TIMED_OUT:
-        _set_runtime_phase(ctx, phase=_running_phase(ctx))
+        await _set_runtime_phase_async(ctx, phase=_running_phase(ctx))
         payload = {
             "status": "timed_out",
             "question_id": record.question_id,
@@ -317,20 +354,20 @@ def _build_question_result(
     )
 
 
-def _resolve_closed_question(
+async def _resolve_closed_question(
     *,
     repo: UserQuestionRepository,
     question_id: str,
 ) -> UserQuestionRequestRecord:
     resolved_record = None
     try:
-        resolved_record = repo.resolve(
+        resolved_record = await repo.resolve_async(
             question_id=question_id,
             status=UserQuestionRequestStatus.COMPLETED,
             expected_status=UserQuestionRequestStatus.REQUESTED,
         )
     except UserQuestionStatusConflictError:
-        resolved_record = repo.get(question_id)
+        resolved_record = await repo.get_async(question_id)
     if resolved_record is None:
         raise KeyError(f"Unknown user question: {question_id}")
     return resolved_record

--- a/src/relay_teams/tools/workspace_tools/read_support.py
+++ b/src/relay_teams/tools/workspace_tools/read_support.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from pydantic import JsonValue
 
 from relay_teams.agents.execution.prompt_instruction_state import (
-    filter_unloaded_prompt_instruction_paths,
-    record_prompt_instruction_paths_loaded,
+    filter_unloaded_prompt_instruction_paths_async,
+    record_prompt_instruction_paths_loaded_async,
 )
 from relay_teams.agents.execution.prompt_instructions import PromptInstructionResolver
 from relay_teams.tools.runtime.context import ToolDeps
@@ -97,7 +97,7 @@ async def resolve_read_instruction_sections(
         file_path=file_path,
         workspace_root=deps.workspace.scope_root,
     )
-    unresolved_paths = filter_unloaded_prompt_instruction_paths(
+    unresolved_paths = await filter_unloaded_prompt_instruction_paths_async(
         shared_store=deps.shared_store,
         task_id=deps.task_id,
         paths=candidate_paths,
@@ -105,7 +105,7 @@ async def resolve_read_instruction_sections(
     if not unresolved_paths:
         return ()
     loaded = await resolver.load_paths(unresolved_paths)
-    record_prompt_instruction_paths_loaded(
+    await record_prompt_instruction_paths_loaded_async(
         shared_store=deps.shared_store,
         task_id=deps.task_id,
         paths=loaded.local_paths,

--- a/src/relay_teams/tools/workspace_tools/shell_approval_repo.py
+++ b/src/relay_teams/tools/workspace_tools/shell_approval_repo.py
@@ -6,12 +6,12 @@ import sqlite3
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from threading import RLock
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.tools.workspace_tools.shell_policy import ShellRuntimeFamily
 from relay_teams.validation import (
     parse_persisted_datetime_or_none,
@@ -37,12 +37,9 @@ class ShellApprovalGrant(BaseModel):
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
-class ShellApprovalRepository:
+class ShellApprovalRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -125,6 +122,22 @@ class ShellApprovalRepository:
             raise RuntimeError("Failed to persist shell approval grant")
         return record
 
+    async def grant_async(
+        self,
+        *,
+        workspace_key: str,
+        runtime_family: ShellRuntimeFamily,
+        scope: ShellApprovalScope,
+        value: str,
+    ) -> ShellApprovalGrant:
+        return await self._call_sync_async(
+            self.grant,
+            workspace_key=workspace_key,
+            runtime_family=runtime_family,
+            scope=scope,
+            value=value,
+        )
+
     def get(
         self,
         *,
@@ -150,6 +163,22 @@ class ShellApprovalRepository:
             return None
         return self._row_to_record(row)
 
+    async def get_async(
+        self,
+        *,
+        workspace_key: str,
+        runtime_family: ShellRuntimeFamily,
+        scope: ShellApprovalScope,
+        value: str,
+    ) -> ShellApprovalGrant | None:
+        return await self._call_sync_async(
+            self.get,
+            workspace_key=workspace_key,
+            runtime_family=runtime_family,
+            scope=scope,
+            value=value,
+        )
+
     def has_exact_grant(
         self,
         *,
@@ -165,6 +194,20 @@ class ShellApprovalRepository:
                 value=normalized_command,
             )
             is not None
+        )
+
+    async def has_exact_grant_async(
+        self,
+        *,
+        workspace_key: str,
+        runtime_family: ShellRuntimeFamily,
+        normalized_command: str,
+    ) -> bool:
+        return await self._call_sync_async(
+            self.has_exact_grant,
+            workspace_key=workspace_key,
+            runtime_family=runtime_family,
+            normalized_command=normalized_command,
         )
 
     def has_prefix_grants(
@@ -190,6 +233,20 @@ class ShellApprovalRepository:
             ).fetchall()
         granted_values = {str(row["value"]) for row in rows}
         return all(candidate in granted_values for candidate in prefix_candidates)
+
+    async def has_prefix_grants_async(
+        self,
+        *,
+        workspace_key: str,
+        runtime_family: ShellRuntimeFamily,
+        prefix_candidates: tuple[str, ...],
+    ) -> bool:
+        return await self._call_sync_async(
+            self.has_prefix_grants,
+            workspace_key=workspace_key,
+            runtime_family=runtime_family,
+            prefix_candidates=prefix_candidates,
+        )
 
     def _row_to_record(self, row: sqlite3.Row) -> ShellApprovalGrant:
         created_at = parse_persisted_datetime_or_none(row["created_at"])

--- a/src/relay_teams/triggers/repository.py
+++ b/src/relay_teams/triggers/repository.py
@@ -292,6 +292,11 @@ class TriggerRepository(SharedSqliteRepository):
             raise
         return record
 
+    async def create_account_async(
+        self, record: GitHubTriggerAccountRecord
+    ) -> GitHubTriggerAccountRecord:
+        return await self._call_sync_async(self.create_account, record)
+
     def update_account(
         self,
         record: GitHubTriggerAccountRecord,
@@ -331,6 +336,11 @@ class TriggerRepository(SharedSqliteRepository):
             raise
         return record
 
+    async def update_account_async(
+        self, record: GitHubTriggerAccountRecord
+    ) -> GitHubTriggerAccountRecord:
+        return await self._call_sync_async(self.update_account, record)
+
     def get_account(self, account_id: str) -> GitHubTriggerAccountRecord:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -342,6 +352,9 @@ class TriggerRepository(SharedSqliteRepository):
             raise KeyError(f"Unknown GitHub trigger account: {account_id}")
         return self._to_account_record(row)
 
+    async def get_account_async(self, account_id: str) -> GitHubTriggerAccountRecord:
+        return await self._call_sync_async(self.get_account, account_id)
+
     def list_accounts(self) -> tuple[GitHubTriggerAccountRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -352,6 +365,9 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_account_record(row) for row in rows)
+
+    async def list_accounts_async(self) -> tuple[GitHubTriggerAccountRecord, ...]:
+        return await self._call_sync_async(self.list_accounts)
 
     def delete_account(self, account_id: str) -> None:
         self._run_write(
@@ -383,6 +399,9 @@ class TriggerRepository(SharedSqliteRepository):
                 ),
             ),
         )
+
+    async def delete_account_async(self, account_id: str) -> None:
+        return await self._call_sync_async(self.delete_account, account_id)
 
     def create_repo_subscription(
         self,
@@ -428,6 +447,11 @@ class TriggerRepository(SharedSqliteRepository):
                 ) from exc
             raise
         return record
+
+    async def create_repo_subscription_async(
+        self, record: GitHubRepoSubscriptionRecord
+    ) -> GitHubRepoSubscriptionRecord:
+        return await self._call_sync_async(self.create_repo_subscription, record)
 
     def update_repo_subscription(
         self,
@@ -482,6 +506,11 @@ class TriggerRepository(SharedSqliteRepository):
             raise
         return record
 
+    async def update_repo_subscription_async(
+        self, record: GitHubRepoSubscriptionRecord
+    ) -> GitHubRepoSubscriptionRecord:
+        return await self._call_sync_async(self.update_repo_subscription, record)
+
     def get_repo_subscription(
         self, repo_subscription_id: str
     ) -> GitHubRepoSubscriptionRecord:
@@ -498,6 +527,13 @@ class TriggerRepository(SharedSqliteRepository):
             raise KeyError(f"Unknown GitHub repo subscription: {repo_subscription_id}")
         return self._to_repo_subscription_record(row)
 
+    async def get_repo_subscription_async(
+        self, repo_subscription_id: str
+    ) -> GitHubRepoSubscriptionRecord:
+        return await self._call_sync_async(
+            self.get_repo_subscription, repo_subscription_id
+        )
+
     def list_repo_subscriptions(self) -> tuple[GitHubRepoSubscriptionRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -508,6 +544,11 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_repo_subscription_record(row) for row in rows)
+
+    async def list_repo_subscriptions_async(
+        self,
+    ) -> tuple[GitHubRepoSubscriptionRecord, ...]:
+        return await self._call_sync_async(self.list_repo_subscriptions)
 
     def list_repo_subscriptions_by_full_name(
         self,
@@ -530,6 +571,15 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return tuple(self._to_repo_subscription_record(row) for row in rows)
 
+    async def list_repo_subscriptions_by_full_name_async(
+        self, full_name: str, *, enabled_only: bool = False
+    ) -> tuple[GitHubRepoSubscriptionRecord, ...]:
+        return await self._call_sync_async(
+            self.list_repo_subscriptions_by_full_name,
+            full_name,
+            enabled_only=enabled_only,
+        )
+
     def list_repo_subscriptions_by_account(
         self,
         account_id: str,
@@ -545,6 +595,13 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_repo_subscription_record(row) for row in rows)
+
+    async def list_repo_subscriptions_by_account_async(
+        self, account_id: str
+    ) -> tuple[GitHubRepoSubscriptionRecord, ...]:
+        return await self._call_sync_async(
+            self.list_repo_subscriptions_by_account, account_id
+        )
 
     def delete_repo_subscription(self, repo_subscription_id: str) -> None:
         self._run_write(
@@ -571,6 +628,11 @@ class TriggerRepository(SharedSqliteRepository):
                     (repo_subscription_id,),
                 ),
             ),
+        )
+
+    async def delete_repo_subscription_async(self, repo_subscription_id: str) -> None:
+        return await self._call_sync_async(
+            self.delete_repo_subscription, repo_subscription_id
         )
 
     def create_rule(self, record: TriggerRuleRecord) -> TriggerRuleRecord:
@@ -610,6 +672,9 @@ class TriggerRepository(SharedSqliteRepository):
                 ) from exc
             raise
         return record
+
+    async def create_rule_async(self, record: TriggerRuleRecord) -> TriggerRuleRecord:
+        return await self._call_sync_async(self.create_rule, record)
 
     def update_rule(self, record: TriggerRuleRecord) -> TriggerRuleRecord:
         try:
@@ -655,6 +720,9 @@ class TriggerRepository(SharedSqliteRepository):
             raise
         return record
 
+    async def update_rule_async(self, record: TriggerRuleRecord) -> TriggerRuleRecord:
+        return await self._call_sync_async(self.update_rule, record)
+
     def get_rule(self, trigger_rule_id: str) -> TriggerRuleRecord:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -666,6 +734,9 @@ class TriggerRepository(SharedSqliteRepository):
             raise KeyError(f"Unknown trigger rule: {trigger_rule_id}")
         return self._to_rule_record(row)
 
+    async def get_rule_async(self, trigger_rule_id: str) -> TriggerRuleRecord:
+        return await self._call_sync_async(self.get_rule, trigger_rule_id)
+
     def list_rules(self) -> tuple[TriggerRuleRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -676,6 +747,9 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_rule_record(row) for row in rows)
+
+    async def list_rules_async(self) -> tuple[TriggerRuleRecord, ...]:
+        return await self._call_sync_async(self.list_rules)
 
     def list_enabled_rules_for_repo(
         self,
@@ -692,6 +766,13 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_rule_record(row) for row in rows)
+
+    async def list_enabled_rules_for_repo_async(
+        self, repo_subscription_id: str
+    ) -> tuple[TriggerRuleRecord, ...]:
+        return await self._call_sync_async(
+            self.list_enabled_rules_for_repo, repo_subscription_id
+        )
 
     def delete_rule(self, trigger_rule_id: str) -> None:
         self._run_write(
@@ -715,6 +796,9 @@ class TriggerRepository(SharedSqliteRepository):
                 ),
             ),
         )
+
+    async def delete_rule_async(self, trigger_rule_id: str) -> None:
+        return await self._call_sync_async(self.delete_rule, trigger_rule_id)
 
     def create_delivery(self, record: TriggerDeliveryRecord) -> TriggerDeliveryRecord:
         try:
@@ -761,6 +845,11 @@ class TriggerRepository(SharedSqliteRepository):
             raise
         return record
 
+    async def create_delivery_async(
+        self, record: TriggerDeliveryRecord
+    ) -> TriggerDeliveryRecord:
+        return await self._call_sync_async(self.create_delivery, record)
+
     def update_delivery(self, record: TriggerDeliveryRecord) -> TriggerDeliveryRecord:
         self._run_write(
             operation_name="update_delivery",
@@ -798,6 +887,11 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return record
 
+    async def update_delivery_async(
+        self, record: TriggerDeliveryRecord
+    ) -> TriggerDeliveryRecord:
+        return await self._call_sync_async(self.update_delivery, record)
+
     def get_delivery(self, trigger_delivery_id: str) -> TriggerDeliveryRecord:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -808,6 +902,11 @@ class TriggerRepository(SharedSqliteRepository):
         if row is None:
             raise KeyError(f"Unknown trigger delivery: {trigger_delivery_id}")
         return self._to_delivery_record(row)
+
+    async def get_delivery_async(
+        self, trigger_delivery_id: str
+    ) -> TriggerDeliveryRecord:
+        return await self._call_sync_async(self.get_delivery, trigger_delivery_id)
 
     def get_delivery_by_provider_id(
         self,
@@ -828,6 +927,15 @@ class TriggerRepository(SharedSqliteRepository):
             return None
         return self._to_delivery_record(row)
 
+    async def get_delivery_by_provider_id_async(
+        self, *, provider: str, provider_delivery_id: str
+    ) -> TriggerDeliveryRecord | None:
+        return await self._call_sync_async(
+            self.get_delivery_by_provider_id,
+            provider=provider,
+            provider_delivery_id=provider_delivery_id,
+        )
+
     def list_deliveries(self) -> tuple[TriggerDeliveryRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -838,6 +946,9 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_delivery_record(row) for row in rows)
+
+    async def list_deliveries_async(self) -> tuple[TriggerDeliveryRecord, ...]:
+        return await self._call_sync_async(self.list_deliveries)
 
     def create_evaluation(
         self,
@@ -866,6 +977,11 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return record
 
+    async def create_evaluation_async(
+        self, record: TriggerEvaluationRecord
+    ) -> TriggerEvaluationRecord:
+        return await self._call_sync_async(self.create_evaluation, record)
+
     def list_evaluations_by_delivery(
         self,
         trigger_delivery_id: str,
@@ -881,6 +997,13 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_evaluation_record(row) for row in rows)
+
+    async def list_evaluations_by_delivery_async(
+        self, trigger_delivery_id: str
+    ) -> tuple[TriggerEvaluationRecord, ...]:
+        return await self._call_sync_async(
+            self.list_evaluations_by_delivery, trigger_delivery_id
+        )
 
     def create_dispatch(self, record: TriggerDispatchRecord) -> TriggerDispatchRecord:
         self._run_write(
@@ -913,6 +1036,11 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return record
 
+    async def create_dispatch_async(
+        self, record: TriggerDispatchRecord
+    ) -> TriggerDispatchRecord:
+        return await self._call_sync_async(self.create_dispatch, record)
+
     def update_dispatch(self, record: TriggerDispatchRecord) -> TriggerDispatchRecord:
         self._run_write(
             operation_name="update_dispatch",
@@ -944,6 +1072,11 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return record
 
+    async def update_dispatch_async(
+        self, record: TriggerDispatchRecord
+    ) -> TriggerDispatchRecord:
+        return await self._call_sync_async(self.update_dispatch, record)
+
     def get_dispatch(self, trigger_dispatch_id: str) -> TriggerDispatchRecord:
         row = self._run_read(
             lambda: self._conn.execute(
@@ -955,6 +1088,11 @@ class TriggerRepository(SharedSqliteRepository):
             raise KeyError(f"Unknown trigger dispatch: {trigger_dispatch_id}")
         return self._to_dispatch_record(row)
 
+    async def get_dispatch_async(
+        self, trigger_dispatch_id: str
+    ) -> TriggerDispatchRecord:
+        return await self._call_sync_async(self.get_dispatch, trigger_dispatch_id)
+
     def list_dispatches(self) -> tuple[TriggerDispatchRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -965,6 +1103,9 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_dispatch_record(row) for row in rows)
+
+    async def list_dispatches_async(self) -> tuple[TriggerDispatchRecord, ...]:
+        return await self._call_sync_async(self.list_dispatches)
 
     def list_dispatches_by_delivery(
         self,
@@ -982,6 +1123,13 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return tuple(self._to_dispatch_record(row) for row in rows)
 
+    async def list_dispatches_by_delivery_async(
+        self, trigger_delivery_id: str
+    ) -> tuple[TriggerDispatchRecord, ...]:
+        return await self._call_sync_async(
+            self.list_dispatches_by_delivery, trigger_delivery_id
+        )
+
     def list_open_dispatches(self) -> tuple[TriggerDispatchRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -993,6 +1141,9 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_dispatch_record(row) for row in rows)
+
+    async def list_open_dispatches_async(self) -> tuple[TriggerDispatchRecord, ...]:
+        return await self._call_sync_async(self.list_open_dispatches)
 
     def create_action_attempt(
         self,
@@ -1029,6 +1180,11 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return record
 
+    async def create_action_attempt_async(
+        self, record: TriggerActionAttemptRecord
+    ) -> TriggerActionAttemptRecord:
+        return await self._call_sync_async(self.create_action_attempt, record)
+
     def update_action_attempt(
         self,
         record: TriggerActionAttemptRecord,
@@ -1063,6 +1219,11 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return record
 
+    async def update_action_attempt_async(
+        self, record: TriggerActionAttemptRecord
+    ) -> TriggerActionAttemptRecord:
+        return await self._call_sync_async(self.update_action_attempt, record)
+
     def list_action_attempts(self) -> tuple[TriggerActionAttemptRecord, ...]:
         rows = self._run_read(
             lambda: self._conn.execute(
@@ -1073,6 +1234,11 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_action_attempt_record(row) for row in rows)
+
+    async def list_action_attempts_async(
+        self,
+    ) -> tuple[TriggerActionAttemptRecord, ...]:
+        return await self._call_sync_async(self.list_action_attempts)
 
     def list_action_attempts_by_dispatch(
         self,
@@ -1090,6 +1256,13 @@ class TriggerRepository(SharedSqliteRepository):
         )
         return tuple(self._to_action_attempt_record(row) for row in rows)
 
+    async def list_action_attempts_by_dispatch_async(
+        self, trigger_dispatch_id: str
+    ) -> tuple[TriggerActionAttemptRecord, ...]:
+        return await self._call_sync_async(
+            self.list_action_attempts_by_dispatch, trigger_dispatch_id
+        )
+
     def list_pending_action_attempts(
         self,
     ) -> tuple[TriggerActionAttemptRecord, ...]:
@@ -1103,6 +1276,11 @@ class TriggerRepository(SharedSqliteRepository):
             ).fetchall()
         )
         return tuple(self._to_action_attempt_record(row) for row in rows)
+
+    async def list_pending_action_attempts_async(
+        self,
+    ) -> tuple[TriggerActionAttemptRecord, ...]:
+        return await self._call_sync_async(self.list_pending_action_attempts)
 
     @staticmethod
     def _to_account_record(row: sqlite3.Row) -> GitHubTriggerAccountRecord:

--- a/src/relay_teams/workspace/ssh_profile_repository.py
+++ b/src/relay_teams/workspace/ssh_profile_repository.py
@@ -5,12 +5,12 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic import JsonValue
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.validation import (
     parse_persisted_datetime_or_none,
     require_persisted_identifier,
@@ -23,12 +23,9 @@ from relay_teams.workspace.ssh_profile_models import (
 LOGGER = get_logger(__name__)
 
 
-class SshProfileRepository:
+class SshProfileRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -76,6 +73,9 @@ class SshProfileRepository:
                 _log_invalid_profile_row(row=row, error=exc)
         return tuple(records)
 
+    async def list_all_async(self) -> tuple[SshProfileRecord, ...]:
+        return await self._call_sync_async(self.list_all)
+
     def get(self, ssh_profile_id: str) -> SshProfileRecord:
         with self._lock:
             row = self._conn.execute(
@@ -89,6 +89,9 @@ class SshProfileRepository:
         except ValueError as exc:
             _log_invalid_profile_row(row=row, error=exc)
             raise KeyError(f"Unknown ssh_profile_id: {ssh_profile_id}") from exc
+
+    async def get_async(self, ssh_profile_id: str) -> SshProfileRecord:
+        return await self._call_sync_async(self.get, ssh_profile_id)
 
     def save(
         self,
@@ -166,6 +169,13 @@ class SshProfileRepository:
         )
         return record
 
+    async def save_async(
+        self, *, ssh_profile_id: str, config: SshProfileStoredConfig
+    ) -> SshProfileRecord:
+        return await self._call_sync_async(
+            self.save, ssh_profile_id=ssh_profile_id, config=config
+        )
+
     def delete(self, ssh_profile_id: str) -> None:
         def operation() -> None:
             self._conn.execute(
@@ -182,6 +192,9 @@ class SshProfileRepository:
             operation_name="delete",
         )
 
+    async def delete_async(self, ssh_profile_id: str) -> None:
+        return await self._call_sync_async(self.delete, ssh_profile_id)
+
     def exists(self, ssh_profile_id: str) -> bool:
         with self._lock:
             row = self._conn.execute(
@@ -189,6 +202,9 @@ class SshProfileRepository:
                 (ssh_profile_id,),
             ).fetchone()
         return row is not None
+
+    async def exists_async(self, ssh_profile_id: str) -> bool:
+        return await self._call_sync_async(self.exists, ssh_profile_id)
 
     def _to_record(self, row: sqlite3.Row) -> SshProfileRecord:
         ssh_profile_id = require_persisted_identifier(

--- a/src/relay_teams/workspace/workspace_repository.py
+++ b/src/relay_teams/workspace/workspace_repository.py
@@ -6,12 +6,12 @@ import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
 
 from pydantic import JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
-from relay_teams.persistence.db import open_sqlite, run_sqlite_write_with_retry
+from relay_teams.persistence.db import run_sqlite_write_with_retry
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.validation import (
     parse_persisted_datetime_or_none,
     require_persisted_identifier,
@@ -32,12 +32,9 @@ from relay_teams.workspace.workspace_models import (
 LOGGER = get_logger(__name__)
 
 
-class WorkspaceRepository:
+class WorkspaceRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
-        self._db_path = Path(db_path)
-        self._conn = open_sqlite(db_path)
-        self._conn.row_factory = sqlite3.Row
-        self._lock = RLock()
+        super().__init__(db_path)
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -179,6 +176,24 @@ class WorkspaceRepository:
         )
         return record
 
+    async def create_async(
+        self,
+        *,
+        workspace_id: str,
+        mounts: tuple[WorkspaceMountRecord, ...] | None = None,
+        default_mount_name: str = "default",
+        root_path: Path | None = None,
+        profile: WorkspaceProfile | None = None,
+    ) -> WorkspaceRecord:
+        return await self._call_sync_async(
+            self.create,
+            workspace_id=workspace_id,
+            mounts=mounts,
+            default_mount_name=default_mount_name,
+            root_path=root_path,
+            profile=profile,
+        )
+
     def get(self, workspace_id: str) -> WorkspaceRecord:
         with self._lock:
             row = self._conn.execute(
@@ -206,6 +221,9 @@ class WorkspaceRepository:
         except (ValidationError, ValueError, json.JSONDecodeError) as exc:
             _log_invalid_workspace_row(row=row, error=exc)
             raise KeyError(f"Unknown workspace_id: {workspace_id}") from exc
+
+    async def get_async(self, workspace_id: str) -> WorkspaceRecord:
+        return await self._call_sync_async(self.get, workspace_id)
 
     def update(
         self,
@@ -268,6 +286,20 @@ class WorkspaceRepository:
         )
         return record
 
+    async def update_async(
+        self,
+        *,
+        workspace_id: str,
+        mounts: tuple[WorkspaceMountRecord, ...],
+        default_mount_name: str,
+    ) -> WorkspaceRecord:
+        return await self._call_sync_async(
+            self.update,
+            workspace_id=workspace_id,
+            mounts=mounts,
+            default_mount_name=default_mount_name,
+        )
+
     def list_all(self) -> tuple[WorkspaceRecord, ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -304,6 +336,9 @@ class WorkspaceRepository:
                 _log_invalid_workspace_row(row=row, error=exc)
         return tuple(records)
 
+    async def list_all_async(self) -> tuple[WorkspaceRecord, ...]:
+        return await self._call_sync_async(self.list_all)
+
     def delete(self, workspace_id: str) -> None:
         def operation() -> None:
             self._conn.execute(
@@ -324,6 +359,9 @@ class WorkspaceRepository:
             operation_name="delete",
         )
 
+    async def delete_async(self, workspace_id: str) -> None:
+        return await self._call_sync_async(self.delete, workspace_id)
+
     def exists(self, workspace_id: str) -> bool:
         with self._lock:
             row = self._conn.execute(
@@ -331,6 +369,9 @@ class WorkspaceRepository:
                 (workspace_id,),
             ).fetchone()
         return row is not None
+
+    async def exists_async(self, workspace_id: str) -> bool:
+        return await self._call_sync_async(self.exists, workspace_id)
 
     def _insert_mount_row(
         self,

--- a/tests/unit_tests/agents/execution/session_prompt_support_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_prompt_support_test_cases.py
@@ -545,6 +545,10 @@ async def test_build_agent_iteration_context_does_not_override_proxy_env_when_ho
     )
 
     assert captured["merged_env"] is None
+    assert (
+        captured["llm_http_client_cache_scope"]
+        == "run-1:session-1:task-1:inst-1:writer"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/session_recovery_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_recovery_test_cases.py
@@ -30,6 +30,8 @@ from .agent_llm_session_test_support import (
     recovery_module,
 )
 
+EXPECTED_LLM_HTTP_CLIENT_CACHE_SCOPE = "run-1:session-1:task-1:inst-1:writer"
+
 
 @pytest.mark.asyncio
 async def test_execute_attempt_recovery_clears_cached_transport_before_retry(
@@ -51,7 +53,7 @@ async def test_execute_attempt_recovery_clears_cached_transport_before_retry(
     cleared: list[str] = []
 
     async def _reset_llm_http_client_cache_entry(**kwargs: object) -> None:
-        assert kwargs["cache_scope"] == "run-1"
+        assert kwargs["cache_scope"] == EXPECTED_LLM_HTTP_CLIENT_CACHE_SCOPE
         cleared.append("cleared")
 
     monkeypatch.setattr(
@@ -131,7 +133,7 @@ async def test_execute_attempt_recovery_keeps_cached_transport_for_non_transport
     cleared: list[str] = []
 
     async def _reset_llm_http_client_cache_entry(**kwargs: object) -> None:
-        assert kwargs["cache_scope"] == "run-1"
+        assert kwargs["cache_scope"] == EXPECTED_LLM_HTTP_CLIENT_CACHE_SCOPE
         cleared.append("cleared")
 
     monkeypatch.setattr(
@@ -207,7 +209,7 @@ async def test_execute_attempt_recovery_clears_cached_transport_before_resume(
     cleared: list[str] = []
 
     async def _reset_llm_http_client_cache_entry(**kwargs: object) -> None:
-        assert kwargs["cache_scope"] == "run-1"
+        assert kwargs["cache_scope"] == EXPECTED_LLM_HTTP_CLIENT_CACHE_SCOPE
         cleared.append("cleared")
 
     monkeypatch.setattr(

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -2,60 +2,66 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
+from collections.abc import AsyncIterator
 from pathlib import Path
-
-import pytest
-from pydantic_ai.messages import ModelRequest, UserPromptPart
 from typing import cast
 
+import pytest
+import pytest_asyncio
+from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.agents.execution.system_prompts import RuntimePromptBuilder
+from relay_teams.agents.execution.system_prompts import RuntimePromptSections
+from relay_teams.agents.instances.enums import InstanceStatus
+from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
+from relay_teams.agents.instances.models import create_subagent_instance
+from relay_teams.agents.orchestration.task_execution_service import TaskExecutionService
+from relay_teams.agents.tasks.enums import TaskStatus
+from relay_teams.agents.tasks.events import EventType
+from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
+from relay_teams.agents.tasks.task_repository import TaskRepository
+from relay_teams.hooks import HookService
 from relay_teams.media import (
     MediaAssetRepository,
     MediaAssetService,
     content_parts_from_text,
 )
-from relay_teams.agents.instances.enums import InstanceStatus
-from relay_teams.agents.instances.models import create_subagent_instance
-from relay_teams.agents.orchestration.task_execution_service import TaskExecutionService
-from relay_teams.agents.execution.system_prompts import RuntimePromptBuilder
-from relay_teams.agents.execution.system_prompts import RuntimePromptSections
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
+from relay_teams.reminders import ReminderStateRepository, SystemReminderService
 from relay_teams.retrieval import RetrievalService, SqliteFts5RetrievalStore
 from relay_teams.roles.memory_repository import RoleMemoryRepository
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
-from relay_teams.sessions.runs.run_control_manager import RunControlManager
-from relay_teams.sessions.runs.event_stream import RunEventHub
-from relay_teams.sessions.runs.injection_queue import RunInjectionManager
-from relay_teams.sessions.runs.system_injection import SystemInjectionSink
-from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
-from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
-from relay_teams.sessions.runs.event_log import EventLog
-from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
-from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.run_models import (
     IntentInput,
     RuntimePromptConversationContext,
     RunThinkingConfig,
 )
-from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
-from relay_teams.sessions.runs.todo_models import TodoItem, TodoStatus
-from relay_teams.sessions.runs.todo_repository import TodoRepository
-from relay_teams.sessions.runs.todo_service import TodoService
+from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
+from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.recoverable_pause import (
     RecoverableRunPauseError,
     RecoverableRunPausePayload,
 )
+from relay_teams.sessions.runs.run_control_manager import RunControlManager
+from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
     RunRuntimeRepository,
     RunRuntimeStatus,
 )
-from relay_teams.persistence.shared_state_repo import SharedStateRepository
-from relay_teams.reminders import ReminderStateRepository, SystemReminderService
-from relay_teams.agents.tasks.task_repository import TaskRepository
-from relay_teams.skills.skill_registry import SkillRegistry
+from relay_teams.sessions.runs.system_injection import SystemInjectionSink
+from relay_teams.sessions.runs.todo_models import TodoItem, TodoStatus
+from relay_teams.sessions.runs.todo_repository import TodoRepository
+from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.skills.skill_routing_service import SkillRuntimeService
 from relay_teams.skills.skill_routing_models import (
     SkillPromptResult,
@@ -63,15 +69,25 @@ from relay_teams.skills.skill_routing_models import (
     SkillRoutingMode,
     SkillRoutingResult,
 )
+from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry.defaults import build_default_registry
+from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.workspace import (
     WorkspaceManager,
     build_conversation_id,
 )
-from relay_teams.agents.tasks.enums import TaskStatus
-from relay_teams.agents.tasks.events import EventType
-from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
-from relay_teams.hooks import HookService
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _close_async_sqlite_repositories_after_test() -> AsyncIterator[None]:
+    yield
+    repositories = tuple(
+        repository
+        for repository in gc.get_objects()
+        if isinstance(repository, SharedSqliteRepository)
+    )
+    for repository in repositories:
+        await repository.close_async()
 
 
 class _CapturingProvider:

--- a/tests/unit_tests/agents/tasks/test_task_repository.py
+++ b/tests/unit_tests/agents/tasks/test_task_repository.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 from pathlib import Path
+
+import pytest
 
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.agents.tasks.enums import TaskStatus
@@ -59,3 +63,95 @@ def test_update_status_clears_stale_result_when_task_restarts(tmp_path: Path) ->
     assert completed.status == TaskStatus.COMPLETED
     assert completed.result == "second result"
     assert completed.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_async_task_repository_methods_share_persisted_state(
+    tmp_path: Path,
+) -> None:
+    repo = TaskRepository(tmp_path / "task_repo_async.db")
+    envelope = TaskEnvelope(
+        task_id="task-async",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        objective="demo",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+
+    try:
+        created = await repo.create_async(envelope)
+        await repo.update_status_async(
+            "task-async",
+            TaskStatus.COMPLETED,
+            assigned_instance_id="inst-1",
+            result="done",
+        )
+        by_trace = await repo.list_by_trace_async("run-1")
+        by_session = await repo.list_by_session_async("session-1")
+        fetched = await repo.get_async("task-async")
+    finally:
+        await repo.close_async()
+
+    assert created.envelope.task_id == "task-async"
+    assert tuple(record.envelope.task_id for record in by_trace) == ("task-async",)
+    assert tuple(record.envelope.task_id for record in by_session) == ("task-async",)
+    assert fetched.status == TaskStatus.COMPLETED
+    assert fetched.assigned_instance_id == "inst-1"
+    assert fetched.result == "done"
+
+
+@pytest.mark.asyncio
+async def test_task_repository_async_hot_paths_do_not_reinitialize_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = TaskRepository(tmp_path / "task_repo_async_no_reinit.db")
+    envelope = TaskEnvelope(
+        task_id="task-async",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        objective="demo",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    updated_envelope = envelope.model_copy(update={"objective": "updated"})
+    delete_envelope = TaskEnvelope(
+        task_id="task-delete",
+        session_id="session-delete",
+        parent_task_id=None,
+        trace_id="run-delete",
+        objective="delete",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+
+    async def _fail_init() -> None:
+        raise AssertionError("async schema init should not run on hot paths")
+
+    try:
+        await repo._init_tables_async()
+        monkeypatch.setattr(repo, "_init_tables_async", _fail_init)
+        created = await repo.create_async(envelope)
+        updated = await repo.update_envelope_async("task-async", updated_envelope)
+        await repo.update_status_async(
+            "task-async",
+            TaskStatus.COMPLETED,
+            assigned_instance_id="inst-1",
+            result="done",
+        )
+        fetched = await repo.get_async("task-async")
+        all_records = await repo.list_all_async()
+        by_trace = await repo.list_by_trace_async("run-1")
+        by_session = await repo.list_by_session_async("session-1")
+        await repo.create_async(delete_envelope)
+        await repo.delete_by_session_async("session-delete")
+        await repo.delete_async("task-async")
+    finally:
+        await repo.close_async()
+
+    assert created.envelope.task_id == "task-async"
+    assert updated.envelope.objective == "updated"
+    assert fetched.status == TaskStatus.COMPLETED
+    assert tuple(record.envelope.task_id for record in all_records) == ("task-async",)
+    assert tuple(record.envelope.task_id for record in by_trace) == ("task-async",)
+    assert tuple(record.envelope.task_id for record in by_session) == ("task-async",)

--- a/tests/unit_tests/interfaces/server/test_async_call.py
+++ b/tests/unit_tests/interfaces/server/test_async_call.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import threading
+from collections.abc import Awaitable
+
+import pytest
+
+from relay_teams.interfaces.server.async_call import call_maybe_async
+
+
+@pytest.mark.asyncio
+async def test_call_maybe_async_awaits_coroutine_function() -> None:
+    async def load_value(value: str) -> str:
+        return f"async:{value}"
+
+    assert await call_maybe_async(load_value, "ok") == "async:ok"
+
+
+@pytest.mark.asyncio
+async def test_call_maybe_async_runs_sync_function_off_loop_thread() -> None:
+    loop_thread_id = threading.get_ident()
+
+    def load_value(value: str) -> tuple[str, bool]:
+        return value, threading.get_ident() != loop_thread_id
+
+    assert await call_maybe_async(load_value, "ok") == ("ok", True)
+
+
+@pytest.mark.asyncio
+async def test_call_maybe_async_awaits_sync_function_returned_awaitable() -> None:
+    async def load_value() -> str:
+        return "ok"
+
+    def make_awaitable() -> Awaitable[str]:
+        return load_value()
+
+    assert await call_maybe_async(make_awaitable) == "ok"

--- a/tests/unit_tests/interfaces/server/test_automation_router.py
+++ b/tests/unit_tests/interfaces/server/test_automation_router.py
@@ -386,7 +386,7 @@ def test_automation_routes_run_service_calls_in_threadpool(monkeypatch) -> None:
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(automation, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(automation, "call_maybe_async", fake_run_in_threadpool)
     fake_service = _FakeAutomationService()
     client = _client(fake_service)
 

--- a/tests/unit_tests/interfaces/server/test_feishu_gateway_router.py
+++ b/tests/unit_tests/interfaces/server/test_feishu_gateway_router.py
@@ -183,7 +183,7 @@ def test_feishu_account_routes_run_service_calls_in_threadpool(monkeypatch) -> N
         calls.append(func.__name__)
         return func()
 
-    monkeypatch.setattr(feishu_gateway, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(feishu_gateway, "call_maybe_async", fake_run_in_threadpool)
     gateway_service = _FakeFeishuGatewayService()
     subscription_service = _FakeSubscriptionService()
     client = _client(gateway_service, subscription_service)

--- a/tests/unit_tests/interfaces/server/test_gateway_router.py
+++ b/tests/unit_tests/interfaces/server/test_gateway_router.py
@@ -219,7 +219,7 @@ def test_start_wechat_login_route_runs_service_call_in_threadpool(monkeypatch) -
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(gateway.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(gateway, "call_maybe_async", fake_to_thread)
     client = _client(_FakeWeChatGatewayService())
 
     response = client.post(
@@ -265,7 +265,7 @@ def test_wait_wechat_login_route_runs_service_call_in_threadpool(monkeypatch) ->
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(gateway.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(gateway, "call_maybe_async", fake_to_thread)
     client = _client(_FakeWeChatGatewayService())
 
     response = client.post(
@@ -290,7 +290,7 @@ def test_wechat_account_routes_run_service_calls_in_threadpool(monkeypatch) -> N
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(gateway.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(gateway, "call_maybe_async", fake_to_thread)
     fake_service = _FakeWeChatGatewayService()
     client = _client(fake_service)
 
@@ -385,7 +385,7 @@ def test_xiaoluban_account_routes_run_service_calls_in_threadpool(monkeypatch) -
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(gateway.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(gateway, "call_maybe_async", fake_to_thread)
     fake_xiaoluban_service = _FakeXiaolubanGatewayService()
     client = _client(_FakeWeChatGatewayService(), fake_xiaoluban_service)
 

--- a/tests/unit_tests/interfaces/server/test_logs_router.py
+++ b/tests/unit_tests/interfaces/server/test_logs_router.py
@@ -66,7 +66,7 @@ def test_frontend_logs_route_runs_batch_in_threadpool(
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(logs, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(logs, "call_maybe_async", fake_run_in_threadpool)
     app = FastAPI()
     app.include_router(logs.router, prefix="/api")
     client = TestClient(app)

--- a/tests/unit_tests/interfaces/server/test_observability_router.py
+++ b/tests/unit_tests/interfaces/server/test_observability_router.py
@@ -129,7 +129,7 @@ def test_observability_routes_offload_sync_service_calls(monkeypatch) -> None:
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(observability.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(observability, "call_maybe_async", fake_to_thread)
     client = _create_client()
 
     overview = client.get(

--- a/tests/unit_tests/interfaces/server/test_roles_router.py
+++ b/tests/unit_tests/interfaces/server/test_roles_router.py
@@ -337,7 +337,7 @@ def test_role_config_routes_run_service_calls_in_threadpool(monkeypatch) -> None
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(roles, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(roles, "call_maybe_async", fake_run_in_threadpool)
     client = _create_test_client()
     role_payload = {
         "role_id": "writer",
@@ -386,7 +386,7 @@ def test_get_role_config_options_runs_in_threadpool(
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(roles, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(roles, "call_maybe_async", fake_run_in_threadpool)
     client = _create_test_client()
 
     response = client.get("/api/roles:options")

--- a/tests/unit_tests/interfaces/server/test_runs_router.py
+++ b/tests/unit_tests/interfaces/server/test_runs_router.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
 from typing import cast
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -14,8 +15,10 @@ from relay_teams.media import (
     InlineMediaContentPart,
     MediaModality,
     MediaRefContentPart,
+    content_parts_from_text,
 )
 from relay_teams.sessions.runs.run_models import IntentInput
+from relay_teams.sessions.runs.run_service import SessionRunService
 from relay_teams.sessions.runs.user_question_models import UserQuestionAnswer
 
 
@@ -68,9 +71,15 @@ class _FakeRunService:
         self.created_run_inputs.append(intent_input)
         return ("run-1", "session-1")
 
+    async def create_run_async(self, intent_input) -> tuple[str, str]:
+        return self.create_run(intent_input)
+
     def resume_run(self, run_id: str) -> str:
         self.resumed_run_ids.append(run_id)
         return "session-1"
+
+    async def resume_run_async(self, run_id: str) -> str:
+        return self.resume_run(run_id)
 
     def resolve_tool_approval(
         self,
@@ -85,8 +94,26 @@ class _FakeRunService:
             )
         self.resolved_tool_approvals.append((run_id, tool_call_id, action, feedback))
 
+    async def resolve_tool_approval_async(
+        self,
+        *,
+        run_id: str,
+        tool_call_id: str,
+        action: str,
+        feedback: str = "",
+    ) -> None:
+        self.resolve_tool_approval(
+            run_id=run_id,
+            tool_call_id=tool_call_id,
+            action=action,
+            feedback=feedback,
+        )
+
     def ensure_run_started(self, run_id: str) -> None:
         self.started_run_ids.append(run_id)
+
+    async def ensure_run_started_async(self, run_id: str) -> None:
+        self.ensure_run_started(run_id)
 
     def inject_message(self, *, run_id: str, source, content: str):
         if self.raise_on_inject:
@@ -97,6 +124,9 @@ class _FakeRunService:
             (),
             {"model_dump": lambda self: {"run_id": run_id, "content": content}},
         )()
+
+    async def inject_message_async(self, *, run_id: str, source, content: str):
+        return self.inject_message(run_id=run_id, source=source, content=content)
 
     def inject_subagent_message(
         self,
@@ -109,13 +139,35 @@ class _FakeRunService:
             raise ValueError("Injection content must not be empty")
         self.subagent_inject_calls.append((run_id, instance_id, content))
 
+    async def inject_subagent_message_async(
+        self,
+        *,
+        run_id: str,
+        instance_id: str,
+        content: str,
+    ) -> None:
+        self.inject_subagent_message(
+            run_id=run_id,
+            instance_id=instance_id,
+            content=content,
+        )
+
     def list_background_tasks(self, run_id: str) -> tuple[dict[str, object], ...]:
         _ = run_id
         return tuple(self.background_tasks.values())
 
+    async def list_background_tasks_async(
+        self,
+        run_id: str,
+    ) -> tuple[dict[str, object], ...]:
+        return self.list_background_tasks(run_id)
+
     def get_todo(self, run_id: str) -> dict[str, object]:
         _ = run_id
         return dict(self.todo)
+
+    async def get_todo_async(self, run_id: str) -> dict[str, object]:
+        return self.get_todo(run_id)
 
     def get_background_task(
         self,
@@ -127,6 +179,17 @@ class _FakeRunService:
         if background_task_id not in self.background_tasks:
             raise KeyError(background_task_id)
         return self.background_tasks[background_task_id]
+
+    async def get_background_task_async(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> dict[str, object]:
+        return self.get_background_task(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
 
     async def stop_background_task(
         self,
@@ -145,6 +208,12 @@ class _FakeRunService:
     def list_monitors(self, run_id: str) -> tuple[dict[str, object], ...]:
         _ = run_id
         return tuple(self.monitors.values())
+
+    async def list_monitors_async(
+        self,
+        run_id: str,
+    ) -> tuple[dict[str, object], ...]:
+        return self.list_monitors(run_id)
 
     def create_monitor(
         self,
@@ -178,11 +247,42 @@ class _FakeRunService:
         self.monitors["mon-2"] = monitor
         return monitor
 
+    async def create_monitor_async(
+        self,
+        *,
+        run_id: str,
+        source_kind,
+        source_key: str,
+        rule,
+        action_type,
+        created_by_instance_id: str | None = None,
+        created_by_role_id: str | None = None,
+        tool_call_id: str | None = None,
+    ) -> dict[str, object]:
+        return self.create_monitor(
+            run_id=run_id,
+            source_kind=source_kind,
+            source_key=source_key,
+            rule=rule,
+            action_type=action_type,
+            created_by_instance_id=created_by_instance_id,
+            created_by_role_id=created_by_role_id,
+            tool_call_id=tool_call_id,
+        )
+
     def stop_monitor(self, *, run_id: str, monitor_id: str) -> dict[str, object]:
         _ = run_id
         monitor = self.monitors[monitor_id]
         monitor["status"] = "stopped"
         return monitor
+
+    async def stop_monitor_async(
+        self,
+        *,
+        run_id: str,
+        monitor_id: str,
+    ) -> dict[str, object]:
+        return self.stop_monitor(run_id=run_id, monitor_id=monitor_id)
 
     def answer_user_question(
         self,
@@ -198,6 +298,67 @@ class _FakeRunService:
             "question_id": question_id,
             "answer_count": len(answers.answers),
         }
+
+    async def answer_user_question_async(
+        self,
+        *,
+        run_id: str,
+        question_id: str,
+        answers,
+    ) -> dict[str, object]:
+        return self.answer_user_question(
+            run_id=run_id,
+            question_id=question_id,
+            answers=answers,
+        )
+
+    def list_open_tool_approvals(self, run_id: str) -> list[dict[str, str]]:
+        _ = run_id
+        return []
+
+    async def list_open_tool_approvals_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, str]]:
+        return self.list_open_tool_approvals(run_id)
+
+    def list_user_questions(self, run_id: str) -> list[dict[str, object]]:
+        _ = run_id
+        return []
+
+    async def list_user_questions_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, object]]:
+        return self.list_user_questions(run_id)
+
+    async def stop_run_async(self, run_id: str) -> None:
+        _ = run_id
+
+    async def stop_subagent_async(
+        self,
+        run_id: str,
+        instance_id: str,
+    ) -> dict[str, str]:
+        return {"instance_id": instance_id, "run_id": run_id}
+
+
+class _CancellationAwareRunService(_FakeRunService):
+    def __init__(self) -> None:
+        super().__init__()
+        self.create_entered = asyncio.Event()
+        self.release_create = asyncio.Event()
+        self.run_started = asyncio.Event()
+
+    async def create_run_async(self, intent_input) -> tuple[str, str]:
+        self.created_run_inputs.append(intent_input)
+        self.create_entered.set()
+        await self.release_create.wait()
+        return ("run-1", "session-1")
+
+    async def ensure_run_started_async(self, run_id: str) -> None:
+        self.started_run_ids.append(run_id)
+        self.run_started.set()
 
 
 class _FakeSkillRegistry:
@@ -296,6 +457,28 @@ def test_resume_route_marks_run_for_resume_and_starts_worker() -> None:
         "session_id": "session-1",
     }
     assert fake_service.resumed_run_ids == ["run-1"]
+    assert fake_service.started_run_ids == ["run-1"]
+
+
+@pytest.mark.asyncio
+async def test_create_and_start_run_finishes_startup_after_cancellation() -> None:
+    fake_service = _CancellationAwareRunService()
+    intent_input = IntentInput(
+        session_id="session-1",
+        input=content_parts_from_text("hello"),
+    )
+
+    task = asyncio.create_task(
+        runs._create_and_start_run(cast(SessionRunService, fake_service), intent_input)
+    )
+    await fake_service.create_entered.wait()
+    task.cancel()
+    fake_service.release_create.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.wait_for(fake_service.run_started.wait(), timeout=1)
+
     assert fake_service.started_run_ids == ["run-1"]
 
 
@@ -678,23 +861,9 @@ def test_stop_monitor_route_returns_updated_monitor() -> None:
     }
 
 
-def test_answer_user_question_route_offloads_service_call(monkeypatch) -> None:
+def test_answer_user_question_route_awaits_service_call() -> None:
     fake_service = _FakeRunService()
     client = _create_client(fake_service)
-    captured: dict[str, object] = {}
-
-    async def fake_to_thread(
-        func: Callable[..., object],
-        /,
-        *args: object,
-        **kwargs: object,
-    ) -> object:
-        captured["func"] = func
-        captured["args"] = args
-        captured["kwargs"] = kwargs
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(runs.asyncio, "to_thread", fake_to_thread)
 
     response = client.post(
         "/api/runs/run-1/questions/question-1:answer",
@@ -708,14 +877,6 @@ def test_answer_user_question_route_offloads_service_call(monkeypatch) -> None:
         "question_id": "question-1",
         "answer_count": 1,
     }
-    captured_kwargs = cast(dict[str, object], captured["kwargs"])
-    assert captured["func"] == fake_service.answer_user_question
-    assert captured["args"] == ()
-    assert captured_kwargs == {
-        "run_id": "run-1",
-        "question_id": "question-1",
-        "answers": captured_kwargs["answers"],
-    }
     answered = fake_service.answered_user_questions
     assert len(answered) == 1
     assert answered[0][0] == "run-1"
@@ -724,28 +885,11 @@ def test_answer_user_question_route_offloads_service_call(monkeypatch) -> None:
     assert answered[0][2][0].selections[0].label == "A"
 
 
-def test_list_monitors_route_offloads_service_call(monkeypatch) -> None:
+def test_list_monitors_route_awaits_service_call() -> None:
     fake_service = _FakeRunService()
     client = _create_client(fake_service)
-    captured: dict[str, object] = {}
-
-    async def fake_to_thread(
-        func: Callable[..., object],
-        /,
-        *args: object,
-        **kwargs: object,
-    ) -> object:
-        captured["func"] = func
-        captured["args"] = args
-        captured["kwargs"] = kwargs
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(runs.asyncio, "to_thread", fake_to_thread)
 
     response = client.get("/api/runs/run-1/monitors")
 
     assert response.status_code == 200
     assert response.json() == {"items": [fake_service.monitors["mon-1"]]}
-    assert captured["func"] == fake_service.list_monitors
-    assert captured["args"] == ("run-1",)
-    assert captured["kwargs"] == {}

--- a/tests/unit_tests/interfaces/server/test_session_media_router.py
+++ b/tests/unit_tests/interfaces/server/test_session_media_router.py
@@ -128,7 +128,7 @@ def test_session_media_routes_offload_sync_service_calls(
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(session_media.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(session_media, "call_maybe_async", fake_to_thread)
     asset_file_path = tmp_path / "image.png"
     asset_file_path.write_bytes(b"seed")
     client, _ = _create_client(asset_file_path)

--- a/tests/unit_tests/interfaces/server/test_sessions_router.py
+++ b/tests/unit_tests/interfaces/server/test_sessions_router.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Callable
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -335,16 +333,7 @@ def test_create_session_route_returns_created_session() -> None:
     assert fake_service.created_calls == [("session-1", "default", None)]
 
 
-def test_create_session_route_runs_service_call_in_threadpool(monkeypatch) -> None:
-    calls: list[str] = []
-
-    async def fake_run_in_threadpool(
-        func: Callable[[], SessionRecord],
-    ) -> SessionRecord:
-        calls.append("create")
-        return func()
-
-    monkeypatch.setattr(sessions, "run_in_threadpool", fake_run_in_threadpool)
+def test_create_session_route_calls_service() -> None:
     fake_service = _FakeSessionService()
     client = _create_client(fake_service)
 
@@ -354,20 +343,10 @@ def test_create_session_route_runs_service_call_in_threadpool(monkeypatch) -> No
     )
 
     assert response.status_code == 200
-    assert calls == ["create"]
     assert fake_service.created_calls == [("session-1", "default", None)]
 
 
-def test_list_sessions_route_runs_service_call_in_threadpool(monkeypatch) -> None:
-    calls: list[str] = []
-
-    async def fake_run_in_threadpool(
-        func: Callable[[], tuple[SessionRecord, ...]],
-    ) -> tuple[SessionRecord, ...]:
-        calls.append("list")
-        return func()
-
-    monkeypatch.setattr(sessions, "run_in_threadpool", fake_run_in_threadpool)
+def test_list_sessions_route_calls_service() -> None:
     fake_service = _FakeSessionService()
     client = _create_client(fake_service)
 
@@ -375,23 +354,10 @@ def test_list_sessions_route_runs_service_call_in_threadpool(monkeypatch) -> Non
 
     assert response.status_code == 200
     assert response.json()[0]["session_id"] == "session-listed"
-    assert calls == ["list"]
     assert fake_service.list_calls == 1
 
 
-def test_sync_session_routes_run_service_calls_in_threadpool(monkeypatch) -> None:
-    calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
-
-    async def fake_run_in_threadpool(
-        func: Callable[..., object],
-        /,
-        *args: object,
-        **kwargs: object,
-    ) -> object:
-        calls.append((func.__name__, args, kwargs))
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(sessions, "run_in_threadpool", fake_run_in_threadpool)
+def test_session_routes_call_service() -> None:
     fake_service = _FakeSessionService()
     client = _create_client(fake_service)
 
@@ -424,27 +390,6 @@ def test_sync_session_routes_run_service_calls_in_threadpool(monkeypatch) -> Non
     ]
 
     assert [response.status_code for response in requests] == [200] * len(requests)
-    assert [call[0] for call in calls] == [
-        "get_session",
-        "update_session",
-        "_update_session_topology",
-        "_delete_session",
-        "_get_session_rounds",
-        "get_recovery_snapshot",
-        "get_round",
-        "list_agents_in_session",
-        "list_normal_mode_subagents",
-        "delete_normal_mode_subagent",
-        "get_agent_reflection",
-        "_update_agent_reflection",
-        "delete_agent_reflection",
-        "get_global_events",
-        "get_session_messages",
-        "get_agent_messages",
-        "get_session_tasks",
-        "get_token_usage_by_session",
-        "get_token_usage_by_run",
-    ]
 
 
 def test_create_session_route_accepts_explicit_metadata_payload() -> None:

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -944,7 +944,7 @@ def test_health_check_builds_payload_in_worker_thread(
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_test_client(_FakeSystemService())
     app = cast(FastAPI, client.app)
     app.state.container = SimpleNamespace(
@@ -1042,7 +1042,7 @@ def test_probe_ssh_profile_connectivity_runs_service_call_in_threadpool(
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_test_client(_FakeSystemService())
 
     response = client.post(
@@ -1066,7 +1066,7 @@ def test_ssh_profile_routes_run_service_calls_in_threadpool(monkeypatch) -> None
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_test_client(_FakeSystemService())
 
     responses = [
@@ -1113,7 +1113,7 @@ def test_sync_system_read_routes_run_service_calls_in_threadpool(monkeypatch) ->
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_test_client(_FakeSystemService())
 
     responses = [
@@ -1187,7 +1187,7 @@ def test_sync_system_write_routes_run_service_calls_in_threadpool(monkeypatch) -
             protocol_version=1,
         )
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     monkeypatch.setattr(system, "probe_acp_agent", fake_probe)
     client = _create_test_client(_FakeSystemService())
 
@@ -1592,7 +1592,7 @@ def test_save_github_config_runs_refresh_in_threadpool(monkeypatch) -> None:
         calls.append("save")
         func()
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     service = _FakeSystemService()
     client = _create_test_client(service)
 
@@ -1686,7 +1686,7 @@ def test_probe_github_webhook_connectivity_runs_service_call_in_threadpool(
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_test_client(_FakeSystemService())
 
     response = client.post(
@@ -1759,7 +1759,7 @@ def test_start_github_webhook_tunnel_runs_service_call_in_threadpool(
         calls.append("start")
         return func()
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     service = _FakeSystemService()
     client = _create_test_client(service)
 
@@ -1813,7 +1813,7 @@ def test_stop_github_webhook_tunnel_runs_service_call_in_threadpool(
         calls.append("stop")
         return func()
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     service = _FakeSystemService()
     service.tunnel_status = LocalhostRunTunnelStatus(
         status="active",
@@ -1881,7 +1881,7 @@ def test_probe_clawhub_connectivity_runs_service_call_in_threadpool(
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_test_client(_FakeSystemService())
 
     response = client.post(
@@ -2253,7 +2253,7 @@ def test_probe_model_connectivity_runs_service_call_in_threadpool(
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_test_client(_FakeSystemService())
 
     response = client.post(
@@ -2297,7 +2297,7 @@ def test_discover_model_catalog_runs_service_call_in_threadpool(
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_test_client(_FakeSystemService())
 
     response = client.post(
@@ -3306,7 +3306,7 @@ def test_environment_variable_routes_run_service_calls_in_threadpool(
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(system.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
     client = _create_env_test_client(_FakeEnvironmentVariableService())
 
     responses = [

--- a/tests/unit_tests/interfaces/server/test_tasks_router.py
+++ b/tests/unit_tests/interfaces/server/test_tasks_router.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from typing import Callable
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -90,19 +88,7 @@ def _create_test_client(service: _FakeTaskService | None = None) -> TestClient:
     return TestClient(app)
 
 
-def test_task_routes_run_sync_service_calls_in_threadpool(monkeypatch) -> None:
-    calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
-
-    async def fake_to_thread(
-        func: Callable[..., object],
-        /,
-        *args: object,
-        **kwargs: object,
-    ) -> object:
-        calls.append((func.__name__, args, kwargs))
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(tasks.asyncio, "to_thread", fake_to_thread)
+def test_task_routes_call_service() -> None:
     client = _create_test_client()
 
     responses = [
@@ -119,12 +105,6 @@ def test_task_routes_run_sync_service_calls_in_threadpool(monkeypatch) -> None:
     ]
 
     assert [response.status_code for response in responses] == [200] * len(responses)
-    assert [call[0] for call in calls] == [
-        "list_tasks",
-        "list_delegated_tasks",
-        "get_task",
-        "update_task",
-    ]
 
 
 def test_create_tasks_for_run_uses_async_service_directly() -> None:

--- a/tests/unit_tests/interfaces/server/test_triggers_router.py
+++ b/tests/unit_tests/interfaces/server/test_triggers_router.py
@@ -313,7 +313,7 @@ def test_github_account_and_list_routes_run_service_calls_in_threadpool(
         calls.append((func.__name__, args, kwargs))
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(triggers, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(triggers, "call_maybe_async", fake_run_in_threadpool)
     client = _client(_FakeGitHubTriggerService())
 
     requests = [
@@ -396,7 +396,7 @@ def test_list_github_available_repositories_runs_service_call_in_threadpool(
         calls.append("list")
         return func()
 
-    monkeypatch.setattr(triggers, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(triggers, "call_maybe_async", fake_run_in_threadpool)
     client = _client(_FakeGitHubTriggerService())
 
     response = client.get(
@@ -485,7 +485,7 @@ def test_create_github_repo_route_runs_service_call_in_threadpool(monkeypatch) -
         calls.append(req)
         return func(req)
 
-    monkeypatch.setattr(triggers, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(triggers, "call_maybe_async", fake_run_in_threadpool)
     client = _client(_FakeGitHubTriggerService())
 
     response = client.post(
@@ -518,7 +518,7 @@ def test_update_github_repo_route_runs_service_call_in_threadpool(monkeypatch) -
         calls.append((repo_subscription_id, req))
         return func(repo_subscription_id, req)
 
-    monkeypatch.setattr(triggers, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(triggers, "call_maybe_async", fake_run_in_threadpool)
     client = _client(_FakeGitHubTriggerService())
 
     response = client.patch(
@@ -598,7 +598,7 @@ def test_create_github_rule_route_runs_service_call_in_threadpool(monkeypatch) -
         calls.append(req)
         return func(req)
 
-    monkeypatch.setattr(triggers, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(triggers, "call_maybe_async", fake_run_in_threadpool)
     client = _client(_FakeGitHubTriggerService())
 
     response = client.post(

--- a/tests/unit_tests/interfaces/server/test_workspaces_router.py
+++ b/tests/unit_tests/interfaces/server/test_workspaces_router.py
@@ -669,7 +669,7 @@ def test_get_workspace_tree_listing_runs_service_call_in_threadpool(
         workspace_id="project-alpha",
         root_path=tmp_path,
     )
-    monkeypatch.setattr(workspaces.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(workspaces, "call_maybe_async", fake_to_thread)
 
     response = client.get("/api/workspaces/project-alpha/tree?path=src&mount=ops")
 
@@ -744,7 +744,7 @@ def test_workspace_diff_routes_run_service_calls_in_threadpool(
         workspace_id="project-alpha",
         root_path=tmp_path,
     )
-    monkeypatch.setattr(workspaces.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(workspaces, "call_maybe_async", fake_to_thread)
 
     diffs_response = client.get("/api/workspaces/project-alpha/diffs?mount=ops")
     diff_file_response = client.get(
@@ -842,7 +842,7 @@ def test_pick_workspace_runs_picker_and_create_in_thread(
         calls.append(func.__name__)
         return func()
 
-    monkeypatch.setattr(workspaces.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(workspaces, "call_maybe_async", fake_to_thread)
     monkeypatch.setattr(
         workspaces,
         "pick_workspace_directory",

--- a/tests/unit_tests/metrics/test_query_service.py
+++ b/tests/unit_tests/metrics/test_query_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from relay_teams.metrics import (
     DEFAULT_DEFINITIONS,
     MetricRecorder,
@@ -13,6 +15,59 @@ from relay_teams.metrics import (
     SqliteMetricAggregateStore,
 )
 from relay_teams.metrics.sinks import AggregateStoreSink
+
+
+@pytest.mark.asyncio
+async def test_metric_store_async_records_queries_and_deletes(tmp_path) -> None:
+    store = SqliteMetricAggregateStore(tmp_path / "metrics-async.db")
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(AggregateStoreSink(store),),
+    )
+    now = datetime.now(tz=timezone.utc)
+    tags = MetricTagSet(
+        workspace_id="default",
+        session_id="session-1",
+        run_id="run-1",
+        instance_id="inst-1",
+        role_id="coordinator",
+        tool_name="shell",
+        tool_source="local",
+        status="success",
+    )
+
+    try:
+        await recorder.emit_async(
+            definition_name="relay_teams.tool.calls",
+            value=2,
+            tags=tags,
+            occurred_at=now,
+        )
+
+        points = await store.query_points_async(
+            scope=MetricScope.SESSION,
+            scope_id="session-1",
+            time_window_minutes=10,
+        )
+        recorded_at = await store.latest_recorded_at_async(
+            scope=MetricScope.SESSION,
+            scope_id="session-1",
+        )
+        await store.delete_by_session_async("session-1")
+        remaining = await store.query_points_async(
+            scope=MetricScope.SESSION,
+            scope_id="session-1",
+            time_window_minutes=10,
+        )
+
+        assert len(points) == 1
+        assert points[0].metric_name == "relay_teams.tool.calls"
+        assert points[0].scope == MetricScope.SESSION
+        assert points[0].value == 2
+        assert recorded_at is not None
+        assert remaining == ()
+    finally:
+        await store.close_async()
 
 
 def test_metrics_query_service_builds_overview_and_breakdowns(tmp_path) -> None:

--- a/tests/unit_tests/metrics/test_tool_metrics.py
+++ b/tests/unit_tests/metrics/test_tool_metrics.py
@@ -4,9 +4,20 @@ from __future__ import annotations
 import pytest
 
 from relay_teams.mcp.mcp_registry import McpRegistry
-from relay_teams.metrics import DEFAULT_DEFINITIONS, MetricEvent, MetricRecorder
+from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
+from relay_teams.metrics import (
+    DEFAULT_DEFINITIONS,
+    MetricEvent,
+    MetricRecorder,
+    MetricTagSet,
+)
+from relay_teams.metrics.adapters.llm_metrics import record_token_usage_async
+from relay_teams.metrics.adapters.session_metrics import record_session_step_async
 from relay_teams.metrics.registry import MetricRegistry
-from relay_teams.metrics.adapters.tool_metrics import record_tool_execution
+from relay_teams.metrics.adapters.tool_metrics import (
+    record_tool_execution,
+    record_tool_execution_async,
+)
 
 
 class _CapturingSink:
@@ -15,6 +26,27 @@ class _CapturingSink:
 
     def record(self, event: MetricEvent) -> None:
         self.events.append(event)
+
+    async def record_async(self, event: MetricEvent) -> None:
+        self.events.append(event)
+
+
+class _SyncOnlyCapturingSink:
+    def __init__(self) -> None:
+        self.events: list[MetricEvent] = []
+
+    def record(self, event: MetricEvent) -> None:
+        self.events.append(event)
+
+
+class _FailingSink:
+    def record(self, event: MetricEvent) -> None:
+        _ = event
+        raise RuntimeError("metric sink failed")
+
+    async def record_async(self, event: MetricEvent) -> None:
+        _ = event
+        raise RuntimeError("metric sink failed")
 
 
 @pytest.mark.parametrize(
@@ -47,3 +79,172 @@ def test_skill_tools_are_recorded_as_skill_source(tool_name: str) -> None:
         "relay_teams.tool.duration_ms",
     }
     assert {event.tags.tool_source for event in sink.events} == {"skill"}
+
+
+@pytest.mark.asyncio
+async def test_async_tool_metrics_record_failure_and_mcp_source() -> None:
+    sink = _CapturingSink()
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(sink,),
+    )
+    registry = McpRegistry(
+        specs=(
+            McpServerSpec(
+                name="filesystem",
+                config={"command": "server"},
+                server_config={"command": "server"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    await record_tool_execution_async(
+        recorder,
+        mcp_registry=registry,
+        workspace_id="workspace-1",
+        session_id="session-1",
+        run_id="run-1",
+        instance_id="instance-1",
+        role_id="MainAgent",
+        tool_name="filesystem_read_file",
+        duration_ms=12,
+        success=False,
+    )
+
+    assert {event.definition_name for event in sink.events} == {
+        "relay_teams.mcp.calls",
+        "relay_teams.tool.calls",
+        "relay_teams.tool.duration_ms",
+        "relay_teams.tool.failures",
+    }
+    assert {event.tags.tool_source for event in sink.events} == {"mcp"}
+    assert {event.tags.mcp_server for event in sink.events} == {"filesystem"}
+    assert {event.tags.status for event in sink.events} == {"failure"}
+
+
+@pytest.mark.asyncio
+async def test_async_tool_metrics_record_skill_source() -> None:
+    sink = _CapturingSink()
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(sink,),
+    )
+
+    await record_tool_execution_async(
+        recorder,
+        mcp_registry=McpRegistry(),
+        workspace_id="workspace-1",
+        session_id="session-1",
+        run_id="run-1",
+        instance_id="instance-1",
+        role_id="MainAgent",
+        tool_name="load_skill",
+        duration_ms=12,
+        success=True,
+    )
+
+    assert {event.definition_name for event in sink.events} == {
+        "relay_teams.skill.calls",
+        "relay_teams.tool.calls",
+        "relay_teams.tool.duration_ms",
+    }
+    assert {event.tags.tool_source for event in sink.events} == {"skill"}
+
+
+@pytest.mark.asyncio
+async def test_async_token_usage_records_positive_counts() -> None:
+    sink = _CapturingSink()
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(sink,),
+    )
+
+    await record_token_usage_async(
+        recorder,
+        workspace_id="workspace-1",
+        session_id="session-1",
+        run_id="run-1",
+        instance_id="instance-1",
+        role_id="MainAgent",
+        input_tokens=120,
+        cached_input_tokens=48,
+        output_tokens=24,
+    )
+
+    assert [event.definition_name for event in sink.events] == [
+        "relay_teams.llm.input_tokens",
+        "relay_teams.llm.cached_input_tokens",
+        "relay_teams.llm.output_tokens",
+    ]
+    assert [event.value for event in sink.events] == [120, 48, 24]
+
+
+@pytest.mark.asyncio
+async def test_async_session_step_uses_recorder_async_path() -> None:
+    sink = _CapturingSink()
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(sink,),
+    )
+
+    await record_session_step_async(
+        recorder,
+        workspace_id="workspace-1",
+        session_id="session-1",
+        run_id="run-1",
+        instance_id="instance-1",
+        role_id="MainAgent",
+    )
+
+    assert [event.definition_name for event in sink.events] == [
+        "relay_teams.session.steps"
+    ]
+    assert sink.events[0].tags.session_id == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_metric_recorder_async_supports_sync_sinks_and_ignores_failures() -> None:
+    sink = _SyncOnlyCapturingSink()
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(_FailingSink(), sink),
+    )
+
+    await recorder.emit_async(
+        definition_name="relay_teams.session.steps",
+        value=1,
+        tags=_metric_tags(),
+    )
+
+    assert [event.definition_name for event in sink.events] == [
+        "relay_teams.session.steps"
+    ]
+
+
+def test_metric_recorder_emit_ignores_sink_failures() -> None:
+    sink = _SyncOnlyCapturingSink()
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(_FailingSink(), sink),
+    )
+
+    recorder.emit(
+        definition_name="relay_teams.session.steps",
+        value=1,
+        tags=_metric_tags(),
+    )
+
+    assert [event.definition_name for event in sink.events] == [
+        "relay_teams.session.steps"
+    ]
+
+
+def _metric_tags() -> MetricTagSet:
+    return MetricTagSet(
+        workspace_id="workspace-1",
+        session_id="session-1",
+        run_id="run-1",
+        instance_id="instance-1",
+        role_id="MainAgent",
+    )

--- a/tests/unit_tests/monitors/test_service.py
+++ b/tests/unit_tests/monitors/test_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from relay_teams.monitors import (
     MonitorAction,
     MonitorEventEnvelope,
@@ -72,6 +74,65 @@ def test_monitor_service_dedupes_and_auto_stops(tmp_path) -> None:
     assert sink.calls[0][1].body_text == "ERROR database down"
 
     stored = service.list_for_run("run-1")[0]
+    assert stored.monitor_id == created.monitor_id
+    assert stored.trigger_count == 1
+    assert stored.status.value == "stopped"
+
+    event_types: list[RunEventType] = []
+    while not queue.empty():
+        event_types.append(queue.get_nowait().event_type)
+    assert event_types == [
+        RunEventType.MONITOR_CREATED,
+        RunEventType.MONITOR_TRIGGERED,
+        RunEventType.MONITOR_STOPPED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_monitor_service_async_dedupes_and_stops(tmp_path) -> None:
+    hub = RunEventHub()
+    repository = MonitorRepository(tmp_path / "monitor-service-async.db")
+    service = MonitorService(repository=repository, run_event_hub=hub)
+    sink = _FakeMonitorSink()
+    service.bind_action_sink(sink)
+    queue = hub.subscribe("run-1")
+
+    created = await service.create_monitor_async(
+        run_id="run-1",
+        session_id="session-1",
+        source_kind=MonitorSourceKind.BACKGROUND_TASK,
+        source_key="background_task_1",
+        rule=MonitorRule(
+            event_names=("background_task.line",),
+            text_patterns_any=("ERROR",),
+            max_triggers=2,
+        ),
+        action=MonitorAction(),
+        created_by_instance_id="inst-1",
+        created_by_role_id="role-1",
+        tool_call_id="toolcall-1",
+    )
+
+    envelope = MonitorEventEnvelope(
+        source_kind=MonitorSourceKind.BACKGROUND_TASK,
+        source_key="background_task_1",
+        event_name="background_task.line",
+        body_text="ERROR database down",
+        dedupe_key="delivery-1",
+    )
+    first = await service.emit_async(envelope)
+    second = await service.emit_async(envelope)
+    stopped = await service.stop_for_run_async(
+        run_id="run-1",
+        monitor_id=created.monitor_id,
+    )
+
+    assert len(first) == 1
+    assert second == ()
+    assert stopped.status.value == "stopped"
+    assert len(sink.calls) == 1
+
+    stored = (await service.list_for_run_async("run-1"))[0]
     assert stored.monitor_id == created.monitor_id
     assert stored.trigger_count == 1
     assert stored.status.value == "stopped"

--- a/tests/unit_tests/net/test_llm_client.py
+++ b/tests/unit_tests/net/test_llm_client.py
@@ -303,6 +303,67 @@ async def test_reset_llm_http_client_cache_entry_isolated_by_cache_scope(
     assert run_b_client.close_calls == 0
 
 
+@pytest.mark.asyncio
+async def test_clear_llm_http_client_cache_async_closes_shared_and_scoped_clients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeAsyncClient:
+        def __init__(self) -> None:
+            self.is_closed = False
+            self.close_calls = 0
+
+        async def aclose(self) -> None:
+            self.close_calls += 1
+            self.is_closed = True
+
+    created_clients: list[_FakeAsyncClient] = []
+
+    def _create_async_http_client(**_: object) -> _FakeAsyncClient:
+        client = _FakeAsyncClient()
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        llm_client,
+        "create_async_http_client",
+        _create_async_http_client,
+    )
+
+    shared_client = cast(
+        _FakeAsyncClient,
+        llm_client.build_llm_http_client(
+            merged_env={"HTTPS_PROXY": "http://proxy.internal:8443"},
+            connect_timeout_seconds=42.5,
+            ssl_verify=False,
+        ),
+    )
+    scoped_client = cast(
+        _FakeAsyncClient,
+        llm_client.build_llm_http_client(
+            merged_env={"HTTPS_PROXY": "http://proxy.internal:8443"},
+            connect_timeout_seconds=42.5,
+            cache_scope="run-a",
+            ssl_verify=False,
+        ),
+    )
+
+    await llm_client.clear_llm_http_client_cache_async()
+
+    assert shared_client.close_calls == 1
+    assert scoped_client.close_calls == 1
+
+    rebuilt_client = cast(
+        _FakeAsyncClient,
+        llm_client.build_llm_http_client(
+            merged_env={"HTTPS_PROXY": "http://proxy.internal:8443"},
+            connect_timeout_seconds=42.5,
+            ssl_verify=False,
+        ),
+    )
+    assert rebuilt_client is not shared_client
+    assert len(created_clients) == 3
+
+
 def test_build_llm_http_client_does_not_evict_scoped_clients(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/notifications/test_notification_service.py
+++ b/tests/unit_tests/notifications/test_notification_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 from typing import cast
 
+import pytest
+
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.notifications import (
@@ -95,6 +97,35 @@ def test_emit_returns_false_when_type_is_disabled() -> None:
     assert hub.events == []
 
 
+@pytest.mark.asyncio
+async def test_emit_async_returns_false_when_type_is_disabled() -> None:
+    hub = _FakeRunEventHub()
+    config = NotificationConfig(
+        tool_approval_requested=NotificationRule(
+            enabled=False,
+            channels=(NotificationChannel.TOAST,),
+        ),
+    )
+    service = NotificationService(
+        run_event_hub=cast(RunEventHub, cast(object, hub)),
+        get_config=lambda: config,
+    )
+
+    emitted = await service.emit_async(
+        notification_type=NotificationType.TOOL_APPROVAL_REQUESTED,
+        title="Approval Required",
+        body="approval pending",
+        context=NotificationContext(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="trace-1",
+        ),
+    )
+
+    assert emitted is False
+    assert hub.events == []
+
+
 def test_emit_dispatches_to_custom_dispatchers() -> None:
     hub = _FakeRunEventHub()
     dispatcher = _FakeDispatcher()
@@ -142,6 +173,39 @@ def test_emit_continues_after_dispatcher_failure() -> None:
     )
 
     emitted = service.emit(
+        notification_type=NotificationType.RUN_COMPLETED,
+        title="Run Completed",
+        body="Run run-1 completed successfully.",
+        context=NotificationContext(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="trace-1",
+        ),
+    )
+
+    assert emitted is True
+    assert len(hub.events) == 1
+    assert len(succeeding_dispatcher.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_async_continues_after_dispatcher_failure() -> None:
+    hub = _FakeRunEventHub()
+    failing_dispatcher = _FailingDispatcher()
+    succeeding_dispatcher = _FakeDispatcher()
+    config = NotificationConfig(
+        run_completed=NotificationRule(
+            enabled=True,
+            channels=(NotificationChannel.FEISHU,),
+        ),
+    )
+    service = NotificationService(
+        run_event_hub=cast(RunEventHub, cast(object, hub)),
+        get_config=lambda: config,
+        dispatchers=(failing_dispatcher, succeeding_dispatcher),
+    )
+
+    emitted = await service.emit_async(
         notification_type=NotificationType.RUN_COMPLETED,
         title="Run Completed",
         body="Run run-1 completed successfully.",

--- a/tests/unit_tests/persistence/test_db.py
+++ b/tests/unit_tests/persistence/test_db.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -140,19 +141,118 @@ def test_resolved_db_path_key_returns_existing_cached_value_after_resolve(
     assert resolved == "cached-after-resolve"
 
 
-def test_write_coordinators_reuse_same_lock_for_same_path(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_write_coordinators_reuse_same_lock_for_same_path(
+    tmp_path: Path,
+) -> None:
     db_path = tmp_path / "relay_teams.db"
+    db_module._CROSS_WRITE_COORDINATORS.clear()
     db_module._WRITE_COORDINATORS.clear()
     db_module._ASYNC_WRITE_COORDINATORS.clear()
     db_module._RESOLVED_DB_PATH_KEYS.clear()
 
+    cross_first = db_module._cross_write_coordinator_for(db_path)
+    cross_second = db_module._cross_write_coordinator_for(db_path)
     sync_first = db_module._write_coordinator_for(db_path)
     sync_second = db_module._write_coordinator_for(db_path)
     async_first = db_module._async_write_coordinator_for(db_path)
     async_second = db_module._async_write_coordinator_for(db_path)
 
+    assert cross_first is cross_second
     assert sync_first is sync_second
     assert async_first is async_second
+
+
+def test_async_write_coordinator_is_scoped_to_event_loop(tmp_path: Path) -> None:
+    db_path = tmp_path / "relay_teams.db"
+    db_module._ASYNC_WRITE_COORDINATORS.clear()
+    db_module._RESOLVED_DB_PATH_KEYS.clear()
+
+    async def bind_lock_to_current_loop() -> asyncio.Lock:
+        lock = db_module._async_write_coordinator_for(db_path)
+        await lock.acquire()
+        waiter = asyncio.create_task(lock.acquire())
+        await asyncio.sleep(0)
+
+        assert not waiter.done()
+
+        lock.release()
+        await waiter
+        lock.release()
+        return lock
+
+    first = asyncio.run(bind_lock_to_current_loop())
+    second = asyncio.run(bind_lock_to_current_loop())
+
+    assert first is not second
+
+
+def test_cross_write_coordinator_allows_sync_reentry() -> None:
+    coordinator = db_module.CrossModeWriteCoordinator()
+
+    first_token = coordinator.acquire_sync()
+    second_token = coordinator.acquire_sync()
+    coordinator.release(second_token)
+    coordinator.release(first_token)
+
+
+@pytest.mark.asyncio
+async def test_cross_write_coordinator_allows_async_reentry() -> None:
+    coordinator = db_module.CrossModeWriteCoordinator()
+
+    first_token = await coordinator.acquire_async()
+    second_token = await coordinator.acquire_async()
+    coordinator.release(second_token)
+    coordinator.release(first_token)
+
+
+@pytest.mark.asyncio
+async def test_cross_write_coordinator_releases_cancelled_async_acquire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = db_module.CrossModeWriteCoordinator()
+
+    async def _cancel_after_acquire(
+        func: Callable[[tuple[str, int]], bool],
+        token: tuple[str, int],
+    ) -> bool:
+        assert func(token) is True
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(db_module.asyncio, "to_thread", _cancel_after_acquire)
+
+    with pytest.raises(asyncio.CancelledError):
+        await coordinator.acquire_async()
+
+    assert coordinator._owner is None
+    assert coordinator._depth == 0
+
+
+@pytest.mark.asyncio
+async def test_cross_write_coordinator_cancelled_reentry_preserves_outer_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = db_module.CrossModeWriteCoordinator()
+    first_token = await coordinator.acquire_async()
+
+    async def _cancel_after_reentry(
+        func: Callable[[tuple[str, int]], bool],
+        token: tuple[str, int],
+    ) -> bool:
+        assert func(token) is True
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(db_module.asyncio, "to_thread", _cancel_after_reentry)
+
+    with pytest.raises(asyncio.CancelledError):
+        await coordinator.acquire_async()
+
+    assert coordinator._owner == first_token
+    assert coordinator._depth == 1
+
+    coordinator.release(first_token)
+    assert coordinator._owner is None
+    assert coordinator._depth == 0
 
 
 def test_run_sqlite_write_with_retry_retries_transient_lock_errors(
@@ -184,6 +284,45 @@ def test_run_sqlite_write_with_retry_retries_transient_lock_errors(
         stored = conn.execute("SELECT value FROM items").fetchall()
         assert result == "done"
         assert attempts == 3
+        assert [row[0] for row in stored] == ["ok"]
+    finally:
+        conn.close()
+
+
+def test_run_sqlite_write_with_retry_rolls_back_failed_operation(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rollback.db"
+    conn = open_sqlite(db_path)
+    try:
+        conn.execute("CREATE TABLE items (value TEXT NOT NULL)")
+        conn.commit()
+
+        def failed_operation() -> None:
+            conn.execute("INSERT INTO items(value) VALUES(?)", ("stale",))
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            run_sqlite_write_with_retry(
+                conn=conn,
+                db_path=db_path,
+                operation=failed_operation,
+                repository_name="test",
+                operation_name="failed_insert",
+            )
+
+        def committed_operation() -> None:
+            conn.execute("INSERT INTO items(value) VALUES(?)", ("ok",))
+
+        run_sqlite_write_with_retry(
+            conn=conn,
+            db_path=db_path,
+            operation=committed_operation,
+            repository_name="test",
+            operation_name="insert_item",
+        )
+
+        stored = conn.execute("SELECT value FROM items").fetchall()
         assert [row[0] for row in stored] == ["ok"]
     finally:
         conn.close()
@@ -241,6 +380,98 @@ async def test_run_async_sqlite_write_with_retry_retries_transient_lock_errors(
         assert result == "done"
         assert attempts == 3
         assert [row[0] for row in rows] == ["ok"]
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_run_async_sqlite_write_with_retry_rolls_back_cancelled_operation(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "async_rollback.db"
+    conn = await open_async_sqlite(db_path)
+    try:
+        await conn.execute("CREATE TABLE items (value TEXT NOT NULL)")
+        await conn.commit()
+
+        async def cancelled_operation() -> None:
+            await conn.execute("INSERT INTO items(value) VALUES(?)", ("stale",))
+            raise asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            await run_async_sqlite_write_with_retry(
+                conn=conn,
+                db_path=db_path,
+                operation=cancelled_operation,
+                repository_name="test",
+                operation_name="cancelled_insert",
+            )
+
+        async def committed_operation() -> None:
+            await conn.execute("INSERT INTO items(value) VALUES(?)", ("ok",))
+
+        await run_async_sqlite_write_with_retry(
+            conn=conn,
+            db_path=db_path,
+            operation=committed_operation,
+            repository_name="test",
+            operation_name="insert_item",
+        )
+
+        rows = await (await conn.execute("SELECT value FROM items")).fetchall()
+        assert [row[0] for row in rows] == ["ok"]
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_run_async_sqlite_write_with_retry_does_not_rollback_while_waiting(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "async_waiting_cancel.db"
+    conn = await open_async_sqlite(db_path)
+    try:
+        await conn.execute("CREATE TABLE items (value TEXT NOT NULL)")
+        await conn.commit()
+        first_operation_started = asyncio.Event()
+        release_first_operation = asyncio.Event()
+
+        async def slow_operation() -> None:
+            await conn.execute("INSERT INTO items(value) VALUES(?)", ("first",))
+            first_operation_started.set()
+            await release_first_operation.wait()
+
+        first_task = asyncio.create_task(
+            run_async_sqlite_write_with_retry(
+                conn=conn,
+                db_path=db_path,
+                operation=slow_operation,
+                repository_name="test",
+                operation_name="slow_insert",
+            )
+        )
+        await first_operation_started.wait()
+
+        second_task = asyncio.create_task(
+            run_async_sqlite_write_with_retry(
+                conn=conn,
+                db_path=db_path,
+                operation=lambda: asyncio.sleep(0),
+                repository_name="test",
+                operation_name="waiting_insert",
+            )
+        )
+        await asyncio.sleep(0.01)
+        second_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await second_task
+
+        release_first_operation.set()
+        await first_task
+
+        rows = await (await conn.execute("SELECT value FROM items")).fetchall()
+        assert [row[0] for row in rows] == ["first"]
     finally:
         await conn.close()
 

--- a/tests/unit_tests/persistence/test_sqlite_repository.py
+++ b/tests/unit_tests/persistence/test_sqlite_repository.py
@@ -164,5 +164,53 @@ async def test_async_shared_sqlite_repository_run_read_uses_lock(
     assert result == "ok"
 
 
+@pytest.mark.asyncio
+async def test_shared_sqlite_repository_async_helpers_use_retry_helper(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    repo = _DummyRepository(tmp_path / "shared_repo_async.db")
+    calls: list[tuple[Path, asyncio.Lock, str, str]] = []
+
+    async def fake_run_async_sqlite_write_with_retry(
+        *,
+        conn: aiosqlite.Connection,
+        db_path: Path,
+        operation: Callable[[], Awaitable[str]],
+        lock: asyncio.Lock,
+        repository_name: str,
+        operation_name: str,
+        max_retries: int = 8,
+    ) -> str:
+        _ = conn
+        _ = max_retries
+        calls.append((db_path, lock, repository_name, operation_name))
+        return await operation()
+
+    monkeypatch.setattr(
+        sqlite_repository_module,
+        "run_async_sqlite_write_with_retry",
+        fake_run_async_sqlite_write_with_retry,
+    )
+
+    try:
+        result = await repo._run_async_write(
+            operation_name="insert_item_async",
+            operation=lambda _conn: _async_value("ok"),
+        )
+    finally:
+        await repo.close_async()
+
+    assert result == "ok"
+    assert calls == [
+        (
+            tmp_path / "shared_repo_async.db",
+            repo._async_lock,
+            "_DummyRepository",
+            "insert_item_async",
+        )
+    ]
+
+
 async def _async_value(value: str) -> str:
     return value

--- a/tests/unit_tests/persistence/test_sqlite_write_inventory.py
+++ b/tests/unit_tests/persistence/test_sqlite_write_inventory.py
@@ -11,6 +11,17 @@ _ALLOWED_COMMIT_FILES = {
     Path("src/relay_teams/persistence/db.py"),
 }
 _SHARED_SQLITE_WRITERS = {
+    Path("src/relay_teams/agents/execution/message_repository.py"): "MessageRepository",
+    Path(
+        "src/relay_teams/agents/instances/instance_repository.py"
+    ): "AgentInstanceRepository",
+    Path("src/relay_teams/agents/tasks/task_repository.py"): "TaskRepository",
+    Path(
+        "src/relay_teams/automation/automation_bound_session_queue_repository.py"
+    ): "AutomationBoundSessionQueueRepository",
+    Path(
+        "src/relay_teams/automation/automation_delivery_repository.py"
+    ): "AutomationDeliveryRepository",
     Path(
         "src/relay_teams/automation/automation_event_repository.py"
     ): "AutomationEventRepository",
@@ -18,15 +29,69 @@ _SHARED_SQLITE_WRITERS = {
         "src/relay_teams/automation/automation_repository.py"
     ): "AutomationProjectRepository",
     Path(
+        "src/relay_teams/external_agents/session_repository.py"
+    ): "ExternalAgentSessionRepository",
+    Path("src/relay_teams/gateway/feishu/account_repository.py"): (
+        "FeishuAccountRepository"
+    ),
+    Path("src/relay_teams/gateway/feishu/message_pool_repository.py"): (
+        "FeishuMessagePoolRepository"
+    ),
+    Path(
         "src/relay_teams/gateway/gateway_session_repository.py"
     ): "GatewaySessionRepository",
+    Path("src/relay_teams/gateway/wechat/account_repository.py"): (
+        "WeChatAccountRepository"
+    ),
+    Path("src/relay_teams/gateway/wechat/inbound_queue_repository.py"): (
+        "WeChatInboundQueueRepository"
+    ),
+    Path("src/relay_teams/gateway/xiaoluban/account_repository.py"): (
+        "XiaolubanAccountRepository"
+    ),
+    Path("src/relay_teams/media/asset_repository.py"): "MediaAssetRepository",
     Path("src/relay_teams/metrics/stores/sqlite.py"): "SqliteMetricAggregateStore",
+    Path("src/relay_teams/monitors/repository.py"): "MonitorRepository",
     Path("src/relay_teams/persistence/shared_state_repo.py"): "SharedStateRepository",
     Path("src/relay_teams/providers/token_usage_repo.py"): "TokenUsageRepository",
     Path("src/relay_teams/retrieval/sqlite_store.py"): "SqliteFts5RetrievalStore",
     Path("src/relay_teams/roles/memory_repository.py"): "RoleMemoryRepository",
+    Path("src/relay_teams/roles/temporary_role_repository.py"): (
+        "TemporaryRoleRepository"
+    ),
+    Path("src/relay_teams/sessions/external_session_binding_repository.py"): (
+        "ExternalSessionBindingRepository"
+    ),
+    Path("src/relay_teams/sessions/runs/background_tasks/repository.py"): (
+        "BackgroundTaskRepository"
+    ),
+    Path("src/relay_teams/sessions/runs/event_log.py"): "EventLog",
     Path("src/relay_teams/sessions/runs/run_intent_repo.py"): "RunIntentRepository",
+    Path("src/relay_teams/sessions/runs/run_runtime_repo.py"): ("RunRuntimeRepository"),
+    Path("src/relay_teams/sessions/runs/run_state_repo.py"): "RunStateRepository",
+    Path("src/relay_teams/sessions/runs/todo_repository.py"): "TodoRepository",
+    Path("src/relay_teams/sessions/runs/user_question_repository.py"): (
+        "UserQuestionRepository"
+    ),
+    Path("src/relay_teams/sessions/session_history_marker_repository.py"): (
+        "SessionHistoryMarkerRepository"
+    ),
     Path("src/relay_teams/sessions/session_repository.py"): "SessionRepository",
+    Path("src/relay_teams/tools/runtime/approval_ticket_repo.py"): (
+        "ApprovalTicketRepository"
+    ),
+    Path("src/relay_teams/tools/workspace_tools/shell_approval_repo.py"): (
+        "ShellApprovalRepository"
+    ),
+    Path("src/relay_teams/triggers/repository.py"): "TriggerRepository",
+    Path("src/relay_teams/workspace/ssh_profile_repository.py"): (
+        "SshProfileRepository"
+    ),
+    Path("src/relay_teams/workspace/workspace_repository.py"): "WorkspaceRepository",
+}
+_ALLOWED_OPEN_SQLITE_FILES = {
+    Path("src/relay_teams/persistence/db.py"),
+    Path("src/relay_teams/persistence/sqlite_repository.py"),
 }
 
 
@@ -53,6 +118,29 @@ def test_shared_sqlite_writers_inherit_shared_repository_base() -> None:
     assert missing == []
 
 
+def test_sqlite_repositories_do_not_open_connections_directly() -> None:
+    offenders: list[str] = []
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        relative_path = path.relative_to(_REPO_ROOT)
+        if relative_path in _ALLOWED_OPEN_SQLITE_FILES:
+            continue
+        if "open_sqlite(" in path.read_text(encoding="utf-8"):
+            offenders.append(relative_path.as_posix())
+
+    assert offenders == []
+
+
+def test_sqlite_repository_public_methods_have_async_interfaces() -> None:
+    missing: list[str] = []
+    for relative_path, class_name in _SHARED_SQLITE_WRITERS.items():
+        module_path = _REPO_ROOT / relative_path
+        missing.extend(
+            _missing_public_async_methods(module_path, class_name=class_name)
+        )
+
+    assert missing == []
+
+
 def _class_bases_from_file(path: Path, *, class_name: str) -> tuple[str, ...]:
     module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     for node in module.body:
@@ -67,3 +155,39 @@ def _base_name(base: ast.expr) -> str:
     if isinstance(base, ast.Attribute):
         return base.attr
     return ast.unparse(base)
+
+
+def _missing_public_async_methods(path: Path, *, class_name: str) -> list[str]:
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return _missing_public_async_methods_from_class(
+                node,
+                path=path,
+                class_name=class_name,
+            )
+    raise AssertionError(f"Class not found: {class_name} in {path}")
+
+
+def _missing_public_async_methods_from_class(
+    node: ast.ClassDef,
+    *,
+    path: Path,
+    class_name: str,
+) -> list[str]:
+    async_methods = {
+        item.name for item in node.body if isinstance(item, ast.AsyncFunctionDef)
+    }
+    missing: list[str] = []
+    for item in node.body:
+        if not isinstance(item, ast.FunctionDef):
+            continue
+        if item.name == "__init__" or item.name.startswith("_"):
+            continue
+        if item.decorator_list:
+            continue
+        async_name = f"{item.name}_async"
+        if async_name not in async_methods:
+            relative_path = path.relative_to(_REPO_ROOT).as_posix()
+            missing.append(f"{relative_path}::{class_name}.{item.name}")
+    return missing

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -2652,11 +2652,11 @@ async def test_subagent_resume_after_tool_result_before_commit_retries_cleanly(
         user_prompt=None,
     )
 
-    def _interrupt_commit(*args, **kwargs):
+    async def _interrupt_commit(*args, **kwargs):
         _ = (args, kwargs)
         raise asyncio.CancelledError
 
-    monkeypatch.setattr(provider, "_commit_all_safe_messages", _interrupt_commit)
+    monkeypatch.setattr(provider, "_commit_all_safe_messages_async", _interrupt_commit)
 
     with pytest.raises(asyncio.CancelledError):
         await provider.generate(request)

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -42,6 +42,14 @@ class _CapturingSink:
         self.appended.append(str(kwargs["content"]))
         return SystemInjectionResult(appended=True)
 
+    async def enqueue_only_async(self, **kwargs: object) -> SystemInjectionResult:
+        self.enqueued.append(str(kwargs["content"]))
+        return SystemInjectionResult(enqueued=True)
+
+    async def append_only_async(self, **kwargs: object) -> SystemInjectionResult:
+        self.appended.append(str(kwargs["content"]))
+        return SystemInjectionResult(appended=True)
+
 
 class _FailingStateRepository(ReminderStateRepository):
     def __init__(self, *, fail_get: bool = False, fail_save: bool = False) -> None:
@@ -56,6 +64,26 @@ class _FailingStateRepository(ReminderStateRepository):
         return ReminderRunState()
 
     def save_run_state(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        state: ReminderRunState,
+    ) -> None:
+        _ = (session_id, run_id)
+        if self._fail_save:
+            raise RuntimeError("state save failed")
+        self.saved_states.append(state)
+
+    async def get_run_state_async(
+        self, *, session_id: str, run_id: str
+    ) -> ReminderRunState:
+        _ = (session_id, run_id)
+        if self._fail_get:
+            raise RuntimeError("state read failed")
+        return ReminderRunState()
+
+    async def save_run_state_async(
         self,
         *,
         session_id: str,
@@ -276,6 +304,166 @@ def test_service_preserves_completion_retry_limit_when_state_load_fails() -> Non
     assert second.fail_completion is True
     assert len(sink.appended) == 1
     assert [state.completion_retry_count for state in repository.saved_states] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_service_async_enqueues_tool_failure_reminder_once(
+    tmp_path: Path,
+) -> None:
+    sink = _CapturingSink()
+    service = _service(tmp_path, sink)
+    observation = ToolResultObservation(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        tool_name="read",
+        tool_call_id="call-1",
+        ok=False,
+        error_type="file_missing",
+        error_message="No such file",
+    )
+
+    first = await service.observe_tool_result_async(observation)
+    second = await service.observe_tool_result_async(observation)
+
+    assert first.issue is True
+    assert second.issue is False
+    assert len(sink.enqueued) == 1
+    assert "No such file" in sink.enqueued[0]
+
+
+@pytest.mark.asyncio
+async def test_service_async_appends_completion_retry_reminder(
+    tmp_path: Path,
+) -> None:
+    sink = _CapturingSink()
+    service = _service(
+        tmp_path,
+        sink,
+        policy=SystemReminderPolicy(ReminderPolicyConfig(completion_max_retries=2)),
+    )
+
+    decision = await service.evaluate_completion_attempt_async(
+        CompletionAttemptObservation(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="role-1",
+            workspace_id="workspace-1",
+            conversation_id="conversation-1",
+            incomplete_todos=(
+                IncompleteTodoItem(content="finish tests", status="pending"),
+            ),
+        )
+    )
+
+    assert decision.retry_completion is True
+    assert len(sink.appended) == 1
+    assert sink.enqueued == []
+    assert "finish tests" in sink.appended[0]
+
+
+@pytest.mark.asyncio
+async def test_service_async_enqueues_context_pressure_reminder(
+    tmp_path: Path,
+) -> None:
+    sink = _CapturingSink()
+    service = _service(tmp_path, sink)
+
+    decision = await service.observe_context_pressure_async(
+        ContextPressureObservation(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="role-1",
+            conversation_id="conversation-1",
+            kind=ReminderKind.POST_COMPACTION,
+            message_count_before=20,
+            message_count_after=8,
+            estimated_tokens_before=1000,
+            estimated_tokens_after=400,
+            threshold_tokens=800,
+            target_tokens=300,
+        )
+    )
+
+    assert decision.issue is True
+    assert len(sink.enqueued) == 1
+    assert "Conversation history was compacted" in sink.enqueued[0]
+
+
+@pytest.mark.asyncio
+async def test_service_async_continues_when_reminder_state_load_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = _CapturingSink()
+    service = SystemReminderService(
+        state_repository=_FailingStateRepository(fail_get=True),
+        injection_sink=cast(SystemInjectionSink, sink),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="relay_teams.reminders.service"):
+        decision = await service.observe_context_pressure_async(
+            ContextPressureObservation(
+                session_id="session-1",
+                run_id="run-1",
+                trace_id="run-1",
+                task_id="task-1",
+                instance_id="inst-1",
+                role_id="role-1",
+                conversation_id="conversation-1",
+                kind=ReminderKind.POST_COMPACTION,
+                message_count_before=20,
+                message_count_after=8,
+                estimated_tokens_before=1000,
+                estimated_tokens_after=400,
+                threshold_tokens=800,
+                target_tokens=300,
+            )
+        )
+
+    assert decision.issue is True
+    assert len(sink.enqueued) == 1
+    assert "reminders.state.load_failed" in _logged_events(caplog)
+
+
+@pytest.mark.asyncio
+async def test_service_async_continues_when_reminder_state_save_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = _CapturingSink()
+    service = SystemReminderService(
+        state_repository=_FailingStateRepository(fail_save=True),
+        injection_sink=cast(SystemInjectionSink, sink),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="relay_teams.reminders.service"):
+        decision = await service.observe_tool_result_async(
+            ToolResultObservation(
+                session_id="session-1",
+                run_id="run-1",
+                trace_id="run-1",
+                task_id="task-1",
+                instance_id="inst-1",
+                role_id="role-1",
+                tool_name="read",
+                tool_call_id="call-1",
+                ok=False,
+                error_type="file_missing",
+                error_message="No such file",
+            )
+        )
+
+    assert decision.issue is True
+    assert len(sink.enqueued) == 1
+    assert "reminders.state.save_failed" in _logged_events(caplog)
 
 
 def _service(

--- a/tests/unit_tests/retrieval/test_sqlite_store.py
+++ b/tests/unit_tests/retrieval/test_sqlite_store.py
@@ -237,6 +237,42 @@ def test_sqlite_store_applies_title_weight_to_ranking(tmp_path: Path) -> None:
     assert hits[0].document_id == "title-match"
 
 
+def test_sqlite_store_unicode61_search_handles_cjk_prompt_without_phrase_query(
+    tmp_path: Path,
+) -> None:
+    store = SqliteFts5RetrievalStore(tmp_path / "cjk-prompt.db")
+    store.replace_scope(
+        config=RetrievalScopeConfig(
+            scope_kind=RetrievalScopeKind.SKILL,
+            scope_id="skills",
+        ),
+        documents=(
+            RetrievalDocument(
+                scope_kind=RetrievalScopeKind.SKILL,
+                scope_id="skills",
+                document_id="shell-guard",
+                title="Shell Guard",
+                body="Guidance for shell execution safety",
+                keywords=("shell",),
+            ),
+        ),
+    )
+
+    hits = store.search(
+        query=RetrievalQuery(
+            scope_kind=RetrievalScopeKind.SKILL,
+            scope_id="skills",
+            text=(
+                "编排模式真实 LLM E2E 测试。请不要访问文件、不要执行 shell、"
+                "不要修改任何内容；只需要回复 ORCH_E2E_OK。"
+            ),
+            limit=5,
+        )
+    )
+
+    assert [hit.document_id for hit in hits] == ["shell-guard"]
+
+
 def test_sqlite_store_requires_fts5_support(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/roles/test_runtime_role_resolver.py
+++ b/tests/unit_tests/roles/test_runtime_role_resolver.py
@@ -68,6 +68,71 @@ def test_runtime_role_resolver_prefers_run_temporary_roles(tmp_path: Path) -> No
     assert role.tools == ("write", "office_read_markdown")
 
 
+@pytest.mark.asyncio
+async def test_runtime_role_resolver_async_prefers_temporary_roles(
+    tmp_path: Path,
+) -> None:
+    resolver = RuntimeRoleResolver(
+        role_registry=_base_registry(),
+        temporary_role_repository=TemporaryRoleRepository(tmp_path / "roles.db"),
+    )
+    resolver.create_temporary_role(
+        run_id="run-1",
+        session_id="session-1",
+        role=TemporaryRoleSpec(
+            role_id="tmp_writer",
+            name="Tmp Writer",
+            description="temporary",
+            system_prompt="tmp",
+            tools=("write",),
+        ),
+    )
+
+    role = await resolver.get_effective_role_async(
+        run_id="run-1",
+        role_id="tmp_writer",
+    )
+    fallback_role = await resolver.get_effective_role_async(
+        run_id="run-1",
+        role_id="Analyst",
+    )
+
+    assert role.role_id == "tmp_writer"
+    assert role.tools == ("write", "office_read_markdown")
+    assert fallback_role.role_id == "Analyst"
+
+
+@pytest.mark.asyncio
+async def test_runtime_role_resolver_async_lists_static_and_temporary_roles(
+    tmp_path: Path,
+) -> None:
+    resolver = RuntimeRoleResolver(
+        role_registry=_base_registry(),
+        temporary_role_repository=TemporaryRoleRepository(tmp_path / "roles.db"),
+    )
+    resolver.create_temporary_role(
+        run_id="run-1",
+        session_id="session-1",
+        role=TemporaryRoleSpec(
+            role_id="tmp_reviewer",
+            name="Tmp Reviewer",
+            description="temporary",
+            system_prompt="tmp",
+            tools=("read",),
+        ),
+    )
+
+    static_roles = await resolver.list_effective_roles_async(run_id=None)
+    run_roles = await resolver.list_effective_roles_async(run_id="run-1")
+
+    assert {role.role_id for role in static_roles} == {
+        "Analyst",
+        "Coordinator",
+        "MainAgent",
+    }
+    assert "tmp_reviewer" in {role.role_id for role in run_roles}
+
+
 def test_runtime_role_resolver_get_temporary_role_rejects_missing_run_id(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/sessions/runs/test_event_log.py
+++ b/tests/unit_tests/sessions/runs/test_event_log.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.run_models import RunEvent
+
+
+@pytest.mark.asyncio
+async def test_event_log_async_methods_share_persisted_state(tmp_path: Path) -> None:
+    event_log = EventLog(tmp_path / "event_log_async.db")
+    event = RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        event_type=RunEventType.RUN_STARTED,
+        payload_json="{}",
+    )
+
+    try:
+        event_id = await event_log.emit_run_event_async(event)
+        by_trace = await event_log.list_by_trace_with_ids_async("run-1")
+        by_session = await event_log.list_by_session_with_ids_async("session-1")
+        run_state = await event_log.get_run_state_async("run-1")
+    finally:
+        await event_log.close_async()
+
+    assert event_id > 0
+    assert tuple(item["id"] for item in by_trace) == (event_id,)
+    assert tuple(item["id"] for item in by_session) == (event_id,)
+    assert run_state is not None
+    assert run_state.run_id == "run-1"
+    assert run_state.checkpoint_event_id == event_id
+
+
+@pytest.mark.asyncio
+async def test_event_log_async_hot_paths_do_not_reinitialize_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_log = EventLog(tmp_path / "event_log_async_no_reinit.db")
+    event = RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        event_type=RunEventType.RUN_STARTED,
+        payload_json="{}",
+    )
+
+    async def _fail_init() -> None:
+        raise AssertionError("async schema init must not run on hot paths")
+
+    monkeypatch.setattr(event_log, "_init_tables_async", _fail_init)
+
+    try:
+        event_id = await event_log.emit_run_event_async(event)
+        by_trace = await event_log.list_by_trace_with_ids_async("run-1")
+        await event_log.delete_by_trace_async("run-1")
+    finally:
+        await event_log.close_async()
+
+    assert event_id > 0
+    assert tuple(item["id"] for item in by_trace) == (event_id,)

--- a/tests/unit_tests/sessions/runs/test_event_stream.py
+++ b/tests/unit_tests/sessions/runs/test_event_stream.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from threading import Lock
+from typing import cast
+
+import pytest
+
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.runs.run_state_models import RunStateRecord
+from relay_teams.sessions.runs.run_state_repo import RunStateRepository
+
+
+class _SequencedEventLog:
+    def __init__(self) -> None:
+        self._next_event_id = 0
+        self._lock = Lock()
+
+    def emit_run_event(self, event: RunEvent) -> int:
+        _ = event
+        with self._lock:
+            self._next_event_id += 1
+            return self._next_event_id
+
+    async def emit_run_event_async(self, event: RunEvent) -> int:
+        _ = event
+        with self._lock:
+            self._next_event_id += 1
+            return self._next_event_id
+
+
+class _ObservedRunStateRepository:
+    def __init__(self) -> None:
+        self.active_updates = 0
+        self.max_active_updates = 0
+        self.applied_event_ids: list[int] = []
+        self.async_update_entered = asyncio.Event()
+        self._lock = Lock()
+
+    def apply_event(self, *, event_id: int, event: RunEvent) -> RunStateRecord:
+        self._begin_update(event_id)
+        try:
+            return self._state_record(event_id=event_id, event=event)
+        finally:
+            self._finish_update()
+
+    async def apply_event_async(
+        self, *, event_id: int, event: RunEvent
+    ) -> RunStateRecord:
+        self._begin_update(event_id)
+        try:
+            if event_id == 1:
+                self.async_update_entered.set()
+                await asyncio.sleep(0.01)
+            else:
+                await asyncio.sleep(0)
+            return self._state_record(event_id=event_id, event=event)
+        finally:
+            self._finish_update()
+
+    def _begin_update(self, event_id: int) -> None:
+        with self._lock:
+            self.active_updates += 1
+            self.max_active_updates = max(self.max_active_updates, self.active_updates)
+            self.applied_event_ids.append(event_id)
+
+    def _finish_update(self) -> None:
+        with self._lock:
+            self.active_updates -= 1
+
+    def _state_record(self, *, event_id: int, event: RunEvent) -> RunStateRecord:
+        return RunStateRecord(
+            run_id=event.run_id,
+            session_id=event.session_id,
+            last_event_id=event_id,
+            checkpoint_event_id=event_id,
+            updated_at=datetime.now(tz=timezone.utc),
+        )
+
+
+def _event(event_type: RunEventType) -> RunEvent:
+    return RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="trace-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        event_type=event_type,
+        payload_json="{}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_publish_async_serializes_state_updates() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    queue = hub.subscribe("run-1")
+
+    await asyncio.gather(
+        hub.publish_async(_event(RunEventType.RUN_STARTED)),
+        hub.publish_async(_event(RunEventType.MODEL_STEP_STARTED)),
+    )
+
+    first = queue.get_nowait()
+    second = queue.get_nowait()
+
+    assert run_state_repo.max_active_updates == 1
+    assert run_state_repo.applied_event_ids == [1, 2]
+    assert first.event_id == 1
+    assert second.event_id == 2
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_publish_async_finishes_projection_when_cancelled() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    queue = hub.subscribe("run-1")
+
+    task = asyncio.create_task(hub.publish_async(_event(RunEventType.RUN_STARTED)))
+    await run_state_repo.async_update_entered.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    delivered = queue.get_nowait()
+
+    assert run_state_repo.max_active_updates == 1
+    assert run_state_repo.applied_event_ids == [1]
+    assert delivered.event_id == 1
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_serializes_mixed_sync_and_async_publishes() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+
+    async_task = asyncio.create_task(
+        hub.publish_async(_event(RunEventType.RUN_STARTED))
+    )
+    await run_state_repo.async_update_entered.wait()
+
+    await asyncio.gather(
+        async_task,
+        asyncio.to_thread(hub.publish, _event(RunEventType.RUN_PAUSED)),
+    )
+
+    assert run_state_repo.max_active_updates == 1
+    assert run_state_repo.applied_event_ids == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_rejects_sync_publish_from_loop_when_async_locked() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+
+    async_task = asyncio.create_task(
+        hub.publish_async(_event(RunEventType.RUN_STARTED))
+    )
+    await run_state_repo.async_update_entered.wait()
+
+    with pytest.raises(RuntimeError, match="use publish_async"):
+        hub.publish(_event(RunEventType.RUN_PAUSED))
+
+    await asyncio.wait_for(async_task, timeout=1)
+
+    assert run_state_repo.max_active_updates == 1
+    assert run_state_repo.applied_event_ids == [1]

--- a/tests/unit_tests/sessions/runs/test_run_auxiliary.py
+++ b/tests/unit_tests/sessions/runs/test_run_auxiliary.py
@@ -1,0 +1,356 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Literal, cast
+
+import pytest
+
+from relay_teams.monitors import (
+    MonitorAction,
+    MonitorActionType,
+    MonitorRule,
+    MonitorService,
+    MonitorSourceKind,
+    MonitorSubscriptionRecord,
+)
+from relay_teams.sessions.runs.background_tasks.manager import BackgroundTaskManager
+from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskRecord
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
+from relay_teams.sessions.runs.run_auxiliary import RunAuxiliaryService
+from relay_teams.sessions.runs.todo_models import TodoSnapshot
+from relay_teams.sessions.runs.todo_service import TodoService
+
+
+class _AsyncOnlyMonitorService:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def create_monitor(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        source_kind: MonitorSourceKind,
+        source_key: str,
+        rule: MonitorRule,
+        action: MonitorAction,
+        created_by_instance_id: str | None,
+        created_by_role_id: str | None,
+        tool_call_id: str | None,
+    ) -> MonitorSubscriptionRecord:
+        _ = (
+            run_id,
+            session_id,
+            source_kind,
+            source_key,
+            rule,
+            action,
+            created_by_instance_id,
+            created_by_role_id,
+            tool_call_id,
+        )
+        raise AssertionError("sync create_monitor must not run")
+
+    async def create_monitor_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        source_kind: MonitorSourceKind,
+        source_key: str,
+        rule: MonitorRule,
+        action: MonitorAction,
+        created_by_instance_id: str | None,
+        created_by_role_id: str | None,
+        tool_call_id: str | None,
+    ) -> MonitorSubscriptionRecord:
+        _ = (
+            rule,
+            action,
+            created_by_instance_id,
+            created_by_role_id,
+            tool_call_id,
+        )
+        self.calls.append(f"create:{source_key}")
+        return MonitorSubscriptionRecord(
+            monitor_id="mon_async",
+            run_id=run_id,
+            session_id=session_id,
+            source_kind=source_kind,
+            source_key=source_key,
+        )
+
+    def list_for_run(self, run_id: str) -> tuple[MonitorSubscriptionRecord, ...]:
+        _ = run_id
+        raise AssertionError("sync list_for_run must not run")
+
+    async def list_for_run_async(
+        self, run_id: str
+    ) -> tuple[MonitorSubscriptionRecord, ...]:
+        self.calls.append(f"list:{run_id}")
+        return (
+            MonitorSubscriptionRecord(
+                monitor_id="mon_async",
+                run_id=run_id,
+                session_id="session-1",
+                source_kind=MonitorSourceKind.BACKGROUND_TASK,
+                source_key="background_task_1",
+            ),
+        )
+
+    def stop_for_run(
+        self,
+        *,
+        run_id: str,
+        monitor_id: str,
+    ) -> MonitorSubscriptionRecord:
+        _ = (run_id, monitor_id)
+        raise AssertionError("sync stop_for_run must not run")
+
+    async def stop_for_run_async(
+        self,
+        *,
+        run_id: str,
+        monitor_id: str,
+    ) -> MonitorSubscriptionRecord:
+        self.calls.append(f"stop:{monitor_id}")
+        return MonitorSubscriptionRecord(
+            monitor_id=monitor_id,
+            run_id=run_id,
+            session_id="session-1",
+            source_kind=MonitorSourceKind.BACKGROUND_TASK,
+            source_key="background_task_1",
+        )
+
+
+class _AsyncOnlyBackgroundTaskService:
+    def __init__(self, record: BackgroundTaskRecord) -> None:
+        self.record = record
+        self.calls: list[str] = []
+
+    def list_for_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        _ = run_id
+        raise AssertionError("sync list_for_run must not run")
+
+    async def list_for_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        self.calls.append(f"list:{run_id}")
+        return (self.record,)
+
+    def get_for_run(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        _ = (run_id, background_task_id)
+        raise AssertionError("sync get_for_run must not run")
+
+    async def get_for_run_async(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        self.calls.append(f"get:{background_task_id}")
+        if (
+            self.record.run_id != run_id
+            or self.record.background_task_id != background_task_id
+        ):
+            raise KeyError(background_task_id)
+        return self.record
+
+
+class _AsyncOnlyBackgroundTaskManager:
+    def __init__(
+        self,
+        background_record: BackgroundTaskRecord,
+        foreground_record: BackgroundTaskRecord,
+    ) -> None:
+        self.background_record = background_record
+        self.foreground_record = foreground_record
+        self.calls: list[str] = []
+
+    def list_for_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        _ = run_id
+        raise AssertionError("sync manager list_for_run must not run")
+
+    async def list_for_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        self.calls.append(f"list:{run_id}")
+        return (self.background_record, self.foreground_record)
+
+    def get_for_run(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        _ = (run_id, background_task_id)
+        raise AssertionError("sync manager get_for_run must not run")
+
+    async def get_for_run_async(
+        self,
+        *,
+        run_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        self.calls.append(f"get:{background_task_id}")
+        if (
+            self.background_record.run_id == run_id
+            and self.background_record.background_task_id == background_task_id
+        ):
+            return self.background_record
+        if (
+            self.foreground_record.run_id == run_id
+            and self.foreground_record.background_task_id == background_task_id
+        ):
+            return self.foreground_record
+        raise KeyError(background_task_id)
+
+
+class _AsyncOnlyTodoService:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def get_for_run(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+    ) -> TodoSnapshot:
+        _ = (run_id, session_id)
+        raise AssertionError("sync get_for_run must not run")
+
+    async def get_for_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+    ) -> TodoSnapshot:
+        self.calls.append(f"get:{run_id}:{session_id}")
+        return TodoSnapshot(run_id=run_id, session_id=session_id)
+
+
+@pytest.mark.asyncio
+async def test_run_auxiliary_monitor_async_uses_async_services() -> None:
+    background_record = _background_record(
+        background_task_id="background_task_1",
+        execution_mode="background",
+    )
+    background_task_service = _AsyncOnlyBackgroundTaskService(background_record)
+    monitor_service = _AsyncOnlyMonitorService()
+    service = RunAuxiliaryService(
+        get_monitor_service=lambda: cast(MonitorService, monitor_service),
+        get_background_task_manager=lambda: None,
+        get_background_task_service=lambda: cast(
+            BackgroundTaskService, background_task_service
+        ),
+        get_todo_service=lambda: None,
+        get_run_session_id=_fail_sync_session_id,
+        get_run_session_id_async=_session_id_async,
+    )
+
+    created = await service.create_monitor_async(
+        run_id="run-1",
+        source_kind=MonitorSourceKind.BACKGROUND_TASK,
+        source_key=" background_task_1 ",
+        rule=MonitorRule(),
+        action_type=MonitorActionType.WAKE_INSTANCE,
+    )
+    listed = await service.list_monitors_async("run-1")
+    stopped = await service.stop_monitor_async(
+        run_id="run-1",
+        monitor_id="mon_async",
+    )
+
+    assert created["monitor_id"] == "mon_async"
+    assert created["session_id"] == "session-for-run-1"
+    assert listed[0]["monitor_id"] == "mon_async"
+    assert stopped["monitor_id"] == "mon_async"
+    assert background_task_service.calls == ["get:background_task_1"]
+    assert monitor_service.calls == [
+        "create:background_task_1",
+        "list:run-1",
+        "stop:mon_async",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_auxiliary_background_task_async_uses_manager_fallback() -> None:
+    background_record = _background_record(
+        background_task_id="background_task_1",
+        execution_mode="background",
+    )
+    foreground_record = _background_record(
+        background_task_id="foreground_task_1",
+        execution_mode="foreground",
+    )
+    manager = _AsyncOnlyBackgroundTaskManager(
+        background_record=background_record,
+        foreground_record=foreground_record,
+    )
+    service = RunAuxiliaryService(
+        get_monitor_service=lambda: None,
+        get_background_task_manager=lambda: cast(BackgroundTaskManager, manager),
+        get_background_task_service=lambda: None,
+        get_todo_service=lambda: None,
+        get_run_session_id=_fail_sync_session_id,
+        get_run_session_id_async=_session_id_async,
+    )
+
+    listed = await service.list_background_tasks_async("run-1")
+    fetched = await service.get_background_task_async(
+        run_id="run-1",
+        background_task_id="background_task_1",
+    )
+
+    assert tuple(item["background_task_id"] for item in listed) == (
+        "background_task_1",
+    )
+    assert fetched["background_task_id"] == "background_task_1"
+    assert manager.calls == ["list:run-1", "get:background_task_1"]
+
+
+@pytest.mark.asyncio
+async def test_run_auxiliary_todo_async_uses_async_session_resolver() -> None:
+    todo_service = _AsyncOnlyTodoService()
+    service = RunAuxiliaryService(
+        get_monitor_service=lambda: None,
+        get_background_task_manager=lambda: None,
+        get_background_task_service=lambda: None,
+        get_todo_service=lambda: cast(TodoService, todo_service),
+        get_run_session_id=_fail_sync_session_id,
+        get_run_session_id_async=_session_id_async,
+    )
+
+    snapshot = await service.get_todo_async("run-1")
+
+    assert snapshot["session_id"] == "session-for-run-1"
+    assert todo_service.calls == ["get:run-1:session-for-run-1"]
+
+
+def _fail_sync_session_id(run_id: str) -> str:
+    _ = run_id
+    raise AssertionError("sync session resolver must not run")
+
+
+async def _session_id_async(run_id: str) -> str:
+    return f"session-for-{run_id}"
+
+
+def _background_record(
+    *,
+    background_task_id: str,
+    execution_mode: Literal["foreground", "background"],
+) -> BackgroundTaskRecord:
+    return BackgroundTaskRecord(
+        background_task_id=background_task_id,
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="instance-1",
+        role_id="role-1",
+        tool_call_id="tool-call-1",
+        command="sleep 1",
+        cwd="/tmp/workspace",
+        execution_mode=execution_mode,
+        log_path="tmp/background_tasks/task.log",
+    )

--- a/tests/unit_tests/sessions/runs/test_run_control_manager.py
+++ b/tests/unit_tests/sessions/runs/test_run_control_manager.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic_ai.messages import UserPromptPart
 
 from relay_teams.agents.instances.enums import InstanceLifecycle, InstanceStatus
+from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
@@ -253,6 +254,51 @@ def test_get_coordinator_instance_id_uses_assigned_ephemeral_root(
         == "inst-ephemeral-root"
     )
     assert agent_repo.get_session_role_instance_id("session-1", "Coordinator") is None
+
+
+@pytest.mark.asyncio
+async def test_inject_to_running_agents_async_publishes_event(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_control_async_injection.db"
+    event_log = EventLog(db_path)
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    agent_repo = AgentInstanceRepository(db_path)
+    mgr = RunControlManager()
+    mgr.bind_runtime(
+        run_event_hub=RunEventHub(
+            event_log=event_log,
+            run_state_repo=RunStateRepository(db_path),
+        ),
+        injection_manager=injection_manager,
+        agent_repo=agent_repo,
+        task_repo=TaskRepository(db_path),
+        message_repo=MessageRepository(db_path),
+        event_bus=event_log,
+        run_runtime_repo=RunRuntimeRepository(db_path),
+    )
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="worker",
+        workspace_id="workspace-1",
+        status=InstanceStatus.RUNNING,
+    )
+
+    message = await mgr.inject_to_running_agents_async(
+        run_id="run-1",
+        source=InjectionSource.USER,
+        content="continue",
+    )
+
+    assert message.recipient_instance_id == "inst-1"
+    queued = injection_manager.drain_at_boundary("run-1", "inst-1")
+    assert len(queued) == 1
+    events = await event_log.list_by_session_with_ids_async("session-1")
+    assert events[-1]["event_type"] == RunEventType.INJECTION_ENQUEUED.value
 
 
 def test_context_raises_when_cancelled() -> None:

--- a/tests/unit_tests/sessions/runs/test_run_runtime_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_runtime_repo.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import sqlite3
 from threading import Barrier
 
+import pytest
+
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
     RunRuntimeRepository,
@@ -181,6 +183,57 @@ def test_run_runtime_repo_upsert_recovers_existing_dirty_rows(tmp_path: Path) ->
 
     assert updated.status == RunRuntimeStatus.PAUSED
     assert updated.phase == RunRuntimePhase.AWAITING_TOOL_APPROVAL
+
+
+@pytest.mark.asyncio
+async def test_run_runtime_repo_async_methods_share_persisted_state(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_runtime_async.db"
+    repo = RunRuntimeRepository(db_path)
+    try:
+        created = await repo.ensure_async(
+            run_id="run-async",
+            session_id="session-1",
+            root_task_id="task-1",
+        )
+
+        assert created.run_id == "run-async"
+        assert repo.get("run-async") is not None
+
+        updated = await repo.update_async(
+            "run-async",
+            status=RunRuntimeStatus.RUNNING,
+            phase=RunRuntimePhase.SUBAGENT_RUNNING,
+            active_instance_id="instance-1",
+        )
+        listed = await repo.list_by_session_async("session-1")
+        recoverable = await repo.list_recoverable_async()
+
+        assert updated.status == RunRuntimeStatus.RUNNING
+        assert [record.run_id for record in listed] == ["run-async"]
+        assert "run-async" in {record.run_id for record in recoverable}
+
+        affected = await repo.mark_transient_runs_interrupted_async()
+        interrupted = await repo.get_async("run-async")
+
+        assert affected == 1
+        assert interrupted is not None
+        assert interrupted.status == RunRuntimeStatus.STOPPED
+        assert interrupted.phase == RunRuntimePhase.IDLE
+        assert interrupted.last_error == "interrupted_by_process_restart"
+
+        await repo.ensure_async(
+            run_id="run-delete",
+            session_id="session-1",
+            root_task_id="task-delete",
+        )
+        await repo.delete_by_session_async("session-1")
+
+        assert await repo.get_async("run-async") is None
+        assert repo.get("run-delete") is None
+    finally:
+        await repo.close_async()
 
 
 def _insert_run_runtime_row(

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -3398,12 +3398,31 @@ async def test_answer_user_question_async_uses_async_resume_path(
     def _sync_runtime_unavailable(run_id: str) -> RunRuntimeRecord | None:
         raise AssertionError(f"sync runtime lookup must not run for {run_id}")
 
+    def _sync_running_agent_check_unavailable(run_id: str) -> bool:
+        raise AssertionError(f"sync running-agent check must not run for {run_id}")
+
+    running_agent_checks: list[str] = []
+
+    async def _capture_running_agent_check(run_id: str) -> bool:
+        running_agent_checks.append(run_id)
+        return False
+
     async def _capture_ensure(run_id: str) -> None:
         ensured.append(run_id)
 
     monkeypatch.setattr(manager, "resume_run", _sync_resume_unavailable)
     monkeypatch.setattr(manager, "_runtime_for_run", _sync_runtime_unavailable)
     monkeypatch.setattr(manager, "ensure_run_started_async", _capture_ensure)
+    monkeypatch.setattr(
+        manager._interaction_service,
+        "_has_running_agents_for_run",
+        _sync_running_agent_check_unavailable,
+    )
+    monkeypatch.setattr(
+        manager._interaction_service,
+        "_has_running_agents_for_run_async",
+        _capture_running_agent_check,
+    )
 
     result = await manager.answer_user_question_async(
         run_id="run-existing",
@@ -3415,6 +3434,7 @@ async def test_answer_user_question_async_uses_async_resume_path(
 
     assert result["status"] == "answered"
     assert "run-existing" in manager._resume_requested_runs
+    assert running_agent_checks == ["run-existing"]
     assert ensured == ["run-existing"]
 
 

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from pathlib import Path
-from typing import Callable, Literal, cast
+from typing import Awaitable, Callable, Literal, cast
 
 import pytest
 from pydantic import JsonValue
@@ -67,6 +68,7 @@ from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
+    RunRuntimeRecord,
     RunRuntimeRepository,
     RunRuntimeStatus,
 )
@@ -122,6 +124,9 @@ class _SessionRepo:
             workspace_id="default",
         )
 
+    async def get_async(self, session_id: str) -> SessionRecord:
+        return self.get(session_id)
+
     def create(
         self,
         session_id: str,
@@ -135,6 +140,9 @@ class _SessionRepo:
 
     def mark_started(self, session_id: str) -> SessionRecord:
         return self.get(session_id)
+
+    async def mark_started_async(self, session_id: str) -> SessionRecord:
+        return self.mark_started(session_id)
 
 
 class _EventBus:
@@ -1776,6 +1784,77 @@ def test_stop_subagent_completes_questions_and_emits_resolution_event(
     }
 
 
+@pytest.mark.asyncio
+async def test_stop_subagent_async_completes_questions_without_sync_wrapper(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_stop_subagent_async_question_event.db"
+    manager = _build_manager(db_path)
+    task_repo = TaskRepository(db_path)
+    user_question_repo = UserQuestionRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _create_root_task(task_repo)
+    run_runtime_repo.ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    _upsert_coordinator(agent_repo)
+    _upsert_instance(
+        agent_repo,
+        instance_id="inst-2",
+        role_id="Writer",
+        status=InstanceStatus.RUNNING,
+    )
+    user_question_repo.upsert_requested(
+        question_id="call-question-async",
+        run_id="run-existing",
+        session_id="session-1",
+        task_id="task-root-1",
+        instance_id="inst-2",
+        role_id="Writer",
+        tool_name="ask_question",
+        questions=(
+            UserQuestionPrompt(
+                question="Pick one",
+                options=(UserQuestionOption(label="Only", description="Only"),),
+                multiple=False,
+            ),
+        ),
+    )
+    question_manager = manager._user_question_manager
+    assert question_manager is not None
+    question_manager.open_question(
+        run_id="run-existing",
+        question_id="call-question-async",
+        instance_id="inst-2",
+        role_id="Writer",
+    )
+
+    result = await manager.stop_subagent_async("run-existing", "inst-2")
+
+    assert result["instance_id"] == "inst-2"
+    record = await user_question_repo.get_async("call-question-async")
+    assert record is not None
+    assert record.status == UserQuestionRequestStatus.COMPLETED
+    assert (
+        question_manager.get_question(
+            run_id="run-existing",
+            question_id="call-question-async",
+        )
+        is None
+    )
+    events = await EventLog(db_path).list_by_session_with_ids_async("session-1")
+    assert [event["event_type"] for event in events[-2:]] == [
+        RunEventType.SUBAGENT_STOPPED.value,
+        RunEventType.USER_QUESTION_ANSWERED.value,
+    ]
+
+
 def test_resume_run_allows_stopped_run_with_pending_tool_approval(
     tmp_path: Path,
 ) -> None:
@@ -3272,6 +3351,908 @@ def test_answer_user_question_validates_payload_and_auto_resumes_stopped_run(
     record = user_question_repo.get("call-question-1")
     assert record is not None
     assert record.status.value == "answered"
+
+
+@pytest.mark.asyncio
+async def test_answer_user_question_async_uses_async_resume_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_answer_user_question_async.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    task_repo = TaskRepository(db_path)
+    user_question_repo = UserQuestionRepository(db_path)
+
+    _create_root_task(task_repo)
+    runtime_repo.ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-existing",
+        status=RunRuntimeStatus.STOPPED,
+        phase=RunRuntimePhase.AWAITING_MANUAL_ACTION,
+    )
+    user_question_repo.upsert_requested(
+        question_id="call-question-async",
+        run_id="run-existing",
+        session_id="session-1",
+        task_id="task-root-1",
+        instance_id="inst-1",
+        role_id="Coordinator",
+        tool_name="ask_question",
+        questions=(
+            UserQuestionPrompt(
+                question="Pick one",
+                options=(UserQuestionOption(label="A", description="Option A"),),
+            ),
+        ),
+    )
+    ensured: list[str] = []
+
+    def _sync_resume_unavailable(run_id: str) -> str:
+        raise AssertionError(f"sync resume must not run for {run_id}")
+
+    def _sync_runtime_unavailable(run_id: str) -> RunRuntimeRecord | None:
+        raise AssertionError(f"sync runtime lookup must not run for {run_id}")
+
+    async def _capture_ensure(run_id: str) -> None:
+        ensured.append(run_id)
+
+    monkeypatch.setattr(manager, "resume_run", _sync_resume_unavailable)
+    monkeypatch.setattr(manager, "_runtime_for_run", _sync_runtime_unavailable)
+    monkeypatch.setattr(manager, "ensure_run_started_async", _capture_ensure)
+
+    result = await manager.answer_user_question_async(
+        run_id="run-existing",
+        question_id="call-question-async",
+        answers=UserQuestionAnswerSubmission.model_validate(
+            {"answers": [{"selections": [{"label": "A"}]}]}
+        ),
+    )
+
+    assert result["status"] == "answered"
+    assert "run-existing" in manager._resume_requested_runs
+    assert ensured == ["run-existing"]
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_async_paths_avoid_sync_scheduler_entrypoints(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_lifecycle_async.db"
+    manager = _build_manager(db_path)
+
+    def _sync_entrypoint_unavailable(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        raise AssertionError("sync scheduler entrypoint must not run")
+
+    monkeypatch.setattr(manager._scheduler, "create_run", _sync_entrypoint_unavailable)
+    monkeypatch.setattr(manager, "_create_run_local", _sync_entrypoint_unavailable)
+    monkeypatch.setattr(
+        manager._scheduler,
+        "ensure_run_started",
+        _sync_entrypoint_unavailable,
+    )
+    monkeypatch.setattr(manager._scheduler, "resume_run", _sync_entrypoint_unavailable)
+    monkeypatch.setattr(manager._scheduler, "stop_run", _sync_entrypoint_unavailable)
+
+    worker_calls: list[tuple[str, str]] = []
+
+    async def _capture_worker(
+        *,
+        run_id: str,
+        session_id: str,
+        runner: Callable[[], Awaitable[RunResult]],
+    ) -> None:
+        _ = runner
+        worker_calls.append((run_id, session_id))
+
+    monkeypatch.setattr(manager, "_worker", _capture_worker)
+
+    run_id, session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("hello"),
+        )
+    )
+    await manager.ensure_run_started_async(run_id)
+    await asyncio.sleep(0)
+
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.update(
+        run_id,
+        status=RunRuntimeStatus.STOPPED,
+        phase=RunRuntimePhase.AWAITING_RECOVERY,
+    )
+    manager._running_run_ids.discard(run_id)
+
+    resumed_session_id = await manager.resume_run_async(run_id)
+    await manager.stop_run_async(run_id)
+
+    assert session_id == "session-1"
+    assert worker_calls == [(run_id, "session-1")]
+    assert resumed_session_id == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_create_run_async_merges_followup_into_pending_run(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_async_pending_merge.db"
+    manager = _build_manager(db_path)
+
+    run_id, session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("first"),
+            skills=("skill-a",),
+        )
+    )
+    next_run_id, next_session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("second"),
+            skills=("skill-b", "skill-a"),
+            yolo=True,
+        )
+    )
+
+    pending = manager._pending_runs[run_id]
+    persisted = RunIntentRepository(db_path).get(run_id)
+
+    assert (next_run_id, next_session_id) == (run_id, session_id)
+    assert pending.intent == "first\n\nsecond"
+    assert pending.skills == ("skill-a", "skill-b")
+    assert pending.yolo is True
+    assert persisted.intent == pending.intent
+    assert persisted.skills == pending.skills
+    assert persisted.yolo is True
+
+
+@pytest.mark.asyncio
+async def test_create_run_async_rejects_detached_and_media_followups(
+    tmp_path: Path,
+) -> None:
+    manager = _build_manager(tmp_path / "run_async_followup_rejections.db")
+
+    run_id, _ = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("first"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match=f"already has active run {run_id}"):
+        await manager.create_detached_run_async(
+            IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("detached"),
+            )
+        )
+    with pytest.raises(RuntimeError, match="does not accept follow-up input"):
+        await manager.create_run_async(
+            IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("draw"),
+                run_kind=RunKind.GENERATE_IMAGE,
+                generation_config=ImageGenerationConfig(),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_run_async_enqueues_followup_to_active_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_async_active_followup.db"
+    manager = _build_manager(db_path)
+
+    run_id, session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("first"),
+        )
+    )
+    manager._running_run_ids.add(run_id)
+    manager._injection_manager.activate(run_id)
+    appended: list[tuple[str, str, bool, InjectionSource]] = []
+
+    def _append_followup(
+        run_id: str,
+        content: str,
+        *,
+        enqueue: bool,
+        source: InjectionSource = InjectionSource.USER,
+    ) -> bool:
+        appended.append((run_id, content, enqueue, source))
+        return True
+
+    monkeypatch.setattr(manager, "_append_followup_to_coordinator", _append_followup)
+
+    next_run_id, next_session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("follow"),
+            yolo=True,
+        )
+    )
+
+    persisted = RunIntentRepository(db_path).get(run_id)
+    assert (next_run_id, next_session_id) == (run_id, session_id)
+    assert appended == [(run_id, "follow", True, InjectionSource.USER)]
+    assert persisted.yolo is True
+
+
+@pytest.mark.asyncio
+async def test_create_run_async_queues_followup_for_recoverable_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_async_recoverable_followup.db"
+    manager = _build_manager(db_path)
+
+    run_id, session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("first"),
+        )
+    )
+    _ = manager._pending_runs.pop(run_id)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.update(
+        run_id,
+        status=RunRuntimeStatus.STOPPED,
+        phase=RunRuntimePhase.AWAITING_RECOVERY,
+    )
+    appended: list[tuple[str, str, bool, InjectionSource]] = []
+
+    def _append_followup(
+        run_id: str,
+        content: str,
+        *,
+        enqueue: bool,
+        source: InjectionSource = InjectionSource.USER,
+    ) -> bool:
+        appended.append((run_id, content, enqueue, source))
+        return False
+
+    monkeypatch.setattr(manager, "_append_followup_to_coordinator", _append_followup)
+
+    next_run_id, next_session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("resume"),
+            yolo=True,
+        )
+    )
+
+    persisted = RunIntentRepository(db_path).get(run_id)
+    assert (next_run_id, next_session_id) == (run_id, session_id)
+    assert appended == [(run_id, "resume", False, InjectionSource.USER)]
+    assert run_id in manager._resume_requested_runs
+    assert persisted.yolo is True
+
+
+@pytest.mark.asyncio
+async def test_async_run_start_helpers_cover_missing_and_failed_startup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_async_start_helper_failures.db"
+    manager = _build_manager(db_path)
+    runtime_repo = manager._run_runtime_repo
+    assert runtime_repo is not None
+
+    assert await manager._active_recoverable_run_async("missing-session") is None
+    with pytest.raises(KeyError, match="Run missing-run not found"):
+        await manager._ensure_run_started_local_async("missing-run")
+    with pytest.raises(KeyError, match="Run missing-run not found"):
+        await manager._start_new_run_worker_async("missing-run")
+    with pytest.raises(KeyError, match="Run missing-run not found"):
+        await manager._start_resume_worker_async("missing-run")
+
+    run_id, _ = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("first"),
+        )
+    )
+
+    async def _raise_update_async(run_id: str, **changes: object) -> RunRuntimeRecord:
+        _ = (run_id, changes)
+        raise RuntimeError("startup write failed")
+
+    monkeypatch.setattr(runtime_repo, "update_async", _raise_update_async)
+    with pytest.raises(RuntimeError, match="startup write failed"):
+        await manager.ensure_run_started_async(run_id)
+
+
+@pytest.mark.asyncio
+async def test_async_resume_startup_failure_and_transition_phase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_async_resume_startup.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        status=RunRuntimeStatus.STOPPED,
+        phase=RunRuntimePhase.AWAITING_RECOVERY,
+    )
+
+    async def _raise_transition(
+        *,
+        run_id: str,
+        session_id: str,
+        reason: str,
+    ) -> dict[str, JsonValue]:
+        _ = (run_id, session_id, reason)
+        raise RuntimeError("resume transition failed")
+
+    monkeypatch.setattr(manager, "_transition_run_to_resumed_async", _raise_transition)
+    with pytest.raises(RuntimeError, match="resume transition failed"):
+        await manager._start_resume_worker_async("run-existing")
+
+    manager = _build_manager(db_path)
+    payload = await manager._transition_run_to_resumed_async(
+        run_id="run-existing",
+        session_id="session-1",
+        reason="resume",
+    )
+    runtime = runtime_repo.get("run-existing")
+
+    assert payload == {"session_id": "session-1", "reason": "resume"}
+    assert runtime is not None
+    assert runtime.phase == RunRuntimePhase.AWAITING_RECOVERY
+
+
+@pytest.mark.asyncio
+async def test_async_followup_validation_helpers_cover_edge_paths(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_async_followup_helper_edges.db"
+    manager = _build_manager(db_path)
+
+    await manager._assert_auto_attach_allowed_async("run-missing", None)
+    with pytest.raises(RuntimeError, match="is stopping"):
+        await manager._assert_auto_attach_allowed_async(
+            "run-stopping",
+            RunRuntimeRecord(
+                run_id="run-stopping",
+                session_id="session-1",
+                status=RunRuntimeStatus.STOPPING,
+            ),
+        )
+    with pytest.raises(RuntimeError, match="Subagent inst-1"):
+        await manager._assert_auto_attach_allowed_async(
+            "run-paused-subagent",
+            RunRuntimeRecord(
+                run_id="run-paused-subagent",
+                session_id="session-1",
+                phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
+                active_subagent_instance_id="inst-1",
+            ),
+        )
+
+    await manager._update_run_yolo_async(
+        run_id="missing-run",
+        session_id="session-1",
+        yolo=True,
+    )
+    manager._run_intent_repo = None
+    await manager._update_run_yolo_async(
+        run_id="missing-run",
+        session_id="session-1",
+        yolo=True,
+    )
+
+    assert await manager._run_accepts_followups_async(
+        "missing-run",
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("hello"),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_run_async_cancels_worker_during_startup_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_startup_stop_async.db"
+    manager = _build_manager(db_path)
+    runtime_repo = manager._run_runtime_repo
+    assert runtime_repo is not None
+
+    worker_started = asyncio.Event()
+
+    async def _capture_worker(
+        *,
+        run_id: str,
+        session_id: str,
+        runner: Callable[[], Awaitable[RunResult]],
+    ) -> None:
+        _ = (run_id, session_id, runner)
+        worker_started.set()
+
+    monkeypatch.setattr(manager, "_worker", _capture_worker)
+
+    run_id, session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("hello"),
+        )
+    )
+
+    startup_entered = asyncio.Event()
+    allow_startup = asyncio.Event()
+    original_ensure_async = runtime_repo.ensure_async
+
+    async def _blocking_ensure_async(
+        *,
+        run_id: str,
+        session_id: str,
+        root_task_id: str | None = None,
+        status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
+        phase: RunRuntimePhase = RunRuntimePhase.IDLE,
+    ) -> RunRuntimeRecord:
+        startup_entered.set()
+        await allow_startup.wait()
+        return await original_ensure_async(
+            run_id=run_id,
+            session_id=session_id,
+            root_task_id=root_task_id,
+            status=status,
+            phase=phase,
+        )
+
+    monkeypatch.setattr(runtime_repo, "ensure_async", _blocking_ensure_async)
+
+    start_task = asyncio.create_task(manager.ensure_run_started_async(run_id))
+    await asyncio.wait_for(startup_entered.wait(), timeout=5)
+
+    await manager.stop_run_async(run_id)
+    allow_startup.set()
+    await asyncio.wait_for(start_task, timeout=5)
+
+    async def _wait_for_finalized_runtime() -> RunRuntimeRecord:
+        while True:
+            runtime = await runtime_repo.get_async(run_id)
+            if (
+                runtime is not None
+                and runtime.status == RunRuntimeStatus.STOPPED
+                and run_id not in manager._pending_runs
+                and run_id not in manager._running_run_ids
+            ):
+                return runtime
+            await asyncio.sleep(0.01)
+
+    runtime = await asyncio.wait_for(_wait_for_finalized_runtime(), timeout=5)
+    await asyncio.sleep(0)
+
+    assert session_id == "session-1"
+    assert not worker_started.is_set()
+    assert run_id not in manager._pending_runs
+    assert run_id not in manager._running_run_ids
+    assert runtime.phase == RunRuntimePhase.IDLE
+    assert runtime.last_error == "stopped_by_user"
+
+    events = EventLog(db_path).list_by_session_with_ids("session-1")
+    stopped_events = [
+        event
+        for event in events
+        if event["event_type"] == RunEventType.RUN_STOPPED.value
+    ]
+    assert json.loads(str(stopped_events[-1]["payload_json"])) == {
+        "reason": "stopped_by_user"
+    }
+
+
+@pytest.mark.asyncio
+async def test_bound_loop_helpers_dispatch_callbacks_to_service_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _build_manager(tmp_path / "run_bound_loop_helpers.db")
+
+    assert manager._call_in_bound_loop(lambda: "local") == "local"
+    assert await manager._call_in_bound_loop_async(lambda: "local-async") == (
+        "local-async"
+    )
+
+    service_loop = asyncio.new_event_loop()
+    ready = threading.Event()
+    callback_thread_ids: list[int] = []
+
+    def _run_service_loop() -> None:
+        asyncio.set_event_loop(service_loop)
+        ready.set()
+        service_loop.run_forever()
+
+    thread = threading.Thread(target=_run_service_loop)
+    thread.start()
+    assert ready.wait(timeout=5)
+    thread_id = thread.ident
+    assert thread_id is not None
+
+    def _capture_thread() -> str:
+        callback_thread_ids.append(threading.get_ident())
+        return "bound"
+
+    def _sync_error() -> str:
+        raise RuntimeError("sync bound failure")
+
+    def _async_error() -> str:
+        raise RuntimeError("async bound failure")
+
+    lifecycle_calls: list[str] = []
+
+    def _create_run(
+        intent: IntentInput,
+        *,
+        source: InjectionSource = InjectionSource.USER,
+    ) -> tuple[str, str]:
+        lifecycle_calls.append(f"create:{intent.intent}:{source.value}")
+        return "run-created", "session-1"
+
+    def _create_detached_run(intent: IntentInput) -> tuple[str, str]:
+        lifecycle_calls.append(f"detached:{intent.intent}")
+        return "run-detached", "session-1"
+
+    def _ensure_started(run_id: str) -> None:
+        lifecycle_calls.append(f"ensure:{run_id}")
+
+    def _inject_message(
+        run_id: str,
+        source: InjectionSource,
+        content: str,
+    ) -> tuple[str, str, str]:
+        lifecycle_calls.append(f"inject:{run_id}:{source.value}:{content}")
+        return run_id, source.value, content
+
+    def _stop_run(run_id: str) -> None:
+        lifecycle_calls.append(f"stop:{run_id}")
+
+    def _resume_run(run_id: str) -> str:
+        lifecycle_calls.append(f"resume:{run_id}")
+        return "session-1"
+
+    def _resolve_tool_approval(
+        run_id: str,
+        tool_call_id: str,
+        action: str,
+        feedback: str = "",
+    ) -> None:
+        lifecycle_calls.append(f"resolve:{run_id}:{tool_call_id}:{action}:{feedback}")
+
+    monkeypatch.setattr(manager, "create_run", _create_run)
+    monkeypatch.setattr(manager, "create_detached_run", _create_detached_run)
+    monkeypatch.setattr(manager, "ensure_run_started", _ensure_started)
+    monkeypatch.setattr(manager, "inject_message", _inject_message)
+    monkeypatch.setattr(manager, "stop_run", _stop_run)
+    monkeypatch.setattr(manager, "resume_run", _resume_run)
+    monkeypatch.setattr(manager, "resolve_tool_approval", _resolve_tool_approval)
+
+    manager._event_loop = service_loop
+    try:
+        assert manager._should_delegate_to_bound_loop() is True
+        assert manager._call_in_bound_loop(_capture_thread) == "bound"
+        assert await manager._call_in_bound_loop_async(lambda: "bound-async") == (
+            "bound-async"
+        )
+        with pytest.raises(RuntimeError, match="sync bound failure"):
+            manager._call_in_bound_loop(_sync_error)
+        with pytest.raises(RuntimeError, match="async bound failure"):
+            await manager._call_in_bound_loop_async(_async_error)
+        assert await manager.create_run_async(
+            IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("create through bound loop"),
+            ),
+            source=InjectionSource.SYSTEM,
+        ) == ("run-created", "session-1")
+        assert await manager.create_detached_run_async(
+            IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("detach through bound loop"),
+            )
+        ) == ("run-detached", "session-1")
+        await manager.ensure_run_started_async("run-created")
+        assert await manager.inject_message_async(
+            run_id="run-created",
+            source=InjectionSource.USER,
+            content="wake up",
+        ) == ("run-created", "user", "wake up")
+        await manager.stop_run_async("run-created")
+        assert await manager.resume_run_async("run-created") == "session-1"
+        await manager.resolve_tool_approval_async(
+            run_id="run-created",
+            tool_call_id="call-1",
+            action="approve",
+            feedback="ok",
+        )
+    finally:
+        manager._event_loop = None
+        service_loop.call_soon_threadsafe(service_loop.stop)
+        thread.join(timeout=5)
+        service_loop.close()
+
+    assert callback_thread_ids == [thread_id]
+    assert lifecycle_calls == [
+        "create:create through bound loop:system",
+        "detached:detach through bound loop",
+        "ensure:run-created",
+        "inject:run-created:user:wake up",
+        "stop:run-created",
+        "resume:run-created",
+        "resolve:run-created:call-1:approve:ok",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_intent_stream_starts_run_before_streaming_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _build_manager(tmp_path / "run_intent_stream.db")
+    calls: list[str] = []
+
+    def _create_run(intent: IntentInput) -> tuple[str, str]:
+        calls.append(f"create:{intent.session_id}")
+        return "run-stream", "session-1"
+
+    def _ensure_run_started(run_id: str) -> None:
+        calls.append(f"ensure:{run_id}")
+
+    async def _stream_run_events(run_id: str):
+        calls.append(f"stream:{run_id}")
+        yield RunEvent(
+            session_id="session-1",
+            run_id=run_id,
+            trace_id=run_id,
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json="{}",
+        )
+
+    monkeypatch.setattr(manager, "create_run", _create_run)
+    monkeypatch.setattr(manager, "ensure_run_started", _ensure_run_started)
+    monkeypatch.setattr(manager, "stream_run_events", _stream_run_events)
+
+    events = [
+        event
+        async for event in manager.run_intent_stream(
+            IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("hello"),
+            )
+        )
+    ]
+
+    assert calls == ["create:session-1", "ensure:run-stream", "stream:run-stream"]
+    assert [event.event_type for event in events] == [RunEventType.RUN_COMPLETED]
+
+
+@pytest.mark.asyncio
+async def test_ensure_run_started_local_async_validates_recoverable_state(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_ensure_local_async_validation.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+
+    manager._running_run_ids.add("run-running")
+    await manager._ensure_run_started_local_async("run-running")
+
+    manager._pending_runs["run-missing-session"] = IntentInput(
+        session_id="session-1",
+        input=content_parts_from_text("missing session"),
+    ).model_copy(update={"session_id": None})
+    with pytest.raises(RuntimeError, match="missing session id"):
+        await manager._ensure_run_started_local_async("run-missing-session")
+
+    manager._resume_requested_runs.add("run-missing-runtime")
+    with pytest.raises(KeyError, match="Run run-missing-runtime not found"):
+        await manager._ensure_run_started_local_async("run-missing-runtime")
+
+    runtime_repo.ensure(
+        run_id="run-invalid-status",
+        session_id="session-1",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    manager._resume_requested_runs.add("run-invalid-status")
+    with pytest.raises(RuntimeError, match="cannot be resumed from status running"):
+        await manager._ensure_run_started_local_async("run-invalid-status")
+
+
+@pytest.mark.asyncio
+async def test_stop_run_async_stops_pending_run_without_sync_entrypoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_stop_pending_async.db"
+    manager = _build_manager(db_path)
+
+    def _sync_stop_unavailable(run_id: str) -> None:
+        raise AssertionError(f"sync stop must not run for {run_id}")
+
+    monkeypatch.setattr(manager._scheduler, "stop_run", _sync_stop_unavailable)
+
+    run_id, session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("hello"),
+        )
+    )
+
+    await manager.stop_run_async(run_id)
+
+    assert session_id == "session-1"
+    assert run_id not in manager._pending_runs
+    runtime = RunRuntimeRepository(db_path).get(run_id)
+    assert runtime is not None
+    assert runtime.status == RunRuntimeStatus.STOPPED
+    assert runtime.phase == RunRuntimePhase.IDLE
+    assert runtime.last_error == "stopped_before_start"
+
+    events = EventLog(db_path).list_by_session_with_ids("session-1")
+    assert events[-1]["event_type"] == RunEventType.RUN_STOPPED.value
+    assert json.loads(str(events[-1]["payload_json"])) == {
+        "reason": "stopped_before_start"
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_tool_approval_async_publishes_for_paused_run(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_resolve_approval_async.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-existing",
+        status=RunRuntimeStatus.PAUSED,
+        phase=RunRuntimePhase.AWAITING_TOOL_APPROVAL,
+    )
+    ApprovalTicketRepository(db_path).upsert_requested(
+        tool_call_id="call-async-1",
+        run_id="run-existing",
+        session_id="session-1",
+        task_id="task-root-1",
+        instance_id="inst-1",
+        role_id="Coordinator",
+        tool_name="orch_create_tasks",
+        args_preview="{}",
+    )
+    manager._tool_approval_manager.open_approval(
+        run_id="run-existing",
+        tool_call_id="call-async-1",
+        instance_id="inst-1",
+        role_id="Coordinator",
+        tool_name="orch_create_tasks",
+        args_preview="{}",
+    )
+
+    await manager.resolve_tool_approval_async(
+        run_id="run-existing",
+        tool_call_id="call-async-1",
+        action="approve",
+    )
+
+    ticket = await ApprovalTicketRepository(db_path).get_async("call-async-1")
+    assert ticket is not None
+    assert ticket.status == ApprovalTicketStatus.APPROVED
+    assert await manager.list_open_tool_approvals_async("run-existing") == []
+
+    events = await EventLog(db_path).list_by_session_with_ids_async("session-1")
+    assert events[-1]["event_type"] == RunEventType.TOOL_APPROVAL_RESOLVED.value
+    payload = json.loads(str(events[-1]["payload_json"]))
+    assert payload["tool_call_id"] == "call-async-1"
+    assert payload["action"] == "approve"
+
+
+@pytest.mark.asyncio
+async def test_resolve_tool_approval_async_rejects_stopped_and_stopping_runs(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_resolve_approval_async_rejected.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-stopped",
+        session_id="session-1",
+        root_task_id="task-root-1",
+        status=RunRuntimeStatus.STOPPED,
+        phase=RunRuntimePhase.IDLE,
+    )
+    runtime_repo.ensure(
+        run_id="run-stopping",
+        session_id="session-1",
+        root_task_id="task-root-2",
+        status=RunRuntimeStatus.STOPPING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+
+    with pytest.raises(RuntimeError, match="Resume the run"):
+        await manager.resolve_tool_approval_async(
+            run_id="run-stopped",
+            tool_call_id="call-missing",
+            action="approve",
+        )
+    with pytest.raises(RuntimeError, match="is stopping"):
+        await manager.resolve_tool_approval_async(
+            run_id="run-stopping",
+            tool_call_id="call-missing",
+            action="approve",
+        )
+
+
+@pytest.mark.asyncio
+async def test_answer_user_question_async_rejects_missing_and_stopping_runs(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_answer_user_question_async_rejected.db"
+    manager = _build_manager(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-stopping",
+        session_id="session-1",
+        root_task_id="task-root-1",
+        status=RunRuntimeStatus.STOPPING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+    submission = UserQuestionAnswerSubmission.model_validate(
+        {"answers": [{"selections": [{"label": "Only"}]}]}
+    )
+
+    with pytest.raises(KeyError, match="Run run-missing not found"):
+        await manager.answer_user_question_async(
+            run_id="run-missing",
+            question_id="call-question-missing",
+            answers=submission,
+        )
+    with pytest.raises(RuntimeError, match="is stopping"):
+        await manager.answer_user_question_async(
+            run_id="run-stopping",
+            question_id="call-question-missing",
+            answers=submission,
+        )
+
+
+@pytest.mark.asyncio
+async def test_resume_run_async_rejects_missing_and_running_runs(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_resume_async_rejected.db"
+    manager = _build_manager(db_path)
+    RunRuntimeRepository(db_path).ensure(
+        run_id="run-running",
+        session_id="session-1",
+        root_task_id="task-root-1",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.COORDINATOR_RUNNING,
+    )
+
+    with pytest.raises(KeyError, match="Run run-missing not found"):
+        await manager.resume_run_async("run-missing")
+    with pytest.raises(RuntimeError, match="already running"):
+        await manager.resume_run_async("run-running")
+    manager._running_run_ids.add("run-running-local")
+    with pytest.raises(RuntimeError, match="already running"):
+        await manager.resume_run_async("run-running-local")
 
 
 def test_answer_user_question_skips_resume_when_session_has_other_pending_question(

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -1931,6 +1931,53 @@ def test_resolve_tool_approval_persists_shell_exact_grant(tmp_path: Path) -> Non
     )
 
 
+@pytest.mark.asyncio
+async def test_resolve_tool_approval_async_persists_shell_exact_grant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_shell_approval_async.db"
+    manager = _build_manager(db_path)
+    RunRuntimeRepository(db_path).ensure(
+        run_id="run-existing",
+        session_id="session-1",
+        root_task_id="task-root-1",
+    )
+    workspace_key = str((tmp_path / "workspace").resolve())
+    await ApprovalTicketRepository(db_path).upsert_requested_async(
+        tool_call_id="call-shell-async-1",
+        run_id="run-existing",
+        session_id="session-1",
+        task_id="task-root-1",
+        instance_id="inst-1",
+        role_id="Coordinator",
+        tool_name="shell",
+        args_preview='{"command":"git status"}',
+        metadata={
+            "workspace_key": workspace_key,
+            "runtime_family": "git-bash",
+            "normalized_command": "git status",
+            "prefix_candidates": ["git status"],
+        },
+    )
+
+    await manager.resolve_tool_approval_async(
+        run_id="run-existing",
+        tool_call_id="call-shell-async-1",
+        action="approve_exact",
+    )
+
+    shell_repo = ShellApprovalRepository(db_path)
+    assert (
+        await shell_repo.get_async(
+            workspace_key=workspace_key,
+            runtime_family=ShellRuntimeFamily.GIT_BASH,
+            scope=ShellApprovalScope.EXACT,
+            value="git status",
+        )
+        is not None
+    )
+
+
 def test_resolve_tool_approval_does_not_persist_shell_grant_from_resolved_ticket(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/sessions/runs/test_run_split_helpers.py
+++ b/tests/unit_tests/sessions/runs/test_run_split_helpers.py
@@ -21,8 +21,11 @@ from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.media_run_executor import MediaRunExecutor
 from relay_teams.sessions.runs.run_event_publisher import RunEventPublisher
 from relay_teams.sessions.runs.run_interactions import parse_tool_approval_action
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.run_models import (
     IntentInput,
+    RunEvent,
     RunKind,
     RunTopologySnapshot,
 )
@@ -64,6 +67,32 @@ def test_parse_tool_approval_action_accepts_all_supported_actions() -> None:
 def test_parse_tool_approval_action_rejects_unknown_action() -> None:
     with pytest.raises(ValueError, match="Unsupported action: later"):
         parse_tool_approval_action("later")
+
+
+@pytest.mark.asyncio
+async def test_run_event_publisher_async_tolerates_publish_failure() -> None:
+    class _FailingAsyncRunEventHub:
+        async def publish_async(self, event: RunEvent) -> None:
+            _ = event
+            raise RuntimeError("publish failed")
+
+    publisher = RunEventPublisher(
+        run_event_hub=cast(RunEventHub, _FailingAsyncRunEventHub()),
+        get_runtime=lambda _run_id: None,
+        get_run_runtime_repo=lambda: None,
+        get_notification_service=lambda: None,
+    )
+
+    await publisher.safe_publish_run_event_async(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json="{}",
+        ),
+        failure_event="run.event.publish_failed",
+    )
 
 
 def test_execute_native_generation_rejects_inline_media_output() -> None:

--- a/tests/unit_tests/sessions/runs/test_run_state_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_state_repo.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.runs.run_state_models import (
+    RunSnapshotRecord,
+    RunStateStatus,
+)
+from relay_teams.sessions.runs.run_state_repo import RunStateRepository
+
+
+@pytest.mark.asyncio
+async def test_run_state_repository_async_methods_share_persisted_state(
+    tmp_path: Path,
+) -> None:
+    repository = RunStateRepository(tmp_path / "run_state_repo_async.db")
+    event = RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        event_type=RunEventType.RUN_STARTED,
+        payload_json="{}",
+    )
+
+    try:
+        state = await repository.apply_event_async(event_id=1, event=event)
+        by_session = await repository.list_by_session_async("session-1")
+        snapshot = await repository.get_latest_snapshot_async("run-1")
+        recoverable = await repository.list_recoverable_async()
+        await repository.delete_async("run-1")
+        deleted = await repository.get_run_state_async("run-1")
+    finally:
+        await repository.close_async()
+
+    assert state.status == RunStateStatus.RUNNING
+    assert tuple(item.run_id for item in by_session) == ("run-1",)
+    assert snapshot is not None
+    assert snapshot.checkpoint_event_id == 1
+    assert tuple(item.run_id for item in recoverable) == ("run-1",)
+    assert deleted is None
+
+
+@pytest.mark.asyncio
+async def test_run_state_async_hot_paths_do_not_reinitialize_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = RunStateRepository(tmp_path / "run_state_repo_no_reinit.db")
+    event = RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        event_type=RunEventType.RUN_STARTED,
+        payload_json="{}",
+    )
+
+    async def _fail_init() -> None:
+        raise AssertionError("async schema init should not run on hot paths")
+
+    monkeypatch.setattr(repository, "_init_tables_async", _fail_init)
+
+    try:
+        state = await repository.apply_event_async(event_id=1, event=event)
+        await repository.upsert_async(state)
+        loaded = await repository.get_run_state_async("run-1")
+        by_session = await repository.list_by_session_async("session-1")
+        snapshot = await repository.get_latest_snapshot_async("run-1")
+        recoverable = await repository.list_recoverable_async()
+        await repository.delete_async("run-1")
+        deleted = await repository.get_run_state_async("run-1")
+    finally:
+        await repository.close_async()
+
+    assert loaded is not None
+    assert loaded.run_id == "run-1"
+    assert tuple(item.run_id for item in by_session) == ("run-1",)
+    assert snapshot is not None
+    assert tuple(item.run_id for item in recoverable) == ("run-1",)
+    assert deleted is None
+
+
+@pytest.mark.asyncio
+async def test_run_state_async_schema_init_and_snapshot_upserts(
+    tmp_path: Path,
+) -> None:
+    repository = RunStateRepository(tmp_path / "run_state_repo_schema_async.db")
+    event = RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        event_type=RunEventType.RUN_STARTED,
+        payload_json="{}",
+    )
+
+    try:
+        await repository._init_tables_async()
+        missing_snapshot = await repository.get_latest_snapshot_async("missing")
+        state = await repository.apply_event_async(event_id=1, event=event)
+        sync_snapshot = RunSnapshotRecord(
+            run_id=state.run_id,
+            session_id=state.session_id,
+            checkpoint_event_id=2,
+            state=state,
+            created_at=state.updated_at,
+        )
+        repository._upsert_snapshot(sync_snapshot)
+        async_snapshot = RunSnapshotRecord(
+            run_id=state.run_id,
+            session_id=state.session_id,
+            checkpoint_event_id=3,
+            state=state,
+            created_at=state.updated_at,
+        )
+        await repository._upsert_snapshot_async(async_snapshot)
+        latest_snapshot = await repository.get_latest_snapshot_async("run-1")
+        recoverable = repository.list_recoverable()
+    finally:
+        await repository.close_async()
+
+    assert missing_snapshot is None
+    assert latest_snapshot is not None
+    assert latest_snapshot.checkpoint_event_id == 3
+    assert tuple(item.run_id for item in recoverable) == ("run-1",)

--- a/tests/unit_tests/sessions/runs/test_todo_repository.py
+++ b/tests/unit_tests/sessions/runs/test_todo_repository.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 import sqlite3
 
+import pytest
+
 from relay_teams.sessions.runs.todo_models import (
     TodoItem,
     TodoStatus,
@@ -49,6 +51,81 @@ def test_list_by_session_skips_rows_with_non_list_items_payload(tmp_path: Path) 
     snapshots = repository.list_by_session("session-1")
 
     assert [snapshot.run_id for snapshot in snapshots] == ["run-valid"]
+
+
+@pytest.mark.asyncio
+async def test_async_todo_repository_methods_share_persisted_state(
+    tmp_path: Path,
+) -> None:
+    repository = TodoRepository(tmp_path / "todo-repository-async.db")
+
+    try:
+        persisted = await repository.upsert_async(
+            build_todo_snapshot(
+                run_id="run-async",
+                session_id="session-1",
+                items=(TodoItem(content="Inspect repo", status=TodoStatus.PENDING),),
+                version=1,
+            )
+        )
+        fetched = await repository.get_async("run-async")
+        listed = await repository.list_by_session_async("session-1")
+        await repository.delete_by_run_async("run-async")
+        deleted = await repository.get_async("run-async")
+    finally:
+        await repository.close_async()
+
+    assert persisted.run_id == "run-async"
+    assert fetched is not None
+    assert fetched.items == persisted.items
+    assert tuple(snapshot.run_id for snapshot in listed) == ("run-async",)
+    assert deleted is None
+
+
+@pytest.mark.asyncio
+async def test_todo_repository_async_hot_paths_do_not_reinitialize_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = TodoRepository(tmp_path / "todo-repository-no-reinit.db")
+    run_snapshot = build_todo_snapshot(
+        run_id="run-async",
+        session_id="session-1",
+        items=(TodoItem(content="Inspect repo", status=TodoStatus.PENDING),),
+        version=1,
+    )
+    session_delete_snapshot = build_todo_snapshot(
+        run_id="run-delete-session",
+        session_id="session-delete",
+        items=(TodoItem(content="Delete by session", status=TodoStatus.PENDING),),
+        version=1,
+    )
+    run_delete_snapshot = build_todo_snapshot(
+        run_id="run-delete",
+        session_id="session-2",
+        items=(TodoItem(content="Delete by run", status=TodoStatus.PENDING),),
+        version=1,
+    )
+
+    async def _fail_init() -> None:
+        raise AssertionError("async schema init should not run on hot paths")
+
+    try:
+        await repository._init_tables_async()
+        monkeypatch.setattr(repository, "_init_tables_async", _fail_init)
+        persisted = await repository.upsert_async(run_snapshot)
+        fetched = await repository.get_async("run-async")
+        listed = await repository.list_by_session_async("session-1")
+        await repository.upsert_async(session_delete_snapshot)
+        await repository.delete_by_session_async("session-delete")
+        await repository.upsert_async(run_delete_snapshot)
+        await repository.delete_by_run_async("run-delete")
+    finally:
+        await repository.close_async()
+
+    assert persisted.run_id == "run-async"
+    assert fetched is not None
+    assert tuple(snapshot.run_id for snapshot in listed) == ("run-async",)
 
 
 def _insert_raw_row(

--- a/tests/unit_tests/sessions/runs/test_todo_service.py
+++ b/tests/unit_tests/sessions/runs/test_todo_service.py
@@ -127,3 +127,86 @@ def test_clear_for_run_persists_empty_list(tmp_path: Path) -> None:
 
     assert cleared.version == 2
     assert cleared.items == ()
+
+
+@pytest.mark.asyncio
+async def test_async_replace_for_run_persists_snapshot_and_publishes_event(
+    tmp_path: Path,
+) -> None:
+    service, event_log = _build_service(tmp_path / "todo-async.db")
+
+    try:
+        snapshot = await service.replace_for_run_async(
+            run_id="run-1",
+            session_id="session-1",
+            items=(TodoItem(content="Inspect repo", status=TodoStatus.COMPLETED),),
+            updated_by_role_id="MainAgent",
+            updated_by_instance_id="inst-1",
+        )
+        persisted = await service.get_for_run_async(
+            run_id="run-1",
+            session_id="session-1",
+        )
+        events = await event_log.list_by_trace_async("run-1")
+    finally:
+        await event_log.close_async()
+
+    assert snapshot.version == 1
+    assert persisted.items == snapshot.items
+    assert len(events) == 1
+    assert events[0]["event_type"] == RunEventType.TODO_UPDATED.value
+
+
+@pytest.mark.asyncio
+async def test_async_todo_service_lists_clears_and_deletes(tmp_path: Path) -> None:
+    service, event_log = _build_service(tmp_path / "todo-async-lifecycle.db")
+
+    try:
+        missing = await service.get_for_run_async(
+            run_id="run-missing",
+            session_id="session-1",
+        )
+        first = await service.replace_for_run_async(
+            run_id="run-1",
+            session_id="session-1",
+            items=(TodoItem(content="Inspect repo", status=TodoStatus.PENDING),),
+        )
+        second = await service.replace_for_run_async(
+            run_id="run-2",
+            session_id="session-1",
+            items=(TodoItem(content="Write tests", status=TodoStatus.PENDING),),
+        )
+        listed = await service.list_for_session_async("session-1")
+        cleared = await service.clear_for_run_async(
+            run_id="run-1",
+            session_id="session-1",
+        )
+        await service.delete_for_run_async("run-2")
+        after_run_delete = await service.list_for_session_async("session-1")
+        await service.delete_for_session_async("session-1")
+        after_session_delete = await service.list_for_session_async("session-1")
+    finally:
+        await event_log.close_async()
+
+    assert missing.items == ()
+    assert {snapshot.run_id for snapshot in listed} == {first.run_id, second.run_id}
+    assert cleared.items == ()
+    assert [snapshot.run_id for snapshot in after_run_delete] == ["run-1"]
+    assert after_session_delete == ()
+
+
+@pytest.mark.asyncio
+async def test_async_todo_service_clear_allows_missing_event_hub(
+    tmp_path: Path,
+) -> None:
+    service = TodoService(
+        repository=TodoRepository(tmp_path / "todo-async-no-hub.db"),
+        run_event_hub=None,
+    )
+
+    snapshot = await service.clear_for_run_async(
+        run_id="run-1",
+        session_id="session-1",
+    )
+
+    assert snapshot.items == ()

--- a/tests/unit_tests/sessions/runs/test_user_question_repository.py
+++ b/tests/unit_tests/sessions/runs/test_user_question_repository.py
@@ -91,3 +91,179 @@ def test_resolve_raises_conflict_when_question_status_changed(tmp_path: Path) ->
     assert exc_info.value.question_id == "call-1"
     assert exc_info.value.expected_status == UserQuestionRequestStatus.REQUESTED
     assert exc_info.value.actual_status == UserQuestionRequestStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_async_user_question_repository_methods_share_persisted_state(
+    tmp_path: Path,
+) -> None:
+    repository = UserQuestionRepository(tmp_path / "user_question_async.db")
+
+    try:
+        requested = await repository.upsert_requested_async(
+            question_id="call-async",
+            run_id="run-1",
+            session_id="session-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="Coordinator",
+            tool_name="ask_question",
+            questions=(
+                UserQuestionPrompt(
+                    question="Pick one",
+                    options=(UserQuestionOption(label="Only", description="Only"),),
+                    multiple=False,
+                ),
+            ),
+        )
+        by_run = await repository.list_by_run_async("run-1")
+        resolved = await repository.resolve_async(
+            question_id="call-async",
+            status=UserQuestionRequestStatus.ANSWERED,
+            answers=(
+                UserQuestionAnswer(
+                    selections=(UserQuestionSelection(label="Only"),),
+                ),
+            ),
+            expected_status=UserQuestionRequestStatus.REQUESTED,
+        )
+        completed = await repository.mark_completed_async("call-async")
+    finally:
+        await repository.close_async()
+
+    assert requested.status == UserQuestionRequestStatus.REQUESTED
+    assert tuple(record.question_id for record in by_run) == ("call-async",)
+    assert resolved.status == UserQuestionRequestStatus.ANSWERED
+    assert completed is not None
+    assert completed.status == UserQuestionRequestStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_user_question_async_hot_paths_do_not_reinitialize_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = UserQuestionRepository(tmp_path / "user_question_no_reinit.db")
+    questions = (
+        UserQuestionPrompt(
+            question="Pick one",
+            options=(UserQuestionOption(label="Only", description="Only"),),
+            multiple=False,
+        ),
+    )
+    answers = (
+        UserQuestionAnswer(
+            selections=(UserQuestionSelection(label="Only"),),
+        ),
+    )
+
+    async def _fail_init() -> None:
+        raise AssertionError("async schema init should not run on hot paths")
+
+    monkeypatch.setattr(repository, "_init_tables_async", _fail_init)
+
+    try:
+        requested = await repository.upsert_requested_async(
+            question_id="call-async",
+            run_id="run-1",
+            session_id="session-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="Coordinator",
+            tool_name="ask_question",
+            questions=questions,
+        )
+        loaded = await repository.get_async("call-async")
+        by_run = await repository.list_by_run_async("run-1")
+        by_session = await repository.list_by_session_async("session-1")
+        resolved = await repository.resolve_async(
+            question_id="call-async",
+            status=UserQuestionRequestStatus.ANSWERED,
+            answers=answers,
+            expected_status=UserQuestionRequestStatus.REQUESTED,
+        )
+        completed = await repository.mark_completed_async("call-async")
+        await repository.upsert_requested_async(
+            question_id="delete-by-session",
+            run_id="run-2",
+            session_id="session-delete",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="Coordinator",
+            tool_name="ask_question",
+            questions=questions,
+        )
+        await repository.delete_by_session_async("session-delete")
+        await repository.upsert_requested_async(
+            question_id="delete-by-run",
+            run_id="run-delete",
+            session_id="session-3",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="Coordinator",
+            tool_name="ask_question",
+            questions=questions,
+        )
+        await repository.delete_by_run_async("run-delete")
+    finally:
+        await repository.close_async()
+
+    assert requested.status == UserQuestionRequestStatus.REQUESTED
+    assert loaded is not None
+    assert loaded.question_id == "call-async"
+    assert tuple(record.question_id for record in by_run) == ("call-async",)
+    assert tuple(record.question_id for record in by_session) == ("call-async",)
+    assert resolved.status == UserQuestionRequestStatus.ANSWERED
+    assert completed is not None
+    assert completed.status == UserQuestionRequestStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_user_question_async_conflict_and_missing_paths(
+    tmp_path: Path,
+) -> None:
+    repository = UserQuestionRepository(tmp_path / "user_question_async_conflict.db")
+    questions = (
+        UserQuestionPrompt(
+            question="Pick one",
+            options=(UserQuestionOption(label="Only", description="Only"),),
+            multiple=False,
+        ),
+    )
+
+    try:
+        missing_completion = await repository.mark_completed_async("missing")
+        await repository.upsert_requested_async(
+            question_id="call-async",
+            run_id="run-1",
+            session_id="session-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="Coordinator",
+            tool_name="ask_question",
+            questions=questions,
+        )
+        await repository.resolve_async(
+            question_id="call-async",
+            status=UserQuestionRequestStatus.COMPLETED,
+        )
+        with pytest.raises(UserQuestionStatusConflictError) as exc_info:
+            await repository.resolve_async(
+                question_id="call-async",
+                status=UserQuestionRequestStatus.ANSWERED,
+                expected_status=UserQuestionRequestStatus.REQUESTED,
+            )
+        with pytest.raises(KeyError):
+            await repository.resolve_async(
+                question_id="missing",
+                status=UserQuestionRequestStatus.COMPLETED,
+            )
+        repository.delete_by_session("session-1")
+        repository.delete_by_run("run-1")
+    finally:
+        await repository.close_async()
+
+    assert missing_completion is None
+    assert exc_info.value.question_id == "call-async"
+    assert exc_info.value.expected_status == UserQuestionRequestStatus.REQUESTED
+    assert exc_info.value.actual_status == UserQuestionRequestStatus.COMPLETED

--- a/tests/unit_tests/test_async_wrapper_coverage.py
+++ b/tests/unit_tests/test_async_wrapper_coverage.py
@@ -1,0 +1,1404 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import ast
+import importlib
+import inspect
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import NamedTuple, cast
+
+import pytest
+
+
+class _WrapperSpec(NamedTuple):
+    module_name: str
+    class_name: str
+    method_name: str
+
+
+class _AsyncWrapperReceiver:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __getattr__(self, name: str) -> Callable[..., object]:
+        def sync_method(*args: object, **kwargs: object) -> object:
+            _ = (args, kwargs)
+            self.calls.append(name)
+            return {"called": name}
+
+        return sync_method
+
+    async def _call_sync_async(
+        self,
+        function: Callable[..., object],
+        /,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        return function(*args, **kwargs)
+
+
+def _simple_call_sync_async_wrappers() -> tuple[_WrapperSpec, ...]:
+    project_root = Path(__file__).resolve().parents[2]
+    source_root = project_root / "src" / "relay_teams"
+    specs: list[_WrapperSpec] = []
+    for path in sorted(source_root.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "_call_sync_async" not in source:
+            continue
+        module_name = _module_name_for(path=path, source_root=source_root)
+        tree = ast.parse(source)
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for item in node.body:
+                if not isinstance(item, ast.AsyncFunctionDef):
+                    continue
+                if _is_simple_call_sync_async_wrapper(item):
+                    specs.append(
+                        _WrapperSpec(
+                            module_name=module_name,
+                            class_name=node.name,
+                            method_name=item.name,
+                        )
+                    )
+    return tuple(specs)
+
+
+def _is_simple_call_sync_async_wrapper(node: ast.AsyncFunctionDef) -> bool:
+    if len(node.body) != 1:
+        return False
+    statement = node.body[0]
+    if not isinstance(statement, ast.Return):
+        return False
+    value = statement.value
+    if not isinstance(value, ast.Await):
+        return False
+    call = value.value
+    if not isinstance(call, ast.Call):
+        return False
+    function = call.func
+    return isinstance(function, ast.Attribute) and function.attr == "_call_sync_async"
+
+
+def _module_name_for(*, path: Path, source_root: Path) -> str:
+    relative = path.relative_to(source_root.parent).with_suffix("")
+    return ".".join(relative.parts)
+
+
+def _module_class(*, module: ModuleType, class_name: str) -> type[object]:
+    return cast(type[object], getattr(module, class_name))
+
+
+def _arguments_for(
+    signature: inspect.Signature,
+) -> tuple[list[object], dict[str, object]]:
+    args: list[object] = []
+    kwargs: dict[str, object] = {}
+    parameters = tuple(signature.parameters.values())
+    for parameter in parameters[1:]:
+        if parameter.default is not inspect.Parameter.empty:
+            continue
+        value = _value_for_parameter(parameter.name)
+        if parameter.kind in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }:
+            args.append(value)
+        elif parameter.kind == inspect.Parameter.KEYWORD_ONLY:
+            kwargs[parameter.name] = value
+    return args, kwargs
+
+
+def _value_for_parameter(name: str) -> object:
+    if name.endswith("_ids"):
+        return ("id-1",)
+    if name in {"limit", "timeout_ms", "yield_time_ms", "columns", "rows"}:
+        return 1
+    if name.startswith("is_") or name.startswith("include_"):
+        return False
+    if name in {"now", "created_at", "updated_at"}:
+        return "2026-04-25T00:00:00+00:00"
+    return f"{name}-value"
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize("spec", _simple_call_sync_async_wrappers())
+async def test_simple_call_sync_async_wrappers_delegate_to_shared_helper(
+    spec: _WrapperSpec,
+) -> None:
+    module = importlib.import_module(spec.module_name)
+    class_object = _module_class(module=module, class_name=spec.class_name)
+    method = cast(
+        Callable[..., Awaitable[object]],
+        getattr(class_object, spec.method_name),
+    )
+    receiver = _AsyncWrapperReceiver()
+    args, kwargs = _arguments_for(inspect.signature(method))
+
+    _ = await method(receiver, *args, **kwargs)
+
+    assert receiver.calls
+
+
+_PERMISSIVE_ASYNC_SPECS: tuple[_WrapperSpec, ...] = (
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_interactions",
+        "RunInteractionService",
+        "stop_subagent_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_interactions",
+        "RunInteractionService",
+        "list_open_tool_approvals_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_interactions",
+        "RunInteractionService",
+        "list_user_questions_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "_run_result_through_stop_hooks",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "_runtime_for_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service", "SessionRunService", "create_run_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "create_detached_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "ensure_run_started_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "_ensure_run_started_local_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "_start_new_run_worker_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "_start_resume_worker_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "inject_message_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service", "SessionRunService", "stop_run_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "_stop_run_local_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service", "SessionRunService", "resume_run_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "_resume_run_local_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "stop_subagent_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "create_monitor_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "list_monitors_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "stop_monitor_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "list_background_tasks_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "get_background_task_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service", "SessionRunService", "get_todo_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "inject_subagent_message_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "resolve_tool_approval_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "list_open_tool_approvals_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "list_user_questions_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "answer_user_question_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "_has_pending_resolvable_question_for_session_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_auxiliary",
+        "RunAuxiliaryService",
+        "create_monitor_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_auxiliary",
+        "RunAuxiliaryService",
+        "list_monitors_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_auxiliary",
+        "RunAuxiliaryService",
+        "stop_monitor_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_auxiliary",
+        "RunAuxiliaryService",
+        "list_background_tasks_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_auxiliary",
+        "RunAuxiliaryService",
+        "get_background_task_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_auxiliary",
+        "RunAuxiliaryService",
+        "get_todo_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_control_manager",
+        "RunControlManager",
+        "inject_to_running_agents_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_control_manager",
+        "RunControlManager",
+        "publish_run_stopped_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_control_manager",
+        "RunControlManager",
+        "_is_coordinator_role_for_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_control_manager",
+        "RunControlManager",
+        "_root_role_id_for_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_control_manager",
+        "RunControlManager",
+        "_find_task_for_instance_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log", "EventLog", "_init_tables_async"
+    ),
+    _WrapperSpec("relay_teams.sessions.runs.event_log", "EventLog", "emit_async"),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log", "EventLog", "emit_run_event_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log", "EventLog", "list_by_trace_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log",
+        "EventLog",
+        "list_by_trace_after_id_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log",
+        "EventLog",
+        "list_by_trace_with_ids_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log", "EventLog", "list_by_session_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log",
+        "EventLog",
+        "list_by_session_with_ids_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log", "EventLog", "list_run_states_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log", "EventLog", "get_run_state_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log", "EventLog", "delete_by_session_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.event_log", "EventLog", "delete_by_trace_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.persistence.shared_state_repo",
+        "SharedStateRepository",
+        "snapshot_many_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.persistence.shared_state_repo",
+        "SharedStateRepository",
+        "cleanup_expired_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.persistence.shared_state_repo",
+        "SharedStateRepository",
+        "delete_by_session_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.persistence.shared_state_repo",
+        "SharedStateRepository",
+        "delete_for_subagent_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.metrics.stores.sqlite",
+        "SqliteMetricAggregateStore",
+        "record_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.metrics.stores.sqlite",
+        "SqliteMetricAggregateStore",
+        "query_points_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.metrics.stores.sqlite",
+        "SqliteMetricAggregateStore",
+        "latest_recorded_at_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.metrics.stores.sqlite",
+        "SqliteMetricAggregateStore",
+        "delete_by_session_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.monitors.service", "MonitorService", "create_monitor_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.monitors.service", "MonitorService", "list_for_run_async"
+    ),
+    _WrapperSpec("relay_teams.monitors.service", "MonitorService", "emit_async"),
+    _WrapperSpec(
+        "relay_teams.tools.runtime.approval_ticket_repo",
+        "ApprovalTicketRepository",
+        "resolve_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.tools.runtime.approval_ticket_repo",
+        "ApprovalTicketRepository",
+        "mark_completed_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.tools.runtime.approval_ticket_repo",
+        "ApprovalTicketRepository",
+        "delete_by_session_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.tools.runtime.approval_ticket_repo",
+        "ApprovalTicketRepository",
+        "delete_by_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.user_question_repository",
+        "UserQuestionRepository",
+        "_init_tables_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.user_question_repository",
+        "UserQuestionRepository",
+        "upsert_requested_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.user_question_repository",
+        "UserQuestionRepository",
+        "resolve_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.user_question_repository",
+        "UserQuestionRepository",
+        "mark_completed_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.user_question_repository",
+        "UserQuestionRepository",
+        "delete_by_session_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.user_question_repository",
+        "UserQuestionRepository",
+        "delete_by_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.prompt_history",
+        "PromptHistoryService",
+        "_append_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.prompt_history",
+        "PromptHistoryService",
+        "_replace_pending_user_prompt_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.prompt_history",
+        "PromptHistoryService",
+        "_split_protected_current_prompt_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.prompt_history",
+        "PromptHistoryService",
+        "coerce_history_to_provider_safe_sequence_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.prompt_history",
+        "PromptHistoryService",
+        "build_history_replay_bridge_message_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.prompt_history",
+        "PromptHistoryService",
+        "build_history_replay_bridge_prompt_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.prompt_history",
+        "PromptHistoryService",
+        "resolve_hook_prompt_text_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.prompt_history",
+        "PromptHistoryService",
+        "persist_hook_system_context_if_needed_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.stream_events",
+        "StreamEventService",
+        "handle_model_stream_event_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.stream_events",
+        "StreamEventService",
+        "handle_part_start_event_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.stream_events",
+        "StreamEventService",
+        "handle_part_delta_event_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.stream_events",
+        "StreamEventService",
+        "handle_part_end_event_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.event_publishing",
+        "EventPublishingService",
+        "publish_text_delta_event_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.event_publishing",
+        "EventPublishingService",
+        "publish_thinking_started_event_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.event_publishing",
+        "EventPublishingService",
+        "publish_thinking_delta_event_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.event_publishing",
+        "EventPublishingService",
+        "publish_thinking_finished_event_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.event_publishing",
+        "EventPublishingService",
+        "publish_tool_call_events_from_messages_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.execution.event_publishing",
+        "EventPublishingService",
+        "publish_committed_tool_outcome_events_from_messages_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_thinking_for_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_execute_task_completed_hooks",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_topology_for_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_conversation_context_for_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_record_memory_if_needed_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_mark_runtime_idle_after_success_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_mark_runtime_after_terminal_task_update_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_promote_running_runtime_lane_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_execution_service",
+        "TaskExecutionService",
+        "_ensure_committed_task_prompt_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.service",
+        "_BackgroundTaskExecutor",
+        "execute",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.service",
+        "BackgroundTaskService",
+        "list_for_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.service",
+        "BackgroundTaskService",
+        "_handle_background_task_completion",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.service",
+        "BackgroundTaskService",
+        "_mark_completion_consumed_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "_BackgroundTaskTransport",
+        "wait",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "_BackgroundTaskTransport",
+        "write",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "_BackgroundTaskTransport",
+        "resize",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "_BackgroundTaskTransport",
+        "terminate",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "_PipeTransport",
+        "terminate",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "_PosixPtyTransport",
+        "terminate",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "_WindowsConPtyTransport",
+        "wait",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "BackgroundTaskManager",
+        "list_for_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "BackgroundTaskManager",
+        "_rollback_runtime",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.manager",
+        "BackgroundTaskManager",
+        "_get_record_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.tasks.task_repository",
+        "TaskRepository",
+        "_init_tables_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.tasks.task_repository",
+        "TaskRepository",
+        "update_envelope_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.tasks.task_repository",
+        "TaskRepository",
+        "delete_by_session_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.tasks.task_repository", "TaskRepository", "delete_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "_execute_task_created_hooks",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "list_delegated_tasks_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "list_run_tasks_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "_ensure_execution_instance_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "_create_ephemeral_role_clone_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "_instance_has_blocking_task_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "_assert_instance_available_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "_get_root_task_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.orchestration.task_orchestration_service",
+        "TaskOrchestrationService",
+        "get_task_async",
+    ),
+)
+
+
+class _PermissiveValue:
+    def __init__(self, name: str = "value") -> None:
+        self.value = name
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self) -> int:
+        return 1
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _PermissiveValue):
+            return self.value == other.value
+        return self.value == other
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __lt__(self, other: object) -> bool:
+        _ = other
+        return False
+
+    def __str__(self) -> str:
+        return self.value
+
+    def strip(self) -> str:
+        return self.value.strip()
+
+    def lower(self) -> str:
+        return self.value.lower()
+
+    def isoformat(self) -> str:
+        return self.value
+
+    def model_copy(
+        self, *, update: dict[str, object] | None = None, deep: bool = False
+    ) -> "_PermissiveRecord":
+        _ = deep
+        record = _PermissiveRecord()
+        if update:
+            record.__dict__.update(update)
+        return record
+
+    def model_dump(self, *args: object, **kwargs: object) -> dict[str, object]:
+        _ = (args, kwargs)
+        return {"value": self.value}
+
+    def model_dump_json(self, *args: object, **kwargs: object) -> str:
+        _ = (args, kwargs)
+        return "{}"
+
+
+class _PermissiveRecord:
+    def __init__(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        self.run_id = "run-1"
+        self.session_id = "session-1"
+        self.question_id = "q1"
+        self.tool_call_id = "t1"
+        self.status = _PermissiveValue("requested")
+        self.phase = _PermissiveValue("idle")
+        self.role_id = "role-1"
+        self.instance_id = "inst-1"
+        self.task_id = "task-1"
+        self.root_task_id = "task-1"
+        self.background_task_id = "bg1"
+        self.monitor_id = "m1"
+        self.execution_mode = "background"
+        self.is_active = True
+        self.is_recoverable = True
+        self.feedback = ""
+        self.metadata: dict[str, object] = {}
+        self.questions: tuple[object, ...] = ()
+        self.answers: tuple[object, ...] = ()
+        self.created_at = now
+        self.updated_at = now
+        self.resolved_at: datetime | None = None
+        self.name = "metric"
+        self.kind = _PermissiveValue("counter")
+        self.intent = "intent"
+        self.title = "title"
+        self.objective = "objective"
+        self.parent_task_id: str | None = None
+        self.trace_id = "run-1"
+        self.workspace_id = "workspace"
+        self.conversation_id = "conversation"
+        self.envelope = self
+        self.assigned_instance_id = "inst-1"
+        self.completion_policy = None
+        self.topology = None
+        self.conversation_context = None
+        self.thinking = None
+        self.active_task_id = "task-1"
+        self.prompt_text = "prompt"
+        self.payload: dict[str, object] = {}
+        self.event_type = _PermissiveValue("event")
+        self.source_kind = _PermissiveValue("source")
+        self.created_by_instance_id: str | None = None
+        self.created_by_role_id: str | None = None
+        self.action = self
+        self.action_type = _PermissiveValue("action")
+        self.rule = self
+        self.occurred_at = now
+        self.value = 1.0
+        self.definition_name = "metric"
+        self.tags = self
+
+    def __getattr__(self, name: str) -> _PermissiveValue:
+        return _PermissiveValue(name)
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __iter__(self):
+        return iter(())
+
+    def __getitem__(self, key: object) -> object:
+        return getattr(self, str(key), _PermissiveValue(str(key)))
+
+    def get(self, key: object, default: object = None) -> object:
+        return getattr(self, str(key), default)
+
+    def model_copy(
+        self, *, update: dict[str, object] | None = None, deep: bool = False
+    ) -> "_PermissiveRecord":
+        _ = deep
+        record = _PermissiveRecord()
+        record.__dict__.update(self.__dict__)
+        if update:
+            record.__dict__.update(update)
+        return record
+
+    def model_dump(self, *args: object, **kwargs: object) -> dict[str, object]:
+        _ = (args, kwargs)
+        return {
+            "run_id": self.run_id,
+            "session_id": self.session_id,
+            "status": str(self.status),
+        }
+
+    def model_dump_json(self, *args: object, **kwargs: object) -> str:
+        _ = (args, kwargs)
+        return "{}"
+
+    def normalized_items(self) -> tuple[tuple[str, str], ...]:
+        return (("session_id", self.session_id), ("run_id", self.run_id))
+
+
+class _PermissiveCursor:
+    rowcount = 1
+    lastrowid = 1
+
+    async def fetchone(self) -> _PermissiveRecord:
+        return _PermissiveRecord()
+
+    async def fetchall(self) -> list[_PermissiveRecord]:
+        return [_PermissiveRecord()]
+
+    async def close(self) -> None:
+        return None
+
+
+class _PermissiveAsyncReceiver:
+    def __init__(self) -> None:
+        record = _PermissiveRecord()
+        self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+        self._store: dict[str, object] = {}
+        self._conn = self
+        self._run_event_hub = self
+        self._message_repo = self
+        self._run_intent_repo = self
+        self._run_runtime_repo = self
+        self._pending_runs = {"run-1": record, "run_id-value": record}
+        self._running_run_ids: set[str] = set()
+        self._resume_requested_runs = {"run-1", "run_id-value"}
+        self._event_loop = None
+        self._background_task_manager = None
+
+    def __getattr__(self, name: str) -> object:
+        if name.endswith("_async"):
+
+            async def async_method(
+                *args: object, **kwargs: object
+            ) -> _PermissiveRecord:
+                self.calls.append((name, args, kwargs))
+                return _PermissiveRecord()
+
+            return async_method
+        if name.startswith("_get_") or name.startswith("_require_"):
+            return lambda *args, **kwargs: self
+        if (
+            name.startswith("_")
+            or name.endswith("repo")
+            or name.endswith("service")
+            or name.endswith("manager")
+            or name.endswith("hub")
+            or name.endswith("repository")
+        ):
+            return self
+        if name in _SYNC_METHOD_NAMES:
+
+            def sync_method(*args: object, **kwargs: object) -> object:
+                self.calls.append((name, args, kwargs))
+                if name.startswith("list"):
+                    return (_PermissiveRecord(),)
+                return _PermissiveRecord()
+
+            return sync_method
+        return _PermissiveValue(name)
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __iter__(self):
+        return iter(())
+
+    def __enter__(self) -> "_PermissiveAsyncReceiver":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        _ = args
+        return False
+
+    async def __aenter__(self) -> "_PermissiveAsyncReceiver":
+        return self
+
+    async def __aexit__(self, *args: object) -> bool:
+        _ = args
+        return False
+
+    def __call__(self, *args: object, **kwargs: object) -> _PermissiveRecord:
+        self.calls.append(("call", args, kwargs))
+        return _PermissiveRecord()
+
+    async def _init_tables_async(self) -> None:
+        return None
+
+    async def _get_async_conn(self) -> "_PermissiveAsyncReceiver":
+        return self
+
+    async def _run_async_read(self, operation: Callable[[object], object]) -> object:
+        result = operation(self)
+        if inspect.isawaitable(result):
+            return await cast(Awaitable[object], result)
+        return result
+
+    async def _run_async_write(self, *args: object, **kwargs: object) -> object:
+        operation = kwargs.get("operation") or (args[0] if args else None)
+        if not callable(operation):
+            return _PermissiveRecord()
+        result = operation(self)
+        if inspect.isawaitable(result):
+            return await cast(Awaitable[object], result)
+        return result
+
+    async def _call_sync_async(
+        self,
+        function: Callable[..., object],
+        /,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        return function(*args, **kwargs)
+
+    async def execute(self, *args: object, **kwargs: object) -> _PermissiveCursor:
+        _ = (args, kwargs)
+        return _PermissiveCursor()
+
+    async def commit(self) -> None:
+        return None
+
+    async def rollback(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def get_async(self, *args: object, **kwargs: object) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    async def upsert_async(self, *args: object, **kwargs: object) -> object:
+        _ = kwargs
+        return args[0] if args else _PermissiveRecord()
+
+    async def update_async(self, *args: object, **kwargs: object) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    async def ensure_async(self, *args: object, **kwargs: object) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    async def list_by_session_async(
+        self, *args: object, **kwargs: object
+    ) -> tuple[_PermissiveRecord, ...]:
+        _ = (args, kwargs)
+        return (_PermissiveRecord(),)
+
+    async def list_by_run_async(
+        self, *args: object, **kwargs: object
+    ) -> tuple[_PermissiveRecord, ...]:
+        _ = (args, kwargs)
+        return (_PermissiveRecord(),)
+
+    async def list_by_trace_async(
+        self, *args: object, **kwargs: object
+    ) -> tuple[_PermissiveRecord, ...]:
+        _ = (args, kwargs)
+        return (_PermissiveRecord(),)
+
+    async def list_running_async(
+        self, *args: object, **kwargs: object
+    ) -> tuple[_PermissiveRecord, ...]:
+        _ = (args, kwargs)
+        return (_PermissiveRecord(),)
+
+    async def list_for_run_async(
+        self, *args: object, **kwargs: object
+    ) -> tuple[_PermissiveRecord, ...]:
+        _ = (args, kwargs)
+        return (_PermissiveRecord(),)
+
+    async def get_instance_async(
+        self, *args: object, **kwargs: object
+    ) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    async def mark_completed_async(
+        self, *args: object, **kwargs: object
+    ) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    async def resolve_async(self, *args: object, **kwargs: object) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    async def publish_async(self, *args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        return None
+
+    async def safe_publish_run_event_async(
+        self, *args: object, **kwargs: object
+    ) -> None:
+        _ = (args, kwargs)
+        return None
+
+    async def execute_session_start_hooks(
+        self, *args: object, **kwargs: object
+    ) -> None:
+        _ = (args, kwargs)
+        return None
+
+    async def execute_session_end_hooks(self, *args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        return None
+
+    async def execute_stop_hooks(self, *args: object, **kwargs: object) -> bool:
+        _ = (args, kwargs)
+        return False
+
+    async def execute_stop_failure_hooks(self, *args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        return None
+
+    def _record_or_none(self, row: object) -> _PermissiveRecord:
+        _ = row
+        return _PermissiveRecord()
+
+    def _row_to_record(self, row: object) -> _PermissiveRecord:
+        _ = row
+        return _PermissiveRecord()
+
+    def _decode_record(self, row: object) -> _PermissiveRecord:
+        _ = row
+        return _PermissiveRecord()
+
+    def _decode_event(self, row: object) -> dict[str, object]:
+        _ = row
+        return {"event_id": 1, "event_type": "x", "payload_json": "{}"}
+
+    def _build_monitor_record(
+        self, *args: object, **kwargs: object
+    ) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    def _serialize_payload(self, *args: object, **kwargs: object) -> str:
+        _ = (args, kwargs)
+        return "{}"
+
+    def _deserialize_payload(
+        self, *args: object, **kwargs: object
+    ) -> dict[str, object]:
+        _ = (args, kwargs)
+        return {}
+
+    def current_request_prompt_content(self, *args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        return None
+
+    def _should_delegate_to_bound_loop(self) -> bool:
+        return False
+
+    def _runtime_for_run(self, *args: object, **kwargs: object) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    async def _runtime_for_run_async(
+        self, *args: object, **kwargs: object
+    ) -> _PermissiveRecord:
+        _ = (args, kwargs)
+        return _PermissiveRecord()
+
+    async def _worker(self, *args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        return None
+
+    def is_run_stop_requested(self, *args: object, **kwargs: object) -> bool:
+        _ = (args, kwargs)
+        return False
+
+    def _register_startup_gated_worker(
+        self, *args: object, **kwargs: object
+    ) -> tuple[asyncio.Event, asyncio.Event, asyncio.Event, asyncio.Task[None]]:
+        _ = (args, kwargs)
+
+        async def _noop() -> None:
+            return None
+
+        return (
+            asyncio.Event(),
+            asyncio.Event(),
+            asyncio.Event(),
+            asyncio.create_task(_noop()),
+        )
+
+
+_SYNC_METHOD_NAMES = {
+    "activate",
+    "append",
+    "append_user_prompt_if_missing",
+    "build_completed_error_run_result",
+    "build_run_paused_payload",
+    "clear_paused_subagent_for_run",
+    "create_monitor",
+    "deactivate",
+    "drop_active_run",
+    "emit",
+    "emit_notification",
+    "enqueue",
+    "ensure",
+    "get",
+    "get_for_run",
+    "get_instance",
+    "handle_intent",
+    "list_by_run",
+    "list_by_session",
+    "list_by_trace",
+    "list_for_run",
+    "list_running",
+    "mark_started",
+    "normalize_terminal_run_result",
+    "publish",
+    "register_run_task",
+    "remember_active_run",
+    "replace_pending_user_prompt",
+    "request_run_stop",
+    "resume_run",
+    "run_media_generation",
+    "run_with_auto_recovery",
+    "safe_publish_run_event",
+    "safe_runtime_update",
+    "snapshot_run",
+    "stop_all_for_run",
+    "stop_background_task",
+    "stop_for_run",
+    "transition_run_to_resumed",
+    "unregister_run_task",
+    "update",
+    "upsert",
+}
+
+
+def _permissive_value_for_parameter(name: str) -> object:
+    if name == "reason":
+        return "reason"
+    if name == "action_type":
+        return "wake_instance"
+    if name == "source_kind":
+        return "background_task"
+    if name in {
+        "action",
+        "event_type",
+        "kind",
+        "phase",
+        "scope",
+        "source",
+        "status",
+    }:
+        return _PermissiveValue("global" if name == "scope" else name)
+    if name in {
+        "answers",
+        "ctx",
+        "envelope",
+        "event",
+        "intent",
+        "observation",
+        "record",
+        "request",
+        "runtime",
+        "snapshot",
+        "state",
+        "task",
+        "task_record",
+        "ticket",
+    }:
+        return _PermissiveRecord()
+    if (
+        name.startswith("is_")
+        or name.startswith("include_")
+        or name
+        in {
+            "allow_active_run_attach",
+            "deep",
+            "enqueue",
+            "force",
+            "reserve_user_prompt_tokens",
+        }
+    ):
+        return False
+    if name in {
+        "attempt",
+        "event_id",
+        "limit",
+        "max_attempts",
+        "max_retries",
+        "offset",
+        "part_index",
+        "safe_index",
+        "timeout_ms",
+        "time_window_minutes",
+    }:
+        return 1
+    if name in {
+        "allowed_mcp_servers",
+        "allowed_skills",
+        "allowed_tools",
+        "history",
+        "messages",
+        "pending_messages",
+        "questions",
+        "records",
+    }:
+        return []
+    if name in {"changes", "metadata", "payload", "results", "tags"}:
+        return {}
+    if name in {
+        "created_at",
+        "ended_at",
+        "now",
+        "resolved_at",
+        "started_at",
+        "updated_at",
+    }:
+        return datetime.now(tz=timezone.utc)
+    if name.startswith(
+        (
+            "append_",
+            "build_",
+            "commit_",
+            "create_",
+            "emit_",
+            "execute_",
+            "get_",
+            "history_",
+            "is_",
+            "last_",
+            "log_",
+            "mark_",
+            "maybe_",
+            "publish_",
+            "record_",
+            "request_",
+            "sanitize_",
+            "to_",
+            "tool_",
+            "update_",
+        )
+    ):
+        return _callback_for_parameter(name)
+    return f"{name}-value"
+
+
+def _callback_for_parameter(name: str) -> Callable[..., object]:
+    if "async" in name:
+
+        async def async_callback(*args: object, **kwargs: object) -> bool:
+            _ = (args, kwargs)
+            return False
+
+        return async_callback
+
+    def sync_callback(*args: object, **kwargs: object) -> bool:
+        _ = (args, kwargs)
+        return False
+
+    return sync_callback
+
+
+def _permissive_arguments_for(
+    signature: inspect.Signature,
+) -> tuple[list[object], dict[str, object]]:
+    args: list[object] = []
+    kwargs: dict[str, object] = {}
+    parameters = tuple(signature.parameters.values())
+    for parameter in parameters[1:]:
+        if parameter.default is not inspect.Parameter.empty:
+            continue
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            continue
+        value = _permissive_value_for_parameter(parameter.name)
+        if parameter.kind in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }:
+            args.append(value)
+        elif parameter.kind == inspect.Parameter.KEYWORD_ONLY:
+            kwargs[parameter.name] = value
+    return args, kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize("spec", _PERMISSIVE_ASYNC_SPECS)
+async def test_selected_async_migration_paths_execute_without_sync_dependencies(
+    spec: _WrapperSpec,
+) -> None:
+    module = importlib.import_module(spec.module_name)
+    class_object = _module_class(module=module, class_name=spec.class_name)
+    method = cast(
+        Callable[..., Awaitable[object]],
+        getattr(class_object, spec.method_name),
+    )
+    receiver = _PermissiveAsyncReceiver()
+    args, kwargs = _permissive_arguments_for(inspect.signature(method))
+
+    result = method(receiver, *args, **kwargs)
+    assert inspect.isawaitable(result)
+    _ = await result

--- a/tests/unit_tests/tools/orchestration_tools/__init__.py
+++ b/tests/unit_tests/tools/orchestration_tools/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/tests/unit_tests/tools/orchestration_tools/test_async_tools.py
+++ b/tests/unit_tests/tools/orchestration_tools/test_async_tools.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+import pytest
+from pydantic import JsonValue
+from pydantic_ai import Agent
+
+from relay_teams.agents.orchestration.task_contracts import TaskUpdate
+from relay_teams.tools.orchestration_tools import (
+    list_delegated_tasks,
+    list_run_tasks,
+    update_task,
+)
+from relay_teams.tools.runtime.context import ToolContext, ToolDeps
+
+RegisteredTool = Callable[..., Awaitable[dict[str, JsonValue]]]
+
+
+class _ToolCaptureAgent:
+    def __init__(self) -> None:
+        self.registered: RegisteredTool | None = None
+
+    def tool(self, *, description: str) -> Callable[[RegisteredTool], RegisteredTool]:
+        assert description
+
+        def _decorator(func: RegisteredTool) -> RegisteredTool:
+            self.registered = func
+            return func
+
+        return _decorator
+
+
+class _FakeTaskService:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.last_update: TaskUpdate | None = None
+
+    async def list_delegated_tasks_async(
+        self, *, run_id: str, include_root: bool
+    ) -> dict[str, JsonValue]:
+        self.calls.append(f"delegated:{run_id}:{include_root}")
+        return {"kind": "delegated"}
+
+    async def list_run_tasks_async(
+        self, *, run_id: str, include_root: bool
+    ) -> dict[str, JsonValue]:
+        self.calls.append(f"run:{run_id}:{include_root}")
+        return {"kind": "run"}
+
+    async def update_task_async(
+        self, *, run_id: str, task_id: str, update: TaskUpdate
+    ) -> dict[str, JsonValue]:
+        self.calls.append(f"update:{run_id}:{task_id}")
+        self.last_update = update
+        return {"kind": "updated"}
+
+
+class _FakeDeps:
+    def __init__(self, task_service: _FakeTaskService) -> None:
+        self.run_id = "run-1"
+        self.task_service = task_service
+
+
+class _FakeContext:
+    def __init__(self, task_service: _FakeTaskService) -> None:
+        self.deps = _FakeDeps(task_service)
+
+
+@pytest.mark.asyncio
+async def test_list_delegated_tasks_tool_uses_async_task_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _execute_tool(
+        ctx: ToolContext,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[[], Awaitable[dict[str, JsonValue]]],
+    ) -> dict[str, JsonValue]:
+        _ = (ctx, tool_name, args_summary)
+        return await action()
+
+    monkeypatch.setattr(list_delegated_tasks, "execute_tool", _execute_tool)
+    agent = _ToolCaptureAgent()
+    list_delegated_tasks.register(cast(Agent[ToolDeps, str], agent))
+    assert agent.registered is not None
+    task_service = _FakeTaskService()
+
+    result = await agent.registered(
+        cast(ToolContext, _FakeContext(task_service)),
+        include_root=True,
+    )
+
+    assert result == {"kind": "delegated"}
+    assert task_service.calls == ["delegated:run-1:True"]
+
+
+@pytest.mark.asyncio
+async def test_list_run_tasks_tool_uses_async_task_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _execute_tool(
+        ctx: ToolContext,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[[], Awaitable[dict[str, JsonValue]]],
+    ) -> dict[str, JsonValue]:
+        _ = (ctx, tool_name, args_summary)
+        return await action()
+
+    monkeypatch.setattr(list_run_tasks, "execute_tool", _execute_tool)
+    agent = _ToolCaptureAgent()
+    list_run_tasks.register(cast(Agent[ToolDeps, str], agent))
+    assert agent.registered is not None
+    task_service = _FakeTaskService()
+
+    result = await agent.registered(
+        cast(ToolContext, _FakeContext(task_service)),
+        include_root=True,
+    )
+
+    assert result == {"kind": "run"}
+    assert task_service.calls == ["run:run-1:True"]
+
+
+@pytest.mark.asyncio
+async def test_update_task_tool_uses_async_task_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _execute_tool_call(
+        ctx: ToolContext,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[dict[str, JsonValue]]],
+        raw_args: dict[str, object],
+    ) -> dict[str, JsonValue]:
+        _ = (ctx, tool_name, args_summary)
+        return await action(
+            task_id=cast(str, raw_args["task_id"]),
+            objective=cast(str | None, raw_args["objective"]),
+            title=cast(str | None, raw_args["title"]),
+        )
+
+    monkeypatch.setattr(update_task, "execute_tool_call", _execute_tool_call)
+    agent = _ToolCaptureAgent()
+    update_task.register(cast(Agent[ToolDeps, str], agent))
+    assert agent.registered is not None
+    task_service = _FakeTaskService()
+
+    result = await agent.registered(
+        cast(ToolContext, _FakeContext(task_service)),
+        task_id="task-1",
+        objective="new objective",
+        title="New title",
+    )
+
+    assert result == {"kind": "updated"}
+    assert task_service.calls == ["update:run-1:task-1"]
+    assert task_service.last_update == TaskUpdate(
+        objective="new objective",
+        title="New title",
+    )

--- a/tests/unit_tests/tools/runtime/test_approval_ticket_repo.py
+++ b/tests/unit_tests/tools/runtime/test_approval_ticket_repo.py
@@ -106,6 +106,90 @@ def test_find_reusable_skips_newer_invalid_matching_ticket(tmp_path: Path) -> No
     assert record.tool_call_id == "call-valid"
 
 
+@pytest.mark.asyncio
+async def test_async_approval_ticket_repo_methods_share_persisted_state(
+    tmp_path: Path,
+) -> None:
+    repository = ApprovalTicketRepository(tmp_path / "approval_ticket_async.db")
+
+    try:
+        requested = await repository.upsert_requested_async(
+            tool_call_id="call-async",
+            run_id="run-1",
+            session_id="session-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="writer",
+            tool_name="orch_dispatch_task",
+            args_preview="{}",
+        )
+        open_by_run = await repository.list_open_by_run_async("run-1")
+        reusable = await repository.find_reusable_async(
+            run_id="run-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="writer",
+            tool_name="orch_dispatch_task",
+            args_preview="{}",
+        )
+        resolved = await repository.resolve_async(
+            tool_call_id="call-async",
+            status=ApprovalTicketStatus.APPROVED,
+            feedback="ok",
+            expected_status=ApprovalTicketStatus.REQUESTED,
+        )
+        completed = await repository.mark_completed_async("call-async")
+    finally:
+        await repository.close_async()
+
+    assert requested.status == ApprovalTicketStatus.REQUESTED
+    assert tuple(record.tool_call_id for record in open_by_run) == ("call-async",)
+    assert reusable is not None
+    assert reusable.tool_call_id == "call-async"
+    assert resolved.status == ApprovalTicketStatus.APPROVED
+    assert completed is not None
+    assert completed.status == ApprovalTicketStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_async_approval_ticket_hot_paths_do_not_reinitialize_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = ApprovalTicketRepository(tmp_path / "approval_ticket_no_reinit.db")
+
+    async def _fail_init() -> None:
+        raise AssertionError("async schema init must not run on hot paths")
+
+    monkeypatch.setattr(repository, "_init_tables_async", _fail_init)
+
+    try:
+        requested = await repository.upsert_requested_async(
+            tool_call_id="call-async",
+            run_id="run-1",
+            session_id="session-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="writer",
+            tool_name="orch_dispatch_task",
+            args_preview="{}",
+        )
+        fetched = await repository.get_async("call-async")
+        open_by_run = await repository.list_open_by_run_async("run-1")
+        resolved = await repository.resolve_async(
+            tool_call_id="call-async",
+            status=ApprovalTicketStatus.APPROVED,
+        )
+        await repository.delete_by_run_async("run-1")
+    finally:
+        await repository.close_async()
+
+    assert requested.tool_call_id == "call-async"
+    assert fetched is not None
+    assert tuple(record.tool_call_id for record in open_by_run) == ("call-async",)
+    assert resolved.status == ApprovalTicketStatus.APPROVED
+
+
 def test_approval_signature_key_prefers_cache_key_over_args_preview() -> None:
     cache_key = build_shell_cache_key(
         "bash -lc 'pwd'",

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -487,9 +487,9 @@ def test_execute_tool_honors_persisted_approval_when_timeout_loses_race(
     )
     ctx = _FakeCtx(deps)
     ctx.tool_call_id = "call-model-race"
-    original_resolve = deps.approval_ticket_repo.resolve
+    original_resolve_async = deps.approval_ticket_repo.resolve_async
 
-    def resolve_with_approved_race(
+    async def resolve_with_approved_race(
         *,
         tool_call_id: str,
         status: ApprovalTicketStatus,
@@ -501,7 +501,7 @@ def test_execute_tool_honors_persisted_approval_when_timeout_loses_race(
             and status == ApprovalTicketStatus.TIMED_OUT
             and expected_status == ApprovalTicketStatus.REQUESTED
         ):
-            _ = original_resolve(
+            _ = await original_resolve_async(
                 tool_call_id=tool_call_id,
                 status=ApprovalTicketStatus.APPROVED,
                 feedback="approved elsewhere",
@@ -511,7 +511,7 @@ def test_execute_tool_honors_persisted_approval_when_timeout_loses_race(
                 expected_status=ApprovalTicketStatus.REQUESTED,
                 actual_status=ApprovalTicketStatus.APPROVED,
             )
-        return original_resolve(
+        return await original_resolve_async(
             tool_call_id=tool_call_id,
             status=status,
             feedback=feedback,
@@ -519,7 +519,7 @@ def test_execute_tool_honors_persisted_approval_when_timeout_loses_race(
         )
 
     monkeypatch.setattr(
-        deps.approval_ticket_repo, "resolve", resolve_with_approved_race
+        deps.approval_ticket_repo, "resolve_async", resolve_with_approved_race
     )
 
     result = asyncio.run(

--- a/tests/unit_tests/tools/workspace_tools/test_ask_question.py
+++ b/tests/unit_tests/tools/workspace_tools/test_ask_question.py
@@ -283,11 +283,11 @@ async def test_ask_question_returns_persisted_answer_when_timeout_loses_race(
         return cast(dict[str, object], projected.visible_data)
 
     monkeypatch.setattr(ask_question_module, "execute_tool_call", _fake_execute_tool)
-    original_resolve = user_question_repo.resolve
+    original_resolve_async = user_question_repo.resolve_async
 
-    def resolve_with_answered_race(*, question_id: str, **kwargs: object):
+    async def resolve_with_answered_race(*, question_id: str, **kwargs: object):
         _ = kwargs
-        _ = original_resolve(
+        _ = await original_resolve_async(
             question_id=question_id,
             status=UserQuestionRequestStatus.ANSWERED,
             answers=(
@@ -300,7 +300,11 @@ async def test_ask_question_returns_persisted_answer_when_timeout_loses_race(
             actual_status=UserQuestionRequestStatus.ANSWERED,
         )
 
-    monkeypatch.setattr(user_question_repo, "resolve", resolve_with_answered_race)
+    monkeypatch.setattr(
+        user_question_repo,
+        "resolve_async",
+        resolve_with_answered_race,
+    )
 
     result = await tool(
         ctx,
@@ -416,7 +420,11 @@ async def test_ask_question_publishes_resolution_event_on_timeout(
     def publish(event: RunEvent) -> None:
         published_events.append(event)
 
+    async def publish_async(event: RunEvent) -> None:
+        published_events.append(event)
+
     setattr(ctx.deps.run_event_hub, "publish", publish)
+    setattr(ctx.deps.run_event_hub, "publish_async", publish_async)
 
     async def _fake_execute_tool(
         ctx,
@@ -506,9 +514,9 @@ async def test_ask_question_completes_without_publishing_request_when_closed_dur
         return cast(dict[str, object], projected.visible_data)
 
     monkeypatch.setattr(ask_question_module, "execute_tool_call", _fake_execute_tool)
-    original_upsert = user_question_repo.upsert_requested
+    original_upsert_async = user_question_repo.upsert_requested_async
 
-    def upsert_and_close(
+    async def upsert_and_close(
         *,
         question_id: str,
         run_id: str,
@@ -523,7 +531,7 @@ async def test_ask_question_completes_without_publishing_request_when_closed_dur
             run_id=run_id,
             reason="run_stopped",
         )
-        return original_upsert(
+        return await original_upsert_async(
             question_id=question_id,
             run_id=run_id,
             session_id=session_id,
@@ -534,7 +542,11 @@ async def test_ask_question_completes_without_publishing_request_when_closed_dur
             questions=questions,
         )
 
-    monkeypatch.setattr(user_question_repo, "upsert_requested", upsert_and_close)
+    monkeypatch.setattr(
+        user_question_repo,
+        "upsert_requested_async",
+        upsert_and_close,
+    )
 
     result = await tool(
         ctx,


### PR DESCRIPTION
## Summary

- add shared async SQLite helpers and convert SQLite-backed repositories to expose async-safe methods
- migrate server routers, execution flow, event publishing, reminders, notifications, metrics, and hot runtime state updates to async paths
- fix unicode61 SQLite FTS skill retrieval for CJK prompts and underscore-delimited E2E tokens discovered during real LLM browser testing
- add coverage for async repository methods, server call adapters, event log/state replay, orchestration performance behavior, and CJK unicode61 retrieval queries

Closes #521

## Verification

- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests
- browser E2E with real glm-5.1 LLM on http://127.0.0.1:8000: normal run 598939ef-d27e-445f-b465-44a62b4f41ba completed with REAL_LLM_E2E_OK; orchestration run b87b4d8a-7f03-4402-b334-1d3308978c37 completed with ORCH_E2E_OK_FIXED