### PR TITLE
Fix streaming session timeline rendering

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -99,9 +99,13 @@ jobs:
           --diff-file .tmp/diff-cover-copy-aware.diff
 
       - name: Install Playwright Chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
         run: uv run --extra dev python -m playwright install --with-deps chromium
 
       - name: Integration tests
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
         run: uv run --extra dev pytest -q tests/integration_tests
 
       - name: Verify repository is unchanged after checks

--- a/frontend/dist/css/components/subagent.css
+++ b/frontend/dist/css/components/subagent.css
@@ -231,6 +231,12 @@
     display: flex;
     flex-direction: column;
     gap: 0.9rem;
+    width: min(1264px, 100%);
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    margin-left: auto;
+    margin-right: auto;
     padding: 0.9rem 0 1.25rem;
 }
 
@@ -287,6 +293,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
+    min-width: 0;
 }
 
 .projects-list .project-session-visibility-btn:hover {

--- a/frontend/dist/js/components/messageRenderer.js
+++ b/frontend/dist/js/components/messageRenderer.js
@@ -25,6 +25,8 @@ export {
     finalizeStream,
     clearStreamState,
     clearRunStreamState,
+    clearStreamOverlayEntry,
+    clearRunRenderedStreamState,
     clearAllStreamState,
     getCoordinatorStreamOverlay,
     getInstanceStreamOverlay,

--- a/frontend/dist/js/components/messageRenderer/helpers/block.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/block.js
@@ -82,7 +82,7 @@ export function renderParts(contentEl, parts, pendingToolBlocks, options = {}) {
     };
 
     parts.forEach(part => {
-        const kind = part.part_kind;
+        const kind = part.part_kind || part.kind;
 
         if (kind === 'text') {
             combinedText += (part.content || '') + '\n\n';
@@ -104,6 +104,9 @@ export function renderParts(contentEl, parts, pendingToolBlocks, options = {}) {
             if (structuredPart) {
                 appendStructuredContentPart(contentEl, structuredPart);
             }
+        } else if (kind === 'media_ref') {
+            flushText();
+            appendStructuredContentPart(contentEl, normalizeMediaRefPart(part));
         } else if (kind === 'tool-call' || (part.tool_name && part.args !== undefined)) {
             flushText();
             const tb = buildToolBlock(part.tool_name, part.args, part.tool_call_id);
@@ -140,6 +143,16 @@ export function renderParts(contentEl, parts, pendingToolBlocks, options = {}) {
     });
 
     flushText();
+}
+
+function normalizeMediaRefPart(part) {
+    return {
+        kind: 'media_ref',
+        modality: String(part?.modality || '').trim(),
+        mime_type: String(part?.mime_type || part?.mimeType || '').trim(),
+        url: String(part?.url || '').trim(),
+        name: String(part?.name || '').trim(),
+    };
 }
 
 function userPromptItemToStructuredPart(item) {

--- a/frontend/dist/js/components/messageRenderer/helpers/toolArgs.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/toolArgs.js
@@ -1,0 +1,61 @@
+/**
+ * components/messageRenderer/helpers/toolArgs.js
+ * DOM-free tool argument normalization shared by renderers and stream caches.
+ */
+
+export function normalizeToolArgs(args) {
+    if (args === null || args === undefined) {
+        return {};
+    }
+    if (Array.isArray(args)) {
+        return { __items: args };
+    }
+    if (typeof args === 'object') {
+        return args;
+    }
+    const raw = String(args || '').trim();
+    if (!raw) {
+        return {};
+    }
+    try {
+        return normalizeParsedArgs(JSON.parse(raw), raw);
+    } catch (_) {
+        const extractedObject = extractJsonValue(raw, '{', '}');
+        if (extractedObject) {
+            try {
+                return normalizeParsedArgs(JSON.parse(extractedObject), raw);
+            } catch (_e) {
+                // Continue to array extraction and raw fallback.
+            }
+        }
+        const extractedArray = extractJsonValue(raw, '[', ']');
+        if (extractedArray) {
+            try {
+                return normalizeParsedArgs(JSON.parse(extractedArray), raw);
+            } catch (_e) {
+                // Continue to raw fallback.
+            }
+        }
+        return { __raw: raw };
+    }
+}
+
+function normalizeParsedArgs(value, rawFallback = '') {
+    if (Array.isArray(value)) {
+        return { __items: value };
+    }
+    if (value && typeof value === 'object') {
+        return value;
+    }
+    const raw = String(value ?? rawFallback ?? '').trim();
+    return raw ? { __raw: raw } : {};
+}
+
+function extractJsonValue(raw, openToken, closeToken) {
+    const start = raw.indexOf(openToken);
+    const end = raw.lastIndexOf(closeToken);
+    if (start < 0 || end <= start) {
+        return '';
+    }
+    return raw.slice(start, end + 1);
+}

--- a/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
+++ b/frontend/dist/js/components/messageRenderer/helpers/toolBlocks.js
@@ -4,6 +4,7 @@
  */
 import { syncApprovalStateFromEnvelope } from './approval.js';
 import { appendStructuredContentPart, renderRichContent } from './content.js';
+import { normalizeToolArgs } from './toolArgs.js';
 import { t, formatMessage } from '../../../utils/i18n.js';
 
 const TOOL_SUMMARY_MAP = {
@@ -56,37 +57,6 @@ function classifyTool(toolName, args) {
         detailKind: 'json',
         args: normalizedArgs,
     };
-}
-
-function normalizeToolArgs(args) {
-    if (!args) return {};
-    if (typeof args === 'object') return args;
-    const raw = String(args || '').trim();
-    if (!raw) return {};
-    try {
-        const parsed = JSON.parse(raw);
-        if (parsed && typeof parsed === 'object') {
-            return parsed;
-        }
-        return { __raw: String(parsed ?? '') };
-    } catch (_) {
-        // Fallback: try to extract a JSON object or array from the string
-        const objMatch = raw.match(/(\{[\s\S]*\})/);
-        if (objMatch) {
-            try {
-                const extracted = JSON.parse(objMatch[1]);
-                if (extracted && typeof extracted === 'object') return extracted;
-            } catch (_e) { /* ignore */ }
-        }
-        const arrMatch = raw.match(/(\[[\s\S]*\])/);
-        if (arrMatch) {
-            try {
-                const extracted = JSON.parse(arrMatch[1]);
-                if (Array.isArray(extracted)) return { __items: extracted };
-            } catch (_e) { /* ignore */ }
-        }
-        return { __raw: raw };
-    }
 }
 
 function pickToolFieldValue(args, fields = []) {

--- a/frontend/dist/js/components/messageRenderer/history.js
+++ b/frontend/dist/js/components/messageRenderer/history.js
@@ -36,7 +36,7 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
         : null;
     const pendingToolBlocks = {};
     const historyMessages = Array.isArray(messages) ? messages.slice() : [];
-    const persistedOverlayIndex = buildPersistedOverlayIndex(historyMessages, runId);
+    const persistedOverlayIndex = buildPersistedOverlayIndex(historyMessages, runId, options);
     const timelineHydration = new Map();
     let lastRenderedMessage = null;
 
@@ -73,7 +73,12 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
         const label = role === 'user' && String(options.userRoleLabel || '').trim()
             ? String(options.userRoleLabel || '').trim()
             : labelFromRole(role, msgItem.role_id, msgItem.instance_id);
-        const streamKey = resolveHistoryStreamKey(runId, msgItem.instance_id, msgItem.role_id);
+        const streamKey = resolveHistoryStreamKey(
+            runId,
+            msgItem.instance_id,
+            msgItem.role_id,
+            options,
+        );
         collectHydratedParts(timelineHydration, {
             runId,
             instanceId: String(msgItem.instance_id || '').trim(),
@@ -130,6 +135,7 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
         streamOverlayEntry,
         persistedOverlayIndex,
         runId,
+        options,
     );
 
     if (
@@ -147,6 +153,12 @@ export function renderHistoricalMessageList(container, messages, options = {}) {
             lastRenderedMessage,
             runId,
             options,
+        );
+    } else if (streamOverlayEntry && runId) {
+        globalThis.__relayTeamsClearStreamOverlayEntry?.(
+            runId,
+            streamOverlayEntry.streamKey || streamOverlayEntry.instanceId,
+            streamOverlayEntry.roleId,
         );
     }
 
@@ -241,16 +253,30 @@ function normalizeHistoryPart(part, index) {
             part_index: index,
         };
     }
+    if (kind === 'media_ref') {
+        return {
+            kind: 'media_ref',
+            modality: String(part.modality || '').trim(),
+            mime_type: String(part.mime_type || part.mimeType || '').trim(),
+            url: String(part.url || '').trim(),
+            name: String(part.name || '').trim(),
+            part_index: index,
+        };
+    }
     if (kind === 'file') {
         return null;
     }
     return null;
 }
 
-function buildPersistedOverlayIndex(historyMessages, runId) {
+function buildPersistedOverlayIndex(historyMessages, runId, options = {}) {
     const index = {
         toolCallIds: new Set(),
+        thinkingAllByStream: new Map(),
+        thinkingAllByStreamPart: new Map(),
         thinkingTailByStream: new Map(),
+        thinkingTailByStreamPart: new Map(),
+        mediaTailByStream: new Map(),
         textTailByStream: new Map(),
     };
     (Array.isArray(historyMessages) ? historyMessages : []).forEach(msgItem => {
@@ -261,8 +287,11 @@ function buildPersistedOverlayIndex(historyMessages, runId) {
             runId,
             msgItem?.instance_id,
             msgItem?.role_id,
+            options,
         );
         const messageThinkingText = new Set();
+        const messageThinkingTextByPart = new Map();
+        const messageMedia = new Set();
         const messageText = new Set();
         parts.forEach(part => {
             if (!part || typeof part !== 'object') return;
@@ -273,39 +302,113 @@ function buildPersistedOverlayIndex(historyMessages, runId) {
             }
             if (kind === 'thinking') {
                 const text = normalizeOverlayTextSignature(part.content);
-                if (text) messageThinkingText.add(text);
+                if (text) {
+                    messageThinkingText.add(text);
+                    const partIndex = normalizeOverlayPartIndex(part.part_index ?? part.part_id ?? '');
+                    if (partIndex) {
+                        let textByPart = messageThinkingTextByPart.get(partIndex);
+                        if (!textByPart) {
+                            textByPart = new Set();
+                            messageThinkingTextByPart.set(partIndex, textByPart);
+                        }
+                        textByPart.add(text);
+                    }
+                }
             }
             if (kind === 'text') {
                 const text = normalizeOverlayTextSignature(part.content || part.text);
                 if (text) messageText.add(text);
             }
+            if (kind === 'media_ref') {
+                const mediaSignature = normalizeOverlayMediaSignature(part);
+                if (mediaSignature) messageMedia.add(mediaSignature);
+            }
         });
         if (messageThinkingText.size > 0) {
-            index.thinkingTailByStream.set(streamKey, messageThinkingText);
+            mergeOverlayTextSet(index.thinkingAllByStream, streamKey, messageThinkingText);
+            replaceOverlayTextSet(index.thinkingTailByStream, streamKey, messageThinkingText);
+            clearOverlayTextByStreamPart(index.thinkingTailByStreamPart, streamKey);
+            messageThinkingTextByPart.forEach((textSet, partIndex) => {
+                mergeOverlayTextSet(
+                    index.thinkingAllByStreamPart,
+                    overlayStreamPartKey(streamKey, partIndex),
+                    textSet,
+                );
+                replaceOverlayTextSet(
+                    index.thinkingTailByStreamPart,
+                    overlayStreamPartKey(streamKey, partIndex),
+                    textSet,
+                );
+            });
         }
         if (messageText.size > 0) {
             index.textTailByStream.set(streamKey, messageText);
         }
+        index.mediaTailByStream.set(streamKey, new Set(messageMedia));
     });
     return index;
 }
 
-function filterPersistedOverlayParts(streamOverlayEntry, persistedIndex, runId) {
+function replaceOverlayTextSet(target, key, values) {
+    if (!target || !key || !values || values.size === 0) {
+        return;
+    }
+    target.set(key, new Set(values));
+}
+
+function mergeOverlayTextSet(target, key, values) {
+    if (!target || !key || !values || values.size === 0) {
+        return;
+    }
+    let existing = target.get(key);
+    if (!existing) {
+        existing = new Set();
+        target.set(key, existing);
+    }
+    values.forEach(value => {
+        if (value) {
+            existing.add(value);
+        }
+    });
+}
+
+function clearOverlayTextByStreamPart(target, streamKey) {
+    if (!target || !streamKey) {
+        return;
+    }
+    const prefix = `${String(streamKey).trim()}::`;
+    Array.from(target.keys()).forEach(key => {
+        if (String(key || '').startsWith(prefix)) {
+            target.delete(key);
+        }
+    });
+}
+
+function filterPersistedOverlayParts(streamOverlayEntry, persistedIndex, runId, options = {}) {
     if (!streamOverlayEntry || typeof streamOverlayEntry !== 'object') {
         return null;
     }
     const parts = Array.isArray(streamOverlayEntry.parts)
         ? streamOverlayEntry.parts
         : [];
-    const streamKey = String(streamOverlayEntry.streamKey || '').trim()
-        || resolveHistoryStreamKey(
-            runId,
-            streamOverlayEntry.instanceId,
-            streamOverlayEntry.roleId,
-        );
+    const streamKeys = resolveOverlayStreamKeys(streamOverlayEntry, runId, options);
     const emptySet = new Set();
-    const persistedThinkingText = persistedIndex.thinkingTailByStream.get(streamKey) || emptySet;
-    const persistedText = persistedIndex.textTailByStream.get(streamKey) || emptySet;
+    const persistedThinkingTailText = collectPersistedOverlayText(
+        persistedIndex.thinkingTailByStream,
+        streamKeys,
+    ) || emptySet;
+    const persistedThinkingAllText = collectPersistedOverlayText(
+        persistedIndex.thinkingAllByStream,
+        streamKeys,
+    ) || emptySet;
+    const persistedText = collectPersistedOverlayText(
+        persistedIndex.textTailByStream,
+        streamKeys,
+    ) || emptySet;
+    const persistedMedia = collectPersistedOverlayText(
+        persistedIndex.mediaTailByStream,
+        streamKeys,
+    ) || emptySet;
     const filteredParts = parts.filter(part => {
         if (!part || typeof part !== 'object') return false;
         if (part.kind === 'tool') {
@@ -314,28 +417,168 @@ function filterPersistedOverlayParts(streamOverlayEntry, persistedIndex, runId) 
         }
         if (part.kind === 'thinking') {
             const text = normalizeOverlayTextSignature(part.content);
-            return !(text && persistedThinkingText.has(text));
+            if (!text) {
+                return part.finished !== true;
+            }
+            return !isPersistedThinkingOverlayPart(
+                text,
+                part,
+                persistedThinkingTailText,
+                persistedIndex.thinkingTailByStreamPart,
+                persistedThinkingAllText,
+                persistedIndex.thinkingAllByStreamPart,
+                streamKeys,
+            );
         }
         if (part.kind === 'text') {
             const text = normalizeOverlayTextSignature(part.content || part.text);
+            if (!text) {
+                return false;
+            }
             return !(text && persistedText.has(text));
+        }
+        if (part.kind === 'media_ref') {
+            const mediaSignature = normalizeOverlayMediaSignature(part);
+            return !(mediaSignature && persistedMedia.has(mediaSignature));
         }
         return true;
     });
+    const allowIdleCursor = streamOverlayEntry.idleCursor === true
+        && (
+            filteredParts.length > 0
+            || parts.length === 0
+        )
+        && !isTerminalRunStatus(options.runStatus);
     const hasRenderableState = filteredParts.length > 0
-        || streamOverlayEntry.textStreaming === true
-        || streamOverlayEntry.idleCursor === true;
+        || allowIdleCursor
+        || streamOverlayEntry.textStreaming === true;
     if (!hasRenderableState) {
         return null;
     }
     return {
         ...streamOverlayEntry,
         parts: filteredParts,
+        idleCursor: allowIdleCursor,
     };
 }
 
 function normalizeOverlayTextSignature(value) {
     return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeOverlayMediaSignature(part) {
+    if (!part || typeof part !== 'object') {
+        return '';
+    }
+    const url = String(part.url || '').trim();
+    const mimeType = String(part.mime_type || part.mimeType || '').trim();
+    const modality = String(part.modality || '').trim();
+    const name = String(part.name || part.filename || '').trim();
+    if (!url) {
+        return '';
+    }
+    return JSON.stringify({ url, mimeType, modality, name });
+}
+
+function normalizeOverlayPartIndex(value) {
+    const safeValue = String(value ?? '').trim();
+    return safeValue;
+}
+
+function overlayStreamPartKey(streamKey, partIndex) {
+    return `${String(streamKey || '').trim()}::${normalizeOverlayPartIndex(partIndex)}`;
+}
+
+function isPersistedThinkingOverlayPart(
+    text,
+    part,
+    persistedThinkingTailText,
+    persistedThinkingTailTextByPart,
+    persistedThinkingAllText,
+    persistedThinkingAllTextByPart,
+    streamKeys,
+) {
+    if (!text) {
+        return false;
+    }
+    const persistedThinkingText = part.finished === true
+        ? persistedThinkingAllText
+        : persistedThinkingTailText;
+    const persistedThinkingTextByPart = part.finished === true
+        ? persistedThinkingAllTextByPart
+        : persistedThinkingTailTextByPart;
+    if (persistedThinkingText?.has?.(text)) {
+        return true;
+    }
+    const partIndex = normalizeOverlayPartIndex(part.part_index ?? part.part_id ?? '');
+    if (partIndex) {
+        const persistedForPart = collectPersistedOverlayTextByPart(
+            persistedThinkingTextByPart,
+            streamKeys,
+            partIndex,
+        );
+        if (
+            part.finished === true
+                ? hasPersistedThinkingOverlap(text, persistedForPart)
+                : hasExactPersistedOverlayText(text, persistedForPart)
+        ) {
+            return true;
+        }
+    }
+    if (part.finished === true && hasPersistedThinkingOverlap(text, persistedThinkingText)) {
+        return true;
+    }
+    return false;
+}
+
+function collectPersistedOverlayTextByPart(textByStreamPart, streamKeys, partIndex) {
+    const values = new Set();
+    (Array.isArray(streamKeys) ? streamKeys : []).forEach(streamKey => {
+        const textSet = textByStreamPart.get(overlayStreamPartKey(streamKey, partIndex));
+        if (!textSet) return;
+        textSet.forEach(value => {
+            if (value) values.add(value);
+        });
+    });
+    return values.size > 0 ? values : null;
+}
+
+function hasExactPersistedOverlayText(text, persistedText) {
+    const candidate = normalizeOverlayTextSignature(text);
+    if (!candidate || !persistedText) {
+        return false;
+    }
+    for (const persistedValue of persistedText) {
+        if (normalizeOverlayTextSignature(persistedValue) === candidate) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function hasPersistedThinkingOverlap(text, persistedText) {
+    const candidate = normalizeOverlayTextSignature(text);
+    if (!candidate || !persistedText) {
+        return false;
+    }
+    for (const persistedValue of persistedText) {
+        const persisted = normalizeOverlayTextSignature(persistedValue);
+        if (!persisted) continue;
+        if (persisted === candidate) {
+            return true;
+        }
+        const shortestLength = Math.min(persisted.length, candidate.length);
+        if (
+            shortestLength >= 24
+            && (
+                persisted.includes(candidate)
+                || candidate.includes(persisted)
+            )
+        ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 function applyPendingApprovalsToHistory(container, approvals, runId) {
@@ -400,6 +643,7 @@ function renderStreamOverlayEntry(
         overlayRunId,
         streamOverlayEntry?.instanceId,
         streamOverlayEntry?.roleId,
+        options,
     );
     const hasLiveTextTail = streamOverlayEntry.textStreaming === true;
     const hasIdleCursor = streamOverlayEntry.idleCursor === true;
@@ -477,7 +721,10 @@ function resolveOverlayContentTarget(
     options = {},
 ) {
     const safeLabel = String(label || '').trim();
-    if (options.separateOverlayMessage === true) {
+    if (
+        options.separateOverlayMessage === true
+        || shouldRenderOverlayInSeparateMessage(streamOverlayEntry, options)
+    ) {
         return renderMessageBlock(container, 'assistant', label, [], {
             runId: runId || lastRenderedMessage?.runId || '',
             roleId: String(streamOverlayEntry?.roleId || '').trim(),
@@ -486,6 +733,7 @@ function resolveOverlayContentTarget(
                 runId || lastRenderedMessage?.runId || '',
                 streamOverlayEntry?.instanceId,
                 streamOverlayEntry?.roleId,
+                options,
             ),
         }).contentEl;
     }
@@ -494,6 +742,7 @@ function resolveOverlayContentTarget(
         runId || lastRenderedMessage?.runId || '',
         streamOverlayEntry?.instanceId,
         streamOverlayEntry?.roleId,
+        options,
     );
     if (
         wrapperMatchesOverlay(lastRenderedMessage?.wrapper, {
@@ -524,6 +773,25 @@ function resolveOverlayContentTarget(
         instanceId: String(streamOverlayEntry?.instanceId || '').trim(),
         streamKey: overlayStreamKey,
     }).contentEl;
+}
+
+function shouldRenderOverlayInSeparateMessage(streamOverlayEntry, options = {}) {
+    if (options.bindStreamOverlay === true) {
+        return false;
+    }
+    const parts = Array.isArray(streamOverlayEntry?.parts)
+        ? streamOverlayEntry.parts
+        : [];
+    return parts.some(part => {
+        if (!part || typeof part !== 'object') {
+            return false;
+        }
+        return (
+            part.kind === 'thinking'
+            || part.kind === 'tool'
+            || part.kind === 'media_ref'
+        );
+    });
 }
 
 function findLastCompatibleMessageContent(container, label, options = {}) {
@@ -590,7 +858,46 @@ function applyOverlayToolState(toolBlock, part) {
     outputEl.textContent = '';
 }
 
-function resolveHistoryStreamKey(runId, instanceId, roleId) {
+function resolveOverlayStreamKeys(streamOverlayEntry, runId, options = {}) {
+    const keys = [];
+    const addKey = value => {
+        const key = String(value || '').trim();
+        if (key && !keys.includes(key)) {
+            keys.push(key);
+        }
+    };
+    addKey(streamOverlayEntry?.streamKey);
+    addKey(resolveHistoryStreamKey(
+        runId,
+        streamOverlayEntry?.instanceId,
+        streamOverlayEntry?.roleId,
+        options,
+    ));
+    addKey(resolveHistoryStreamKey(
+        runId,
+        streamOverlayEntry?.instanceId,
+        streamOverlayEntry?.roleId,
+    ));
+    return keys;
+}
+
+function collectPersistedOverlayText(textByStream, streamKeys) {
+    const values = new Set();
+    (Array.isArray(streamKeys) ? streamKeys : []).forEach(streamKey => {
+        const textSet = textByStream.get(streamKey);
+        if (!textSet) return;
+        textSet.forEach(value => {
+            if (value) values.add(value);
+        });
+    });
+    return values.size > 0 ? values : null;
+}
+
+function resolveHistoryStreamKey(runId, instanceId, roleId, options = {}) {
+    const canonicalStreamKey = normalizeCanonicalHistoryStreamKey(options);
+    if (canonicalStreamKey) {
+        return canonicalStreamKey;
+    }
     const safeRoleId = String(roleId || '').trim();
     const safeInstanceId = String(instanceId || '').trim();
     if (!safeRoleId || safeInstanceId === 'primary' || safeInstanceId === 'coordinator') {
@@ -602,8 +909,17 @@ function resolveHistoryStreamKey(runId, instanceId, roleId) {
     return safeInstanceId || `role:${safeRoleId}`;
 }
 
+function normalizeCanonicalHistoryStreamKey(options = {}) {
+    const streamKey = String(options.canonicalStreamKey || '').trim();
+    if (!streamKey) {
+        return '';
+    }
+    return streamKey === 'coordinator' ? 'primary' : streamKey;
+}
+
 function collapseIntermediateMessages(container) {
     if (!container) return;
+    if (container.querySelector(':scope > .tool-group')) return;
     const messages = Array.from(container.querySelectorAll(':scope > .message'));
     if (messages.length === 0) return;
 
@@ -698,20 +1014,25 @@ function collapseIntermediateMessages(container) {
 function shouldCollapseIntermediateMessages(streamOverlayEntry, options = {}) {
     const runStatus = String(options.runStatus || '').trim().toLowerCase();
     const isLatestRound = options.isLatestRound === true;
-    if (isLatestRound && runStatus !== 'completed') {
+    const isTerminalStatus = isTerminalRunStatus(runStatus);
+    const hasFinalOutput = options.hasFinalOutput === true;
+    if (isLatestRound && !isTerminalStatus) {
+        return false;
+    }
+    if (!hasFinalOutput) {
         return false;
     }
     if (!streamOverlayEntry || typeof streamOverlayEntry !== 'object') {
         return true;
     }
+    const parts = Array.isArray(streamOverlayEntry.parts) ? streamOverlayEntry.parts : [];
     if (streamOverlayEntry.textStreaming === true) {
         return false;
     }
-    if (streamOverlayEntry.idleCursor === true) {
+    if (streamOverlayEntry.idleCursor === true && parts.length > 0) {
         return false;
     }
-    const parts = Array.isArray(streamOverlayEntry.parts) ? streamOverlayEntry.parts : [];
-    return !parts.some(part => {
+    const hasActiveOverlayPart = parts.some(part => {
         if (!part || typeof part !== 'object') return false;
         if (part.kind === 'thinking') {
             return part.finished !== true;
@@ -729,7 +1050,19 @@ function shouldCollapseIntermediateMessages(streamOverlayEntry, options = {}) {
             || (part.result === undefined && part.validation === undefined)
         );
     });
+    return !hasActiveOverlayPart;
 }
+
+function isTerminalRunStatus(runStatus) {
+    return [
+        'completed',
+        'stopped',
+        'failed',
+        'cancelled',
+        'canceled',
+    ].includes(String(runStatus || '').trim().toLowerCase());
+}
+
 function isApprovedApprovalStatus(value) {
     const approvalStatus = String(value || '').trim().toLowerCase();
     return (

--- a/frontend/dist/js/components/messageRenderer/index.js
+++ b/frontend/dist/js/components/messageRenderer/index.js
@@ -31,6 +31,8 @@ export {
     finalizeStream,
     clearStreamState,
     clearRunStreamState,
+    clearStreamOverlayEntry,
+    clearRunRenderedStreamState,
     clearRenderedStreamState,
     clearAllStreamState,
     getCoordinatorStreamOverlay,

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -26,6 +26,7 @@ import { formatMessage, t } from '../../utils/i18n.js';
 
 const streamState = new Map();
 const overlayState = new Map();
+const overlaySeenEventIdsByRun = new Map();
 const overlayCleanupTimers = new Map();
 const PRIMARY_KEY = 'primary';
 const pendingTextUpdates = new Map();
@@ -34,6 +35,7 @@ const streamFollowState = new WeakMap();
 const LARGE_STREAM_TEXT_THRESHOLD = 12000;
 const BOTTOM_FOLLOW_THRESHOLD_PX = 96;
 const STREAM_USER_SCROLL_LOCK_MS = 1800;
+const MAX_OVERLAY_SEEN_EVENT_IDS_PER_RUN = 2000;
 let pendingTextFrame = 0;
 let pendingScrollFrame = 0;
 
@@ -45,7 +47,12 @@ export function getOrCreateStreamBlock(
     runId = '',
 ) {
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    let st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     if (!st || st.container !== container) {
         st = createStreamState({
             container,
@@ -54,7 +61,7 @@ export function getOrCreateStreamBlock(
             label,
             runId,
         });
-        streamState.set(streamKey, st);
+        streamState.set(stateKey, st);
     } else {
         if (!st.thinkingParts) st.thinkingParts = new Map();
         if (!st.thinkingActiveByPart) st.thinkingActiveByPart = new Map();
@@ -67,8 +74,8 @@ export function getOrCreateStreamBlock(
 }
 
 export function appendStreamChunk(instanceId, text, runId = '', roleId = '', label = '') {
-    const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    const st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    const st = streamState.get(stateKey);
     if (!st) return;
     const follow = captureStreamFollow(st.container);
 
@@ -132,7 +139,12 @@ export function appendStreamOutputParts(
     const label = String(options.label || '');
     const container = options.container || null;
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    let st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container || st.container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     if (!st && container) {
         st = createStreamState({
             container,
@@ -141,7 +153,7 @@ export function appendStreamOutputParts(
             label: label || 'Agent',
             runId,
         });
-        streamState.set(streamKey, st);
+        streamState.set(stateKey, st);
     }
     if (!st || !Array.isArray(outputParts)) return;
     const follow = captureStreamFollow(st.container || container);
@@ -183,10 +195,11 @@ export function appendStreamOutputParts(
 export function finalizeStream(instanceId, roleId = '', options = {}) {
     const runId = String(options.runId || '').trim();
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
     const matchedEntries = [];
-    const direct = streamState.get(streamKey);
+    const direct = streamState.get(stateKey);
     if (direct) {
-        matchedEntries.push([streamKey, direct]);
+        matchedEntries.push([stateKey, direct]);
     } else if (runId) {
         Array.from(streamState.entries()).forEach(([key, entry]) => {
             if (!entry || String(entry.runId || '').trim() !== runId) {
@@ -219,7 +232,8 @@ export function finalizeStream(instanceId, roleId = '', options = {}) {
         matchedEntries[0]?.[1]?.roleId || roleId || '',
     ).trim();
     if (overlayRunId) {
-        clearOverlayEntry(overlayRunId, overlayInstanceId, overlayRoleId);
+        setOverlayTextStreaming(overlayRunId, overlayInstanceId, overlayRoleId, '', false);
+        setOverlayIdleCursor(overlayRunId, overlayInstanceId, overlayRoleId, '', false);
     }
 }
 
@@ -237,7 +251,12 @@ export function bindStreamOverlayToContainer(
         return null;
     }
     const streamKey = resolveStreamKey(instanceId, roleId, safeRunId);
-    const existing = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, safeRunId);
+    let existing = streamState.get(stateKey);
+    if (existing && isStreamStateDetachedFromContainer(existing, container)) {
+        streamState.delete(stateKey);
+        existing = null;
+    }
     if (existing && existing.container === container) {
         return existing;
     }
@@ -255,17 +274,39 @@ export function bindStreamOverlayToContainer(
     if (!reused) {
         return null;
     }
-    streamState.set(streamKey, reused);
+    streamState.set(stateKey, reused);
     return reused;
 }
 
-export function clearStreamState(instanceId, roleId = '') {
-    const streamKey = resolveStreamKey(instanceId, roleId);
-    const entry = streamState.get(streamKey);
-    if (entry?.activeTextEl) {
-        syncStreamingCursor(entry.activeTextEl, false);
+export function clearStreamState(instanceId, roleId = '', runId = '') {
+    const safeRunId = String(runId || '').trim();
+    const streamKey = resolveStreamKey(instanceId, roleId, safeRunId);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, safeRunId);
+    const entries = safeRunId
+        ? [[stateKey, streamState.get(stateKey)]]
+        : Array.from(streamState.entries()).filter(([, entry]) => (
+            String(entry?.streamKey || '').trim() === streamKey
+        ));
+    entries.forEach(([key, entry]) => {
+        if (!entry) return;
+        if (entry.activeTextEl) {
+            syncStreamingCursor(entry.activeTextEl, false);
+        }
+        streamState.delete(key);
+    });
+}
+
+function clearPendingStreamWork() {
+    if (pendingTextFrame && typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(pendingTextFrame);
     }
-    streamState.delete(streamKey);
+    if (pendingScrollFrame && typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(pendingScrollFrame);
+    }
+    pendingTextFrame = 0;
+    pendingScrollFrame = 0;
+    pendingTextUpdates.clear();
+    pendingScrollContainers.clear();
 }
 
 export function clearRunStreamState(runId) {
@@ -273,11 +314,45 @@ export function clearRunStreamState(runId) {
     if (!safeRunId) return;
     clearRunOverlayCleanupTimer(safeRunId);
     overlayState.delete(safeRunId);
+    overlaySeenEventIdsByRun.delete(safeRunId);
     clearTimelineRun(safeRunId);
     Array.from(streamState.entries()).forEach(([key, entry]) => {
         if (entry.runId === safeRunId) {
             if (entry.activeTextEl) {
+                flushRichTextUpdate(entry.activeTextEl);
                 syncStreamingCursor(entry.activeTextEl, false);
+            }
+            if (entry.thinkingParts instanceof Map) {
+                entry.thinkingParts.forEach(thinkingEntry => {
+                    flushRichTextUpdate(thinkingEntry.textEl);
+                });
+            }
+            streamState.delete(key);
+        }
+    });
+}
+
+export function clearStreamOverlayEntry(runId, instanceId = '', roleId = '') {
+    clearOverlayEntry(runId, instanceId, roleId);
+}
+
+if (typeof globalThis !== 'undefined') {
+    globalThis.__relayTeamsClearStreamOverlayEntry = clearStreamOverlayEntry;
+}
+
+export function clearRunRenderedStreamState(runId) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) return;
+    Array.from(streamState.entries()).forEach(([key, entry]) => {
+        if (entry.runId === safeRunId) {
+            if (entry.activeTextEl) {
+                flushRichTextUpdate(entry.activeTextEl);
+                syncStreamingCursor(entry.activeTextEl, false);
+            }
+            if (entry.thinkingParts instanceof Map) {
+                entry.thinkingParts.forEach(thinkingEntry => {
+                    flushRichTextUpdate(thinkingEntry.textEl);
+                });
             }
             streamState.delete(key);
         }
@@ -292,6 +367,7 @@ export function clearRenderedStreamState() {
         }
     });
     streamState.clear();
+    clearPendingStreamWork();
 }
 
 export function clearAllStreamState(options = {}) {
@@ -304,6 +380,7 @@ export function clearAllStreamState(options = {}) {
     });
     overlayCleanupTimers.clear();
     overlayState.clear();
+    overlaySeenEventIdsByRun.clear();
     clearTimelineState();
 }
 
@@ -347,7 +424,12 @@ export function appendToolCallBlock(
     const roleId = String(options.roleId || '');
     const label = String(options.label || '');
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    let st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     if (!st) {
         const actorLabel = label || (toolName ? 'Tool' : 'Agent');
         st = createStreamState({
@@ -357,7 +439,7 @@ export function appendToolCallBlock(
             label: actorLabel,
             runId,
         });
-        streamState.set(streamKey, st);
+        streamState.set(stateKey, st);
     } else {
         if (!st.thinkingParts) st.thinkingParts = new Map();
         if (!st.thinkingActiveByPart) st.thinkingActiveByPart = new Map();
@@ -407,7 +489,12 @@ export function updateToolResult(
     const label = String(options.label || '');
     const container = options.container || null;
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    const st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container || st.container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     const resolvedRunId = (st && st.runId) || runId;
     const resolvedInstanceId = (st && st.instanceId) || instanceId;
     const resolvedRoleId = (st && st.roleId) || roleId;
@@ -464,7 +551,12 @@ export function markToolInputValidationFailed(instanceId, payload, options = {})
     const roleId = String(options.roleId || '');
     const container = options.container || null;
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    const st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container || st.container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     const toolBlock = resolveToolBlockTarget(
         st,
         container,
@@ -500,7 +592,12 @@ export function startThinkingBlock(instanceId, partIndex, options = {}) {
     const label = String(options.label || '');
     const container = options.container || null;
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    let st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container || st.container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     if (!st && container) {
         const actorLabel = label || 'Agent';
         st = createStreamState({
@@ -510,7 +607,7 @@ export function startThinkingBlock(instanceId, partIndex, options = {}) {
             label: actorLabel,
             runId,
         });
-        streamState.set(streamKey, st);
+        streamState.set(stateKey, st);
     } else if (st) {
         if (!st.thinkingParts) st.thinkingParts = new Map();
         if (!st.thinkingActiveByPart) st.thinkingActiveByPart = new Map();
@@ -542,7 +639,22 @@ export function appendThinkingChunk(instanceId, partIndex, text, options = {}) {
     const label = String(options.label || '');
     const container = options.container || null;
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    const st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container || st.container)) {
+        streamState.delete(stateKey);
+        st = null;
+        if (container) {
+            st = createStreamState({
+                container,
+                instanceId,
+                roleId,
+                label: label || 'Agent',
+                runId,
+            });
+            streamState.set(stateKey, st);
+        }
+    }
     if (!st) {
         updateOverlayThinkingText(runId, instanceId, roleId, label, partIndex, text, { append: true });
         return false;
@@ -586,7 +698,12 @@ export function finalizeThinking(instanceId, partIndex, options = {}) {
     const runId = String(options.runId || '');
     const roleId = String(options.roleId || '');
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    const st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, options.container || st.container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     const entry = resolveThinkingEntry(st, partIndex, { allowCreate: false });
     if (!entry) {
         finishOverlayThinking(runId, instanceId, roleId, partIndex);
@@ -636,7 +753,12 @@ export function attachToolApprovalControls(instanceId, toolName, payload, handle
     const roleId = String(options.roleId || '');
     const container = options.container || null;
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    const st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container || st.container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     const toolBlock = resolveToolBlockTarget(
         st,
         container,
@@ -680,7 +802,12 @@ export function markToolApprovalResolved(instanceId, payload, options = {}) {
     const roleId = String(options.roleId || '');
     const container = options.container || null;
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    const st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
+    if (st && isStreamStateDetachedFromContainer(st, container || st.container)) {
+        streamState.delete(stateKey);
+        st = null;
+    }
     updateOverlayToolApproval(
         (st && st.runId) || runId,
         (st && st.instanceId) || instanceId,
@@ -736,11 +863,13 @@ export function markToolApprovalResolved(instanceId, payload, options = {}) {
 export function applyStreamOverlayEvent(evType, payload, options = {}) {
     const runId = String(options.runId || '').trim();
     if (!runId) return;
+    if (isDuplicateOverlayEvent(runId, payload?.event_id || options.eventId)) {
+        return;
+    }
     const instanceId = String(options.instanceId || '').trim();
     const roleId = String(options.roleId || '').trim();
     const label = String(options.label || '').trim();
     const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    const cleanupDelayMs = Number(options.cleanupDelayMs || 0);
     applyRunEventToTimeline(evType, payload, {
         event_id: payload?.event_id || options.eventId || '',
         run_id: runId,
@@ -762,7 +891,7 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
     }
     if (evType === 'output_delta') {
         clearOverlayEntryCleanupTimer(runId, streamKey);
-        appendOverlayOutputParts(
+        const hasTextOutput = appendOverlayOutputParts(
             runId,
             streamKey,
             roleId,
@@ -770,6 +899,9 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
             Array.isArray(payload?.output) ? payload.output : [],
             { includeText: true },
         );
+        if (hasTextOutput) {
+            setOverlayTextStreaming(runId, streamKey, roleId, label, true);
+        }
         setOverlayIdleCursor(runId, streamKey, roleId, label, false);
         return;
     }
@@ -854,14 +986,32 @@ export function applyStreamOverlayEvent(evType, payload, options = {}) {
     if (evType === 'model_step_finished') {
         setOverlayTextStreaming(runId, streamKey, roleId, label, false);
         setOverlayIdleCursor(runId, streamKey, roleId, label, false);
-        scheduleOverlayEntryCleanup(runId, streamKey, roleId, cleanupDelayMs);
         return;
     }
     if (evType === 'run_completed' || evType === 'run_failed' || evType === 'run_stopped') {
         setOverlayTextStreaming(runId, streamKey, roleId, label, false);
         setOverlayIdleCursor(runId, streamKey, roleId, label, false);
-        scheduleRunOverlayCleanup(runId, cleanupDelayMs);
+        overlaySeenEventIdsByRun.delete(runId);
+        clearTimelineRun(runId);
     }
+}
+
+function isDuplicateOverlayEvent(runId, eventId) {
+    const safeRunId = String(runId || '').trim();
+    const safeEventId = String(eventId || '').trim();
+    if (!safeRunId || !safeEventId) return false;
+    let seen = overlaySeenEventIdsByRun.get(safeRunId);
+    if (!seen) {
+        seen = new Set();
+        overlaySeenEventIdsByRun.set(safeRunId, seen);
+    }
+    if (seen.has(safeEventId)) return true;
+    seen.add(safeEventId);
+    if (seen.size > MAX_OVERLAY_SEEN_EVENT_IDS_PER_RUN) {
+        const overflow = seen.size - MAX_OVERLAY_SEEN_EVENT_IDS_PER_RUN;
+        Array.from(seen).slice(0, overflow).forEach(id => seen.delete(id));
+    }
+    return false;
 }
 
 function ensureApprovalState(toolBlock) {
@@ -962,6 +1112,12 @@ function resolveStreamKey(instanceId, roleId, runId = '') {
     return `role:${safeRoleId}`;
 }
 
+function resolveStreamStateKey(instanceId, roleId, runId = '') {
+    const streamKey = resolveStreamKey(instanceId, roleId, runId);
+    const safeRunId = String(runId || '').trim();
+    return safeRunId ? `${safeRunId}::${streamKey}` : streamKey;
+}
+
 function createStreamState({
     container,
     instanceId,
@@ -1005,6 +1161,37 @@ function createStreamState({
         instanceId: String(instanceId || ''),
         streamKey,
     };
+}
+
+function isStreamStateDetachedFromContainer(st, container) {
+    if (!st || !container) {
+        return false;
+    }
+    if (isDisconnectedNode(st.wrapper) || isDisconnectedNode(st.contentEl)) {
+        return true;
+    }
+    if (Array.isArray(container.__messages)) {
+        return !container.__messages.some(item => (
+            item?.wrapper === st.wrapper
+            || item?.contentEl === st.contentEl
+        ));
+    }
+    if (typeof container.contains === 'function' && st.wrapper) {
+        try {
+            return !container.contains(st.wrapper);
+        } catch (_) {
+            return false;
+        }
+    }
+    return false;
+}
+
+function isDisconnectedNode(node) {
+    return !!(
+        node
+        && typeof node.isConnected === 'boolean'
+        && node.isConnected === false
+    );
 }
 
 function findReusableStreamState({
@@ -1305,8 +1492,8 @@ function materializeToolBlockFromOverlay({
     const overlayPart = overlayEntry
         ? findOverlayToolPart(overlayEntry, toolName, toolCallId)
         : null;
-    const streamKey = resolveStreamKey(instanceId, roleId, runId);
-    let st = streamState.get(streamKey);
+    const stateKey = resolveStreamStateKey(instanceId, roleId, runId);
+    let st = streamState.get(stateKey);
     if (!st) {
         st = createStreamState({
             container,
@@ -1315,7 +1502,7 @@ function materializeToolBlockFromOverlay({
             label: String(label || overlayEntry?.label || roleId || 'Agent'),
             runId,
         });
-        streamState.set(streamKey, st);
+        streamState.set(stateKey, st);
     }
     const existing = resolveToolBlockTarget(
         st,
@@ -1373,6 +1560,7 @@ function ensureOverlayEntry(runId, instanceId, roleId, label) {
         entry = {
             instanceId: String(instanceId || ''),
             roleId: String(roleId || ''),
+            streamKey: key,
             label: String(label || ''),
             parts: [],
             thinkingActiveByPart: new Map(),
@@ -1385,6 +1573,7 @@ function ensureOverlayEntry(runId, instanceId, roleId, label) {
     } else {
         if (instanceId) entry.instanceId = String(instanceId);
         if (roleId) entry.roleId = String(roleId);
+        entry.streamKey = key;
         if (label) entry.label = String(label);
         if (!entry.thinkingActiveByPart) entry.thinkingActiveByPart = new Map();
         if (typeof entry.thinkingSequence !== 'number') entry.thinkingSequence = 0;
@@ -1504,9 +1693,10 @@ function appendOverlayOutputParts(
     options = {},
 ) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, label);
-    if (!entry) return;
+    if (!entry) return false;
     const includeText = options.includeText === true;
     const parts = Array.isArray(outputParts) ? outputParts : [];
+    let hasTextOutput = false;
     parts.forEach(rawPart => {
         const normalizedPart = normalizeOverlayOutputPart(rawPart);
         if (!normalizedPart) {
@@ -1522,10 +1712,12 @@ function appendOverlayOutputParts(
             } else {
                 entry.parts.push(normalizedPart);
             }
+            hasTextOutput = true;
             return;
         }
         entry.parts.push(normalizedPart);
     });
+    return hasTextOutput;
 }
 
 function setOverlayTextStreaming(runId, instanceId, roleId, label, isStreaming) {
@@ -1602,8 +1794,14 @@ function updateOverlayToolCall(runId, instanceId, roleId, label, toolPart) {
         toolPart.args || {},
         { createForCall: true },
     );
+    const wasTerminal = isTerminalOverlayToolPart(part);
     part.args = normalizeOverlayToolArgs(toolPart.args);
+    if (wasTerminal) {
+        return;
+    }
     part.status = String(toolPart.status || 'pending');
+    delete part.result;
+    delete part.validation;
 }
 
 function updateOverlayToolResult(runId, instanceId, roleId, label, toolName, toolCallId, result, isError) {
@@ -1617,7 +1815,12 @@ function updateOverlayToolResult(runId, instanceId, roleId, label, toolName, too
 function updateOverlayToolValidation(runId, instanceId, roleId, payload) {
     const entry = ensureOverlayEntry(runId, instanceId, roleId, '');
     if (!entry) return;
-    const part = findOverlayToolPart(entry, payload?.tool_name, payload?.tool_call_id || null);
+    const part = findOverlayToolPart(
+        entry,
+        payload?.tool_name,
+        payload?.tool_call_id || null,
+        { matchUnidentifiedPendingByName: true },
+    );
     if (!part) return;
     part.status = 'validation_failed';
     part.validation = {
@@ -1638,11 +1841,21 @@ function updateOverlayToolApproval(runId, instanceId, roleId, toolName, payload,
 }
 
 function upsertOverlayToolPart(entry, toolName, toolCallId, args = {}, options = {}) {
+    const safeToolCallId = String(toolCallId || '').trim();
     let part = findOverlayToolPart(entry, toolName, toolCallId, {
-        preferUnresolved: !toolCallId && options.createForCall !== true,
+        matchUnidentifiedPendingByName: !!safeToolCallId && options.createForCall !== true,
+        preferUnresolved: !safeToolCallId && options.createForCall !== true,
     });
+    if (
+        part
+        && options.createForCall === true
+        && !safeToolCallId
+        && isTerminalOverlayToolPart(part)
+        && hasMeaningfulOverlayToolArgs(part.args)
+    ) {
+        part = null;
+    }
     if (!part) {
-        const safeToolCallId = String(toolCallId || '').trim();
         const localKey = safeToolCallId
             ? ''
             : `${String(toolName || 'unknown_tool')}:${entry.toolSequence++}`;
@@ -1672,11 +1885,76 @@ function upsertOverlayToolPart(entry, toolName, toolCallId, args = {}, options =
     return part;
 }
 
+function isTerminalOverlayToolPart(part) {
+    const status = String(part?.status || '').trim().toLowerCase();
+    return (
+        status === 'completed'
+        || status === 'error'
+        || status === 'validation_failed'
+        || part?.result !== undefined
+        || part?.validation !== undefined
+    );
+}
+
+function hasMeaningfulOverlayToolArgs(args) {
+    return Object.keys(normalizeOverlayToolArgs(args)).length > 0;
+}
+
 function normalizeOverlayToolArgs(args) {
-    if (args && typeof args === 'object' && !Array.isArray(args)) {
+    if (args === null || args === undefined) {
+        return {};
+    }
+    if (Array.isArray(args)) {
+        return { __items: args };
+    }
+    if (typeof args === 'object') {
         return args;
     }
-    return {};
+    const raw = String(args || '').trim();
+    if (!raw) {
+        return {};
+    }
+    try {
+        return normalizeOverlayParsedToolArgs(JSON.parse(raw), raw);
+    } catch (_) {
+        const extractedObject = extractOverlayJsonValue(raw, '{', '}');
+        if (extractedObject) {
+            try {
+                return normalizeOverlayParsedToolArgs(JSON.parse(extractedObject), raw);
+            } catch (_e) {
+                // Continue to array extraction and raw fallback.
+            }
+        }
+        const extractedArray = extractOverlayJsonValue(raw, '[', ']');
+        if (extractedArray) {
+            try {
+                return normalizeOverlayParsedToolArgs(JSON.parse(extractedArray), raw);
+            } catch (_e) {
+                // Continue to raw fallback.
+            }
+        }
+        return { __raw: raw };
+    }
+}
+
+function normalizeOverlayParsedToolArgs(value, rawFallback = '') {
+    if (Array.isArray(value)) {
+        return { __items: value };
+    }
+    if (value && typeof value === 'object') {
+        return value;
+    }
+    const raw = String(value ?? rawFallback ?? '').trim();
+    return raw ? { __raw: raw } : {};
+}
+
+function extractOverlayJsonValue(raw, openToken, closeToken) {
+    const start = raw.indexOf(openToken);
+    const end = raw.lastIndexOf(closeToken);
+    if (start < 0 || end <= start) {
+        return '';
+    }
+    return raw.slice(start, end + 1);
 }
 
 function normalizeOverlayOutputPart(part) {
@@ -1740,6 +2018,7 @@ function findOverlayThinkingPart(entry, partIndex, options = {}) {
 
 function findOverlayToolPart(entry, toolName, toolCallId, options = {}) {
     const safeToolCallId = String(toolCallId || '').trim();
+    const safeToolName = String(toolName || '').trim();
     if (safeToolCallId) {
         for (let index = entry.parts.length - 1; index >= 0; index -= 1) {
             const part = entry.parts[index];
@@ -1748,24 +2027,16 @@ function findOverlayToolPart(entry, toolName, toolCallId, options = {}) {
                 return part;
             }
         }
+        if (options.matchUnidentifiedPendingByName === true && safeToolName) {
+            return findSinglePendingUnidentifiedOverlayToolPart(entry, safeToolName);
+        }
+        return null;
     }
-    const safeToolName = String(toolName || '').trim();
     if (!safeToolName) return null;
     if (options.preferUnresolved === true) {
-        const unresolved = entry.parts.filter(part => (
-            part.kind === 'tool'
-            && String(part.tool_name || '') === safeToolName
-            && !String(part.tool_call_id || '').trim()
-            && part.result === undefined
-            && part.validation === undefined
-            && !['completed', 'error', 'validation_failed'].includes(String(part.status || '').trim().toLowerCase())
-        ));
-        if (unresolved.length === 1) {
-            return unresolved[0];
-        }
-        if (unresolved.length > 1) {
-            return null;
-        }
+        const unresolved = findSinglePendingUnidentifiedOverlayToolPart(entry, safeToolName);
+        if (unresolved) return unresolved;
+        if (hasMultiplePendingUnidentifiedOverlayToolParts(entry, safeToolName)) return null;
     }
     for (let index = entry.parts.length - 1; index >= 0; index -= 1) {
         const part = entry.parts[index];
@@ -1775,6 +2046,32 @@ function findOverlayToolPart(entry, toolName, toolCallId, options = {}) {
         }
     }
     return null;
+}
+
+function findSinglePendingUnidentifiedOverlayToolPart(entry, safeToolName) {
+    const unresolved = entry.parts.filter(part => isPendingUnidentifiedOverlayToolPart(part, safeToolName));
+    return unresolved.length === 1 ? unresolved[0] : null;
+}
+
+function hasMultiplePendingUnidentifiedOverlayToolParts(entry, safeToolName) {
+    let count = 0;
+    for (const part of entry.parts) {
+        if (!isPendingUnidentifiedOverlayToolPart(part, safeToolName)) continue;
+        count += 1;
+        if (count > 1) return true;
+    }
+    return false;
+}
+
+function isPendingUnidentifiedOverlayToolPart(part, safeToolName) {
+    return (
+        part.kind === 'tool'
+        && String(part.tool_name || '') === safeToolName
+        && !String(part.tool_call_id || '').trim()
+        && part.result === undefined
+        && part.validation === undefined
+        && !['completed', 'error', 'validation_failed'].includes(String(part.status || '').trim().toLowerCase())
+    );
 }
 
 function hasActiveThinking(st) {
@@ -1872,6 +2169,7 @@ function cloneOverlayEntry(entry) {
     return {
         instanceId: entry.instanceId,
         roleId: entry.roleId,
+        streamKey: entry.streamKey || '',
         label: entry.label,
         parts: entry.parts.map(part => cloneOverlayPart(part)),
         textStreaming: entry.textStreaming === true,

--- a/frontend/dist/js/components/messageTimeline/store.js
+++ b/frontend/dist/js/components/messageTimeline/store.js
@@ -7,6 +7,7 @@ import {
     timelinePartId,
     timelineStreamId,
 } from './keys.js';
+import { normalizeToolArgs } from '../messageRenderer/helpers/toolArgs.js';
 
 const streams = new Map();
 const seenEventsByRun = new Map();
@@ -155,6 +156,7 @@ function ensureStream(scope) {
             updatedAt: Date.now(),
             source: 'live',
             activeThinkingByPart: new Map(),
+            thinkingSequence: 0,
             textSequence: 0,
             mediaSequence: 0,
             toolSequence: 0,
@@ -162,6 +164,7 @@ function ensureStream(scope) {
         streams.set(streamId, stream);
     } else {
         stream.scope = { ...stream.scope, ...normalized };
+        if (typeof stream.thinkingSequence !== 'number') stream.thinkingSequence = 0;
         if (typeof stream.textSequence !== 'number') stream.textSequence = 0;
         if (typeof stream.mediaSequence !== 'number') stream.mediaSequence = 0;
         if (typeof stream.toolSequence !== 'number') stream.toolSequence = 0;
@@ -222,16 +225,36 @@ function appendOutputParts(stream, scope, outputParts, action) {
 function startThinkingPart(stream, scope, action) {
     finishTextTail(stream);
     const partIndex = String(action.partIndex ?? action.part_index ?? 0);
-    const id = timelinePartId(scope, { kind: 'thinking', partIndex });
-    const part = {
-        id,
+    const existingActiveId = stream.activeThinkingByPart.get(partIndex);
+    const existingActivePart = stream.parts.find(item => item.id === existingActiveId);
+    if (existingActivePart && existingActivePart.finished !== true) {
+        existingActivePart.streaming = true;
+        stream.textStreaming = false;
+        stream.idleCursor = false;
+        return;
+    }
+    const eventId = String(action.eventId || action.event_id || '').trim();
+    const uniquePartIndex = eventId ? '' : `thinking-${partIndex}-${stream.thinkingSequence++}`;
+    const id = timelinePartId(scope, {
         kind: 'thinking',
-        part_index: Number(partIndex),
-        content: '',
-        streaming: true,
-        finished: false,
-    };
-    stream.parts.push(part);
+        eventId,
+        partIndex: uniquePartIndex,
+    });
+    let part = stream.parts.find(item => item.id === id);
+    if (!part) {
+        part = {
+            id,
+            kind: 'thinking',
+            part_index: Number(partIndex),
+            content: '',
+            streaming: true,
+            finished: false,
+        };
+        stream.parts.push(part);
+    } else {
+        part.streaming = true;
+        part.finished = false;
+    }
     stream.activeThinkingByPart.set(partIndex, id);
     stream.textStreaming = false;
     stream.idleCursor = false;
@@ -300,14 +323,27 @@ function upsertToolPart(stream, scope, action, updates = {}) {
             tool_call_id: toolCallId,
             local_tool_key: localToolKey,
             tool_name: toolName,
-            args: normalizeObject(action.args || action.payload?.args),
+            args: normalizeToolArgs(readToolArgs(action)),
             status: 'pending',
         };
         stream.parts.push(part);
     }
     if (toolName && part.tool_name === 'unknown_tool') part.tool_name = toolName;
-    if (action.args || action.payload?.args) {
-        part.args = normalizeObject(action.args || action.payload?.args);
+    if (hasToolArgs(action)) {
+        part.args = normalizeToolArgs(readToolArgs(action));
+    }
+    if (
+        updates.status === 'pending'
+        && ['completed', 'error', 'validation_failed'].includes(
+            String(part.status || '').trim().toLowerCase(),
+        )
+    ) {
+        const safeUpdates = { ...updates };
+        delete safeUpdates.status;
+        Object.assign(part, safeUpdates);
+        stream.textStreaming = false;
+        stream.idleCursor = part.status === 'completed' || part.status === 'error';
+        return;
     }
     Object.assign(part, updates);
     stream.textStreaming = false;
@@ -337,19 +373,57 @@ function finishTextTail(stream) {
 }
 
 function normalizeHydratedParts(scope, parts) {
-    return (Array.isArray(parts) ? parts : []).map((part, index) => ({
-        id: part.id || timelinePartId(scope, {
-            kind: part.kind || part.part_kind || 'part',
-            partIndex: part.part_index ?? index,
-            toolCallId: part.tool_call_id,
-            messageId: part.message_id,
-        }),
-        ...part,
-    }));
+    return (Array.isArray(parts) ? parts : []).map((part, index) => {
+        const normalized = {
+            id: part.id || timelinePartId(scope, {
+                kind: part.kind || part.part_kind || 'part',
+                partIndex: part.part_index ?? index,
+                toolCallId: part.tool_call_id,
+                messageId: part.message_id,
+            }),
+            ...part,
+        };
+        if (isToolLikePart(normalized)) {
+            normalized.args = normalizeToolArgs(normalized.args);
+        }
+        return normalized;
+    });
 }
 
-function normalizeObject(value) {
-    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+function isToolLikePart(part) {
+    if (!part || typeof part !== 'object') {
+        return false;
+    }
+    const kind = String(part.kind || part.part_kind || '').trim();
+    return kind === 'tool' || kind === 'tool-call' || !!part.tool_name;
+}
+
+function hasToolArgs(action) {
+    if (!action || typeof action !== 'object') {
+        return false;
+    }
+    if (Object.prototype.hasOwnProperty.call(action, 'args')) {
+        return true;
+    }
+    return !!(
+        action.payload
+        && typeof action.payload === 'object'
+        && Object.prototype.hasOwnProperty.call(action.payload, 'args')
+    );
+}
+
+function readToolArgs(action) {
+    if (Object.prototype.hasOwnProperty.call(action, 'args')) {
+        return action.args;
+    }
+    if (
+        action.payload
+        && typeof action.payload === 'object'
+        && Object.prototype.hasOwnProperty.call(action.payload, 'args')
+    ) {
+        return action.payload.args;
+    }
+    return {};
 }
 
 function isDuplicateEvent(action) {

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -1169,9 +1169,11 @@ function renderRoundSection(round, index) {
             runId: round.run_id,
             runStatus: round.run_status,
             runPhase: round.run_phase,
+            hasFinalOutput: round.has_final_output === true,
             isLatestRound,
             streamOverlayEntry: coordinatorOverlay,
             timelineView: 'main',
+            canonicalStreamKey: 'primary',
         });
     } else if (pendingCoordinatorApprovals.length > 0 || coordinatorOverlay) {
         renderHistoricalMessageList(section, [], {
@@ -1181,9 +1183,11 @@ function renderRoundSection(round, index) {
             runId: round.run_id,
             runStatus: round.run_status,
             runPhase: round.run_phase,
+            hasFinalOutput: round.has_final_output === true,
             isLatestRound,
             streamOverlayEntry: coordinatorOverlay,
             timelineView: 'main',
+            canonicalStreamKey: 'primary',
         });
     } else if (!round.has_user_messages) {
         const empty = document.createElement('div');

--- a/frontend/dist/js/core/eventRouter/index.js
+++ b/frontend/dist/js/core/eventRouter/index.js
@@ -45,9 +45,14 @@ import {
 import { handleNotificationRequested } from './notificationEvents.js';
 
 const BACKGROUND_TASK_UPDATE_REFRESH_DELAY_MS = 250;
+const seenEventIdsByRun = new Map();
+const MAX_SEEN_EVENT_IDS_PER_RUN = 2000;
 
 export function routeEvent(evType, payload, eventMeta) {
     const eventRunId = String(eventMeta?.run_id || eventMeta?.trace_id || '').trim();
+    if (isDuplicateRunEvent(eventRunId, eventMeta?.event_id)) {
+        return;
+    }
     const isSubagentRun = eventRunId.startsWith('subagent_run_');
     if (isSubagentRun && evType === 'token_usage') {
         scheduleSessionTokenUsageRefresh({ immediate: true });
@@ -96,7 +101,7 @@ export function routeEvent(evType, payload, eventMeta) {
         } else if (evType === 'thinking_finished') {
             handleThinkingFinished(payload, eventMeta, instanceId, roleId);
         } else if (evType === 'model_step_finished') {
-            handleModelStepFinished(eventMeta, instanceId);
+            handleModelStepFinished(eventMeta, instanceId, roleId);
         } else if (evType === 'tool_call') {
             handleToolCall(payload, eventMeta, instanceId, roleId);
         } else if (evType === 'tool_input_validation_failed') {
@@ -114,6 +119,7 @@ export function routeEvent(evType, payload, eventMeta) {
         } else if (evType === 'run_stopped') {
             handleSubagentRunTerminal(instanceId, 'stopped', eventMeta, roleId);
         }
+        clearSeenRunEventsForTerminal(evType, eventRunId);
         return;
     }
     if (evType === 'run_started') {
@@ -145,7 +151,7 @@ export function routeEvent(evType, payload, eventMeta) {
     } else if (evType === 'thinking_finished') {
         handleThinkingFinished(payload, eventMeta, instanceId, roleId);
     } else if (evType === 'model_step_finished') {
-        handleModelStepFinished(eventMeta, instanceId);
+        handleModelStepFinished(eventMeta, instanceId, roleId);
     } else if (evType === 'run_completed') {
         handleRunCompleted(eventMeta);
         syncRoundTodoVisibility();
@@ -194,6 +200,39 @@ export function routeEvent(evType, payload, eventMeta) {
     } else {
         sysLog(`[evt] ${evType}`, 'log-info');
     }
+    clearSeenRunEventsForTerminal(evType, eventRunId);
+}
+
+function isDuplicateRunEvent(runId, eventId) {
+    const safeRunId = String(runId || '').trim();
+    const safeEventId = String(eventId || '').trim();
+    if (!safeRunId || !safeEventId) return false;
+    let seen = seenEventIdsByRun.get(safeRunId);
+    if (!seen) {
+        seen = new Set();
+        seenEventIdsByRun.set(safeRunId, seen);
+    }
+    if (seen.has(safeEventId)) return true;
+    seen.add(safeEventId);
+    if (seen.size > MAX_SEEN_EVENT_IDS_PER_RUN) {
+        const overflow = seen.size - MAX_SEEN_EVENT_IDS_PER_RUN;
+        Array.from(seen).slice(0, overflow).forEach(id => seen.delete(id));
+    }
+    return false;
+}
+
+function clearSeenRunEventsForTerminal(evType, runId) {
+    if (!isTerminalRunEvent(evType)) {
+        return;
+    }
+    const safeRunId = String(runId || '').trim();
+    if (safeRunId) {
+        seenEventIdsByRun.delete(safeRunId);
+    }
+}
+
+function isTerminalRunEvent(evType) {
+    return evType === 'run_completed' || evType === 'run_failed' || evType === 'run_stopped';
 }
 
 function scheduleContinuityRefreshForEvent(evType) {

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -135,6 +135,7 @@ export function handleTextDelta(payload, eventMeta, instanceId, roleId) {
                 instanceId: 'primary',
                 roleId: primaryRoleId,
                 label,
+                eventId: eventMeta?.event_id || '',
             });
             return;
         }
@@ -151,6 +152,7 @@ export function handleTextDelta(payload, eventMeta, instanceId, roleId) {
                 instanceId,
                 roleId,
                 label,
+                eventId: eventMeta?.event_id || '',
             });
             return;
         }
@@ -174,16 +176,13 @@ export function handleOutputDelta(payload, eventMeta, instanceId, roleId) {
 
     if (isPrimary) {
         if (state.activeSubagentSession) {
-            for (const part of output) {
-                if (part?.kind === 'text') {
-                    applyStreamOverlayEvent('text_delta', { text: String(part.text || '') }, {
-                        runId,
-                        instanceId: 'primary',
-                        roleId: primaryRoleId,
-                        label,
-                    });
-                }
-            }
+            applyStreamOverlayEvent('output_delta', payload, {
+                runId,
+                instanceId: 'primary',
+                roleId: primaryRoleId,
+                label,
+                eventId: eventMeta?.event_id || '',
+            });
             return;
         }
         const container = coordinatorContainerFor(eventMeta);
@@ -201,16 +200,13 @@ export function handleOutputDelta(payload, eventMeta, instanceId, roleId) {
         ? getActiveSubagentSessionStreamContainer(instanceId)
         : getPanelScrollContainer(instanceId, roleId);
     if (normalModeSubagent && !container) {
-        for (const part of output) {
-            if (part?.kind === 'text') {
-                applyStreamOverlayEvent('text_delta', { text: String(part.text || '') }, {
-                    runId,
-                    instanceId,
-                    roleId,
-                    label,
-                });
-            }
-        }
+        applyStreamOverlayEvent('output_delta', payload, {
+            runId,
+            instanceId,
+            roleId,
+            label,
+            eventId: eventMeta?.event_id || '',
+        });
         return;
     }
     if (!normalModeSubagent && !getActiveInstanceId()) {
@@ -257,6 +253,7 @@ export function handleThinkingStarted(payload, eventMeta, instanceId, roleId) {
                 instanceId: 'primary',
                 roleId: primaryRoleId,
                 label,
+                eventId: eventMeta?.event_id || '',
             });
             return;
         }
@@ -281,6 +278,7 @@ export function handleThinkingStarted(payload, eventMeta, instanceId, roleId) {
             instanceId,
             roleId,
             label,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -312,6 +310,7 @@ export function handleThinkingDelta(payload, eventMeta, instanceId, roleId) {
                 instanceId: 'primary',
                 roleId: primaryRoleId,
                 label,
+                eventId: eventMeta?.event_id || '',
             });
             return;
         }
@@ -336,6 +335,7 @@ export function handleThinkingDelta(payload, eventMeta, instanceId, roleId) {
             instanceId,
             roleId,
             label,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -363,6 +363,7 @@ export function handleThinkingFinished(payload, eventMeta, instanceId, roleId) {
             runId,
             instanceId: 'primary',
             roleId: primaryRoleId,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -371,6 +372,7 @@ export function handleThinkingFinished(payload, eventMeta, instanceId, roleId) {
             runId,
             instanceId,
             roleId,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -382,8 +384,8 @@ export function handleThinkingFinished(payload, eventMeta, instanceId, roleId) {
     });
 }
 
-export function handleModelStepFinished(eventMeta, instanceId) {
-    const roleId = state.instanceRoleMap?.[instanceId] || '';
+export function handleModelStepFinished(eventMeta, instanceId, roleIdOverride = '') {
+    const roleId = String(roleIdOverride || state.instanceRoleMap?.[instanceId] || '').trim();
     const runId = eventMeta?.run_id || eventMeta?.trace_id || state.activeRunId || '';
     const isPrimary = !instanceId || (!roleId && instanceId === 'primary') || isRunPrimaryRoleId(roleId, runId);
     const normalModeSubagent = isNormalModeSubagentRun(runId, roleId);
@@ -393,6 +395,7 @@ export function handleModelStepFinished(eventMeta, instanceId) {
             instanceId: 'primary',
             roleId: getRunPrimaryRoleId(runId),
             cleanupDelayMs: 1200,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -405,6 +408,7 @@ export function handleModelStepFinished(eventMeta, instanceId) {
                 instanceId,
                 roleId,
                 cleanupDelayMs: 1200,
+                eventId: eventMeta?.event_id || '',
             });
             return;
         }
@@ -463,7 +467,7 @@ export function handleRunCompleted(eventMeta) {
             els.promptInput.focus();
         }
     }
-    finalizeStream('primary', getRunPrimaryRoleId(runId));
+    finalizeStream('primary', getRunPrimaryRoleId(runId), { runId });
     clearRunPrimaryRole(runId);
 }
 
@@ -496,7 +500,7 @@ export function handleRunStopped(eventMeta, payload) {
             els.promptInput.focus();
         }
     }
-    finalizeStream('primary', getRunPrimaryRoleId(runId));
+    finalizeStream('primary', getRunPrimaryRoleId(runId), { runId });
     clearRunPrimaryRole(runId);
 }
 
@@ -523,6 +527,7 @@ export function handleRunFailed(eventMeta, payload) {
         els.stopBtn.style.display = 'none';
     }
     if (els.promptInput) els.promptInput.disabled = !!state.activeSubagentSession;
+    finalizeStream('primary', getRunPrimaryRoleId(runId), { runId });
     clearRunPrimaryRole(runId);
 }
 

--- a/frontend/dist/js/core/eventRouter/toolEvents.js
+++ b/frontend/dist/js/core/eventRouter/toolEvents.js
@@ -53,6 +53,7 @@ export function handleToolCall(payload, eventMeta, instanceId, roleId) {
             instanceId: isPrimary ? 'primary' : instanceId,
             roleId: isPrimary ? primaryRoleId : roleId,
             label,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -85,6 +86,7 @@ export function handleToolInputValidationFailed(payload, instanceId, eventMeta =
             runId,
             instanceId: isPrimary ? 'primary' : instanceId,
             roleId,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -119,6 +121,7 @@ export function handleToolResult(payload, instanceId, eventMeta = null, roleId =
             instanceId: isPrimary ? 'primary' : instanceId,
             roleId: isPrimary ? primaryRoleId : roleId,
             label,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -166,6 +169,7 @@ export function handleToolApprovalRequested(payload, eventMeta, instanceId) {
             runId,
             instanceId: isPrimary ? 'primary' : instanceId,
             roleId,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }
@@ -190,6 +194,7 @@ export function handleToolApprovalResolved(payload, instanceId, eventMeta = null
             runId,
             instanceId: isPrimary ? 'primary' : instanceId,
             roleId,
+            eventId: eventMeta?.event_id || '',
         });
         return;
     }

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -15,6 +15,7 @@ from relay_teams.media import normalize_user_prompt_content
 from relay_teams.media import text_part
 from relay_teams.media import user_prompt_content_to_text
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRecord
+from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRecord
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
@@ -116,7 +117,7 @@ def build_session_rounds(
 
     retry_events_by_run: dict[str, list[dict[str, object]]] = defaultdict(list)
     fallback_events_by_run: dict[str, list[dict[str, object]]] = defaultdict(list)
-    completed_output_by_run: dict[str, dict[str, str]] = {}
+    final_output_by_run = _project_terminal_final_outputs(session_events)
     microcompact_by_run: dict[str, dict[str, object]] = {}
     retry_clear_events = {
         RunEventType.MODEL_STEP_STARTED.value,
@@ -214,14 +215,6 @@ def build_session_rounds(
                 }
             )
             continue
-        if event_type == RunEventType.RUN_COMPLETED.value:
-            payload = _parse_event_payload(event.get("payload_json"))
-            output = extract_terminal_output(payload)
-            if output:
-                completed_output_by_run[run_id] = {
-                    "output": output,
-                    "occurred_at": str(event.get("occurred_at") or ""),
-                }
         if event_type in {
             RunEventType.MODEL_STEP_STARTED.value,
             RunEventType.MODEL_STEP_FINISHED.value,
@@ -252,7 +245,7 @@ def build_session_rounds(
     run_ids = set(root_task_by_run.keys())
     run_ids.update(messages_by_run.keys())
     run_ids.update(retry_events_by_run.keys())
-    run_ids.update(completed_output_by_run.keys())
+    run_ids.update(final_output_by_run.keys())
     run_ids.update(delegated_tasks_by_run.keys())
     run_ids.update(run_runtime.keys())
     if excluded_run_ids:
@@ -290,7 +283,7 @@ def build_session_rounds(
                 root_task=root_task,
                 coordinator_role_id=coordinator_role_id,
                 role_instance_map=role_instance_by_run.get(run_id, {}),
-                output_event=completed_output_by_run.get(run_id),
+                output_event=final_output_by_run.get(run_id),
             )
             if reconstructed is not None:
                 coordinator_messages = [reconstructed]
@@ -320,6 +313,7 @@ def build_session_rounds(
             "pending_tool_approval_count": len(pending_approvals),
             "run_status": runtime.status.value if runtime is not None else None,
             "run_phase": runtime.phase.value if runtime is not None else None,
+            "has_final_output": run_id in final_output_by_run,
             "is_recoverable": runtime.is_recoverable if runtime is not None else False,
             "clear_marker_before": None,
             "compaction_marker_before": None,
@@ -365,6 +359,7 @@ def build_session_timeline_rounds(
     retry_events_by_run, microcompact_by_run = _project_timeline_event_overlays(
         session_events
     )
+    final_output_by_run = _project_terminal_final_outputs(session_events)
 
     root_task_by_run: dict[str, object] = {}
     primary_role_by_run: dict[str, str] = {}
@@ -385,6 +380,7 @@ def build_session_timeline_rounds(
     run_ids = set(root_task_by_run.keys())
     run_ids.update(messages_by_run.keys())
     run_ids.update(retry_events_by_run.keys())
+    run_ids.update(final_output_by_run.keys())
     run_ids.update(run_runtime.keys())
     if excluded_run_ids:
         run_ids.difference_update(excluded_run_ids)
@@ -417,6 +413,7 @@ def build_session_timeline_rounds(
                 "pending_tool_approval_count": len(pending_approvals),
                 "run_status": runtime.status.value if runtime is not None else None,
                 "run_phase": runtime.phase.value if runtime is not None else None,
+                "has_final_output": run_id in final_output_by_run,
                 "is_recoverable": (
                     runtime.is_recoverable if runtime is not None else False
                 ),
@@ -589,6 +586,55 @@ def _project_timeline_event_overlays(
     return dict(retry_events_by_run), microcompact_by_run
 
 
+def _project_terminal_final_outputs(
+    session_events: list[dict[str, object]],
+) -> dict[str, dict[str, str]]:
+    final_output_by_run: dict[str, dict[str, str]] = {}
+    sorted_session_events = sorted(
+        session_events,
+        key=lambda item: str(item.get("occurred_at") or ""),
+    )
+    for event in sorted_session_events:
+        event_type = str(event.get("event_type") or "")
+        if event_type not in {
+            RunEventType.RUN_COMPLETED.value,
+            RunEventType.RUN_FAILED.value,
+        }:
+            continue
+        run_id = str(event.get("trace_id") or "")
+        if not run_id:
+            continue
+        payload = _parse_event_payload(event.get("payload_json"))
+        output = extract_terminal_output(payload).strip()
+        if not _event_has_final_output(
+            event_type=event_type,
+            payload=payload,
+            output=output,
+        ):
+            continue
+        final_output_by_run[run_id] = {
+            "output": output,
+            "occurred_at": str(event.get("occurred_at") or ""),
+        }
+    return final_output_by_run
+
+
+def _event_has_final_output(
+    *,
+    event_type: str,
+    payload: dict[str, object],
+    output: str,
+) -> bool:
+    if not output:
+        return False
+    if event_type == RunEventType.RUN_COMPLETED.value:
+        return True
+    if event_type != RunEventType.RUN_FAILED.value:
+        return False
+    completion_reason = str(payload.get("completion_reason") or "").strip().lower()
+    return completion_reason == RunCompletionReason.ASSISTANT_RESPONSE.value
+
+
 def _should_clear_active_retry_event(
     active_event: dict[str, object],
     *,
@@ -613,6 +659,7 @@ _TIMELINE_ROUND_KEYS = (
     "pending_tool_approval_count",
     "run_status",
     "run_phase",
+    "has_final_output",
     "is_recoverable",
     "clear_marker_before",
     "compaction_marker_before",
@@ -937,7 +984,7 @@ def _parse_event_payload(payload_json: object) -> dict[str, object]:
 def _reconstruct_completed_output_message(
     *,
     run_id: str,
-    root_task: object,
+    root_task: object | None,
     coordinator_role_id: str | None,
     role_instance_map: dict[str, str],
     output_event: dict[str, str] | None,

--- a/src/relay_teams/tools/computer_tools/__init__.py
+++ b/src/relay_teams/tools/computer_tools/__init__.py
@@ -1,24 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from pydantic_ai import Agent
 
-if TYPE_CHECKING:
-    from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.context import ToolDeps
 
-_REGISTERED_AGENT_IDS: set[int] = set()
+_COMPUTER_REGISTERED_ATTR = "_agent_teams_computer_tools_registered"
 
 
 def register_computer_tools(agent: Agent[ToolDeps, str]) -> None:
-    agent_id = id(agent)
-    if agent_id in _REGISTERED_AGENT_IDS:
+    if bool(getattr(agent, _COMPUTER_REGISTERED_ATTR, False)):
         return
-    _REGISTERED_AGENT_IDS.add(agent_id)
     from relay_teams.tools.computer_tools.runtime import register as register_impl
 
     register_impl(agent)
+    setattr(agent, _COMPUTER_REGISTERED_ATTR, True)
 
 
 TOOLS = {

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -1,0 +1,1811 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import SimpleHTTPRequestHandler
+from http.server import ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import threading
+from typing import cast
+from urllib.parse import unquote
+from urllib.parse import urlsplit
+
+from playwright.sync_api import Page
+from playwright.sync_api import sync_playwright
+import pytest
+
+
+_VIEWPORT_WIDTH = 1280
+_VIEWPORT_HEIGHT = 900
+_WAIT_TIMEOUT_MS = 10_000
+
+
+@pytest.fixture()
+def browser_page() -> Iterator[Page]:
+    browser_root = _resolve_playwright_browser_root()
+    previous_browser_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_root)
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            context = browser.new_context(
+                viewport={"width": _VIEWPORT_WIDTH, "height": _VIEWPORT_HEIGHT},
+                color_scheme="light",
+            )
+            page = context.new_page()
+            try:
+                yield page
+            finally:
+                context.close()
+                browser.close()
+    finally:
+        if previous_browser_root is None:
+            os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
+        else:
+            os.environ["PLAYWRIGHT_BROWSERS_PATH"] = previous_browser_root
+
+
+def test_streamed_tool_args_match_persisted_history_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderToolArgsParity()
+        """
+    )
+
+    assert payload["livePreview"] == "Anthropic funding 2026"
+    assert payload["persistedPreview"] == "Anthropic funding 2026"
+    assert payload["persistedToolCount"] == 1
+    assert payload["overlayAfterPersist"] is None
+
+
+def test_session_switching_keeps_stream_overlays_isolated_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderSessionSwitchIsolation()
+        """
+    )
+
+    assert "S1 private thought" not in payload["sessionTwoText"]
+    assert "S2 visible thought" in payload["sessionTwoText"]
+    assert payload["sessionOneThinkingCount"] == 1
+    assert payload["hydratedSessionOneThinkingCount"] == 1
+    assert payload["hydratedSessionOneText"].count("S1 private thought") == 1
+
+
+def test_main_history_overlay_dedupes_primary_alias_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderMainPrimaryAliasDedup()
+        """
+    )
+
+    assert payload["thinkingCount"] == 1
+    assert payload["toolCount"] == 1
+    assert payload["text"].count("DUP_THINK") == 1
+    assert payload["overlayAfterPersist"] is None
+
+
+def test_repeated_session_switch_stress_does_not_duplicate_stream_blocks_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderRepeatedSessionSwitchStress()
+        """
+    )
+
+    assert payload["iterations"] == 120
+    assert payload["maxIntroOccurrences"] == 1
+    assert payload["maxToolDuplicateCount"] == 1
+    assert payload["foreignLeakCount"] == 0
+    assert payload["finalRunAThinkingCount"] == 3
+    assert payload["finalRunBThinkingCount"] == 3
+    assert payload["overlayAfterFullRunA"] is None
+    assert payload["overlayAfterFullRunB"] is None
+
+
+def test_partial_overlay_replay_does_not_duplicate_earlier_thinking_blocks_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderPartialThinkingReplayStress()
+        """
+    )
+
+    assert payload["introOccurrences"] == 1
+    assert payload["planOccurrences"] == 1
+    assert payload["thinkingCount"] == 2
+    assert payload["toolCount"] == 2
+    assert payload["overlayAfterPersist"] is None
+
+
+def test_direct_stream_state_isolated_across_concurrent_primary_runs_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderConcurrentPrimaryDirectStreamStress()
+        """
+    )
+
+    assert payload["runAText"].count("A late") == 1
+    assert "A late" not in payload["runBText"]
+    assert payload["runBText"].count("B first") == 1
+    assert payload["runACursorCountAfterFinalize"] == 0
+
+
+def test_empty_active_thinking_overlay_survives_history_replay_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderEmptyActiveThinkingOverlay()
+        """
+    )
+
+    assert payload["thinkingCount"] == 1
+    assert payload["overlayAfterReplay"]["parts"][0]["finished"] is False
+
+
+def test_missing_tool_call_ids_create_new_pending_overlay_invocations_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderMissingToolCallIdReinvocation()
+        """
+    )
+
+    assert payload["toolPartCount"] == 2
+    assert payload["statuses"] == ["completed", "pending"]
+    assert payload["results"] == [True, False]
+
+
+def test_missing_tool_call_id_out_of_order_result_reuses_overlay_part_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderMissingToolCallIdOutOfOrderResult()
+        """
+    )
+
+    assert payload["toolPartCount"] == 1
+    assert payload["status"] == "completed"
+    assert payload["hasResult"] is True
+    assert payload["args"] == {"command": "date"}
+
+
+def test_ided_tool_result_reuses_pending_missing_id_tool_call_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderIdedToolResultAfterMissingCallId()
+        """
+    )
+
+    assert payload["toolPartCount"] == 1
+    assert payload["status"] == "completed"
+    assert payload["toolCallId"] == "call-shell-1"
+    assert payload["hasResult"] is True
+    assert payload["args"] == {"command": "date"}
+
+
+def test_repeated_live_thinking_text_from_older_history_survives_replay_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderRepeatedLiveThinkingTextFromOlderHistory()
+        """
+    )
+
+    assert payload["olderPhraseOccurrences"] == 2
+    assert payload["latestPhraseOccurrences"] == 1
+    assert payload["thinkingCount"] == 3
+
+
+def test_unfinished_thinking_with_persisted_prefix_survives_replay_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderUnfinishedThinkingWithPersistedPrefix()
+        """
+    )
+
+    assert payload["prefixOccurrences"] == 2
+    assert payload["suffixOccurrences"] == 1
+    assert payload["thinkingCount"] == 2
+
+
+def test_run_stream_cleanup_clears_overlay_and_event_dedupe_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderRunStreamCleanupReleasesOverlayAndDedupe()
+        """
+    )
+
+    assert payload["beforeClearToolCount"] == 1
+    assert payload["overlayAfterClear"] is None
+    assert payload["afterReplayToolCount"] == 1
+
+
+def test_output_delta_overlay_keeps_text_streaming_state_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderOutputDeltaOverlayStreamingState()
+        """
+    )
+
+    assert payload["textStreaming"] is True
+    assert payload["cursorCount"] == 1
+
+
+def test_persisted_media_ref_filters_finalized_stream_overlay_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderPersistedMediaRefOverlayDedupe()
+        """
+    )
+
+    assert payload["imageCount"] == 1
+    assert payload["imageNames"] == ["image.png"]
+
+
+def test_reused_media_ref_from_older_history_survives_overlay_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderOlderMediaRefReuseOverlay()
+        """
+    )
+
+    assert payload["imageCount"] == 2
+    assert payload["imageNames"] == ["image.png", "image.png"]
+
+
+def test_terminal_overlay_event_clears_event_dedupe_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderTerminalOverlayEventClearsDedupe()
+        """
+    )
+
+    assert payload["firstOccurrences"] == 1
+    assert payload["secondOccurrences"] == 1
+    assert payload["textStreaming"] is True
+
+
+def test_replayed_stopped_session_events_do_not_duplicate_history_overlay_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderStoppedReplayDedup()
+        """
+    )
+
+    assert payload["firstThinkingCount"] == 1
+    assert payload["secondThinkingCount"] == 1
+    assert payload["firstToolCount"] == 1
+    assert payload["secondToolCount"] == 1
+    assert payload["firstCursorCount"] == 0
+    assert payload["secondCursorCount"] == 0
+    assert payload["secondGroupCount"] == 0
+    assert payload["overlayAfterFirst"] is None
+    assert payload["overlayAfterSecond"] is None
+
+
+def test_unpersisted_thinking_overlay_renders_after_history_message_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderThinkingOverlayPlacement()
+        """
+    )
+
+    assert payload["messageCount"] == 2
+    assert "live thought in progress" not in payload["firstMessageText"]
+    assert "live thought in progress" in payload["secondMessageText"]
+
+
+def test_late_tool_call_rebinds_after_stream_container_rerender_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderDetachedStreamRebind()
+        """
+    )
+
+    assert payload["beforeClearToolCount"] == 1
+    assert payload["afterClearToolCount"] == 1
+    assert payload["toolCallIds"] == ["call-2"]
+
+
+def test_terminal_completed_overlay_does_not_block_processed_group_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderTerminalCollapseWithCompletedOverlay()
+        """
+    )
+
+    assert payload["groupCount"] == 1
+    assert payload["groupToolCount"] == 1
+
+
+def test_terminal_rounds_collapse_only_when_final_output_is_projected_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderFinalMessageCollapseMatrix()
+        """
+    )
+
+    assert payload["stoppedNoFinalGroupCount"] == 0
+    assert payload["failedFinalGroupCount"] == 1
+    assert payload["cancelledFinalGroupCount"] == 1
+    assert payload["completedNoFinalGroupCount"] == 0
+    assert "failed final answer" in payload["failedFinalText"]
+    assert "loop middle output" in payload["completedNoFinalText"]
+    assert "cancelled final answer" in payload["cancelledFinalText"]
+
+
+def test_subagent_session_width_stays_stable_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.measureSubagentSessionWidth()
+        """
+    )
+
+    assert payload["beforeWidth"] == payload["afterWidth"]
+    assert payload["beforeWithinScroll"] is True
+    assert payload["afterWithinScroll"] is True
+
+
+def _open_harness(page: Page, tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    html_path = tmp_path / "stream_timeline_harness.html"
+    with _serve_harness_directory(repo_root, tmp_path) as base_url:
+        stream_module = (
+            f"{base_url}/frontend/dist/js/components/messageRenderer/stream.js"
+        )
+        history_module = (
+            f"{base_url}/frontend/dist/js/components/messageRenderer/history.js"
+        )
+        html_path.write_text(
+            f"""
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>stream timeline harness</title>
+  <link rel="stylesheet" href="{base_url}/frontend/dist/css/layout.css">
+  <link rel="stylesheet" href="{base_url}/frontend/dist/css/components/subagent.css">
+</head>
+<body>
+  <script type="module">
+    import {{
+      appendStreamChunk,
+      appendThinkingChunk,
+      appendToolCallBlock,
+      applyStreamOverlayEvent,
+      clearAllStreamState,
+      clearRunStreamState,
+      finalizeStream,
+      finalizeThinking,
+      getCoordinatorStreamOverlay,
+      getOrCreateStreamBlock,
+      startThinkingBlock,
+    }} from {json.dumps(stream_module)};
+    import {{
+      renderHistoricalMessageList,
+    }} from {json.dumps(history_module)};
+
+    function makeContainer(id) {{
+      const container = document.createElement('section');
+      container.id = id;
+      document.body.appendChild(container);
+      return container;
+    }}
+
+    function renderHistory(container, messages, options) {{
+      container.replaceChildren();
+      renderHistoricalMessageList(container, messages, {{
+        pendingToolApprovals: [],
+        isLatestRound: true,
+        ...options,
+      }});
+    }}
+
+    function countSubstring(source, needle) {{
+      const haystack = String(source || '');
+      const target = String(needle || '');
+      if (!target) return 0;
+      return haystack.split(target).length - 1;
+    }}
+
+    function maxDuplicateToolCount(container) {{
+      const counts = new Map();
+      Array.from(container.querySelectorAll('.tool-block')).forEach(block => {{
+        const key = block.dataset.toolCallId || block.textContent || '';
+        counts.set(key, (counts.get(key) || 0) + 1);
+      }});
+      return Math.max(0, ...Array.from(counts.values()));
+    }}
+
+    function waitForAnimationFrame() {{
+      return new Promise(resolve => {{
+        window.requestAnimationFrame(() => window.requestAnimationFrame(resolve));
+      }});
+    }}
+
+    window.__streamTimelineHarness = {{
+      renderToolArgsParity() {{
+        clearAllStreamState();
+        const container = makeContainer('tool-args');
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'websearch',
+            tool_call_id: 'call-search',
+            args: '{{"query":"Anthropic funding 2026"}}',
+          }},
+          {{
+            runId: 'run-tool-args',
+            instanceId: 'primary',
+            roleId: 'main-role',
+            label: 'Main Agent',
+          }},
+        );
+        renderHistory(container, [], {{
+          runId: 'run-tool-args',
+          streamOverlayEntry: getCoordinatorStreamOverlay('run-tool-args'),
+        }});
+        const livePreview = container.querySelector('.tool-summary-preview')?.textContent?.trim() || '';
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'main-role',
+          instance_id: 'primary',
+          message: {{
+            parts: [{{
+              part_kind: 'tool-call',
+              tool_name: 'websearch',
+              tool_call_id: 'call-search',
+              args: '{{"query":"Anthropic funding 2026"}}',
+            }}],
+          }},
+        }}], {{
+          runId: 'run-tool-args',
+          runStatus: 'completed',
+          streamOverlayEntry: getCoordinatorStreamOverlay('run-tool-args'),
+        }});
+        return {{
+          livePreview,
+          persistedPreview: container.querySelector('.tool-summary-preview')?.textContent?.trim() || '',
+          persistedToolCount: container.querySelectorAll('.tool-block').length,
+          overlayAfterPersist: getCoordinatorStreamOverlay('run-tool-args'),
+        }};
+      }},
+
+      renderSessionSwitchIsolation() {{
+        clearAllStreamState();
+        const sessionOne = makeContainer('session-one');
+        const sessionTwo = makeContainer('session-two');
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 0 }},
+          {{ runId: 'run-s1', instanceId: 'primary', roleId: 'main-role', label: 'Main Agent' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 0, text: 'S1 private thought' }},
+          {{ runId: 'run-s1', instanceId: 'primary', roleId: 'main-role', label: 'Main Agent' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_finished',
+          {{ part_index: 0 }},
+          {{ runId: 'run-s1', instanceId: 'primary', roleId: 'main-role', label: 'Main Agent' }},
+        );
+        applyStreamOverlayEvent(
+          'run_completed',
+          {{}},
+          {{ runId: 'run-s1', instanceId: 'primary', roleId: 'main-role', label: 'Main Agent' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 0 }},
+          {{ runId: 'run-s2', instanceId: 'primary', roleId: 'main-role', label: 'Main Agent' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 0, text: 'S2 visible thought' }},
+          {{ runId: 'run-s2', instanceId: 'primary', roleId: 'main-role', label: 'Main Agent' }},
+        );
+        renderHistory(sessionTwo, [], {{
+          runId: 'run-s2',
+          streamOverlayEntry: getCoordinatorStreamOverlay('run-s2'),
+        }});
+        renderHistory(sessionOne, [], {{
+          runId: 'run-s1',
+          streamOverlayEntry: getCoordinatorStreamOverlay('run-s1'),
+        }});
+        const sessionOneThinkingCount = sessionOne.querySelectorAll('.thinking-block').length;
+        renderHistory(sessionOne, [{{
+          role: 'assistant',
+          role_id: 'main-role',
+          instance_id: 'primary',
+          message: {{
+            parts: [{{
+              part_kind: 'thinking',
+              part_index: 0,
+              content: 'S1 private thought',
+            }}],
+          }},
+        }}], {{
+          runId: 'run-s1',
+          runStatus: 'completed',
+          streamOverlayEntry: getCoordinatorStreamOverlay('run-s1'),
+        }});
+        return {{
+          sessionTwoText: sessionTwo.textContent || '',
+          sessionOneThinkingCount,
+          hydratedSessionOneThinkingCount: sessionOne.querySelectorAll('.thinking-block').length,
+          hydratedSessionOneText: sessionOne.textContent || '',
+        }};
+      }},
+
+      renderMainPrimaryAliasDedup() {{
+        clearAllStreamState();
+        const container = makeContainer('primary-alias-dedup');
+        const runId = 'run-primary-alias-dedup';
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 0 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'alias-1' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 0, text: 'DUP_THINK' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'alias-2' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_finished',
+          {{ part_index: 0 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'alias-3' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'load_skill',
+            tool_call_id: 'call-alias-load',
+            args: {{ name: 'deepresearch' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'alias-4' }},
+        );
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'Coordinator',
+          instance_id: 'inst-main-after-switch',
+          created_at: '2026-04-26T09:46:41Z',
+          message: {{
+            parts: [
+              {{ part_kind: 'thinking', part_index: 0, content: 'DUP_THINK' }},
+              {{
+                part_kind: 'tool-call',
+                tool_name: 'load_skill',
+                tool_call_id: 'call-alias-load',
+                args: {{ name: 'deepresearch' }},
+              }},
+            ],
+          }},
+        }}], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          thinkingCount: container.querySelectorAll('.thinking-block').length,
+          toolCount: container.querySelectorAll('.tool-block').length,
+          text: container.textContent || '',
+          overlayAfterPersist: getCoordinatorStreamOverlay(runId),
+        }};
+      }},
+
+      renderRepeatedSessionSwitchStress() {{
+        clearAllStreamState();
+        const container = makeContainer('session-switch-stress');
+        const runA = 'session-17606bc3-run';
+        const runB = 'session-70b72c62-run';
+        const seedRun = (runId, label) => {{
+          applyStreamOverlayEvent(
+            'thinking_started',
+            {{ part_index: 0 }},
+            {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: `${{label}}-think-intro-start` }},
+          );
+          applyStreamOverlayEvent(
+            'thinking_delta',
+            {{ part_index: 0, text: `${{label}} intro thinking` }},
+            {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: `${{label}}-think-intro-delta` }},
+          );
+          applyStreamOverlayEvent(
+            'thinking_finished',
+            {{ part_index: 0 }},
+            {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: `${{label}}-think-intro-finish` }},
+          );
+          applyStreamOverlayEvent(
+            'tool_call',
+            {{
+              tool_name: 'load_skill',
+              tool_call_id: `${{label}}-load-deepresearch`,
+              args: {{ name: 'deepresearch' }},
+            }},
+            {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: `${{label}}-tool-1` }},
+          );
+          applyStreamOverlayEvent(
+            'tool_call',
+            {{
+              tool_name: 'load_skill',
+              tool_call_id: `${{label}}-load-pptx`,
+              args: {{ name: 'pptx-craft' }},
+            }},
+            {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: `${{label}}-tool-2` }},
+          );
+          applyStreamOverlayEvent(
+            'thinking_started',
+            {{ part_index: 1 }},
+            {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: `${{label}}-think-plan-start` }},
+          );
+          applyStreamOverlayEvent(
+            'thinking_delta',
+            {{ part_index: 1, text: `${{label}} plan thinking` }},
+            {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: `${{label}}-think-plan-delta` }},
+          );
+          applyStreamOverlayEvent(
+            'thinking_finished',
+            {{ part_index: 1 }},
+            {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: `${{label}}-think-plan-finish` }},
+          );
+        }};
+        const persistedPartial = (runId, label) => [{{
+          role: 'assistant',
+          role_id: 'Coordinator',
+          instance_id: `${{label}}-persisted-instance-after-switch`,
+          created_at: '2026-04-26T09:46:41Z',
+          message: {{
+            parts: [
+              {{ part_kind: 'thinking', part_index: 0, content: `${{label}} intro thinking` }},
+              {{
+                part_kind: 'tool-call',
+                tool_name: 'load_skill',
+                tool_call_id: `${{label}}-load-deepresearch`,
+                args: {{ name: 'deepresearch' }},
+              }},
+              {{
+                part_kind: 'tool-call',
+                tool_name: 'load_skill',
+                tool_call_id: `${{label}}-load-pptx`,
+                args: {{ name: 'pptx-craft' }},
+              }},
+            ],
+          }},
+        }}];
+        const persistedFull = (runId, label) => [{{
+          role: 'assistant',
+          role_id: 'Coordinator',
+          instance_id: `${{label}}-persisted-instance-after-switch`,
+          created_at: '2026-04-26T09:46:41Z',
+          message: {{
+            parts: [
+              {{ part_kind: 'thinking', part_index: 0, content: `${{label}} intro thinking` }},
+              {{
+                part_kind: 'tool-call',
+                tool_name: 'load_skill',
+                tool_call_id: `${{label}}-load-deepresearch`,
+                args: {{ name: 'deepresearch' }},
+              }},
+              {{
+                part_kind: 'tool-call',
+                tool_name: 'load_skill',
+                tool_call_id: `${{label}}-load-pptx`,
+                args: {{ name: 'pptx-craft' }},
+              }},
+              {{ part_kind: 'thinking', part_index: 1, content: `${{label}} plan thinking` }},
+              {{ part_kind: 'thinking', part_index: 2, content: `${{label}} final planning thought` }},
+            ],
+          }},
+        }}];
+        const renderRun = (runId, label, messages, runStatus = 'running') => {{
+          renderHistory(container, messages, {{
+            runId,
+            runStatus,
+            streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+            timelineView: 'main',
+            canonicalStreamKey: 'primary',
+          }});
+          const text = container.textContent || '';
+          return {{
+            introOccurrences: countSubstring(text, `${{label}} intro thinking`),
+            foreignOccurrences: countSubstring(text, `${{label === 'A' ? 'B' : 'A'}} intro thinking`),
+            maxToolDuplicateCount: maxDuplicateToolCount(container),
+          }};
+        }};
+        seedRun(runA, 'A');
+        seedRun(runB, 'B');
+        let maxIntroOccurrences = 0;
+        let maxToolDuplicateCount = 0;
+        let foreignLeakCount = 0;
+        for (let i = 0; i < 120; i += 1) {{
+          Object.defineProperty(document, 'hidden', {{
+            configurable: true,
+            value: i % 7 === 0,
+          }});
+          document.dispatchEvent(new Event('visibilitychange'));
+          const label = i % 2 === 0 ? 'A' : 'B';
+          const result = renderRun(
+            label === 'A' ? runA : runB,
+            label,
+            persistedPartial(label === 'A' ? runA : runB, label),
+          );
+          maxIntroOccurrences = Math.max(maxIntroOccurrences, result.introOccurrences);
+          maxToolDuplicateCount = Math.max(maxToolDuplicateCount, result.maxToolDuplicateCount);
+          foreignLeakCount += result.foreignOccurrences;
+        }}
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 2 }},
+          {{ runId: runA, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'A-think-final-start' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 2, text: 'A final planning thought' }},
+          {{ runId: runA, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'A-think-final-delta' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_finished',
+          {{ part_index: 2 }},
+          {{ runId: runA, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'A-think-final-finish' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 2 }},
+          {{ runId: runB, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'B-think-final-start' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 2, text: 'B final planning thought' }},
+          {{ runId: runB, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'B-think-final-delta' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_finished',
+          {{ part_index: 2 }},
+          {{ runId: runB, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'B-think-final-finish' }},
+        );
+        renderRun(runA, 'A', persistedFull(runA, 'A'), 'completed');
+        const finalRunAThinkingCount = container.querySelectorAll('.thinking-block').length;
+        const overlayAfterFullRunA = getCoordinatorStreamOverlay(runA);
+        renderRun(runB, 'B', persistedFull(runB, 'B'), 'completed');
+        const finalRunBThinkingCount = container.querySelectorAll('.thinking-block').length;
+        const overlayAfterFullRunB = getCoordinatorStreamOverlay(runB);
+        return {{
+          iterations: 120,
+          maxIntroOccurrences,
+          maxToolDuplicateCount,
+          foreignLeakCount,
+          finalRunAThinkingCount,
+          finalRunBThinkingCount,
+          overlayAfterFullRunA,
+          overlayAfterFullRunB,
+        }};
+      }},
+
+      renderPartialThinkingReplayStress() {{
+        clearAllStreamState();
+        const container = makeContainer('partial-thinking-replay-stress');
+        const runId = 'session-7f051512';
+        const introPrefix = 'The user wants me to: use deepresearch and pptx-craft';
+        const introFull = `${{introPrefix}} before loading both skills and planning the workflow.`;
+        const planFull = 'Now I have both skills loaded. Let me plan the workflow in detail.';
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 0 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-1' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 0, text: introPrefix }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-2' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_finished',
+          {{ part_index: 0 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-3' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'load_skill',
+            tool_call_id: 'partial-load-deepresearch',
+            args: {{ name: 'deepresearch' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-4' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'load_skill',
+            tool_call_id: 'partial-load-pptx',
+            args: {{ name: 'pptx-craft' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-5' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 1 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-6' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 1, text: planFull }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-7' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_finished',
+          {{ part_index: 1 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'partial-8' }},
+        );
+        const messages = [
+          {{
+            role: 'assistant',
+            role_id: 'Coordinator',
+            instance_id: 'persisted-main-before-switch',
+            created_at: '2026-04-26T09:46:41Z',
+            message: {{
+              parts: [
+                {{ part_kind: 'thinking', part_index: 0, content: introFull }},
+                {{
+                  part_kind: 'tool-call',
+                  tool_name: 'load_skill',
+                  tool_call_id: 'partial-load-deepresearch',
+                  args: {{ name: 'deepresearch' }},
+                }},
+                {{
+                  part_kind: 'tool-call',
+                  tool_name: 'load_skill',
+                  tool_call_id: 'partial-load-pptx',
+                  args: {{ name: 'pptx-craft' }},
+                }},
+              ],
+            }},
+          }},
+          {{
+            role: 'assistant',
+            role_id: 'Coordinator',
+            instance_id: 'persisted-main-after-switch',
+            created_at: '2026-04-26T09:46:49Z',
+            message: {{
+              parts: [
+                {{ part_kind: 'thinking', part_index: 1, content: planFull }},
+                {{ part_kind: 'text', content: 'Starting the long research loop.' }},
+              ],
+            }},
+          }},
+        ];
+        for (let i = 0; i < 180; i += 1) {{
+          Object.defineProperty(document, 'hidden', {{
+            configurable: true,
+            value: i % 5 === 0,
+          }});
+          document.dispatchEvent(new Event('visibilitychange'));
+          renderHistory(container, messages, {{
+            runId,
+            runStatus: 'running',
+            streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+            timelineView: 'main',
+            canonicalStreamKey: 'primary',
+          }});
+        }}
+        const text = container.textContent || '';
+        return {{
+          introOccurrences: countSubstring(text, introPrefix),
+          planOccurrences: countSubstring(text, planFull),
+          thinkingCount: container.querySelectorAll('.thinking-block').length,
+          toolCount: container.querySelectorAll('.tool-block').length,
+          overlayAfterPersist: getCoordinatorStreamOverlay(runId),
+        }};
+      }},
+
+      async renderConcurrentPrimaryDirectStreamStress() {{
+        clearAllStreamState();
+        const runA = 'session-7f051512';
+        const runB = 'session-8bcc5caa';
+        const roleId = 'Coordinator';
+        const containerA = makeContainer('direct-stream-run-a');
+        const containerB = makeContainer('direct-stream-run-b');
+        getOrCreateStreamBlock(containerA, 'primary', roleId, 'Main Agent', runA);
+        appendStreamChunk('primary', 'A first', runA, roleId, 'Main Agent');
+        startThinkingBlock('primary', 0, {{
+          container: containerA,
+          runId: runA,
+          roleId,
+          label: 'Main Agent',
+        }});
+        appendThinkingChunk('primary', 0, 'A thought', {{
+          container: containerA,
+          runId: runA,
+          roleId,
+          label: 'Main Agent',
+        }});
+        finalizeThinking('primary', 0, {{
+          container: containerA,
+          runId: runA,
+          roleId,
+        }});
+        getOrCreateStreamBlock(containerB, 'primary', roleId, 'Main Agent', runB);
+        appendStreamChunk('primary', 'B first', runB, roleId, 'Main Agent');
+        appendStreamChunk('primary', ' A late', runA, roleId, 'Main Agent');
+        finalizeStream('primary', roleId, {{ runId: runA }});
+        await waitForAnimationFrame();
+        return {{
+          runAText: containerA.textContent || '',
+          runBText: containerB.textContent || '',
+          runACursorCountAfterFinalize: containerA.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderEmptyActiveThinkingOverlay() {{
+        clearAllStreamState();
+        const container = makeContainer('empty-active-thinking-overlay');
+        const runId = 'run-empty-thinking';
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 3 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'empty-think-1' }},
+        );
+        renderHistory(container, [], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          thinkingCount: container.querySelectorAll('.thinking-block').length,
+          overlayAfterReplay: getCoordinatorStreamOverlay(runId),
+        }};
+      }},
+
+      renderMissingToolCallIdReinvocation() {{
+        clearAllStreamState();
+        const runId = 'run-missing-tool-call-id';
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'shell',
+            args: {{ command: 'date' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'missing-tool-1' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_result',
+          {{
+            tool_name: 'shell',
+            result: {{ ok: true }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'missing-tool-2' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'shell',
+            args: {{ command: 'pwd' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'missing-tool-3' }},
+        );
+        const parts = getCoordinatorStreamOverlay(runId).parts.filter(part => part.kind === 'tool');
+        return {{
+          toolPartCount: parts.length,
+          statuses: parts.map(part => part.status || ''),
+          results: parts.map(part => part.result !== undefined),
+        }};
+      }},
+
+      renderMissingToolCallIdOutOfOrderResult() {{
+        clearAllStreamState();
+        const runId = 'run-missing-tool-call-id-out-of-order';
+        applyStreamOverlayEvent(
+          'tool_result',
+          {{
+            tool_name: 'shell',
+            result: {{ ok: true, output: 'done' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'missing-tool-ooo-1' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'shell',
+            args: {{ command: 'date' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'missing-tool-ooo-2' }},
+        );
+        const parts = getCoordinatorStreamOverlay(runId).parts.filter(part => part.kind === 'tool');
+        const part = parts[0] || {{}};
+        return {{
+          toolPartCount: parts.length,
+          status: part.status || '',
+          hasResult: part.result !== undefined,
+          args: part.args || {{}},
+        }};
+      }},
+
+      renderIdedToolResultAfterMissingCallId() {{
+        clearAllStreamState();
+        const runId = 'run-ided-tool-result-after-missing-call-id';
+        applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'shell',
+            args: {{ command: 'date' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'missing-tool-later-id-1' }},
+        );
+        applyStreamOverlayEvent(
+          'tool_result',
+          {{
+            tool_name: 'shell',
+            tool_call_id: 'call-shell-1',
+            result: {{ ok: true, output: 'done' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'missing-tool-later-id-2' }},
+        );
+        const parts = getCoordinatorStreamOverlay(runId).parts.filter(part => part.kind === 'tool');
+        const part = parts[0] || {{}};
+        return {{
+          toolPartCount: parts.length,
+          status: part.status || '',
+          toolCallId: part.tool_call_id || '',
+          hasResult: part.result !== undefined,
+          args: part.args || {{}},
+        }};
+      }},
+
+      renderRepeatedLiveThinkingTextFromOlderHistory() {{
+        clearAllStreamState();
+        const container = makeContainer('repeated-live-thinking-text');
+        const runId = 'run-repeated-live-thinking';
+        const olderPhrase = 'Now let me plan the workflow.';
+        const latestPhrase = 'Latest persisted thinking tail.';
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 2 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'repeat-live-1' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 2, text: olderPhrase }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'repeat-live-2' }},
+        );
+        renderHistory(container, [
+          {{
+            role: 'assistant',
+            role_id: 'Coordinator',
+            instance_id: 'primary',
+            created_at: '2026-04-26T09:46:41Z',
+            message: {{
+              parts: [{{ part_kind: 'thinking', part_index: 0, content: olderPhrase }}],
+            }},
+          }},
+          {{
+            role: 'assistant',
+            role_id: 'Coordinator',
+            instance_id: 'primary',
+            created_at: '2026-04-26T09:46:49Z',
+            message: {{
+              parts: [{{ part_kind: 'thinking', part_index: 1, content: latestPhrase }}],
+            }},
+          }},
+        ], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        const text = container.textContent || '';
+        return {{
+          olderPhraseOccurrences: countSubstring(text, olderPhrase),
+          latestPhraseOccurrences: countSubstring(text, latestPhrase),
+          thinkingCount: container.querySelectorAll('.thinking-block').length,
+        }};
+      }},
+
+      renderUnfinishedThinkingWithPersistedPrefix() {{
+        clearAllStreamState();
+        const container = makeContainer('unfinished-thinking-prefix');
+        const runId = 'run-unfinished-thinking-prefix';
+        const prefix = 'Now let me analyze the session switching timeline carefully.';
+        const suffix = ' This live suffix must remain visible.';
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 2 }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'thinking-prefix-1' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 2, text: `${{prefix}}${{suffix}}` }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'thinking-prefix-2' }},
+        );
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'Coordinator',
+          instance_id: 'primary',
+          created_at: '2026-04-26T09:46:41Z',
+          message: {{
+            parts: [{{ part_kind: 'thinking', part_index: 2, content: prefix }}],
+          }},
+        }}], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        const text = container.textContent || '';
+        return {{
+          prefixOccurrences: countSubstring(text, prefix),
+          suffixOccurrences: countSubstring(text, suffix.trim()),
+          thinkingCount: container.querySelectorAll('.thinking-block').length,
+        }};
+      }},
+
+      renderRunStreamCleanupReleasesOverlayAndDedupe() {{
+        clearAllStreamState();
+        const runId = 'run-cleanup-dedupe';
+        const emitToolCall = () => applyStreamOverlayEvent(
+          'tool_call',
+          {{
+            tool_name: 'shell',
+            tool_call_id: 'call-cleanup',
+            args: {{ command: 'date' }},
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'cleanup-evt-1' }},
+        );
+        emitToolCall();
+        const beforeClearToolCount = getCoordinatorStreamOverlay(runId)?.parts?.length || 0;
+        clearRunStreamState(runId);
+        const overlayAfterClear = getCoordinatorStreamOverlay(runId);
+        emitToolCall();
+        const afterReplayToolCount = getCoordinatorStreamOverlay(runId)?.parts?.length || 0;
+        return {{
+          beforeClearToolCount,
+          overlayAfterClear,
+          afterReplayToolCount,
+        }};
+      }},
+
+      renderOutputDeltaOverlayStreamingState() {{
+        clearAllStreamState();
+        const container = makeContainer('output-delta-overlay-streaming');
+        const runId = 'run-output-delta-overlay';
+        applyStreamOverlayEvent(
+          'output_delta',
+          {{
+            output: [{{ kind: 'text', text: 'streamed output delta text' }}],
+          }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'output-delta-1' }},
+        );
+        const overlay = getCoordinatorStreamOverlay(runId);
+        renderHistory(container, [], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: overlay,
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          textStreaming: overlay?.textStreaming === true,
+          cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderPersistedMediaRefOverlayDedupe() {{
+        clearAllStreamState();
+        const container = makeContainer('persisted-media-ref-overlay-dedupe');
+        const runId = 'run-persisted-media-ref-overlay-dedupe';
+        const mediaPart = {{
+          kind: 'media_ref',
+          modality: 'image',
+          mime_type: 'image/png',
+          url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+          name: 'image.png',
+        }};
+        applyStreamOverlayEvent(
+          'output_delta',
+          {{ output: [mediaPart] }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'media-dedupe-1' }},
+        );
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'Coordinator',
+          instance_id: 'primary',
+          message: {{
+            parts: [mediaPart],
+          }},
+        }}], {{
+          runId,
+          runStatus: 'completed',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          imageCount: container.querySelectorAll('.msg-image-preview').length,
+          imageNames: Array.from(container.querySelectorAll('.msg-image-preview'))
+            .map(image => image.getAttribute('data-image-preview-name') || ''),
+        }};
+      }},
+
+      renderOlderMediaRefReuseOverlay() {{
+        clearAllStreamState();
+        const container = makeContainer('older-media-ref-reuse-overlay');
+        const runId = 'run-older-media-ref-reuse-overlay';
+        const mediaPart = {{
+          kind: 'media_ref',
+          modality: 'image',
+          mime_type: 'image/png',
+          url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+          name: 'image.png',
+        }};
+        applyStreamOverlayEvent(
+          'output_delta',
+          {{ output: [mediaPart] }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'media-reuse-1' }},
+        );
+        renderHistory(container, [
+          {{
+            role: 'assistant',
+            role_id: 'Coordinator',
+            instance_id: 'primary',
+            message: {{
+              parts: [mediaPart],
+            }},
+          }},
+          {{
+            role: 'assistant',
+            role_id: 'Coordinator',
+            instance_id: 'primary',
+            message: {{
+              parts: [{{ part_kind: 'text', content: 'newer persisted text' }}],
+            }},
+          }},
+        ], {{
+          runId,
+          runStatus: 'running',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        return {{
+          imageCount: container.querySelectorAll('.msg-image-preview').length,
+          imageNames: Array.from(container.querySelectorAll('.msg-image-preview'))
+            .map(image => image.getAttribute('data-image-preview-name') || ''),
+        }};
+      }},
+
+      renderTerminalOverlayEventClearsDedupe() {{
+        clearAllStreamState();
+        const runId = 'run-terminal-clears-overlay-dedupe';
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'first lifecycle text' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'repeat-event-id' }},
+        );
+        applyStreamOverlayEvent(
+          'run_completed',
+          {{}},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'terminal-event-id' }},
+        );
+        applyStreamOverlayEvent(
+          'text_delta',
+          {{ text: 'second lifecycle text' }},
+          {{ runId, instanceId: 'primary', roleId: 'Coordinator', label: 'Main Agent', eventId: 'repeat-event-id' }},
+        );
+        const overlay = getCoordinatorStreamOverlay(runId);
+        const text = overlay?.parts
+          ?.filter(part => part.kind === 'text')
+          ?.map(part => part.content || '')
+          ?.join('\\n') || '';
+        return {{
+          firstOccurrences: countSubstring(text, 'first lifecycle text'),
+          secondOccurrences: countSubstring(text, 'second lifecycle text'),
+          textStreaming: overlay?.textStreaming === true,
+        }};
+      }},
+
+      renderStoppedReplayDedup() {{
+        clearAllStreamState();
+        const container = makeContainer('stopped-replay');
+        const runId = 'run-stopped-replay';
+        const messages = [{{
+          role: 'assistant',
+          role_id: 'main-role',
+          instance_id: 'primary',
+          created_at: '2026-04-25T12:00:02Z',
+          message: {{
+            parts: [
+              {{
+                part_kind: 'thinking',
+                part_index: 0,
+                content: 'persisted thought',
+              }},
+              {{
+                part_kind: 'tool-call',
+                tool_name: 'shell',
+                tool_call_id: 'call-1',
+                args: {{ command: 'date' }},
+              }},
+              {{
+                part_kind: 'text',
+                content: 'final answer',
+              }},
+            ],
+          }},
+        }}];
+        const events = [
+          ['thinking_started', {{ part_index: 0 }}, 'evt-1'],
+          ['thinking_delta', {{ part_index: 0, text: 'persisted thought' }}, 'evt-2'],
+          ['thinking_finished', {{ part_index: 0 }}, 'evt-3'],
+          [
+            'tool_call',
+            {{
+              tool_name: 'shell',
+              tool_call_id: 'call-1',
+              args: {{ command: 'date' }},
+            }},
+            'evt-4',
+          ],
+          [
+            'tool_result',
+            {{
+              tool_name: 'shell',
+              tool_call_id: 'call-1',
+              result: {{ ok: true, output: 'done' }},
+            }},
+            'evt-5',
+          ],
+          ['run_stopped', {{}}, 'evt-6'],
+        ];
+        const replayEvents = () => {{
+          events.forEach(([type, payload, eventId]) => {{
+            applyStreamOverlayEvent(type, payload, {{
+              runId,
+              instanceId: 'primary',
+              roleId: 'main-role',
+              label: 'Main Agent',
+              eventId,
+            }});
+          }});
+        }};
+        replayEvents();
+        renderHistory(container, messages, {{
+          runId,
+          runStatus: 'stopped',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+        }});
+        const firstThinkingCount = container.querySelectorAll('.thinking-block').length;
+        const firstToolCount = container.querySelectorAll('.tool-block').length;
+        const firstCursorCount = container.querySelectorAll('.streaming-cursor').length;
+        const overlayAfterFirst = getCoordinatorStreamOverlay(runId);
+        replayEvents();
+        renderHistory(container, messages, {{
+          runId,
+          runStatus: 'stopped',
+          streamOverlayEntry: getCoordinatorStreamOverlay(runId),
+        }});
+        return {{
+          firstThinkingCount,
+          firstToolCount,
+          firstCursorCount,
+          overlayAfterFirst,
+          secondThinkingCount: container.querySelectorAll('.thinking-block').length,
+          secondToolCount: container.querySelectorAll('.tool-block').length,
+          secondCursorCount: container.querySelectorAll('.streaming-cursor').length,
+          secondGroupCount: container.querySelectorAll('.tool-group').length,
+          overlayAfterSecond: getCoordinatorStreamOverlay(runId),
+        }};
+      }},
+
+      renderThinkingOverlayPlacement() {{
+        clearAllStreamState();
+        const container = makeContainer('thinking-placement');
+        applyStreamOverlayEvent(
+          'thinking_started',
+          {{ part_index: 0 }},
+          {{ runId: 'run-placement', instanceId: 'primary', roleId: 'main-role', label: 'Main Agent' }},
+        );
+        applyStreamOverlayEvent(
+          'thinking_delta',
+          {{ part_index: 0, text: 'live thought in progress' }},
+          {{ runId: 'run-placement', instanceId: 'primary', roleId: 'main-role', label: 'Main Agent' }},
+        );
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'main-role',
+          instance_id: 'primary',
+          message: {{
+            parts: [{{ part_kind: 'text', content: 'persisted final answer' }}],
+          }},
+        }}], {{
+          runId: 'run-placement',
+          streamOverlayEntry: getCoordinatorStreamOverlay('run-placement'),
+        }});
+        const messages = Array.from(container.querySelectorAll(':scope > .message'));
+        return {{
+          messageCount: messages.length,
+          firstMessageText: messages[0]?.textContent || '',
+          secondMessageText: messages[1]?.textContent || '',
+        }};
+      }},
+
+      renderDetachedStreamRebind() {{
+        clearAllStreamState();
+        const container = makeContainer('detached-rebind');
+        getOrCreateStreamBlock(container, 'inst-live', 'Writer', 'Writer', 'subagent_run_live');
+        appendToolCallBlock(
+          container,
+          'inst-live',
+          'shell',
+          {{ command: 'echo before' }},
+          'call-1',
+          {{ runId: 'subagent_run_live', roleId: 'Writer', label: 'Writer' }},
+        );
+        const beforeClearToolCount = container.querySelectorAll('.tool-block').length;
+        container.replaceChildren();
+        appendToolCallBlock(
+          container,
+          'inst-live',
+          'write_file',
+          {{ path: 'page.svg' }},
+          'call-2',
+          {{ runId: 'subagent_run_live', roleId: 'Writer', label: 'Writer' }},
+        );
+        return {{
+          beforeClearToolCount,
+          afterClearToolCount: container.querySelectorAll('.tool-block').length,
+          toolCallIds: Array.from(container.querySelectorAll('.tool-block'))
+            .map(item => item.dataset.toolCallId || ''),
+        }};
+      }},
+
+      renderTerminalCollapseWithCompletedOverlay() {{
+        clearAllStreamState();
+        const container = makeContainer('terminal-collapse');
+        container.dataset.roundCreatedAt = '2026-04-25T12:00:00Z';
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'main-role',
+          instance_id: 'primary',
+          created_at: '2026-04-25T12:00:02Z',
+          message: {{
+            parts: [{{ part_kind: 'text', content: 'planning complete' }}],
+          }},
+        }}], {{
+          runId: 'run-terminal-collapse',
+          runStatus: 'completed',
+          hasFinalOutput: true,
+          streamOverlayEntry: {{
+            roleId: 'main-role',
+            instanceId: 'primary',
+            streamKey: 'primary',
+            label: 'Main Agent',
+            parts: [{{
+              kind: 'tool',
+              tool_name: 'write_file',
+              tool_call_id: 'call-final',
+              args: {{ path: 'page.svg' }},
+              status: 'completed',
+              result: {{ ok: true }},
+            }}],
+            textStreaming: false,
+            idleCursor: false,
+          }},
+        }});
+        return {{
+          groupCount: container.querySelectorAll('.tool-group').length,
+          groupToolCount: container.querySelectorAll('.tool-group .tool-block').length,
+        }};
+      }},
+
+      renderFinalMessageCollapseMatrix() {{
+        clearAllStreamState();
+        const renderCase = (id, runStatus, hasFinalOutput, parts) => {{
+          const container = makeContainer(id);
+          container.dataset.roundCreatedAt = '2026-04-25T12:00:00Z';
+          renderHistory(container, [{{
+            role: 'assistant',
+            role_id: 'main-role',
+            instance_id: 'primary',
+            created_at: '2026-04-25T12:00:02Z',
+            message: {{ parts }},
+          }}], {{
+            runId: `run-${{id}}`,
+            runStatus,
+            hasFinalOutput,
+            streamOverlayEntry: null,
+          }});
+          return {{
+            groupCount: container.querySelectorAll('.tool-group').length,
+            text: container.textContent || '',
+          }};
+        }};
+        const stoppedNoFinal = renderCase('stopped-no-final', 'stopped', false, [
+          {{ part_kind: 'thinking', part_index: 0, content: 'stopped thought' }},
+          {{
+            part_kind: 'tool-call',
+            tool_name: 'shell',
+            tool_call_id: 'call-stopped',
+            args: {{ command: 'date' }},
+          }},
+        ]);
+        const failedFinal = renderCase('failed-final', 'failed', true, [
+          {{ part_kind: 'thinking', part_index: 0, content: 'failed thought' }},
+          {{
+            part_kind: 'tool-call',
+            tool_name: 'shell',
+            tool_call_id: 'call-failed',
+            args: {{ command: 'date' }},
+          }},
+          {{ part_kind: 'text', content: 'failed final answer' }},
+        ]);
+        const cancelledFinal = renderCase('cancelled-final', 'cancelled', true, [
+          {{ part_kind: 'thinking', part_index: 0, content: 'cancelled thought' }},
+          {{ part_kind: 'text', content: 'cancelled final answer' }},
+        ]);
+        const completedNoFinal = renderCase('completed-no-final', 'completed', false, [
+          {{ part_kind: 'thinking', part_index: 0, content: 'completed thought' }},
+          {{
+            part_kind: 'tool-call',
+            tool_name: 'shell',
+            tool_call_id: 'call-completed',
+            args: {{ command: 'date' }},
+          }},
+          {{ part_kind: 'text', content: 'loop middle output' }},
+        ]);
+        return {{
+          stoppedNoFinalGroupCount: stoppedNoFinal.groupCount,
+          failedFinalGroupCount: failedFinal.groupCount,
+          cancelledFinalGroupCount: cancelledFinal.groupCount,
+          completedNoFinalGroupCount: completedNoFinal.groupCount,
+          failedFinalText: failedFinal.text,
+          cancelledFinalText: cancelledFinal.text,
+          completedNoFinalText: completedNoFinal.text,
+        }};
+      }},
+
+      measureSubagentSessionWidth() {{
+        const shell = document.createElement('main');
+        shell.id = 'chat-container';
+        shell.style.width = '960px';
+        shell.style.height = '400px';
+        shell.style.display = 'block';
+        const scroll = document.createElement('div');
+        scroll.className = 'chat-scroll';
+        scroll.style.width = '960px';
+        scroll.style.height = '400px';
+        const wrapper = document.createElement('section');
+        wrapper.className = 'subagent-session-view';
+        const body = document.createElement('div');
+        body.className = 'subagent-session-body';
+        wrapper.appendChild(body);
+        scroll.appendChild(wrapper);
+        shell.appendChild(scroll);
+        document.body.appendChild(shell);
+        const beforeWidth = Math.round(wrapper.getBoundingClientRect().width);
+        body.appendChild(document.createElement('div'));
+        const afterWidth = Math.round(wrapper.getBoundingClientRect().width);
+        const scrollWidth = Math.round(scroll.getBoundingClientRect().width);
+        return {{
+          beforeWidth,
+          afterWidth,
+          beforeWithinScroll: beforeWidth <= scrollWidth,
+          afterWithinScroll: afterWidth <= scrollWidth,
+        }};
+      }},
+    }};
+    window.__streamTimelineHarnessReady = true;
+  </script>
+</body>
+</html>
+""".strip(),
+            encoding="utf-8",
+        )
+        page.goto(f"{base_url}/{html_path.name}")
+        page.wait_for_function(
+            "() => window.__streamTimelineHarnessReady === true",
+            timeout=_WAIT_TIMEOUT_MS,
+        )
+
+
+@contextmanager
+def _serve_harness_directory(repo_root: Path, harness_root: Path) -> Iterator[str]:
+    class Handler(SimpleHTTPRequestHandler):
+        def translate_path(self, path: str) -> str:
+            request_path = unquote(urlsplit(path).path).lstrip("/")
+            if request_path.startswith("frontend/"):
+                return str(repo_root / request_path)
+            return str(harness_root / request_path)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = cast(tuple[str, int], server.server_address)
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _resolve_playwright_browser_root() -> Path:
+    env_value = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    candidates: list[Path] = []
+    if env_value:
+        candidates.append(Path(env_value).expanduser())
+    if os.name == "nt":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        if local_app_data:
+            candidates.append(Path(local_app_data).expanduser() / "ms-playwright")
+        user_profile = os.environ.get("USERPROFILE")
+        if user_profile:
+            candidates.append(
+                Path(user_profile).expanduser() / "AppData" / "Local" / "ms-playwright"
+            )
+    candidates.append(Path.home() / ".cache" / "ms-playwright")
+    for candidate in candidates:
+        if _has_playwright_chromium(candidate):
+            return candidate
+    return candidates[0] if candidates else Path.home() / ".cache" / "ms-playwright"
+
+
+def _has_playwright_chromium(path: Path) -> bool:
+    if not path.exists():
+        return False
+    executable_names = {
+        "chrome",
+        "chrome.exe",
+        "chrome-headless-shell",
+        "chrome-headless-shell.exe",
+        "Chromium",
+    }
+    for child in path.glob("chromium*"):
+        if not child.is_dir():
+            continue
+        for executable in child.rglob("*"):
+            if executable.name in executable_names and executable.is_file():
+                return True
+    return False

--- a/tests/integration_tests/support/test_fake_llm_server.py
+++ b/tests/integration_tests/support/test_fake_llm_server.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import cast
+
+from integration_tests.support.fake_llm_server import plan_fake_response
+
+
+def test_computer_validation_mode_uses_latest_user_prompt_only() -> None:
+    response = plan_fake_response(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "[computer-real-validation] open notepad",
+                },
+                {
+                    "role": "user",
+                    "content": "runtime context appended after the original prompt",
+                },
+            ],
+            "tools": [
+                {"function": {"name": "launch_app"}},
+                {"function": {"name": "wait_for_window"}},
+                {"function": {"name": "capture_screen"}},
+            ],
+        }
+    )
+
+    assert response["kind"] == "text"
+    content = cast(str, response["content"])
+    assert "runtime context appended after the original prompt" in content
+
+
+def test_computer_validation_mode_detects_marker_on_latest_user_prompt() -> None:
+    response = plan_fake_response(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "[computer-real-validation] open notepad",
+                },
+            ],
+            "tools": [
+                {"function": {"name": "launch_app"}},
+                {"function": {"name": "wait_for_window"}},
+                {"function": {"name": "capture_screen"}},
+            ],
+        }
+    )
+
+    assert response["kind"] == "tool_call"
+    assert response["tool_name"] == "launch_app"
+    assert response["tool_call_id"] == "call-real-launch-app-1"

--- a/tests/unit_tests/frontend/test_message_rich_content_ui.py
+++ b/tests/unit_tests/frontend/test_message_rich_content_ui.py
@@ -308,7 +308,21 @@ def test_read_tool_return_renders_media_ref_preview(tmp_path: Path) -> None:
         tool_blocks_source_path.read_text(encoding="utf-8")
         .replace("./approval.js", "./mockApproval.mjs")
         .replace("./content.js", "./content.mjs")
+        .replace("./toolArgs.js", "./toolArgs.mjs")
         .replace("../../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (tmp_path / "toolArgs.mjs").write_text(
+        (
+            repo_root
+            / "frontend"
+            / "dist"
+            / "js"
+            / "components"
+            / "messageRenderer"
+            / "helpers"
+            / "toolArgs.js"
+        ).read_text(encoding="utf-8"),
         encoding="utf-8",
     )
 

--- a/tests/unit_tests/frontend/test_message_timeline_ui.py
+++ b/tests/unit_tests/frontend/test_message_timeline_ui.py
@@ -122,6 +122,71 @@ console.log(JSON.stringify(getRunTimelineSnapshot('run-1').coordinator.parts));
     assert parts[0]["id"] != parts[2]["id"]
 
 
+def test_message_timeline_gives_repeated_thinking_parts_unique_event_ids() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    runner = """
+import {
+  applyRunEventToTimeline,
+} from './frontend/dist/js/components/messageTimeline/actions.js';
+import {
+  clearTimelineState,
+  getRunTimelineSnapshot,
+} from './frontend/dist/js/components/messageTimeline/store.js';
+
+clearTimelineState();
+
+applyRunEventToTimeline(
+  'thinking_started',
+  { part_index: 0 },
+  { run_id: 'run-1', event_id: 1 },
+);
+applyRunEventToTimeline(
+  'thinking_delta',
+  { part_index: 0, text: 'first thought' },
+  { run_id: 'run-1', event_id: 2 },
+);
+applyRunEventToTimeline(
+  'thinking_finished',
+  { part_index: 0 },
+  { run_id: 'run-1', event_id: 3 },
+);
+applyRunEventToTimeline(
+  'thinking_started',
+  { part_index: 0 },
+  { run_id: 'run-1', event_id: 4 },
+);
+applyRunEventToTimeline(
+  'thinking_delta',
+  { part_index: 0, text: 'second thought' },
+  { run_id: 'run-1', event_id: 5 },
+);
+applyRunEventToTimeline(
+  'thinking_finished',
+  { part_index: 0 },
+  { run_id: 'run-1', event_id: 6 },
+);
+
+console.log(JSON.stringify(getRunTimelineSnapshot('run-1').coordinator.parts));
+""".strip()
+
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=10,
+    )
+
+    parts = json.loads(completed.stdout)
+    assert [part["kind"] for part in parts] == ["thinking", "thinking"]
+    assert [part["content"] for part in parts] == ["first thought", "second thought"]
+    assert parts[0]["id"] != parts[1]["id"]
+    assert parts[0]["id"].endswith("::thinking::1")
+    assert parts[1]["id"].endswith("::thinking::4")
+
+
 def test_message_timeline_gives_media_parts_without_event_ids_unique_ids() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     runner = """
@@ -165,3 +230,156 @@ console.log(JSON.stringify(getRunTimelineSnapshot('run-1').coordinator.parts));
     assert parts[0]["id"].endswith("::media_ref::media-0")
     assert parts[1]["id"].endswith("::media_ref::media-1")
     assert parts[0]["id"] != parts[1]["id"]
+
+
+def test_message_timeline_keeps_completed_tool_status_when_call_arrives_late() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    runner = """
+import {
+  applyRunEventToTimeline,
+} from './frontend/dist/js/components/messageTimeline/actions.js';
+import {
+  clearTimelineState,
+  getRunTimelineSnapshot,
+} from './frontend/dist/js/components/messageTimeline/store.js';
+
+clearTimelineState();
+
+applyRunEventToTimeline(
+  'tool_result',
+  {
+    tool_name: 'shell',
+    tool_call_id: 'call-b',
+    result: { ok: true, output: 'done' },
+  },
+  { run_id: 'run-1', event_id: 2 },
+);
+applyRunEventToTimeline(
+  'tool_call',
+  {
+    tool_name: 'shell',
+    tool_call_id: 'call-b',
+    args: { command: 'echo b' },
+  },
+  { run_id: 'run-1', event_id: 1 },
+);
+
+console.log(JSON.stringify(getRunTimelineSnapshot('run-1').coordinator.parts));
+""".strip()
+
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=10,
+    )
+
+    parts = json.loads(completed.stdout)
+    assert len(parts) == 1
+    assert parts[0]["tool_call_id"] == "call-b"
+    assert parts[0]["status"] == "completed"
+    assert parts[0]["args"] == {"command": "echo b"}
+
+
+def test_message_timeline_normalizes_string_tool_args_for_live_and_hydrated_parts() -> (
+    None
+):
+    repo_root = Path(__file__).resolve().parents[3]
+    runner = """
+import {
+  applyRunEventToTimeline,
+} from './frontend/dist/js/components/messageTimeline/actions.js';
+import {
+  applyTimelineAction,
+  clearTimelineState,
+  getRunTimelineSnapshot,
+} from './frontend/dist/js/components/messageTimeline/store.js';
+
+clearTimelineState();
+
+applyRunEventToTimeline(
+  'tool_call',
+  {
+    tool_name: 'websearch',
+    tool_call_id: 'call-live',
+    args: '{"query":"Anthropic funding 2026"}',
+  },
+  { run_id: 'run-live', event_id: 1 },
+);
+applyRunEventToTimeline(
+  'tool_result',
+  {
+    tool_name: 'websearch',
+    tool_call_id: 'call-late',
+    result: { ok: true, output: 'done' },
+  },
+  { run_id: 'run-late', event_id: 1 },
+);
+applyRunEventToTimeline(
+  'tool_call',
+  {
+    tool_name: 'websearch',
+    tool_call_id: 'call-late',
+    args: '{"query":"Anthropic model release"}',
+  },
+  { run_id: 'run-late', event_id: 2 },
+);
+applyTimelineAction({
+  type: 'hydrate_parts',
+  scope: { runId: 'run-history', streamKey: 'primary', view: 'main' },
+  parts: [{
+    kind: 'tool',
+    tool_name: 'websearch',
+    tool_call_id: 'call-history',
+    args: '{"query":"Anthropic safety policy"}',
+    status: 'pending',
+  }],
+});
+applyRunEventToTimeline(
+  'tool_call',
+  {
+    tool_name: 'batch',
+    tool_call_id: 'call-array',
+    args: '["one","two"]',
+  },
+  { run_id: 'run-array', event_id: 1 },
+);
+applyRunEventToTimeline(
+  'tool_call',
+  {
+    tool_name: 'raw',
+    tool_call_id: 'call-raw',
+    args: 'not json',
+  },
+  { run_id: 'run-raw', event_id: 1 },
+);
+
+console.log(JSON.stringify({
+  live: getRunTimelineSnapshot('run-live').coordinator.parts[0],
+  late: getRunTimelineSnapshot('run-late').coordinator.parts[0],
+  hydrated: getRunTimelineSnapshot('run-history').coordinator.parts[0],
+  arrayArgs: getRunTimelineSnapshot('run-array').coordinator.parts[0].args,
+  rawArgs: getRunTimelineSnapshot('run-raw').coordinator.parts[0].args,
+}));
+""".strip()
+
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=10,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["live"]["args"] == {"query": "Anthropic funding 2026"}
+    assert payload["late"]["status"] == "completed"
+    assert payload["late"]["args"] == {"query": "Anthropic model release"}
+    assert payload["hydrated"]["args"] == {"query": "Anthropic safety policy"}
+    assert payload["arrayArgs"] == {"__items": ["one", "two"]}
+    assert payload["rawArgs"] == {"__raw": "not json"}

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -202,10 +202,19 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     )
     assert "const overlayCleanupTimers = new Map();" in renderer_stream_script
     assert (
-        "scheduleOverlayEntryCleanup(runId, streamKey, roleId, cleanupDelayMs);"
-        in renderer_stream_script
+        "export function clearRunRenderedStreamState(runId)" in renderer_stream_script
     )
-    assert "scheduleRunOverlayCleanup(runId, cleanupDelayMs);" in renderer_stream_script
+    assert (
+        "scheduleOverlayEntryCleanup(runId, streamKey, roleId, cleanupDelayMs);"
+        not in renderer_stream_script
+    )
+    assert (
+        "scheduleRunOverlayCleanup(runId, cleanupDelayMs);"
+        not in renderer_stream_script
+    )
+    assert "messageRenderer.clearRunStreamState(finishedRunId);" in stream_script
+    assert "overlaySeenEventIdsByRun.delete(safeRunId);" in renderer_stream_script
+    assert "clearTimelineRun(safeRunId);" in renderer_stream_script
     assert "st = createStreamState({" in renderer_stream_script
     assert "function findReusableStreamState({" in renderer_stream_script
     assert (

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+from typing import cast
 
 
 def test_model_step_started_refreshes_subagent_runtime_snapshot(
@@ -137,6 +138,55 @@ console.log(JSON.stringify({
             ],
         }
     ]
+
+
+def test_route_event_prunes_dedupe_state_after_terminal_run_event(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+routeEvent('text_delta', { text: 'first' }, {
+    run_id: 'run-1',
+    trace_id: 'run-1',
+    event_id: 'evt-1',
+});
+routeEvent('text_delta', { text: 'duplicate' }, {
+    run_id: 'run-1',
+    trace_id: 'run-1',
+    event_id: 'evt-1',
+});
+routeEvent('run_completed', {}, {
+    run_id: 'run-1',
+    trace_id: 'run-1',
+    event_id: 'evt-2',
+});
+routeEvent('text_delta', { text: 'new lifecycle' }, {
+    run_id: 'run-1',
+    trace_id: 'run-1',
+    event_id: 'evt-1',
+});
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    runEventCalls: globalThis.__runEventCalls,
+}));
+""".strip(),
+    )
+
+    run_event_calls = cast(list[dict[str, object]], payload["runEventCalls"])
+    assert [item["name"] for item in run_event_calls] == [
+        "handleTextDelta",
+        "handleRunCompleted",
+        "handleTextDelta",
+    ]
+    first_args = cast(list[object], run_event_calls[0]["args"])
+    last_args = cast(list[object], run_event_calls[2]["args"])
+    assert first_args[0] == {"text": "first"}
+    assert last_args[0] == {"text": "new lifecycle"}
 
 
 def test_route_event_refreshes_recovery_for_subagent_user_question_events(
@@ -367,6 +417,49 @@ globalThis.__activeSubagentSessionStreamContainer = {};
 handleModelStepFinished(
     { run_id: 'subagent_run_deadbeef', trace_id: 'subagent_run_deadbeef' },
     'writer-1',
+);
+
+console.log(JSON.stringify({
+    finalizeCalls: globalThis.__finalizeStreamCalls,
+    statusCalls: globalThis.__updateNormalModeSubagentSessionStatusCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["finalizeCalls"] == [
+        {
+            "instanceId": "writer-1",
+            "roleId": "writer",
+            "options": {"runId": "subagent_run_deadbeef"},
+        }
+    ]
+    assert payload["statusCalls"] == [
+        {
+            "sessionId": "session-1",
+            "instanceId": "writer-1",
+            "status": "completed",
+        }
+    ]
+
+
+def test_handle_model_step_finished_uses_event_role_when_role_map_missing(
+    tmp_path: Path,
+) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleModelStepFinished } = await import('./runEvents.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+state.currentSessionMode = 'normal';
+state.mainAgentRoleId = 'MainAgent';
+globalThis.__activeSubagentSessionStreamContainer = {};
+
+handleModelStepFinished(
+    { run_id: 'subagent_run_deadbeef', trace_id: 'subagent_run_deadbeef' },
+    'writer-1',
+    'writer',
 );
 
 console.log(JSON.stringify({

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -6,6 +6,370 @@ from pathlib import Path
 import subprocess
 
 
+def _write_stream_overlay_test_modules(temp_dir: Path, source: str) -> None:
+    (temp_dir / "stream.js").write_text(
+        source.replace("../../core/state.js", "./mockState.mjs")
+        .replace("./helpers.js", "./mockHelpers.mjs")
+        .replace("../../utils/i18n.js", "./mockI18n.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export function getRunPrimaryRoleId(runId) {
+    return runId === "run-primary" ? "main-role" : "";
+}
+
+export function isPrimaryRoleId() {
+    return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockHelpers.mjs").write_text(
+        """
+export function applyToolReturn() {}
+export function appendStructuredContentPart() {}
+export function appendThinkingText() { return {}; }
+export function buildPendingToolBlock() { return { querySelector() { return null; } }; }
+export function findToolBlock() { return null; }
+export function findToolBlockInContainer() { return null; }
+export function indexPendingToolBlock() {}
+export function renderMessageBlock() {
+    return {
+        wrapper: {
+            dataset: {},
+            querySelector() { return null; },
+            closest() { return null; },
+        },
+        contentEl: {
+            appendChild() {},
+            querySelector() { return null; },
+            querySelectorAll() { return []; },
+        },
+    };
+}
+export function resolvePendingToolBlock() { return null; }
+export function scrollBottom() {}
+export function setToolStatus() {}
+export function setToolValidationFailureState() {}
+export function syncStreamingCursor() {}
+export function updateThinkingText() {}
+export function updateMessageText() {}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function formatMessage(_key, values = {}) {
+    return JSON.stringify(values);
+}
+
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def test_stream_overlay_keeps_unpersisted_cache_after_terminal_events(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_overlay_terminal"
+    temp_dir.mkdir()
+    _write_stream_overlay_test_modules(temp_dir, source)
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+} from "./stream.js";
+
+applyStreamOverlayEvent(
+  "text_delta",
+  { text: "still not persisted" },
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+applyStreamOverlayEvent(
+  "model_step_finished",
+  {},
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+applyStreamOverlayEvent(
+  "run_completed",
+  {},
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+
+console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-primary")));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["coordinator"]["parts"] == [
+        {"kind": "text", "content": "still not persisted"}
+    ]
+    assert payload["coordinator"]["textStreaming"] is False
+
+
+def test_stream_overlay_replayed_event_ids_do_not_duplicate_parts(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_overlay_replayed_event_ids"
+    temp_dir.mkdir()
+    _write_stream_overlay_test_modules(temp_dir, source)
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+} from "./stream.js";
+
+const options = {
+  runId: "run-primary",
+  instanceId: "primary",
+  roleId: "main-role",
+  label: "Main Agent",
+};
+const events = [
+  ["thinking_started", { part_index: 0 }, "evt-1"],
+  ["thinking_delta", { part_index: 0, text: "plan" }, "evt-2"],
+  ["thinking_finished", { part_index: 0 }, "evt-3"],
+  [
+    "tool_call",
+    {
+      tool_name: "shell",
+      tool_call_id: "call-1",
+      args: { command: "date" },
+    },
+    "evt-4",
+  ],
+  [
+    "tool_result",
+    {
+      tool_name: "shell",
+      tool_call_id: "call-1",
+      result: { ok: true, output: "done" },
+    },
+    "evt-5",
+  ],
+];
+
+events.forEach(([type, payload, eventId]) => {
+  applyStreamOverlayEvent(type, payload, { ...options, eventId });
+});
+events.forEach(([type, payload, eventId]) => {
+  applyStreamOverlayEvent(type, payload, { ...options, eventId });
+});
+
+console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-primary").coordinator));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    overlay = json.loads(result.stdout)
+    assert [part["kind"] for part in overlay["parts"]] == ["thinking", "tool"]
+    assert overlay["parts"][0]["content"] == "plan"
+    assert overlay["parts"][1]["tool_call_id"] == "call-1"
+    assert overlay["parts"][1]["status"] == "completed"
+
+
+def test_stream_overlay_merges_out_of_order_parallel_tool_events(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_overlay_parallel_tools"
+    temp_dir.mkdir()
+    _write_stream_overlay_test_modules(temp_dir, source)
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+} from "./stream.js";
+
+applyStreamOverlayEvent(
+  "tool_result",
+  {
+    tool_name: "shell",
+    tool_call_id: "call-b",
+    result: { ok: true, output: "b done" },
+  },
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+applyStreamOverlayEvent(
+  "tool_call",
+  {
+    tool_name: "shell",
+    tool_call_id: "call-a",
+    args: { command: "echo a" },
+  },
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+applyStreamOverlayEvent(
+  "tool_call",
+  {
+    tool_name: "shell",
+    tool_call_id: "call-b",
+    args: { command: "echo b" },
+  },
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+
+console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-primary").coordinator.parts));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    parts = json.loads(result.stdout)
+    assert [part["tool_call_id"] for part in parts] == ["call-b", "call-a"]
+    assert parts[0]["status"] == "completed"
+    assert parts[0]["args"] == {"command": "echo b"}
+    assert parts[1]["status"] == "pending"
+
+
+def test_stream_overlay_normalizes_string_tool_args_and_keeps_stream_key(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_overlay_string_args"
+    temp_dir.mkdir()
+    _write_stream_overlay_test_modules(temp_dir, source)
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+} from "./stream.js";
+
+applyStreamOverlayEvent(
+  "tool_call",
+  {
+    tool_name: "websearch",
+    tool_call_id: "call-json",
+    args: '{"query":"Anthropic funding 2026"}',
+  },
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+applyStreamOverlayEvent(
+  "tool_call",
+  {
+    tool_name: "batch",
+    tool_call_id: "call-array",
+    args: '["one","two"]',
+  },
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+applyStreamOverlayEvent(
+  "tool_call",
+  {
+    tool_name: "raw",
+    tool_call_id: "call-raw",
+    args: "not json",
+  },
+  {
+    runId: "run-primary",
+    instanceId: "primary",
+    roleId: "main-role",
+    label: "Main Agent",
+  },
+);
+
+console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-primary").coordinator));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    overlay = json.loads(result.stdout)
+    assert overlay["streamKey"] == "primary"
+    assert overlay["parts"][0]["args"] == {"query": "Anthropic funding 2026"}
+    assert overlay["parts"][1]["args"] == {"__items": ["one", "two"]}
+    assert overlay["parts"][2]["args"] == {"__raw": "not json"}
+
+
 def test_stream_overlay_uses_run_primary_role_for_primary_key(tmp_path: Path) -> None:
     source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
         encoding="utf-8"
@@ -1170,7 +1534,7 @@ console.log(JSON.stringify({
     ]
 
 
-def test_finalize_stream_clears_overlay_without_live_stream_state(
+def test_finalize_stream_preserves_unpersisted_overlay_without_live_state(
     tmp_path: Path,
 ) -> None:
     source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
@@ -1283,13 +1647,24 @@ console.log(JSON.stringify({ before, after }));
         "inst-sub-1": {
             "instanceId": "inst-sub-1",
             "roleId": "Crafter",
+            "streamKey": "inst-sub-1",
             "label": "Crafter",
             "parts": [{"kind": "text", "content": "stale overlay"}],
             "textStreaming": True,
             "idleCursor": False,
         }
     }
-    assert payload["after"] == {"coordinator": None, "byInstance": {}}
+    assert payload["after"]["byInstance"] == {
+        "inst-sub-1": {
+            "instanceId": "inst-sub-1",
+            "roleId": "Crafter",
+            "streamKey": "inst-sub-1",
+            "label": "Crafter",
+            "parts": [{"kind": "text", "content": "stale overlay"}],
+            "textStreaming": False,
+            "idleCursor": False,
+        }
+    }
 
 
 def test_finalize_stream_turns_off_streaming_cursor_for_live_subagent_text(
@@ -1694,6 +2069,7 @@ console.log(JSON.stringify({
     assert payload["overlay"] == {
         "instanceId": "inst-1",
         "roleId": "Writer",
+        "streamKey": "inst-1",
         "label": "Writer",
         "parts": [
             {
@@ -1827,6 +2203,7 @@ console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-2")));
             "inst-2": {
                 "instanceId": "inst-2",
                 "roleId": "Researcher",
+                "streamKey": "inst-2",
                 "label": "Researcher",
                 "parts": [
                     {
@@ -1958,6 +2335,7 @@ console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-3")));
             "inst-3": {
                 "instanceId": "inst-3",
                 "roleId": "Writer",
+                "streamKey": "inst-3",
                 "label": "Writer",
                 "parts": [],
                 "textStreaming": False,

--- a/tests/unit_tests/frontend/test_streaming_tool_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_tool_ui.py
@@ -102,6 +102,14 @@ def test_live_streaming_tool_overlay_skips_processed_group_summary() -> None:
     )
     assert "const filteredOverlayEntry = filterPersistedOverlayParts(" in history_script
     assert (
+        "function normalizeCanonicalHistoryStreamKey(options = {}) {" in history_script
+    )
+    assert "options.canonicalStreamKey" in history_script
+    assert (
+        "function resolveOverlayStreamKeys(streamOverlayEntry, runId, options = {}) {"
+        in history_script
+    )
+    assert (
         "function shouldCollapseIntermediateMessages(streamOverlayEntry, options = {}) {"
         in history_script
     )
@@ -110,8 +118,13 @@ def test_live_streaming_tool_overlay_skips_processed_group_summary() -> None:
         in history_script
     )
     assert "const isLatestRound = options.isLatestRound === true;" in history_script
-    assert "if (isLatestRound && runStatus !== 'completed') {" in history_script
+    assert "const isTerminalStatus = isTerminalRunStatus(runStatus);" in history_script
+    assert "const hasFinalOutput = options.hasFinalOutput === true;" in history_script
+    assert "if (isLatestRound && !isTerminalStatus) {" in history_script
+    assert "if (!hasFinalOutput) {" in history_script
+    assert "hasFinalVisibleMessage" not in history_script
     assert "if (streamOverlayEntry.textStreaming === true) {" in history_script
+    assert "function isTerminalRunStatus(runStatus)" in history_script
     assert "status === 'pending'" in history_script
     assert "status === 'running'" in history_script
     assert "approvalStatus === 'requested'" in history_script
@@ -138,6 +151,12 @@ def test_pending_tool_block_name_fallback_does_not_merge_parallel_calls(
     temp_dir = tmp_path / "tool_block_parallel_fallback"
     temp_dir.mkdir()
     (temp_dir / "toolBlocks.js").write_text(source, encoding="utf-8")
+    (temp_dir / "toolArgs.js").write_text(
+        Path(
+            "frontend/dist/js/components/messageRenderer/helpers/toolArgs.js"
+        ).read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
 
     runner = """
 import {
@@ -200,18 +219,30 @@ def test_tool_blocks_extract_effective_inputs_instead_of_footer_status() -> None
         / "helpers"
         / "toolBlocks.js"
     ).read_text(encoding="utf-8")
+    tool_args_script = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "messageRenderer"
+        / "helpers"
+        / "toolArgs.js"
+    ).read_text(encoding="utf-8")
     tools_css = (
         repo_root / "frontend" / "dist" / "css" / "components" / "tools.css"
     ).read_text(encoding="utf-8")
 
+    assert "import { normalizeToolArgs } from './toolArgs.js';" in tool_blocks_script
     assert "fields: ['command', 'cmd']" in tool_blocks_script
     assert (
         "fields: ['path', 'file_path', 'filepath', 'target_path']" in tool_blocks_script
     )
     assert "fields: ['query', 'q', 'search_query']" in tool_blocks_script
     assert "fields: ['url', 'uri']" in tool_blocks_script
-    assert "function normalizeToolArgs(args) {" in tool_blocks_script
-    assert "return { __raw: raw };" in tool_blocks_script
+    assert "export function normalizeToolArgs(args) {" in tool_args_script
+    assert "return { __items: args };" in tool_args_script
+    assert "return { __raw: raw };" in tool_args_script
     assert (
         'return `<div class="tool-input-value"><code>${escapeHtml(info.detailText)}</code></div>`;'
         in tool_blocks_script

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -19,9 +19,12 @@ from pydantic_ai.messages import (
 
 from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.sessions.session_rounds_projection import build_session_rounds
+from relay_teams.sessions.session_rounds_projection import build_session_timeline_rounds
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.media import content_parts_from_text
+from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
+from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_models import RunResult
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
@@ -617,6 +620,7 @@ def test_build_session_rounds_reconstructs_completed_output_and_marks_clear_boun
         "label": "History cleared",
     }
     assert round_new["primary_role_id"] == "Coordinator"
+    assert round_new["has_final_output"] is True
     assert coordinator_messages[0]["reconstructed"] is True
     assert parts[0]["content"] == "reconstructed final output"
 
@@ -678,8 +682,137 @@ def test_build_session_rounds_reconstructs_structured_completed_output(
     reconstructed_message = cast(dict[str, object], coordinator_messages[0]["message"])
     parts = cast(list[dict[str, object]], reconstructed_message["parts"])
 
+    assert round_item["has_final_output"] is True
     assert coordinator_messages[0]["reconstructed"] is True
     assert parts[0]["content"] == "structured reconstructed output"
+
+
+def test_build_session_rounds_projects_failed_assistant_response_output_as_final(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_failed_final_output.db"
+    session_id = "session-1"
+    run_id = "run-failed-final"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    message_repo = MessageRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id="task-root-failed-final",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="new objective",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    event: dict[str, object] = {
+        "event_type": RunEventType.RUN_FAILED.value,
+        "trace_id": run_id,
+        "payload_json": RunResult(
+            trace_id=run_id,
+            root_task_id="task-root-failed-final",
+            status="failed",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+            output=content_parts_from_text("failed final output"),
+        ).model_dump_json(),
+        "occurred_at": "2026-03-25T09:31:00+00:00",
+    }
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda sid: cast(
+            list[dict[str, object]],
+            message_repo.get_messages_by_session(sid, include_cleared=True),
+        ),
+        get_session_events=lambda _sid: [event],
+    )
+    timeline_rounds = build_session_timeline_rounds(
+        session_id=session_id,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_user_messages=lambda _sid: [],
+        get_session_events=lambda _sid: [event],
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+    timeline_item = next(item for item in timeline_rounds if item["run_id"] == run_id)
+    coordinator_messages = cast(
+        list[dict[str, object]],
+        round_item["coordinator_messages"],
+    )
+    reconstructed_message = cast(dict[str, object], coordinator_messages[0]["message"])
+    parts = cast(list[dict[str, object]], reconstructed_message["parts"])
+
+    assert round_item["has_final_output"] is True
+    assert timeline_item["has_final_output"] is True
+    assert coordinator_messages[0]["reconstructed"] is True
+    assert parts[0]["content"] == "failed final output"
+
+
+def test_build_session_rounds_ignores_assistant_error_output_for_final_flag(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_failed_error_output.db"
+    session_id = "session-1"
+    run_id = "run-failed-error"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    message_repo = MessageRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id="task-root-failed-error",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="new objective",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda sid: cast(
+            list[dict[str, object]],
+            message_repo.get_messages_by_session(sid, include_cleared=True),
+        ),
+        get_session_events=lambda _sid: [
+            {
+                "event_type": RunEventType.RUN_FAILED.value,
+                "trace_id": run_id,
+                "payload_json": RunResult(
+                    trace_id=run_id,
+                    root_task_id="task-root-failed-error",
+                    status="failed",
+                    completion_reason=RunCompletionReason.ASSISTANT_ERROR,
+                    output=content_parts_from_text("assistant error output"),
+                ).model_dump_json(),
+                "occurred_at": "2026-03-25T09:31:00+00:00",
+            }
+        ],
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+
+    assert round_item["has_final_output"] is False
+    assert round_item["coordinator_messages"] == []
 
 
 def test_build_session_rounds_marks_compaction_boundary_for_matching_conversation(

--- a/tests/unit_tests/sessions/test_session_agent_messages.py
+++ b/tests/unit_tests/sessions/test_session_agent_messages.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
-from pydantic_ai.messages import ModelRequest, UserPromptPart
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 
 from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.sessions.runs.event_stream import RunEventHub
@@ -69,6 +76,90 @@ def test_get_agent_messages_includes_role_id(tmp_path: Path) -> None:
     assert len(messages) == 1
     assert messages[0]["entry_type"] == "message"
     assert messages[0]["role_id"] == "time"
+
+
+def test_get_agent_messages_preserves_parallel_tool_calls_and_args(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_agent_messages_tool_parts.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="subagent_run_1",
+        trace_id="subagent_run_1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="researcher",
+        workspace_id="default",
+        status=InstanceStatus.COMPLETED,
+    )
+
+    message_repo = MessageRepository(db_path)
+    message_repo.append(
+        session_id="session-1",
+        workspace_id="default",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="subagent_run_1",
+        messages=[
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="websearch",
+                        args={"query": "Anthropic funding 2026"},
+                        tool_call_id="call-search-1",
+                    ),
+                    ToolCallPart(
+                        tool_name="webfetch",
+                        args={"url": "https://www.anthropic.com/news"},
+                        tool_call_id="call-fetch-1",
+                    ),
+                ]
+            ),
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="websearch",
+                        tool_call_id="call-search-1",
+                        content={"ok": True, "data": ["result"]},
+                    ),
+                    ToolReturnPart(
+                        tool_name="webfetch",
+                        tool_call_id="call-fetch-1",
+                        content={"ok": True, "data": "<html></html>"},
+                    ),
+                ]
+            ),
+        ],
+    )
+
+    timeline = service.get_agent_messages("session-1", "inst-1")
+
+    assert len(timeline) == 2
+    response_message = cast(dict[str, object], timeline[0]["message"])
+    result_message = cast(dict[str, object], timeline[1]["message"])
+    response_parts = cast(list[dict[str, object]], response_message["parts"])
+    result_parts = cast(list[dict[str, object]], result_message["parts"])
+    assert [part["part_kind"] for part in response_parts] == [
+        "tool-call",
+        "tool-call",
+    ]
+    assert [part["tool_call_id"] for part in response_parts] == [
+        "call-search-1",
+        "call-fetch-1",
+    ]
+    assert response_parts[0]["args"] == {"query": "Anthropic funding 2026"}
+    assert response_parts[1]["args"] == {"url": "https://www.anthropic.com/news"}
+    assert [part["part_kind"] for part in result_parts] == [
+        "tool-return",
+        "tool-return",
+    ]
+    assert [part["tool_call_id"] for part in result_parts] == [
+        "call-search-1",
+        "call-fetch-1",
+    ]
 
 
 def test_get_agent_messages_returns_hidden_history_and_compaction_marker(

--- a/tests/unit_tests/tools/computer_tools/test_registration.py
+++ b/tests/unit_tests/tools/computer_tools/test_registration.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import builtins
+from collections.abc import Callable
+from typing import cast
+
+from pydantic_ai import Agent
+from pytest import MonkeyPatch
+
+from relay_teams.tools.computer_tools import register_computer_tools
+from relay_teams.tools.runtime.context import ToolDeps
+
+
+class _RecordingAgent:
+    def __init__(self) -> None:
+        self.tool_names: list[str] = []
+
+    def tool(
+        self,
+        *,
+        description: str | None = None,
+    ) -> Callable[[Callable[..., object]], Callable[..., object]]:
+        _ = description
+
+        def _decorator(func: Callable[..., object]) -> Callable[..., object]:
+            self.tool_names.append(func.__name__)
+            return func
+
+        return _decorator
+
+
+def test_computer_tool_registration_is_deduplicated_per_agent(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    first_agent = _RecordingAgent()
+    second_agent = _RecordingAgent()
+    original_id = builtins.id
+    target_ids = {original_id(first_agent), original_id(second_agent)}
+
+    def reused_id(value: object) -> int:
+        if original_id(value) in target_ids:
+            return 1
+        return original_id(value)
+
+    monkeypatch.setattr(builtins, "id", reused_id)
+
+    register_computer_tools(cast(Agent[ToolDeps, str], cast(object, first_agent)))
+    register_computer_tools(cast(Agent[ToolDeps, str], cast(object, first_agent)))
+    register_computer_tools(cast(Agent[ToolDeps, str], cast(object, second_agent)))
+
+    assert first_agent.tool_names == second_agent.tool_names
+    assert first_agent.tool_names.count("capture_screen") == 1
+    assert first_agent.tool_names.count("click_at") == 1
+    assert second_agent.tool_names.count("capture_screen") == 1
+    assert second_agent.tool_names.count("click_at") == 1


### PR DESCRIPTION
﻿## Summary
- dedupe run and overlay stream events so session switching and replayed SSE events do not duplicate thinking/tool blocks
- keep streamed and persisted tool arguments normalized and synchronized through history rendering
- isolate live primary stream state per run, preserve active empty thinking overlays, and handle missing tool call IDs safely
- clear terminal idle cursors, stabilize subagent message width, and fix computer tool registration id-reuse flake

## Validation
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev ruff check
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests
- uv run --extra dev pytest -q tests/integration_tests/browser/test_streaming_message_timeline.py

Fixes #527
