### PR TITLE
Remove sync SQLite persistence path

### DIFF
--- a/src/relay_teams/persistence/__init__.py
+++ b/src/relay_teams/persistence/__init__.py
@@ -10,7 +10,7 @@ from relay_teams.persistence.db import (
     async_sqlite_supports_fts5,
     is_retryable_sqlite_error,
     open_async_sqlite,
-    open_sqlite,
+    run_async_blocking,
     run_async_sqlite_write_with_retry,
     run_sqlite_write_with_retry,
     sqlite_compile_options,
@@ -18,7 +18,8 @@ from relay_teams.persistence.db import (
 )
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.sqlite_repository import (
-    AsyncSharedSqliteRepository,
+    BlockingAsyncSqliteConnection,
+    BlockingAsyncSqliteCursor,
     SharedSqliteRepository,
     async_fetchall,
     async_fetchone,
@@ -33,7 +34,8 @@ __all__ = [
     "SQLITE_BUSY_TIMEOUT_MS",
     "SQLITE_TIMEOUT_SECONDS",
     "SQLITE_WRITE_RETRY_ATTEMPTS",
-    "AsyncSharedSqliteRepository",
+    "BlockingAsyncSqliteConnection",
+    "BlockingAsyncSqliteCursor",
     "ScopeRef",
     "ScopeType",
     "SharedSqliteRepository",
@@ -46,7 +48,7 @@ __all__ = [
     "build_global_scope_ref",
     "is_retryable_sqlite_error",
     "open_async_sqlite",
-    "open_sqlite",
+    "run_async_blocking",
     "run_async_sqlite_write_with_retry",
     "run_sqlite_write_with_retry",
     "sqlite_compile_options",

--- a/src/relay_teams/persistence/db.py
+++ b/src/relay_teams/persistence/db.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine, Sequence
 import logging
 import sqlite3
 import time
 from pathlib import Path
-from threading import Condition, RLock, get_ident
-from typing import Awaitable, Callable, Optional, TypeVar
+from threading import Condition, Event, RLock, Thread, get_ident
+from typing import Awaitable, Callable, Optional, Protocol, TypeVar
 from weakref import WeakKeyDictionary
 
 import aiosqlite
@@ -22,6 +23,7 @@ SQLITE_WRITE_RETRY_MAX_DELAY_SECONDS = 0.2
 
 LOGGER = get_logger(__name__)
 type _WriteOwnerToken = tuple[str, int]
+type SqliteParameters = Sequence[object]
 _CROSS_WRITE_COORDINATORS: dict[str, CrossModeWriteCoordinator] = {}
 _WRITE_COORDINATORS: dict[str, RLock] = {}
 _WRITE_COORDINATORS_LOCK = RLock()
@@ -29,7 +31,64 @@ _ASYNC_WRITE_COORDINATORS: dict[
     str, WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]
 ] = {}
 _RESOLVED_DB_PATH_KEYS: dict[str, str] = {}
+_ASYNC_BLOCKING_RUNNER: _AsyncBlockingRunner | None = None
 ResultT = TypeVar("ResultT")
+
+
+class BlockingSqliteCursor(Protocol):
+    @property
+    def rowcount(self) -> int:
+        raise NotImplementedError
+
+    def fetchall(self) -> list[sqlite3.Row]:
+        raise NotImplementedError
+
+
+class BlockingSqliteConnection(Protocol):
+    def execute(
+        self,
+        sql: str,
+        parameters: SqliteParameters = (),
+    ) -> BlockingSqliteCursor:
+        raise NotImplementedError
+
+    def commit(self) -> None:
+        raise NotImplementedError
+
+    def rollback(self) -> None:
+        raise NotImplementedError
+
+
+class _AsyncBlockingRunner:
+    def __init__(self) -> None:
+        self._ready = Event()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread = Thread(
+            target=self._run_loop,
+            name="relay-teams-sqlite-async-bridge",
+            daemon=True,
+        )
+        self._thread.start()
+        self._ready.wait()
+
+    def run(self, coro: Coroutine[object, object, ResultT]) -> ResultT:
+        loop = self._loop
+        if loop is None:
+            raise RuntimeError("SQLite async bridge loop did not start")
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if running_loop is loop:
+            raise RuntimeError("Cannot block on SQLite async bridge from its own loop")
+        return asyncio.run_coroutine_threadsafe(coro, loop).result()
+
+    def _run_loop(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._ready.set()
+        loop.run_forever()
 
 
 class CrossModeWriteCoordinator:
@@ -95,50 +154,6 @@ class CrossModeWriteCoordinator:
         self.release(token)
 
 
-def _configure_connection(
-    conn: sqlite3.Connection,
-    *,
-    enable_wal: bool,
-) -> sqlite3.Connection:
-    conn.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.execute("PRAGMA temp_store = MEMORY")
-    conn.execute("PRAGMA synchronous = NORMAL")
-    try:
-        if enable_wal:
-            conn.execute("PRAGMA journal_mode = WAL")
-    except sqlite3.OperationalError:
-        # WAL is best-effort. In-memory fallback and some filesystems do not support it.
-        pass
-    return conn
-
-
-def open_sqlite(db_path: Path) -> sqlite3.Connection:
-    file_path = Path(db_path)
-    try:
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        return _configure_connection(
-            sqlite3.connect(
-                str(file_path),
-                timeout=SQLITE_TIMEOUT_SECONDS,
-                check_same_thread=False,
-            ),
-            enable_wal=True,
-        )
-    except sqlite3.OperationalError:
-        pass
-
-    return _configure_connection(
-        sqlite3.connect(
-            MEMORY_DSN,
-            uri=True,
-            timeout=SQLITE_TIMEOUT_SECONDS,
-            check_same_thread=False,
-        ),
-        enable_wal=False,
-    )
-
-
 async def _configure_async_connection(
     conn: aiosqlite.Connection,
     *,
@@ -181,12 +196,24 @@ async def open_async_sqlite(db_path: Path) -> aiosqlite.Connection:
     )
 
 
-def sqlite_compile_options(conn: sqlite3.Connection) -> frozenset[str]:
+def run_async_blocking(coro: Coroutine[object, object, ResultT]) -> ResultT:
+    return _async_blocking_runner().run(coro)
+
+
+def _async_blocking_runner() -> _AsyncBlockingRunner:
+    global _ASYNC_BLOCKING_RUNNER
+    with _WRITE_COORDINATORS_LOCK:
+        if _ASYNC_BLOCKING_RUNNER is None:
+            _ASYNC_BLOCKING_RUNNER = _AsyncBlockingRunner()
+        return _ASYNC_BLOCKING_RUNNER
+
+
+def sqlite_compile_options(conn: BlockingSqliteConnection) -> frozenset[str]:
     rows = conn.execute("PRAGMA compile_options").fetchall()
     return frozenset(str(row[0]) for row in rows)
 
 
-def sqlite_supports_fts5(conn: sqlite3.Connection) -> bool:
+def sqlite_supports_fts5(conn: BlockingSqliteConnection) -> bool:
     return "ENABLE_FTS5" in sqlite_compile_options(conn)
 
 
@@ -275,7 +302,7 @@ async def run_async_sqlite_write_with_retry(
 # noinspection PyTypeHints
 def run_sqlite_write_with_retry(
     *,
-    conn: sqlite3.Connection,
+    conn: BlockingSqliteConnection,
     db_path: Path,
     operation: Callable[[], ResultT],
     lock: Optional[RLock] = None,
@@ -385,7 +412,7 @@ def _async_write_coordinator_for(db_path: Path) -> asyncio.Lock:
     return coordinator
 
 
-def _rollback_quietly(conn: sqlite3.Connection) -> None:
+def _rollback_quietly(conn: BlockingSqliteConnection) -> None:
     try:
         conn.rollback()
     except sqlite3.Error:

--- a/src/relay_teams/persistence/shared_state_repo.py
+++ b/src/relay_teams/persistence/shared_state_repo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from relay_teams.persistence.db import run_async_blocking
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.sqlite_repository import (
     SharedSqliteRepository,
@@ -18,9 +19,12 @@ class SharedStateRepository(SharedSqliteRepository):
         self._init_tables()
 
     def _init_tables(self) -> None:
-        self._run_write(
-            operation_name="init_tables",
-            operation=lambda: self._conn.execute(
+        run_async_blocking(self._init_tables_async())
+
+    async def _init_tables_async(self) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            await conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS shared_state (
                     scope_type  TEXT NOT NULL,
@@ -32,7 +36,11 @@ class SharedStateRepository(SharedSqliteRepository):
                     PRIMARY KEY (scope_type, scope_id, state_key)
                 )
                 """
-            ),
+            )
+
+        await self._run_async_write(
+            operation_name="init_tables",
+            operation=lambda _conn: operation(),
         )
 
     def manage_state(
@@ -40,30 +48,7 @@ class SharedStateRepository(SharedSqliteRepository):
         mutation: StateMutation,
         ttl_seconds: int | None = None,
     ) -> None:
-        expires_at: str | None = None
-        if ttl_seconds is not None:
-            expires_at = (
-                datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
-            ).isoformat()
-        self._run_write(
-            operation_name="manage_state",
-            operation=lambda: self._conn.execute(
-                """
-                INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
-                VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
-                ON CONFLICT(scope_type, scope_id, state_key)
-                DO UPDATE SET value_json=excluded.value_json, updated_at=CURRENT_TIMESTAMP,
-                              expires_at=COALESCE(excluded.expires_at, expires_at)
-                """,
-                (
-                    mutation.scope.scope_type.value,
-                    mutation.scope.scope_id,
-                    mutation.key,
-                    mutation.value_json,
-                    expires_at,
-                ),
-            ),
-        )
+        run_async_blocking(self.manage_state_async(mutation, ttl_seconds=ttl_seconds))
 
     async def manage_state_async(
         self, mutation: StateMutation, ttl_seconds: int | None = None
@@ -99,19 +84,7 @@ class SharedStateRepository(SharedSqliteRepository):
         )
 
     def get_state(self, scope: ScopeRef, key: str) -> str | None:
-        row = self._run_read(
-            lambda: self._conn.execute(
-                """
-                SELECT value_json FROM shared_state
-                WHERE scope_type=? AND scope_id=? AND state_key=?
-                  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
-                """,
-                (scope.scope_type.value, scope.scope_id, key),
-            ).fetchone()
-        )
-        if row is None:
-            return None
-        return str(row["value_json"])
+        return run_async_blocking(self.get_state_async(scope, key))
 
     async def get_state_async(self, scope: ScopeRef, key: str) -> str | None:
         row = await self._run_async_read(
@@ -130,17 +103,7 @@ class SharedStateRepository(SharedSqliteRepository):
         return str(row["value_json"])
 
     def snapshot(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
-        rows = self._run_read(
-            lambda: self._conn.execute(
-                """
-                SELECT state_key, value_json FROM shared_state
-                WHERE scope_type=? AND scope_id=?
-                  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
-                """,
-                (scope.scope_type.value, scope.scope_id),
-            ).fetchall()
-        )
-        return tuple((str(row["state_key"]), str(row["value_json"])) for row in rows)
+        return run_async_blocking(self.snapshot_async(scope))
 
     async def snapshot_async(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
         rows = await self._run_async_read(
@@ -162,14 +125,12 @@ class SharedStateRepository(SharedSqliteRepository):
         *,
         exclude_key_prefixes: tuple[str, ...] = (),
     ) -> tuple[tuple[str, str], ...]:
-        merged: dict[str, str] = {}
-        for scope in scopes:
-            for key, value in self.snapshot(scope):
-                if key.startswith(exclude_key_prefixes):
-                    continue
-                merged[key] = value
-        ordered_items = sorted(merged.items(), key=lambda item: item[0])
-        return tuple((key, value) for key, value in ordered_items)
+        return run_async_blocking(
+            self.snapshot_many_async(
+                scopes,
+                exclude_key_prefixes=exclude_key_prefixes,
+            )
+        )
 
     async def snapshot_many_async(
         self,
@@ -187,14 +148,7 @@ class SharedStateRepository(SharedSqliteRepository):
         return tuple((key, value) for key, value in ordered_items)
 
     def cleanup_expired(self) -> int:
-        return self._run_write(
-            operation_name="cleanup_expired",
-            operation=lambda: (
-                self._conn.execute(
-                    "DELETE FROM shared_state WHERE expires_at IS NOT NULL AND expires_at <= CURRENT_TIMESTAMP"
-                ).rowcount
-            ),
-        )
+        return run_async_blocking(self.cleanup_expired_async())
 
     async def cleanup_expired_async(self) -> int:
         async def operation() -> int:
@@ -213,22 +167,7 @@ class SharedStateRepository(SharedSqliteRepository):
         )
 
     def delete_by_scope_key_prefix(self, scope: ScopeRef, key_prefix: str) -> None:
-        self._run_write(
-            operation_name="delete_by_scope_key_prefix",
-            operation=lambda: self._conn.execute(
-                """
-                DELETE FROM shared_state
-                WHERE scope_type=? AND scope_id=?
-                  AND substr(state_key, 1, ?) = ?
-                """,
-                (
-                    scope.scope_type.value,
-                    scope.scope_id,
-                    len(key_prefix),
-                    key_prefix,
-                ),
-            ),
-        )
+        run_async_blocking(self.delete_by_scope_key_prefix_async(scope, key_prefix))
 
     async def delete_by_scope_key_prefix_async(
         self, scope: ScopeRef, key_prefix: str
@@ -264,51 +203,16 @@ class SharedStateRepository(SharedSqliteRepository):
         conversation_ids: list[str] | None = None,
         workspace_ids: list[str] | None = None,
     ) -> None:
-        if not task_ids:
-            task_ids = ["__dummy_id__"]
-        if not instance_ids:
-            instance_ids = ["__dummy_id__"]
-        session_scope_values = list(
-            dict.fromkeys([session_id, *(session_scope_ids or [])])
-        )
-        role_scope_values = role_scope_ids or ["__dummy_id__"]
-        conversation_values = conversation_ids or ["__dummy_id__"]
-        workspace_values = workspace_ids or ["__dummy_id__"]
-
-        session_placeholders = ",".join("?" * len(session_scope_values))
-        task_placeholders = ",".join("?" * len(task_ids))
-        instance_placeholders = ",".join("?" * len(instance_ids))
-        role_placeholders = ",".join("?" * len(role_scope_values))
-        conversation_placeholders = ",".join("?" * len(conversation_values))
-        workspace_placeholders = ",".join("?" * len(workspace_values))
-
-        self._run_write(
-            operation_name="delete_by_session",
-            operation=lambda: self._conn.execute(
-                f"""
-                DELETE FROM shared_state WHERE
-                (scope_type=? AND scope_id IN ({session_placeholders})) OR
-                (scope_type=? AND scope_id IN ({task_placeholders})) OR
-                (scope_type=? AND scope_id IN ({instance_placeholders})) OR
-                (scope_type=? AND scope_id IN ({role_placeholders})) OR
-                (scope_type=? AND scope_id IN ({conversation_placeholders})) OR
-                (scope_type=? AND scope_id IN ({workspace_placeholders}))
-                """,
-                (
-                    ScopeType.SESSION.value,
-                    *session_scope_values,
-                    ScopeType.TASK.value,
-                    *task_ids,
-                    ScopeType.INSTANCE.value,
-                    *instance_ids,
-                    ScopeType.ROLE.value,
-                    *role_scope_values,
-                    ScopeType.CONVERSATION.value,
-                    *conversation_values,
-                    ScopeType.WORKSPACE.value,
-                    *workspace_values,
-                ),
-            ),
+        run_async_blocking(
+            self.delete_by_session_async(
+                session_id=session_id,
+                task_ids=task_ids,
+                instance_ids=instance_ids,
+                role_scope_ids=role_scope_ids,
+                session_scope_ids=session_scope_ids,
+                conversation_ids=conversation_ids,
+                workspace_ids=workspace_ids,
+            )
         )
 
     async def delete_by_session_async(
@@ -381,34 +285,14 @@ class SharedStateRepository(SharedSqliteRepository):
         conversation_id: str,
         task_ids: list[str] | None = None,
     ) -> None:
-        task_values = task_ids or ["__dummy_id__"]
-        self._run_write(
-            operation_name="delete_for_subagent",
-            operation=lambda: self._conn.execute(
-                """
-                DELETE FROM shared_state WHERE
-                (scope_type=? AND scope_id=?) OR
-                (scope_type=? AND scope_id=?) OR
-                (scope_type=? AND scope_id=?) OR
-                (scope_type=? AND scope_id=?) OR
-                (scope_type=? AND scope_id IN ({task_placeholders}))
-                """.replace(
-                    "{task_placeholders}",
-                    ",".join("?" for _ in task_values),
-                ),
-                (
-                    ScopeType.INSTANCE.value,
-                    instance_id,
-                    ScopeType.SESSION.value,
-                    session_scope_id,
-                    ScopeType.ROLE.value,
-                    role_scope_id,
-                    ScopeType.CONVERSATION.value,
-                    conversation_id,
-                    ScopeType.TASK.value,
-                    *task_values,
-                ),
-            ),
+        run_async_blocking(
+            self.delete_for_subagent_async(
+                instance_id=instance_id,
+                session_scope_id=session_scope_id,
+                role_scope_id=role_scope_id,
+                conversation_id=conversation_id,
+                task_ids=task_ids,
+            )
         )
 
     async def delete_for_subagent_async(

--- a/src/relay_teams/persistence/sqlite_repository.py
+++ b/src/relay_teams/persistence/sqlite_repository.py
@@ -3,23 +3,24 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
-from collections.abc import Sequence
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from threading import RLock
-from typing import Awaitable, Callable, Optional, ParamSpec, Self, TypeVar
+from typing import Awaitable, Callable, Optional, ParamSpec, TypeVar, cast
+from weakref import WeakKeyDictionary
 
 import aiosqlite
 
 from relay_teams.persistence.db import (
+    SqliteParameters,
     open_async_sqlite,
-    open_sqlite,
+    run_async_blocking,
     run_async_sqlite_write_with_retry,
     run_sqlite_write_with_retry,
 )
 
 ResultT = TypeVar("ResultT")
 ParamT = ParamSpec("ParamT")
-SqliteParameters = Sequence[object]
 
 
 async def async_fetchone(
@@ -47,6 +48,122 @@ async def async_fetchall(
     return list(rows)
 
 
+class BlockingAsyncSqliteCursor:
+    def __init__(self, cursor: aiosqlite.Cursor) -> None:
+        self._cursor: aiosqlite.Cursor | None = cursor
+        self._rowcount = cursor.rowcount
+        self._lastrowid = cursor.lastrowid
+
+    @property
+    def rowcount(self) -> int:
+        return self._rowcount
+
+    @property
+    def lastrowid(self) -> int | None:
+        return self._lastrowid
+
+    def fetchone(self) -> sqlite3.Row | None:
+        return cast(sqlite3.Row | None, run_async_blocking(self._fetchone()))
+
+    def fetchall(self) -> list[sqlite3.Row]:
+        rows = run_async_blocking(self._fetchall())
+        return [cast(sqlite3.Row, row) for row in rows]
+
+    def close(self) -> None:
+        run_async_blocking(self._close())
+
+    def __iter__(self) -> Iterator[sqlite3.Row]:
+        return iter(self.fetchall())
+
+    async def _fetchone(self) -> sqlite3.Row | None:
+        cursor = self._cursor
+        if cursor is None:
+            return None
+        try:
+            return cast(sqlite3.Row | None, await cursor.fetchone())
+        finally:
+            await self._close()
+
+    async def _fetchall(self) -> list[sqlite3.Row]:
+        cursor = self._cursor
+        if cursor is None:
+            return []
+        try:
+            rows = await cursor.fetchall()
+            return [cast(sqlite3.Row, row) for row in rows]
+        finally:
+            await self._close()
+
+    async def _close(self) -> None:
+        cursor = self._cursor
+        if cursor is None:
+            return
+        self._cursor = None
+        await cursor.close()
+
+
+class BlockingAsyncSqliteConnection:
+    def __init__(self, repository: SharedSqliteRepository) -> None:
+        self._repository = repository
+
+    def execute(
+        self,
+        sql: str,
+        parameters: SqliteParameters = (),
+    ) -> BlockingAsyncSqliteCursor:
+        return run_async_blocking(self._execute(sql, parameters))
+
+    def executemany(
+        self,
+        sql: str,
+        parameters: Iterable[SqliteParameters],
+    ) -> BlockingAsyncSqliteCursor:
+        return run_async_blocking(self._executemany(sql, tuple(parameters)))
+
+    def commit(self) -> None:
+        run_async_blocking(self._commit())
+
+    def rollback(self) -> None:
+        run_async_blocking(self._rollback())
+
+    async def _execute(
+        self,
+        sql: str,
+        parameters: SqliteParameters,
+    ) -> BlockingAsyncSqliteCursor:
+        conn = await self._repository._get_async_conn()
+        cursor = BlockingAsyncSqliteCursor(await conn.execute(sql, tuple(parameters)))
+        if _closes_without_fetch(sql):
+            await cursor._close()
+        return cursor
+
+    async def _executemany(
+        self,
+        sql: str,
+        parameters: tuple[SqliteParameters, ...],
+    ) -> BlockingAsyncSqliteCursor:
+        conn = await self._repository._get_async_conn()
+        cursor = BlockingAsyncSqliteCursor(await conn.executemany(sql, parameters))
+        await cursor._close()
+        return cursor
+
+    async def _commit(self) -> None:
+        conn = await self._repository._get_async_conn()
+        await conn.commit()
+
+    async def _rollback(self) -> None:
+        conn = await self._repository._get_async_conn()
+        await conn.rollback()
+
+
+def _closes_without_fetch(sql: str) -> bool:
+    tokens = sql.lstrip().split(maxsplit=1)
+    if not tokens:
+        return True
+    first_token = tokens[0].lower()
+    return first_token not in {"select", "pragma", "with"}
+
+
 class SharedSqliteRepository:
     def __init__(
         self,
@@ -55,12 +172,15 @@ class SharedSqliteRepository:
         repository_name: Optional[str] = None,
     ) -> None:
         self._db_path = Path(db_path)
-        self._conn = open_sqlite(self._db_path)
-        self._conn.row_factory = sqlite3.Row
+        self._conn = BlockingAsyncSqliteConnection(self)
         self._lock = RLock()
-        self._async_conn: aiosqlite.Connection | None = None
-        self._async_conn_lock = asyncio.Lock()
-        self._async_lock = asyncio.Lock()
+        self._async_conn_guard = RLock()
+        self._async_conns: WeakKeyDictionary[
+            asyncio.AbstractEventLoop, aiosqlite.Connection
+        ] = WeakKeyDictionary()
+        self._async_locks: WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Lock
+        ] = WeakKeyDictionary()
         self._repository_name = repository_name or type(self).__name__
 
     # noinspection PyTypeHints
@@ -85,18 +205,46 @@ class SharedSqliteRepository:
         )
 
     async def close_async(self) -> None:
-        async with self._async_conn_lock:
-            if self._async_conn is None:
-                return
-            await self._async_conn.close()
-            self._async_conn = None
+        current_loop = asyncio.get_running_loop()
+        with self._async_conn_guard:
+            connections = tuple(self._async_conns.items())
+            self._async_conns = WeakKeyDictionary()
+            self._async_locks = WeakKeyDictionary()
+        for loop, conn in connections:
+            if loop is current_loop:
+                await conn.close()
+            elif loop.is_running():
+                await asyncio.wrap_future(
+                    asyncio.run_coroutine_threadsafe(conn.close(), loop)
+                )
+            else:
+                await conn.close()
 
     async def _get_async_conn(self) -> aiosqlite.Connection:
-        async with self._async_conn_lock:
-            if self._async_conn is None:
-                self._async_conn = await open_async_sqlite(self._db_path)
-                self._async_conn.row_factory = sqlite3.Row
-            return self._async_conn
+        loop = asyncio.get_running_loop()
+        with self._async_conn_guard:
+            conn = self._async_conns.get(loop)
+            if conn is not None:
+                return conn
+
+        new_conn = await open_async_sqlite(self._db_path)
+        new_conn.row_factory = sqlite3.Row
+        with self._async_conn_guard:
+            existing = self._async_conns.get(loop)
+            if existing is None:
+                self._async_conns[loop] = new_conn
+                return new_conn
+        await new_conn.close()
+        return existing
+
+    def _async_lock_for_current_loop(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        with self._async_conn_guard:
+            lock = self._async_locks.get(loop)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._async_locks[loop] = lock
+            return lock
 
     # noinspection PyTypeHints
     async def _run_async_read(
@@ -104,7 +252,7 @@ class SharedSqliteRepository:
         operation: Callable[[aiosqlite.Connection], Awaitable[ResultT]],
     ) -> ResultT:
         conn = await self._get_async_conn()
-        async with self._async_lock:
+        async with self._async_lock_for_current_loop():
             return await operation(conn)
 
     # noinspection PyTypeHints
@@ -119,7 +267,7 @@ class SharedSqliteRepository:
             conn=conn,
             db_path=self._db_path,
             operation=lambda: operation(conn),
-            lock=self._async_lock,
+            lock=self._async_lock_for_current_loop(),
             repository_name=self._repository_name,
             operation_name=operation_name,
         )
@@ -133,64 +281,3 @@ class SharedSqliteRepository:
         **kwargs: ParamT.kwargs,
     ) -> ResultT:
         return await asyncio.to_thread(function, *args, **kwargs)
-
-
-class AsyncSharedSqliteRepository:
-    def __init__(
-        self,
-        db_path: Path,
-        conn: aiosqlite.Connection,
-        *,
-        repository_name: Optional[str] = None,
-    ) -> None:
-        self._db_path = Path(db_path)
-        self._conn = conn
-        self._conn.row_factory = sqlite3.Row
-        self._lock = asyncio.Lock()
-        self._repository_name = repository_name or type(self).__name__
-
-    @classmethod
-    async def open(
-        cls,
-        db_path: Path,
-        *,
-        repository_name: Optional[str] = None,
-    ) -> Self:
-        repository = cls(
-            db_path,
-            await open_async_sqlite(db_path),
-            repository_name=repository_name,
-        )
-        await repository._initialize()
-        return repository
-
-    async def close(self) -> None:
-        await self._conn.close()
-
-    async def _initialize(self) -> None:
-        self._conn.row_factory = sqlite3.Row
-
-    # noinspection PyTypeHints
-    async def _run_read(
-        self,
-        operation: Callable[[], Awaitable[ResultT]],
-    ) -> ResultT:
-        async with self._lock:
-            return await operation()
-        raise RuntimeError("Async SQLite read helper exited without a result")
-
-    # noinspection PyTypeHints
-    async def _run_write(
-        self,
-        *,
-        operation_name: str,
-        operation: Callable[[], Awaitable[ResultT]],
-    ) -> ResultT:
-        return await run_async_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name=self._repository_name,
-            operation_name=operation_name,
-        )

--- a/src/relay_teams/persistence/sqlite_repository.py
+++ b/src/relay_teams/persistence/sqlite_repository.py
@@ -6,7 +6,7 @@ import sqlite3
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 from threading import RLock
-from typing import Awaitable, Callable, Optional, ParamSpec, TypeVar, cast
+from typing import Awaitable, Callable, Optional, ParamSpec, TypeVar
 from weakref import WeakKeyDictionary
 
 import aiosqlite
@@ -63,14 +63,13 @@ class BlockingAsyncSqliteCursor:
         return self._lastrowid
 
     def fetchone(self) -> sqlite3.Row | None:
-        return cast(sqlite3.Row | None, run_async_blocking(self._fetchone()))
+        return run_async_blocking(self._fetchone())
 
     def fetchall(self) -> list[sqlite3.Row]:
-        rows = run_async_blocking(self._fetchall())
-        return [cast(sqlite3.Row, row) for row in rows]
+        return run_async_blocking(self._fetchall())
 
     def close(self) -> None:
-        run_async_blocking(self._close())
+        run_async_blocking(self.close_async())
 
     def __iter__(self) -> Iterator[sqlite3.Row]:
         return iter(self.fetchall())
@@ -80,9 +79,9 @@ class BlockingAsyncSqliteCursor:
         if cursor is None:
             return None
         try:
-            return cast(sqlite3.Row | None, await cursor.fetchone())
+            return await cursor.fetchone()
         finally:
-            await self._close()
+            await self.close_async()
 
     async def _fetchall(self) -> list[sqlite3.Row]:
         cursor = self._cursor
@@ -90,11 +89,11 @@ class BlockingAsyncSqliteCursor:
             return []
         try:
             rows = await cursor.fetchall()
-            return [cast(sqlite3.Row, row) for row in rows]
+            return list(rows)
         finally:
-            await self._close()
+            await self.close_async()
 
-    async def _close(self) -> None:
+    async def close_async(self) -> None:
         cursor = self._cursor
         if cursor is None:
             return
@@ -131,10 +130,10 @@ class BlockingAsyncSqliteConnection:
         sql: str,
         parameters: SqliteParameters,
     ) -> BlockingAsyncSqliteCursor:
-        conn = await self._repository._get_async_conn()
+        conn = await self._repository.get_async_connection()
         cursor = BlockingAsyncSqliteCursor(await conn.execute(sql, tuple(parameters)))
         if _closes_without_fetch(sql):
-            await cursor._close()
+            await cursor.close_async()
         return cursor
 
     async def _executemany(
@@ -142,17 +141,17 @@ class BlockingAsyncSqliteConnection:
         sql: str,
         parameters: tuple[SqliteParameters, ...],
     ) -> BlockingAsyncSqliteCursor:
-        conn = await self._repository._get_async_conn()
+        conn = await self._repository.get_async_connection()
         cursor = BlockingAsyncSqliteCursor(await conn.executemany(sql, parameters))
-        await cursor._close()
+        await cursor.close_async()
         return cursor
 
     async def _commit(self) -> None:
-        conn = await self._repository._get_async_conn()
+        conn = await self._repository.get_async_connection()
         await conn.commit()
 
     async def _rollback(self) -> None:
-        conn = await self._repository._get_async_conn()
+        conn = await self._repository.get_async_connection()
         await conn.rollback()
 
 
@@ -219,6 +218,9 @@ class SharedSqliteRepository:
                 )
             else:
                 await conn.close()
+
+    async def get_async_connection(self) -> aiosqlite.Connection:
+        return await self._get_async_conn()
 
     async def _get_async_conn(self) -> aiosqlite.Connection:
         loop = asyncio.get_running_loop()

--- a/src/relay_teams/triggers/repository.py
+++ b/src/relay_teams/triggers/repository.py
@@ -9,7 +9,10 @@ from pathlib import Path
 from pydantic import JsonValue, TypeAdapter
 
 from relay_teams.logger import get_logger
-from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
+from relay_teams.persistence.sqlite_repository import (
+    BlockingAsyncSqliteConnection,
+    SharedSqliteRepository,
+)
 from relay_teams.triggers.models import (
     GitHubActionSpec,
     GitHubActionType,
@@ -1459,7 +1462,7 @@ def _json_dumps(value: object) -> str:
 
 
 def _column_exists(
-    conn: sqlite3.Connection,
+    conn: BlockingAsyncSqliteConnection,
     *,
     table_name: str,
     column_name: str,

--- a/tests/unit_tests/persistence/test_db.py
+++ b/tests/unit_tests/persistence/test_db.py
@@ -15,73 +15,55 @@ from relay_teams.persistence.db import (
     async_sqlite_supports_fts5,
     is_retryable_sqlite_error,
     open_async_sqlite,
-    open_sqlite,
+    run_async_blocking,
     run_async_sqlite_write_with_retry,
     run_sqlite_write_with_retry,
     sqlite_compile_options,
     sqlite_supports_fts5,
 )
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
 
-def test_open_sqlite_enables_busy_timeout_and_wal_for_file_db(tmp_path: Path) -> None:
-    conn = open_sqlite(tmp_path / "relay_teams.db")
-    try:
-        foreign_keys = int(conn.execute("PRAGMA foreign_keys").fetchone()[0])
-        busy_timeout = int(conn.execute("PRAGMA busy_timeout").fetchone()[0])
-        journal_mode = str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
-
-        assert foreign_keys == 1
-        assert busy_timeout == SQLITE_BUSY_TIMEOUT_MS
-        assert journal_mode == "wal"
-    finally:
-        conn.close()
-
-
-def test_open_sqlite_falls_back_to_shared_memory_when_file_open_fails(
+@pytest.mark.asyncio
+async def test_open_async_sqlite_falls_back_to_shared_memory_when_file_open_fails(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    real_connect = sqlite3.connect
+    real_connect = aiosqlite.connect
     calls: list[tuple[str, bool]] = []
 
-    def fake_connect(
+    async def fake_connect(
         database: str,
         *,
         timeout: float,
-        check_same_thread: bool = True,
         uri: bool = False,
-    ) -> sqlite3.Connection:
-        _ = (timeout, check_same_thread)
+    ) -> aiosqlite.Connection:
+        _ = timeout
         calls.append((database, uri))
         if len(calls) == 1:
             raise sqlite3.OperationalError("readonly")
-        return real_connect(
-            database,
-            timeout=timeout,
-            check_same_thread=check_same_thread,
-            uri=uri,
-        )
+        return await real_connect(database, timeout=timeout, uri=uri)
 
-    monkeypatch.setattr(db_module.sqlite3, "connect", fake_connect)
+    monkeypatch.setattr(db_module.aiosqlite, "connect", fake_connect)
 
-    conn = open_sqlite(tmp_path / "readonly" / "relay_teams.db")
+    conn = await open_async_sqlite(tmp_path / "readonly" / "relay_teams.db")
     try:
         assert calls == [
             (str(tmp_path / "readonly" / "relay_teams.db"), False),
             (db_module.MEMORY_DSN, True),
         ]
     finally:
-        conn.close()
+        await conn.close()
 
 
 def test_sqlite_compile_options_reports_fts5_support(tmp_path: Path) -> None:
-    conn = open_sqlite(tmp_path / "compile-options.db")
+    repo = SharedSqliteRepository(tmp_path / "compile-options.db")
     try:
-        options = sqlite_compile_options(conn)
+        options = sqlite_compile_options(repo._conn)
         assert "ENABLE_FTS5" in options
-        assert sqlite_supports_fts5(conn) is True
+        assert sqlite_supports_fts5(repo._conn) is True
     finally:
-        conn.close()
+        run_async_blocking(repo.close_async())
 
 
 def test_is_retryable_sqlite_error_matches_lock_contention() -> None:
@@ -259,7 +241,8 @@ def test_run_sqlite_write_with_retry_retries_transient_lock_errors(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "retry.db"
-    conn = open_sqlite(db_path)
+    repo = SharedSqliteRepository(db_path)
+    conn = repo._conn
     try:
         conn.execute("CREATE TABLE items (value TEXT NOT NULL)")
         conn.commit()
@@ -286,14 +269,15 @@ def test_run_sqlite_write_with_retry_retries_transient_lock_errors(
         assert attempts == 3
         assert [row[0] for row in stored] == ["ok"]
     finally:
-        conn.close()
+        run_async_blocking(repo.close_async())
 
 
 def test_run_sqlite_write_with_retry_rolls_back_failed_operation(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "rollback.db"
-    conn = open_sqlite(db_path)
+    repo = SharedSqliteRepository(db_path)
+    conn = repo._conn
     try:
         conn.execute("CREATE TABLE items (value TEXT NOT NULL)")
         conn.commit()
@@ -325,7 +309,7 @@ def test_run_sqlite_write_with_retry_rolls_back_failed_operation(
         stored = conn.execute("SELECT value FROM items").fetchall()
         assert [row[0] for row in stored] == ["ok"]
     finally:
-        conn.close()
+        run_async_blocking(repo.close_async())
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/persistence/test_sqlite_repository.py
+++ b/tests/unit_tests/persistence/test_sqlite_repository.py
@@ -5,7 +5,6 @@ import asyncio
 from collections.abc import Awaitable
 from collections.abc import Callable
 from pathlib import Path
-import sqlite3
 import threading
 
 import aiosqlite
@@ -14,8 +13,9 @@ from pytest import MonkeyPatch
 
 import relay_teams.persistence.sqlite_repository as sqlite_repository_module
 from relay_teams.persistence.sqlite_repository import (
-    AsyncSharedSqliteRepository,
+    BlockingAsyncSqliteConnection,
     SharedSqliteRepository,
+    async_fetchone,
 )
 from relay_teams.retrieval.sqlite_store import SqliteFts5RetrievalStore
 
@@ -23,10 +23,6 @@ from relay_teams.retrieval.sqlite_store import SqliteFts5RetrievalStore
 class _DummyRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path, *, repository_name: str | None = None) -> None:
         super().__init__(db_path, repository_name=repository_name)
-
-
-class _AsyncDummyRepository(AsyncSharedSqliteRepository):
-    pass
 
 
 def test_shared_sqlite_repository_run_write_uses_retry_helper(
@@ -38,7 +34,7 @@ def test_shared_sqlite_repository_run_write_uses_retry_helper(
 
     def fake_run_sqlite_write_with_retry(
         *,
-        conn: sqlite3.Connection,
+        conn: BlockingAsyncSqliteConnection,
         db_path: Path,
         operation: Callable[[], str],
         lock: object,
@@ -104,12 +100,13 @@ def test_sqlite_retrieval_store_uses_stable_repository_name(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_async_shared_sqlite_repository_run_write_uses_retry_helper(
+async def test_shared_sqlite_repository_run_async_write_uses_retry_helper(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    repo = await _AsyncDummyRepository.open(tmp_path / "async_shared_repo.db")
-    calls: list[tuple[Path, asyncio.Lock, str, str]] = []
+    repo = _DummyRepository(tmp_path / "async_shared_repo.db")
+    calls: list[tuple[Path, str, str]] = []
+    locks: list[asyncio.Lock] = []
 
     async def fake_run_async_sqlite_write_with_retry(
         *,
@@ -123,7 +120,8 @@ async def test_async_shared_sqlite_repository_run_write_uses_retry_helper(
     ) -> str:
         _ = conn
         _ = max_retries
-        calls.append((db_path, lock, repository_name, operation_name))
+        locks.append(lock)
+        calls.append((db_path, repository_name, operation_name))
         return await operation()
 
     monkeypatch.setattr(
@@ -133,33 +131,34 @@ async def test_async_shared_sqlite_repository_run_write_uses_retry_helper(
     )
 
     try:
-        result = await repo._run_write(
+        result = await repo._run_async_write(
             operation_name="insert_item",
-            operation=lambda: _async_value("ok"),
+            operation=lambda _conn: _async_value("ok"),
         )
     finally:
-        await repo.close()
+        await repo.close_async()
 
     assert result == "ok"
     assert calls == [
         (
             tmp_path / "async_shared_repo.db",
-            repo._lock,
-            "_AsyncDummyRepository",
+            "_DummyRepository",
             "insert_item",
         )
     ]
+    assert len(locks) == 1
+    assert not locks[0].locked()
 
 
 @pytest.mark.asyncio
-async def test_async_shared_sqlite_repository_run_read_uses_lock(
+async def test_shared_sqlite_repository_run_async_read_uses_lock(
     tmp_path: Path,
 ) -> None:
-    repo = await _AsyncDummyRepository.open(tmp_path / "async_shared_repo_read.db")
+    repo = _DummyRepository(tmp_path / "async_shared_repo_read.db")
     try:
-        result = await repo._run_read(lambda: _async_value("ok"))
+        result = await repo._run_async_read(lambda _conn: _async_value("ok"))
     finally:
-        await repo.close()
+        await repo.close_async()
 
     assert result == "ok"
 
@@ -170,7 +169,8 @@ async def test_shared_sqlite_repository_async_helpers_use_retry_helper(
     monkeypatch: MonkeyPatch,
 ) -> None:
     repo = _DummyRepository(tmp_path / "shared_repo_async.db")
-    calls: list[tuple[Path, asyncio.Lock, str, str]] = []
+    calls: list[tuple[Path, str, str]] = []
+    locks: list[asyncio.Lock] = []
 
     async def fake_run_async_sqlite_write_with_retry(
         *,
@@ -184,7 +184,8 @@ async def test_shared_sqlite_repository_async_helpers_use_retry_helper(
     ) -> str:
         _ = conn
         _ = max_retries
-        calls.append((db_path, lock, repository_name, operation_name))
+        locks.append(lock)
+        calls.append((db_path, repository_name, operation_name))
         return await operation()
 
     monkeypatch.setattr(
@@ -205,11 +206,32 @@ async def test_shared_sqlite_repository_async_helpers_use_retry_helper(
     assert calls == [
         (
             tmp_path / "shared_repo_async.db",
-            repo._async_lock,
             "_DummyRepository",
             "insert_item_async",
         )
     ]
+    assert len(locks) == 1
+    assert not locks[0].locked()
+
+
+@pytest.mark.asyncio
+async def test_shared_sqlite_repository_sync_facade_writes_are_visible_to_async_helpers(
+    tmp_path: Path,
+) -> None:
+    repo = _DummyRepository(tmp_path / "shared_repo_unified.db")
+    try:
+        repo._conn.execute("CREATE TABLE items (value TEXT NOT NULL)")
+        repo._conn.execute("INSERT INTO items(value) VALUES(?)", ("sync",))
+        repo._conn.commit()
+
+        row = await repo._run_async_read(
+            lambda conn: async_fetchone(conn, "SELECT value FROM items")
+        )
+    finally:
+        await repo.close_async()
+
+    assert row is not None
+    assert row["value"] == "sync"
 
 
 async def _async_value(value: str) -> str:

--- a/tests/unit_tests/persistence/test_sqlite_write_inventory.py
+++ b/tests/unit_tests/persistence/test_sqlite_write_inventory.py
@@ -9,6 +9,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SRC_ROOT = _REPO_ROOT / "src" / "relay_teams"
 _ALLOWED_COMMIT_FILES = {
     Path("src/relay_teams/persistence/db.py"),
+    Path("src/relay_teams/persistence/sqlite_repository.py"),
 }
 _SHARED_SQLITE_WRITERS = {
     Path("src/relay_teams/agents/execution/message_repository.py"): "MessageRepository",

--- a/tests/unit_tests/sessions/runs/test_run_runtime_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_runtime_repo.py
@@ -16,6 +16,7 @@ from relay_teams.sessions.runs.run_runtime_repo import (
 )
 
 
+@pytest.mark.timeout(10)
 def test_run_runtime_repo_handles_concurrent_reads_and_writes(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/workspace/test_repository.py
+++ b/tests/unit_tests/workspace/test_repository.py
@@ -16,6 +16,7 @@ from relay_teams.workspace import (
 )
 
 
+@pytest.mark.timeout(10)
 def test_workspace_repository_supports_concurrent_reads(tmp_path: Path) -> None:
     root_path = tmp_path / "workspace-root"
     root_path.mkdir()


### PR DESCRIPTION
Closes #536\n\n## Summary\n- remove the direct sqlite3 connection helper and the separate AsyncSharedSqliteRepository base\n- route the shared repository sync facade through the async SQLite connection path while keeping per-event-loop async connections isolated\n- collapse SharedStateRepository sync methods onto the async implementations and update persistence tests\n\n## Verification\n- uv run --extra dev ruff check --fix\n- uv run --extra dev ruff format --no-cache --force-exclude\n- uv run --extra dev basedpyright\n- uv run --extra dev pytest -q tests/unit_tests\n- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests