### PR TITLE
Fix concurrent background spawn_subagent handling

### DIFF
--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import datetime, timezone
 import logging
 from pathlib import Path
-from typing import Optional, Protocol, cast
+from typing import Optional, Protocol, cast, runtime_checkable
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -77,7 +77,19 @@ class BackgroundTaskCompletionSink(Protocol):
         *,
         record: BackgroundTaskRecord,
         message: str,
-    ) -> None: ...
+    ) -> None:
+        pass
+
+
+@runtime_checkable
+class AsyncBackgroundTaskCompletionSink(Protocol):
+    async def handle_background_task_completion_async(
+        self,
+        *,
+        record: BackgroundTaskRecord,
+        message: str,
+    ) -> None:
+        pass
 
 
 class _BackgroundTaskExecutor(Protocol):
@@ -361,7 +373,8 @@ class BackgroundTaskService:
         task_execution_service = self._require_task_execution_service()
         run_control_manager = self._require_run_control_manager()
         background_task_id = f"background_task_{uuid4().hex[:12]}"
-        prepared = self._prepare_subagent_launch(
+        prepared = await asyncio.to_thread(
+            self._prepare_subagent_launch,
             run_id=run_id,
             session_id=session_id,
             workspace_id=workspace_id,
@@ -370,7 +383,8 @@ class BackgroundTaskService:
             title=title,
             prompt=prompt,
         )
-        record = self._repository.upsert(
+        record = await asyncio.to_thread(
+            self._repository.upsert,
             BackgroundTaskRecord(
                 background_task_id=background_task_id,
                 run_id=run_id,
@@ -391,7 +405,7 @@ class BackgroundTaskService:
                 subagent_run_id=prepared.subagent_run_id,
                 subagent_task_id=prepared.subagent_task.task_id,
                 subagent_instance_id=prepared.subagent_instance.instance_id,
-            )
+            ),
         )
         await self._execute_subagent_start_hooks(
             run_id=run_id,
@@ -399,8 +413,11 @@ class BackgroundTaskService:
             prepared=prepared,
         )
 
+        worker_start_gate = asyncio.Event()
+
         async def run_worker() -> None:
             try:
+                await worker_start_gate.wait()
                 result = await task_execution_service.execute(
                     instance_id=prepared.subagent_instance.instance_id,
                     role_id=prepared.subagent_role_id,
@@ -448,10 +465,17 @@ class BackgroundTaskService:
             session_id=session_id,
             task=worker_task,
         )
-        self._publish_background_task_event(
-            event_type=RunEventType.BACKGROUND_TASK_STARTED,
-            record=record,
-        )
+        try:
+            await asyncio.to_thread(
+                self._publish_background_task_event,
+                event_type=RunEventType.BACKGROUND_TASK_STARTED,
+                record=record,
+            )
+        except Exception:
+            worker_task.cancel()
+            await asyncio.gather(worker_task, return_exceptions=True)
+            raise
+        worker_start_gate.set()
         return record
 
     async def run_subagent(
@@ -468,7 +492,8 @@ class BackgroundTaskService:
     ) -> SynchronousSubagentResult:
         task_execution_service = self._require_task_execution_service()
         run_control_manager = self._require_run_control_manager()
-        prepared = self._prepare_subagent_launch(
+        prepared = await asyncio.to_thread(
+            self._prepare_subagent_launch,
             run_id=run_id,
             session_id=session_id,
             workspace_id=workspace_id,
@@ -481,27 +506,15 @@ class BackgroundTaskService:
         if suppress_hooks:
             self._prime_subagent_hook_snapshot(subagent_run_id=prepared.subagent_run_id)
         background_task_id = f"sync_subagent_{uuid4().hex[:12]}"
-        _ = self._repository.upsert(
-            BackgroundTaskRecord(
+        _ = await asyncio.to_thread(
+            self._repository.upsert,
+            self._build_synchronous_subagent_record(
                 background_task_id=background_task_id,
                 run_id=run_id,
                 session_id=session_id,
-                kind=BackgroundTaskKind.SUBAGENT,
-                instance_id=prepared.subagent_instance.instance_id,
-                role_id=prepared.subagent_role_id,
-                title=prepared.normalized_title,
-                command=f"{_SUBAGENT_COMMAND_PREFIX}{prepared.subagent_role_id}",
-                cwd=workspace_id,
-                execution_mode="foreground",
-                status=BackgroundTaskStatus.RUNNING,
-                tty=False,
-                timeout_ms=None,
-                log_path="",
-                subagent_role_id=prepared.subagent_role_id,
-                subagent_run_id=prepared.subagent_run_id,
-                subagent_task_id=prepared.subagent_task.task_id,
-                subagent_instance_id=prepared.subagent_instance.instance_id,
-            )
+                workspace_id=workspace_id,
+                prepared=prepared,
+            ),
         )
         await self._execute_subagent_start_hooks(
             run_id=run_id,
@@ -536,12 +549,14 @@ class BackgroundTaskService:
                     status=status,
                     output_text=output,
                 )
-                self._finalize_synchronous_subagent_record(
+                await asyncio.to_thread(
+                    self._finalize_synchronous_subagent_record,
                     background_task_id=background_task_id,
                     status=status,
                     output=output,
                 )
-                self._finalize_subagent_run_runtime(
+                await asyncio.to_thread(
+                    self._finalize_subagent_run_runtime,
                     subagent_run_id=prepared.subagent_run_id,
                     status=status,
                     output=output,
@@ -556,12 +571,14 @@ class BackgroundTaskService:
                     status=BackgroundTaskStatus.FAILED,
                     output_text=output,
                 )
-                self._finalize_synchronous_subagent_record(
+                await asyncio.to_thread(
+                    self._finalize_synchronous_subagent_record,
                     background_task_id=background_task_id,
                     status=BackgroundTaskStatus.FAILED,
                     output=output,
                 )
-                self._finalize_subagent_run_runtime(
+                await asyncio.to_thread(
+                    self._finalize_subagent_run_runtime,
                     subagent_run_id=prepared.subagent_run_id,
                     status=BackgroundTaskStatus.FAILED,
                     output=output,
@@ -577,12 +594,14 @@ class BackgroundTaskService:
                 status=status,
                 output_text=output,
             )
-            self._finalize_synchronous_subagent_record(
+            await asyncio.to_thread(
+                self._finalize_synchronous_subagent_record,
                 background_task_id=background_task_id,
                 status=status,
                 output=output,
             )
-            self._finalize_subagent_run_runtime(
+            await asyncio.to_thread(
+                self._finalize_subagent_run_runtime,
                 subagent_run_id=prepared.subagent_run_id,
                 status=status,
                 output=output,
@@ -647,8 +666,10 @@ class BackgroundTaskService:
             if result is None:
                 raise RuntimeError("Subagent completed without returning a result")
             return result
-        return self._synchronous_subagent_result_from_record(
-            parent_run_id=normalized_parent_run_id, subagent_run_id=normalized_run_id
+        return await asyncio.to_thread(
+            self._synchronous_subagent_result_from_record,
+            parent_run_id=normalized_parent_run_id,
+            subagent_run_id=normalized_run_id,
         )
 
     def list_for_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
@@ -807,7 +828,8 @@ class BackgroundTaskService:
             runtime.subagent_run_id if runtime is not None else record.subagent_run_id
         )
         if subagent_run_id:
-            self._finalize_subagent_run_runtime(
+            await asyncio.to_thread(
+                self._finalize_subagent_run_runtime,
                 subagent_run_id=subagent_run_id,
                 status=status,
                 output=summarized_output,
@@ -827,6 +849,36 @@ class BackgroundTaskService:
         if status != BackgroundTaskStatus.STOPPED:
             await self._handle_background_task_completion(record)
         return record
+
+    @staticmethod
+    def _build_synchronous_subagent_record(
+        *,
+        background_task_id: str,
+        run_id: str,
+        session_id: str,
+        workspace_id: str,
+        prepared: _PreparedSubagentLaunch,
+    ) -> BackgroundTaskRecord:
+        return BackgroundTaskRecord(
+            background_task_id=background_task_id,
+            run_id=run_id,
+            session_id=session_id,
+            kind=BackgroundTaskKind.SUBAGENT,
+            instance_id=prepared.subagent_instance.instance_id,
+            role_id=prepared.subagent_role_id,
+            title=prepared.normalized_title,
+            command=f"{_SUBAGENT_COMMAND_PREFIX}{prepared.subagent_role_id}",
+            cwd=workspace_id,
+            execution_mode="foreground",
+            status=BackgroundTaskStatus.RUNNING,
+            tty=False,
+            timeout_ms=None,
+            log_path="",
+            subagent_role_id=prepared.subagent_role_id,
+            subagent_run_id=prepared.subagent_run_id,
+            subagent_task_id=prepared.subagent_task.task_id,
+            subagent_instance_id=prepared.subagent_instance.instance_id,
+        )
 
     def _finalize_synchronous_subagent_record(
         self,
@@ -897,9 +949,45 @@ class BackgroundTaskService:
         self, record: BackgroundTaskRecord
     ) -> None:
         await asyncio.sleep(0)
-        delivered = self._attempt_completion_delivery(record.background_task_id)
+        delivered = await self._attempt_completion_delivery_async(
+            record.background_task_id
+        )
         if not delivered and self._completion_sink is not None:
             self._schedule_completion_retry(record.background_task_id)
+
+    async def _attempt_completion_delivery_async(self, background_task_id: str) -> bool:
+        current = await asyncio.to_thread(self._repository.get, background_task_id)
+        if current is None:
+            return True
+        if not self._should_notify_completion(current):
+            return True
+        if self._completion_sink is None:
+            return False
+        message = build_background_task_completion_message(current)
+        try:
+            if isinstance(self._completion_sink, AsyncBackgroundTaskCompletionSink):
+                await self._completion_sink.handle_background_task_completion_async(
+                    record=current,
+                    message=message,
+                )
+            else:
+                await asyncio.to_thread(
+                    self._completion_sink.handle_background_task_completion,
+                    record=current,
+                    message=message,
+                )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.ERROR,
+                event="background_task.notification_failed",
+                message="Failed to deliver background task completion notification",
+                payload={"background_task_id": current.background_task_id},
+                exc_info=exc,
+            )
+            return False
+        _ = await asyncio.to_thread(self._mark_completion_consumed, current)
+        return True
 
     def _attempt_completion_delivery(self, background_task_id: str) -> bool:
         current = self._repository.get(background_task_id)
@@ -968,7 +1056,7 @@ class BackgroundTaskService:
             while True:
                 if delay_seconds > 0:
                     await asyncio.sleep(delay_seconds)
-                if self._attempt_completion_delivery(background_task_id):
+                if await self._attempt_completion_delivery_async(background_task_id):
                     return
                 if self._completion_sink is None:
                     return

--- a/src/relay_teams/sessions/runs/run_followups.py
+++ b/src/relay_teams/sessions/runs/run_followups.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from pydantic import JsonValue
 from pydantic_ai.messages import ModelRequest, UserPromptPart
@@ -25,7 +26,7 @@ from relay_teams.sessions.runs.background_tasks.manager import BackgroundTaskMan
 from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskRecord
 from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
@@ -66,6 +67,11 @@ class RunFollowupRouter:
         create_run: Callable[[IntentInput, InjectionSource], tuple[str, str]],
         ensure_run_started: Callable[[str], None],
         remember_active_run: Callable[[str, str], None],
+        create_run_async: Callable[
+            [IntentInput, InjectionSource], Awaitable[tuple[str, str]]
+        ]
+        | None = None,
+        ensure_run_started_async: Callable[[str], Awaitable[None]] | None = None,
     ) -> None:
         self._injection_manager = injection_manager
         self._run_control_manager = run_control_manager
@@ -84,7 +90,9 @@ class RunFollowupRouter:
         self._runtime_for_run = runtime_for_run
         self._ensure_session = ensure_session
         self._create_run = create_run
+        self._create_run_async = create_run_async
         self._ensure_run_started = ensure_run_started
+        self._ensure_run_started_async = ensure_run_started_async
         self._remember_active_run = remember_active_run
 
     def handle_background_task_completion(
@@ -106,6 +114,29 @@ class RunFollowupRouter:
             allow_coordinator=True,
             event_prefix="background_task.notification",
             payload=payload,
+            spawn_if_unroutable=False,
+        )
+
+    async def handle_background_task_completion_async(
+        self,
+        *,
+        record: BackgroundTaskRecord,
+        message: str,
+    ) -> None:
+        payload: dict[str, JsonValue] = {
+            "background_task_id": record.background_task_id,
+        }
+        await self.route_system_message_async(
+            source_run_id=record.run_id,
+            session_id=record.session_id,
+            preferred_instance_id=record.instance_id,
+            role_id=record.role_id,
+            task_id_fallback="background-task-notification",
+            message=message,
+            allow_coordinator=True,
+            event_prefix="background_task.notification",
+            payload=payload,
+            spawn_if_unroutable=False,
         )
 
     def handle_monitor_trigger(
@@ -161,6 +192,7 @@ class RunFollowupRouter:
         allow_coordinator: bool,
         event_prefix: str,
         payload: dict[str, JsonValue],
+        spawn_if_unroutable: bool = True,
     ) -> None:
         task_id = self.find_task_for_instance(
             run_id=source_run_id,
@@ -218,6 +250,44 @@ class RunFollowupRouter:
                         payload=payload,
                     )
                 return
+        active_run_id = self._active_run_registry.get_active_run_id(session_id)
+        if (
+            allow_coordinator
+            and active_run_id
+            and active_run_id != source_run_id
+            and self.can_enqueue_followup_to_coordinator(active_run_id)
+            and self.append_followup_to_coordinator(
+                active_run_id,
+                message,
+                enqueue=True,
+                source=InjectionSource.SYSTEM,
+            )
+        ):
+            with bind_trace_context(
+                trace_id=active_run_id,
+                run_id=active_run_id,
+                session_id=session_id,
+            ):
+                log_event(
+                    logger,
+                    logging.INFO,
+                    event=f"{event_prefix}.enqueued",
+                    message="System follow-up enqueued to active coordinator",
+                    payload={
+                        **payload,
+                        "source_run_id": source_run_id,
+                        "target_run_id": active_run_id,
+                    },
+                )
+            return
+        if not spawn_if_unroutable:
+            self._log_unroutable_system_message(
+                source_run_id=source_run_id,
+                session_id=session_id,
+                event_prefix=event_prefix,
+                payload=payload,
+            )
+            return
         self.spawn_system_followup_run(
             source_run_id=source_run_id,
             session_id=session_id,
@@ -225,6 +295,155 @@ class RunFollowupRouter:
             event_prefix=event_prefix,
             payload=payload,
         )
+
+    async def route_system_message_async(
+        self,
+        *,
+        source_run_id: str,
+        session_id: str,
+        preferred_instance_id: str | None,
+        role_id: str | None,
+        task_id_fallback: str,
+        message: str,
+        allow_coordinator: bool,
+        event_prefix: str,
+        payload: dict[str, JsonValue],
+        spawn_if_unroutable: bool = True,
+    ) -> None:
+        task_id = await asyncio.to_thread(
+            self.find_task_for_instance,
+            run_id=source_run_id,
+            instance_id=preferred_instance_id or "",
+        )
+        can_append_to_instance = preferred_instance_id and await asyncio.to_thread(
+            self.can_enqueue_followup_to_instance,
+            run_id=source_run_id,
+            instance_id=preferred_instance_id,
+        )
+        if can_append_to_instance and preferred_instance_id:
+            appended_to_instance = await asyncio.to_thread(
+                self.append_followup_to_instance,
+                run_id=source_run_id,
+                instance_id=preferred_instance_id,
+                task_id=task_id or task_id_fallback,
+                content=message,
+                enqueue=True,
+                source=InjectionSource.SYSTEM,
+            )
+            if appended_to_instance:
+                with bind_trace_context(
+                    trace_id=source_run_id,
+                    run_id=source_run_id,
+                    session_id=session_id,
+                    instance_id=preferred_instance_id,
+                    role_id=role_id,
+                ):
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        event=f"{event_prefix}.enqueued",
+                        message="System follow-up enqueued to originating instance",
+                        payload=payload,
+                    )
+                return
+        can_append_to_coordinator = allow_coordinator and await asyncio.to_thread(
+            self.can_enqueue_followup_to_coordinator,
+            source_run_id,
+        )
+        if can_append_to_coordinator:
+            appended_to_coordinator = await asyncio.to_thread(
+                self.append_followup_to_coordinator,
+                source_run_id,
+                message,
+                enqueue=True,
+                source=InjectionSource.SYSTEM,
+            )
+            if appended_to_coordinator:
+                with bind_trace_context(
+                    trace_id=source_run_id,
+                    run_id=source_run_id,
+                    session_id=session_id,
+                ):
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        event=f"{event_prefix}.enqueued",
+                        message="System follow-up enqueued to coordinator",
+                        payload=payload,
+                    )
+                return
+        active_run_id = self._active_run_registry.get_active_run_id(session_id)
+        can_append_to_active = (
+            allow_coordinator
+            and active_run_id
+            and active_run_id != source_run_id
+            and await asyncio.to_thread(
+                self.can_enqueue_followup_to_coordinator,
+                active_run_id,
+            )
+        )
+        if can_append_to_active and active_run_id:
+            appended_to_active = await asyncio.to_thread(
+                self.append_followup_to_coordinator,
+                active_run_id,
+                message,
+                enqueue=True,
+                source=InjectionSource.SYSTEM,
+            )
+            if appended_to_active:
+                with bind_trace_context(
+                    trace_id=active_run_id,
+                    run_id=active_run_id,
+                    session_id=session_id,
+                ):
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        event=f"{event_prefix}.enqueued",
+                        message="System follow-up enqueued to active coordinator",
+                        payload={
+                            **payload,
+                            "source_run_id": source_run_id,
+                            "target_run_id": active_run_id,
+                        },
+                    )
+                return
+        if not spawn_if_unroutable:
+            self._log_unroutable_system_message(
+                source_run_id=source_run_id,
+                session_id=session_id,
+                event_prefix=event_prefix,
+                payload=payload,
+            )
+            return
+        await self.spawn_system_followup_run_async(
+            source_run_id=source_run_id,
+            session_id=session_id,
+            message=message,
+            event_prefix=event_prefix,
+            payload=payload,
+        )
+
+    @staticmethod
+    def _log_unroutable_system_message(
+        *,
+        source_run_id: str,
+        session_id: str,
+        event_prefix: str,
+        payload: dict[str, JsonValue],
+    ) -> None:
+        with bind_trace_context(
+            trace_id=source_run_id,
+            run_id=source_run_id,
+            session_id=session_id,
+        ):
+            log_event(
+                logger,
+                logging.INFO,
+                event=f"{event_prefix}.skipped",
+                message="System follow-up skipped because the source run is no longer accepting injections",
+                payload=payload,
+            )
 
     def spawn_system_followup_run(
         self,
@@ -254,6 +473,92 @@ class RunFollowupRouter:
             source_run_id,
         } and self.has_active_background_tasks(source_run_id):
             self._remember_active_run(normalized_session_id, source_run_id)
+            with bind_trace_context(
+                trace_id=source_run_id,
+                run_id=source_run_id,
+                session_id=normalized_session_id,
+            ):
+                log_event(
+                    logger,
+                    logging.INFO,
+                    event=f"{event_prefix}.source_run_retained",
+                    message="Source run remains active while sibling background tasks are still running",
+                    payload={
+                        **payload,
+                        "source_run_id": source_run_id,
+                        "target_run_id": new_run_id,
+                    },
+                )
+        with bind_trace_context(
+            trace_id=new_run_id,
+            run_id=new_run_id,
+            session_id=normalized_session_id,
+        ):
+            log_event(
+                logger,
+                logging.INFO,
+                event=f"{event_prefix}.spawned",
+                message="System follow-up routed through create_run",
+                payload={
+                    **payload,
+                    "source_run_id": source_run_id,
+                    "target_run_id": new_run_id,
+                },
+            )
+        return new_run_id
+
+    async def spawn_system_followup_run_async(
+        self,
+        *,
+        source_run_id: str,
+        session_id: str,
+        message: str,
+        event_prefix: str,
+        payload: dict[str, JsonValue],
+    ) -> str:
+        normalized_session_id = await asyncio.to_thread(
+            self._ensure_session,
+            session_id,
+        )
+        active_run_before = self._active_run_registry.get_active_run_id(
+            normalized_session_id
+        )
+        await asyncio.to_thread(
+            self._run_control_manager.assert_session_allows_main_input,
+            normalized_session_id,
+        )
+        _ = await asyncio.to_thread(
+            self._session_repo.mark_started,
+            normalized_session_id,
+        )
+        intent = IntentInput(
+            session_id=normalized_session_id,
+            input=(TextContentPart(text=message),),
+        )
+        if self._create_run_async is None:
+            new_run_id, _ = await asyncio.to_thread(
+                self._create_run,
+                intent,
+                InjectionSource.SYSTEM,
+            )
+        else:
+            new_run_id, _ = await self._create_run_async(
+                intent,
+                InjectionSource.SYSTEM,
+            )
+        if self._ensure_run_started_async is None:
+            await asyncio.to_thread(self._ensure_run_started, new_run_id)
+        else:
+            await self._ensure_run_started_async(new_run_id)
+        if active_run_before in {
+            None,
+            source_run_id,
+        } and await asyncio.to_thread(self.has_active_background_tasks, source_run_id):
+            await asyncio.to_thread(
+                self._remember_active_run,
+                normalized_session_id,
+                source_run_id,
+            )
             with bind_trace_context(
                 trace_id=source_run_id,
                 run_id=source_run_id,
@@ -565,15 +870,42 @@ class RunFollowupRouter:
         record: AgentRuntimeRecord,
         payload: str,
     ) -> None:
-        self._run_event_hub.publish(
-            RunEvent(
-                session_id=record.session_id,
-                run_id=run_id,
-                trace_id=run_id,
-                task_id=None,
-                instance_id=record.instance_id,
-                role_id=record.role_id,
-                event_type=RunEventType.INJECTION_ENQUEUED,
-                payload_json=payload,
-            )
+        event = RunEvent(
+            session_id=record.session_id,
+            run_id=run_id,
+            trace_id=run_id,
+            task_id=None,
+            instance_id=record.instance_id,
+            role_id=record.role_id,
+            event_type=RunEventType.INJECTION_ENQUEUED,
+            payload_json=payload,
         )
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self._run_event_hub.publish(event)
+            return
+        _ = asyncio.create_task(self._publish_injection_event_async(event))
+
+    async def _publish_injection_event_async(self, event: RunEvent) -> None:
+        try:
+            await publish_run_event_async(self._run_event_hub, event)
+        except Exception as exc:
+            with bind_trace_context(
+                trace_id=event.trace_id,
+                run_id=event.run_id,
+                session_id=event.session_id,
+                instance_id=event.instance_id,
+                role_id=event.role_id,
+            ):
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event="run.followup.injection_event_publish_failed",
+                    message="Failed to publish follow-up injection event",
+                    payload={
+                        "event_type": event.event_type.value,
+                        "error": str(exc),
+                    },
+                    exc_info=exc,
+                )

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -252,6 +252,11 @@ class SessionRunService:
                 session_id,
                 run_id,
             ),
+            create_run_async=lambda intent, source: self.create_run_async(
+                intent,
+                source=source,
+            ),
+            ensure_run_started_async=self.ensure_run_started_async,
         )
         self._interaction_service = RunInteractionService(
             run_control_manager=self._run_control_manager,
@@ -1589,16 +1594,18 @@ class SessionRunService:
         record: "BackgroundTaskRecord",
         message: str,
     ) -> None:
-        if self._should_delegate_to_bound_loop():
-            record_copy = record.model_copy(deep=True)
-            self._call_in_bound_loop(
-                lambda: self._handle_background_task_completion_local(
-                    record=record_copy,
-                    message=message,
-                )
-            )
-            return
         self._handle_background_task_completion_local(record=record, message=message)
+
+    async def handle_background_task_completion_async(
+        self,
+        *,
+        record: "BackgroundTaskRecord",
+        message: str,
+    ) -> None:
+        await self._followup_router.handle_background_task_completion_async(
+            record=record,
+            message=message,
+        )
 
     def handle_monitor_trigger(
         self,

--- a/tests/unit_tests/sessions/runs/background_tasks/test_service.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_service.py
@@ -30,8 +30,13 @@ from relay_teams.sessions.runs.background_tasks.projection import (
     build_background_task_result_payload,
 )
 from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
-from relay_teams.sessions.runs.enums import ExecutionMode
-from relay_teams.sessions.runs.run_models import IntentInput, RunThinkingConfig
+from relay_teams.sessions.runs.enums import ExecutionMode, RunEventType
+from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.run_models import (
+    IntentInput,
+    RunEvent,
+    RunThinkingConfig,
+)
 from relay_teams.sessions.session_models import SessionMode
 from relay_teams.sessions.runs.background_tasks.repository import (
     BackgroundTaskRepository,
@@ -164,6 +169,28 @@ class _CapturingCompletionSink:
         self.calls: list[tuple[BackgroundTaskRecord, str]] = []
 
     def handle_background_task_completion(
+        self,
+        *,
+        record: BackgroundTaskRecord,
+        message: str,
+    ) -> None:
+        self.calls.append((record, message))
+
+
+class _AsyncCapturingCompletionSink:
+    def __init__(self) -> None:
+        self.calls: list[tuple[BackgroundTaskRecord, str]] = []
+
+    def handle_background_task_completion(
+        self,
+        *,
+        record: BackgroundTaskRecord,
+        message: str,
+    ) -> None:
+        _ = (record, message)
+        raise AssertionError("sync completion sink must not be used")
+
+    async def handle_background_task_completion_async(
         self,
         *,
         record: BackgroundTaskRecord,
@@ -313,6 +340,67 @@ class _FakeRunControlManager:
         return run_id in self._stopped_run_ids
 
 
+class _LoopGuardRunEventHub:
+    def __init__(self) -> None:
+        self.events: list[RunEvent] = []
+
+    def publish(self, event: RunEvent) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self.events.append(event)
+            return
+        raise AssertionError("sync publish must not run on the event loop")
+
+    async def publish_async(self, event: RunEvent) -> None:
+        self.events.append(event)
+
+
+class _FailingStartRunEventHub(_LoopGuardRunEventHub):
+    def publish(self, event: RunEvent) -> None:
+        if event.event_type == RunEventType.BACKGROUND_TASK_STARTED:
+            raise RuntimeError("start publish failed")
+        super().publish(event)
+
+
+class _LoopGuardRunRuntimeRepository:
+    def __init__(self, wrapped: RunRuntimeRepository) -> None:
+        self._wrapped = wrapped
+
+    def ensure(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        root_task_id: str | None = None,
+        status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
+        phase: RunRuntimePhase = RunRuntimePhase.IDLE,
+    ) -> object:
+        self._raise_if_running_on_event_loop()
+        return self._wrapped.ensure(
+            run_id=run_id,
+            session_id=session_id,
+            root_task_id=root_task_id,
+            status=status,
+            phase=phase,
+        )
+
+    def get(self, run_id: str) -> object | None:
+        self._raise_if_running_on_event_loop()
+        return self._wrapped.get(run_id)
+
+    def update(self, run_id: str, **changes: object) -> object:
+        self._raise_if_running_on_event_loop()
+        return self._wrapped.update(run_id, **changes)
+
+    def _raise_if_running_on_event_loop(self) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        raise AssertionError("run runtime repository must not run on the event loop")
+
+
 class _CapturingHookService:
     def __init__(self) -> None:
         self.executed_events: list[str] = []
@@ -415,6 +503,46 @@ async def test_background_task_service_notifies_sink_and_persists_completion_mar
             include_task_id=True,
         )
     )
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_uses_async_completion_sink(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(tmp_path / "background-task-service-async-sink.db")
+    manager = _FakeBackgroundTaskManager()
+    service = BackgroundTaskService(
+        background_task_manager=cast(BackgroundTaskManager, manager),
+        repository=repo,
+    )
+    sink = _AsyncCapturingCompletionSink()
+    service.bind_completion_sink(sink)
+    record = repo.upsert(_build_record(recent_output=("async done",)))
+
+    assert manager._listener is not None
+    await manager._listener(record)
+
+    persisted = repo.get(record.background_task_id)
+    assert persisted is not None
+    assert persisted.completion_notified_at is not None
+    assert len(sink.calls) == 1
+    assert sink.calls[0][0] == record
+    assert "async done" in sink.calls[0][1]
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_treats_missing_completion_as_delivered(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(tmp_path / "background-task-service-missing.db")
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+    )
+
+    delivered = await service._attempt_completion_delivery_async("missing-task")
+
+    assert delivered is True
 
 
 @pytest.mark.asyncio
@@ -760,6 +888,111 @@ async def test_background_task_service_start_subagent_completes_and_persists_res
     assert runtime is not None
     assert runtime.status == RunRuntimeStatus.COMPLETED
     assert runtime.phase == RunRuntimePhase.TERMINAL
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_start_subagent_publishes_start_event_async(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(tmp_path / "background-task-subagent-events.db")
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    run_event_hub = _LoopGuardRunEventHub()
+    run_runtime_repo = _LoopGuardRunRuntimeRepository(
+        RunRuntimeRepository(tmp_path / "background-task-subagent-events.db")
+    )
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        run_event_hub=cast(RunEventHub, run_event_hub),
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=cast(RunRuntimeRepository, run_runtime_repo),
+    )
+
+    started = await service.start_subagent(
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="MainAgent",
+        tool_call_id="call-1",
+        workspace_id="workspace-1",
+        cwd=Path("C:/workspace"),
+        subagent_role_id="Crafter",
+        title="Investigate failures",
+        prompt="Inspect the failing tests and summarize the cause.",
+    )
+    _, completed = await service.wait_for_run(
+        run_id="run-1",
+        background_task_id=started.background_task_id,
+    )
+
+    assert completed is True
+    assert [event.event_type for event in run_event_hub.events] == [
+        RunEventType.BACKGROUND_TASK_STARTED,
+        RunEventType.BACKGROUND_TASK_COMPLETED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_start_subagent_cleans_up_when_start_event_fails(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-subagent-start-event-failure.db"
+    )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    run_control_manager = _FakeRunControlManager()
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        run_event_hub=cast(RunEventHub, _FailingStartRunEventHub()),
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=run_control_manager,
+    )
+
+    with pytest.raises(RuntimeError, match="start publish failed"):
+        await service.start_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="MainAgent",
+            tool_call_id="call-1",
+            workspace_id="workspace-1",
+            cwd=Path("C:/workspace"),
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests and summarize the cause.",
+        )
+
+    records = repo.list_by_run("run-1")
+    assert len(records) == 1
+    subagent_run_id = records[0].subagent_run_id
+    assert subagent_run_id is not None
+    assert records[0].status == BackgroundTaskStatus.FAILED
+    assert records[0].output_excerpt == "Task cancelled"
+    assert executor.calls == []
+    assert run_control_manager.registered_run_ids == [
+        subagent_run_id,
+    ]
+    assert run_control_manager.unregistered_run_ids == [
+        subagent_run_id,
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_run_followups.py
+++ b/tests/unit_tests/sessions/runs/test_run_followups.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+import pytest
+
+from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.agents.instances.enums import InstanceStatus
+from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
+from relay_teams.agents.instances.models import AgentRuntimeRecord
+from relay_teams.agents.tasks.task_repository import TaskRepository
+from relay_teams.sessions.runs.active_run_registry import ActiveSessionRunRegistry
+from relay_teams.sessions.runs.background_tasks.manager import BackgroundTaskManager
+from relay_teams.sessions.runs.background_tasks.models import (
+    BackgroundTaskKind,
+    BackgroundTaskRecord,
+    BackgroundTaskStatus,
+)
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
+from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
+from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.injection_queue import RunInjectionManager
+from relay_teams.sessions.runs.run_control_manager import RunControlManager
+from relay_teams.sessions.runs.run_followups import RunFollowupRouter
+from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
+from relay_teams.sessions.runs.run_models import IntentInput, RunEvent
+from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRecord
+from relay_teams.sessions.runs.user_question_repository import UserQuestionRepository
+from relay_teams.sessions.session_repository import SessionRepository
+from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+
+
+class _LoopGuardRunEventHub:
+    def __init__(self) -> None:
+        self.events: list[RunEvent] = []
+
+    def publish(self, event: RunEvent) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self.events.append(event)
+            return
+        raise AssertionError("sync publish must not run on the event loop")
+
+    async def publish_async(self, event: RunEvent) -> None:
+        self.events.append(event)
+
+
+class _RecordingSessionRepo:
+    def __init__(self) -> None:
+        self.started_sessions: list[str] = []
+
+    def mark_started(self, session_id: str) -> object:
+        self.started_sessions.append(session_id)
+        return object()
+
+
+def _build_router(run_event_hub: RunEventHub) -> RunFollowupRouter:
+    return RunFollowupRouter(
+        injection_manager=cast(RunInjectionManager, object()),
+        run_control_manager=cast(RunControlManager, object()),
+        active_run_registry=cast(ActiveSessionRunRegistry, object()),
+        session_repo=cast(SessionRepository, object()),
+        run_event_hub=run_event_hub,
+        get_background_task_manager=lambda: cast(BackgroundTaskManager | None, None),
+        get_background_task_service=lambda: cast(BackgroundTaskService | None, None),
+        get_run_intent_repo=lambda: cast(RunIntentRepository | None, None),
+        get_approval_ticket_repo=lambda: cast(ApprovalTicketRepository | None, None),
+        get_agent_repo=lambda: cast(AgentInstanceRepository | None, None),
+        get_user_question_repo=lambda: cast(UserQuestionRepository | None, None),
+        require_agent_repo=lambda: cast(AgentInstanceRepository, object()),
+        require_message_repo=lambda: cast(MessageRepository, object()),
+        require_task_repo=lambda: cast(TaskRepository, object()),
+        runtime_for_run=lambda _: cast(RunRuntimeRecord | None, None),
+        ensure_session=lambda session_id: session_id,
+        create_run=_create_run,
+        ensure_run_started=lambda _: None,
+        remember_active_run=lambda _, __: None,
+    )
+
+
+def _create_run(_: IntentInput, __: InjectionSource) -> tuple[str, str]:
+    return "run-created", "session-created"
+
+
+class _RecordingRunFollowupRouter(RunFollowupRouter):
+    def __init__(
+        self,
+        *,
+        active_run_registry: ActiveSessionRunRegistry | None = None,
+        session_repo: SessionRepository | None = None,
+        create_run_async: Callable[
+            [IntentInput, InjectionSource], Awaitable[tuple[str, str]]
+        ]
+        | None = None,
+        ensure_run_started_async: Callable[[str], Awaitable[None]] | None = None,
+        has_active_tasks: bool = False,
+    ) -> None:
+        self.appended_instances: list[tuple[str, str, str]] = []
+        self.appended_coordinators: list[tuple[str, str]] = []
+        self.started_runs: list[str] = []
+        self.created_intents: list[IntentInput] = []
+        self.remembered_runs: list[tuple[str, str]] = []
+        self.instance_can_enqueue = True
+        self.coordinator_can_enqueue: dict[str, bool] = {}
+        self.append_instance_result = True
+        self.append_coordinator_result: dict[str, bool] = {}
+        self.has_active_tasks = has_active_tasks
+        super().__init__(
+            injection_manager=cast(RunInjectionManager, object()),
+            run_control_manager=RunControlManager(),
+            active_run_registry=active_run_registry or ActiveSessionRunRegistry(),
+            session_repo=session_repo or cast(SessionRepository, object()),
+            run_event_hub=cast(RunEventHub, _LoopGuardRunEventHub()),
+            get_background_task_manager=lambda: cast(
+                BackgroundTaskManager | None, None
+            ),
+            get_background_task_service=lambda: cast(
+                BackgroundTaskService | None, None
+            ),
+            get_run_intent_repo=lambda: cast(RunIntentRepository | None, None),
+            get_approval_ticket_repo=lambda: cast(
+                ApprovalTicketRepository | None, None
+            ),
+            get_agent_repo=lambda: cast(AgentInstanceRepository | None, None),
+            get_user_question_repo=lambda: cast(UserQuestionRepository | None, None),
+            require_agent_repo=lambda: cast(AgentInstanceRepository, object()),
+            require_message_repo=lambda: cast(MessageRepository, object()),
+            require_task_repo=lambda: cast(TaskRepository, object()),
+            runtime_for_run=lambda _: cast(RunRuntimeRecord | None, None),
+            ensure_session=lambda session_id: session_id,
+            create_run=self._record_create_run,
+            ensure_run_started=self._record_run_started,
+            remember_active_run=self._record_remember_active_run,
+            create_run_async=create_run_async,
+            ensure_run_started_async=ensure_run_started_async,
+        )
+
+    def find_task_for_instance(self, *, run_id: str, instance_id: str) -> str | None:
+        _ = (run_id, instance_id)
+        return "task-existing"
+
+    def can_enqueue_followup_to_instance(
+        self, *, run_id: str, instance_id: str
+    ) -> bool:
+        _ = (run_id, instance_id)
+        return self.instance_can_enqueue
+
+    def append_followup_to_instance(
+        self,
+        *,
+        run_id: str,
+        instance_id: str,
+        task_id: str,
+        content: str,
+        enqueue: bool,
+        source: InjectionSource,
+    ) -> bool:
+        _ = (enqueue, source)
+        self.appended_instances.append((run_id, instance_id, task_id))
+        _ = content
+        return self.append_instance_result
+
+    def can_enqueue_followup_to_coordinator(self, run_id: str) -> bool:
+        return self.coordinator_can_enqueue.get(run_id, False)
+
+    def append_followup_to_coordinator(
+        self,
+        run_id: str,
+        content: str,
+        *,
+        enqueue: bool,
+        source: InjectionSource = InjectionSource.USER,
+    ) -> bool:
+        _ = (enqueue, source)
+        self.appended_coordinators.append((run_id, content))
+        return self.append_coordinator_result.get(run_id, True)
+
+    def has_active_background_tasks(self, run_id: str) -> bool:
+        _ = run_id
+        return self.has_active_tasks
+
+    def _record_create_run(
+        self,
+        intent: IntentInput,
+        source: InjectionSource,
+    ) -> tuple[str, str]:
+        _ = source
+        self.created_intents.append(intent)
+        return "run-created-sync", "session-1"
+
+    def _record_run_started(self, run_id: str) -> None:
+        self.started_runs.append(run_id)
+
+    def _record_remember_active_run(self, session_id: str, run_id: str) -> None:
+        self.remembered_runs.append((session_id, run_id))
+
+
+def _background_record() -> BackgroundTaskRecord:
+    return BackgroundTaskRecord(
+        background_task_id="background-task-1",
+        run_id="run-source",
+        session_id="session-1",
+        kind=BackgroundTaskKind.SUBAGENT,
+        instance_id="instance-1",
+        role_id="role-1",
+        tool_call_id="tool-call-1",
+        title="Explorer",
+        command="subagent:Explorer",
+        cwd="/workspace",
+        execution_mode="background",
+        status=BackgroundTaskStatus.COMPLETED,
+        exit_code=0,
+        recent_output=("done",),
+        output_excerpt="done",
+        log_path="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_injection_event_uses_async_publish_on_running_loop() -> None:
+    run_event_hub = _LoopGuardRunEventHub()
+    router = _build_router(cast(RunEventHub, run_event_hub))
+    record = AgentRuntimeRecord(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id="instance-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        status=InstanceStatus.RUNNING,
+    )
+
+    router.publish_injection_event(run_id="run-1", record=record, payload="{}")
+    for _ in range(5):
+        if run_event_hub.events:
+            break
+        await asyncio.sleep(0)
+
+    assert [event.event_type for event in run_event_hub.events] == [
+        RunEventType.INJECTION_ENQUEUED
+    ]
+
+
+@pytest.mark.asyncio
+async def test_background_task_completion_async_enqueues_to_origin_instance() -> None:
+    router = _RecordingRunFollowupRouter()
+
+    await router.handle_background_task_completion_async(
+        record=_background_record(),
+        message="background finished",
+    )
+
+    assert router.appended_instances == [("run-source", "instance-1", "task-existing")]
+
+
+@pytest.mark.asyncio
+async def test_route_system_message_async_enqueues_to_source_coordinator() -> None:
+    router = _RecordingRunFollowupRouter()
+    router.instance_can_enqueue = False
+    router.coordinator_can_enqueue = {"run-source": True}
+
+    await router.route_system_message_async(
+        source_run_id="run-source",
+        session_id="session-1",
+        preferred_instance_id="instance-1",
+        role_id="role-1",
+        task_id_fallback="task-fallback",
+        message="coordinator follow-up",
+        allow_coordinator=True,
+        event_prefix="test.followup",
+        payload={"test": "payload"},
+    )
+
+    assert router.appended_coordinators == [("run-source", "coordinator follow-up")]
+
+
+@pytest.mark.asyncio
+async def test_route_system_message_async_enqueues_to_other_active_run() -> None:
+    active_run_registry = ActiveSessionRunRegistry()
+    active_run_registry.remember_active_run(
+        session_id="session-1",
+        run_id="run-active",
+    )
+    router = _RecordingRunFollowupRouter(active_run_registry=active_run_registry)
+    router.instance_can_enqueue = False
+    router.coordinator_can_enqueue = {"run-active": True}
+
+    await router.route_system_message_async(
+        source_run_id="run-source",
+        session_id="session-1",
+        preferred_instance_id="instance-1",
+        role_id="role-1",
+        task_id_fallback="task-fallback",
+        message="active follow-up",
+        allow_coordinator=True,
+        event_prefix="test.followup",
+        payload={"test": "payload"},
+    )
+
+    assert router.appended_coordinators == [("run-active", "active follow-up")]
+
+
+@pytest.mark.asyncio
+async def test_route_system_message_async_skips_unroutable_background_completion() -> (
+    None
+):
+    router = _RecordingRunFollowupRouter()
+    router.instance_can_enqueue = False
+
+    await router.route_system_message_async(
+        source_run_id="run-source",
+        session_id="session-1",
+        preferred_instance_id="instance-1",
+        role_id="role-1",
+        task_id_fallback="task-fallback",
+        message="dropped follow-up",
+        allow_coordinator=True,
+        event_prefix="test.followup",
+        payload={"test": "payload"},
+        spawn_if_unroutable=False,
+    )
+
+    assert router.created_intents == []
+    assert router.started_runs == []
+
+
+@pytest.mark.asyncio
+async def test_spawn_system_followup_run_async_uses_async_entrypoints() -> None:
+    session_repo = _RecordingSessionRepo()
+    created_sources: list[InjectionSource] = []
+    started_runs: list[str] = []
+
+    async def _create_run_async(
+        intent: IntentInput,
+        source: InjectionSource,
+    ) -> tuple[str, str]:
+        created_sources.append(source)
+        assert intent.session_id == "session-1"
+        return "run-created-async", "session-1"
+
+    async def _ensure_started_async(run_id: str) -> None:
+        started_runs.append(run_id)
+
+    router = _RecordingRunFollowupRouter(
+        session_repo=cast(SessionRepository, session_repo),
+        create_run_async=_create_run_async,
+        ensure_run_started_async=_ensure_started_async,
+        has_active_tasks=True,
+    )
+
+    run_id = await router.spawn_system_followup_run_async(
+        source_run_id="run-source",
+        session_id="session-1",
+        message="spawn follow-up",
+        event_prefix="test.followup",
+        payload={"test": "payload"},
+    )
+
+    assert run_id == "run-created-async"
+    assert created_sources == [InjectionSource.SYSTEM]
+    assert started_runs == ["run-created-async"]
+    assert session_repo.started_sessions == ["session-1"]
+    assert router.remembered_runs == [("session-1", "run-source")]
+
+
+@pytest.mark.asyncio
+async def test_spawn_system_followup_run_async_falls_back_to_sync_entrypoints() -> None:
+    session_repo = _RecordingSessionRepo()
+    router = _RecordingRunFollowupRouter(
+        session_repo=cast(SessionRepository, session_repo)
+    )
+
+    run_id = await router.spawn_system_followup_run_async(
+        source_run_id="run-source",
+        session_id="session-1",
+        message="spawn follow-up",
+        event_prefix="test.followup",
+        payload={"test": "payload"},
+    )
+
+    assert run_id == "run-created-sync"
+    assert router.started_runs == ["run-created-sync"]
+    assert session_repo.started_sessions == ["session-1"]
+    assert [intent.session_id for intent in router.created_intents] == ["session-1"]

--- a/tests/unit_tests/sessions/runs/test_run_service_entrypoint.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_entrypoint.py
@@ -1,8 +1,31 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import cast
+
+from relay_teams.sessions.runs.background_tasks.models import (
+    BackgroundTaskRecord,
+    BackgroundTaskStatus,
+)
 from relay_teams.sessions.runs.run_recovery import AutoRecoveryReason
+from relay_teams.sessions.runs.run_followups import RunFollowupRouter
 from relay_teams.sessions.runs.run_service import SessionRunService
+
+
+class _CapturingFollowupRouter:
+    def __init__(self) -> None:
+        self.records: list[BackgroundTaskRecord] = []
+        self.messages: list[str] = []
+
+    def handle_background_task_completion(
+        self,
+        *,
+        record: BackgroundTaskRecord,
+        message: str,
+    ) -> None:
+        self.records.append(record)
+        self.messages.append(message)
 
 
 def test_session_run_service_is_available_from_explicit_module() -> None:
@@ -11,3 +34,39 @@ def test_session_run_service_is_available_from_explicit_module() -> None:
 
 def test_auto_recovery_types_remain_available_from_recovery_module() -> None:
     assert AutoRecoveryReason.NETWORK_TIMEOUT.value == "auto_recovery_network_timeout"
+
+
+def test_background_task_completion_is_not_delegated_to_event_loop() -> None:
+    service = cast(
+        SessionRunService,
+        SessionRunService.__new__(SessionRunService),
+    )
+    router = _CapturingFollowupRouter()
+    object.__setattr__(service, "_followup_router", cast(RunFollowupRouter, router))
+    object.__setattr__(service, "_event_loop", object())
+    object.__setattr__(service, "_call_in_bound_loop", _raise_if_delegated)
+    record = BackgroundTaskRecord(
+        background_task_id="background-task-1",
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="instance-1",
+        role_id="role-1",
+        tool_call_id="tool-call-1",
+        command="subagent:Explorer",
+        cwd="workspace-1",
+        execution_mode="background",
+        status=BackgroundTaskStatus.COMPLETED,
+        exit_code=0,
+        recent_output=("done",),
+        output_excerpt="done",
+        log_path="",
+    )
+
+    service.handle_background_task_completion(record=record, message="done")
+
+    assert router.records == [record]
+    assert router.messages == ["done"]
+
+
+def _raise_if_delegated(_: Callable[[], object]) -> object:
+    raise AssertionError("background task completion must not run on the event loop")

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -910,10 +910,8 @@ async def test_background_task_completion_keeps_source_run_active_when_siblings_
         record=_build_background_record(),
         message="background task finished",
     )
-    await asyncio.wait_for(meta_agent.started.wait(), timeout=1)
-
-    assert meta_agent.trace_id is not None
-    assert meta_agent.trace_id != "run-existing"
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(meta_agent.started.wait(), timeout=0.05)
     assert manager._active_run_registry.get_active_run_id("session-1") == "run-existing"
 
     meta_agent.release.set()
@@ -921,7 +919,7 @@ async def test_background_task_completion_keeps_source_run_active_when_siblings_
 
 
 @pytest.mark.asyncio
-async def test_background_task_completion_starts_new_run_when_live_delivery_is_unavailable(
+async def test_background_task_completion_skips_new_run_when_live_delivery_is_unavailable(
     tmp_path: Path,
 ) -> None:
     class _BlockingMetaAgent:
@@ -979,14 +977,12 @@ async def test_background_task_completion_starts_new_run_when_live_delivery_is_u
         record=_build_background_record(),
         message="background task finished",
     )
-    await asyncio.wait_for(meta_agent.started.wait(), timeout=1)
-
-    assert meta_agent.intent is not None
-    assert meta_agent.trace_id is not None
-    assert meta_agent.trace_id != "run-existing"
-    assert meta_agent.intent.intent == "background task finished"
-    assert meta_agent.intent.target_role_id is None
-    assert meta_agent.trace_id in manager._running_run_ids
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(meta_agent.started.wait(), timeout=0.05)
+    assert meta_agent.intent is None
+    assert meta_agent.trace_id is None
+    assert manager._running_run_ids == set()
+    assert manager._active_run_registry.get_active_run_id("session-1") == "run-existing"
 
     meta_agent.release.set()
     await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- make background spawn_subagent launch, completion, and injection event publishing safe from running event loops
- deliver background task completion notifications through async-safe paths and avoid per-completion follow-up run storms
- add regression coverage for event-loop guarded background task and follow-up paths

Fixes #541

## Validation
- uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/sessions/runs/run_followups.py src/relay_teams/sessions/runs/background_tasks/service.py src/relay_teams/sessions/runs/run_service.py tests/unit_tests/sessions/runs/test_run_followups.py tests/unit_tests/sessions/runs/test_run_service_entrypoint.py tests/unit_tests/sessions/runs/background_tasks/test_service.py
- uv run --extra dev ruff check src/relay_teams/sessions/runs/run_followups.py src/relay_teams/sessions/runs/background_tasks/service.py src/relay_teams/sessions/runs/run_service.py tests/unit_tests/sessions/runs/test_run_followups.py tests/unit_tests/sessions/runs/test_run_service_entrypoint.py tests/unit_tests/sessions/runs/background_tasks/test_service.py
- uv run --extra dev basedpyright src/relay_teams/sessions/runs/run_followups.py src/relay_teams/sessions/runs/background_tasks/service.py src/relay_teams/sessions/runs/run_service.py tests/unit_tests/sessions/runs/test_run_followups.py tests/unit_tests/sessions/runs/test_run_service_entrypoint.py tests/unit_tests/sessions/runs/background_tasks/test_service.py
- uv run --extra dev pytest -q tests/unit_tests/sessions/runs/test_run_followups.py tests/unit_tests/sessions/runs/test_run_service_entrypoint.py
- uv run --extra dev pytest -q tests/unit_tests/sessions/runs/background_tasks/test_service.py
- Browser E2E against fake LLM: 5 concurrent background spawn_subagent calls completed; /api/sessions responded after completion; logs had no RunEventHub.publish/tool.call.failed/background_task.notification_failed/ERROR matches
