### PR TITLE
Reduce skill discovery warning noise

### DIFF
--- a/src/relay_teams/skills/discovery.py
+++ b/src/relay_teams/skills/discovery.py
@@ -26,6 +26,11 @@ _SCRIPT_DESCRIPTION_PATTERN = re.compile(
     r"^- ([\w-]+):\s*(.*?)(?:\s*\((.*?)\))?$",
     re.MULTILINE,
 )
+_DISCOVERY_WARNING_SAMPLE_LIMIT = 5
+
+_SkillDiscoverySignature = tuple[tuple[str, str, int, int], ...]
+_SkillLoadWarningEntry = tuple[Path, str]
+_SkillDuplicateWarningEntry = tuple[str, Path, SkillSource, Path, SkillSource]
 
 
 def get_builtin_skills_dir_path() -> Path:
@@ -77,6 +82,7 @@ class SkillsDirectory:
             (source, _resolve_dir(base_dir)) for source, base_dir in sources
         )
         self._skills: dict[str, Skill] = {}
+        self._discovery_signature: _SkillDiscoverySignature | None = None
         self._lock = RLock()
 
     @classmethod
@@ -154,33 +160,132 @@ class SkillsDirectory:
                 "max_depth": self.max_depth,
             },
         ):
+            discovery_signature = self._build_discovery_signature()
+            with self._lock:
+                if discovery_signature == self._discovery_signature:
+                    return
+
             discovered_skills: dict[str, Skill] = {}
+            duplicate_warnings: list[_SkillDuplicateWarningEntry] = []
+            load_warnings: list[_SkillLoadWarningEntry] = []
+            had_transient_load_failure = False
             for source, base_dir in self.sources:
                 if not base_dir.exists():
                     continue
-                for path in sorted(base_dir.rglob("SKILL.md")):
+                for path in self._iter_skill_manifest_paths(base_dir):
                     try:
-                        rel = path.relative_to(base_dir)
-                        if len(rel.parts) > self.max_depth + 1:
-                            continue
-                        skill = self._load_skill(path=path, source=source)
+                        skill = self._load_skill(
+                            path=path,
+                            source=source,
+                            load_warnings=load_warnings,
+                        )
                         if skill is None:
                             continue
                         existing_skill = discovered_skills.get(skill.metadata.name)
                         if existing_skill is not None:
-                            logger.warning(
-                                "Overriding duplicate skill %s from %s (%s) with %s (%s)",
-                                skill.metadata.name,
-                                existing_skill.directory,
-                                existing_skill.source.value,
-                                skill.directory,
-                                skill.source.value,
+                            duplicate_warnings.append(
+                                (
+                                    skill.metadata.name,
+                                    existing_skill.directory,
+                                    existing_skill.source,
+                                    skill.directory,
+                                    skill.source,
+                                )
                             )
                         discovered_skills[skill.metadata.name] = skill
+                    except OSError as exc:
+                        had_transient_load_failure = True
+                        load_warnings.append((path, str(exc)))
                     except Exception as exc:
-                        logger.warning("Failed to load skill at %s: %s", path, exc)
+                        load_warnings.append((path, str(exc)))
             with self._lock:
                 self._skills = discovered_skills
+                if had_transient_load_failure:
+                    self._discovery_signature = None
+                else:
+                    self._discovery_signature = discovery_signature
+            self._log_discovery_warnings(
+                duplicate_warnings=duplicate_warnings,
+                load_warnings=load_warnings,
+            )
+
+    def _build_discovery_signature(self) -> _SkillDiscoverySignature:
+        signature: list[tuple[str, str, int, int]] = []
+        for source, base_dir in self.sources:
+            if not base_dir.exists():
+                continue
+            for manifest_path in self._iter_skill_manifest_paths(base_dir):
+                try:
+                    discovery_paths = _iter_skill_discovery_paths(manifest_path)
+                except (OSError, RuntimeError):
+                    signature.append(
+                        (source.value, _safe_signature_path(manifest_path), -1, -1)
+                    )
+                    continue
+                for path in discovery_paths:
+                    signature_path = _safe_signature_path(path)
+                    try:
+                        stat_result = path.stat()
+                        signature.append(
+                            (
+                                source.value,
+                                signature_path,
+                                stat_result.st_mtime_ns,
+                                stat_result.st_size,
+                            )
+                        )
+                    except OSError:
+                        signature.append((source.value, signature_path, -1, -1))
+        return tuple(signature)
+
+    def _iter_skill_manifest_paths(self, base_dir: Path) -> tuple[Path, ...]:
+        return tuple(
+            path
+            for path in sorted(base_dir.rglob("SKILL.md"))
+            if len(path.relative_to(base_dir).parts) <= self.max_depth + 1
+        )
+
+    @staticmethod
+    def _log_discovery_warnings(
+        *,
+        duplicate_warnings: list[_SkillDuplicateWarningEntry],
+        load_warnings: list[_SkillLoadWarningEntry],
+    ) -> None:
+        if duplicate_warnings:
+            samples = tuple(
+                (
+                    f"{name}: {previous_path} ({previous_source.value}) -> "
+                    f"{selected_path} ({selected_source.value})"
+                )
+                for (
+                    name,
+                    previous_path,
+                    previous_source,
+                    selected_path,
+                    selected_source,
+                ) in duplicate_warnings[:_DISCOVERY_WARNING_SAMPLE_LIMIT]
+            )
+            logger.info(
+                "Resolved %s duplicate skill definitions by source precedence. %s",
+                len(duplicate_warnings),
+                _format_discovery_warning_samples(
+                    samples=samples,
+                    total_count=len(duplicate_warnings),
+                ),
+            )
+        if load_warnings:
+            samples = tuple(
+                f"{path}: {message}"
+                for path, message in load_warnings[:_DISCOVERY_WARNING_SAMPLE_LIMIT]
+            )
+            logger.warning(
+                "Skipped %s invalid skill manifests during discovery. %s",
+                len(load_warnings),
+                _format_discovery_warning_samples(
+                    samples=samples,
+                    total_count=len(load_warnings),
+                ),
+            )
 
     def list_skills(self) -> list[Skill]:
         with self._lock:
@@ -211,7 +316,13 @@ class SkillsDirectory:
         body = "".join(lines[end_index + 1 :])
         return front_matter, body
 
-    def _load_skill(self, *, path: Path, source: SkillSource) -> Skill | None:
+    def _load_skill(
+        self,
+        *,
+        path: Path,
+        source: SkillSource,
+        load_warnings: list[_SkillLoadWarningEntry] | None = None,
+    ) -> Skill | None:
         with trace_span(
             logger,
             component="skills.discovery",
@@ -223,7 +334,8 @@ class SkillsDirectory:
                 front_matter, body = self._split_front_matter(raw)
                 data = _as_object_mapping(yaml.safe_load(front_matter))
             except Exception as exc:
-                logger.warning("Skipping %s due to parsing error: %s", path, exc)
+                if load_warnings is not None:
+                    load_warnings.append((path, str(exc)))
                 return None
 
             if data is None:
@@ -388,6 +500,42 @@ def _resolve_optional_path(base_dir: Path, value: object) -> Path | None:
     if not isinstance(value, str) or not value.strip():
         return None
     return base_dir / value
+
+
+def _safe_signature_path(path: Path) -> str:
+    try:
+        return path.resolve().as_posix()
+    except (OSError, RuntimeError):
+        return path.absolute().as_posix()
+
+
+def _iter_skill_discovery_paths(manifest_path: Path) -> tuple[Path, ...]:
+    skill_dir = manifest_path.parent
+    paths: list[Path] = [manifest_path]
+    for resource_dir_name in ("resources", "assets"):
+        resource_dir = skill_dir / resource_dir_name
+        if resource_dir.exists() and resource_dir.is_dir():
+            paths.extend(
+                path for path in sorted(resource_dir.glob("*")) if path.is_file()
+            )
+    scripts_dir = skill_dir / "scripts"
+    if scripts_dir.exists() and scripts_dir.is_dir():
+        paths.extend(sorted(scripts_dir.glob("*.py")))
+    return tuple(paths)
+
+
+def _format_discovery_warning_samples(
+    *,
+    samples: tuple[str, ...],
+    total_count: int,
+) -> str:
+    if not samples:
+        return "No examples available."
+    examples = "; ".join(samples)
+    omitted_count = total_count - len(samples)
+    if omitted_count <= 0:
+        return f"Examples: {examples}."
+    return f"Examples: {examples}; {omitted_count} more omitted."
 
 
 def _parse_frontmatter_hooks(value: object) -> HooksConfig:

--- a/tests/unit_tests/skills/test_discovery.py
+++ b/tests/unit_tests/skills/test_discovery.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import logging
+from os import stat_result
 from pathlib import Path
+
+import pytest
 
 from relay_teams.hooks.hook_models import HookEventName
 from relay_teams.hooks.hook_models import HooksConfig
@@ -447,6 +451,60 @@ def test_discover_uses_later_sources_to_override_duplicate_names(
     }
 
 
+def test_discover_aggregates_duplicate_skill_logs(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    first_dir = tmp_path / "first" / "skills"
+    second_dir = tmp_path / "second" / "skills"
+    third_dir = tmp_path / "third" / "skills"
+    _write_skill(
+        first_dir / "shared",
+        name="shared",
+        description="first shared skill",
+        instructions="Use the first shared skill.",
+    )
+    _write_skill(
+        second_dir / "shared",
+        name="shared",
+        description="second shared skill",
+        instructions="Use the second shared skill.",
+    )
+    _write_skill(
+        third_dir / "shared",
+        name="shared",
+        description="third shared skill",
+        instructions="Use the third shared skill.",
+    )
+    directory = SkillsDirectory(
+        sources=(
+            (SkillSource.USER_CODEX, first_dir),
+            (SkillSource.USER_CLAUDE, second_dir),
+            (SkillSource.USER_AGENTS, third_dir),
+        )
+    )
+
+    with caplog.at_level(
+        logging.INFO,
+        logger="relay_teams.backend.skills.discovery",
+    ):
+        directory.discover()
+        messages = [record.getMessage() for record in caplog.records]
+        caplog.clear()
+        directory.discover()
+        repeat_messages = [record.getMessage() for record in caplog.records]
+
+    assert any(
+        "Resolved 2 duplicate skill definitions by source precedence" in message
+        and "shared:" in message
+        and "user_claude" in message
+        and "user_agents" in message
+        for message in messages
+    )
+    assert all("Overriding duplicate skill" not in message for message in messages)
+    assert repeat_messages == []
+
+
 def test_default_scope_discovery_prefers_project_and_native_skill_sources(
     tmp_path: Path,
     monkeypatch,
@@ -720,6 +778,202 @@ def test_discover_skips_invalid_and_excessively_nested_skills(tmp_path: Path) ->
     assert tuple(skill.ref for skill in directory.list_skills()) == ("valid",)
     assert directory.get_skill("invalid") is None
     assert directory.get_skill("too-deep") is None
+
+
+def test_discover_aggregates_invalid_skill_warnings_and_skips_unchanged_scan(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir / "valid",
+        name="valid",
+        description="valid skill",
+        instructions="Use the valid skill.",
+    )
+    for index in range(6):
+        invalid_dir = skills_dir / f"invalid-{index}"
+        invalid_dir.mkdir(parents=True)
+        (invalid_dir / "SKILL.md").write_text("name: invalid\n", encoding="utf-8")
+    directory = SkillsDirectory(
+        sources=((SkillSource.USER_RELAY_TEAMS, skills_dir),),
+        max_depth=3,
+    )
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="relay_teams.backend.skills.discovery",
+    ):
+        directory.discover()
+        messages = [record.getMessage() for record in caplog.records]
+        caplog.clear()
+        directory.discover()
+        repeat_messages = [record.getMessage() for record in caplog.records]
+
+    assert tuple(skill.ref for skill in directory.list_skills()) == ("valid",)
+    assert any(
+        "Skipped 6 invalid skill manifests during discovery" in message
+        and "invalid-0" in message
+        and "1 more omitted" in message
+        for message in messages
+    )
+    assert all("due to parsing error" not in message for message in messages)
+    assert repeat_messages == []
+
+
+def test_discover_refreshes_cache_when_autodiscovered_resource_changes(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "valid"
+    _write_skill(
+        skill_dir,
+        name="valid",
+        description="valid skill",
+        instructions="Use the valid skill.",
+    )
+    directory = SkillsDirectory(
+        sources=((SkillSource.USER_RELAY_TEAMS, skills_dir),),
+        max_depth=3,
+    )
+
+    directory.discover()
+    first_skill = directory.get_skill("valid")
+
+    resources_dir = skill_dir / "resources"
+    resources_dir.mkdir()
+    (resources_dir / "usage.txt").write_text("Usage\n", encoding="utf-8")
+    directory.discover()
+    refreshed_skill = directory.get_skill("valid")
+
+    assert first_skill is not None
+    assert "usage.txt" not in first_skill.metadata.resources
+    assert refreshed_skill is not None
+    assert "usage.txt" in refreshed_skill.metadata.resources
+
+
+def test_discover_retries_when_manifest_read_fails_transiently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "valid"
+    _write_skill(
+        skill_dir,
+        name="valid",
+        description="valid skill",
+        instructions="Use the valid skill.",
+    )
+    manifest_path = skill_dir / "SKILL.md"
+    original_read_text = Path.read_text
+    failed_reads = 0
+
+    def flaky_read_text(
+        self: Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+    ) -> str:
+        nonlocal failed_reads
+        if self == manifest_path and failed_reads == 0:
+            failed_reads += 1
+            raise OSError("temporarily unavailable")
+        return original_read_text(self, encoding=encoding, errors=errors)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+    directory = SkillsDirectory(
+        sources=((SkillSource.USER_RELAY_TEAMS, skills_dir),),
+        max_depth=3,
+    )
+
+    directory.discover()
+    first_skill = directory.get_skill("valid")
+    directory.discover()
+    retried_skill = directory.get_skill("valid")
+
+    assert failed_reads == 1
+    assert first_skill is None
+    assert retried_skill is not None
+
+
+def test_discover_signature_tolerates_unresolvable_autodiscovered_script(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "valid"
+    scripts_dir = skill_dir / "scripts"
+    _write_skill(
+        skill_dir,
+        name="valid",
+        description="valid skill",
+        instructions="Use the valid skill.",
+    )
+    scripts_dir.mkdir()
+    script_path = scripts_dir / "loop.py"
+    script_path.write_text("print('loop')\n", encoding="utf-8")
+    original_stat = Path.stat
+    original_resolve = Path.resolve
+
+    def broken_stat(self: Path, *, follow_symlinks: bool = True) -> stat_result:
+        if self == script_path:
+            raise OSError("symlink loop")
+        return original_stat(self, follow_symlinks=follow_symlinks)
+
+    def loop_resolve(self: Path, strict: bool = False) -> Path:
+        if self == script_path:
+            raise RuntimeError("Symlink loop from loop.py")
+        return original_resolve(self, strict=strict)
+
+    monkeypatch.setattr(Path, "stat", broken_stat)
+    monkeypatch.setattr(Path, "resolve", loop_resolve)
+    directory = SkillsDirectory(
+        sources=((SkillSource.USER_RELAY_TEAMS, skills_dir),),
+        max_depth=3,
+    )
+
+    directory.discover()
+    skill = directory.get_skill("valid")
+
+    assert skill is not None
+    assert "scripts/loop.py" in skill.metadata.resources
+
+
+def test_discover_signature_scan_error_skips_only_that_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir / "valid",
+        name="valid",
+        description="valid skill",
+        instructions="Use the valid skill.",
+    )
+    bad_dir = skills_dir / "bad"
+    bad_dir.mkdir(parents=True)
+    bad_manifest = bad_dir / "SKILL.md"
+    bad_manifest.write_text("name: bad\n", encoding="utf-8")
+    original_iter_discovery_paths = discovery._iter_skill_discovery_paths
+
+    def broken_iter_discovery_paths(manifest_path: Path) -> tuple[Path, ...]:
+        if manifest_path == bad_manifest:
+            raise PermissionError("resources unavailable")
+        return original_iter_discovery_paths(manifest_path)
+
+    monkeypatch.setattr(
+        discovery,
+        "_iter_skill_discovery_paths",
+        broken_iter_discovery_paths,
+    )
+    directory = SkillsDirectory(
+        sources=((SkillSource.USER_RELAY_TEAMS, skills_dir),),
+        max_depth=3,
+    )
+
+    directory.discover()
+
+    assert directory.get_skill("valid") is not None
+    assert directory.get_skill("bad") is None
 
 
 def test_discover_keeps_skill_when_one_frontmatter_hook_group_is_empty(

--- a/tests/unit_tests/skills/test_skill_registry.py
+++ b/tests/unit_tests/skills/test_skill_registry.py
@@ -446,15 +446,29 @@ def test_skills_directory_discover_replaces_skill_cache_atomically(
     )
     directory = _skills_directory(tmp_path / "skills")
     directory.discover()
+    alpha_manifest = tmp_path / "skills" / "alpha" / "SKILL.md"
+    alpha_manifest.write_text(
+        f"{alpha_manifest.read_text(encoding='utf-8')}\n",
+        encoding="utf-8",
+    )
     original_load_skill = directory._load_skill
     load_started = threading.Event()
     allow_continue = threading.Event()
 
-    def blocking_load_skill(*, path: Path, source: SkillSource):
+    def blocking_load_skill(
+        *,
+        path: Path,
+        source: SkillSource,
+        load_warnings: list[tuple[Path, str]] | None = None,
+    ):
         if path.parent.name == "alpha":
             load_started.set()
             assert allow_continue.wait(timeout=5)
-        return original_load_skill(path=path, source=source)
+        return original_load_skill(
+            path=path,
+            source=source,
+            load_warnings=load_warnings,
+        )
 
     directory._load_skill = blocking_load_skill
     worker = threading.Thread(target=directory.discover)


### PR DESCRIPTION
﻿## Summary
- cache skill discovery by `SKILL.md` path/mtime/size signatures so repeated role/session/UI reads do not re-parse unchanged skills
- aggregate invalid skill manifest warnings into a single sampled warning per changed discovery scan
- aggregate duplicate skill precedence messages into a single info log instead of one warning per duplicate

## Validation
- uv run --extra dev pytest -q tests/unit_tests/skills/test_discovery.py tests/unit_tests/skills/test_skill_registry.py
- uv run --extra dev pytest -q tests/unit_tests/skills tests/unit_tests/interfaces/server/test_roles_router.py tests/unit_tests/interfaces/server/test_container.py
- uv run --extra dev ruff check --fix src/relay_teams/skills/discovery.py tests/unit_tests/skills/test_discovery.py tests/unit_tests/skills/test_skill_registry.py
- uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/skills/discovery.py tests/unit_tests/skills/test_discovery.py tests/unit_tests/skills/test_skill_registry.py
- uv run --extra dev basedpyright

Closes #544
