### PR TITLE
Fix system reminder completion retry handling

### DIFF
--- a/src/relay_teams/agents/execution/message_repository.py
+++ b/src/relay_teams/agents/execution/message_repository.py
@@ -34,6 +34,7 @@ from relay_teams.sessions.session_history_marker_models import SessionHistoryMar
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )
+from relay_teams.system_reminder_text import is_rendered_system_reminder_text
 
 
 class MessageRepository(SharedSqliteRepository):
@@ -237,6 +238,8 @@ class MessageRepository(SharedSqliteRepository):
         for row in rows:
             msg_list = _load_message_list(str(row["message_json"]))
             msg = msg_list[0] if msg_list and isinstance(msg_list[0], dict) else {}
+            if _is_system_reminder_projection_message(msg):
+                continue
             results.append(
                 {
                     "conversation_id": str(row["conversation_id"] or ""),
@@ -280,6 +283,8 @@ class MessageRepository(SharedSqliteRepository):
         for row in rows:
             msg_list = _load_message_list(str(row["message_json"]))
             msg = msg_list[0] if msg_list and isinstance(msg_list[0], dict) else {}
+            if _is_system_reminder_projection_message(msg):
+                continue
             results.append(
                 {
                     "conversation_id": str(row["conversation_id"] or ""),
@@ -352,6 +357,8 @@ class MessageRepository(SharedSqliteRepository):
         for row in rows:
             msg_list = _load_message_list(str(row["message_json"]))
             msg = msg_list[0] if msg_list and isinstance(msg_list[0], dict) else {}
+            if _is_system_reminder_projection_message(msg):
+                continue
             results.append(
                 {
                     "conversation_id": str(row["conversation_id"] or ""),
@@ -1133,6 +1140,27 @@ def _extract_repeatable_user_prompt(message: object) -> str | None:
     return user_prompt_content_key(
         prompt_chunks[0] if len(prompt_chunks) == 1 else prompt_chunks
     )
+
+
+def _is_system_reminder_projection_message(message: object) -> bool:
+    if not isinstance(message, dict):
+        return False
+    parts = message.get("parts")
+    if not isinstance(parts, list) or not parts:
+        return False
+    for part in parts:
+        if not isinstance(part, dict):
+            return False
+        if str(part.get("part_kind") or "") != "user-prompt":
+            return False
+        content = user_prompt_content_to_text(part.get("content"))
+        if not _is_system_reminder_text(content):
+            return False
+    return True
+
+
+def _is_system_reminder_text(content: object) -> bool:
+    return is_rendered_system_reminder_text(str(content or ""))
 
 
 def _truncate_message_rows_to_safe_boundary(

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -36,6 +36,7 @@ from relay_teams.providers.llm_retry import extract_retry_error_info
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_stream import publish_run_event_async
+from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
 from relay_teams.tools.runtime.context import ToolDeps
@@ -379,6 +380,59 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                     coordination_agent = cast(CoordinationAgent, agent)
                 else:
                     history = persisted_history
+            startup_injections = (
+                self._injection_manager.drain_system_reminders_at_start(
+                    request.run_id, request.instance_id
+                )
+                if isinstance(self._injection_manager, RunInjectionManager)
+                else ()
+            )
+            if startup_injections:
+                startup_injection_appended = False
+                for msg in startup_injections:
+                    await publish_run_event_async(
+                        self._run_event_hub,
+                        RunEvent(
+                            session_id=request.session_id,
+                            run_id=request.run_id,
+                            trace_id=request.trace_id,
+                            task_id=request.task_id,
+                            instance_id=request.instance_id,
+                            role_id=request.role_id,
+                            event_type=RunEventType.INJECTION_APPLIED,
+                            payload_json=msg.model_dump_json(),
+                        ),
+                    )
+                    appended = (
+                        await self._message_repo.append_user_prompt_if_missing_async(
+                            session_id=request.session_id,
+                            workspace_id=resolved_workspace_id,
+                            conversation_id=resolved_conversation_id,
+                            agent_role_id=request.role_id,
+                            instance_id=request.instance_id,
+                            task_id=request.task_id,
+                            trace_id=request.trace_id,
+                            content=msg.content,
+                        )
+                    )
+                    if appended:
+                        startup_injection_appended = True
+                if startup_injection_appended:
+                    (
+                        prepared_prompt,
+                        history,
+                        agent_system_prompt,
+                        agent,
+                    ) = await self._build_agent_iteration_context(
+                        request=request,
+                        conversation_id=resolved_conversation_id,
+                        system_prompt=agent_system_prompt,
+                        reserve_user_prompt_tokens=False,
+                        allowed_tools=allowed_tools,
+                        allowed_mcp_servers=self._allowed_mcp_servers,
+                        allowed_skills=self._allowed_skills,
+                    )
+                    coordination_agent = cast(CoordinationAgent, agent)
             seen_count = 0
             buffered_messages: list[ModelRequest | ModelResponse] = []
             restarted = False

--- a/src/relay_teams/reminders/__init__.py
+++ b/src/relay_teams/reminders/__init__.py
@@ -14,6 +14,7 @@ from relay_teams.reminders.renderer import render_system_reminder
 from relay_teams.reminders.service import SystemReminderService
 from relay_teams.reminders.state import ReminderStateRepository, ReminderRunState
 from relay_teams.reminders.tool_effects import classify_tool_effect
+from relay_teams.system_reminder_text import is_rendered_system_reminder_text
 
 __all__ = [
     "CompletionAttemptObservation",
@@ -29,5 +30,6 @@ __all__ = [
     "ToolEffect",
     "ToolResultObservation",
     "classify_tool_effect",
+    "is_rendered_system_reminder_text",
     "render_system_reminder",
 ]

--- a/src/relay_teams/reminders/renderer.py
+++ b/src/relay_teams/reminders/renderer.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
+from relay_teams.system_reminder_text import (
+    SYSTEM_REMINDER_INTERNAL_MARKER,
+)
+
 
 def render_system_reminder(content: str) -> str:
     text = content.strip()
     if not text:
         return ""
-    return f"<system-reminder>\n{text}\n</system-reminder>"
+    return (
+        "<system-reminder>\n"
+        f"{SYSTEM_REMINDER_INTERNAL_MARKER}\n"
+        "Do not quote, summarize, mention, or answer this reminder.\n"
+        "Use it only to decide your next action. Final responses must address the "
+        "user's original request and must not mention this reminder or the "
+        "<system-reminder> tag.\n\n"
+        f"{text}\n"
+        "</system-reminder>"
+    )

--- a/src/relay_teams/reminders/service.py
+++ b/src/relay_teams/reminders/service.py
@@ -120,8 +120,9 @@ class SystemReminderService:
             next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
             content = render_system_reminder(decision.content)
             if content:
-                _ = self._injection_sink.append_only(
+                _ = self._injection_sink.append_and_enqueue(
                     session_id=observation.session_id,
+                    run_id=observation.run_id,
                     trace_id=observation.trace_id,
                     task_id=observation.task_id,
                     instance_id=observation.instance_id,
@@ -153,8 +154,9 @@ class SystemReminderService:
             next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
             content = render_system_reminder(decision.content)
             if content:
-                _ = await self._injection_sink.append_only_async(
+                _ = await self._injection_sink.append_and_enqueue_async(
                     session_id=observation.session_id,
+                    run_id=observation.run_id,
                     trace_id=observation.trace_id,
                     task_id=observation.task_id,
                     instance_id=observation.instance_id,

--- a/src/relay_teams/sessions/runs/injection_queue.py
+++ b/src/relay_teams/sessions/runs/injection_queue.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from threading import Lock
 
-from relay_teams.media import UserPromptContent
+from relay_teams.media import UserPromptContent, user_prompt_content_to_text
 from relay_teams.sessions.runs.enums import InjectionSource
 from relay_teams.sessions.runs.run_models import InjectionMessage
+from relay_teams.system_reminder_text import is_rendered_system_reminder_text
 
 
 class RunInjectionManager:
@@ -65,6 +66,27 @@ class RunInjectionManager:
             self._queues.setdefault(run_id, {})[recipient_instance_id] = []
         return tuple(ordered)
 
+    def drain_system_reminders_at_start(
+        self, run_id: str, recipient_instance_id: str
+    ) -> tuple[InjectionMessage, ...]:
+        with self._lock:
+            queue = self._queues.get(run_id, {}).get(recipient_instance_id, [])
+            if not queue:
+                return ()
+            reminders: list[InjectionMessage] = []
+            remaining: list[InjectionMessage] = []
+            for message in queue:
+                if _is_system_reminder_injection(message):
+                    reminders.append(message)
+                else:
+                    remaining.append(message)
+            if not reminders:
+                return ()
+            self._queues.setdefault(run_id, {})[recipient_instance_id] = remaining
+        return tuple(
+            sorted(reminders, key=lambda item: (item.priority, item.created_at))
+        )
+
 
 def _priority_for(source: InjectionSource) -> int:
     if source == InjectionSource.SYSTEM:
@@ -72,3 +94,10 @@ def _priority_for(source: InjectionSource) -> int:
     if source == InjectionSource.USER:
         return 1
     return 2
+
+
+def _is_system_reminder_injection(message: InjectionMessage) -> bool:
+    if message.source != InjectionSource.SYSTEM:
+        return False
+    text = user_prompt_content_to_text(message.content).strip()
+    return is_rendered_system_reminder_text(text)

--- a/src/relay_teams/system_reminder_text.py
+++ b/src/relay_teams/system_reminder_text.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+SYSTEM_REMINDER_INTERNAL_MARKER = (
+    "This is an internal runtime reminder for you to consider silently."
+)
+
+
+def is_rendered_system_reminder_text(content: str) -> bool:
+    text = content.strip()
+    return (
+        text.startswith("<system-reminder>")
+        and text.endswith("</system-reminder>")
+        and SYSTEM_REMINDER_INTERNAL_MARKER in text
+    )

--- a/tests/unit_tests/agents/execution/test_message_repository.py
+++ b/tests/unit_tests/agents/execution/test_message_repository.py
@@ -14,7 +14,11 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
-from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.agents.execution.message_repository import (
+    MessageRepository,
+    _is_system_reminder_projection_message,
+)
+from relay_teams.reminders import render_system_reminder
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )
@@ -121,6 +125,84 @@ def test_message_repo_hides_duplicate_task_objective_messages(tmp_path: Path) ->
     messages = repo.get_messages_by_session("session-1")
 
     assert len(messages) == 1
+
+
+def test_message_repo_filters_system_reminders_from_public_message_reads(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "message_repo_system_reminder.db"
+    repo = MessageRepository(db_path)
+    reminder = render_system_reminder("Check todos.")
+    repo.append(
+        session_id="session-1",
+        workspace_id="default",
+        conversation_id="conversation-1",
+        agent_role_id="time",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        messages=[ModelRequest(parts=[UserPromptPart(content="query time")])],
+    )
+    repo.append_user_prompt_if_missing(
+        session_id="session-1",
+        workspace_id="default",
+        conversation_id="conversation-1",
+        agent_role_id="time",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        content=reminder,
+    )
+
+    session_messages = repo.get_messages_by_session("session-1")
+    user_messages = repo.get_user_messages_by_session("session-1")
+    instance_messages = repo.get_messages_for_instance("session-1", "inst-1")
+    history = repo.get_history_for_conversation("conversation-1")
+
+    assert len(session_messages) == 1
+    assert len(user_messages) == 1
+    assert len(instance_messages) == 1
+    assert len(history) == 2
+    assert isinstance(history[-1], ModelRequest)
+    assert history[-1].parts[0].content == reminder
+
+
+def test_message_repo_keeps_user_authored_system_reminder_wrappers(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "message_repo_user_system_reminder.db"
+    repo = MessageRepository(db_path)
+    content = "<system-reminder>\nQuoted docs.\n</system-reminder>"
+    repo.append(
+        session_id="session-1",
+        workspace_id="default",
+        conversation_id="conversation-1",
+        agent_role_id="time",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        messages=[ModelRequest(parts=[UserPromptPart(content=content)])],
+    )
+
+    messages = repo.get_messages_by_session("session-1")
+    message = messages[0]["message"]
+
+    assert len(messages) == 1
+    assert isinstance(message, dict)
+    parts = message["parts"]
+    assert isinstance(parts, list)
+    first_part = parts[0]
+    assert isinstance(first_part, dict)
+    assert first_part.get("content") == content
+
+
+def test_system_reminder_projection_filter_rejects_non_prompt_shapes() -> None:
+    assert not _is_system_reminder_projection_message(object())
+    assert not _is_system_reminder_projection_message({"parts": []})
+    assert not _is_system_reminder_projection_message({"parts": [object()]})
+    assert not _is_system_reminder_projection_message(
+        {"parts": [{"part_kind": "system-prompt", "content": "system"}]}
+    )
 
 
 def test_append_user_prompt_if_missing_dedupes_only_tail_prompt(tmp_path: Path) -> None:

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -10,7 +10,7 @@ from typing import cast
 
 import pytest
 import pytest_asyncio
-from pydantic_ai.messages import ModelRequest, UserPromptPart
+from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelRequest, UserPromptPart
 
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.agents.execution.system_prompts import RuntimePromptBuilder
@@ -494,10 +494,12 @@ async def test_execute_retries_root_completion_when_todos_are_incomplete(
 
     refreshed = task_repo.get("task-1")
     messages = message_repo.get_messages_for_instance("session-1", instance.instance_id)
-    serialized_messages = json.dumps(messages, ensure_ascii=False)
+    history = message_repo.get_history_for_conversation(instance.conversation_id)
+    serialized_messages = ModelMessagesTypeAdapter.dump_json(history).decode()
     assert provider.calls == 2
     assert result.output == "ok-2"
     assert refreshed.status == TaskStatus.COMPLETED
+    assert "<system-reminder>" not in json.dumps(messages, ensure_ascii=False)
     assert "<system-reminder>" in serialized_messages
     assert "finish verification" in serialized_messages
 

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -61,11 +61,12 @@ from relay_teams.providers.model_config import (
     ModelModalityMatrix,
     SamplingConfig,
 )
+from relay_teams.reminders import render_system_reminder
 from relay_teams.roles import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
-from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_models import RunEvent
@@ -1135,6 +1136,82 @@ async def test_generate_recomputes_budget_after_injection_restart(
     assert isinstance(first_budget, int)
     assert isinstance(second_budget, int)
     assert second_budget < first_budget
+
+
+@pytest.mark.asyncio
+async def test_generate_persists_startup_system_reminders_before_first_agent_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "startup_system_reminder.db",
+        fake_hub,
+    )
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-startup-reminder")
+    reminder = render_system_reminder("Finish pending todos.")
+    _ = injection_manager.enqueue(
+        "run-startup-reminder",
+        "inst-startup-reminder",
+        InjectionSource.SYSTEM,
+        reminder,
+    )
+    provider._session._injection_manager = injection_manager
+
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(parts=[TextPart(content="ok")]),
+                    messages=[ModelResponse(parts=[TextPart(content="ok")])],
+                ),
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+
+    request = LLMRequest(
+        run_id="run-startup-reminder",
+        trace_id="trace-startup-reminder",
+        task_id="task-startup-reminder",
+        session_id="session-startup-reminder",
+        workspace_id="default",
+        instance_id="inst-startup-reminder",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="start",
+    )
+
+    response = await provider.generate(request)
+    history = message_repo.get_history_for_conversation(
+        build_conversation_id("session-startup-reminder", "Coordinator")
+    )
+
+    assert response == "ok"
+    assert len(scripted_agent.histories) == 1
+    agent_history = cast(
+        list[ModelRequest | ModelResponse], scripted_agent.histories[0]
+    )
+    assert isinstance(agent_history[-1], ModelRequest)
+    assert agent_history[-1].parts[0].content == reminder
+    assert isinstance(history[-2], ModelRequest)
+    assert history[-2].parts[0].content == reminder
+    assert (
+        injection_manager.drain_at_boundary(
+            "run-startup-reminder", "inst-startup-reminder"
+        )
+        == ()
+    )
+    event_types = [event.event_type for event in fake_hub.events]
+    assert RunEventType.INJECTION_APPLIED in event_types
+    assert RunEventType.TOKEN_USAGE in event_types
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/reminders/test_renderer.py
+++ b/tests/unit_tests/reminders/test_renderer.py
@@ -5,7 +5,14 @@ from relay_teams.reminders import render_system_reminder
 
 def test_render_system_reminder_wraps_content() -> None:
     assert render_system_reminder(" Pay attention. ") == (
-        "<system-reminder>\nPay attention.\n</system-reminder>"
+        "<system-reminder>\n"
+        "This is an internal runtime reminder for you to consider silently.\n"
+        "Do not quote, summarize, mention, or answer this reminder.\n"
+        "Use it only to decide your next action. Final responses must address the "
+        "user's original request and must not mention this reminder or the "
+        "<system-reminder> tag.\n\n"
+        "Pay attention.\n"
+        "</system-reminder>"
     )
 
 

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -36,6 +36,7 @@ class _CapturingSink:
 
     def append_and_enqueue(self, **kwargs: object) -> SystemInjectionResult:
         self.appended.append(str(kwargs["content"]))
+        self.enqueued.append(str(kwargs["content"]))
         return SystemInjectionResult(appended=True, enqueued=True)
 
     def append_only(self, **kwargs: object) -> SystemInjectionResult:
@@ -49,6 +50,11 @@ class _CapturingSink:
     async def append_only_async(self, **kwargs: object) -> SystemInjectionResult:
         self.appended.append(str(kwargs["content"]))
         return SystemInjectionResult(appended=True)
+
+    async def append_and_enqueue_async(self, **kwargs: object) -> SystemInjectionResult:
+        self.appended.append(str(kwargs["content"]))
+        self.enqueued.append(str(kwargs["content"]))
+        return SystemInjectionResult(appended=True, enqueued=True)
 
 
 class _FailingStateRepository(ReminderStateRepository):
@@ -149,8 +155,9 @@ def test_service_appends_completion_retry_reminder(tmp_path: Path) -> None:
 
     assert decision.retry_completion is True
     assert len(sink.appended) == 1
-    assert sink.enqueued == []
+    assert len(sink.enqueued) == 1
     assert "finish tests" in sink.appended[0]
+    assert sink.enqueued[0] == sink.appended[0]
 
 
 def test_service_enqueues_context_pressure_reminder(tmp_path: Path) -> None:
@@ -364,8 +371,9 @@ async def test_service_async_appends_completion_retry_reminder(
 
     assert decision.retry_completion is True
     assert len(sink.appended) == 1
-    assert sink.enqueued == []
+    assert len(sink.enqueued) == 1
     assert "finish tests" in sink.appended[0]
+    assert sink.enqueued[0] == sink.appended[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_injection_queue.py
+++ b/tests/unit_tests/sessions/runs/test_injection_queue.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 from pydantic_ai.messages import ImageUrl
 
 from relay_teams.media import user_prompt_content_to_text
+from relay_teams.reminders import render_system_reminder
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.enums import InjectionSource
 from relay_teams.sessions.runs.run_models import InjectionMessage
@@ -61,6 +62,48 @@ def test_injection_manager_preserves_structured_prompt_content() -> None:
     assert user_prompt_content_to_text(injected[0].content) == (
         "inspect this image\n\n[image: file]"
     )
+
+
+def test_injection_manager_drains_system_reminders_at_start_only() -> None:
+    mgr = RunInjectionManager()
+    mgr.activate("run1")
+    reminder = render_system_reminder("Check todos.")
+
+    mgr.enqueue("run1", "a1", InjectionSource.USER, "follow up")
+    mgr.enqueue("run1", "a1", InjectionSource.SYSTEM, reminder)
+    mgr.enqueue("run1", "a1", InjectionSource.SYSTEM, "plain system note")
+    mgr.enqueue(
+        "run1",
+        "a1",
+        InjectionSource.SYSTEM,
+        "<system-reminder>\nUser-authored wrapper.\n</system-reminder>",
+    )
+
+    startup = mgr.drain_system_reminders_at_start("run1", "a1")
+    remaining = mgr.drain_at_boundary("run1", "a1")
+
+    assert [message.content for message in startup] == [reminder]
+    assert [message.content for message in remaining] == [
+        "plain system note",
+        "<system-reminder>\nUser-authored wrapper.\n</system-reminder>",
+        "follow up",
+    ]
+
+
+def test_injection_manager_startup_drain_returns_empty_without_runtime_reminders() -> (
+    None
+):
+    mgr = RunInjectionManager()
+    mgr.activate("run1")
+
+    assert mgr.drain_system_reminders_at_start("run1", "a1") == ()
+
+    mgr.enqueue("run1", "a1", InjectionSource.SYSTEM, "plain system note")
+
+    assert mgr.drain_system_reminders_at_start("run1", "a1") == ()
+    assert [message.content for message in mgr.drain_at_boundary("run1", "a1")] == [
+        "plain system note"
+    ]
 
 
 def test_injection_message_serializes_structured_prompt_content() -> None:


### PR DESCRIPTION
## Summary
- Route completion-retry system reminders through append-and-enqueue so the retry turn is queued consistently.
- Mark rendered system reminders as internal/silent model context and filter pure reminder messages from public message projections.
- Drain queued system reminders at the start of the retry call so they are persisted for model history without later surfacing as normal injections.

Fixes #529.

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests/sessions/runs/test_injection_queue.py tests/unit_tests/reminders tests/unit_tests/agents/execution/test_message_repository.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_recomputes_budget_after_injection_restart tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_defers_injection_restart_until_pending_tool_call_completes
- uv run --extra dev pytest --timeout=60 -q tests/unit_tests/agents/orchestration/test_task_execution_service.py::test_execute_retries_root_completion_when_todos_are_incomplete