### PR TITLE
Fix CodeAgent SSO verification state

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -286,7 +286,7 @@ For a small set of known provider/model pairs, the backend also applies a built-
 
 Verifies whether a saved CodeAgent profile still has a usable SSO session.
 The request body is `{ "profile_name": "<saved profile name>" }`.
-The backend only accepts saved `codeagent` profiles for this endpoint and performs a forced token refresh check against the saved credentials.
+The backend only accepts saved `codeagent` profiles for this endpoint. It validates the saved session by making a lightweight authenticated CodeAgent request with the currently available token, and only forces a refresh when the first authenticated request comes back `401/403`.
 
 The response shape is:
 
@@ -294,7 +294,7 @@ The response shape is:
 - `checked_at`
 - optional `detail`
 
-`reauth_required` means the saved CodeAgent refresh path is no longer accepted upstream and the user must sign in again. The persisted `codeagent_auth.has_refresh_token` flag still means saved credentials exist; it does not mean the current session has already been verified.
+`reauth_required` means the saved session can no longer complete an authenticated CodeAgent request, including one retry through the refresh path, and the user must sign in again. The persisted `codeagent_auth.has_refresh_token` flag still means saved credentials exist; it does not mean the current session has already been verified.
 
 ### `POST /system/configs/model:reload`
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -282,6 +282,20 @@ When the provider exposes per-model context-limit metadata in the catalog payloa
 The settings UI uses `model_entries[].context_window` to auto-fill the profile context window field after model discovery. Providers that return only model ids will still populate `models[]`, but `context_window` remains user-specified.
 For a small set of known provider/model pairs, the backend also applies a built-in context-window fallback when the provider returns only model ids.
 
+### `POST /system/configs/model/codeagent/auth:verify`
+
+Verifies whether a saved CodeAgent profile still has a usable SSO session.
+The request body is `{ "profile_name": "<saved profile name>" }`.
+The backend only accepts saved `codeagent` profiles for this endpoint and performs a forced token refresh check against the saved credentials.
+
+The response shape is:
+
+- `status`: `valid`, `reauth_required`, or `error`
+- `checked_at`
+- optional `detail`
+
+`reauth_required` means the saved CodeAgent refresh path is no longer accepted upstream and the user must sign in again. The persisted `codeagent_auth.has_refresh_token` flag still means saved credentials exist; it does not mean the current session has already been verified.
+
 ### `POST /system/configs/model:reload`
 
 Reloads model config into runtime.

--- a/docs/codeagent-provider-design.md
+++ b/docs/codeagent-provider-design.md
@@ -167,3 +167,19 @@ CodeAgent OAuth 和 API 参数均由后端硬编码值决定。
 
 外部 CodeAgent 网络连通性依赖运行环境，因此浏览器验证只要求前端流程和本地 API
 请求/响应结构正确。
+
+## 持久化登录态与校验
+
+保存后的 `codeagent_auth.has_refresh_token` 仅表示本地已保存过 CodeAgent SSO 凭据，不表示当前登录态已经过实时校验。
+
+设置页编辑已保存的 CodeAgent profile 时，前端会调用：
+
+- `POST /api/system/configs/model/codeagent/auth:verify`
+
+该接口只接受已保存的 CodeAgent profile 名称，并强制执行一次 refresh 校验：
+
+- `status = "valid"`：refresh 仍可用，可显示为已登录
+- `status = "reauth_required"`：refresh 已被上游拒绝，需要重新 SSO 登录
+- `status = "error"`：网络或上游异常，无法确认当前登录状态
+
+运行时 chat / model discovery 仍保持原有的按需 refresh 机制；新增接口只用于设置页区分“保存过凭据”和“当前鉴权已验证”这两个状态。

--- a/frontend/dist/css/components/settings.css
+++ b/frontend/dist/css/components/settings.css
@@ -2342,6 +2342,7 @@
 .codeagent-sso-login-btn {
     width: auto;
     min-width: 0;
+    min-height: 42px;
     max-width: 100%;
     white-space: nowrap;
 }
@@ -3379,6 +3380,10 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
     font-size: 0.76rem;
     font-weight: 500;
     line-height: 1.2;
+}
+
+.settings-list-action.codeagent-sso-login-btn {
+    min-height: 42px;
 }
 
 .settings-list-action:hover {

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -14,6 +14,7 @@ import {
     reloadModelConfig,
     saveModelProfile,
     startCodeAgentOAuth,
+    verifyCodeAgentAuth,
 } from '../../core/api.js';
 import { showConfirmDialog, showToast } from '../../utils/feedback.js';
 import { t } from '../../utils/i18n.js';
@@ -980,10 +981,18 @@ function handleEditProfile(name) {
     const codeagentAuth = profile.codeagent_auth || {};
     draftCodeAgentAuthState = {
         authSessionId: '',
-        completed: Boolean(codeagentAuth.has_refresh_token),
+        completed: false,
+        verified: false,
+        verifying: false,
+        reauthRequired: false,
         hasPersistedAccessToken: Boolean(codeagentAuth.has_access_token),
         hasPersistedRefreshToken: Boolean(codeagentAuth.has_refresh_token),
-        statusMessage: Boolean(codeagentAuth.has_refresh_token) ? 'Signed in' : 'Not signed in',
+        loginInProgress: false,
+        pendingAuthorizationUrl: '',
+        verificationRequestId: 0,
+        statusMessage: Boolean(codeagentAuth.has_refresh_token)
+            ? 'Saved sign-in requires verification'
+            : 'Not signed in',
     };
     document.getElementById('profile-is-default').checked = profile.is_default === true;
     document.getElementById('profile-temperature').value = profile.temperature || 0.7;
@@ -1022,6 +1031,9 @@ function handleEditProfile(name) {
     setModelMenuOpen(false);
     if (draftProviderMode === PROVIDER_MODES.EXTERNAL) {
         void loadModelCatalogForNewProfile();
+    }
+    if (isCodeAgentProvider(profile.provider) && Boolean(codeagentAuth.has_refresh_token)) {
+        void verifyPersistedCodeAgentAuth(name);
     }
 }
 
@@ -1271,6 +1283,9 @@ async function handleTestDraftProfile() {
 
     try {
         const result = await probeModelConnection(payload);
+        if (isCodeAgentAuthInvalidResult(result)) {
+            markCodeAgentAuthReauthRequired();
+        }
         draftProbeState = buildProbeState(result);
     } catch (e) {
         draftProbeState = {
@@ -1321,6 +1336,9 @@ async function handleDiscoverDraftModels() {
     try {
         const result = await discoverModelCatalog(payload);
         if (!result.ok) {
+            if (isCodeAgentAuthInvalidResult(result)) {
+                markCodeAgentAuthReauthRequired();
+            }
             draftDiscoveredModels = [];
             draftModelDiscoveryState = {
                 status: 'failed',
@@ -1363,6 +1381,8 @@ async function handleCodeAgentLogin() {
     }
     const authPopup = openCodeAgentAuthorizationPopup();
     draftCodeAgentAuthState.loginInProgress = true;
+    draftCodeAgentAuthState.verifying = false;
+    draftCodeAgentAuthState.reauthRequired = false;
     draftCodeAgentAuthState.statusMessage = 'Starting SSO login';
     renderDraftCodeAgentAuthState();
     try {
@@ -1414,6 +1434,8 @@ async function continueCodeAgentLogin() {
     }
     draftCodeAgentAuthState.pendingAuthorizationUrl = '';
     draftCodeAgentAuthState.loginInProgress = true;
+    draftCodeAgentAuthState.verifying = false;
+    draftCodeAgentAuthState.reauthRequired = false;
     draftCodeAgentAuthState.statusMessage = 'Waiting for SSO callback';
     renderDraftCodeAgentAuthState();
     try {
@@ -1476,6 +1498,9 @@ async function pollCodeAgentOAuthSession(authSessionId) {
             return;
         }
         draftCodeAgentAuthState.completed = true;
+        draftCodeAgentAuthState.verified = true;
+        draftCodeAgentAuthState.verifying = false;
+        draftCodeAgentAuthState.reauthRequired = false;
         draftCodeAgentAuthState.hasPersistedAccessToken = true;
         draftCodeAgentAuthState.hasPersistedRefreshToken = true;
         draftCodeAgentAuthState.statusMessage = 'Signed in';
@@ -1487,6 +1512,71 @@ async function pollCodeAgentOAuthSession(authSessionId) {
     }
     draftCodeAgentAuthState.statusMessage = 'SSO login timed out';
     renderDraftCodeAgentAuthState();
+}
+
+async function verifyPersistedCodeAgentAuth(profileName) {
+    const normalizedProfileName = String(profileName || '').trim();
+    if (!normalizedProfileName || !isCodeAgentProvider(getDraftProvider())) {
+        return;
+    }
+    if (editingProfile !== normalizedProfileName || !draftCodeAgentAuthState.hasPersistedRefreshToken) {
+        return;
+    }
+    const verificationRequestId = Number(draftCodeAgentAuthState.verificationRequestId || 0) + 1;
+    draftCodeAgentAuthState.verificationRequestId = verificationRequestId;
+    draftCodeAgentAuthState.verified = false;
+    draftCodeAgentAuthState.verifying = true;
+    draftCodeAgentAuthState.reauthRequired = false;
+    draftCodeAgentAuthState.statusMessage = 'Verifying saved sign-in';
+    renderDraftCodeAgentAuthState();
+
+    try {
+        const result = await verifyCodeAgentAuth(normalizedProfileName);
+        if (!isActiveCodeAgentVerification(normalizedProfileName, verificationRequestId)) {
+            return;
+        }
+        draftCodeAgentAuthState.verifying = false;
+        if (result.status === 'valid') {
+            draftCodeAgentAuthState.verified = true;
+            draftCodeAgentAuthState.reauthRequired = false;
+            draftCodeAgentAuthState.statusMessage = 'Signed in';
+            renderDraftCodeAgentAuthState();
+            return;
+        }
+        if (result.status === 'reauth_required') {
+            markCodeAgentAuthReauthRequired();
+            return;
+        }
+        draftCodeAgentAuthState.statusMessage = result.detail || 'Saved sign-in could not be verified';
+    } catch (e) {
+        if (!isActiveCodeAgentVerification(normalizedProfileName, verificationRequestId)) {
+            return;
+        }
+        draftCodeAgentAuthState.verifying = false;
+        draftCodeAgentAuthState.statusMessage = `SSO failed: ${e.message}`;
+    }
+    renderDraftCodeAgentAuthState();
+}
+
+function isActiveCodeAgentVerification(profileName, verificationRequestId) {
+    return (
+        isCodeAgentProvider(getDraftProvider())
+        && editingProfile === profileName
+        && Number(draftCodeAgentAuthState.verificationRequestId || 0) === verificationRequestId
+    );
+}
+
+function markCodeAgentAuthReauthRequired() {
+    draftCodeAgentAuthState.completed = false;
+    draftCodeAgentAuthState.verified = false;
+    draftCodeAgentAuthState.verifying = false;
+    draftCodeAgentAuthState.reauthRequired = true;
+    draftCodeAgentAuthState.statusMessage = 'Saved sign-in expired. Sign in with SSO again';
+    renderDraftCodeAgentAuthState();
+}
+
+function isCodeAgentAuthInvalidResult(result) {
+    return result && result.error_code === 'auth_invalid';
 }
 
 function buildDraftProbePayload() {
@@ -1522,6 +1612,14 @@ function buildDraftProbePayload() {
             return null;
         }
     } else if (isCodeAgentProvider(provider)) {
+        if (draftCodeAgentAuthState.reauthRequired) {
+            draftProbeState = {
+                status: 'failed',
+                message: 'SSO login expired. Sign in with SSO again before testing a CodeAgent profile.',
+            };
+            renderDraftProbeState();
+            return null;
+        }
         if (!hasDraftCodeAgentAuth()) {
             draftProbeState = {
                 status: 'failed',
@@ -1601,6 +1699,16 @@ function buildDraftModelDiscoveryPayload() {
             return null;
         }
     } else if (isCodeAgentProvider(provider)) {
+        if (draftCodeAgentAuthState.reauthRequired) {
+            draftDiscoveredModels = [];
+            draftModelDiscoveryState = {
+                status: 'failed',
+                message: 'SSO login expired. Sign in with SSO again before fetching CodeAgent models.',
+            };
+            renderDiscoveredModels();
+            renderDraftModelDiscoveryState();
+            return null;
+        }
         if (!hasDraftCodeAgentAuth()) {
             draftDiscoveredModels = [];
             draftModelDiscoveryState = {
@@ -2572,17 +2680,24 @@ function renderDraftCodeAgentAuthState() {
     const provider = getDraftProvider();
     const isCodeAgent = isCodeAgentProvider(provider);
     const hasAuth = hasDraftCodeAgentAuth();
+    const authVerified = Boolean(draftCodeAgentAuthState.verified || draftCodeAgentAuthState.completed);
     const statusMessage = draftCodeAgentAuthState.statusMessage
-        || (hasAuth ? 'Signed in' : 'Not signed in');
+        || (
+            draftCodeAgentAuthState.hasPersistedRefreshToken
+                ? 'Saved sign-in requires verification'
+                : hasAuth
+                    ? 'Signed in'
+                    : 'Not signed in'
+        );
     const loginLabel = t('settings.model.codeagent_sign_in_sso');
     const showStatus = isCodeAgent && statusMessage && statusMessage !== 'Not signed in';
-    const statusTone = getCodeAgentAuthStatusTone(statusMessage, hasAuth);
+    const statusTone = getCodeAgentAuthStatusTone(statusMessage, authVerified);
 
     if (loginBtn) {
         loginBtn.textContent = loginLabel;
         loginBtn.title = loginLabel;
         loginBtn.setAttribute('aria-label', loginLabel);
-        loginBtn.disabled = !isCodeAgent || draftCodeAgentAuthState.loginInProgress;
+        loginBtn.disabled = !isCodeAgent || draftCodeAgentAuthState.loginInProgress || draftCodeAgentAuthState.verifying;
     }
     if (statusMessageEl) {
         statusMessageEl.textContent = showStatus ? localizeCodeAgentAuthStatusMessage(statusMessage) : '';
@@ -2598,11 +2713,20 @@ function localizeCodeAgentAuthStatusMessage(statusMessage) {
     if (message === 'Starting SSO login') {
         return t('settings.model.codeagent_sso_starting');
     }
+    if (message === 'Saved sign-in requires verification') {
+        return t('settings.model.codeagent_sso_saved');
+    }
+    if (message === 'Verifying saved sign-in') {
+        return t('settings.model.codeagent_sso_verifying');
+    }
     if (message === 'Waiting for SSO callback') {
         return t('settings.model.codeagent_sso_waiting');
     }
     if (message === 'Signed in') {
         return t('settings.model.codeagent_sso_signed_in');
+    }
+    if (message === 'Saved sign-in expired. Sign in with SSO again') {
+        return t('settings.model.codeagent_sso_reauth_required');
     }
     if (message === 'SSO popup blocked') {
         return t('settings.model.codeagent_sso_popup_blocked');
@@ -2620,7 +2744,11 @@ function localizeCodeAgentAuthStatusMessage(statusMessage) {
 
 function getCodeAgentAuthStatusTone(statusMessage, hasAuth) {
     const normalizedMessage = String(statusMessage || '').toLowerCase();
-    if (normalizedMessage.includes('failed') || normalizedMessage.includes('timed out')) {
+    if (
+        normalizedMessage.includes('failed')
+        || normalizedMessage.includes('timed out')
+        || normalizedMessage.includes('expired')
+    ) {
         return 'failed';
     }
     if (hasAuth || normalizedMessage.includes('signed in')) {
@@ -2776,10 +2904,14 @@ function createDraftCodeAgentAuthState() {
     return {
         authSessionId: '',
         completed: false,
+        verified: false,
+        verifying: false,
+        reauthRequired: false,
         hasPersistedAccessToken: false,
         hasPersistedRefreshToken: false,
         loginInProgress: false,
         pendingAuthorizationUrl: '',
+        verificationRequestId: 0,
         statusMessage: 'Not signed in',
     };
 }

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -23,6 +23,7 @@ import { errorToPayload, logError } from '../../utils/logger.js';
 let profiles = {};
 let fallbackConfig = { policies: [] };
 let editingProfile = null;
+let nextDraftCodeAgentVerificationScopeId = 1;
 let profileProbeStates = {};
 let draftProbeState = null;
 let draftDiscoveredModels = [];
@@ -989,6 +990,7 @@ function handleEditProfile(name) {
         hasPersistedRefreshToken: Boolean(codeagentAuth.has_refresh_token),
         loginInProgress: false,
         pendingAuthorizationUrl: '',
+        verificationScopeId: nextDraftCodeAgentVerificationScopeId++,
         verificationRequestId: 0,
         statusMessage: Boolean(codeagentAuth.has_refresh_token)
             ? 'Saved sign-in requires verification'
@@ -1522,6 +1524,7 @@ async function verifyPersistedCodeAgentAuth(profileName) {
     if (editingProfile !== normalizedProfileName || !draftCodeAgentAuthState.hasPersistedRefreshToken) {
         return;
     }
+    const verificationScopeId = Number(draftCodeAgentAuthState.verificationScopeId || 0);
     const verificationRequestId = Number(draftCodeAgentAuthState.verificationRequestId || 0) + 1;
     draftCodeAgentAuthState.verificationRequestId = verificationRequestId;
     draftCodeAgentAuthState.verified = false;
@@ -1532,7 +1535,7 @@ async function verifyPersistedCodeAgentAuth(profileName) {
 
     try {
         const result = await verifyCodeAgentAuth(normalizedProfileName);
-        if (!isActiveCodeAgentVerification(normalizedProfileName, verificationRequestId)) {
+        if (!isActiveCodeAgentVerification(normalizedProfileName, verificationScopeId, verificationRequestId)) {
             return;
         }
         draftCodeAgentAuthState.verifying = false;
@@ -1549,7 +1552,7 @@ async function verifyPersistedCodeAgentAuth(profileName) {
         }
         draftCodeAgentAuthState.statusMessage = result.detail || 'Saved sign-in could not be verified';
     } catch (e) {
-        if (!isActiveCodeAgentVerification(normalizedProfileName, verificationRequestId)) {
+        if (!isActiveCodeAgentVerification(normalizedProfileName, verificationScopeId, verificationRequestId)) {
             return;
         }
         draftCodeAgentAuthState.verifying = false;
@@ -1558,10 +1561,10 @@ async function verifyPersistedCodeAgentAuth(profileName) {
     renderDraftCodeAgentAuthState();
 }
 
-function isActiveCodeAgentVerification(profileName, verificationRequestId) {
+function isActiveCodeAgentVerification(profileName, verificationScopeId, verificationRequestId) {
     return (
-        isCodeAgentProvider(getDraftProvider())
-        && editingProfile === profileName
+        editingProfile === profileName
+        && Number(draftCodeAgentAuthState.verificationScopeId || 0) === verificationScopeId
         && Number(draftCodeAgentAuthState.verificationRequestId || 0) === verificationRequestId
     );
 }
@@ -2911,6 +2914,7 @@ function createDraftCodeAgentAuthState() {
         hasPersistedRefreshToken: false,
         loginInProgress: false,
         pendingAuthorizationUrl: '',
+        verificationScopeId: nextDraftCodeAgentVerificationScopeId++,
         verificationRequestId: 0,
         statusMessage: 'Not signed in',
     };

--- a/frontend/dist/js/core/api.js
+++ b/frontend/dist/js/core/api.js
@@ -61,6 +61,7 @@ export {
     fetchModelConfig,
     fetchModelCatalog,
     fetchCodeAgentOAuthSession,
+    verifyCodeAgentAuth,
     fetchModelFallbackConfig,
     fetchModelProfiles,
     fetchNotificationConfig,

--- a/frontend/dist/js/core/api/index.js
+++ b/frontend/dist/js/core/api/index.js
@@ -79,6 +79,7 @@ export {
     fetchSystemHealth,
     discoverModelCatalog,
     fetchCodeAgentOAuthSession,
+    verifyCodeAgentAuth,
     probeClawHubConnectivity,
     deleteClawHubSkill,
     probeGitHubConnectivity,

--- a/frontend/dist/js/core/api/system.js
+++ b/frontend/dist/js/core/api/system.js
@@ -410,6 +410,18 @@ export async function fetchCodeAgentOAuthSession(authSessionId) {
     );
 }
 
+export async function verifyCodeAgentAuth(profileName) {
+    return requestJson(
+        '/api/system/configs/model/codeagent/auth:verify',
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ profile_name: profileName }),
+        },
+        'Failed to verify CodeAgent SSO status',
+    );
+}
+
 export async function saveModelProfile(name, profile) {
     return requestJson(
         `/api/system/configs/model/profiles/${name}`,

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -3799,8 +3799,11 @@ Object.assign(TRANSLATIONS['zh-CN'], {
 Object.assign(TRANSLATIONS['en-US'], {
     'settings.model.codeagent_sign_in_sso': 'Sign in with SSO',
     'settings.model.codeagent_sso_starting': 'Starting SSO login...',
+    'settings.model.codeagent_sso_saved': 'Saved sign-in requires verification',
+    'settings.model.codeagent_sso_verifying': 'Verifying saved sign-in',
     'settings.model.codeagent_sso_waiting': 'Waiting for SSO callback',
     'settings.model.codeagent_sso_signed_in': 'Signed in',
+    'settings.model.codeagent_sso_reauth_required': 'Saved sign-in expired. Sign in with SSO again.',
     'settings.model.codeagent_sso_popup_blocked': 'SSO popup was blocked. Click Sign in with SSO again to continue.',
     'settings.model.codeagent_sso_timed_out': 'SSO login timed out',
     'settings.model.codeagent_sso_failed': 'SSO failed: {error}',
@@ -3809,8 +3812,11 @@ Object.assign(TRANSLATIONS['en-US'], {
 Object.assign(TRANSLATIONS['zh-CN'], {
     'settings.model.codeagent_sign_in_sso': '使用 SSO 登录',
     'settings.model.codeagent_sso_starting': '正在启动 SSO 登录...',
+    'settings.model.codeagent_sso_saved': '已保存登录，需校验状态',
+    'settings.model.codeagent_sso_verifying': '正在校验已保存的登录状态',
     'settings.model.codeagent_sso_waiting': '等待 SSO 回调',
     'settings.model.codeagent_sso_signed_in': '已登录',
+    'settings.model.codeagent_sso_reauth_required': '已保存登录已失效，请重新使用 SSO 登录。',
     'settings.model.codeagent_sso_popup_blocked': 'SSO 弹窗被拦截，请再次点击“使用 SSO 登录”继续。',
     'settings.model.codeagent_sso_timed_out': 'SSO 登录超时',
     'settings.model.codeagent_sso_failed': 'SSO 登录失败：{error}',

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -125,6 +125,7 @@ from relay_teams.providers.codeagent_auth import (
 )
 from relay_teams.providers.model_config_service import ModelConfigService
 from relay_teams.providers.model_connectivity import (
+    CodeAgentAuthVerifyResult,
     ModelDiscoveryRequest,
     ModelDiscoveryResult,
     ModelConnectivityProbeRequest,
@@ -403,6 +404,16 @@ class CodeAgentOAuthSessionResponse(BaseModel):
     codeagent_auth: CodeAgentAuthConfig | None = None
 
 
+class CodeAgentAuthVerifyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    profile_name: str
+
+
+class CodeAgentAuthVerifyResponse(CodeAgentAuthVerifyResult):
+    model_config = ConfigDict(extra="forbid")
+
+
 @router.put("/configs/model/profiles/{name}")
 async def save_model_profile(
     name: str,
@@ -555,6 +566,23 @@ def get_codeagent_oauth_session_status(
         error_message=session.error_message,
         codeagent_auth=codeagent_auth,
     )
+
+
+@router.post("/configs/model/codeagent/auth:verify")
+async def verify_codeagent_auth(
+    req: CodeAgentAuthVerifyRequest,
+    service: ModelConfigService = Depends(get_model_config_service),
+) -> CodeAgentAuthVerifyResponse:
+    try:
+        result = await call_maybe_async(
+            service.verify_codeagent_auth,
+            profile_name=req.profile_name,
+        )
+        return CodeAgentAuthVerifyResponse.model_validate(
+            result.model_dump(mode="json")
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/configs/model/providers/models")

--- a/src/relay_teams/providers/codeagent_auth.py
+++ b/src/relay_teams/providers/codeagent_auth.py
@@ -91,9 +91,25 @@ class _CodeAgentTokenRecord:
 
 
 class CodeAgentOAuthError(RuntimeError):
-    def __init__(self, message: str, *, status_code: int | None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None,
+        error_code: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.status_code = status_code
+        self.error_code = error_code
+
+    @property
+    def auth_invalid(self) -> bool:
+        if self.status_code in {401, 403}:
+            return True
+        if self.error_code == "DEV.00000001":
+            return True
+        normalized_message = str(self).strip()
+        return normalized_message == "未识别到用户认证信息"
 
 
 class CodeAgentTokenService:
@@ -829,11 +845,13 @@ def _build_token_result(
 ) -> CodeAgentOAuthTokenResult:
     payload = _response_json(response)
     if response.status_code >= 400:
+        error_code = _extract_error_code(payload)
         raise CodeAgentOAuthError(
             _extract_error_message(payload)
             or response.text
             or "CodeAgent OAuth request failed.",
             status_code=response.status_code,
+            error_code=error_code,
         )
     access_token = _extract_str(payload, ("access_token", "accessToken", "token"))
     refresh_token = _extract_str(payload, ("refresh_token", "refreshToken"))
@@ -860,11 +878,13 @@ def _build_polled_token_result(
 ) -> CodeAgentOAuthTokenResult | None:
     payload = _response_json(response)
     if response.status_code >= 400:
+        error_code = _extract_error_code(payload)
         raise CodeAgentOAuthError(
             _extract_error_message(payload)
             or response.text
             or "CodeAgent OAuth token polling failed.",
             status_code=response.status_code,
+            error_code=error_code,
         )
     if response.status_code != 200:
         return None
@@ -877,6 +897,7 @@ def _build_polled_token_result(
             raise CodeAgentOAuthError(
                 error_message,
                 status_code=response.status_code,
+                error_code=_extract_error_code(payload),
             )
         return None
     refresh_token = _extract_str(payload, ("refresh_token", "refreshToken"))
@@ -964,7 +985,7 @@ def _extract_int(payload: object, keys: tuple[str, ...]) -> int | None:
 
 def _extract_error_message(payload: object) -> str | None:
     if isinstance(payload, dict):
-        for key in ("message", "detail", "error_description"):
+        for key in ("message", "detail", "error_description", "error_msg"):
             value = payload.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
@@ -975,6 +996,21 @@ def _extract_error_message(payload: object) -> str | None:
                 return message.strip()
         if isinstance(error, str) and error.strip():
             return error.strip()
+    return None
+
+
+def _extract_error_code(payload: object) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    for key in ("error_code", "errorCode", "code"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    error = payload.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        if isinstance(code, str) and code.strip():
+            return code.strip()
     return None
 
 

--- a/src/relay_teams/providers/model_config_service.py
+++ b/src/relay_teams/providers/model_config_service.py
@@ -14,6 +14,7 @@ from relay_teams.providers.model_config import (
 )
 from relay_teams.providers.model_catalog import ModelCatalogResult, ModelCatalogService
 from relay_teams.providers.model_connectivity import (
+    CodeAgentAuthVerifyResult,
     ModelConnectivityProbeRequest,
     ModelConnectivityProbeResult,
     ModelConnectivityProbeService,
@@ -118,6 +119,15 @@ class ModelConfigService:
         request: ModelDiscoveryRequest,
     ) -> ModelDiscoveryResult:
         return self._model_connectivity_probe_service.discover_models(request)
+
+    def verify_codeagent_auth(
+        self,
+        *,
+        profile_name: str,
+    ) -> CodeAgentAuthVerifyResult:
+        return self._model_connectivity_probe_service.verify_codeagent_auth(
+            profile_name=profile_name
+        )
 
     def reload_model_config(self) -> None:
         runtime = load_runtime_config(

--- a/src/relay_teams/providers/model_connectivity.py
+++ b/src/relay_teams/providers/model_connectivity.py
@@ -326,42 +326,71 @@ class ModelConnectivityProbeService:
                 f"Model profile '{profile_name}' does not have CodeAgent auth configured."
             )
         checked_at = datetime.now(timezone.utc)
-        try:
-            auth_config = self._resolve_codeagent_auth_for_request(
-                config.codeagent_auth
-            )
-            get_codeagent_token_service().get_token_result_sync(
-                base_url=config.base_url,
-                auth_config=auth_config,
-                ssl_verify=config.ssl_verify,
-                connect_timeout_seconds=config.connect_timeout_seconds,
-                force_refresh=True,
-            )
-        except httpx.TimeoutException as exc:
-            return CodeAgentAuthVerifyResult(
-                status="error",
-                checked_at=checked_at,
-                detail=str(exc) or "Connection timed out.",
-            )
-        except httpx.RequestError as exc:
-            return CodeAgentAuthVerifyResult(
-                status="error",
-                checked_at=checked_at,
-                detail=str(exc) or "Failed to reach CodeAgent endpoint.",
-            )
-        except CodeAgentOAuthError as exc:
-            return CodeAgentAuthVerifyResult(
-                status=(
-                    "reauth_required"
-                    if self._is_codeagent_auth_invalid_error(exc)
-                    else "error"
-                ),
-                checked_at=checked_at,
-                detail=str(exc) or "CodeAgent OAuth request failed.",
-            )
-        return CodeAgentAuthVerifyResult(
-            status="valid",
+        return self._verify_codeagent_auth_config(
+            config=config,
             checked_at=checked_at,
+        )
+
+    def _verify_codeagent_auth_config(
+        self,
+        *,
+        config: ModelEndpointConfig,
+        checked_at: datetime,
+    ) -> CodeAgentAuthVerifyResult:
+        token_or_result = self._get_codeagent_token_for_verify(
+            config=config,
+            checked_at=checked_at,
+        )
+        if isinstance(token_or_result, CodeAgentAuthVerifyResult):
+            return token_or_result
+        response_or_result = self._send_codeagent_auth_verify_request(
+            config=config,
+            checked_at=checked_at,
+            token=token_or_result,
+        )
+        if isinstance(response_or_result, CodeAgentAuthVerifyResult):
+            return response_or_result
+        response = response_or_result
+        if response.status_code < 400:
+            return CodeAgentAuthVerifyResult(
+                status="valid",
+                checked_at=checked_at,
+            )
+        if response.status_code not in {401, 403}:
+            return self._build_codeagent_auth_verify_http_error_result(
+                checked_at=checked_at,
+                response=response,
+            )
+        retry_token_or_result = self._get_codeagent_token_for_verify(
+            config=config,
+            checked_at=checked_at,
+            force_refresh=True,
+        )
+        if isinstance(retry_token_or_result, CodeAgentAuthVerifyResult):
+            return retry_token_or_result
+        retry_response_or_result = self._send_codeagent_auth_verify_request(
+            config=config,
+            checked_at=checked_at,
+            token=retry_token_or_result,
+        )
+        if isinstance(retry_response_or_result, CodeAgentAuthVerifyResult):
+            return retry_response_or_result
+        retry_response = retry_response_or_result
+        if retry_response.status_code < 400:
+            return CodeAgentAuthVerifyResult(
+                status="valid",
+                checked_at=checked_at,
+            )
+        if retry_response.status_code in {401, 403}:
+            return CodeAgentAuthVerifyResult(
+                status="reauth_required",
+                checked_at=checked_at,
+                detail=self._extract_codeagent_auth_verify_error_message(retry_response)
+                or "CodeAgent authentication is no longer valid.",
+            )
+        return self._build_codeagent_auth_verify_http_error_result(
+            checked_at=checked_at,
+            response=retry_response,
         )
 
     def _resolve_endpoint_config(
@@ -1658,6 +1687,47 @@ class ModelConnectivityProbeService:
                 error=exc,
             )
 
+    def _get_codeagent_token_for_verify(
+        self,
+        *,
+        config: ModelEndpointConfig,
+        checked_at: datetime,
+        force_refresh: bool = False,
+    ) -> str | CodeAgentAuthVerifyResult:
+        try:
+            auth_config = self._resolve_codeagent_auth_for_request(
+                cast(CodeAgentAuthConfig, config.codeagent_auth)
+            )
+            return get_codeagent_token_service().get_token_sync(
+                base_url=config.base_url,
+                auth_config=auth_config,
+                ssl_verify=config.ssl_verify,
+                connect_timeout_seconds=config.connect_timeout_seconds,
+                force_refresh=force_refresh,
+            )
+        except httpx.TimeoutException as exc:
+            return CodeAgentAuthVerifyResult(
+                status="error",
+                checked_at=checked_at,
+                detail=str(exc) or "Connection timed out.",
+            )
+        except httpx.RequestError as exc:
+            return CodeAgentAuthVerifyResult(
+                status="error",
+                checked_at=checked_at,
+                detail=str(exc) or "Failed to reach CodeAgent endpoint.",
+            )
+        except CodeAgentOAuthError as exc:
+            return CodeAgentAuthVerifyResult(
+                status=(
+                    "reauth_required"
+                    if self._is_codeagent_auth_invalid_error(exc)
+                    else "error"
+                ),
+                checked_at=checked_at,
+                detail=str(exc) or "CodeAgent OAuth request failed.",
+            )
+
     def _get_codeagent_token_for_discovery(
         self,
         *,
@@ -1736,6 +1806,50 @@ class ModelConnectivityProbeService:
         raise CodeAgentOAuthError(
             "CodeAgent OAuth session is missing, expired, or already consumed.",
             status_code=400,
+        )
+
+    def _send_codeagent_auth_verify_request(
+        self,
+        *,
+        config: ModelEndpointConfig,
+        checked_at: datetime,
+        token: str,
+    ) -> httpx.Response | CodeAgentAuthVerifyResult:
+        endpoint = f"{config.base_url.rstrip('/')}/chat/modles?checkUserPermission=TRUE"
+        try:
+            with create_sync_http_client(
+                timeout_seconds=config.connect_timeout_seconds,
+                connect_timeout_seconds=config.connect_timeout_seconds,
+                ssl_verify=config.ssl_verify,
+            ) as client:
+                return client.get(
+                    endpoint,
+                    headers=build_codeagent_request_headers(token=token),
+                )
+        except httpx.TimeoutException as exc:
+            return CodeAgentAuthVerifyResult(
+                status="error",
+                checked_at=checked_at,
+                detail=str(exc) or "Connection timed out.",
+            )
+        except httpx.RequestError as exc:
+            return CodeAgentAuthVerifyResult(
+                status="error",
+                checked_at=checked_at,
+                detail=str(exc) or "Failed to reach CodeAgent endpoint.",
+            )
+
+    def _build_codeagent_auth_verify_http_error_result(
+        self,
+        *,
+        checked_at: datetime,
+        response: httpx.Response,
+    ) -> CodeAgentAuthVerifyResult:
+        return CodeAgentAuthVerifyResult(
+            status="error",
+            checked_at=checked_at,
+            detail=self._extract_codeagent_auth_verify_error_message(response)
+            or "Failed to verify CodeAgent authentication.",
         )
 
     def _build_codeagent_oauth_error_result(
@@ -2184,7 +2298,7 @@ class ModelConnectivityProbeService:
     def _extract_error_message(self, payload: object) -> str | None:
         if not isinstance(payload, dict):
             return None
-        for key in ("message", "detail", "error_description"):
+        for key in ("message", "detail", "error_description", "error_msg"):
             value = payload.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
@@ -2196,6 +2310,13 @@ class ModelConnectivityProbeService:
         if isinstance(error_payload, str) and error_payload.strip():
             return error_payload.strip()
         return None
+
+    def _extract_codeagent_auth_verify_error_message(
+        self,
+        response: httpx.Response,
+    ) -> str | None:
+        payload = self._response_payload(response)
+        return self._extract_error_message(payload) or response.text.strip() or None
 
     def _extract_model_entries(
         self,

--- a/src/relay_teams/providers/model_connectivity.py
+++ b/src/relay_teams/providers/model_connectivity.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 import json
 from time import perf_counter
-from typing import cast
+from typing import Literal, cast
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -213,6 +213,14 @@ class ModelDiscoveryResolvedConfig(BaseModel):
     connect_timeout_seconds: float = Field(gt=0.0, le=300.0)
 
 
+class CodeAgentAuthVerifyResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["valid", "reauth_required", "error"]
+    checked_at: datetime
+    detail: str | None = None
+
+
 class ModelConnectivityProbeService:
     def __init__(
         self,
@@ -288,6 +296,72 @@ class ModelConnectivityProbeService:
             )
         raise ValueError(
             f"Model discovery is not supported for provider '{resolved_config.provider.value}'."
+        )
+
+    def verify_codeagent_auth(
+        self,
+        *,
+        profile_name: str,
+    ) -> CodeAgentAuthVerifyResult:
+        runtime = self._get_runtime()
+        resolved_profile_name = _resolve_runtime_profile_name(
+            runtime=runtime,
+            requested_profile_name=profile_name,
+        )
+        if resolved_profile_name is None:
+            raise ValueError(
+                f"Model profile '{profile_name}' was not found in runtime config."
+            )
+        config = runtime.llm_profiles.get(resolved_profile_name)
+        if config is None:
+            raise ValueError(
+                f"Model profile '{profile_name}' was not found in runtime config."
+            )
+        if config.provider != ProviderType.CODEAGENT:
+            raise ValueError(
+                f"Model profile '{profile_name}' is not a CodeAgent profile."
+            )
+        if config.codeagent_auth is None:
+            raise ValueError(
+                f"Model profile '{profile_name}' does not have CodeAgent auth configured."
+            )
+        checked_at = datetime.now(timezone.utc)
+        try:
+            auth_config = self._resolve_codeagent_auth_for_request(
+                config.codeagent_auth
+            )
+            get_codeagent_token_service().get_token_result_sync(
+                base_url=config.base_url,
+                auth_config=auth_config,
+                ssl_verify=config.ssl_verify,
+                connect_timeout_seconds=config.connect_timeout_seconds,
+                force_refresh=True,
+            )
+        except httpx.TimeoutException as exc:
+            return CodeAgentAuthVerifyResult(
+                status="error",
+                checked_at=checked_at,
+                detail=str(exc) or "Connection timed out.",
+            )
+        except httpx.RequestError as exc:
+            return CodeAgentAuthVerifyResult(
+                status="error",
+                checked_at=checked_at,
+                detail=str(exc) or "Failed to reach CodeAgent endpoint.",
+            )
+        except CodeAgentOAuthError as exc:
+            return CodeAgentAuthVerifyResult(
+                status=(
+                    "reauth_required"
+                    if self._is_codeagent_auth_invalid_error(exc)
+                    else "error"
+                ),
+                checked_at=checked_at,
+                detail=str(exc) or "CodeAgent OAuth request failed.",
+            )
+        return CodeAgentAuthVerifyResult(
+            status="valid",
+            checked_at=checked_at,
         )
 
     def _resolve_endpoint_config(
@@ -1675,6 +1749,22 @@ class ModelConnectivityProbeService:
         status_code = error.status_code
         error_message = str(error) or "CodeAgent OAuth request failed."
         if status_code is None or status_code < 400:
+            if self._is_codeagent_auth_invalid_error(error):
+                return ModelConnectivityProbeResult(
+                    ok=False,
+                    provider=config.provider,
+                    model=config.model,
+                    latency_ms=self._latency_ms(started),
+                    checked_at=checked_at,
+                    diagnostics=ModelConnectivityDiagnostics(
+                        endpoint_reachable=True,
+                        auth_valid=False,
+                        rate_limited=False,
+                    ),
+                    error_code="auth_invalid",
+                    error_message=error_message,
+                    retryable=False,
+                )
             return ModelConnectivityProbeResult(
                 ok=False,
                 provider=config.provider,
@@ -1687,6 +1777,22 @@ class ModelConnectivityProbeService:
                     rate_limited=False,
                 ),
                 error_code="invalid_response",
+                error_message=error_message,
+                retryable=False,
+            )
+        if self._is_codeagent_auth_invalid_error(error):
+            return ModelConnectivityProbeResult(
+                ok=False,
+                provider=config.provider,
+                model=config.model,
+                latency_ms=self._latency_ms(started),
+                checked_at=checked_at,
+                diagnostics=ModelConnectivityDiagnostics(
+                    endpoint_reachable=True,
+                    auth_valid=False,
+                    rate_limited=False,
+                ),
+                error_code="auth_invalid",
                 error_message=error_message,
                 retryable=False,
             )
@@ -1709,6 +1815,22 @@ class ModelConnectivityProbeService:
         status_code = error.status_code
         error_message = str(error) or "CodeAgent OAuth request failed."
         if status_code is None or status_code < 400:
+            if self._is_codeagent_auth_invalid_error(error):
+                return ModelDiscoveryResult(
+                    ok=False,
+                    provider=config.provider,
+                    base_url=config.base_url,
+                    latency_ms=self._latency_ms(started),
+                    checked_at=checked_at,
+                    diagnostics=ModelConnectivityDiagnostics(
+                        endpoint_reachable=True,
+                        auth_valid=False,
+                        rate_limited=False,
+                    ),
+                    error_code="auth_invalid",
+                    error_message=error_message,
+                    retryable=False,
+                )
             return ModelDiscoveryResult(
                 ok=False,
                 provider=config.provider,
@@ -1721,6 +1843,22 @@ class ModelConnectivityProbeService:
                     rate_limited=False,
                 ),
                 error_code="invalid_response",
+                error_message=error_message,
+                retryable=False,
+            )
+        if self._is_codeagent_auth_invalid_error(error):
+            return ModelDiscoveryResult(
+                ok=False,
+                provider=config.provider,
+                base_url=config.base_url,
+                latency_ms=self._latency_ms(started),
+                checked_at=checked_at,
+                diagnostics=ModelConnectivityDiagnostics(
+                    endpoint_reachable=True,
+                    auth_valid=False,
+                    rate_limited=False,
+                ),
+                error_code="auth_invalid",
                 error_message=error_message,
                 retryable=False,
             )
@@ -2361,6 +2499,9 @@ class ModelConnectivityProbeService:
         if status_code >= 500:
             return "provider_error"
         return "request_invalid"
+
+    def _is_codeagent_auth_invalid_error(self, error: CodeAgentOAuthError) -> bool:
+        return error.auth_invalid
 
     def _latency_ms(self, started: float) -> int:
         return max(0, int((perf_counter() - started) * 1000))

--- a/src/relay_teams/providers/model_connectivity.py
+++ b/src/relay_teams/providers/model_connectivity.py
@@ -351,7 +351,7 @@ class ModelConnectivityProbeService:
         if isinstance(response_or_result, CodeAgentAuthVerifyResult):
             return response_or_result
         response = response_or_result
-        if response.status_code < 400:
+        if 200 <= response.status_code < 300:
             return CodeAgentAuthVerifyResult(
                 status="valid",
                 checked_at=checked_at,
@@ -376,7 +376,7 @@ class ModelConnectivityProbeService:
         if isinstance(retry_response_or_result, CodeAgentAuthVerifyResult):
             return retry_response_or_result
         retry_response = retry_response_or_result
-        if retry_response.status_code < 400:
+        if 200 <= retry_response.status_code < 300:
             return CodeAgentAuthVerifyResult(
                 status="valid",
                 checked_at=checked_at,
@@ -1654,7 +1654,7 @@ class ModelConnectivityProbeService:
     ) -> str | ModelConnectivityProbeResult:
         try:
             auth_config = self._resolve_codeagent_auth_for_request(
-                cast(CodeAgentAuthConfig, config.codeagent_auth)
+                self._require_codeagent_auth_config(config.codeagent_auth)
             )
             return get_codeagent_token_service().get_token_sync(
                 base_url=config.base_url,
@@ -1696,7 +1696,7 @@ class ModelConnectivityProbeService:
     ) -> str | CodeAgentAuthVerifyResult:
         try:
             auth_config = self._resolve_codeagent_auth_for_request(
-                cast(CodeAgentAuthConfig, config.codeagent_auth)
+                self._require_codeagent_auth_config(config.codeagent_auth)
             )
             return get_codeagent_token_service().get_token_sync(
                 base_url=config.base_url,
@@ -1739,7 +1739,7 @@ class ModelConnectivityProbeService:
     ) -> str | ModelDiscoveryResult:
         try:
             auth_config = self._resolve_codeagent_auth_for_request(
-                cast(CodeAgentAuthConfig, config.codeagent_auth)
+                self._require_codeagent_auth_config(config.codeagent_auth)
             )
             return get_codeagent_token_service().get_token_sync(
                 base_url=config.base_url,
@@ -1808,8 +1808,19 @@ class ModelConnectivityProbeService:
             status_code=400,
         )
 
+    @staticmethod
+    def _require_codeagent_auth_config(
+        auth_config: CodeAgentAuthConfig | None,
+    ) -> CodeAgentAuthConfig:
+        if auth_config is None:
+            raise CodeAgentOAuthError(
+                "CodeAgent auth is not configured.",
+                status_code=None,
+            )
+        return auth_config
+
+    @staticmethod
     def _send_codeagent_auth_verify_request(
-        self,
         *,
         config: ModelEndpointConfig,
         checked_at: datetime,
@@ -2621,7 +2632,8 @@ class ModelConnectivityProbeService:
             return "provider_error"
         return "request_invalid"
 
-    def _is_codeagent_auth_invalid_error(self, error: CodeAgentOAuthError) -> bool:
+    @staticmethod
+    def _is_codeagent_auth_invalid_error(error: CodeAgentOAuthError) -> bool:
         return error.auth_invalid
 
     def _latency_ms(self, started: float) -> int:

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -3683,6 +3683,167 @@ export async function verifyCodeAgentAuth(profileName) {
     assert payload["authStatus"] == "Signed in"
 
 
+def test_saved_codeagent_profile_clears_verifying_after_provider_switch_during_verify(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+await loadModelProfilesPanel();
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "codeagent-profile").onclick();
+await Promise.resolve();
+
+const verifyingWhilePending = document.getElementById("profile-codeagent-login-status").disabled;
+document.getElementById("profile-provider").value = "openai_compatible";
+document.getElementById("profile-provider").onchange();
+
+globalThis.__resolveCodeAgentAuthVerify({
+    status: "valid",
+    checked_at: "2026-04-27T02:00:00Z",
+    detail: null,
+});
+await Promise.resolve();
+
+document.getElementById("profile-provider").value = "codeagent";
+document.getElementById("profile-provider").onchange();
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    verifyCalls: globalThis.__codeAgentAuthVerifyCalls,
+    verifyingWhilePending,
+    loginDisabledAfterResolve: document.getElementById("profile-codeagent-login-status").disabled,
+    authStatus: document.getElementById("profile-codeagent-login-status-message").textContent,
+    providerValue: document.getElementById("profile-provider").value,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "codeagent-profile": {
+            provider: "codeagent",
+            model: "codeagent-chat",
+            base_url: "https://codeagentcli.rnd.huawei.com/codeAgentPro",
+            codeagent_auth: {
+                has_access_token: true,
+                has_refresh_token: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function fetchModelFallbackConfig() {
+    return { policies: [] };
+}
+
+export async function verifyCodeAgentAuth(profileName) {
+    globalThis.__codeAgentAuthVerifyCalls = globalThis.__codeAgentAuthVerifyCalls || [];
+    globalThis.__codeAgentAuthVerifyCalls.push(profileName);
+    return new Promise(resolve => {
+        globalThis.__resolveCodeAgentAuthVerify = resolve;
+    });
+}
+""".strip(),
+    )
+
+    assert payload["verifyCalls"] == ["codeagent-profile"]
+    assert payload["verifyingWhilePending"] is True
+    assert payload["loginDisabledAfterResolve"] is False
+    assert payload["authStatus"] == "Signed in"
+    assert payload["providerValue"] == "codeagent"
+
+
+def test_saved_codeagent_profile_ignores_stale_verify_response_after_reopen(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+await loadModelProfilesPanel();
+const editButtons = document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn");
+editButtons.find(btn => btn.dataset.name === "codeagent-profile").onclick();
+await Promise.resolve();
+
+document.getElementById("cancel-profile-btn").onclick();
+editButtons.find(btn => btn.dataset.name === "codeagent-profile").onclick();
+await Promise.resolve();
+
+globalThis.__verifyResolvers[1]({
+    status: "valid",
+    checked_at: "2026-04-27T02:00:01Z",
+    detail: null,
+});
+await Promise.resolve();
+
+globalThis.__verifyResolvers[0]({
+    status: "reauth_required",
+    checked_at: "2026-04-27T02:00:00Z",
+    detail: "expired session",
+});
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    verifyCalls: globalThis.__codeAgentAuthVerifyCalls,
+    authStatus: document.getElementById("profile-codeagent-login-status-message").textContent,
+    loginDisabled: document.getElementById("profile-codeagent-login-status").disabled,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "codeagent-profile": {
+            provider: "codeagent",
+            model: "codeagent-chat",
+            base_url: "https://codeagentcli.rnd.huawei.com/codeAgentPro",
+            codeagent_auth: {
+                has_access_token: true,
+                has_refresh_token: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function fetchModelFallbackConfig() {
+    return { policies: [] };
+}
+
+export async function verifyCodeAgentAuth(profileName) {
+    globalThis.__codeAgentAuthVerifyCalls = globalThis.__codeAgentAuthVerifyCalls || [];
+    globalThis.__codeAgentAuthVerifyCalls.push(profileName);
+    globalThis.__verifyResolvers = globalThis.__verifyResolvers || [];
+    return new Promise(resolve => {
+        globalThis.__verifyResolvers.push(resolve);
+    });
+}
+""".strip(),
+    )
+
+    assert payload["verifyCalls"] == ["codeagent-profile", "codeagent-profile"]
+    assert payload["authStatus"] == "Signed in"
+    assert payload["loginDisabled"] is False
+
+
 def test_saved_codeagent_profile_with_expired_sign_in_requires_reauth_before_discovery(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -164,6 +164,16 @@ export async function fetchCodeAgentOAuthSession(authSessionId) {
     };
 }
 
+export async function verifyCodeAgentAuth(profileName) {
+    globalThis.__codeAgentAuthVerifyCalls = globalThis.__codeAgentAuthVerifyCalls || [];
+    globalThis.__codeAgentAuthVerifyCalls.push(profileName);
+    return {
+        status: "valid",
+        checked_at: "2026-04-27T02:00:00Z",
+        detail: null,
+    };
+}
+
 export async function reloadModelConfig() {
     globalThis.__reloadCalled = true;
 }
@@ -3596,6 +3606,138 @@ export async function deleteModelProfile(name) {
     assert payload["authStatus"] == "SSO failed: poll failed for failed-auth-session"
 
 
+def test_editing_saved_codeagent_profile_verifies_persisted_sign_in(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+await loadModelProfilesPanel();
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "codeagent-profile").onclick();
+await Promise.resolve();
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    verifyCalls: globalThis.__codeAgentAuthVerifyCalls,
+    authStatus: document.getElementById("profile-codeagent-login-status-message").textContent,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "codeagent-profile": {
+            provider: "codeagent",
+            model: "codeagent-chat",
+            base_url: "https://codeagentcli.rnd.huawei.com/codeAgentPro",
+            codeagent_auth: {
+                has_access_token: true,
+                has_refresh_token: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function fetchModelFallbackConfig() {
+    return { policies: [] };
+}
+
+export async function verifyCodeAgentAuth(profileName) {
+    globalThis.__codeAgentAuthVerifyCalls = globalThis.__codeAgentAuthVerifyCalls || [];
+    globalThis.__codeAgentAuthVerifyCalls.push(profileName);
+    return { status: "valid", checked_at: "2026-04-27T02:00:00Z", detail: null };
+}
+""".strip(),
+    )
+
+    assert payload["verifyCalls"] == ["codeagent-profile"]
+    assert payload["authStatus"] == "Signed in"
+
+
+def test_saved_codeagent_profile_with_expired_sign_in_requires_reauth_before_discovery(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+await loadModelProfilesPanel();
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "codeagent-profile").onclick();
+await Promise.resolve();
+await Promise.resolve();
+await document.getElementById("fetch-profile-models-btn").onclick();
+
+console.log(JSON.stringify({
+    verifyCalls: globalThis.__codeAgentAuthVerifyCalls,
+    discoverPayload: globalThis.__discoverPayload || null,
+    authStatus: document.getElementById("profile-codeagent-login-status-message").textContent,
+    discoveryStatus: document.getElementById("profile-model-discovery-status").textContent,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "codeagent-profile": {
+            provider: "codeagent",
+            model: "codeagent-chat",
+            base_url: "https://codeagentcli.rnd.huawei.com/codeAgentPro",
+            codeagent_auth: {
+                has_access_token: true,
+                has_refresh_token: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function fetchModelFallbackConfig() {
+    return { policies: [] };
+}
+
+export async function verifyCodeAgentAuth(profileName) {
+    globalThis.__codeAgentAuthVerifyCalls = globalThis.__codeAgentAuthVerifyCalls || [];
+    globalThis.__codeAgentAuthVerifyCalls.push(profileName);
+    return {
+        status: "reauth_required",
+        checked_at: "2026-04-27T02:00:00Z",
+        detail: "未识别到用户认证信息",
+    };
+}
+
+export async function discoverModelCatalog(payload) {
+    globalThis.__discoverPayload = payload;
+    return { ok: true, latency_ms: 37, models: ["codeagent-chat"] };
+}
+""".strip(),
+    )
+
+    assert payload["verifyCalls"] == ["codeagent-profile"]
+    assert payload["discoverPayload"] is None
+    assert payload["authStatus"] == "Saved sign-in expired. Sign in with SSO again."
+    assert payload["discoveryStatus"] == (
+        "SSO login expired. Sign in with SSO again before fetching CodeAgent models."
+    )
+
+
 def test_codeagent_sso_polling_stops_when_auth_session_changes(
     tmp_path: Path,
 ) -> None:
@@ -3903,6 +4045,13 @@ def _run_model_profiles_script(
             "    return { policies: [] };\n"
             "}\n"
         )
+    if "fetchModelProfiles" not in resolved_mock_api_source:
+        resolved_mock_api_source = (
+            f"{resolved_mock_api_source}\n\n"
+            "export async function fetchModelProfiles() {\n"
+            "    return {};\n"
+            "}\n"
+        )
     if "fetchModelCatalog" not in resolved_mock_api_source:
         resolved_mock_api_source = (
             f"{resolved_mock_api_source}\n\n"
@@ -3912,6 +4061,22 @@ def _run_model_profiles_script(
             "export async function refreshModelCatalog() {\n"
             "    globalThis.__refreshModelCatalogCount = (globalThis.__refreshModelCatalogCount || 0) + 1;\n"
             "    return fetchModelCatalog();\n"
+            "}\n"
+        )
+    if "probeModelConnection" not in resolved_mock_api_source:
+        resolved_mock_api_source = (
+            f"{resolved_mock_api_source}\n\n"
+            "export async function probeModelConnection(payload) {\n"
+            "    globalThis.__probePayload = payload;\n"
+            "    return { ok: true, latency_ms: 42 };\n"
+            "}\n"
+        )
+    if "discoverModelCatalog" not in resolved_mock_api_source:
+        resolved_mock_api_source = (
+            f"{resolved_mock_api_source}\n\n"
+            "export async function discoverModelCatalog(payload) {\n"
+            "    globalThis.__discoverPayload = payload;\n"
+            "    return { ok: true, latency_ms: 37, models: [] };\n"
             "}\n"
         )
     if "startCodeAgentOAuth" not in resolved_mock_api_source:
@@ -3932,6 +4097,36 @@ def _run_model_profiles_script(
             "    globalThis.__codeAgentOAuthSessionChecks = globalThis.__codeAgentOAuthSessionChecks || [];\n"
             "    globalThis.__codeAgentOAuthSessionChecks.push(authSessionId);\n"
             "    return { completed: true };\n"
+            "}\n"
+        )
+    if "verifyCodeAgentAuth" not in resolved_mock_api_source:
+        resolved_mock_api_source = (
+            f"{resolved_mock_api_source}\n\n"
+            "export async function verifyCodeAgentAuth(profileName) {\n"
+            "    globalThis.__codeAgentAuthVerifyCalls = globalThis.__codeAgentAuthVerifyCalls || [];\n"
+            "    globalThis.__codeAgentAuthVerifyCalls.push(profileName);\n"
+            "    return { status: 'valid', checked_at: '2026-04-27T02:00:00Z', detail: null };\n"
+            "}\n"
+        )
+    if "saveModelProfile" not in resolved_mock_api_source:
+        resolved_mock_api_source = (
+            f"{resolved_mock_api_source}\n\n"
+            "export async function saveModelProfile(name, profile) {\n"
+            "    globalThis.__savedProfile = { name, profile };\n"
+            "}\n"
+        )
+    if "reloadModelConfig" not in resolved_mock_api_source:
+        resolved_mock_api_source = (
+            f"{resolved_mock_api_source}\n\n"
+            "export async function reloadModelConfig() {\n"
+            "    globalThis.__reloadCalled = true;\n"
+            "}\n"
+        )
+    if "deleteModelProfile" not in resolved_mock_api_source:
+        resolved_mock_api_source = (
+            f"{resolved_mock_api_source}\n\n"
+            "export async function deleteModelProfile(name) {\n"
+            "    globalThis.__deletedProfileName = name;\n"
             "}\n"
         )
     mock_api_path.write_text(resolved_mock_api_source, encoding="utf-8")
@@ -4018,8 +4213,11 @@ const translations = {
     "settings.model.image_capability_unsupported": "Text only",
     "settings.model.codeagent_sign_in_sso": "Sign in with SSO",
     "settings.model.codeagent_sso_starting": "Starting SSO login",
+    "settings.model.codeagent_sso_saved": "Saved sign-in requires verification",
+    "settings.model.codeagent_sso_verifying": "Verifying saved sign-in",
     "settings.model.codeagent_sso_waiting": "Waiting for SSO callback",
     "settings.model.codeagent_sso_signed_in": "Signed in",
+    "settings.model.codeagent_sso_reauth_required": "Saved sign-in expired. Sign in with SSO again.",
     "settings.model.codeagent_sso_popup_blocked": "SSO popup was blocked. Click Sign in with SSO again to continue.",
     "settings.model.codeagent_sso_timed_out": "SSO login timed out",
     "settings.model.codeagent_sso_failed": "SSO failed: {error}",

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import subprocess
 from typing import cast
 
+from .css_helpers import load_components_css
+
 DEFAULT_MOCK_API_SOURCE = """
 export async function fetchModelProfiles() {
     return {
@@ -182,6 +184,23 @@ export async function deleteModelProfile(name) {
     globalThis.__deletedProfileName = name;
 }
 """.strip()
+
+
+def test_codeagent_sso_button_uses_shared_form_control_height() -> None:
+    components_css = load_components_css()
+    rule_start = components_css.index(".codeagent-sso-login-btn {")
+    rule_end = components_css.index(".codeagent-sso-login-btn:disabled {", rule_start)
+    button_rule = components_css[rule_start:rule_end]
+    override_rule_start = components_css.index(
+        ".settings-list-action.codeagent-sso-login-btn {"
+    )
+    override_rule_end = components_css.index(
+        ".settings-list-action:hover {", override_rule_start
+    )
+    override_rule = components_css[override_rule_start:override_rule_end]
+
+    assert "min-height: 42px;" in button_rule
+    assert "min-height: 42px;" in override_rule
 
 
 def test_saving_model_profile_restores_profile_list_visibility(

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -82,6 +82,7 @@ from relay_teams.interfaces.server.ui_language_models import (
 )
 from relay_teams.interfaces.server.routers import system
 from relay_teams.providers.model_connectivity import (
+    CodeAgentAuthVerifyResult,
     ModelConnectivityProbeRequest,
     ModelConnectivityProbeResult,
     ModelDiscoveryRequest,
@@ -132,6 +133,12 @@ class _FakeSystemService:
         self.saved_model_fallback_config: dict[str, object] | None = None
         self.saved_model_profile: tuple[str, dict[str, object], str | None] | None = (
             None
+        )
+        self.last_verified_codeagent_profile_name: str | None = None
+        self.codeagent_auth_verify_result = CodeAgentAuthVerifyResult(
+            status="valid",
+            checked_at=datetime.now(UTC),
+            detail=None,
         )
         self.model_profile_error: Exception | None = None
         self.model_profile_delete_error: Exception | None = None
@@ -740,6 +747,14 @@ class _FakeSystemService:
                 "retryable": False,
             }
         )
+
+    def verify_codeagent_auth(
+        self,
+        *,
+        profile_name: str,
+    ) -> CodeAgentAuthVerifyResult:
+        self.last_verified_codeagent_profile_name = profile_name
+        return self.codeagent_auth_verify_result
 
     def probe_webhook_connectivity(
         self,
@@ -3132,6 +3147,49 @@ def test_codeagent_oauth_status_preserves_explicit_oauth_error_status(
     assert response.status_code == 409
     assert response.json()["detail"] == "session denied"
     clear_codeagent_oauth_session_store()
+
+
+def test_verify_codeagent_auth_returns_service_result() -> None:
+    service = _FakeSystemService()
+    service.codeagent_auth_verify_result = CodeAgentAuthVerifyResult(
+        status="reauth_required",
+        checked_at=datetime(2026, 4, 27, 2, 0, tzinfo=UTC),
+        detail="未识别到用户认证信息",
+    )
+    client = _create_test_client(service)
+
+    response = client.post(
+        "/api/system/configs/model/codeagent/auth:verify",
+        json={"profile_name": "codeagent-profile"},
+    )
+
+    assert response.status_code == 200
+    assert service.last_verified_codeagent_profile_name == "codeagent-profile"
+    assert response.json() == {
+        "status": "reauth_required",
+        "checked_at": "2026-04-27T02:00:00Z",
+        "detail": "未识别到用户认证信息",
+    }
+
+
+def test_verify_codeagent_auth_returns_bad_request_for_validation_errors() -> None:
+    class _InvalidCodeAgentService(_FakeSystemService):
+        def verify_codeagent_auth(
+            self,
+            *,
+            profile_name: str,
+        ) -> CodeAgentAuthVerifyResult:
+            raise ValueError(f"Unknown CodeAgent profile: {profile_name}")
+
+    client = _create_test_client(_InvalidCodeAgentService())
+
+    response = client.post(
+        "/api/system/configs/model/codeagent/auth:verify",
+        json={"profile_name": "missing"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unknown CodeAgent profile: missing"
 
 
 def test_save_model_profile_accepts_source_name_for_rename() -> None:

--- a/tests/unit_tests/providers/test_codeagent_auth.py
+++ b/tests/unit_tests/providers/test_codeagent_auth.py
@@ -1061,6 +1061,16 @@ def test_get_codeagent_oauth_session_by_state_returns_saved_session() -> None:
     )
 
 
+def test_extract_error_code_reads_nested_error_code() -> None:
+    payload = {
+        "error": {
+            "code": " DEV.00000001 ",
+        }
+    }
+
+    assert codeagent_auth_module._extract_error_code(payload) == "DEV.00000001"
+
+
 def test_get_codeagent_oauth_session_by_state_returns_none_for_missing_state() -> None:
     clear_codeagent_oauth_session_store()
 

--- a/tests/unit_tests/providers/test_codeagent_auth.py
+++ b/tests/unit_tests/providers/test_codeagent_auth.py
@@ -1162,6 +1162,26 @@ def test_build_token_result_uses_response_text_for_http_errors() -> None:
         )
 
 
+def test_build_token_result_extracts_codeagent_auth_invalid_error_details() -> None:
+    response = httpx.Response(
+        401,
+        json={
+            "error_code": "DEV.00000001",
+            "error_msg": "未识别到用户认证信息",
+        },
+    )
+
+    with pytest.raises(CodeAgentOAuthError) as exc_info:
+        codeagent_auth_module._build_token_result(
+            response,
+            fallback_refresh_token=None,
+        )
+
+    assert str(exc_info.value) == "未识别到用户认证信息"
+    assert exc_info.value.error_code == "DEV.00000001"
+    assert exc_info.value.auth_invalid is True
+
+
 def test_build_polled_token_result_returns_none_for_non_200_response() -> None:
     response = httpx.Response(202, json={"message": "pending"})
 

--- a/tests/unit_tests/providers/test_model_config_service.py
+++ b/tests/unit_tests/providers/test_model_config_service.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -10,6 +11,10 @@ from relay_teams.providers.model_config import (
 )
 from relay_teams.providers.model_catalog import ModelCatalogResult, ModelCatalogService
 from relay_teams.providers.model_config_manager import ModelConfigManager
+from relay_teams.providers.model_connectivity import (
+    CodeAgentAuthVerifyResult,
+    ModelConnectivityProbeService,
+)
 from relay_teams.providers.model_config_service import ModelConfigService
 from relay_teams.providers.model_fallback_config_manager import (
     ModelFallbackConfigManager,
@@ -119,3 +124,43 @@ def test_save_model_config_preserves_omitted_optional_fields() -> None:
             "max_tokens": None,
         },
     }
+
+
+def test_verify_codeagent_auth_delegates_to_probe_service() -> None:
+    service = ModelConfigService(
+        config_dir=Path("."),
+        roles_dir=Path("."),
+        db_path=Path("relay-teams.db"),
+        model_config_manager=cast(ModelConfigManager, _RecordingModelConfigManager()),
+        model_fallback_config_manager=cast(
+            ModelFallbackConfigManager,
+            _RecordingModelFallbackConfigManager(),
+        ),
+        model_catalog_service=cast(
+            ModelCatalogService, _RecordingModelCatalogService()
+        ),
+        get_runtime=lambda: RuntimeConfig.model_construct(),
+        on_runtime_reloaded=lambda runtime: None,
+    )
+    expected = CodeAgentAuthVerifyResult(
+        status="valid",
+        checked_at=datetime(2026, 4, 27, 2, 0, tzinfo=UTC),
+        detail=None,
+    )
+    captured: dict[str, object] = {}
+
+    class _FakeProbeService:
+        def verify_codeagent_auth(
+            self, *, profile_name: str
+        ) -> CodeAgentAuthVerifyResult:
+            captured["profile_name"] = profile_name
+            return expected
+
+    service._model_connectivity_probe_service = cast(
+        ModelConnectivityProbeService, _FakeProbeService()
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert captured["profile_name"] == "default"
+    assert result == expected

--- a/tests/unit_tests/providers/test_model_connectivity.py
+++ b/tests/unit_tests/providers/test_model_connectivity.py
@@ -1330,7 +1330,7 @@ def test_probe_codeagent_returns_invalid_response_for_oauth_error_without_http_s
 def test_probe_codeagent_maps_codeagent_auth_invalid_error_without_http_status(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
         def get_token_sync(
@@ -1549,6 +1549,242 @@ def test_verify_codeagent_auth_returns_valid_when_saved_token_request_succeeds(
     assert headers["User-Agent"] == "AgentKernel/1.0"
 
 
+def test_verify_codeagent_auth_raises_for_missing_profile() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    with pytest.raises(
+        ValueError,
+        match="Model profile 'missing' was not found in runtime config.",
+    ):
+        service.verify_codeagent_auth(profile_name="missing")
+
+
+def test_verify_codeagent_auth_raises_for_non_codeagent_profile() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    with pytest.raises(
+        ValueError,
+        match="Model profile 'default' is not a CodeAgent profile.",
+    ):
+        service.verify_codeagent_auth(profile_name="default")
+
+
+def test_verify_codeagent_auth_raises_without_codeagent_auth() -> None:
+    invalid_config = ModelEndpointConfig.model_construct(
+        provider=ProviderType.CODEAGENT,
+        model="codeagent-chat",
+        base_url=DEFAULT_CODEAGENT_BASE_URL,
+        api_key=None,
+        maas_auth=None,
+        codeagent_auth=None,
+        ssl_verify=True,
+        sampling=SamplingConfig(
+            temperature=1.0,
+            top_p=0.95,
+            max_tokens=128,
+        ),
+        connect_timeout_seconds=17.5,
+    )
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: RuntimeConfig.model_construct(
+            paths=RuntimePaths(
+                config_dir=Path("D:/tmp/.agent_teams"),
+                env_file=Path("D:/tmp/.agent_teams/.env"),
+                db_path=Path("D:/tmp/.agent_teams/relay_teams.db"),
+                roles_dir=Path("D:/tmp/.agent_teams/roles"),
+            ),
+            llm_profiles={"default": invalid_config},
+            default_model_profile="default",
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Model profile 'default' does not have CodeAgent auth configured.",
+    ):
+        service.verify_codeagent_auth(profile_name="default")
+
+
+def test_verify_codeagent_auth_returns_error_when_token_refresh_times_out(
+    monkeypatch,
+) -> None:
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            api_key=None,
+            codeagent_auth=CodeAgentAuthConfig(refresh_token="refresh-token"),
+        )
+    )
+
+    class _TimeoutTokenService:
+        def get_token_sync(
+            self,
+            *,
+            base_url: str,
+            auth_config: CodeAgentAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> str:
+            _ = (
+                base_url,
+                auth_config,
+                ssl_verify,
+                connect_timeout_seconds,
+                force_refresh,
+            )
+            raise httpx.ReadTimeout("token request timed out")
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _TimeoutTokenService(),
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert result.status == "error"
+    assert result.detail == "token request timed out"
+
+
+def test_verify_codeagent_auth_returns_error_when_verify_request_times_out(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            api_key=None,
+            codeagent_auth=CodeAgentAuthConfig(refresh_token="refresh-token"),
+        )
+    )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _FakeCodeAgentTokenService(["codeagent-access-token"], captured),
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **_kwargs: _FakeHttpClient(
+            error=httpx.ReadTimeout("verify request timed out")
+        ),
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert result.status == "error"
+    assert result.detail == "verify request timed out"
+
+
+def test_verify_codeagent_auth_returns_error_when_verify_request_fails(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            api_key=None,
+            codeagent_auth=CodeAgentAuthConfig(refresh_token="refresh-token"),
+        )
+    )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _FakeCodeAgentTokenService(["codeagent-access-token"], captured),
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **_kwargs: _FakeHttpClient(
+            error=httpx.ConnectError("failed to reach codeagent")
+        ),
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert result.status == "error"
+    assert result.detail == "failed to reach codeagent"
+
+
+def test_verify_codeagent_auth_returns_error_for_redirect_response(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            api_key=None,
+            codeagent_auth=CodeAgentAuthConfig(
+                access_token="saved-access-token",
+                refresh_token="refresh-token",
+            ),
+        )
+    )
+
+    class _TokenService:
+        def get_token_sync(
+            self,
+            *,
+            base_url: str,
+            auth_config: CodeAgentAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> str:
+            calls = captured.setdefault("token_calls", [])
+            assert isinstance(calls, list)
+            calls.append(
+                {
+                    "base_url": base_url,
+                    "access_token": auth_config.access_token,
+                    "refresh_token": auth_config.refresh_token,
+                    "ssl_verify": ssl_verify,
+                    "connect_timeout_seconds": connect_timeout_seconds,
+                    "force_refresh": force_refresh,
+                }
+            )
+            return "saved-access-token"
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _TokenService(),
+    )
+    responses = [
+        httpx.Response(
+            302,
+            headers={"location": "https://login.example/sso"},
+        )
+    ]
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **_kwargs: _QueuedHttpClient(
+            captured=captured,
+            responses=responses,
+        ),
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert result.status == "error"
+    assert result.detail == "Failed to verify CodeAgent authentication."
+    assert captured["token_calls"] == [
+        {
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "access_token": "saved-access-token",
+            "refresh_token": "refresh-token",
+            "ssl_verify": True,
+            "connect_timeout_seconds": 17.5,
+            "force_refresh": False,
+        }
+    ]
+
+
 def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
     monkeypatch,
 ) -> None:
@@ -1609,6 +1845,84 @@ def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
 
     assert result.status == "valid"
     assert result.detail is None
+    assert captured["token_calls"] == [
+        {
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "refresh_token": "refresh-token",
+            "ssl_verify": True,
+            "connect_timeout_seconds": 17.5,
+            "force_refresh": False,
+        },
+        {
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "refresh_token": "refresh-token",
+            "ssl_verify": True,
+            "connect_timeout_seconds": 17.5,
+            "force_refresh": True,
+        },
+    ]
+
+
+def test_verify_codeagent_auth_returns_error_when_refresh_redirects(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            api_key=None,
+            codeagent_auth=CodeAgentAuthConfig(refresh_token="refresh-token"),
+        )
+    )
+
+    class _SuccessfulCodeAgentTokenService:
+        def get_token_sync(
+            self,
+            *,
+            base_url: str,
+            auth_config: CodeAgentAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> str:
+            calls = captured.setdefault("token_calls", [])
+            assert isinstance(calls, list)
+            calls.append(
+                {
+                    "base_url": base_url,
+                    "refresh_token": auth_config.refresh_token,
+                    "ssl_verify": ssl_verify,
+                    "connect_timeout_seconds": connect_timeout_seconds,
+                    "force_refresh": force_refresh,
+                }
+            )
+            return "fresh-access-token" if force_refresh else "saved-access-token"
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _SuccessfulCodeAgentTokenService(),
+    )
+    responses = [
+        httpx.Response(401, json={"detail": "expired access token"}),
+        httpx.Response(
+            302,
+            headers={"location": "https://login.example/sso"},
+        ),
+    ]
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **_kwargs: _QueuedHttpClient(
+            captured=captured,
+            responses=responses,
+        ),
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert result.status == "error"
+    assert result.detail == "Failed to verify CodeAgent authentication."
     assert captured["token_calls"] == [
         {
             "base_url": DEFAULT_CODEAGENT_BASE_URL,

--- a/tests/unit_tests/providers/test_model_connectivity.py
+++ b/tests/unit_tests/providers/test_model_connectivity.py
@@ -83,6 +83,40 @@ class _FakeHttpClient:
         return self._response
 
 
+class _QueuedHttpClient:
+    def __init__(
+        self,
+        *,
+        responses: list[httpx.Response],
+        captured: dict[str, object] | None = None,
+    ) -> None:
+        self._responses = responses
+        self._captured = captured if captured is not None else {}
+
+    def __enter__(self) -> _QueuedHttpClient:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+    ) -> httpx.Response:
+        requests = self._captured.setdefault("requests", [])
+        assert isinstance(requests, list)
+        requests.append(
+            {
+                "url": url,
+                "headers": dict(headers),
+            }
+        )
+        assert self._responses
+        return self._responses.pop(0)
+
+
 class _FakeMaaSTokenService:
     def __init__(
         self,
@@ -1431,21 +1465,25 @@ def test_discover_models_codeagent_returns_invalid_response_for_oauth_error(
     assert result.retryable is False
 
 
-def test_verify_codeagent_auth_returns_reauth_required_for_auth_invalid(
+def test_verify_codeagent_auth_returns_valid_when_saved_token_request_succeeds(
     monkeypatch,
 ) -> None:
+    captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(
         get_runtime=lambda: _runtime_config(
             provider=ProviderType.CODEAGENT,
             model="codeagent-chat",
             base_url=DEFAULT_CODEAGENT_BASE_URL,
             api_key=None,
-            codeagent_auth=CodeAgentAuthConfig(refresh_token="refresh-token"),
+            codeagent_auth=CodeAgentAuthConfig(
+                access_token="saved-access-token",
+                refresh_token="refresh-token",
+            ),
         )
     )
 
-    class _FailingCodeAgentTokenService:
-        def get_token_result_sync(
+    class _TokenService:
+        def get_token_sync(
             self,
             *,
             base_url: str,
@@ -1453,29 +1491,62 @@ def test_verify_codeagent_auth_returns_reauth_required_for_auth_invalid(
             ssl_verify: bool | None,
             connect_timeout_seconds: float,
             force_refresh: bool = False,
-        ) -> CodeAgentOAuthTokenResult:
-            _ = (
-                base_url,
-                auth_config,
-                ssl_verify,
-                connect_timeout_seconds,
-                force_refresh,
+        ) -> str:
+            calls = captured.setdefault("token_calls", [])
+            assert isinstance(calls, list)
+            calls.append(
+                {
+                    "base_url": base_url,
+                    "access_token": auth_config.access_token,
+                    "refresh_token": auth_config.refresh_token,
+                    "ssl_verify": ssl_verify,
+                    "connect_timeout_seconds": connect_timeout_seconds,
+                    "force_refresh": force_refresh,
+                }
             )
-            raise CodeAgentOAuthError(
-                "未识别到用户认证信息",
-                status_code=401,
-                error_code="DEV.00000001",
-            )
+            return "saved-access-token"
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
-        lambda: _FailingCodeAgentTokenService(),
+        lambda: _TokenService(),
+    )
+    responses = [
+        httpx.Response(
+            200,
+            json={"models": [{"id": "codeagent-chat"}]},
+        )
+    ]
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **_kwargs: _QueuedHttpClient(
+            captured=captured,
+            responses=responses,
+        ),
     )
 
     result = service.verify_codeagent_auth(profile_name="default")
 
-    assert result.status == "reauth_required"
-    assert result.detail == "未识别到用户认证信息"
+    assert result.status == "valid"
+    assert result.detail is None
+    assert captured["token_calls"] == [
+        {
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "access_token": "saved-access-token",
+            "refresh_token": "refresh-token",
+            "ssl_verify": True,
+            "connect_timeout_seconds": 17.5,
+            "force_refresh": False,
+        }
+    ]
+    requests = cast(list[dict[str, object]], captured["requests"])
+    assert len(requests) == 1
+    assert requests[0]["url"] == (
+        f"{DEFAULT_CODEAGENT_BASE_URL}/chat/modles?checkUserPermission=TRUE"
+    )
+    headers = cast(dict[str, str], requests[0]["headers"])
+    assert headers["X-Auth-Token"] == "saved-access-token"
+    assert headers["app-id"] == "CodeAgent2.0"
+    assert headers["User-Agent"] == "AgentKernel/1.0"
 
 
 def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
@@ -1493,7 +1564,7 @@ def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
     )
 
     class _SuccessfulCodeAgentTokenService:
-        def get_token_result_sync(
+        def get_token_sync(
             self,
             *,
             base_url: str,
@@ -1501,34 +1572,126 @@ def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
             ssl_verify: bool | None,
             connect_timeout_seconds: float,
             force_refresh: bool = False,
-        ) -> CodeAgentOAuthTokenResult:
-            captured["base_url"] = base_url
-            captured["refresh_token"] = auth_config.refresh_token
-            captured["ssl_verify"] = ssl_verify
-            captured["connect_timeout_seconds"] = connect_timeout_seconds
-            captured["force_refresh"] = force_refresh
-            return CodeAgentOAuthTokenResult(
-                access_token="fresh-access-token",
-                refresh_token="fresh-refresh-token",
-                expires_at=datetime.now(UTC) + timedelta(hours=1),
+        ) -> str:
+            calls = captured.setdefault("token_calls", [])
+            assert isinstance(calls, list)
+            calls.append(
+                {
+                    "base_url": base_url,
+                    "refresh_token": auth_config.refresh_token,
+                    "ssl_verify": ssl_verify,
+                    "connect_timeout_seconds": connect_timeout_seconds,
+                    "force_refresh": force_refresh,
+                }
             )
+            return "fresh-access-token" if force_refresh else "saved-access-token"
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
         lambda: _SuccessfulCodeAgentTokenService(),
+    )
+    responses = [
+        httpx.Response(401, json={"detail": "expired access token"}),
+        httpx.Response(
+            200,
+            json={"models": [{"id": "codeagent-chat"}]},
+        ),
+    ]
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **_kwargs: _QueuedHttpClient(
+            captured=captured,
+            responses=responses,
+        ),
     )
 
     result = service.verify_codeagent_auth(profile_name="default")
 
     assert result.status == "valid"
     assert result.detail is None
-    assert captured == {
-        "base_url": DEFAULT_CODEAGENT_BASE_URL,
-        "refresh_token": "refresh-token",
-        "ssl_verify": True,
-        "connect_timeout_seconds": 17.5,
-        "force_refresh": True,
-    }
+    assert captured["token_calls"] == [
+        {
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "refresh_token": "refresh-token",
+            "ssl_verify": True,
+            "connect_timeout_seconds": 17.5,
+            "force_refresh": False,
+        },
+        {
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "refresh_token": "refresh-token",
+            "ssl_verify": True,
+            "connect_timeout_seconds": 17.5,
+            "force_refresh": True,
+        },
+    ]
+
+
+def test_verify_codeagent_auth_returns_reauth_required_after_refresh_denied(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            api_key=None,
+            codeagent_auth=CodeAgentAuthConfig(
+                access_token="saved-access-token",
+                refresh_token="refresh-token",
+            ),
+        )
+    )
+
+    class _FailingRefreshTokenService:
+        def get_token_sync(
+            self,
+            *,
+            base_url: str,
+            auth_config: CodeAgentAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> str:
+            calls = captured.setdefault("token_calls", [])
+            assert isinstance(calls, list)
+            calls.append(
+                {
+                    "base_url": base_url,
+                    "refresh_token": auth_config.refresh_token,
+                    "ssl_verify": ssl_verify,
+                    "connect_timeout_seconds": connect_timeout_seconds,
+                    "force_refresh": force_refresh,
+                }
+            )
+            if force_refresh:
+                raise CodeAgentOAuthError(
+                    "未识别到用户认证信息",
+                    status_code=401,
+                    error_code="DEV.00000001",
+                )
+            return "saved-access-token"
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _FailingRefreshTokenService(),
+    )
+    responses = [
+        httpx.Response(401, json={"detail": "expired access token"}),
+    ]
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        lambda **_kwargs: _QueuedHttpClient(
+            captured=captured,
+            responses=responses,
+        ),
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert result.status == "reauth_required"
+    assert result.detail == "未识别到用户认证信息"
 
 
 def test_discover_models_codeagent_oauth_http_error_is_retryable_for_server_errors(

--- a/tests/unit_tests/providers/test_model_connectivity.py
+++ b/tests/unit_tests/providers/test_model_connectivity.py
@@ -1293,6 +1293,57 @@ def test_probe_codeagent_returns_invalid_response_for_oauth_error_without_http_s
     assert result.retryable is False
 
 
+def test_probe_codeagent_maps_codeagent_auth_invalid_error_without_http_status(
+    monkeypatch,
+) -> None:
+    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+
+    class _FailingCodeAgentTokenService:
+        def get_token_sync(
+            self,
+            *,
+            base_url: str,
+            auth_config: CodeAgentAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> str:
+            _ = (
+                base_url,
+                auth_config,
+                ssl_verify,
+                connect_timeout_seconds,
+                force_refresh,
+            )
+            raise CodeAgentOAuthError(
+                "未识别到用户认证信息",
+                status_code=None,
+                error_code="DEV.00000001",
+            )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _FailingCodeAgentTokenService(),
+    )
+
+    result = service.probe(
+        ModelConnectivityProbeRequest(
+            override=ModelConnectivityProbeOverride(
+                provider=ProviderType.CODEAGENT,
+                model="codeagent-chat",
+                codeagent_auth=CodeAgentAuthConfig(
+                    refresh_token="refresh-token",
+                ),
+            )
+        )
+    )
+
+    assert result.ok is False
+    assert result.error_code == "auth_invalid"
+    assert result.diagnostics.auth_valid is False
+    assert result.retryable is False
+
+
 def test_discover_models_codeagent_returns_timeout_for_request_exception(
     monkeypatch,
 ) -> None:
@@ -1378,6 +1429,106 @@ def test_discover_models_codeagent_returns_invalid_response_for_oauth_error(
     assert result.ok is False
     assert result.error_code == "invalid_response"
     assert result.retryable is False
+
+
+def test_verify_codeagent_auth_returns_reauth_required_for_auth_invalid(
+    monkeypatch,
+) -> None:
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            api_key=None,
+            codeagent_auth=CodeAgentAuthConfig(refresh_token="refresh-token"),
+        )
+    )
+
+    class _FailingCodeAgentTokenService:
+        def get_token_result_sync(
+            self,
+            *,
+            base_url: str,
+            auth_config: CodeAgentAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> CodeAgentOAuthTokenResult:
+            _ = (
+                base_url,
+                auth_config,
+                ssl_verify,
+                connect_timeout_seconds,
+                force_refresh,
+            )
+            raise CodeAgentOAuthError(
+                "未识别到用户认证信息",
+                status_code=401,
+                error_code="DEV.00000001",
+            )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _FailingCodeAgentTokenService(),
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert result.status == "reauth_required"
+    assert result.detail == "未识别到用户认证信息"
+
+
+def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(
+        get_runtime=lambda: _runtime_config(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            api_key=None,
+            codeagent_auth=CodeAgentAuthConfig(refresh_token="refresh-token"),
+        )
+    )
+
+    class _SuccessfulCodeAgentTokenService:
+        def get_token_result_sync(
+            self,
+            *,
+            base_url: str,
+            auth_config: CodeAgentAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> CodeAgentOAuthTokenResult:
+            captured["base_url"] = base_url
+            captured["refresh_token"] = auth_config.refresh_token
+            captured["ssl_verify"] = ssl_verify
+            captured["connect_timeout_seconds"] = connect_timeout_seconds
+            captured["force_refresh"] = force_refresh
+            return CodeAgentOAuthTokenResult(
+                access_token="fresh-access-token",
+                refresh_token="fresh-refresh-token",
+                expires_at=datetime.now(UTC) + timedelta(hours=1),
+            )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _SuccessfulCodeAgentTokenService(),
+    )
+
+    result = service.verify_codeagent_auth(profile_name="default")
+
+    assert result.status == "valid"
+    assert result.detail is None
+    assert captured == {
+        "base_url": DEFAULT_CODEAGENT_BASE_URL,
+        "refresh_token": "refresh-token",
+        "ssl_verify": True,
+        "connect_timeout_seconds": 17.5,
+        "force_refresh": True,
+    }
 
 
 def test_discover_models_codeagent_oauth_http_error_is_retryable_for_server_errors(


### PR DESCRIPTION
﻿## Summary
- fix CodeAgent saved SSO verification so expired or invalid auth is surfaced as reauth-required instead of being treated as usable login state
- reuse the verified CodeAgent auth state in model discovery and connectivity flows, with server and frontend coverage for the new verification path
- align the CodeAgent SSO login button height with the surrounding model configuration text inputs

## Why
Issue #540 reports that the SSO login status is displayed incorrectly. The branch fixes the auth verification path that was leaving the UI in a false signed-in state and also cleans up the related CodeAgent settings interaction.

## Validation
- `uv run --extra dev pytest -q tests/unit_tests/frontend/test_model_profiles_ui.py tests/unit_tests/interfaces/server/test_system_router.py tests/unit_tests/providers/test_codeagent_auth.py tests/unit_tests/providers/test_model_connectivity.py`
- Chrome DevTools check on `http://127.0.0.1:8000` confirming the CodeAgent SSO button and text inputs all render at `42px` height

Fixes #540
