### PR TITLE
Fix tool call recovery persistence

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -239,8 +239,9 @@ Purpose: cross-agent key-value state.
 
 `expires_at` controls TTL.
 
-Task-scoped tool runtime state is also stored here under `state_key` values such as `tool_call_state:<tool_call_id>`.
-Current tool-call state payloads include run/session linkage, `run_yolo`, and `approval_mode` metadata so SQLite analysis can distinguish YOLO approval bypass from policy-exempt tools.
+Task-scoped tool runtime state is also stored here under `state_key` values such as `tool_call_state:<tool_call_id>` and `tool_call_batch:<batch_id>`.
+Current tool-call state payloads include run/session linkage, batch linkage, result event ids, `run_yolo`, and `approval_mode` metadata so SQLite analysis can distinguish YOLO approval bypass from policy-exempt tools.
+Tool-call batch payloads group all tool calls emitted by one assistant response, including parallel tool calls, so crash recovery can replay only complete sealed batches.
 Sanitized internal tool data may include provider or upstream host identifiers, but must not persist API-key-bearing URLs.
 
 ---
@@ -264,6 +265,7 @@ CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
 ```
 
 Purpose: append-only business/run event log.
+Tool call and tool result events are the durable source used to rebuild missing `tool_call_state:*` and `tool_call_batch:*` shared-state entries after a forced backend stop.
 
 ---
 
@@ -724,6 +726,7 @@ CREATE TABLE IF NOT EXISTS background_tasks (
     role_id             TEXT,
     tool_call_id        TEXT,
     title               TEXT NOT NULL DEFAULT '',
+    input_text          TEXT NOT NULL DEFAULT '',
     command             TEXT NOT NULL,
     cwd                 TEXT NOT NULL,
     execution_mode      TEXT NOT NULL,
@@ -739,6 +742,7 @@ CREATE TABLE IF NOT EXISTS background_tasks (
     subagent_run_id     TEXT,
     subagent_task_id    TEXT,
     subagent_instance_id TEXT,
+    subagent_suppress_hooks INTEGER NOT NULL DEFAULT 0,
     created_at          TEXT NOT NULL,
     updated_at          TEXT NOT NULL,
     completed_at        TEXT,
@@ -753,7 +757,9 @@ CREATE INDEX IF NOT EXISTS idx_background_tasks_status
     ON background_tasks(status, updated_at DESC);
 ```
 
-Purpose: durable metadata for managed background tasks bound to one run.
+Purpose: durable metadata for managed background tasks bound to one run. Foreground
+subagent rows retain enough launch metadata to reattach or resume a synchronous
+`spawn_subagent` call after a forced backend stop.
 
 Notes:
 - `execution_mode` is currently fixed to `background`.

--- a/src/relay_teams/agents/execution/event_publishing.py
+++ b/src/relay_teams/agents/execution/event_publishing.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import json
+import logging
+import sqlite3
 from collections.abc import Awaitable, Callable, Sequence
 from typing import cast
+from uuid import uuid4
 
 from pydantic import JsonValue
 from pydantic_ai.messages import (
@@ -25,6 +28,24 @@ from relay_teams.sessions.runs.event_stream import (
     publish_run_event_async,
 )
 from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.logger import get_logger, log_event
+from relay_teams.tools.runtime.persisted_state import (
+    PersistedToolCallState,
+    PersistedToolCallBatchItem,
+    ToolCallBatchStatus,
+    ToolExecutionStatus,
+    load_tool_call_batch_state,
+    load_tool_call_batch_state_async,
+    load_tool_call_state,
+    load_tool_call_state_async,
+    merge_tool_call_batch_state,
+    merge_tool_call_batch_state_async,
+    merge_tool_call_state,
+    merge_tool_call_state_async,
+)
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+
+LOGGER = get_logger(__name__)
 
 
 class EventPublishingService:
@@ -32,8 +53,10 @@ class EventPublishingService:
         self,
         *,
         run_event_hub: AsyncRunEventPublisher | SyncRunEventPublisher | None,
+        shared_store: SharedStateRepository | None = None,
     ) -> None:
         self._run_event_hub = run_event_hub
+        self._shared_store = shared_store
 
     def publish_text_delta_event(
         self,
@@ -178,27 +201,683 @@ class EventPublishingService:
         for msg in messages:
             if not isinstance(msg, ModelResponse):
                 continue
-            for part in msg.parts:
-                if not isinstance(part, ToolCallPart):
-                    continue
-                tool_call_id = str(part.tool_call_id or "").strip()
-                if tool_call_id and published_tool_call_ids is not None:
-                    if tool_call_id in published_tool_call_ids:
-                        continue
-                    published_tool_call_ids.add(tool_call_id)
-                self._publish_run_event(
+            tool_calls = _tool_calls_from_response(msg)
+            if not tool_calls:
+                continue
+            batch_id = self._batch_id_for_tool_calls(
+                request=request,
+                tool_calls=tool_calls,
+            )
+            batch_emitted = False
+            for batch_index, part in tool_calls:
+                if self.publish_observed_tool_call_event(
                     request=request,
-                    event_type=RunEventType.TOOL_CALL,
-                    payload={
-                        "tool_name": part.tool_name,
-                        "tool_call_id": tool_call_id,
-                        "args": part.args,
-                        "role_id": request.role_id,
-                        "instance_id": request.instance_id,
-                    },
+                    part=part,
+                    batch_id=batch_id,
+                    batch_index=batch_index,
+                    batch_size=len(tool_calls),
+                    published_tool_call_ids=published_tool_call_ids,
+                ):
+                    emitted = True
+                    batch_emitted = True
+            if batch_emitted or self._tool_call_batch_has_observed_items(
+                request=request,
+                batch_id=batch_id,
+            ):
+                self.seal_tool_call_batch(
+                    request=request,
+                    batch_id=batch_id,
+                    tool_calls=tool_calls,
                 )
-                emitted = True
         return emitted
+
+    def publish_observed_tool_call_event(
+        self,
+        *,
+        request: LLMRequest,
+        part: ToolCallPart,
+        batch_id: str,
+        batch_index: int,
+        batch_size: int,
+        published_tool_call_ids: set[str] | None = None,
+    ) -> bool:
+        tool_call_id = str(part.tool_call_id or "").strip()
+        tool_name = str(part.tool_name or "").strip()
+        if not tool_call_id or not tool_name:
+            return False
+        if published_tool_call_ids is not None:
+            if tool_call_id in published_tool_call_ids:
+                return False
+            published_tool_call_ids.add(tool_call_id)
+        self._publish_run_event(
+            request=request,
+            event_type=RunEventType.TOOL_CALL,
+            payload={
+                "run_id": request.run_id,
+                "session_id": request.session_id,
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "args": part.args,
+                "batch_id": batch_id,
+                "batch_index": batch_index,
+                "batch_size": batch_size,
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+        )
+        try:
+            self._persist_observed_tool_call(
+                request=request,
+                part=part,
+                batch_id=batch_id,
+                batch_index=batch_index,
+                batch_size=batch_size,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            self._log_observed_tool_call_persistence_skipped(
+                request=request,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                batch_id=batch_id,
+                error=exc,
+            )
+        return True
+
+    def seal_tool_call_batch(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+        tool_calls: Sequence[tuple[int, ToolCallPart]],
+    ) -> None:
+        if not tool_calls:
+            return
+        items = _batch_items(tool_calls)
+        if not items:
+            return
+        if self._tool_call_batch_is_sealed(request=request, batch_id=batch_id):
+            return
+        self._publish_run_event(
+            request=request,
+            event_type=RunEventType.TOOL_CALL_BATCH_SEALED,
+            payload={
+                "run_id": request.run_id,
+                "session_id": request.session_id,
+                "batch_id": batch_id,
+                "tool_calls": [
+                    {
+                        "tool_call_id": item.tool_call_id,
+                        "tool_name": item.tool_name,
+                        "args": item.args_preview,
+                        "index": item.index,
+                    }
+                    for item in items
+                ],
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+        )
+        try:
+            self._persist_tool_call_batch_seal(
+                request=request,
+                batch_id=batch_id,
+                items=items,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            self._log_tool_call_batch_seal_persistence_skipped(
+                request=request,
+                batch_id=batch_id,
+                error=exc,
+            )
+
+    async def publish_observed_tool_call_event_async(
+        self,
+        *,
+        request: LLMRequest,
+        part: ToolCallPart,
+        batch_id: str,
+        batch_index: int,
+        batch_size: int,
+        published_tool_call_ids: set[str] | None = None,
+    ) -> bool:
+        tool_call_id = str(part.tool_call_id or "").strip()
+        tool_name = str(part.tool_name or "").strip()
+        if not tool_call_id or not tool_name:
+            return False
+        if published_tool_call_ids is not None:
+            if tool_call_id in published_tool_call_ids:
+                return False
+            published_tool_call_ids.add(tool_call_id)
+        await self._publish_run_event_async(
+            request=request,
+            event_type=RunEventType.TOOL_CALL,
+            payload={
+                "run_id": request.run_id,
+                "session_id": request.session_id,
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "args": part.args,
+                "batch_id": batch_id,
+                "batch_index": batch_index,
+                "batch_size": batch_size,
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+        )
+        try:
+            await self._persist_observed_tool_call_async(
+                request=request,
+                part=part,
+                batch_id=batch_id,
+                batch_index=batch_index,
+                batch_size=batch_size,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            self._log_observed_tool_call_persistence_skipped(
+                request=request,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                batch_id=batch_id,
+                error=exc,
+            )
+        return True
+
+    async def seal_tool_call_batch_async(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+        tool_calls: Sequence[tuple[int, ToolCallPart]],
+    ) -> None:
+        if not tool_calls:
+            return
+        items = _batch_items(tool_calls)
+        if not items:
+            return
+        if await self._tool_call_batch_is_sealed_async(
+            request=request,
+            batch_id=batch_id,
+        ):
+            return
+        await self._publish_run_event_async(
+            request=request,
+            event_type=RunEventType.TOOL_CALL_BATCH_SEALED,
+            payload={
+                "run_id": request.run_id,
+                "session_id": request.session_id,
+                "batch_id": batch_id,
+                "tool_calls": [
+                    {
+                        "tool_call_id": item.tool_call_id,
+                        "tool_name": item.tool_name,
+                        "args": item.args_preview,
+                        "index": item.index,
+                    }
+                    for item in items
+                ],
+                "role_id": request.role_id,
+                "instance_id": request.instance_id,
+            },
+        )
+        try:
+            await self._persist_tool_call_batch_seal_async(
+                request=request,
+                batch_id=batch_id,
+                items=items,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            self._log_tool_call_batch_seal_persistence_skipped(
+                request=request,
+                batch_id=batch_id,
+                error=exc,
+            )
+
+    def _persist_tool_call_batch_seal(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+        items: tuple[PersistedToolCallBatchItem, ...],
+    ) -> None:
+        if self._shared_store is None:
+            return
+        merge_tool_call_batch_state(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            batch_id=batch_id,
+            run_id=request.run_id,
+            session_id=request.session_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            status=ToolCallBatchStatus.SEALED,
+            items=items,
+        )
+        for item in items:
+            current = load_tool_call_state(
+                shared_store=self._shared_store,
+                task_id=request.task_id,
+                tool_call_id=item.tool_call_id,
+            )
+            merge_tool_call_state(
+                shared_store=self._shared_store,
+                task_id=request.task_id,
+                tool_call_id=item.tool_call_id,
+                tool_name=item.tool_name,
+                run_id=request.run_id,
+                session_id=request.session_id,
+                instance_id=request.instance_id,
+                role_id=request.role_id,
+                args_preview=item.args_preview,
+                execution_status=(
+                    ToolExecutionStatus.READY
+                    if current is None
+                    else current.execution_status
+                ),
+                batch_id=batch_id,
+                batch_index=item.index,
+                batch_size=len(items),
+            )
+
+    async def _persist_tool_call_batch_seal_async(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+        items: tuple[PersistedToolCallBatchItem, ...],
+    ) -> None:
+        if self._shared_store is None:
+            return
+        await merge_tool_call_batch_state_async(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            batch_id=batch_id,
+            run_id=request.run_id,
+            session_id=request.session_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            status=ToolCallBatchStatus.SEALED,
+            items=items,
+        )
+        for item in items:
+            current = await load_tool_call_state_async(
+                shared_store=self._shared_store,
+                task_id=request.task_id,
+                tool_call_id=item.tool_call_id,
+            )
+            await merge_tool_call_state_async(
+                shared_store=self._shared_store,
+                task_id=request.task_id,
+                tool_call_id=item.tool_call_id,
+                tool_name=item.tool_name,
+                run_id=request.run_id,
+                session_id=request.session_id,
+                instance_id=request.instance_id,
+                role_id=request.role_id,
+                args_preview=item.args_preview,
+                execution_status=(
+                    ToolExecutionStatus.READY
+                    if current is None
+                    else current.execution_status
+                ),
+                batch_id=batch_id,
+                batch_index=item.index,
+                batch_size=len(items),
+            )
+
+    def _batch_id_for_tool_calls(
+        self,
+        *,
+        request: LLMRequest,
+        tool_calls: Sequence[tuple[int, ToolCallPart]],
+    ) -> str:
+        if self._shared_store is not None:
+            try:
+                for _index, part in tool_calls:
+                    tool_call_id = str(part.tool_call_id or "").strip()
+                    if not tool_call_id:
+                        continue
+                    state = load_tool_call_state(
+                        shared_store=self._shared_store,
+                        task_id=request.task_id,
+                        tool_call_id=tool_call_id,
+                    )
+                    if state is not None and state.batch_id:
+                        return state.batch_id
+            except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+                self._log_tool_call_batch_state_lookup_skipped(
+                    request=request,
+                    batch_id=None,
+                    operation="batch_id_lookup",
+                    error=exc,
+                )
+        return f"toolbatch_{uuid4().hex[:16]}"
+
+    def _tool_call_batch_is_sealed(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+    ) -> bool:
+        if self._shared_store is None:
+            return False
+        try:
+            current = load_tool_call_batch_state(
+                shared_store=self._shared_store,
+                task_id=request.task_id,
+                batch_id=batch_id,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            self._log_tool_call_batch_state_lookup_skipped(
+                request=request,
+                batch_id=batch_id,
+                operation="sealed_status_lookup",
+                error=exc,
+            )
+            return False
+        return current is not None and current.status == ToolCallBatchStatus.SEALED
+
+    def _tool_call_batch_has_observed_items(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+    ) -> bool:
+        if self._shared_store is None:
+            return False
+        try:
+            current = load_tool_call_batch_state(
+                shared_store=self._shared_store,
+                task_id=request.task_id,
+                batch_id=batch_id,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            self._log_tool_call_batch_state_lookup_skipped(
+                request=request,
+                batch_id=batch_id,
+                operation="observed_items_lookup",
+                error=exc,
+            )
+            return False
+        return current is not None and bool(current.items)
+
+    async def _batch_id_for_tool_calls_async(
+        self,
+        *,
+        request: LLMRequest,
+        tool_calls: Sequence[tuple[int, ToolCallPart]],
+    ) -> str:
+        if self._shared_store is not None:
+            try:
+                for _index, part in tool_calls:
+                    tool_call_id = str(part.tool_call_id or "").strip()
+                    if not tool_call_id:
+                        continue
+                    state = await load_tool_call_state_async(
+                        shared_store=self._shared_store,
+                        task_id=request.task_id,
+                        tool_call_id=tool_call_id,
+                    )
+                    if state is not None and state.batch_id:
+                        return state.batch_id
+            except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+                self._log_tool_call_batch_state_lookup_skipped(
+                    request=request,
+                    batch_id=None,
+                    operation="batch_id_lookup",
+                    error=exc,
+                )
+        return f"toolbatch_{uuid4().hex[:16]}"
+
+    async def _tool_call_batch_is_sealed_async(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+    ) -> bool:
+        if self._shared_store is None:
+            return False
+        try:
+            current = await load_tool_call_batch_state_async(
+                shared_store=self._shared_store,
+                task_id=request.task_id,
+                batch_id=batch_id,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            self._log_tool_call_batch_state_lookup_skipped(
+                request=request,
+                batch_id=batch_id,
+                operation="sealed_status_lookup",
+                error=exc,
+            )
+            return False
+        return current is not None and current.status == ToolCallBatchStatus.SEALED
+
+    async def _tool_call_batch_has_observed_items_async(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+    ) -> bool:
+        if self._shared_store is None:
+            return False
+        try:
+            current = await load_tool_call_batch_state_async(
+                shared_store=self._shared_store,
+                task_id=request.task_id,
+                batch_id=batch_id,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            self._log_tool_call_batch_state_lookup_skipped(
+                request=request,
+                batch_id=batch_id,
+                operation="observed_items_lookup",
+                error=exc,
+            )
+            return False
+        return current is not None and bool(current.items)
+
+    def _persist_observed_tool_call(
+        self,
+        *,
+        request: LLMRequest,
+        part: ToolCallPart,
+        batch_id: str,
+        batch_index: int,
+        batch_size: int,
+    ) -> None:
+        if self._shared_store is None:
+            return
+        current_batch = load_tool_call_batch_state(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            batch_id=batch_id,
+        )
+        item = _batch_item(batch_index, part)
+        items = (
+            (item,)
+            if current_batch is None
+            else _merge_items(
+                current_batch.items,
+                (item,),
+            )
+        )
+        merge_tool_call_batch_state(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            batch_id=batch_id,
+            run_id=request.run_id,
+            session_id=request.session_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            status=ToolCallBatchStatus.OPEN
+            if current_batch is None
+            else current_batch.status,
+            items=items,
+        )
+        current_call = load_tool_call_state(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            tool_call_id=item.tool_call_id,
+        )
+        merge_tool_call_state(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            tool_call_id=item.tool_call_id,
+            tool_name=item.tool_name,
+            run_id=request.run_id,
+            session_id=request.session_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            args_preview=item.args_preview,
+            execution_status=_observed_tool_execution_status(current_call),
+            batch_id=batch_id,
+            batch_index=batch_index,
+            batch_size=batch_size,
+        )
+
+    async def _persist_observed_tool_call_async(
+        self,
+        *,
+        request: LLMRequest,
+        part: ToolCallPart,
+        batch_id: str,
+        batch_index: int,
+        batch_size: int,
+    ) -> None:
+        if self._shared_store is None:
+            return
+        current_batch = await load_tool_call_batch_state_async(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            batch_id=batch_id,
+        )
+        item = _batch_item(batch_index, part)
+        items = (
+            (item,)
+            if current_batch is None
+            else _merge_items(
+                current_batch.items,
+                (item,),
+            )
+        )
+        await merge_tool_call_batch_state_async(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            batch_id=batch_id,
+            run_id=request.run_id,
+            session_id=request.session_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            status=ToolCallBatchStatus.OPEN
+            if current_batch is None
+            else current_batch.status,
+            items=items,
+        )
+        current_call = await load_tool_call_state_async(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            tool_call_id=item.tool_call_id,
+        )
+        await merge_tool_call_state_async(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            tool_call_id=item.tool_call_id,
+            tool_name=item.tool_name,
+            run_id=request.run_id,
+            session_id=request.session_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            args_preview=item.args_preview,
+            execution_status=_observed_tool_execution_status(current_call),
+            batch_id=batch_id,
+            batch_index=batch_index,
+            batch_size=batch_size,
+        )
+
+    @staticmethod
+    def _log_observed_tool_call_persistence_skipped(
+        *,
+        request: LLMRequest,
+        tool_name: str,
+        tool_call_id: str,
+        batch_id: str,
+        error: Exception,
+    ) -> None:
+        payload: dict[str, JsonValue] = {
+            "run_id": request.run_id,
+            "task_id": request.task_id,
+            "trace_id": request.trace_id,
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "batch_id": batch_id,
+            "error_type": error.__class__.__name__,
+            "error": str(error),
+        }
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="llm.request.skipped_observed_tool_call_persistence",
+            message=(
+                "Skipped best-effort observed tool-call persistence after "
+                "TOOL_CALL event publication"
+            ),
+            payload=payload,
+        )
+
+    @staticmethod
+    def _log_tool_call_batch_seal_persistence_skipped(
+        *,
+        request: LLMRequest,
+        batch_id: str,
+        error: Exception,
+    ) -> None:
+        payload: dict[str, JsonValue] = {
+            "run_id": request.run_id,
+            "task_id": request.task_id,
+            "trace_id": request.trace_id,
+            "batch_id": batch_id,
+            "error_type": error.__class__.__name__,
+            "error": str(error),
+        }
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="llm.request.skipped_tool_call_batch_seal_persistence",
+            message=(
+                "Skipped best-effort tool-call batch seal persistence after "
+                "TOOL_CALL_BATCH_SEALED event publication"
+            ),
+            payload=payload,
+        )
+
+    @staticmethod
+    def _log_tool_call_batch_state_lookup_skipped(
+        *,
+        request: LLMRequest,
+        batch_id: str | None,
+        operation: str,
+        error: Exception,
+    ) -> None:
+        payload: dict[str, JsonValue] = {
+            "run_id": request.run_id,
+            "task_id": request.task_id,
+            "trace_id": request.trace_id,
+            "operation": operation,
+            "error_type": error.__class__.__name__,
+            "error": str(error),
+        }
+        if batch_id is not None:
+            payload["batch_id"] = batch_id
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="llm.request.skipped_tool_call_batch_state_lookup",
+            message=(
+                "Skipped best-effort tool-call batch shared-state lookup before "
+                "event publication"
+            ),
+            payload=payload,
+        )
 
     async def publish_tool_call_events_from_messages_async(
         self,
@@ -211,26 +890,34 @@ class EventPublishingService:
         for msg in messages:
             if not isinstance(msg, ModelResponse):
                 continue
-            for part in msg.parts:
-                if not isinstance(part, ToolCallPart):
-                    continue
-                tool_call_id = str(part.tool_call_id or "").strip()
-                if tool_call_id and published_tool_call_ids is not None:
-                    if tool_call_id in published_tool_call_ids:
-                        continue
-                    published_tool_call_ids.add(tool_call_id)
-                await self._publish_run_event_async(
+            tool_calls = _tool_calls_from_response(msg)
+            if not tool_calls:
+                continue
+            batch_id = await self._batch_id_for_tool_calls_async(
+                request=request,
+                tool_calls=tool_calls,
+            )
+            batch_emitted = False
+            for batch_index, part in tool_calls:
+                if await self.publish_observed_tool_call_event_async(
                     request=request,
-                    event_type=RunEventType.TOOL_CALL,
-                    payload={
-                        "tool_name": part.tool_name,
-                        "tool_call_id": tool_call_id,
-                        "args": part.args,
-                        "role_id": request.role_id,
-                        "instance_id": request.instance_id,
-                    },
+                    part=part,
+                    batch_id=batch_id,
+                    batch_index=batch_index,
+                    batch_size=len(tool_calls),
+                    published_tool_call_ids=published_tool_call_ids,
+                ):
+                    emitted = True
+                    batch_emitted = True
+            if batch_emitted or await self._tool_call_batch_has_observed_items_async(
+                request=request,
+                batch_id=batch_id,
+            ):
+                await self.seal_tool_call_batch_async(
+                    request=request,
+                    batch_id=batch_id,
+                    tool_calls=tool_calls,
                 )
-                emitted = True
         return emitted
 
     def publish_committed_tool_outcome_events_from_messages(
@@ -450,3 +1137,60 @@ class EventPublishingService:
             return json.dumps(obj, ensure_ascii=False, default=str)
         except Exception:
             return json.dumps({"error": "unserializable", "repr": str(obj)})
+
+
+def _tool_calls_from_response(
+    message: ModelResponse,
+) -> tuple[tuple[int, ToolCallPart], ...]:
+    return tuple(
+        (index, part)
+        for index, part in enumerate(message.parts)
+        if isinstance(part, ToolCallPart)
+    )
+
+
+def _batch_item(index: int, part: ToolCallPart) -> PersistedToolCallBatchItem:
+    return PersistedToolCallBatchItem(
+        tool_call_id=str(part.tool_call_id or "").strip(),
+        tool_name=str(part.tool_name or "").strip(),
+        args_preview=_args_preview(cast(object, part.args)),
+        index=index,
+    )
+
+
+def _observed_tool_execution_status(
+    current: PersistedToolCallState | None,
+) -> ToolExecutionStatus:
+    if current is None:
+        return ToolExecutionStatus.READY
+    return current.execution_status
+
+
+def _batch_items(
+    tool_calls: Sequence[tuple[int, ToolCallPart]],
+) -> tuple[PersistedToolCallBatchItem, ...]:
+    items = tuple(
+        _batch_item(index, part)
+        for index, part in tool_calls
+        if str(part.tool_call_id or "").strip() and str(part.tool_name or "").strip()
+    )
+    return tuple(sorted(items, key=lambda item: item.index))
+
+
+def _merge_items(
+    current: tuple[PersistedToolCallBatchItem, ...],
+    incoming: tuple[PersistedToolCallBatchItem, ...],
+) -> tuple[PersistedToolCallBatchItem, ...]:
+    merged = {item.tool_call_id: item for item in current}
+    for item in incoming:
+        merged[item.tool_call_id] = item
+    return tuple(sorted(merged.values(), key=lambda item: item.index))
+
+
+def _args_preview(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(value)

--- a/src/relay_teams/agents/execution/message_commit.py
+++ b/src/relay_teams/agents/execution/message_commit.py
@@ -456,7 +456,7 @@ class MessageCommitService:
         self,
         messages: Sequence[ModelRequest | ModelResponse],
     ) -> int:
-        pending: set[str] = set()
+        pending: dict[str, str] = {}
         last_safe_index = 0
         for index, msg in enumerate(messages, start=1):
             if isinstance(msg, ModelResponse):
@@ -465,14 +465,20 @@ class MessageCommitService:
                         continue
                     tool_call_id = str(part.tool_call_id or "").strip()
                     if tool_call_id:
-                        pending.add(tool_call_id)
+                        pending[tool_call_id] = str(part.tool_name or "")
             else:
                 for part in msg.parts:
                     tool_call_id = str(getattr(part, "tool_call_id", "") or "").strip()
                     if not tool_call_id:
                         continue
                     if isinstance(part, (ToolReturnPart, RetryPromptPart)):
-                        pending.discard(tool_call_id)
+                        pending_tool_name = pending.get(tool_call_id)
+                        result_tool_name = str(getattr(part, "tool_name", "") or "")
+                        if pending_tool_name is not None and (
+                            not result_tool_name
+                            or pending_tool_name == result_tool_name
+                        ):
+                            pending.pop(tool_call_id, None)
             if not pending:
                 last_safe_index = index
         return last_safe_index

--- a/src/relay_teams/agents/execution/message_repository.py
+++ b/src/relay_teams/agents/execution/message_repository.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pydantic import JsonValue
 
 import json
+import logging
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import replace
@@ -34,9 +35,13 @@ from relay_teams.sessions.session_history_marker_models import SessionHistoryMar
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )
+from relay_teams.logger import get_logger, log_event
 from relay_teams.system_reminder_text import is_rendered_system_reminder_text
 
 _SQLITE_SAFE_VARIABLE_LIMIT = 900
+
+
+LOGGER = get_logger(__name__)
 
 
 class MessageRepository(SharedSqliteRepository):
@@ -201,7 +206,7 @@ class MessageRepository(SharedSqliteRepository):
 
     def get_history(self, instance_id: str) -> list[ModelMessage]:
         return self._read_history(
-            "SELECT session_id, message_json, created_at, hidden_from_context FROM messages WHERE instance_id=? ORDER BY id ASC",
+            "SELECT id, session_id, message_json, created_at, hidden_from_context FROM messages WHERE instance_id=? ORDER BY id ASC",
             (instance_id,),
         )
 
@@ -210,7 +215,7 @@ class MessageRepository(SharedSqliteRepository):
 
     def get_history_for_conversation(self, conversation_id: str) -> list[ModelMessage]:
         return self._read_history(
-            "SELECT session_id, message_json, created_at, hidden_from_context FROM messages WHERE conversation_id=? ORDER BY id ASC",
+            "SELECT id, session_id, message_json, created_at, hidden_from_context FROM messages WHERE conversation_id=? ORDER BY id ASC",
             (conversation_id,),
         )
 
@@ -1009,7 +1014,7 @@ class MessageRepository(SharedSqliteRepository):
         self, instance_id: str, task_id: str
     ) -> list[ModelMessage]:
         return self._read_history(
-            "SELECT session_id, message_json, created_at, hidden_from_context FROM messages WHERE instance_id=? AND task_id=? ORDER BY id ASC",
+            "SELECT id, session_id, message_json, created_at, hidden_from_context FROM messages WHERE instance_id=? AND task_id=? ORDER BY id ASC",
             (instance_id, task_id),
         )
 
@@ -1024,7 +1029,7 @@ class MessageRepository(SharedSqliteRepository):
         self, conversation_id: str, task_id: str
     ) -> list[ModelMessage]:
         return self._read_history(
-            "SELECT session_id, message_json, created_at, hidden_from_context FROM messages WHERE conversation_id=? AND task_id=? ORDER BY id ASC",
+            "SELECT id, session_id, message_json, created_at, hidden_from_context FROM messages WHERE conversation_id=? AND task_id=? ORDER BY id ASC",
             (conversation_id, task_id),
         )
 
@@ -1049,9 +1054,7 @@ class MessageRepository(SharedSqliteRepository):
         )
         result: list[ModelMessage] = []
         for row in rows:
-            msgs = ModelMessagesTypeAdapter.validate_json(
-                _sanitize_message_json(str(row["message_json"]))
-            )
+            msgs = _validate_message_row(row)
             result.extend(msgs)
         return _truncate_model_history_to_safe_boundary(result)
 
@@ -1508,11 +1511,41 @@ def _safe_row_ids(rows: Sequence[sqlite3.Row]) -> set[int]:
         row_id = row["id"]
         if not isinstance(row_id, int):
             continue
-        messages = ModelMessagesTypeAdapter.validate_json(
-            _sanitize_message_json(str(row["message_json"]))
-        )
+        messages = _validate_message_row(row)
+        if not messages:
+            continue
         history_rows.append((row_id, messages))
     return collect_safe_row_ids(history_rows)
+
+
+def _validate_message_row(row: sqlite3.Row) -> list[ModelMessage]:
+    try:
+        return list(
+            ModelMessagesTypeAdapter.validate_json(
+                _sanitize_message_json(str(row["message_json"]))
+            )
+        )
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="llm.history.dropped_invalid_message_row",
+            message="Dropped invalid persisted message row during history replay",
+            payload={
+                "row_id": _row_id(row),
+                "error_type": exc.__class__.__name__,
+                "error": str(exc),
+            },
+        )
+        return []
+
+
+def _row_id(row: sqlite3.Row) -> int:
+    try:
+        raw_row_id = row["id"]
+    except (IndexError, KeyError):
+        return 0
+    return raw_row_id if isinstance(raw_row_id, int) else 0
 
 
 def _ensure_after_iso_value(candidate: datetime, raw_value: str | None) -> datetime:

--- a/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
+++ b/src/relay_teams/agents/execution/recoverable_openai_chat_model.py
@@ -11,7 +11,10 @@ from openai.types.chat.chat_completion_message_function_tool_call_param import (
 from pydantic_ai._utils import guard_tool_call_id
 from pydantic_ai.messages import (
     ModelMessage,
+    ModelResponse,
     ModelRequestPart,
+    TextPart,
+    ThinkingPart,
     ToolCallPart,
 )
 from pydantic_ai.models import ModelRequestParameters
@@ -32,10 +35,18 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
         messages: Sequence[ModelMessage],
         model_request_parameters: ModelRequestParameters,
     ) -> list[chat.ChatCompletionMessageParam]:
-        return await super()._map_messages(
+        mapped = await super()._map_messages(
             self._sanitize_replayed_messages(messages),
             model_request_parameters,
         )
+        for message in mapped:
+            if not isinstance(message, dict):
+                continue
+            if message.get("role") != "assistant":
+                continue
+            if message.get("content") is None:
+                message["content"] = ""
+        return mapped
 
     @staticmethod
     def _map_tool_call(t: ToolCallPart) -> ChatCompletionMessageFunctionToolCallParam:
@@ -66,7 +77,8 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
         messages: Sequence[ModelMessage],
     ) -> list[ModelMessage]:
         return normalize_replayed_messages(
-            messages, on_drop=cls._log_dropped_tool_result
+            _drop_provider_empty_responses(messages),
+            on_drop=cls._log_dropped_tool_result,
         )
 
     @staticmethod
@@ -89,3 +101,32 @@ class RecoverableOpenAIChatModel(OpenAIChatModel):
                 "tool_name": str(getattr(part, "tool_name", "") or ""),
             },
         )
+
+
+def _drop_provider_empty_responses(
+    messages: Sequence[ModelMessage],
+) -> list[ModelMessage]:
+    sanitized: list[ModelMessage] = []
+    for message in messages:
+        if not isinstance(message, ModelResponse):
+            sanitized.append(message)
+            continue
+        if _is_thinking_only_response(message):
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="llm.history.dropped_thinking_only_response",
+                message="Dropped thinking-only assistant response before provider replay",
+                payload={},
+            )
+            continue
+        sanitized.append(message)
+    return sanitized
+
+
+def _is_thinking_only_response(message: ModelResponse) -> bool:
+    if not message.parts:
+        return False
+    if any(isinstance(part, (TextPart, ToolCallPart)) for part in message.parts):
+        return False
+    return all(isinstance(part, ThinkingPart) for part in message.parts)

--- a/src/relay_teams/agents/execution/session_mixin_base.py
+++ b/src/relay_teams/agents/execution/session_mixin_base.py
@@ -80,6 +80,7 @@ from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry import ToolRegistry
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from relay_teams.tools.runtime.context import ToolDeps
 from relay_teams.tools.runtime.persisted_state import PersistedToolCallState
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.workspace_tools.shell_approval_repo import (
@@ -498,6 +499,16 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
         *,
         request: LLMRequest,
         pending_messages: Sequence[ModelRequest | ModelResponse],
+    ) -> tuple[list[ModelRequest | ModelResponse], int]:
+        raise NotImplementedError
+
+    async def _recover_uncommitted_tool_batches_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        deps: ToolDeps,
+        recover_ready_calls: bool,
     ) -> tuple[list[ModelRequest | ModelResponse], int]:
         raise NotImplementedError
 

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -15,6 +15,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    PartEndEvent,
     RetryPromptPart,
     TextPart,
     ToolCallPart,
@@ -22,6 +23,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
 )
 from pydantic_ai.usage import UsageLimits
+from uuid import uuid4
 
 from relay_teams.agents.execution.message_commit import (
     tool_input_validation_failure_to_tool_return,
@@ -492,6 +494,17 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                         allowed_skills=self._allowed_skills,
                     )
                     coordination_agent = cast(CoordinationAgent, agent)
+            (
+                history,
+                _recovered_batch_tool_count,
+            ) = await self._recover_uncommitted_tool_batches_async(
+                request=request,
+                history=history,
+                deps=deps,
+                recover_ready_calls=(
+                    retry_number == 0 and not skip_initial_user_prompt_persist
+                ),
+            )
             seen_count = 0
             buffered_messages: list[ModelRequest | ModelResponse] = []
             restarted = False
@@ -533,6 +546,9 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                     dict[int, ToolCallPart | ToolCallPartDelta],
                                     {},
                                 )
+                                active_tool_call_batch_id = (
+                                    f"toolbatch_{uuid4().hex[:16]}"
+                                )
                                 streamed_text_start = len(emitted_text_chunks)
                                 usage_before = deepcopy(agent_run.usage())
                                 async with streamable_node.stream(
@@ -554,6 +570,23 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                                 started_thinking_parts=started_thinking_parts,
                                                 streamed_tool_calls=streamed_tool_calls,
                                             )
+                                            if isinstance(
+                                                stream_event, PartEndEvent
+                                            ) and isinstance(
+                                                stream_event.part, ToolCallPart
+                                            ):
+                                                tool_call_event_emitted = await self._event_publishing_service().publish_observed_tool_call_event_async(
+                                                    request=request,
+                                                    part=stream_event.part,
+                                                    batch_id=active_tool_call_batch_id,
+                                                    batch_index=stream_event.index,
+                                                    batch_size=0,
+                                                    published_tool_call_ids=published_tool_call_ids,
+                                                )
+                                                if tool_call_event_emitted:
+                                                    attempt_tool_call_event_emitted = (
+                                                        True
+                                                    )
                                             if text_emitted:
                                                 printed_any = True
                                                 attempt_text_emitted = True

--- a/src/relay_teams/agents/execution/session_support.py
+++ b/src/relay_teams/agents/execution/session_support.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import asyncio
 import ast
-import logging
 import json
+import logging
+import sqlite3
 from collections.abc import Sequence
 from dataclasses import replace
+from datetime import datetime, timezone
 from typing import Protocol, cast, runtime_checkable
 
 from pydantic import JsonValue
@@ -18,6 +20,8 @@ from pydantic_ai.messages import (
     PartEndEvent,
     PartStartEvent,
     RetryPromptPart,
+    TextPart,
+    ThinkingPart,
     ToolCallPart,
     ToolCallPartDelta,
     ToolReturnPart,
@@ -37,6 +41,9 @@ from relay_teams.agents.execution.stream_events import StreamEventService
 from relay_teams.agents.execution.tool_args_recovery import ToolArgsRecoveryService
 from relay_teams.agents.execution.tool_result_state import ToolResultStateService
 from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.agents.execution.tool_call_history import (
+    normalize_replayed_messages_to_safe_boundary,
+)
 from relay_teams.logger import get_logger, log_event, log_model_stream_chunk
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType
@@ -44,13 +51,23 @@ from relay_teams.providers.llm_retry import LlmRetryErrorInfo
 from relay_teams.providers.model_config import LlmRetryConfig, ModelEndpointConfig
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.sessions.runs.assistant_errors import build_tool_error_result
+from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskRecord
+from relay_teams.sessions.runs.background_tasks.projection import (
+    build_background_task_result_payload,
+)
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.tools.runtime.persisted_state import (
+    PersistedToolCallBatchState,
     PersistedToolCallState,
+    ToolCallBatchStatus,
     ToolExecutionStatus,
+    merge_tool_call_state_async,
     load_or_recover_tool_call_state,
+    recover_tool_call_batches_from_event_log,
 )
+from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.recoverable_invoker import RecoverableToolInvoker
 from relay_teams.workspace import build_conversation_id
 
 LOGGER = get_logger(__name__)
@@ -248,6 +265,33 @@ class _NullPromptHistoryMessageRepo:
         )
 
 
+@runtime_checkable
+class _SubagentWaitResult(Protocol):
+    output: str
+
+
+@runtime_checkable
+class _SubagentWaitService(Protocol):
+    async def wait_for_subagent_run(
+        self,
+        *,
+        parent_run_id: str,
+        subagent_run_id: str,
+    ) -> _SubagentWaitResult:
+        raise NotImplementedError  # pragma: no cover
+
+
+@runtime_checkable
+class _SubagentRecordLookupService(Protocol):
+    def subagent_record_for_tool_call(
+        self,
+        *,
+        parent_run_id: str,
+        tool_call_id: str,
+    ) -> BackgroundTaskRecord | None:
+        raise NotImplementedError  # pragma: no cover
+
+
 class _NullRunIntentRepo:
     def get(self, run_id: str, *, fallback_session_id: str | None = None) -> object:
         _ = (run_id, fallback_session_id)
@@ -267,8 +311,29 @@ def _tool_result_error_code(result: dict[str, JsonValue]) -> str:
             return code.strip()
     visible_result = result.get("visible_result")
     if isinstance(visible_result, dict):
-        return _tool_result_error_code(cast(dict[str, JsonValue], visible_result))
+        return _tool_result_error_code(visible_result)
     return ""
+
+
+def _is_thinking_only_response(message: ModelResponse) -> bool:
+    if not message.parts:
+        return False
+    if any(isinstance(part, (TextPart, ToolCallPart)) for part in message.parts):
+        return False
+    return all(isinstance(part, ThinkingPart) for part in message.parts)
+
+
+def _tool_args_from_preview(value: str) -> dict[str, JsonValue] | str:
+    text = value.strip()
+    if not text:
+        return {}
+    try:
+        decoded = json.loads(text)
+    except Exception:
+        return text
+    if isinstance(decoded, dict):
+        return cast(dict[str, JsonValue], decoded)
+    return text
 
 
 class SessionSupportMixin(AgentLlmSessionMixinBase):
@@ -826,7 +891,23 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
     def _filter_model_messages(
         self, messages: Sequence[ModelRequest | ModelResponse]
     ) -> list[ModelRequest | ModelResponse]:
-        return list(messages)
+        filtered: list[ModelRequest | ModelResponse] = []
+        for message in messages:
+            if isinstance(message, ModelResponse) and _is_thinking_only_response(
+                message
+            ):
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="llm.history.dropped_thinking_only_response",
+                    message=(
+                        "Dropped thinking-only assistant response before prompt replay"
+                    ),
+                    payload={},
+                )
+                continue
+            filtered.append(message)
+        return filtered
 
     def _collect_pending_tool_calls(
         self, messages: Sequence[ModelRequest | ModelResponse]
@@ -928,6 +1009,21 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             )
         if not recovered_parts and not recovered_orphaned_parts:
             return next_pending_messages, 0
+        recovered_tool_call_id_values: list[JsonValue] = [
+            value for value in recovered_tool_call_ids
+        ]
+        recovered_tool_name_values: list[JsonValue] = [
+            value for value in recovered_tool_names
+        ]
+        recovery_payload: dict[str, JsonValue] = {
+            "run_id": request.run_id,
+            "task_id": request.task_id,
+            "role_id": request.role_id,
+            "instance_id": request.instance_id,
+            "recovered_tool_call_ids": recovered_tool_call_id_values,
+            "recovered_tool_names": recovered_tool_name_values,
+            "recovered_count": len(recovered_parts),
+        }
         log_event(
             LOGGER,
             logging.WARNING,
@@ -935,23 +1031,301 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             message=(
                 "Recovered persisted tool results for pending tool calls before resume"
             ),
-            payload=cast(
-                dict[str, JsonValue],
-                {
-                    "run_id": request.run_id,
-                    "task_id": request.task_id,
-                    "role_id": request.role_id,
-                    "instance_id": request.instance_id,
-                    "recovered_tool_call_ids": recovered_tool_call_ids,
-                    "recovered_tool_names": recovered_tool_names,
-                    "recovered_count": len(recovered_parts),
-                },
-            ),
+            payload=recovery_payload,
         )
         if recovered_parts:
             next_pending_messages.append(ModelRequest(parts=recovered_parts))
         return next_pending_messages, len(recovered_parts) + len(
             recovered_orphaned_parts
+        )
+
+    async def _recover_uncommitted_tool_batches_async(
+        self,
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        deps: ToolDeps,
+        recover_ready_calls: bool,
+    ) -> tuple[list[ModelRequest | ModelResponse], int]:
+        if self._shared_store is None or self._event_bus is None:
+            return history, 0
+        try:
+            _ = recover_tool_call_batches_from_event_log(
+                event_log=self._event_bus,
+                shared_store=self._shared_store,
+                trace_id=request.trace_id,
+                task_id=request.task_id,
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            skipped_payload: dict[str, JsonValue] = {
+                "run_id": request.run_id,
+                "task_id": request.task_id,
+                "trace_id": request.trace_id,
+                "error_type": exc.__class__.__name__,
+                "error": str(exc),
+            }
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="llm.request.skipped_tool_batch_event_log_recovery",
+                message=(
+                    "Skipped best-effort tool-call batch event-log recovery before "
+                    "resume"
+                ),
+                payload=skipped_payload,
+            )
+        committed_tool_call_ids = self._committed_tool_call_ids_from_history(history)
+        recovered_count = 0
+        current_history = history
+        for batch in self._task_tool_call_batch_states(request.task_id):
+            if not self._batch_matches_request(batch=batch, request=request):
+                continue
+            if not self._is_recoverable_tool_call_batch(batch):
+                continue
+            batch_call_ids = {
+                item.tool_call_id for item in batch.items if item.tool_call_id
+            }
+            uncommitted_items = tuple(
+                item
+                for item in batch.items
+                if item.tool_call_id
+                and item.tool_call_id not in committed_tool_call_ids
+            )
+            uncommitted_call_ids = {
+                item.tool_call_id for item in uncommitted_items if item.tool_call_id
+            }
+            if not batch_call_ids or not uncommitted_call_ids:
+                continue
+            recovered_messages = await self._recovered_batch_messages(
+                request=request,
+                deps=deps,
+                batch=batch.model_copy(update={"items": uncommitted_items}),
+                recover_ready_calls=recover_ready_calls,
+            )
+            if recovered_messages is None:
+                continue
+            (
+                current_history,
+                remaining,
+                _published,
+                _validation_failures,
+            ) = await self._commit_all_safe_messages_async(
+                request=request,
+                history=current_history,
+                pending_messages=recovered_messages,
+            )
+            if remaining:
+                continue
+            committed_tool_call_ids.update(uncommitted_call_ids)
+            recovered_count += len(uncommitted_call_ids)
+        return current_history, recovered_count
+
+    async def _recovered_batch_messages(
+        self,
+        *,
+        request: LLMRequest,
+        deps: ToolDeps,
+        batch: PersistedToolCallBatchState,
+        recover_ready_calls: bool,
+    ) -> list[ModelRequest | ModelResponse] | None:
+        call_parts: list[ToolCallPart] = []
+        result_parts: list[ToolReturnPart] = []
+        for item in sorted(batch.items, key=lambda candidate: candidate.index):
+            try:
+                state = load_or_recover_tool_call_state(
+                    shared_store=self._shared_store,
+                    event_log=self._event_bus,
+                    trace_id=request.trace_id,
+                    task_id=request.task_id,
+                    tool_call_id=item.tool_call_id,
+                    task_repo=self._task_repo,
+                )
+            except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+                skipped_payload: dict[str, JsonValue] = {
+                    "run_id": request.run_id,
+                    "task_id": request.task_id,
+                    "trace_id": request.trace_id,
+                    "batch_id": batch.batch_id,
+                    "tool_call_id": item.tool_call_id,
+                    "error_type": exc.__class__.__name__,
+                    "error": str(exc),
+                }
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="llm.request.skipped_tool_batch_item_state_recovery",
+                    message=(
+                        "Skipped tool-call batch recovery after item state "
+                        "lookup failed"
+                    ),
+                    payload=skipped_payload,
+                )
+                return None
+            call_parts.append(
+                ToolCallPart(
+                    tool_name=item.tool_name,
+                    args=_tool_args_from_preview(item.args_preview),
+                    tool_call_id=item.tool_call_id,
+                )
+            )
+            visible_result = await self._visible_result_for_batch_item(
+                request=request,
+                deps=deps,
+                state=state,
+                tool_call_id=item.tool_call_id,
+                tool_name=item.tool_name,
+                raw_args=item.args_preview,
+                recover_ready_calls=recover_ready_calls,
+            )
+            if visible_result is None:
+                return None
+            result_parts.append(
+                ToolReturnPart(
+                    tool_name=item.tool_name,
+                    tool_call_id=item.tool_call_id,
+                    content=visible_result,
+                )
+            )
+        if not call_parts or len(call_parts) != len(result_parts):
+            return None
+        return [ModelResponse(parts=call_parts), ModelRequest(parts=result_parts)]
+
+    @staticmethod
+    def _is_recoverable_tool_call_batch(batch: PersistedToolCallBatchState) -> bool:
+        if batch.status == ToolCallBatchStatus.SEALED:
+            return True
+        return batch.status == ToolCallBatchStatus.OPEN and bool(batch.items)
+
+    async def _visible_result_for_batch_item(
+        self,
+        *,
+        request: LLMRequest,
+        deps: ToolDeps,
+        state: PersistedToolCallState | None,
+        tool_call_id: str,
+        tool_name: str,
+        raw_args: object,
+        recover_ready_calls: bool,
+    ) -> dict[str, JsonValue] | None:
+        visible_result = self._visible_tool_result_from_state(
+            state=state,
+            expected_tool_name=tool_name,
+        )
+        if visible_result is not None:
+            return visible_result
+        if state is None:
+            return None
+        if state.execution_status == ToolExecutionStatus.READY:
+            if not recover_ready_calls:
+                return None
+            return await self._invoke_and_persist_recovered_tool_call_async(
+                request=request,
+                deps=deps,
+                state=state,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                raw_args=raw_args,
+            )
+        if (
+            state.execution_status == ToolExecutionStatus.RUNNING
+            and tool_name == "spawn_subagent"
+        ):
+            resumed_result = await self._resume_pending_spawn_subagent_call(
+                request=request,
+                state=state,
+            )
+            if resumed_result is not None:
+                return resumed_result
+            if recover_ready_calls and not self._spawn_subagent_has_durable_launch(
+                request=request,
+                state=state,
+            ):
+                return await self._invoke_and_persist_recovered_tool_call_async(
+                    request=request,
+                    deps=deps,
+                    state=state,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                    raw_args=raw_args,
+                )
+            return None
+        if state.execution_status == ToolExecutionStatus.RUNNING:
+            return cast(
+                dict[str, JsonValue],
+                build_tool_error_result(
+                    error_code="tool_execution_interrupted",
+                    message=(
+                        "Tool execution was interrupted before its result was "
+                        "durably recorded; it was not retried automatically."
+                    ),
+                ),
+            )
+        return None
+
+    async def _invoke_and_persist_recovered_tool_call_async(
+        self,
+        *,
+        request: LLMRequest,
+        deps: ToolDeps,
+        state: PersistedToolCallState,
+        tool_call_id: str,
+        tool_name: str,
+        raw_args: object,
+    ) -> dict[str, JsonValue]:
+        visible_result = await RecoverableToolInvoker().invoke_async(
+            tool_registry=self._tool_registry,
+            deps=deps,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            raw_args=raw_args,
+        )
+        shared_store = getattr(self, "_shared_store", None)
+        if shared_store is None:
+            return visible_result
+        runtime_meta: dict[str, JsonValue] = {
+            "tool_result_durably_recorded": True,
+            "tool_result_event_published": False,
+            "recovered_tool_call": True,
+        }
+        result_envelope: dict[str, JsonValue] = {
+            "visible_result": visible_result,
+            "runtime_meta": runtime_meta,
+        }
+        await merge_tool_call_state_async(
+            shared_store=shared_store,
+            task_id=request.task_id,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            run_id=request.run_id,
+            session_id=request.session_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            args_preview=state.args_preview,
+            execution_status=(
+                ToolExecutionStatus.FAILED
+                if visible_result.get("ok") is False
+                else ToolExecutionStatus.COMPLETED
+            ),
+            result_envelope=result_envelope,
+            batch_id=state.batch_id,
+            batch_index=state.batch_index,
+            batch_size=state.batch_size,
+            finished_at=datetime.now(tz=timezone.utc).isoformat(),
+        )
+        return visible_result
+
+    @staticmethod
+    def _batch_matches_request(
+        *,
+        batch: PersistedToolCallBatchState,
+        request: LLMRequest,
+    ) -> bool:
+        return (
+            batch.run_id == request.run_id
+            and batch.session_id == request.session_id
+            and batch.instance_id == request.instance_id
+            and batch.role_id == request.role_id
+            and batch.task_id == request.task_id
         )
 
     def _interleave_recovered_orphaned_tool_results(
@@ -1099,7 +1473,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             return set()
         try:
             events = event_bus.list_by_trace(request.trace_id)
-        except Exception:
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error):
             return set()
         superseded_ids: set[str] = set()
         for event in events:
@@ -1172,10 +1546,17 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             history = message_repo.get_history_for_conversation(
                 resolved_conversation_id
             )
-        except Exception:
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error):
             return set()
+        return self._committed_tool_call_ids_from_history(history)
+
+    @staticmethod
+    def _committed_tool_call_ids_from_history(
+        history: Sequence[ModelRequest | ModelResponse],
+    ) -> set[str]:
+        safe_history = normalize_replayed_messages_to_safe_boundary(history)
         committed_ids: set[str] = set()
-        for message in history:
+        for message in safe_history:
             for part in message.parts:
                 if isinstance(part, ToolCallPart | ToolReturnPart):
                     tool_call_id = str(part.tool_call_id or "").strip()
@@ -1190,16 +1571,72 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         shared_store = getattr(self, "_shared_store", None)
         if shared_store is None:
             return ()
-        entries = shared_store.snapshot(
-            ScopeRef(scope_type=ScopeType.TASK, scope_id=task_id)
-        )
+        try:
+            entries = shared_store.snapshot(
+                ScopeRef(scope_type=ScopeType.TASK, scope_id=task_id)
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="llm.request.skipped_tool_call_state_snapshot",
+                message=(
+                    "Skipped best-effort persisted tool-call state snapshot before "
+                    "resume"
+                ),
+                payload={
+                    "task_id": task_id,
+                    "error_type": exc.__class__.__name__,
+                    "error": str(exc),
+                },
+            )
+            return ()
         states: list[PersistedToolCallState] = []
         for key, raw_value in entries:
             if not key.startswith("tool_call_state:"):
                 continue
             try:
                 state = PersistedToolCallState.model_validate_json(raw_value)
-            except Exception:
+            except ValueError:
+                continue
+            states.append(state)
+        states.sort(key=lambda item: item.updated_at)
+        return tuple(states)
+
+    def _task_tool_call_batch_states(
+        self,
+        task_id: str,
+    ) -> tuple[PersistedToolCallBatchState, ...]:
+        shared_store = getattr(self, "_shared_store", None)
+        if shared_store is None:
+            return ()
+        try:
+            entries = shared_store.snapshot(
+                ScopeRef(scope_type=ScopeType.TASK, scope_id=task_id)
+            )
+        except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="llm.request.skipped_tool_call_batch_state_snapshot",
+                message=(
+                    "Skipped best-effort persisted tool-call batch state snapshot "
+                    "before resume"
+                ),
+                payload={
+                    "task_id": task_id,
+                    "error_type": exc.__class__.__name__,
+                    "error": str(exc),
+                },
+            )
+            return ()
+        states: list[PersistedToolCallBatchState] = []
+        for key, raw_value in entries:
+            if not key.startswith("tool_call_batch:"):
+                continue
+            try:
+                state = PersistedToolCallBatchState.model_validate_json(raw_value)
+            except ValueError:
                 continue
             states.append(state)
         states.sort(key=lambda item: item.updated_at)
@@ -1218,12 +1655,29 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             return None
         call_state = state.call_state
         call_state_kind = str(call_state.get("kind") or "").strip()
-        if call_state_kind and call_state_kind != "spawn_subagent_sync":
+        if call_state_kind and call_state_kind not in {
+            "spawn_subagent_sync",
+            "spawn_subagent_background",
+        }:
             return None
         background_task_service = getattr(self, "_background_task_service", None)
-        if background_task_service is None:
+        if not isinstance(background_task_service, _SubagentWaitService):
             return None
+        record = self._subagent_record_for_tool_state(
+            service=background_task_service,
+            request=request,
+            state=state,
+        )
+        if self._is_background_subagent_recovery(
+            call_state=call_state,
+            record=record,
+        ):
+            if record is None:
+                return None
+            return self._visible_background_subagent_result(record)
         subagent_run_id = str(call_state.get("subagent_run_id") or "").strip()
+        if not subagent_run_id and record is not None:
+            subagent_run_id = str(record.subagent_run_id or "").strip()
         if not subagent_run_id:
             return None
         try:
@@ -1236,20 +1690,14 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             current_task = asyncio.current_task()
             if current_task is not None and current_task.cancelling():
                 raise
-            return cast(
-                dict[str, JsonValue],
-                build_tool_error_result(
-                    error_code="subagent_execution_cancelled",
-                    message="Subagent was cancelled during recovery",
-                ),
+            return build_tool_error_result(
+                error_code="subagent_execution_cancelled",
+                message="Subagent was cancelled during recovery",
             )
         except RuntimeError as exc:
-            return cast(
-                dict[str, JsonValue],
-                build_tool_error_result(
-                    error_code="subagent_execution_failed",
-                    message=str(exc) or "Subagent failed",
-                ),
+            return build_tool_error_result(
+                error_code="subagent_execution_failed",
+                message=str(exc) or "Subagent failed",
             )
         return {
             "ok": True,
@@ -1257,6 +1705,78 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
                 "completed": True,
                 "output": result.output,
             },
+            "meta": {
+                "tool_result_event_published": True,
+            },
+        }
+
+    @staticmethod
+    def _subagent_record_for_tool_state(
+        *,
+        service: _SubagentWaitService,
+        request: LLMRequest,
+        state: PersistedToolCallState,
+    ) -> BackgroundTaskRecord | None:
+        if not isinstance(service, _SubagentRecordLookupService):
+            return None
+        tool_call_id = str(state.tool_call_id or "").strip()
+        if not tool_call_id:
+            return None
+        return service.subagent_record_for_tool_call(
+            parent_run_id=request.run_id,
+            tool_call_id=tool_call_id,
+        )
+
+    def _spawn_subagent_has_durable_launch(
+        self,
+        *,
+        request: LLMRequest,
+        state: PersistedToolCallState,
+    ) -> bool:
+        call_state = state.call_state
+        for key in (
+            "background_task_id",
+            "subagent_run_id",
+            "subagent_task_id",
+            "subagent_instance_id",
+        ):
+            if str(call_state.get(key) or "").strip():
+                return True
+        background_task_service = getattr(self, "_background_task_service", None)
+        if not isinstance(background_task_service, _SubagentWaitService):
+            return False
+        return (
+            self._subagent_record_for_tool_state(
+                service=background_task_service,
+                request=request,
+                state=state,
+            )
+            is not None
+        )
+
+    @staticmethod
+    def _is_background_subagent_recovery(
+        *,
+        call_state: dict[str, JsonValue],
+        record: BackgroundTaskRecord | None,
+    ) -> bool:
+        if str(call_state.get("kind") or "").strip() == "spawn_subagent_background":
+            return True
+        if SessionSupportMixin._truthy_json_value(call_state.get("background")):
+            return True
+        return record is not None and record.execution_mode == "background"
+
+    @staticmethod
+    def _visible_background_subagent_result(
+        record: BackgroundTaskRecord,
+    ) -> dict[str, JsonValue]:
+        return {
+            "ok": True,
+            "data": build_background_task_result_payload(
+                record,
+                completed=not record.is_active,
+                include_task_id=True,
+            ),
             "meta": {
                 "tool_result_event_published": True,
             },
@@ -1448,6 +1968,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
     def _event_publishing_service(self) -> EventPublishingService:
         return EventPublishingService(
             run_event_hub=getattr(self, "_run_event_hub", None),
+            shared_store=getattr(self, "_shared_store", None),
         )
 
     def _message_commit_service(self) -> MessageCommitService:

--- a/src/relay_teams/agents/execution/tool_call_history.py
+++ b/src/relay_teams/agents/execution/tool_call_history.py
@@ -34,13 +34,13 @@ def normalize_replayed_messages(
     *,
     on_drop: ToolResultDropLogger | None = None,
 ) -> list[ModelMessage]:
-    pending_tool_call_ids: set[str] = set()
+    pending_tool_calls: dict[str, str] = {}
     seen_tool_call_ids: set[str] = set()
     sanitized_messages: list[ModelMessage] = []
     for message in messages:
         if isinstance(message, ModelResponse):
             _advance_tool_call_state(
-                pending_tool_call_ids=pending_tool_call_ids,
+                pending_tool_calls=pending_tool_calls,
                 seen_tool_call_ids=seen_tool_call_ids,
                 message=message,
             )
@@ -51,7 +51,7 @@ def normalize_replayed_messages(
             continue
         next_parts = _sanitize_request_parts(
             parts=message.parts,
-            pending_tool_call_ids=pending_tool_call_ids,
+            pending_tool_calls=pending_tool_calls,
             seen_tool_call_ids=seen_tool_call_ids,
             on_drop=on_drop,
         )
@@ -68,16 +68,16 @@ def normalize_replayed_messages_to_safe_boundary(
     on_drop: ToolResultDropLogger | None = None,
 ) -> list[ModelMessage]:
     normalized = normalize_replayed_messages(messages, on_drop=on_drop)
-    pending_tool_call_ids: set[str] = set()
+    pending_tool_calls: dict[str, str] = {}
     seen_tool_call_ids: set[str] = set()
     last_safe_index = 0
     for index, message in enumerate(normalized, start=1):
         _advance_tool_call_state(
-            pending_tool_call_ids=pending_tool_call_ids,
+            pending_tool_calls=pending_tool_calls,
             seen_tool_call_ids=seen_tool_call_ids,
             message=message,
         )
-        if not pending_tool_call_ids:
+        if not pending_tool_calls:
             last_safe_index = index
     return normalized[:last_safe_index]
 
@@ -87,19 +87,19 @@ def collect_safe_row_ids(
     *,
     on_drop: ToolResultDropLogger | None = None,
 ) -> set[int]:
-    pending_tool_call_ids: set[str] = set()
+    pending_tool_calls: dict[str, str] = {}
     seen_tool_call_ids: set[str] = set()
     candidate_ids: set[int] = set()
     safe_ids: set[int] = set()
     for row_id, messages in rows:
         normalize_replayed_messages_against_pending(
             messages,
-            pending_tool_call_ids=pending_tool_call_ids,
+            pending_tool_calls=pending_tool_calls,
             seen_tool_call_ids=seen_tool_call_ids,
             on_drop=on_drop,
         )
         candidate_ids.add(row_id)
-        if not pending_tool_call_ids:
+        if not pending_tool_calls:
             safe_ids = candidate_ids.copy()
     return safe_ids
 
@@ -107,15 +107,21 @@ def collect_safe_row_ids(
 def normalize_replayed_messages_against_pending(
     messages: Sequence[ModelMessage],
     *,
-    pending_tool_call_ids: set[str],
+    pending_tool_call_ids: set[str] | None = None,
+    pending_tool_calls: dict[str, str] | None = None,
     seen_tool_call_ids: set[str],
     on_drop: ToolResultDropLogger | None = None,
 ) -> list[ModelMessage]:
+    active_pending = (
+        {tool_call_id: "" for tool_call_id in pending_tool_call_ids}
+        if pending_tool_calls is None and pending_tool_call_ids is not None
+        else (pending_tool_calls or {})
+    )
     sanitized_messages: list[ModelMessage] = []
     for message in messages:
         if isinstance(message, ModelResponse):
             _advance_tool_call_state(
-                pending_tool_call_ids=pending_tool_call_ids,
+                pending_tool_calls=active_pending,
                 seen_tool_call_ids=seen_tool_call_ids,
                 message=message,
             )
@@ -126,7 +132,7 @@ def normalize_replayed_messages_against_pending(
             continue
         next_parts = _sanitize_request_parts(
             parts=message.parts,
-            pending_tool_call_ids=pending_tool_call_ids,
+            pending_tool_calls=active_pending,
             seen_tool_call_ids=seen_tool_call_ids,
             on_drop=on_drop,
         )
@@ -140,7 +146,7 @@ def normalize_replayed_messages_against_pending(
 def _sanitize_request_parts(
     *,
     parts: Sequence[ModelRequestPart],
-    pending_tool_call_ids: set[str],
+    pending_tool_calls: dict[str, str],
     seen_tool_call_ids: set[str],
     on_drop: ToolResultDropLogger | None = None,
 ) -> list[ModelRequestPart]:
@@ -150,18 +156,24 @@ def _sanitize_request_parts(
         if not isinstance(part, (ToolReturnPart, RetryPromptPart)) or not tool_call_id:
             sanitized_parts.append(part)
             continue
-        if tool_call_id not in pending_tool_call_ids:
+        expected_tool_name = pending_tool_calls.get(tool_call_id)
+        actual_tool_name = str(getattr(part, "tool_name", "") or "")
+        if expected_tool_name is None or (
+            expected_tool_name
+            and actual_tool_name
+            and actual_tool_name != expected_tool_name
+        ):
             if on_drop is not None:
                 on_drop(part, tool_call_id in seen_tool_call_ids)
             continue
-        pending_tool_call_ids.discard(tool_call_id)
+        pending_tool_calls.pop(tool_call_id, None)
         sanitized_parts.append(part)
     return sanitized_parts
 
 
 def _advance_tool_call_state(
     *,
-    pending_tool_call_ids: set[str],
+    pending_tool_calls: dict[str, str],
     seen_tool_call_ids: set[str],
     message: ModelMessage,
 ) -> None:
@@ -172,13 +184,13 @@ def _advance_tool_call_state(
             tool_call_id = str(part.tool_call_id or "").strip()
             if tool_call_id:
                 seen_tool_call_ids.add(tool_call_id)
-                pending_tool_call_ids.add(tool_call_id)
+                pending_tool_calls[tool_call_id] = str(part.tool_name or "")
         return
     if not isinstance(message, ModelRequest):
         return
     _sanitize_request_parts(
         parts=message.parts,
-        pending_tool_call_ids=pending_tool_call_ids,
+        pending_tool_calls=pending_tool_calls,
         seen_tool_call_ids=seen_tool_call_ids,
         on_drop=None,
     )

--- a/src/relay_teams/agents/execution/tool_result_state.py
+++ b/src/relay_teams/agents/execution/tool_result_state.py
@@ -40,9 +40,16 @@ class ToolResultStateService:
         visible_result = self.visible_tool_result_from_envelope(raw_result_envelope)
         if not isinstance(visible_result, dict):
             return None
-        if not self.tool_result_event_was_published(
-            result_envelope=raw_result_envelope,
-            visible_result=visible_result,
+        if (
+            state.result_event_id <= 0
+            and not self.tool_result_event_was_published(
+                result_envelope=raw_result_envelope,
+                visible_result=visible_result,
+            )
+            and not self.tool_result_was_durably_recorded(
+                result_envelope=raw_result_envelope,
+                visible_result=visible_result,
+            )
         ):
             return None
         normalized = to_json_compatible(visible_result)
@@ -77,6 +84,21 @@ class ToolResultStateService:
             return False
         return meta.get("tool_result_event_published") is True
 
+    @staticmethod
+    def tool_result_was_durably_recorded(
+        *,
+        result_envelope: dict[str, JsonValue],
+        visible_result: dict[str, JsonValue] | None = None,
+    ) -> bool:
+        runtime_meta = result_envelope.get("runtime_meta")
+        if isinstance(runtime_meta, dict):
+            return runtime_meta.get("tool_result_durably_recorded") is True
+        envelope = result_envelope if visible_result is None else visible_result
+        meta = envelope.get("meta")
+        if not isinstance(meta, dict):
+            return False
+        return meta.get("tool_result_durably_recorded") is True
+
     def tool_result_already_emitted_from_runtime(
         self,
         *,
@@ -103,6 +125,8 @@ class ToolResultStateService:
         result_envelope = state.result_envelope
         if not isinstance(result_envelope, dict):
             return False
+        if state.result_event_id > 0:
+            return True
         visible_result = self.visible_tool_result_from_envelope(result_envelope)
         return self.tool_result_event_was_published(
             result_envelope=result_envelope,
@@ -138,6 +162,8 @@ class ToolResultStateService:
         result_envelope = state.result_envelope
         if not isinstance(result_envelope, dict):
             return False
+        if state.result_event_id > 0:
+            return True
         visible_result = self.visible_tool_result_from_envelope(result_envelope)
         return self.tool_result_event_was_published(
             result_envelope=result_envelope,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -181,6 +181,7 @@ from relay_teams.sessions.runs.background_tasks.command_runtime import (
     kill_process_tree_by_pid,
 )
 from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskKind
 from relay_teams.sessions.runs.background_tasks.repository import (
     BackgroundTaskRepository,
 )
@@ -1418,6 +1419,11 @@ class ServerContainer:
         interrupted = self.background_task_repository.list_interruptible()
         interrupted_ids: List[str] = []
         for record in interrupted:
+            if (
+                record.kind == BackgroundTaskKind.SUBAGENT
+                and record.execution_mode == "foreground"
+            ):
+                continue
             if record.pid is None:
                 LOGGER.warning(
                     "Persisted background task lost pid before interruption cleanup",

--- a/src/relay_teams/sessions/runs/assistant_errors.py
+++ b/src/relay_teams/sessions/runs/assistant_errors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, JsonValue
 from pydantic_ai.messages import ModelResponse, TextPart
 
 
@@ -151,7 +151,7 @@ def build_tool_error_result(
     *,
     error_code: str,
     message: str,
-) -> dict[str, object]:
+) -> dict[str, JsonValue]:
     return {
         "ok": False,
         "error": {

--- a/src/relay_teams/sessions/runs/background_tasks/models.py
+++ b/src/relay_teams/sessions/runs/background_tasks/models.py
@@ -34,6 +34,7 @@ class BackgroundTaskRecord(BaseModel):
     role_id: OptionalIdentifierStr = None
     tool_call_id: OptionalIdentifierStr = None
     title: str = ""
+    input_text: str = ""
     command: str = Field(min_length=1)
     cwd: str = Field(min_length=1)
     execution_mode: Literal["foreground", "background"] = "background"
@@ -49,6 +50,7 @@ class BackgroundTaskRecord(BaseModel):
     subagent_run_id: OptionalIdentifierStr = None
     subagent_task_id: OptionalIdentifierStr = None
     subagent_instance_id: OptionalIdentifierStr = None
+    subagent_suppress_hooks: bool = False
     created_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     completed_at: datetime | None = None

--- a/src/relay_teams/sessions/runs/background_tasks/repository.py
+++ b/src/relay_teams/sessions/runs/background_tasks/repository.py
@@ -44,6 +44,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     role_id          TEXT,
                     tool_call_id     TEXT,
                     title            TEXT NOT NULL DEFAULT '',
+                    input_text       TEXT NOT NULL DEFAULT '',
                     command          TEXT NOT NULL,
                     cwd              TEXT NOT NULL,
                     execution_mode   TEXT NOT NULL,
@@ -59,6 +60,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     subagent_run_id TEXT,
                     subagent_task_id TEXT,
                     subagent_instance_id TEXT,
+                    subagent_suppress_hooks INTEGER NOT NULL DEFAULT 0,
                     created_at       TEXT NOT NULL,
                     updated_at       TEXT NOT NULL,
                     completed_at     TEXT,
@@ -88,6 +90,10 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 self._conn.execute(
                     "ALTER TABLE background_tasks ADD COLUMN title TEXT NOT NULL DEFAULT ''"
                 )
+            if "input_text" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE background_tasks ADD COLUMN input_text TEXT NOT NULL DEFAULT ''"
+                )
             if "subagent_role_id" not in columns:
                 self._conn.execute(
                     "ALTER TABLE background_tasks ADD COLUMN subagent_role_id TEXT"
@@ -103,6 +109,10 @@ class BackgroundTaskRepository(SharedSqliteRepository):
             if "subagent_instance_id" not in columns:
                 self._conn.execute(
                     "ALTER TABLE background_tasks ADD COLUMN subagent_instance_id TEXT"
+                )
+            if "subagent_suppress_hooks" not in columns:
+                self._conn.execute(
+                    "ALTER TABLE background_tasks ADD COLUMN subagent_suppress_hooks INTEGER NOT NULL DEFAULT 0"
                 )
             self._conn.execute(
                 """
@@ -145,6 +155,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     role_id,
                     tool_call_id,
                     title,
+                    input_text,
                     command,
                     cwd,
                     execution_mode,
@@ -160,12 +171,13 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     subagent_run_id,
                     subagent_task_id,
                     subagent_instance_id,
+                    subagent_suppress_hooks,
                     created_at,
                     updated_at,
                     completed_at,
                     completion_notified_at
                 )
-                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(background_task_id)
                 DO UPDATE SET
                     run_id=excluded.run_id,
@@ -175,6 +187,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     role_id=excluded.role_id,
                     tool_call_id=excluded.tool_call_id,
                     title=excluded.title,
+                    input_text=excluded.input_text,
                     command=excluded.command,
                     cwd=excluded.cwd,
                     execution_mode=excluded.execution_mode,
@@ -190,6 +203,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     subagent_run_id=excluded.subagent_run_id,
                     subagent_task_id=excluded.subagent_task_id,
                     subagent_instance_id=excluded.subagent_instance_id,
+                    subagent_suppress_hooks=excluded.subagent_suppress_hooks,
                     created_at=excluded.created_at,
                     updated_at=excluded.updated_at,
                     completed_at=excluded.completed_at,
@@ -226,6 +240,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     role_id,
                     tool_call_id,
                     title,
+                    input_text,
                     command,
                     cwd,
                     execution_mode,
@@ -241,12 +256,13 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     subagent_run_id,
                     subagent_task_id,
                     subagent_instance_id,
+                    subagent_suppress_hooks,
                     created_at,
                     updated_at,
                     completed_at,
                     completion_notified_at
                 )
-                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(background_task_id)
                 DO UPDATE SET
                     run_id=excluded.run_id,
@@ -256,6 +272,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     role_id=excluded.role_id,
                     tool_call_id=excluded.tool_call_id,
                     title=excluded.title,
+                    input_text=excluded.input_text,
                     command=excluded.command,
                     cwd=excluded.cwd,
                     execution_mode=excluded.execution_mode,
@@ -271,6 +288,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     subagent_run_id=excluded.subagent_run_id,
                     subagent_task_id=excluded.subagent_task_id,
                     subagent_instance_id=excluded.subagent_instance_id,
+                    subagent_suppress_hooks=excluded.subagent_suppress_hooks,
                     created_at=excluded.created_at,
                     updated_at=excluded.updated_at,
                     completed_at=excluded.completed_at,
@@ -328,7 +346,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 SELECT *
                 FROM background_tasks
                 WHERE run_id=?
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (run_id,),
             ).fetchall()
@@ -342,7 +360,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 SELECT *
                 FROM background_tasks
                 WHERE run_id=?
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (run_id,),
             )
@@ -356,7 +374,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 SELECT *
                 FROM background_tasks
                 WHERE session_id=?
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (session_id,),
             ).fetchall()
@@ -405,7 +423,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 SELECT *
                 FROM background_tasks
                 WHERE session_id=?
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (session_id,),
             )
@@ -418,7 +436,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 """
                 SELECT *
                 FROM background_tasks
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """
             ).fetchall()
         return tuple(_row_to_record(row) for row in rows)
@@ -430,7 +448,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 """
                 SELECT *
                 FROM background_tasks
-                ORDER BY updated_at DESC, created_at DESC
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
             )
         )
@@ -443,11 +461,14 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 SELECT *
                 FROM background_tasks
                 WHERE status IN (?, ?)
-                ORDER BY updated_at DESC, created_at DESC
+                  AND NOT (kind=? AND execution_mode=?)
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (
                     BackgroundTaskStatus.RUNNING.value,
                     BackgroundTaskStatus.BLOCKED.value,
+                    BackgroundTaskKind.SUBAGENT.value,
+                    "foreground",
                 ),
             ).fetchall()
         return tuple(_row_to_record(row) for row in rows)
@@ -460,11 +481,14 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                 SELECT *
                 FROM background_tasks
                 WHERE status IN (?, ?)
-                ORDER BY updated_at DESC, created_at DESC
+                  AND NOT (kind=? AND execution_mode=?)
+                ORDER BY updated_at DESC, created_at DESC, rowid DESC
                 """,
                 (
                     BackgroundTaskStatus.RUNNING.value,
                     BackgroundTaskStatus.BLOCKED.value,
+                    BackgroundTaskKind.SUBAGENT.value,
+                    "foreground",
                 ),
             )
         )
@@ -541,6 +565,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     UPDATE background_tasks
                     SET status=?, updated_at=?, completed_at=COALESCE(completed_at, ?), pid=NULL
                     WHERE status IN (?, ?)
+                      AND NOT (kind=? AND execution_mode=?)
                     """,
                     (
                         BackgroundTaskStatus.STOPPED.value,
@@ -548,6 +573,8 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                         now,
                         BackgroundTaskStatus.RUNNING.value,
                         BackgroundTaskStatus.BLOCKED.value,
+                        BackgroundTaskKind.SUBAGENT.value,
+                        "foreground",
                     ),
                 )
             else:
@@ -557,6 +584,7 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                     UPDATE background_tasks
                     SET status=?, updated_at=?, completed_at=COALESCE(completed_at, ?), pid=NULL
                     WHERE background_task_id IN ({placeholders}) AND status IN (?, ?)
+                      AND NOT (kind=? AND execution_mode=?)
                     """,
                     (
                         BackgroundTaskStatus.STOPPED.value,
@@ -565,6 +593,8 @@ class BackgroundTaskRepository(SharedSqliteRepository):
                         *background_task_ids,
                         BackgroundTaskStatus.RUNNING.value,
                         BackgroundTaskStatus.BLOCKED.value,
+                        BackgroundTaskKind.SUBAGENT.value,
+                        "foreground",
                     ),
                 )
             affected = int(cursor.rowcount or 0)
@@ -639,6 +669,7 @@ def _record_params(record: BackgroundTaskRecord) -> tuple[object, ...]:
         record.role_id,
         record.tool_call_id,
         record.title,
+        record.input_text,
         record.command,
         record.cwd,
         record.execution_mode,
@@ -654,6 +685,7 @@ def _record_params(record: BackgroundTaskRecord) -> tuple[object, ...]:
         record.subagent_run_id,
         record.subagent_task_id,
         record.subagent_instance_id,
+        1 if record.subagent_suppress_hooks else 0,
         record.created_at.isoformat(),
         record.updated_at.isoformat(),
         record.completed_at.isoformat() if record.completed_at is not None else None,
@@ -683,6 +715,7 @@ def _row_to_record(row: sqlite3.Row) -> BackgroundTaskRecord:
         role_id=normalize_persisted_text(row["role_id"]),
         tool_call_id=normalize_persisted_text(row["tool_call_id"]),
         title=str(row["title"] or ""),
+        input_text=str(row["input_text"] or ""),
         command=str(row["command"]),
         cwd=str(row["cwd"]),
         execution_mode=_decode_execution_mode(row["execution_mode"]),
@@ -698,6 +731,7 @@ def _row_to_record(row: sqlite3.Row) -> BackgroundTaskRecord:
         subagent_run_id=normalize_persisted_text(row["subagent_run_id"]),
         subagent_task_id=normalize_persisted_text(row["subagent_task_id"]),
         subagent_instance_id=normalize_persisted_text(row["subagent_instance_id"]),
+        subagent_suppress_hooks=bool(int(row["subagent_suppress_hooks"] or 0)),
         created_at=created_at,
         updated_at=updated_at,
         completed_at=parse_persisted_datetime_or_none(row["completed_at"]),

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 import logging
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Optional, Protocol, cast, runtime_checkable
 from uuid import uuid4
@@ -17,7 +18,7 @@ from relay_teams.agents.instances.models import (
 )
 from relay_teams.agents.tasks.enums import TaskStatus
 from relay_teams.agents.tasks.ids import new_task_id
-from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
+from relay_teams.agents.tasks.models import TaskEnvelope, TaskRecord, VerificationPlan
 from relay_teams.logger import get_logger, log_event
 from relay_teams.media import content_parts_from_text
 from relay_teams.roles.role_models import RoleDefinition, RoleMode
@@ -55,6 +56,7 @@ from relay_teams.sessions.runs.run_runtime_repo import (
 )
 from relay_teams.sessions.session_models import SessionMode
 from relay_teams.workspace import WorkspaceHandle
+from relay_teams.workspace.ids import build_instance_conversation_id
 from relay_teams.env.hook_runtime_env import merge_tool_hook_runtime_env
 from relay_teams.hooks import (
     HookDecisionBundle,
@@ -71,6 +73,14 @@ LOGGER = get_logger(__name__)
 _COMPLETION_RETRY_INITIAL_DELAY_SECONDS = 1.0
 _COMPLETION_RETRY_MAX_DELAY_SECONDS = 30.0
 _SUBAGENT_COMMAND_PREFIX = "subagent:"
+_TERMINAL_SUBAGENT_TASK_STATUSES = frozenset(
+    {
+        TaskStatus.COMPLETED,
+        TaskStatus.FAILED,
+        TaskStatus.STOPPED,
+        TaskStatus.TIMEOUT,
+    }
+)
 
 
 class BackgroundTaskCompletionSink(Protocol):
@@ -102,7 +112,9 @@ class _BackgroundTaskExecutor(Protocol):
         role_id: str,
         task: TaskEnvelope,
         user_prompt_override: str | None = None,
-    ) -> TaskExecutionResult: ...
+    ) -> TaskExecutionResult:
+        _ = (self, instance_id, role_id, task, user_prompt_override)
+        return TaskExecutionResult(output="")
 
 
 class _BackgroundTaskRunController(Protocol):
@@ -112,13 +124,17 @@ class _BackgroundTaskRunController(Protocol):
         run_id: str,
         session_id: str,
         task: asyncio.Task[None],
-    ) -> None: ...
+    ) -> None:
+        pass
 
-    def unregister_run_task(self, run_id: str) -> None: ...
+    def unregister_run_task(self, run_id: str) -> None:
+        pass
 
-    def request_run_stop(self, run_id: str) -> bool: ...
+    def request_run_stop(self, run_id: str) -> bool:
+        raise NotImplementedError
 
-    def is_run_stop_requested(self, run_id: str) -> bool: ...
+    def is_run_stop_requested(self, run_id: str) -> bool:
+        raise NotImplementedError
 
 
 class _BackgroundTaskRunRuntimeRepository(Protocol):
@@ -130,11 +146,14 @@ class _BackgroundTaskRunRuntimeRepository(Protocol):
         root_task_id: str | None = None,
         status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
         phase: RunRuntimePhase = RunRuntimePhase.IDLE,
-    ) -> object: ...
+    ) -> object:
+        raise NotImplementedError
 
-    def get(self, run_id: str) -> object | None: ...
+    def get(self, run_id: str) -> object | None:
+        raise NotImplementedError
 
-    def update(self, run_id: str, **changes: object) -> object: ...
+    def update(self, run_id: str, **changes: object) -> object:
+        raise NotImplementedError
 
 
 class _BackgroundTaskAgentRepository(Protocol):
@@ -151,14 +170,19 @@ class _BackgroundTaskAgentRepository(Protocol):
         status: InstanceStatus,
         lifecycle: Optional[InstanceLifecycle] = None,
         parent_instance_id: Optional[str] = None,
-    ) -> None: ...
+    ) -> None:
+        pass
 
     def mark_status(self, instance_id: str, status: InstanceStatus) -> None:
         pass
 
 
 class _BackgroundTaskTaskRepository(Protocol):
-    def create(self, envelope: TaskEnvelope) -> object: ...
+    def get(self, task_id: str) -> object:
+        raise NotImplementedError
+
+    def create(self, envelope: TaskEnvelope) -> object:
+        raise NotImplementedError
 
     def update_status(
         self,
@@ -167,7 +191,8 @@ class _BackgroundTaskTaskRepository(Protocol):
         assigned_instance_id: str | None = None,
         result: str | None = None,
         error_message: str | None = None,
-    ) -> None: ...
+    ) -> None:
+        pass
 
 
 class _BackgroundTaskIntentRepository(Protocol):
@@ -176,9 +201,11 @@ class _BackgroundTaskIntentRepository(Protocol):
         run_id: str,
         *,
         fallback_session_id: str | None = None,
-    ) -> IntentInput: ...
+    ) -> IntentInput:
+        raise NotImplementedError
 
-    def upsert(self, *, run_id: str, session_id: str, intent: IntentInput) -> None: ...
+    def upsert(self, *, run_id: str, session_id: str, intent: IntentInput) -> None:
+        pass
 
 
 class _ManagedSubagentTaskRuntime:
@@ -232,6 +259,9 @@ class _PreparedSubagentLaunch(BaseModel):
     suppress_hooks: bool = False
     subagent_instance: SubAgentInstance
     subagent_task: TaskEnvelope
+
+
+type SyncSubagentLaunchCallback = Callable[[BackgroundTaskRecord], Awaitable[None]]
 
 
 class BackgroundTaskService:
@@ -374,17 +404,17 @@ class BackgroundTaskService:
         subagent_role: RoleDefinition | None = None,
         title: str,
         prompt: str,
+        on_launch_prepared: SyncSubagentLaunchCallback | None = None,
     ) -> BackgroundTaskRecord:
         task_execution_service = self._require_task_execution_service()
         run_control_manager = self._require_run_control_manager()
         background_task_id = f"background_task_{uuid4().hex[:12]}"
         prepared = await asyncio.to_thread(
-            self._prepare_subagent_launch,
+            self._build_subagent_launch,
             run_id=run_id,
             session_id=session_id,
             workspace_id=workspace_id,
             subagent_role_id=subagent_role_id,
-            subagent_role=subagent_role,
             title=title,
             prompt=prompt,
         )
@@ -398,6 +428,7 @@ class BackgroundTaskService:
                 role_id=role_id,
                 tool_call_id=tool_call_id,
                 title=prepared.normalized_title,
+                input_text=prepared.normalized_prompt,
                 command=f"{_SUBAGENT_COMMAND_PREFIX}{prepared.subagent_role_id}",
                 cwd=str(cwd),
                 execution_mode="background",
@@ -409,9 +440,20 @@ class BackgroundTaskService:
                 subagent_run_id=prepared.subagent_run_id,
                 subagent_task_id=prepared.subagent_task.task_id,
                 subagent_instance_id=prepared.subagent_instance.instance_id,
+                subagent_suppress_hooks=prepared.suppress_hooks,
             ),
         )
         try:
+            if on_launch_prepared is not None:
+                await on_launch_prepared(record)
+            await asyncio.to_thread(
+                self._materialize_prepared_subagent_launch,
+                parent_run_id=run_id,
+                session_id=session_id,
+                workspace_id=workspace_id,
+                prepared=prepared,
+                subagent_role=subagent_role,
+            )
             hook_context = await self._execute_subagent_start_hooks(
                 run_id=run_id,
                 session_id=session_id,
@@ -509,21 +551,22 @@ class BackgroundTaskService:
         run_id: str,
         session_id: str,
         workspace_id: str,
+        tool_call_id: str | None = None,
+        parent_instance_id: str | None = None,
+        parent_role_id: str | None = None,
         subagent_role_id: str,
         subagent_role: RoleDefinition | None = None,
         title: str,
         prompt: str,
         suppress_hooks: bool = False,
+        on_launch_prepared: SyncSubagentLaunchCallback | None = None,
     ) -> SynchronousSubagentResult:
-        task_execution_service = self._require_task_execution_service()
-        run_control_manager = self._require_run_control_manager()
         prepared = await asyncio.to_thread(
-            self._prepare_subagent_launch,
+            self._build_subagent_launch,
             run_id=run_id,
             session_id=session_id,
             workspace_id=workspace_id,
             subagent_role_id=subagent_role_id,
-            subagent_role=subagent_role,
             title=title,
             prompt=prompt,
             suppress_hooks=suppress_hooks,
@@ -531,16 +574,29 @@ class BackgroundTaskService:
         if suppress_hooks:
             self._prime_subagent_hook_snapshot(subagent_run_id=prepared.subagent_run_id)
         background_task_id = f"sync_subagent_{uuid4().hex[:12]}"
-        _ = await self._repository.upsert_async(
+        record = await self._repository.upsert_async(
             self._build_synchronous_subagent_record(
                 background_task_id=background_task_id,
                 run_id=run_id,
                 session_id=session_id,
                 workspace_id=workspace_id,
                 prepared=prepared,
+                tool_call_id=tool_call_id,
+                parent_instance_id=parent_instance_id,
+                parent_role_id=parent_role_id,
             ),
         )
         try:
+            if on_launch_prepared is not None:
+                await on_launch_prepared(record)
+            await asyncio.to_thread(
+                self._materialize_prepared_subagent_launch,
+                parent_run_id=run_id,
+                session_id=session_id,
+                workspace_id=workspace_id,
+                prepared=prepared,
+                subagent_role=subagent_role,
+            )
             hook_context = await self._execute_subagent_start_hooks(
                 run_id=run_id,
                 session_id=session_id,
@@ -550,7 +606,7 @@ class BackgroundTaskService:
             await self._finalize_subagent_launch_failure(
                 background_task_id=background_task_id,
                 prepared=prepared,
-                output=str(exc),
+                output=str(exc) or exc.__class__.__name__,
                 synchronous=True,
             )
             raise
@@ -558,7 +614,203 @@ class BackgroundTaskService:
             prompt=prepared.normalized_prompt,
             contexts=hook_context,
         )
+        return await self._run_prepared_synchronous_subagent(
+            parent_run_id=run_id,
+            session_id=session_id,
+            background_task_id=background_task_id,
+            prepared=prepared,
+            launch_prompt=launch_prompt,
+        )
 
+    async def wait_for_subagent_run(
+        self,
+        *,
+        parent_run_id: str,
+        subagent_run_id: str,
+    ) -> SynchronousSubagentResult:
+        normalized_parent_run_id = parent_run_id.strip()
+        normalized_run_id = subagent_run_id.strip()
+        runtime = self._synchronous_subagent_runtimes.get(normalized_run_id)
+        if runtime is not None:
+            if runtime.parent_run_id != normalized_parent_run_id:
+                raise KeyError(f"Unknown synchronous subagent run: {normalized_run_id}")
+            await asyncio.shield(runtime.worker_task)
+            result = runtime.result_holder.get("result")
+            if result is None:
+                raise RuntimeError("Subagent completed without returning a result")
+            return result
+        record = await self._synchronous_subagent_record(
+            parent_run_id=normalized_parent_run_id,
+            subagent_run_id=normalized_run_id,
+        )
+        if record is not None and record.is_active:
+            finalized_record = (
+                await self._finalize_active_synchronous_record_from_terminal_task(
+                    record
+                )
+            )
+            if finalized_record is not None:
+                return await self._synchronous_subagent_result_from_record(
+                    parent_run_id=normalized_parent_run_id,
+                    subagent_run_id=normalized_run_id,
+                )
+            return await self._resume_synchronous_subagent_record(record)
+        return await self._synchronous_subagent_result_from_record(
+            parent_run_id=normalized_parent_run_id,
+            subagent_run_id=normalized_run_id,
+        )
+
+    async def _resume_synchronous_subagent_record(
+        self,
+        record: BackgroundTaskRecord,
+    ) -> SynchronousSubagentResult:
+        prepared = self._prepared_launch_from_synchronous_record(record)
+        if prepared.suppress_hooks:
+            self._prime_subagent_hook_snapshot(subagent_run_id=prepared.subagent_run_id)
+        try:
+            await asyncio.to_thread(
+                self._materialize_prepared_subagent_launch,
+                parent_run_id=record.run_id,
+                session_id=record.session_id,
+                workspace_id=record.cwd,
+                prepared=prepared,
+                subagent_role=self._temporary_subagent_role_from_parent(
+                    parent_run_id=record.run_id,
+                    subagent_role_id=prepared.subagent_role_id,
+                ),
+            )
+            hook_context = await self._execute_subagent_start_hooks(
+                run_id=record.run_id,
+                session_id=record.session_id,
+                prepared=prepared,
+            )
+        except Exception as exc:
+            await self._finalize_subagent_launch_failure(
+                background_task_id=record.background_task_id,
+                prepared=prepared,
+                output=str(exc) or exc.__class__.__name__,
+                synchronous=True,
+            )
+            raise
+        launch_prompt = _append_subagent_start_context(
+            prompt=prepared.normalized_prompt,
+            contexts=hook_context,
+        )
+        return await self._run_prepared_synchronous_subagent(
+            parent_run_id=record.run_id,
+            session_id=record.session_id,
+            background_task_id=record.background_task_id,
+            prepared=prepared,
+            launch_prompt=launch_prompt,
+        )
+
+    @staticmethod
+    def _prepared_launch_from_synchronous_record(
+        record: BackgroundTaskRecord,
+    ) -> _PreparedSubagentLaunch:
+        subagent_run_id = str(record.subagent_run_id or "").strip()
+        subagent_role_id = str(record.subagent_role_id or "").strip()
+        subagent_task_id = str(record.subagent_task_id or "").strip()
+        subagent_instance_id = str(record.subagent_instance_id or "").strip()
+        prompt = record.input_text.strip()
+        if (
+            not subagent_run_id
+            or not subagent_role_id
+            or not subagent_task_id
+            or not subagent_instance_id
+            or not prompt
+        ):
+            raise RuntimeError(
+                "Synchronous subagent record is missing recovery metadata"
+            )
+        title = record.title.strip() or _default_subagent_title(
+            role_id=subagent_role_id,
+            prompt=prompt,
+        )
+        workspace_id = record.cwd.strip()
+        if not workspace_id:
+            raise RuntimeError("Synchronous subagent workspace is unavailable")
+        subagent_instance = SubAgentInstance(
+            instance_id=subagent_instance_id,
+            role_id=subagent_role_id,
+            workspace_id=workspace_id,
+            conversation_id=build_instance_conversation_id(
+                record.session_id,
+                subagent_role_id,
+                subagent_instance_id,
+            ),
+        )
+        subagent_task = TaskEnvelope(
+            task_id=subagent_task_id,
+            session_id=record.session_id,
+            parent_task_id=None,
+            trace_id=subagent_run_id,
+            role_id=subagent_role_id,
+            title=title,
+            objective=prompt,
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+        return _PreparedSubagentLaunch(
+            normalized_prompt=prompt,
+            normalized_title=title,
+            subagent_run_id=subagent_run_id,
+            subagent_role_id=subagent_role_id,
+            suppress_hooks=record.subagent_suppress_hooks,
+            subagent_instance=subagent_instance,
+            subagent_task=subagent_task,
+        )
+
+    async def _finalize_active_synchronous_record_from_terminal_task(
+        self,
+        record: BackgroundTaskRecord,
+    ) -> BackgroundTaskRecord | None:
+        task_record = self._terminal_subagent_task_record(record)
+        if task_record is None:
+            return None
+        status = _background_status_from_task_status(task_record.status)
+        output = _output_from_terminal_task_record(task_record)
+        finalized = await self._finalize_synchronous_subagent_record(
+            background_task_id=record.background_task_id,
+            status=status,
+            output=output,
+        )
+        subagent_run_id = str(record.subagent_run_id or "").strip()
+        if subagent_run_id:
+            self._finalize_subagent_run_runtime(
+                subagent_run_id=subagent_run_id,
+                status=status,
+                output=output,
+            )
+        return finalized
+
+    def _terminal_subagent_task_record(
+        self,
+        record: BackgroundTaskRecord,
+    ) -> TaskRecord | None:
+        task_id = str(record.subagent_task_id or "").strip()
+        if not task_id:
+            return None
+        try:
+            task_record = self._require_task_repo().get(task_id)
+        except (KeyError, RuntimeError, ValueError):
+            return None
+        if not isinstance(task_record, TaskRecord):
+            return None
+        if task_record.status not in _TERMINAL_SUBAGENT_TASK_STATUSES:
+            return None
+        return task_record
+
+    async def _run_prepared_synchronous_subagent(
+        self,
+        *,
+        parent_run_id: str,
+        session_id: str,
+        background_task_id: str,
+        prepared: _PreparedSubagentLaunch,
+        launch_prompt: str,
+    ) -> SynchronousSubagentResult:
+        task_execution_service = self._require_task_execution_service()
+        run_control_manager = self._require_run_control_manager()
         result_holder: dict[str, SynchronousSubagentResult] = {}
 
         async def finalize_after_stop_hooks(
@@ -571,7 +823,7 @@ class BackgroundTaskService:
             final_output = output
             try:
                 await self._execute_subagent_stop_hooks_for_launch(
-                    run_id=run_id,
+                    run_id=parent_run_id,
                     session_id=session_id,
                     prepared=prepared,
                     status=status,
@@ -652,7 +904,7 @@ class BackgroundTaskService:
         worker_task = asyncio.create_task(run_worker())
         managed_runtime = _ManagedSynchronousSubagentRuntime(
             worker_task=worker_task,
-            parent_run_id=run_id,
+            parent_run_id=parent_run_id,
             subagent_run_id=prepared.subagent_run_id,
             result_holder=result_holder,
         )
@@ -680,28 +932,6 @@ class BackgroundTaskService:
             raise RuntimeError("Subagent completed without returning a result")
         return result
 
-    async def wait_for_subagent_run(
-        self,
-        *,
-        parent_run_id: str,
-        subagent_run_id: str,
-    ) -> SynchronousSubagentResult:
-        normalized_parent_run_id = parent_run_id.strip()
-        normalized_run_id = subagent_run_id.strip()
-        runtime = self._synchronous_subagent_runtimes.get(normalized_run_id)
-        if runtime is not None:
-            if runtime.parent_run_id != normalized_parent_run_id:
-                raise KeyError(f"Unknown synchronous subagent run: {normalized_run_id}")
-            await asyncio.shield(runtime.worker_task)
-            result = runtime.result_holder.get("result")
-            if result is None:
-                raise RuntimeError("Subagent completed without returning a result")
-            return result
-        return await self._synchronous_subagent_result_from_record(
-            parent_run_id=normalized_parent_run_id,
-            subagent_run_id=normalized_run_id,
-        )
-
     def list_for_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
         return tuple(
             record
@@ -715,6 +945,24 @@ class BackgroundTaskService:
             for record in await self._repository.list_by_run_async(run_id)
             if record.execution_mode == "background"
         )
+
+    def subagent_record_for_tool_call(
+        self,
+        *,
+        parent_run_id: str,
+        tool_call_id: str,
+    ) -> BackgroundTaskRecord | None:
+        normalized_run_id = parent_run_id.strip()
+        normalized_tool_call_id = tool_call_id.strip()
+        if not normalized_run_id or not normalized_tool_call_id:
+            return None
+        for record in self._repository.list_by_run(normalized_run_id):
+            if (
+                record.kind == BackgroundTaskKind.SUBAGENT
+                and record.tool_call_id == normalized_tool_call_id
+            ):
+                return record
+        return None
 
     def get_for_run(
         self,
@@ -936,16 +1184,42 @@ class BackgroundTaskService:
         output: str,
     ) -> None:
         summarized_output = output.strip()
-        self._require_task_repo().update_status(
-            prepared.subagent_task.task_id,
-            TaskStatus.FAILED,
-            assigned_instance_id=prepared.subagent_instance.instance_id,
-            error_message=summarized_output,
-        )
-        self._require_agent_repo().mark_status(
-            prepared.subagent_instance.instance_id,
-            InstanceStatus.FAILED,
-        )
+        try:
+            self._require_task_repo().update_status(
+                prepared.subagent_task.task_id,
+                TaskStatus.FAILED,
+                assigned_instance_id=prepared.subagent_instance.instance_id,
+                error_message=summarized_output,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task.subagent_launch_task_mark_failed_skipped",
+                message="Failed to mark subagent task failed during launch cleanup",
+                payload={
+                    "subagent_run_id": prepared.subagent_run_id,
+                    "subagent_task_id": prepared.subagent_task.task_id,
+                },
+                exc_info=exc,
+            )
+        try:
+            self._require_agent_repo().mark_status(
+                prepared.subagent_instance.instance_id,
+                InstanceStatus.FAILED,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task.subagent_launch_instance_mark_failed_skipped",
+                message="Failed to mark subagent instance failed during launch cleanup",
+                payload={
+                    "subagent_run_id": prepared.subagent_run_id,
+                    "subagent_instance_id": prepared.subagent_instance.instance_id,
+                },
+                exc_info=exc,
+            )
 
     @staticmethod
     def _build_synchronous_subagent_record(
@@ -955,15 +1229,20 @@ class BackgroundTaskService:
         session_id: str,
         workspace_id: str,
         prepared: _PreparedSubagentLaunch,
+        tool_call_id: str | None = None,
+        parent_instance_id: str | None = None,
+        parent_role_id: str | None = None,
     ) -> BackgroundTaskRecord:
         return BackgroundTaskRecord(
             background_task_id=background_task_id,
             run_id=run_id,
             session_id=session_id,
             kind=BackgroundTaskKind.SUBAGENT,
-            instance_id=prepared.subagent_instance.instance_id,
-            role_id=prepared.subagent_role_id,
+            instance_id=parent_instance_id or prepared.subagent_instance.instance_id,
+            role_id=parent_role_id or prepared.subagent_role_id,
+            tool_call_id=tool_call_id,
             title=prepared.normalized_title,
+            input_text=prepared.normalized_prompt,
             command=f"{_SUBAGENT_COMMAND_PREFIX}{prepared.subagent_role_id}",
             cwd=workspace_id,
             execution_mode="foreground",
@@ -975,6 +1254,7 @@ class BackgroundTaskService:
             subagent_run_id=prepared.subagent_run_id,
             subagent_task_id=prepared.subagent_task.task_id,
             subagent_instance_id=prepared.subagent_instance.instance_id,
+            subagent_suppress_hooks=prepared.suppress_hooks,
         )
 
     async def _finalize_synchronous_subagent_record(
@@ -1302,9 +1582,35 @@ class BackgroundTaskService:
         prompt: str,
         suppress_hooks: bool = False,
     ) -> _PreparedSubagentLaunch:
-        agent_repo = self._require_agent_repo()
-        task_repo = self._require_task_repo()
+        prepared = self._build_subagent_launch(
+            run_id=run_id,
+            session_id=session_id,
+            workspace_id=workspace_id,
+            subagent_role_id=subagent_role_id,
+            title=title,
+            prompt=prompt,
+            suppress_hooks=suppress_hooks,
+        )
+        self._materialize_prepared_subagent_launch(
+            parent_run_id=run_id,
+            session_id=session_id,
+            workspace_id=workspace_id,
+            prepared=prepared,
+            subagent_role=subagent_role,
+        )
+        return prepared
 
+    def _build_subagent_launch(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        workspace_id: str,
+        subagent_role_id: str,
+        title: str,
+        prompt: str,
+        suppress_hooks: bool = False,
+    ) -> _PreparedSubagentLaunch:
         normalized_prompt = prompt.strip()
         if not normalized_prompt:
             raise ValueError("prompt must not be empty")
@@ -1340,57 +1646,6 @@ class BackgroundTaskService:
             objective=normalized_prompt,
             verification=VerificationPlan(checklist=("non_empty_response",)),
         )
-        agent_repo.upsert_instance(
-            run_id=subagent_run_id,
-            trace_id=subagent_run_id,
-            session_id=session_id,
-            instance_id=subagent_instance.instance_id,
-            role_id=subagent_role_id,
-            workspace_id=workspace_id,
-            conversation_id=subagent_instance.conversation_id,
-            status=InstanceStatus.IDLE,
-            lifecycle=InstanceLifecycle.EPHEMERAL,
-        )
-        task_repo.create(subagent_task)
-        self._record_subagent_task_created(
-            task=subagent_task,
-            suppress_hooks=suppress_hooks,
-        )
-        task_repo.update_status(
-            subagent_task.task_id,
-            TaskStatus.ASSIGNED,
-            assigned_instance_id=subagent_instance.instance_id,
-        )
-        self._upsert_subagent_intent(
-            parent_run_id=run_id,
-            subagent_run_id=subagent_run_id,
-            session_id=session_id,
-            subagent_role_id=subagent_role_id,
-            prompt=normalized_prompt,
-        )
-        self._clone_subagent_role_snapshot(
-            subagent_run_id=subagent_run_id,
-            session_id=session_id,
-            subagent_role=subagent_role,
-        )
-        if self._run_runtime_repo is not None:
-            _ = self._run_runtime_repo.ensure(
-                run_id=subagent_run_id,
-                session_id=session_id,
-                root_task_id=subagent_task.task_id,
-                status=RunRuntimeStatus.RUNNING,
-                phase=RunRuntimePhase.SUBAGENT_RUNNING,
-            )
-            _ = self._run_runtime_repo.update(
-                subagent_run_id,
-                status=RunRuntimeStatus.RUNNING,
-                phase=RunRuntimePhase.SUBAGENT_RUNNING,
-                active_instance_id=subagent_instance.instance_id,
-                active_task_id=subagent_task.task_id,
-                active_role_id=subagent_role_id,
-                active_subagent_instance_id=subagent_instance.instance_id,
-                last_error=None,
-            )
         return _PreparedSubagentLaunch(
             normalized_prompt=normalized_prompt,
             normalized_title=normalized_title,
@@ -1400,6 +1655,83 @@ class BackgroundTaskService:
             subagent_instance=subagent_instance,
             subagent_task=subagent_task,
         )
+
+    def _materialize_prepared_subagent_launch(
+        self,
+        *,
+        parent_run_id: str,
+        session_id: str,
+        workspace_id: str,
+        prepared: _PreparedSubagentLaunch,
+        subagent_role: RoleDefinition | None = None,
+    ) -> None:
+        agent_repo = self._require_agent_repo()
+        task_repo = self._require_task_repo()
+        subagent_instance = prepared.subagent_instance
+        subagent_task = prepared.subagent_task
+        agent_repo.upsert_instance(
+            run_id=prepared.subagent_run_id,
+            trace_id=prepared.subagent_run_id,
+            session_id=session_id,
+            instance_id=subagent_instance.instance_id,
+            role_id=prepared.subagent_role_id,
+            workspace_id=workspace_id,
+            conversation_id=subagent_instance.conversation_id,
+            status=InstanceStatus.IDLE,
+            lifecycle=InstanceLifecycle.EPHEMERAL,
+        )
+        if not self._subagent_task_exists(task_repo, subagent_task.task_id):
+            task_repo.create(subagent_task)
+            self._record_subagent_task_created(
+                task=subagent_task,
+                suppress_hooks=prepared.suppress_hooks,
+            )
+        task_repo.update_status(
+            subagent_task.task_id,
+            TaskStatus.ASSIGNED,
+            assigned_instance_id=subagent_instance.instance_id,
+        )
+        self._upsert_subagent_intent(
+            parent_run_id=parent_run_id,
+            subagent_run_id=prepared.subagent_run_id,
+            session_id=session_id,
+            subagent_role_id=prepared.subagent_role_id,
+            prompt=prepared.normalized_prompt,
+        )
+        self._clone_subagent_role_snapshot(
+            subagent_run_id=prepared.subagent_run_id,
+            session_id=session_id,
+            subagent_role=subagent_role,
+        )
+        if self._run_runtime_repo is not None:
+            _ = self._run_runtime_repo.ensure(
+                run_id=prepared.subagent_run_id,
+                session_id=session_id,
+                root_task_id=subagent_task.task_id,
+                status=RunRuntimeStatus.RUNNING,
+                phase=RunRuntimePhase.SUBAGENT_RUNNING,
+            )
+            _ = self._run_runtime_repo.update(
+                prepared.subagent_run_id,
+                status=RunRuntimeStatus.RUNNING,
+                phase=RunRuntimePhase.SUBAGENT_RUNNING,
+                active_instance_id=subagent_instance.instance_id,
+                active_task_id=subagent_task.task_id,
+                active_role_id=prepared.subagent_role_id,
+                active_subagent_instance_id=subagent_instance.instance_id,
+                last_error=None,
+            )
+
+    @staticmethod
+    def _subagent_task_exists(
+        task_repo: _BackgroundTaskTaskRepository,
+        task_id: str,
+    ) -> bool:
+        try:
+            _ = task_repo.get(task_id)
+        except KeyError:
+            return False
+        return True
 
     def _clone_subagent_role_snapshot(
         self,
@@ -1419,6 +1751,23 @@ class BackgroundTaskService:
             source=TemporaryRoleSource.SKILL_TEAM,
             role=_temporary_role_spec_from_definition(subagent_role),
         )
+
+    def _temporary_subagent_role_from_parent(
+        self,
+        *,
+        parent_run_id: str,
+        subagent_role_id: str,
+    ) -> RoleDefinition | None:
+        runtime_role_resolver = self._get_runtime_role_resolver()
+        if runtime_role_resolver is None:
+            return None
+        try:
+            return runtime_role_resolver.get_temporary_role(
+                run_id=parent_run_id,
+                role_id=subagent_role_id,
+            )
+        except KeyError:
+            return None
 
     def _get_runtime_role_resolver(self) -> RuntimeRoleResolver | None:
         if self._task_execution_service is None:
@@ -1685,6 +2034,20 @@ def _recent_output_lines(output: str) -> tuple[str, ...]:
     if not lines:
         return ()
     return tuple(lines[-3:])
+
+
+def _background_status_from_task_status(status: TaskStatus) -> BackgroundTaskStatus:
+    if status == TaskStatus.COMPLETED:
+        return BackgroundTaskStatus.COMPLETED
+    if status == TaskStatus.STOPPED:
+        return BackgroundTaskStatus.STOPPED
+    return BackgroundTaskStatus.FAILED
+
+
+def _output_from_terminal_task_record(record: TaskRecord) -> str:
+    if record.status == TaskStatus.COMPLETED:
+        return record.result or ""
+    return record.error_message or record.result or record.status.value
 
 
 def _status_from_execution_result(

--- a/src/relay_teams/sessions/runs/enums.py
+++ b/src/relay_teams/sessions/runs/enums.py
@@ -39,6 +39,7 @@ class RunEventType(str, Enum):
     THINKING_DELTA = "thinking_delta"
     THINKING_FINISHED = "thinking_finished"
     TOOL_CALL = "tool_call"
+    TOOL_CALL_BATCH_SEALED = "tool_call_batch_sealed"
     TOOL_INPUT_VALIDATION_FAILED = "tool_input_validation_failed"
     TOOL_RESULT = "tool_result"
     INJECTION_ENQUEUED = "injection_enqueued"

--- a/src/relay_teams/sessions/runs/event_stream.py
+++ b/src/relay_teams/sessions/runs/event_stream.py
@@ -11,24 +11,25 @@ from relay_teams.sessions.runs.run_state_repo import RunStateRepository
 
 @runtime_checkable
 class AsyncRunEventPublisher(Protocol):
-    async def publish_async(self, event: RunEvent) -> None:
+    async def publish_async(self, event: RunEvent) -> int | None:
         pass
 
 
 @runtime_checkable
 class SyncRunEventPublisher(Protocol):
-    def publish(self, event: RunEvent) -> None:
+    def publish(self, event: RunEvent) -> int | None:
         pass
 
 
 async def publish_run_event_async(
     publisher: AsyncRunEventPublisher | SyncRunEventPublisher,
     event: RunEvent,
-) -> None:
+) -> int:
     if isinstance(publisher, AsyncRunEventPublisher):
-        await publisher.publish_async(event)
-        return
-    publisher.publish(event)
+        event_id = await publisher.publish_async(event)
+        return event_id if isinstance(event_id, int) else 0
+    event_id = publisher.publish(event)
+    return event_id if isinstance(event_id, int) else 0
 
 
 class RunEventHub:
@@ -91,11 +92,11 @@ class RunEventHub:
         if not self._session_subscribers[session_id]:
             self._session_subscribers.pop(session_id, None)
 
-    def publish(self, event: RunEvent) -> None:
+    def publish(self, event: RunEvent) -> int:
         if self._publish_from_running_loop(event):
-            return
+            return int(event.event_id or 0)
         with self._publish_lock:
-            self._publish_sync_with_lock(event)
+            return self._publish_sync_with_lock(event)
 
     def _publish_from_running_loop(self, event: RunEvent) -> bool:
         try:
@@ -104,7 +105,9 @@ class RunEventHub:
             return False
         if self._publish_lock.acquire(blocking=False):
             try:
-                self._publish_sync_with_lock(event)
+                event_id = self._publish_sync_with_lock(event)
+                if event_id > 0:
+                    event.event_id = event_id
             finally:
                 self._publish_lock.release()
             return True
@@ -113,7 +116,7 @@ class RunEventHub:
             "a running event loop; use publish_async instead."
         )
 
-    def _publish_sync_with_lock(self, event: RunEvent) -> None:
+    def _publish_sync_with_lock(self, event: RunEvent) -> int:
         event_id = 0
         if self._event_log:
             event_id = self._event_log.emit_run_event(event)
@@ -129,17 +132,18 @@ class RunEventHub:
         session_listeners = self._session_subscribers.get(event.session_id, [])
         for queue in session_listeners:
             queue.put_nowait(event)
+        return event_id
 
-    async def publish_async(self, event: RunEvent) -> None:
+    async def publish_async(self, event: RunEvent) -> int:
         await self._acquire_publish_lock_async()
         task = asyncio.create_task(self._publish_async_with_lock(event))
         try:
-            _ = await asyncio.shield(task)
+            return await asyncio.shield(task)
         except asyncio.CancelledError:
             _ = await task
             raise
 
-    async def _publish_async_with_lock(self, event: RunEvent) -> None:
+    async def _publish_async_with_lock(self, event: RunEvent) -> int:
         try:
             event_id = 0
             if self._event_log:
@@ -159,6 +163,7 @@ class RunEventHub:
             session_listeners = self._session_subscribers.get(event.session_id, [])
             for queue in session_listeners:
                 queue.put_nowait(event)
+            return event_id
         finally:
             self._publish_lock.release()
 

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -15,6 +15,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from collections.abc import Awaitable, Callable, Mapping
+from datetime import datetime, timezone
 from enum import Enum
 from json import dumps
 from typing import (
@@ -346,7 +347,6 @@ async def execute_tool(
         if approval_error is not None:
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             meta["duration_ms"] = elapsed_ms
-            meta["tool_result_event_published"] = True
             envelope = _visible_envelope(
                 ok=False,
                 error=approval_error,
@@ -358,7 +358,7 @@ async def execute_tool(
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            await _persist_tool_record_async(
+            await _persist_and_publish_tool_result_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
@@ -373,12 +373,6 @@ async def execute_tool(
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=False,
-            )
-            await _publish_tool_result_event_async(
-                ctx=ctx,
-                tool_call_id=tool_call_id,
-                tool_name=tool_name,
-                visible_envelope=envelope,
             )
             return envelope
 
@@ -399,6 +393,32 @@ async def execute_tool(
             ),
             last_error=None,
         )
+        try:
+            await _mark_tool_running_async(
+                ctx=ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                args_summary=args_summary,
+                runtime_meta=meta,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="tool.running_state_persist_failed",
+                message=(
+                    "Tool call will run, but its pre-run recovery state could "
+                    "not be persisted"
+                ),
+                payload={
+                    "run_id": ctx.deps.run_id,
+                    "task_id": ctx.deps.task_id,
+                    "tool_name": tool_name,
+                    "tool_call_id": tool_call_id,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
 
         try:
             _raise_if_stopped(ctx)
@@ -428,7 +448,6 @@ async def execute_tool(
                 payload={"tool_name": tool_name},
             )
 
-            meta["tool_result_event_published"] = True
             envelope = _visible_envelope(
                 ok=True,
                 data=visible_data,
@@ -446,7 +465,6 @@ async def execute_tool(
                     tool_content_parts=tool_content_parts,
                 )
 
-            meta["tool_result_event_published"] = True
             envelope = await _apply_post_tool_hooks(
                 ctx=ctx,
                 tool_name=tool_name,
@@ -460,7 +478,7 @@ async def execute_tool(
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            await _persist_tool_record_async(
+            await _persist_and_publish_tool_result_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
@@ -476,12 +494,6 @@ async def execute_tool(
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=True,
-            )
-            await _publish_tool_result_event_async(
-                ctx=ctx,
-                tool_call_id=tool_call_id,
-                tool_name=tool_name,
-                visible_envelope=envelope,
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
                 await ctx.deps.approval_ticket_repo.mark_completed_async(
@@ -523,7 +535,6 @@ async def execute_tool(
                     "details": error.details,
                 },
             )
-            meta["tool_result_event_published"] = True
             envelope = _visible_envelope(
                 ok=False,
                 error=error,
@@ -542,7 +553,7 @@ async def execute_tool(
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            await _persist_tool_record_async(
+            await _persist_and_publish_tool_result_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
@@ -557,12 +568,6 @@ async def execute_tool(
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
                 success=False,
-            )
-            await _publish_tool_result_event_async(
-                ctx=ctx,
-                tool_call_id=tool_call_id,
-                tool_name=tool_name,
-                visible_envelope=envelope,
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
                 await ctx.deps.approval_ticket_repo.mark_completed_async(
@@ -816,13 +821,13 @@ async def _publish_tool_result_event_async(
     tool_call_id: str,
     tool_name: str,
     visible_envelope: dict[str, JsonValue],
-) -> None:
+) -> int:
     result_payload = cast(
         JsonValue,
         sanitize_task_status_payload(visible_envelope),
     )
     is_error = bool(visible_envelope.get("ok") is False)
-    await publish_run_event_async(
+    return await publish_run_event_async(
         ctx.deps.run_event_hub,
         RunEvent(
             session_id=ctx.deps.session_id,
@@ -843,6 +848,131 @@ async def _publish_tool_result_event_async(
                 }
             ),
         ),
+    )
+
+
+def _mark_tool_result_event_state(
+    *,
+    runtime_meta: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    published: bool,
+) -> None:
+    runtime_meta["tool_result_durably_recorded"] = True
+    runtime_meta["tool_result_event_published"] = published
+    raw_meta = visible_envelope.get("meta")
+    envelope_meta = (
+        dict(cast(dict[str, JsonValue], raw_meta)) if isinstance(raw_meta, dict) else {}
+    )
+    envelope_meta["tool_result_durably_recorded"] = True
+    envelope_meta["tool_result_event_published"] = published
+    visible_envelope["meta"] = envelope_meta
+
+
+async def _persist_and_publish_tool_result_async(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    runtime_meta: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+    tool_content_parts: tuple[ContentPart, ...] = (),
+) -> None:
+    _mark_tool_result_event_state(
+        runtime_meta=runtime_meta,
+        visible_envelope=visible_envelope,
+        published=False,
+    )
+    await _persist_tool_record_async(
+        ctx=ctx,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        args_summary=args_summary,
+        visible_envelope=visible_envelope,
+        internal_data=internal_data,
+        runtime_meta=runtime_meta,
+        execution_status=execution_status,
+        tool_content_parts=tool_content_parts,
+    )
+    _mark_tool_result_event_state(
+        runtime_meta=runtime_meta,
+        visible_envelope=visible_envelope,
+        published=True,
+    )
+    result_event_id = await _publish_tool_result_event_async(
+        ctx=ctx,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        visible_envelope=visible_envelope,
+    )
+    try:
+        await _persist_tool_record_async(
+            ctx=ctx,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            args_summary=args_summary,
+            visible_envelope=visible_envelope,
+            internal_data=internal_data,
+            runtime_meta=runtime_meta,
+            execution_status=execution_status,
+            tool_content_parts=tool_content_parts,
+            result_event_id=result_event_id,
+        )
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tool.result_linkage_persist_failed",
+            message=(
+                "Tool result event was published, but the result linkage state "
+                "could not be updated"
+            ),
+            payload={
+                "run_id": ctx.deps.run_id,
+                "task_id": ctx.deps.task_id,
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "result_event_id": result_event_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+
+async def _mark_tool_running_async(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    runtime_meta: dict[str, JsonValue],
+) -> None:
+    current_state = await load_tool_call_state_async(
+        shared_store=ctx.deps.shared_store,
+        task_id=ctx.deps.task_id,
+        tool_call_id=tool_call_id,
+    )
+    existing_call_state = (
+        dict(current_state.call_state) if current_state is not None else {}
+    )
+    await merge_tool_call_state_async(
+        shared_store=ctx.deps.shared_store,
+        task_id=ctx.deps.task_id,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        args_preview=_safe_json(args_summary),
+        run_yolo=bool(runtime_meta.get("run_yolo") is True),
+        approval_mode=_approval_mode_from_meta(runtime_meta),
+        approval_status=_approval_status_from_meta(runtime_meta),
+        execution_status=ToolExecutionStatus.RUNNING,
+        call_state=existing_call_state,
+        started_at=datetime.now(tz=timezone.utc).isoformat(),
     )
 
 
@@ -1558,9 +1688,7 @@ async def _apply_post_tool_failure_hooks(
         return envelope
     error_payload = envelope.get("error")
     tool_error = (
-        cast(dict[str, JsonValue], error_payload)
-        if isinstance(error_payload, dict)
-        else {}
+        _normalize_json_object(error_payload) if isinstance(error_payload, dict) else {}
     )
     bundle = await hook_service.execute(
         event_input=PostToolUseFailureInput(
@@ -2476,6 +2604,7 @@ async def _persist_tool_record_async(
     runtime_meta: dict[str, JsonValue],
     execution_status: ToolExecutionStatus,
     tool_content_parts: tuple[ContentPart, ...] = (),
+    result_event_id: int = 0,
 ) -> None:
     approval_status = _approval_status_from_meta(runtime_meta)
     approval_mode = _approval_mode_from_meta(runtime_meta)
@@ -2511,6 +2640,8 @@ async def _persist_tool_record_async(
         execution_status=execution_status,
         result_envelope=result_record,
         call_state=existing_call_state,
+        result_event_id=result_event_id,
+        finished_at=datetime.now(tz=timezone.utc).isoformat(),
     )
 
 

--- a/src/relay_teams/tools/runtime/persisted_state.py
+++ b/src/relay_teams/tools/runtime/persisted_state.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from datetime import datetime, timezone
 from enum import Enum
-from collections.abc import Callable
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
@@ -40,6 +40,44 @@ class ToolExecutionStatus(str, Enum):
     FAILED = "failed"
 
 
+_TERMINAL_TOOL_EXECUTION_STATUSES = frozenset(
+    {ToolExecutionStatus.COMPLETED, ToolExecutionStatus.FAILED}
+)
+
+
+class ToolCallBatchStatus(str, Enum):
+    OPEN = "open"
+    SEALED = "sealed"
+
+
+class PersistedToolCallBatchItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tool_call_id: str = Field(min_length=1)
+    tool_name: str = Field(min_length=1)
+    args_preview: str = ""
+    index: int = Field(ge=0)
+
+
+class PersistedToolCallBatchState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    batch_id: str = Field(min_length=1)
+    run_id: str = ""
+    session_id: str = ""
+    instance_id: str = Field(min_length=1)
+    role_id: str = Field(min_length=1)
+    task_id: str = ""
+    status: ToolCallBatchStatus = ToolCallBatchStatus.OPEN
+    items: tuple[PersistedToolCallBatchItem, ...] = ()
+    created_at: str = Field(
+        default_factory=lambda: datetime.now(tz=timezone.utc).isoformat()
+    )
+    updated_at: str = Field(
+        default_factory=lambda: datetime.now(tz=timezone.utc).isoformat()
+    )
+
+
 class PersistedToolCallState(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -57,6 +95,12 @@ class PersistedToolCallState(BaseModel):
     execution_status: ToolExecutionStatus = ToolExecutionStatus.WAITING_APPROVAL
     result_envelope: dict[str, JsonValue] | None = None
     call_state: dict[str, JsonValue] = Field(default_factory=dict)
+    batch_id: str = ""
+    batch_index: int = -1
+    batch_size: int = 0
+    result_event_id: int = 0
+    started_at: str = ""
+    finished_at: str = ""
     created_at: str = Field(
         default_factory=lambda: datetime.now(tz=timezone.utc).isoformat()
     )
@@ -76,7 +120,7 @@ def load_tool_call_state(
         return None
     try:
         return PersistedToolCallState.model_validate_json(raw)
-    except Exception:
+    except ValueError:
         return None
 
 
@@ -93,7 +137,39 @@ async def load_tool_call_state_async(
         return None
     try:
         return PersistedToolCallState.model_validate_json(raw)
-    except Exception:
+    except ValueError:
+        return None
+
+
+def load_tool_call_batch_state(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    batch_id: str,
+) -> PersistedToolCallBatchState | None:
+    raw = shared_store.get_state(_task_scope(task_id), _batch_state_key(batch_id))
+    if raw is None:
+        return None
+    try:
+        return PersistedToolCallBatchState.model_validate_json(raw)
+    except ValueError:
+        return None
+
+
+async def load_tool_call_batch_state_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    batch_id: str,
+) -> PersistedToolCallBatchState | None:
+    raw = await shared_store.get_state_async(
+        _task_scope(task_id), _batch_state_key(batch_id)
+    )
+    if raw is None:
+        return None
+    try:
+        return PersistedToolCallBatchState.model_validate_json(raw)
+    except ValueError:
         return None
 
 
@@ -115,6 +191,12 @@ def merge_tool_call_state(
     execution_status: ToolExecutionStatus | None = None,
     result_envelope: dict[str, JsonValue] | None = None,
     call_state: dict[str, JsonValue] | None = None,
+    batch_id: str | None = None,
+    batch_index: int | None = None,
+    batch_size: int | None = None,
+    result_event_id: int | None = None,
+    started_at: str | None = None,
+    finished_at: str | None = None,
 ) -> PersistedToolCallState:
     current = load_tool_call_state(
         shared_store=shared_store,
@@ -163,6 +245,18 @@ def merge_tool_call_state(
         update["result_envelope"] = result_envelope
     if call_state is not None:
         update["call_state"] = call_state
+    if batch_id is not None:
+        update["batch_id"] = batch_id
+    if batch_index is not None:
+        update["batch_index"] = batch_index
+    if batch_size is not None:
+        update["batch_size"] = batch_size
+    if result_event_id is not None:
+        update["result_event_id"] = result_event_id
+    if started_at is not None:
+        update["started_at"] = started_at
+    if finished_at is not None:
+        update["finished_at"] = finished_at
     next_state = current.model_copy(update=update)
     shared_store.manage_state(
         StateMutation(
@@ -192,6 +286,12 @@ async def merge_tool_call_state_async(
     execution_status: ToolExecutionStatus | None = None,
     result_envelope: dict[str, JsonValue] | None = None,
     call_state: dict[str, JsonValue] | None = None,
+    batch_id: str | None = None,
+    batch_index: int | None = None,
+    batch_size: int | None = None,
+    result_event_id: int | None = None,
+    started_at: str | None = None,
+    finished_at: str | None = None,
 ) -> PersistedToolCallState:
     current = await load_tool_call_state_async(
         shared_store=shared_store,
@@ -240,6 +340,18 @@ async def merge_tool_call_state_async(
         update["result_envelope"] = result_envelope
     if call_state is not None:
         update["call_state"] = call_state
+    if batch_id is not None:
+        update["batch_id"] = batch_id
+    if batch_index is not None:
+        update["batch_index"] = batch_index
+    if batch_size is not None:
+        update["batch_size"] = batch_size
+    if result_event_id is not None:
+        update["result_event_id"] = result_event_id
+    if started_at is not None:
+        update["started_at"] = started_at
+    if finished_at is not None:
+        update["finished_at"] = finished_at
     next_state = current.model_copy(update=update)
     await shared_store.manage_state_async(
         StateMutation(
@@ -251,10 +363,116 @@ async def merge_tool_call_state_async(
     return next_state
 
 
+def merge_tool_call_batch_state(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    batch_id: str,
+    run_id: str | None = None,
+    session_id: str | None = None,
+    instance_id: str,
+    role_id: str,
+    status: ToolCallBatchStatus | None = None,
+    items: tuple[PersistedToolCallBatchItem, ...] | None = None,
+) -> PersistedToolCallBatchState:
+    current = load_tool_call_batch_state(
+        shared_store=shared_store,
+        task_id=task_id,
+        batch_id=batch_id,
+    )
+    now = datetime.now(tz=timezone.utc).isoformat()
+    if current is None:
+        current = PersistedToolCallBatchState(
+            batch_id=batch_id,
+            run_id=run_id or "",
+            session_id=session_id or "",
+            instance_id=instance_id,
+            role_id=role_id,
+            task_id=task_id,
+            updated_at=now,
+        )
+    update: dict[str, object] = {
+        "instance_id": instance_id,
+        "role_id": role_id,
+        "task_id": task_id,
+        "updated_at": now,
+    }
+    if run_id is not None:
+        update["run_id"] = run_id
+    if session_id is not None:
+        update["session_id"] = session_id
+    if status is not None:
+        update["status"] = status
+    if items is not None:
+        update["items"] = items
+    next_state = current.model_copy(update=update)
+    shared_store.manage_state(
+        StateMutation(
+            scope=_task_scope(task_id),
+            key=_batch_state_key(batch_id),
+            value_json=next_state.model_dump_json(),
+        )
+    )
+    return next_state
+
+
+async def merge_tool_call_batch_state_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    batch_id: str,
+    run_id: str | None = None,
+    session_id: str | None = None,
+    instance_id: str,
+    role_id: str,
+    status: ToolCallBatchStatus | None = None,
+    items: tuple[PersistedToolCallBatchItem, ...] | None = None,
+) -> PersistedToolCallBatchState:
+    current = await load_tool_call_batch_state_async(
+        shared_store=shared_store,
+        task_id=task_id,
+        batch_id=batch_id,
+    )
+    now = datetime.now(tz=timezone.utc).isoformat()
+    if current is None:
+        current = PersistedToolCallBatchState(
+            batch_id=batch_id,
+            run_id=run_id or "",
+            session_id=session_id or "",
+            instance_id=instance_id,
+            role_id=role_id,
+            task_id=task_id,
+            updated_at=now,
+        )
+    update: dict[str, object] = {
+        "instance_id": instance_id,
+        "role_id": role_id,
+        "task_id": task_id,
+        "updated_at": now,
+    }
+    if run_id is not None:
+        update["run_id"] = run_id
+    if session_id is not None:
+        update["session_id"] = session_id
+    if status is not None:
+        update["status"] = status
+    if items is not None:
+        update["items"] = items
+    next_state = current.model_copy(update=update)
+    await shared_store.manage_state_async(
+        StateMutation(
+            scope=_task_scope(task_id),
+            key=_batch_state_key(batch_id),
+            value_json=next_state.model_dump_json(),
+        )
+    )
+    return next_state
+
+
 def load_or_recover_tool_call_state(
     *,
     shared_store: SharedStateRepository,
-    event_log: EventLog,
+    event_log: EventLog | None,
     trace_id: str,
     task_id: str,
     tool_call_id: str,
@@ -265,16 +483,49 @@ def load_or_recover_tool_call_state(
         task_id=task_id,
         tool_call_id=tool_call_id,
     )
-    if current is not None:
+    if (
+        current is not None
+        and current.execution_status in _TERMINAL_TOOL_EXECUTION_STATUSES
+        and _state_has_published_tool_result_linkage(current)
+    ):
         return current
-    return recover_tool_call_state_from_event_log(
+    if event_log is None:
+        return current
+    recovered = recover_tool_call_state_from_event_log(
         event_log=event_log,
         shared_store=shared_store,
         trace_id=trace_id,
         task_id=task_id,
         tool_call_id=tool_call_id,
         task_repo=task_repo,
+        current_state=current,
     )
+    if recovered is None:
+        return current
+    if current is None:
+        return recovered
+    if recovered.execution_status in _TERMINAL_TOOL_EXECUTION_STATUSES:
+        return recovered
+    if recovered.result_event_id > current.result_event_id:
+        return recovered
+    return current
+
+
+def _state_has_published_tool_result_linkage(state: PersistedToolCallState) -> bool:
+    if state.result_event_id > 0:
+        return True
+    result_envelope = state.result_envelope
+    if result_envelope is None:
+        return False
+    runtime_meta = result_envelope.get("runtime_meta")
+    if isinstance(runtime_meta, dict):
+        return runtime_meta.get("tool_result_event_published") is True
+    visible_result = result_envelope.get("visible_result")
+    envelope = visible_result if isinstance(visible_result, dict) else result_envelope
+    meta = envelope.get("meta")
+    if not isinstance(meta, dict):
+        return False
+    return meta.get("tool_result_event_published") is True
 
 
 def update_tool_call_call_state(
@@ -307,6 +558,36 @@ def update_tool_call_call_state(
     )
 
 
+async def update_tool_call_call_state_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    tool_call_id: str,
+    tool_name: str,
+    instance_id: str,
+    role_id: str,
+    mutate: Callable[[dict[str, JsonValue]], dict[str, JsonValue]],
+) -> PersistedToolCallState:
+    current = await load_tool_call_state_async(
+        shared_store=shared_store,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+    )
+    base_state = dict(current.call_state) if current is not None else {}
+    next_call_state = mutate(base_state)
+    return await merge_tool_call_state_async(
+        shared_store=shared_store,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        run_id=None,
+        session_id=None,
+        instance_id=instance_id,
+        role_id=role_id,
+        call_state=next_call_state,
+    )
+
+
 def recover_tool_call_state_from_event_log(
     *,
     event_log: EventLog,
@@ -315,18 +596,21 @@ def recover_tool_call_state_from_event_log(
     task_id: str,
     tool_call_id: str,
     task_repo: TaskRepository | None = None,
+    current_state: PersistedToolCallState | None = None,
 ) -> PersistedToolCallState | None:
-    recovered = load_tool_call_state(
-        shared_store=shared_store,
-        task_id=task_id,
-        tool_call_id=tool_call_id,
-    )
-    if recovered is not None:
-        return recovered
+    if current_state is None:
+        recovered = load_tool_call_state(
+            shared_store=shared_store,
+            task_id=task_id,
+            tool_call_id=tool_call_id,
+        )
+        if recovered is not None:
+            return recovered
 
-    state: PersistedToolCallState | None = None
+    state: PersistedToolCallState | None = current_state
+    observed_terminal_event = False
     tool_args: dict[str, JsonValue] = {}
-    for row in event_log.list_by_trace(trace_id):
+    for row in event_log.list_by_trace_with_ids(trace_id):
         if str(row.get("task_id") or "") != task_id:
             continue
         payload = _parse_payload(row.get("payload_json"))
@@ -335,6 +619,22 @@ def recover_tool_call_state_from_event_log(
         event_type = str(row.get("event_type") or "")
         if event_type == RunEventType.TOOL_CALL.value:
             tool_args = _parse_tool_args(payload)
+        raw_result_event_id = (
+            row.get("id") if event_type == RunEventType.TOOL_RESULT.value else None
+        )
+        result_event_id = (
+            raw_result_event_id if isinstance(raw_result_event_id, int) else 0
+        )
+        batch_id = str(payload.get("batch_id") or (state.batch_id if state else ""))
+        batch_index = _batch_index_from_payload(
+            payload, default=state.batch_index if state else -1
+        )
+        raw_batch_size = payload.get("batch_size")
+        batch_size = (
+            raw_batch_size
+            if isinstance(raw_batch_size, int)
+            else (state.batch_size if state else 0)
+        )
         tool_name = str(payload.get("tool_name") or (state.tool_name if state else ""))
         run_id = str(payload.get("run_id") or (state.run_id if state else trace_id))
         session_id = str(
@@ -348,9 +648,9 @@ def recover_tool_call_state_from_event_log(
             or (state.instance_id if state else "")
         )
         role_id = str(payload.get("role_id") or (state.role_id if state else ""))
-        args_preview = str(
-            payload.get("args_preview")
-            or payload.get("args")
+        args_preview = (
+            _args_preview_from_value(payload.get("args_preview"))
+            or _args_preview_from_value(payload.get("args"))
             or (state.args_preview if state else "")
         )
         if not tool_name or not instance_id or not role_id:
@@ -368,6 +668,9 @@ def recover_tool_call_state_from_event_log(
                 approval_mode=ToolApprovalMode.UNKNOWN,
                 approval_status=ToolApprovalStatus.NOT_REQUIRED,
                 execution_status=ToolExecutionStatus.READY,
+                batch_id=batch_id,
+                batch_index=batch_index,
+                batch_size=batch_size,
             )
         else:
             state = state.model_copy(
@@ -378,6 +681,9 @@ def recover_tool_call_state_from_event_log(
                     "instance_id": instance_id,
                     "role_id": role_id,
                     "args_preview": args_preview,
+                    "batch_id": batch_id,
+                    "batch_index": batch_index,
+                    "batch_size": batch_size,
                 }
             )
 
@@ -401,6 +707,7 @@ def recover_tool_call_state_from_event_log(
                     }
                 )
             elif action == "deny":
+                observed_terminal_event = True
                 state = state.model_copy(
                     update={
                         "approval_status": ToolApprovalStatus.DENY,
@@ -410,6 +717,7 @@ def recover_tool_call_state_from_event_log(
                     }
                 )
             elif action == "timeout":
+                observed_terminal_event = True
                 state = state.model_copy(
                     update={
                         "approval_status": ToolApprovalStatus.TIMEOUT,
@@ -420,6 +728,7 @@ def recover_tool_call_state_from_event_log(
         elif event_type == RunEventType.TOOL_RESULT.value:
             result = payload.get("result")
             if isinstance(result, dict):
+                observed_terminal_event = True
                 meta = result.get("meta")
                 approval_status = None
                 approval_mode = None
@@ -439,6 +748,9 @@ def recover_tool_call_state_from_event_log(
                     approval_mode = _parse_approval_mode(meta.get("approval_mode"))
                     if isinstance(meta.get("run_yolo"), bool):
                         run_yolo = bool(meta["run_yolo"])
+                result_failed = (
+                    payload.get("error") is True or result.get("ok") is False
+                )
                 state = state.model_copy(
                     update={
                         "run_yolo": state.run_yolo if run_yolo is None else run_yolo,
@@ -448,13 +760,18 @@ def recover_tool_call_state_from_event_log(
                             else approval_mode
                         ),
                         "approval_status": approval_status or state.approval_status,
-                        "execution_status": ToolExecutionStatus.COMPLETED,
+                        "execution_status": ToolExecutionStatus.FAILED
+                        if result_failed
+                        else ToolExecutionStatus.COMPLETED,
                         "result_envelope": result,
+                        "result_event_id": result_event_id,
                     }
                 )
 
     if state is None:
         return None
+    if current_state is not None and not observed_terminal_event:
+        return current_state
     recovered_call_state = dict(state.call_state)
     if not recovered_call_state:
         recovered_call_state = _recover_call_state(
@@ -482,7 +799,74 @@ def recover_tool_call_state_from_event_log(
         execution_status=state.execution_status,
         result_envelope=state.result_envelope,
         call_state=recovered_call_state,
+        batch_id=state.batch_id,
+        batch_index=state.batch_index,
+        batch_size=state.batch_size,
+        result_event_id=state.result_event_id,
+        started_at=state.started_at,
+        finished_at=state.finished_at,
     )
+
+
+def recover_tool_call_batches_from_event_log(
+    *,
+    event_log: EventLog,
+    shared_store: SharedStateRepository,
+    trace_id: str,
+    task_id: str,
+) -> tuple[PersistedToolCallBatchState, ...]:
+    recovered: dict[str, PersistedToolCallBatchState] = {}
+    for row in event_log.list_by_trace_with_ids(trace_id):
+        if str(row.get("task_id") or "") != task_id:
+            continue
+        event_type = str(row.get("event_type") or "")
+        payload = _parse_payload(row.get("payload_json"))
+        batch_id = str(payload.get("batch_id") or "").strip()
+        if not batch_id:
+            continue
+        if event_type == RunEventType.TOOL_CALL.value:
+            item = _batch_item_from_tool_call_payload(payload)
+            if item is None:
+                continue
+            current = recovered.get(batch_id) or load_tool_call_batch_state(
+                shared_store=shared_store,
+                task_id=task_id,
+                batch_id=batch_id,
+            )
+            recovered[batch_id] = merge_tool_call_batch_state(
+                shared_store=shared_store,
+                task_id=task_id,
+                batch_id=batch_id,
+                run_id=str(payload.get("run_id") or row.get("trace_id") or trace_id),
+                session_id=str(
+                    payload.get("session_id") or row.get("session_id") or ""
+                ),
+                instance_id=str(payload.get("instance_id") or ""),
+                role_id=str(payload.get("role_id") or ""),
+                status=ToolCallBatchStatus.OPEN if current is None else current.status,
+                items=_merge_batch_items(
+                    () if current is None else current.items,
+                    (item,),
+                ),
+            )
+            continue
+        if event_type != RunEventType.TOOL_CALL_BATCH_SEALED.value:
+            continue
+        items = _batch_items_from_payload(payload)
+        if not items:
+            continue
+        recovered[batch_id] = merge_tool_call_batch_state(
+            shared_store=shared_store,
+            task_id=task_id,
+            batch_id=batch_id,
+            run_id=str(payload.get("run_id") or row.get("trace_id") or trace_id),
+            session_id=str(payload.get("session_id") or row.get("session_id") or ""),
+            instance_id=str(payload.get("instance_id") or ""),
+            role_id=str(payload.get("role_id") or ""),
+            status=ToolCallBatchStatus.SEALED,
+            items=items,
+        )
+    return tuple(sorted(recovered.values(), key=lambda state: state.updated_at))
 
 
 def _task_scope(task_id: str) -> ScopeRef:
@@ -493,12 +877,93 @@ def _state_key(tool_call_id: str) -> str:
     return f"tool_call_state:{tool_call_id}"
 
 
+def _batch_state_key(batch_id: str) -> str:
+    return f"tool_call_batch:{batch_id}"
+
+
+def _batch_index_from_payload(
+    payload: dict[str, JsonValue],
+    *,
+    default: int = 0,
+) -> int:
+    raw = payload.get("batch_index")
+    if isinstance(raw, int):
+        return raw
+    raw = payload.get("index")
+    return raw if isinstance(raw, int) else default
+
+
+def _batch_item_from_tool_call_payload(
+    payload: dict[str, JsonValue],
+) -> PersistedToolCallBatchItem | None:
+    tool_call_id = str(payload.get("tool_call_id") or "").strip()
+    tool_name = str(payload.get("tool_name") or "").strip()
+    if not tool_call_id or not tool_name:
+        return None
+    return PersistedToolCallBatchItem(
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        args_preview=(
+            _args_preview_from_value(payload.get("args_preview"))
+            or _args_preview_from_value(payload.get("args"))
+        ),
+        index=_batch_index_from_payload(payload),
+    )
+
+
+def _batch_items_from_payload(
+    payload: dict[str, JsonValue],
+) -> tuple[PersistedToolCallBatchItem, ...]:
+    raw_items = payload.get("tool_calls")
+    items: list[PersistedToolCallBatchItem] = []
+    if not isinstance(raw_items, list):
+        return ()
+    for fallback_index, raw_item in enumerate(raw_items):
+        if not isinstance(raw_item, dict):
+            continue
+        tool_call_id = str(raw_item.get("tool_call_id") or "").strip()
+        tool_name = str(raw_item.get("tool_name") or "").strip()
+        if not tool_call_id or not tool_name:
+            continue
+        raw_index = raw_item.get("index")
+        items.append(
+            PersistedToolCallBatchItem(
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                args_preview=(
+                    _args_preview_from_value(raw_item.get("args_preview"))
+                    or _args_preview_from_value(raw_item.get("args"))
+                ),
+                index=raw_index if isinstance(raw_index, int) else fallback_index,
+            )
+        )
+    return tuple(sorted(items, key=lambda item: item.index))
+
+
+def _args_preview_from_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _merge_batch_items(
+    current: tuple[PersistedToolCallBatchItem, ...],
+    incoming: tuple[PersistedToolCallBatchItem, ...],
+) -> tuple[PersistedToolCallBatchItem, ...]:
+    merged = {item.tool_call_id: item for item in current}
+    for item in incoming:
+        merged[item.tool_call_id] = item
+    return tuple(sorted(merged.values(), key=lambda item: item.index))
+
+
 def _parse_payload(raw_payload: object) -> dict[str, JsonValue]:
     if not isinstance(raw_payload, str) or not raw_payload:
         return {}
     try:
         decoded = json.loads(raw_payload)
-    except Exception:
+    except json.JSONDecodeError:
         return {}
     return decoded if isinstance(decoded, dict) else {}
 
@@ -510,7 +975,7 @@ def _parse_tool_args(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:
     if isinstance(raw_args, str) and raw_args.strip():
         try:
             decoded = json.loads(raw_args)
-        except Exception:
+        except json.JSONDecodeError:
             return {}
         return decoded if isinstance(decoded, dict) else {}
     return {}

--- a/src/relay_teams/tools/runtime/recoverable_invoker.py
+++ b/src/relay_teams/tools/runtime/recoverable_invoker.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import inspect
+import json
+from collections.abc import Callable, Mapping
+from typing import cast
+
+from pydantic import JsonValue
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ToolReturn
+from pydantic_ai.models import Model
+from pydantic_ai.usage import RunUsage
+
+from relay_teams.sessions.runs.assistant_errors import build_tool_error_result
+from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
+from relay_teams.tools.runtime.context import ToolDeps
+
+
+class RecoverableToolInvoker:
+    async def invoke_async(
+        self,
+        *,
+        tool_registry: ToolRegistry,
+        deps: ToolDeps,
+        tool_name: str,
+        tool_call_id: str,
+        raw_args: object,
+    ) -> dict[str, JsonValue]:
+        try:
+            function = self._resolve_tool_function(
+                tool_registry=tool_registry,
+                deps=deps,
+                tool_name=tool_name,
+            )
+        except Exception as exc:
+            return build_tool_error_result(
+                error_code="tool_recovery_unavailable",
+                message=str(exc) or exc.__class__.__name__,
+            )
+        if function is None:
+            return build_tool_error_result(
+                error_code="tool_recovery_unavailable",
+                message=f"Tool is no longer available for recovery: {tool_name}",
+            )
+        args = self._tool_args(raw_args)
+        ctx = RunContext(
+            deps=deps,
+            model=cast(Model, object()),
+            usage=RunUsage(),
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            run_id=deps.run_id,
+        )
+        try:
+            result = function(ctx, **args)
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as exc:
+            return build_tool_error_result(
+                error_code="tool_recovery_failed",
+                message=str(exc) or exc.__class__.__name__,
+            )
+        if isinstance(result, ToolReturn):
+            value = result.return_value
+            if isinstance(value, dict):
+                return _json_mapping(value)
+            return {"ok": True, "data": _json_value(value)}
+        if isinstance(result, dict):
+            return _json_mapping(result)
+        return {"ok": True, "data": _json_value(result)}
+
+    @staticmethod
+    def _resolve_tool_function(
+        *,
+        tool_registry: ToolRegistry,
+        deps: ToolDeps,
+        tool_name: str,
+    ) -> Callable[..., object] | None:
+        try:
+            resolved = tool_registry.resolve_known(
+                (tool_name,),
+                context=ToolResolutionContext(session_id=deps.session_id),
+                strict=False,
+                consumer="tools.runtime.recoverable_invoker",
+            )
+        except AttributeError:
+            return None
+        if tool_name not in resolved:
+            return None
+        collector = _ToolFunctionCollector()
+        registration_agent = cast(Agent[ToolDeps, str], cast(object, collector))
+        setattr(collector, "_agent_teams_role_registry", deps.role_registry)
+        for register in tool_registry.require(resolved):
+            register(registration_agent)
+        return collector.functions.get(tool_name)
+
+    @staticmethod
+    def _tool_args(raw_args: object) -> dict[str, JsonValue]:
+        if isinstance(raw_args, str):
+            try:
+                decoded = json.loads(raw_args)
+            except json.JSONDecodeError:
+                return {}
+            if isinstance(decoded, dict):
+                return _json_mapping(decoded)
+            return {}
+        if isinstance(raw_args, Mapping):
+            return _json_mapping(raw_args)
+        return {}
+
+
+class _ToolFunctionCollector:
+    def __init__(self) -> None:
+        self.functions: dict[str, Callable[..., object]] = {}
+
+    def tool(self, *, description: str | None = None) -> Callable[..., object]:
+        _ = description
+
+        def _decorator(func: object) -> object:
+            if callable(func):
+                self.functions[getattr(func, "__name__", "")] = func
+            return func
+
+        return _decorator
+
+
+def _json_mapping(mapping: object) -> dict[str, JsonValue]:
+    if not isinstance(mapping, Mapping):
+        return {}
+    normalized: dict[str, JsonValue] = {}
+    for key, value in mapping.items():
+        normalized[str(key)] = _json_value(value)
+    return normalized
+
+
+def _json_value(value: object) -> JsonValue:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, Mapping):
+        return _json_mapping(value)
+    if isinstance(value, list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    return str(value)

--- a/src/relay_teams/tools/task_tools/spawn_subagent.py
+++ b/src/relay_teams/tools/task_tools/spawn_subagent.py
@@ -14,10 +14,12 @@ from relay_teams.tools.runtime.context import (
 )
 from relay_teams.tools.runtime.execution import execute_tool_call
 from relay_teams.tools.runtime.models import ToolResultProjection
+from relay_teams.tools.runtime.persisted_state import update_tool_call_call_state_async
 from relay_teams.tools.workspace_tools.background_task_tool_support import (
     project_background_task_tool_result,
     require_background_task_service,
 )
+from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskRecord
 
 DESCRIPTION = load_tool_description(__file__)
 _ROLE_REGISTRY_ATTR = "_agent_teams_role_registry"
@@ -43,6 +45,20 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             service = require_background_task_service(ctx)
             resolved_role_id, role_snapshot = _resolve_subagent_role(ctx, role_id)
             if background:
+
+                async def _on_background_launch_prepared(
+                    prepared_record: BackgroundTaskRecord,
+                ) -> None:
+                    await _persist_spawn_subagent_call_state(
+                        ctx=ctx,
+                        record=prepared_record,
+                        requested_role_id=role_id,
+                        resolved_role_id=resolved_role_id,
+                        description=description,
+                        prompt=prompt,
+                        background=True,
+                    )
+
                 record = await service.start_subagent(
                     run_id=ctx.deps.run_id,
                     session_id=ctx.deps.session_id,
@@ -55,20 +71,39 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                     subagent_role=role_snapshot,
                     title=description,
                     prompt=prompt,
+                    on_launch_prepared=_on_background_launch_prepared,
                 )
                 return project_background_task_tool_result(
                     record,
                     completed=False,
                     include_task_id=True,
                 )
+
+            async def _on_launch_prepared(
+                prepared_record: BackgroundTaskRecord,
+            ) -> None:
+                await _persist_spawn_subagent_call_state(
+                    ctx=ctx,
+                    record=prepared_record,
+                    requested_role_id=role_id,
+                    resolved_role_id=resolved_role_id,
+                    description=description,
+                    prompt=prompt,
+                    background=False,
+                )
+
             result = await service.run_subagent(
                 run_id=ctx.deps.run_id,
                 session_id=ctx.deps.session_id,
                 workspace_id=ctx.deps.workspace.ref.workspace_id,
+                tool_call_id=ctx.tool_call_id,
+                parent_instance_id=ctx.deps.instance_id,
+                parent_role_id=ctx.deps.role_id,
                 subagent_role_id=resolved_role_id,
                 subagent_role=role_snapshot,
                 title=description,
                 prompt=prompt,
+                on_launch_prepared=_on_launch_prepared,
             )
             visible_payload: dict[str, JsonValue] = {
                 "completed": True,
@@ -98,6 +133,60 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             action=_action,
             raw_args=locals(),
         )
+
+
+async def _persist_spawn_subagent_call_state(
+    *,
+    ctx: ToolContext,
+    record: BackgroundTaskRecord,
+    requested_role_id: str,
+    resolved_role_id: str,
+    description: str,
+    prompt: str,
+    background: bool,
+) -> None:
+    tool_call_id = str(ctx.tool_call_id or "").strip()
+    if not tool_call_id:
+        return
+    try:
+        shared_store = ctx.deps.shared_store
+        task_id = ctx.deps.task_id
+        instance_id = ctx.deps.instance_id
+        parent_role_id = ctx.deps.role_id
+    except AttributeError:
+        return
+
+    def mutate(current: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        next_state = dict(current)
+        next_state.update(
+            {
+                "kind": (
+                    "spawn_subagent_background" if background else "spawn_subagent_sync"
+                ),
+                "background": background,
+                "background_task_id": record.background_task_id,
+                "subagent_run_id": record.subagent_run_id or "",
+                "subagent_instance_id": record.subagent_instance_id or "",
+                "subagent_task_id": record.subagent_task_id or "",
+                "subagent_role_id": record.subagent_role_id or resolved_role_id,
+                "requested_role_id": requested_role_id,
+                "resolved_role_id": resolved_role_id,
+                "description": description,
+                "title": record.title,
+                "prompt": prompt,
+            }
+        )
+        return next_state
+
+    await update_tool_call_call_state_async(
+        shared_store=shared_store,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+        tool_name="spawn_subagent",
+        instance_id=instance_id,
+        role_id=parent_role_id,
+        mutate=mutate,
+    )
 
 
 def _build_spawn_subagent_description(agent: Agent[ToolDeps, str]) -> str:

--- a/tests/unit_tests/agents/execution/session_prompt_support_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_prompt_support_test_cases.py
@@ -2,12 +2,23 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
+from relay_teams.agents.execution.event_publishing import EventPublishingService
+from relay_teams.agents.execution import event_publishing as event_publishing_module
 from relay_teams.agents.execution import session_prompt as session_prompt_module
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.tools.runtime.persisted_state import (
+    load_tool_call_state,
+    load_tool_call_state_async,
+    merge_tool_call_state,
+    merge_tool_call_state_async,
+)
 
 from .agent_llm_session_test_support import (
     AgentLlmSession,
@@ -225,6 +236,35 @@ def test_last_committable_index_stops_before_open_tool_call() -> None:
     assert AgentLlmSession._has_pending_tool_calls(session, messages) is True
 
 
+def test_last_committable_index_closes_retry_prompt_without_tool_name() -> None:
+    session = object.__new__(AgentLlmSession)
+    messages: list[ModelRequest | ModelResponse] = [
+        ModelRequest(parts=[UserPromptPart(content="User prompt")]),
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="search",
+                    args='{"q":"moon"}',
+                    tool_call_id="call-1",
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                RetryPromptPart(
+                    content="Input validation failed",
+                    tool_call_id="call-1",
+                )
+            ]
+        ),
+    ]
+
+    safe_index = AgentLlmSession._last_committable_index(session, messages)
+
+    assert safe_index == 3
+    assert AgentLlmSession._has_pending_tool_calls(session, messages) is False
+
+
 def test_commit_ready_messages_commits_only_safe_prefix() -> None:
     session = object.__new__(AgentLlmSession)
     persisted_history: list[ModelRequest | ModelResponse] = [
@@ -388,15 +428,433 @@ def test_publish_tool_call_events_from_messages_deduplicates_tool_call_ids() -> 
     )
 
     assert next_emitted is True
-    assert len(published_events) == 1
+    assert len(published_events) == 2
     assert published_events[0].event_type == RunEventType.TOOL_CALL
-    assert json.loads(cast(str, published_events[0].payload_json)) == {
+    tool_call_payload = json.loads(cast(str, published_events[0].payload_json))
+    batch_id = str(tool_call_payload["batch_id"])
+    assert tool_call_payload == {
+        "run_id": "run-1",
+        "session_id": "session-1",
         "tool_name": "search",
         "tool_call_id": "call-2",
         "args": '{"q":"mars"}',
+        "batch_id": batch_id,
+        "batch_index": 0,
+        "batch_size": 1,
         "role_id": "writer",
         "instance_id": "inst-1",
     }
+    assert published_events[1].event_type == RunEventType.TOOL_CALL_BATCH_SEALED
+    assert json.loads(cast(str, published_events[1].payload_json)) == {
+        "run_id": "run-1",
+        "session_id": "session-1",
+        "batch_id": batch_id,
+        "tool_calls": [
+            {
+                "tool_call_id": "call-2",
+                "tool_name": "search",
+                "args": '{"q":"mars"}',
+                "index": 0,
+            }
+        ],
+        "role_id": "writer",
+        "instance_id": "inst-1",
+    }
+
+
+def test_publish_tool_call_events_keeps_event_when_batch_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _RunEventHub:
+        def publish(self, event: RunEvent) -> int:
+            published_events.append(event)
+            return len(published_events)
+
+    def _raise_tool_state_read_failure(
+        *,
+        shared_store: object,
+        task_id: str,
+        tool_call_id: str,
+    ) -> None:
+        _ = (shared_store, task_id, tool_call_id)
+        raise sqlite3.OperationalError("database is locked")
+
+    published_events: list[RunEvent] = []
+    monkeypatch.setattr(
+        event_publishing_module,
+        "load_tool_call_state",
+        _raise_tool_state_read_failure,
+    )
+    service = EventPublishingService(
+        run_event_hub=_RunEventHub(),
+        shared_store=SharedStateRepository(tmp_path / "batch-lookup-failure-sync.db"),
+    )
+
+    emitted = service.publish_tool_call_events_from_messages(
+        request=_build_request(),
+        messages=[
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search",
+                        args='{"q":"moon"}',
+                        tool_call_id="call-batch-lookup-failure",
+                    )
+                ]
+            )
+        ],
+    )
+
+    assert emitted is True
+    assert [event.event_type for event in published_events] == [
+        RunEventType.TOOL_CALL,
+        RunEventType.TOOL_CALL_BATCH_SEALED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_publish_tool_call_events_async_keeps_event_when_batch_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _AsyncRunEventHub:
+        def __init__(self) -> None:
+            self.events: list[RunEvent] = []
+
+        async def publish_async(self, event: RunEvent) -> int:
+            self.events.append(event)
+            return len(self.events)
+
+    async def _raise_tool_state_read_failure(
+        *,
+        shared_store: object,
+        task_id: str,
+        tool_call_id: str,
+    ) -> None:
+        _ = (shared_store, task_id, tool_call_id)
+        raise sqlite3.OperationalError("database is locked")
+
+    run_event_hub = _AsyncRunEventHub()
+    monkeypatch.setattr(
+        event_publishing_module,
+        "load_tool_call_state_async",
+        _raise_tool_state_read_failure,
+    )
+    service = EventPublishingService(
+        run_event_hub=run_event_hub,
+        shared_store=SharedStateRepository(tmp_path / "batch-lookup-failure-async.db"),
+    )
+
+    emitted = await service.publish_tool_call_events_from_messages_async(
+        request=_build_request(),
+        messages=[
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search",
+                        args='{"q":"moon"}',
+                        tool_call_id="call-batch-lookup-failure",
+                    )
+                ]
+            )
+        ],
+    )
+
+    assert emitted is True
+    assert [event.event_type for event in run_event_hub.events] == [
+        RunEventType.TOOL_CALL,
+        RunEventType.TOOL_CALL_BATCH_SEALED,
+    ]
+
+
+def test_publish_observed_tool_call_preserves_terminal_tool_state(
+    tmp_path: Path,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "observed-terminal-sync.db")
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_run_event_hub"] = None
+    request = _build_request()
+    merge_tool_call_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-complete",
+        tool_name="search",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        args_preview='{"q":"old"}',
+        execution_status=ToolExecutionStatus.COMPLETED,
+        result_envelope={"visible_result": {"ok": True}},
+        result_event_id=42,
+        finished_at="2026-04-27T00:00:00+00:00",
+    )
+
+    emitted = AgentLlmSession._publish_tool_call_events_from_messages(
+        session,
+        request=request,
+        messages=[
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search",
+                        args='{"q":"new"}',
+                        tool_call_id="call-complete",
+                    )
+                ]
+            )
+        ],
+    )
+
+    assert emitted is True
+    state = load_tool_call_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-complete",
+    )
+    assert state is not None
+    assert state.execution_status == ToolExecutionStatus.COMPLETED
+    assert state.result_event_id == 42
+    assert state.result_envelope == {"visible_result": {"ok": True}}
+    assert state.args_preview == '{"q":"new"}'
+    assert state.batch_id
+    assert state.batch_index == 0
+    assert state.batch_size == 1
+
+
+def test_publish_observed_tool_call_keeps_event_when_persistence_fails() -> None:
+    class _RunEventHub:
+        def publish(self, event: RunEvent) -> int:
+            published_events.append(event)
+            return len(published_events)
+
+    published_events: list[RunEvent] = []
+    service = EventPublishingService(
+        run_event_hub=_RunEventHub(),
+        shared_store=None,
+    )
+
+    def _raise_persistence_failure(
+        *,
+        request: object,
+        part: object,
+        batch_id: str,
+        batch_index: int,
+        batch_size: int,
+    ) -> None:
+        _ = (request, part, batch_id, batch_index, batch_size)
+        raise sqlite3.OperationalError("database is locked")
+
+    service.__dict__["_persist_observed_tool_call"] = _raise_persistence_failure
+
+    emitted = service.publish_observed_tool_call_event(
+        request=_build_request(),
+        part=ToolCallPart(
+            tool_name="search",
+            args='{"q":"moon"}',
+            tool_call_id="call-persist-failure",
+        ),
+        batch_id="batch-1",
+        batch_index=0,
+        batch_size=1,
+    )
+
+    assert emitted is True
+    assert len(published_events) == 1
+    assert published_events[0].event_type == RunEventType.TOOL_CALL
+
+
+@pytest.mark.asyncio
+async def test_publish_observed_tool_call_async_preserves_terminal_tool_state(
+    tmp_path: Path,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "observed-terminal-async.db")
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_run_event_hub"] = None
+    request = _build_request()
+    await merge_tool_call_state_async(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-failed",
+        tool_name="search",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        args_preview='{"q":"old"}',
+        execution_status=ToolExecutionStatus.FAILED,
+        result_envelope={"visible_result": {"ok": False}},
+        result_event_id=43,
+        finished_at="2026-04-27T00:00:00+00:00",
+    )
+
+    emitted = await AgentLlmSession._publish_tool_call_events_from_messages_async(
+        session,
+        request=request,
+        messages=[
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search",
+                        args='{"q":"new"}',
+                        tool_call_id="call-failed",
+                    )
+                ]
+            )
+        ],
+    )
+
+    assert emitted is True
+    state = await load_tool_call_state_async(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-failed",
+    )
+    assert state is not None
+    assert state.execution_status == ToolExecutionStatus.FAILED
+    assert state.result_event_id == 43
+    assert state.result_envelope == {"visible_result": {"ok": False}}
+    assert state.args_preview == '{"q":"new"}'
+    assert state.batch_id
+    assert state.batch_index == 0
+    assert state.batch_size == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_observed_tool_call_async_keeps_event_when_persistence_fails() -> (
+    None
+):
+    class _AsyncRunEventHub:
+        def __init__(self) -> None:
+            self.events: list[RunEvent] = []
+
+        async def publish_async(self, event: RunEvent) -> int:
+            self.events.append(event)
+            return len(self.events)
+
+    run_event_hub = _AsyncRunEventHub()
+    service = EventPublishingService(run_event_hub=run_event_hub, shared_store=None)
+
+    async def _raise_persistence_failure(
+        *,
+        request: object,
+        part: object,
+        batch_id: str,
+        batch_index: int,
+        batch_size: int,
+    ) -> None:
+        _ = (request, part, batch_id, batch_index, batch_size)
+        raise sqlite3.OperationalError("database is locked")
+
+    service.__dict__["_persist_observed_tool_call_async"] = _raise_persistence_failure
+
+    emitted = await service.publish_observed_tool_call_event_async(
+        request=_build_request(),
+        part=ToolCallPart(
+            tool_name="search",
+            args='{"q":"moon"}',
+            tool_call_id="call-persist-failure",
+        ),
+        batch_id="batch-1",
+        batch_index=0,
+        batch_size=1,
+    )
+
+    assert emitted is True
+    assert len(run_event_hub.events) == 1
+    assert run_event_hub.events[0].event_type == RunEventType.TOOL_CALL
+
+
+def test_seal_tool_call_batch_keeps_event_when_persistence_fails() -> None:
+    class _RunEventHub:
+        def publish(self, event: RunEvent) -> int:
+            published_events.append(event)
+            return len(published_events)
+
+    published_events: list[RunEvent] = []
+    service = EventPublishingService(
+        run_event_hub=_RunEventHub(),
+        shared_store=None,
+    )
+
+    def _raise_batch_seal_persistence_failure(
+        *,
+        request: object,
+        batch_id: str,
+        items: object,
+    ) -> None:
+        _ = (request, batch_id, items)
+        raise sqlite3.OperationalError("database is locked")
+
+    service.__dict__["_persist_tool_call_batch_seal"] = (
+        _raise_batch_seal_persistence_failure
+    )
+
+    service.seal_tool_call_batch(
+        request=_build_request(),
+        batch_id="batch-seal-failure",
+        tool_calls=[
+            (
+                0,
+                ToolCallPart(
+                    tool_name="search",
+                    args='{"q":"moon"}',
+                    tool_call_id="call-seal-failure",
+                ),
+            )
+        ],
+    )
+
+    assert len(published_events) == 1
+    assert published_events[0].event_type == RunEventType.TOOL_CALL_BATCH_SEALED
+
+
+@pytest.mark.asyncio
+async def test_seal_tool_call_batch_async_keeps_event_when_persistence_fails() -> None:
+    class _AsyncRunEventHub:
+        def __init__(self) -> None:
+            self.events: list[RunEvent] = []
+
+        async def publish_async(self, event: RunEvent) -> int:
+            self.events.append(event)
+            return len(self.events)
+
+    run_event_hub = _AsyncRunEventHub()
+    service = EventPublishingService(run_event_hub=run_event_hub, shared_store=None)
+
+    async def _raise_batch_seal_persistence_failure(
+        *,
+        request: object,
+        batch_id: str,
+        items: object,
+    ) -> None:
+        _ = (request, batch_id, items)
+        raise sqlite3.OperationalError("database is locked")
+
+    service.__dict__["_persist_tool_call_batch_seal_async"] = (
+        _raise_batch_seal_persistence_failure
+    )
+
+    await service.seal_tool_call_batch_async(
+        request=_build_request(),
+        batch_id="batch-seal-failure",
+        tool_calls=[
+            (
+                0,
+                ToolCallPart(
+                    tool_name="search",
+                    args='{"q":"moon"}',
+                    tool_call_id="call-seal-failure",
+                ),
+            )
+        ],
+    )
+
+    assert len(run_event_hub.events) == 1
+    assert run_event_hub.events[0].event_type == RunEventType.TOOL_CALL_BATCH_SEALED
 
 
 def test_publish_committed_tool_outcome_events_emits_result_and_validation_failure() -> (
@@ -490,6 +948,44 @@ def test_tool_result_already_emitted_from_runtime_uses_persisted_state(
     )
 
     assert already_emitted is True
+
+
+def test_tool_result_already_emitted_ignores_durable_pre_publish_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from .agent_llm_session_test_support import PersistedToolCallState
+
+    session = object.__new__(AgentLlmSession)
+    session.__dict__["_shared_store"] = cast(object, None)
+    persisted_state = PersistedToolCallState(
+        tool_call_id="call-1",
+        tool_name="search",
+        instance_id="inst-1",
+        role_id="writer",
+        execution_status=ToolExecutionStatus.COMPLETED,
+        result_envelope={
+            "visible_result": {"ok": True},
+            "runtime_meta": {
+                "tool_result_durably_recorded": True,
+                "tool_result_event_published": False,
+            },
+        },
+    )
+
+    monkeypatch.setattr(
+        session_prompt_module,
+        "load_tool_call_state",
+        lambda **kwargs: persisted_state,
+    )
+
+    already_emitted = AgentLlmSession._tool_result_already_emitted_from_runtime(
+        session,
+        request=_build_request(),
+        tool_name="search",
+        tool_call_id="call-1",
+    )
+
+    assert already_emitted is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/test_message_repository.py
+++ b/tests/unit_tests/agents/execution/test_message_repository.py
@@ -527,6 +527,43 @@ def test_message_repo_drops_orphan_tool_return_request_from_history(
     assert history[0].parts[0].content == "continue"
 
 
+def test_message_repo_skips_invalid_history_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "message_repo_invalid_row.db"
+    repo = MessageRepository(db_path)
+    repo.append(
+        session_id="session-1",
+        workspace_id="default",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        messages=[ModelRequest(parts=[UserPromptPart(content="continue")])],
+    )
+    repo._conn.execute(
+        "INSERT INTO messages(session_id, workspace_id, conversation_id, agent_role_id, instance_id, task_id, trace_id, role, message_json, created_at) "
+        "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "session-1",
+            "default",
+            "inst-1",
+            "time",
+            "inst-1",
+            "task-1",
+            "run-1",
+            "assistant",
+            "{not valid json",
+            "2026-03-07T10:00:01+00:00",
+        ),
+    )
+    repo._conn.commit()
+
+    history = repo.get_history("inst-1")
+
+    assert len(history) == 1
+    assert isinstance(history[0], ModelRequest)
+    assert isinstance(history[0].parts[0], UserPromptPart)
+    assert history[0].parts[0].content == "continue"
+
+
 def test_message_repo_append_is_thread_safe_under_parallel_writes(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
+++ b/tests/unit_tests/agents/execution/test_recoverable_openai_chat_model.py
@@ -12,6 +12,7 @@ from pydantic_ai.models import ModelRequestParameters
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
+    ThinkingPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
@@ -169,6 +170,23 @@ def test_sanitize_replayed_messages_drops_duplicate_late_tool_results() -> None:
     assert len(sanitized[2].parts) == 1
     assert isinstance(sanitized[2].parts[0], UserPromptPart)
     assert sanitized[2].parts[0].content == "optimize it"
+
+
+def test_sanitize_replayed_messages_drops_thinking_only_response() -> None:
+    messages = [
+        ModelRequest(parts=[UserPromptPart(content="continue")]),
+        ModelResponse(parts=[ThinkingPart(content="internal notes")]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name="write", args={}, tool_call_id="call-1")]
+        ),
+    ]
+
+    sanitized = RecoverableOpenAIChatModel._sanitize_replayed_messages(messages)
+
+    assert len(sanitized) == 2
+    assert isinstance(sanitized[0], ModelRequest)
+    assert isinstance(sanitized[1], ModelResponse)
+    assert isinstance(sanitized[1].parts[0], ToolCallPart)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/test_session_support.py
+++ b/tests/unit_tests/agents/execution/test_session_support.py
@@ -3,14 +3,31 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 from pathlib import Path
 from typing import cast
 
 import pytest
+from pydantic_ai.messages import ThinkingPart
 
+from relay_teams.agents.execution.tool_result_state import ToolResultStateService
+from relay_teams.sessions.runs.background_tasks.models import (
+    BackgroundTaskKind,
+    BackgroundTaskRecord,
+    BackgroundTaskStatus,
+)
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.agents.execution import session_support as session_support_module
+from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.persisted_state import (
+    PersistedToolCallBatchState,
+    PersistedToolCallBatchItem,
+    ToolCallBatchStatus,
+    load_tool_call_state,
+    merge_tool_call_batch_state,
+    merge_tool_call_state,
+)
 
 from .agent_llm_session_test_support import (
     AgentLlmSession,
@@ -41,6 +58,10 @@ class _FakeEventLog:
         self.requested_trace_ids: list[str] = []
 
     def list_by_trace(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
+        self.requested_trace_ids.append(trace_id)
+        return self._events
+
+    def list_by_trace_with_ids(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
         self.requested_trace_ids.append(trace_id)
         return self._events
 
@@ -232,6 +253,110 @@ def test_visible_tool_result_from_state_returns_none_without_published_marker() 
     )
 
     assert visible is None
+
+
+def test_visible_tool_result_from_state_returns_durable_pre_publish_result() -> None:
+    session = object.__new__(AgentLlmSession)
+    state = PersistedToolCallState(
+        tool_call_id="call-1",
+        tool_name="search",
+        instance_id="inst-1",
+        role_id="writer",
+        execution_status=ToolExecutionStatus.COMPLETED,
+        result_envelope={
+            "visible_result": {
+                "ok": True,
+                "data": {"task": {"status": "completed"}},
+            },
+            "runtime_meta": {
+                "tool_result_durably_recorded": True,
+                "tool_result_event_published": False,
+            },
+        },
+    )
+
+    visible = AgentLlmSession._visible_tool_result_from_state(
+        session,
+        state=state,
+        expected_tool_name="search",
+    )
+
+    assert visible == {"ok": True, "data": {"task": {"status": "completed"}}}
+
+
+def test_tool_result_state_checks_runtime_event_id_paths() -> None:
+    request = _build_request()
+    state = PersistedToolCallState(
+        tool_call_id="call-1",
+        tool_name="search",
+        instance_id="inst-1",
+        role_id="writer",
+        execution_status=ToolExecutionStatus.COMPLETED,
+        result_envelope={"ok": True, "meta": {"tool_result_event_published": False}},
+        result_event_id=42,
+    )
+    service = ToolResultStateService()
+
+    assert (
+        service.tool_result_was_durably_recorded(
+            result_envelope={"ok": True, "meta": "not-meta"}
+        )
+        is False
+    )
+    assert service.tool_result_already_emitted_from_runtime(
+        request=request,
+        tool_name="search",
+        tool_call_id="call-1",
+        shared_store=object(),
+        load_tool_call_state=lambda **_kwargs: state,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_result_state_checks_async_runtime_event_id_path() -> None:
+    request = _build_request()
+    state = PersistedToolCallState(
+        tool_call_id="call-1",
+        tool_name="search",
+        instance_id="inst-1",
+        role_id="writer",
+        execution_status=ToolExecutionStatus.COMPLETED,
+        result_envelope={"ok": True, "meta": {"tool_result_event_published": False}},
+        result_event_id=42,
+    )
+
+    async def load_state(**_kwargs: object) -> PersistedToolCallState:
+        return state
+
+    assert (
+        await ToolResultStateService().tool_result_already_emitted_from_runtime_async(
+            request=request,
+            tool_name="search",
+            tool_call_id="call-1",
+            shared_store=object(),
+            load_tool_call_state=load_state,
+        )
+    )
+
+
+def test_filter_model_messages_drops_thinking_only_response() -> None:
+    session = object.__new__(AgentLlmSession)
+    filtered = AgentLlmSession._filter_model_messages(
+        session,
+        [
+            ModelResponse(parts=[ThinkingPart(content="plan")]),
+            ModelResponse(parts=[TextPart(content="visible")]),
+        ],
+    )
+
+    assert len(filtered) == 1
+    assert isinstance(filtered[0], ModelResponse)
+
+
+def test_tool_args_from_preview_handles_empty_invalid_and_scalar_json() -> None:
+    assert session_support_module._tool_args_from_preview("") == {}
+    assert session_support_module._tool_args_from_preview("{not-json") == "{not-json"
+    assert session_support_module._tool_args_from_preview('"scalar"') == '"scalar"'
 
 
 def test_handle_part_start_event_emits_text_suffix(
@@ -770,6 +895,944 @@ async def test_restore_pending_tool_results_from_state_reattaches_ready_spawn_su
 
 
 @pytest.mark.asyncio
+async def test_restore_pending_tool_results_reattaches_subagent_from_record_lookup(
+    tmp_path: Path,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "session-support-state.db")
+    state = PersistedToolCallState(
+        tool_call_id="call-subagent-record",
+        tool_name="spawn_subagent",
+        run_id="run-1",
+        instance_id="inst-1",
+        role_id="writer",
+        execution_status=ToolExecutionStatus.RUNNING,
+        call_state={
+            "kind": "spawn_subagent_sync",
+            "requested_role_id": "Explorer",
+            "description": "Investigate",
+            "prompt": "Inspect the failing tests and summarize the root cause.",
+            "background": False,
+        },
+    )
+    shared_store.manage_state(
+        StateMutation(
+            scope=ScopeRef(scope_type=ScopeType.TASK, scope_id="task-1"),
+            key="tool_call_state:call-subagent-record",
+            value_json=state.model_dump_json(),
+        )
+    )
+    record = BackgroundTaskRecord(
+        background_task_id="sync-subagent-record",
+        run_id="run-1",
+        session_id="session-1",
+        kind=BackgroundTaskKind.SUBAGENT,
+        instance_id="inst-1",
+        role_id="writer",
+        tool_call_id="call-subagent-record",
+        title="Investigate",
+        input_text="Inspect the failing tests and summarize the root cause.",
+        command="subagent:Explorer",
+        cwd="workspace-1",
+        execution_mode="foreground",
+        status=BackgroundTaskStatus.RUNNING,
+        tty=False,
+        subagent_role_id="Explorer",
+        subagent_run_id="subagent-run-record",
+        subagent_task_id="task-sub-record",
+        subagent_instance_id="inst-sub-record",
+    )
+    wait_for_subagent_run_calls: list[tuple[str, str]] = []
+
+    class _FakeBackgroundTaskService:
+        def subagent_record_for_tool_call(
+            self,
+            *,
+            parent_run_id: str,
+            tool_call_id: str,
+        ) -> BackgroundTaskRecord | None:
+            assert parent_run_id == "run-1"
+            assert tool_call_id == "call-subagent-record"
+            return record
+
+        async def wait_for_subagent_run(
+            self,
+            *,
+            parent_run_id: str,
+            subagent_run_id: str,
+        ) -> object:
+            wait_for_subagent_run_calls.append((parent_run_id, subagent_run_id))
+            return type(
+                "_Result",
+                (),
+                {
+                    "run_id": "subagent-run-record",
+                    "output": "record result",
+                },
+            )()
+
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_background_task_service"] = _FakeBackgroundTaskService()
+
+    (
+        recovered_messages,
+        recovered_count,
+    ) = await AgentLlmSession._restore_pending_tool_results_from_state(
+        session,
+        request=_build_request(),
+        pending_messages=[],
+    )
+
+    assert recovered_count == 1
+    assert wait_for_subagent_run_calls == [("run-1", "subagent-run-record")]
+    recovered_result = recovered_messages[1]
+    assert isinstance(recovered_result, ModelRequest)
+    result_part = recovered_result.parts[0]
+    assert isinstance(result_part, ToolReturnPart)
+    assert result_part.content == {
+        "ok": True,
+        "data": {
+            "completed": True,
+            "output": "record result",
+        },
+        "meta": {"tool_result_event_published": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_restore_pending_tool_results_recovers_background_subagent_result(
+    tmp_path: Path,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "session-support-state.db")
+    state = PersistedToolCallState(
+        tool_call_id="call-subagent-background",
+        tool_name="spawn_subagent",
+        run_id="run-1",
+        instance_id="inst-1",
+        role_id="writer",
+        execution_status=ToolExecutionStatus.RUNNING,
+        call_state={
+            "kind": "spawn_subagent_background",
+            "background": True,
+            "requested_role_id": "Explorer",
+        },
+    )
+    shared_store.manage_state(
+        StateMutation(
+            scope=ScopeRef(scope_type=ScopeType.TASK, scope_id="task-1"),
+            key="tool_call_state:call-subagent-background",
+            value_json=state.model_dump_json(),
+        )
+    )
+    record = BackgroundTaskRecord(
+        background_task_id="background-subagent-record",
+        run_id="run-1",
+        session_id="session-1",
+        kind=BackgroundTaskKind.SUBAGENT,
+        instance_id="inst-1",
+        role_id="writer",
+        tool_call_id="call-subagent-background",
+        title="Investigate",
+        input_text="Inspect in background.",
+        command="subagent:Explorer",
+        cwd="workspace-1",
+        execution_mode="background",
+        status=BackgroundTaskStatus.RUNNING,
+        tty=False,
+        subagent_role_id="Explorer",
+        subagent_run_id="subagent-run-background",
+        subagent_task_id="task-sub-background",
+        subagent_instance_id="inst-sub-background",
+    )
+
+    class _FakeBackgroundTaskService:
+        def subagent_record_for_tool_call(
+            self,
+            *,
+            parent_run_id: str,
+            tool_call_id: str,
+        ) -> BackgroundTaskRecord | None:
+            assert parent_run_id == "run-1"
+            assert tool_call_id == "call-subagent-background"
+            return record
+
+        async def wait_for_subagent_run(
+            self,
+            *,
+            parent_run_id: str,
+            subagent_run_id: str,
+        ) -> object:
+            raise AssertionError((parent_run_id, subagent_run_id))
+
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_event_bus"] = cast(object, None)
+    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_background_task_service"] = _FakeBackgroundTaskService()
+    pending_messages = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="spawn_subagent",
+                    args={
+                        "role_id": "Explorer",
+                        "description": "Investigate",
+                        "prompt": "Inspect in background.",
+                        "background": True,
+                    },
+                    tool_call_id="call-subagent-background",
+                )
+            ]
+        )
+    ]
+
+    (
+        recovered_messages,
+        recovered_count,
+    ) = await AgentLlmSession._restore_pending_tool_results_from_state(
+        session,
+        request=_build_request(),
+        pending_messages=pending_messages,
+    )
+
+    assert recovered_count == 1
+    recovered_result = recovered_messages[1]
+    assert isinstance(recovered_result, ModelRequest)
+    result_part = recovered_result.parts[0]
+    assert isinstance(result_part, ToolReturnPart)
+    content = result_part.content
+    assert isinstance(content, dict)
+    assert content["ok"] is True
+    data = content["data"]
+    assert isinstance(data, dict)
+    assert data["background_task_id"] == "background-subagent-record"
+    assert data["completed"] is False
+    assert data["subagent_run_id"] == "subagent-run-background"
+
+
+@pytest.mark.asyncio
+async def test_running_spawn_subagent_without_durable_launch_reinvokes_batch_item(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    state = PersistedToolCallState(
+        tool_call_id="call-subagent-prelaunch",
+        tool_name="spawn_subagent",
+        run_id="run-1",
+        instance_id="inst-1",
+        role_id="writer",
+        execution_status=ToolExecutionStatus.RUNNING,
+        call_state={
+            "kind": "spawn_subagent_sync",
+            "requested_role_id": "Explorer",
+            "background": False,
+        },
+    )
+    invoke_calls: list[dict[str, object]] = []
+
+    class _FakeBackgroundTaskService:
+        def subagent_record_for_tool_call(
+            self,
+            *,
+            parent_run_id: str,
+            tool_call_id: str,
+        ) -> BackgroundTaskRecord | None:
+            assert parent_run_id == "run-1"
+            assert tool_call_id == "call-subagent-prelaunch"
+            return None
+
+        async def wait_for_subagent_run(
+            self,
+            *,
+            parent_run_id: str,
+            subagent_run_id: str,
+        ) -> object:
+            raise AssertionError((parent_run_id, subagent_run_id))
+
+    class _FakeRecoverableToolInvoker:
+        async def invoke_async(
+            self,
+            *,
+            tool_registry: object,
+            deps: object,
+            tool_name: str,
+            tool_call_id: str,
+            raw_args: object,
+        ) -> dict[str, JsonValue]:
+            invoke_calls.append(
+                {
+                    "tool_registry": tool_registry,
+                    "deps": deps,
+                    "tool_name": tool_name,
+                    "tool_call_id": tool_call_id,
+                    "raw_args": raw_args,
+                }
+            )
+            return {"ok": True, "data": {"reinvoked": True}}
+
+    monkeypatch.setattr(
+        session_support_module,
+        "RecoverableToolInvoker",
+        _FakeRecoverableToolInvoker,
+    )
+    session.__dict__["_tool_registry"] = object()
+    session.__dict__["_background_task_service"] = _FakeBackgroundTaskService()
+
+    visible = await AgentLlmSession._visible_result_for_batch_item(
+        session,
+        request=_build_request(),
+        deps=cast(ToolDeps, object()),
+        state=state,
+        tool_call_id="call-subagent-prelaunch",
+        tool_name="spawn_subagent",
+        raw_args={
+            "role_id": "Explorer",
+            "description": "Investigate",
+            "prompt": "Recover this subagent launch.",
+            "background": False,
+        },
+        recover_ready_calls=True,
+    )
+
+    assert visible == {"ok": True, "data": {"reinvoked": True}}
+    assert len(invoke_calls) == 1
+    assert invoke_calls[0]["tool_name"] == "spawn_subagent"
+    assert invoke_calls[0]["tool_call_id"] == "call-subagent-prelaunch"
+
+
+def test_task_tool_call_batch_states_handles_missing_store_and_invalid_rows(
+    tmp_path: Path,
+) -> None:
+    session = object.__new__(AgentLlmSession)
+    setattr(session, "_shared_store", None)
+    assert AgentLlmSession._task_tool_call_batch_states(session, "task-1") == ()
+
+    shared_store = SharedStateRepository(tmp_path / "session-batch-states.db")
+    shared_store.manage_state(
+        StateMutation(
+            scope=ScopeRef(scope_type=ScopeType.TASK, scope_id="task-1"),
+            key="tool_call_batch:bad",
+            value_json="{not-json",
+        )
+    )
+    good = PersistedToolCallBatchState(
+        batch_id="batch-1",
+        instance_id="inst-1",
+        role_id="writer",
+        task_id="task-1",
+        status=ToolCallBatchStatus.SEALED,
+        items=(
+            PersistedToolCallBatchItem(
+                tool_call_id="call-1",
+                tool_name="search",
+                index=0,
+            ),
+        ),
+    )
+    shared_store.manage_state(
+        StateMutation(
+            scope=ScopeRef(scope_type=ScopeType.TASK, scope_id="task-1"),
+            key="tool_call_batch:good",
+            value_json=good.model_dump_json(),
+        )
+    )
+    session._shared_store = shared_store
+
+    assert AgentLlmSession._task_tool_call_batch_states(session, "task-1") == (good,)
+
+
+@pytest.mark.asyncio
+async def test_recover_uncommitted_tool_batches_ignores_event_log_read_failures(
+    tmp_path: Path,
+) -> None:
+    request = _build_request()
+    session = object.__new__(AgentLlmSession)
+    history: list[ModelRequest | ModelResponse] = []
+
+    class _FailingBatchReplayEventLog:
+        def list_by_trace_with_ids(
+            self,
+            trace_id: str,
+        ) -> tuple[dict[str, JsonValue], ...]:
+            _ = trace_id
+            raise sqlite3.OperationalError("database is locked")
+
+    session.__dict__["_shared_store"] = SharedStateRepository(
+        tmp_path / "session-batch-read-failure.db"
+    )
+    session.__dict__["_event_bus"] = _FailingBatchReplayEventLog()
+    session.__dict__["_message_repo"] = None
+
+    (
+        recovered_history,
+        recovered_count,
+    ) = await AgentLlmSession._recover_uncommitted_tool_batches_async(
+        session,
+        request=request,
+        history=history,
+        deps=cast(ToolDeps, object()),
+        recover_ready_calls=True,
+    )
+
+    assert recovered_history == history
+    assert recovered_count == 0
+
+
+@pytest.mark.asyncio
+async def test_recover_uncommitted_tool_batches_ignores_batch_snapshot_failures() -> (
+    None
+):
+    request = _build_request()
+    session = object.__new__(AgentLlmSession)
+    history: list[ModelRequest | ModelResponse] = []
+
+    class _FailingBatchSnapshotStore:
+        def snapshot(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
+            _ = scope
+            raise sqlite3.OperationalError("database is locked")
+
+    session.__dict__["_shared_store"] = _FailingBatchSnapshotStore()
+    session.__dict__["_event_bus"] = _FakeEventLog(())
+    session.__dict__["_message_repo"] = None
+
+    (
+        recovered_history,
+        recovered_count,
+    ) = await AgentLlmSession._recover_uncommitted_tool_batches_async(
+        session,
+        request=request,
+        history=history,
+        deps=cast(ToolDeps, object()),
+        recover_ready_calls=True,
+    )
+
+    assert recovered_history == history
+    assert recovered_count == 0
+
+
+@pytest.mark.asyncio
+async def test_recover_uncommitted_tool_batches_recovers_open_observed_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    request = _build_request()
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "session-open-batch-recovery.db")
+    merge_tool_call_batch_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        batch_id="batch-open",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        status=ToolCallBatchStatus.OPEN,
+        items=(
+            PersistedToolCallBatchItem(
+                tool_call_id="call-open",
+                tool_name="read_file",
+                args_preview='{"path":"README.md"}',
+                index=0,
+            ),
+        ),
+    )
+    merge_tool_call_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-open",
+        tool_name="read_file",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        args_preview='{"path":"README.md"}',
+        execution_status=ToolExecutionStatus.READY,
+        batch_id="batch-open",
+        batch_index=0,
+        batch_size=0,
+    )
+    invoke_calls: list[dict[str, object]] = []
+
+    class _FakeRecoverableToolInvoker:
+        async def invoke_async(
+            self,
+            *,
+            tool_registry: object,
+            deps: object,
+            tool_name: str,
+            tool_call_id: str,
+            raw_args: object,
+        ) -> dict[str, JsonValue]:
+            invoke_calls.append(
+                {
+                    "tool_registry": tool_registry,
+                    "deps": deps,
+                    "tool_name": tool_name,
+                    "tool_call_id": tool_call_id,
+                    "raw_args": raw_args,
+                }
+            )
+            return {"ok": True, "data": {"content": "readme"}}
+
+    committed_messages: list[ModelRequest | ModelResponse] = []
+
+    async def _commit_all_safe_messages_async(
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        list[int],
+        list[str],
+    ]:
+        _ = request
+        committed_messages.extend(pending_messages)
+        return [*history, *pending_messages], [], [], []
+
+    monkeypatch.setattr(
+        session_support_module,
+        "RecoverableToolInvoker",
+        _FakeRecoverableToolInvoker,
+    )
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_event_bus"] = _FakeEventLog(())
+    session.__dict__["_task_repo"] = None
+    session.__dict__["_message_repo"] = None
+    session.__dict__["_tool_registry"] = object()
+    session.__dict__["_commit_all_safe_messages_async"] = (
+        _commit_all_safe_messages_async
+    )
+    deps = cast(ToolDeps, object())
+
+    (
+        history,
+        recovered_count,
+    ) = await AgentLlmSession._recover_uncommitted_tool_batches_async(
+        session,
+        request=request,
+        history=[],
+        deps=deps,
+        recover_ready_calls=True,
+    )
+
+    assert recovered_count == 1
+    assert len(history) == 2
+    assert len(committed_messages) == 2
+    response = committed_messages[0]
+    result_request = committed_messages[1]
+    assert isinstance(response, ModelResponse)
+    assert isinstance(result_request, ModelRequest)
+    assert isinstance(response.parts[0], ToolCallPart)
+    assert response.parts[0].tool_call_id == "call-open"
+    assert isinstance(result_request.parts[0], ToolReturnPart)
+    assert result_request.parts[0].tool_call_id == "call-open"
+    assert result_request.parts[0].content == {
+        "ok": True,
+        "data": {"content": "readme"},
+    }
+    persisted_state = load_tool_call_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-open",
+    )
+    assert persisted_state is not None
+    assert persisted_state.execution_status == ToolExecutionStatus.COMPLETED
+    assert persisted_state.result_envelope == {
+        "visible_result": {"ok": True, "data": {"content": "readme"}},
+        "runtime_meta": {
+            "tool_result_durably_recorded": True,
+            "tool_result_event_published": False,
+            "recovered_tool_call": True,
+        },
+    }
+    assert invoke_calls == [
+        {
+            "tool_registry": session.__dict__["_tool_registry"],
+            "deps": deps,
+            "tool_name": "read_file",
+            "tool_call_id": "call-open",
+            "raw_args": '{"path":"README.md"}',
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recover_uncommitted_tool_batches_ignores_unsafe_trailing_tool_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    request = _build_request()
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "session-unsafe-history.db")
+    merge_tool_call_batch_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        batch_id="batch-unsafe",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        status=ToolCallBatchStatus.SEALED,
+        items=(
+            PersistedToolCallBatchItem(
+                tool_call_id="call-unsafe",
+                tool_name="read_file",
+                args_preview='{"path":"README.md"}',
+                index=0,
+            ),
+        ),
+    )
+    merge_tool_call_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-unsafe",
+        tool_name="read_file",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        args_preview='{"path":"README.md"}',
+        execution_status=ToolExecutionStatus.READY,
+        batch_id="batch-unsafe",
+        batch_index=0,
+        batch_size=1,
+    )
+    unsafe_history: list[ModelRequest | ModelResponse] = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read_file",
+                    args='{"path":"README.md"}',
+                    tool_call_id="call-unsafe",
+                )
+            ]
+        )
+    ]
+    invoke_calls: list[str] = []
+
+    class _FakeRecoverableToolInvoker:
+        async def invoke_async(
+            self,
+            *,
+            tool_registry: object,
+            deps: object,
+            tool_name: str,
+            tool_call_id: str,
+            raw_args: object,
+        ) -> dict[str, JsonValue]:
+            _ = (tool_registry, deps, tool_name, raw_args)
+            invoke_calls.append(tool_call_id)
+            return {"ok": True, "data": {"content": "readme"}}
+
+    async def _commit_all_safe_messages_async(
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        list[int],
+        list[str],
+    ]:
+        _ = request
+        return [*history, *pending_messages], [], [], []
+
+    monkeypatch.setattr(
+        session_support_module,
+        "RecoverableToolInvoker",
+        _FakeRecoverableToolInvoker,
+    )
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_event_bus"] = _FakeEventLog(())
+    session.__dict__["_task_repo"] = None
+    session.__dict__["_message_repo"] = _FakeMessageRepo(unsafe_history)
+    session.__dict__["_tool_registry"] = object()
+    session.__dict__["_commit_all_safe_messages_async"] = (
+        _commit_all_safe_messages_async
+    )
+
+    (
+        recovered_history,
+        recovered_count,
+    ) = await AgentLlmSession._recover_uncommitted_tool_batches_async(
+        session,
+        request=request,
+        history=unsafe_history,
+        deps=cast(ToolDeps, object()),
+        recover_ready_calls=True,
+    )
+
+    assert recovered_count == 1
+    assert invoke_calls == ["call-unsafe"]
+    assert len(recovered_history) == 3
+    result_request = recovered_history[-1]
+    assert isinstance(result_request, ModelRequest)
+    assert isinstance(result_request.parts[0], ToolReturnPart)
+    assert result_request.parts[0].tool_call_id == "call-unsafe"
+
+
+@pytest.mark.asyncio
+async def test_recover_uncommitted_tool_batches_skips_item_state_read_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    request = _build_request()
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "session-state-read-failure.db")
+    merge_tool_call_batch_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        batch_id="batch-read-failure",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        status=ToolCallBatchStatus.SEALED,
+        items=(
+            PersistedToolCallBatchItem(
+                tool_call_id="call-read-failure",
+                tool_name="read_file",
+                args_preview='{"path":"README.md"}',
+                index=0,
+            ),
+        ),
+    )
+
+    def _raise_state_read_failure(
+        *,
+        shared_store: object,
+        event_log: object,
+        trace_id: str,
+        task_id: str,
+        tool_call_id: str,
+        task_repo: object,
+    ) -> PersistedToolCallState | None:
+        _ = (shared_store, event_log, trace_id, task_id, tool_call_id, task_repo)
+        raise sqlite3.OperationalError("database is locked")
+
+    async def _commit_all_safe_messages_async(
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        list[int],
+        list[str],
+    ]:
+        _ = (request, history, pending_messages)
+        raise AssertionError("batch with unreadable state must not be committed")
+
+    monkeypatch.setattr(
+        session_support_module,
+        "load_or_recover_tool_call_state",
+        _raise_state_read_failure,
+    )
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_event_bus"] = _FakeEventLog(())
+    session.__dict__["_task_repo"] = None
+    session.__dict__["_message_repo"] = None
+    session.__dict__["_tool_registry"] = object()
+    session.__dict__["_commit_all_safe_messages_async"] = (
+        _commit_all_safe_messages_async
+    )
+
+    (
+        recovered_history,
+        recovered_count,
+    ) = await AgentLlmSession._recover_uncommitted_tool_batches_async(
+        session,
+        request=request,
+        history=[],
+        deps=cast(ToolDeps, object()),
+        recover_ready_calls=True,
+    )
+
+    assert recovered_history == []
+    assert recovered_count == 0
+
+
+@pytest.mark.asyncio
+async def test_recover_uncommitted_tool_batches_recovers_only_missing_batch_items(
+    tmp_path: Path,
+) -> None:
+    request = _build_request()
+    session = object.__new__(AgentLlmSession)
+    shared_store = SharedStateRepository(tmp_path / "session-mixed-batch-recovery.db")
+    merge_tool_call_batch_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        batch_id="batch-mixed",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        status=ToolCallBatchStatus.SEALED,
+        items=(
+            PersistedToolCallBatchItem(
+                tool_call_id="call-committed",
+                tool_name="read_file",
+                args_preview='{"path":"committed.md"}',
+                index=0,
+            ),
+            PersistedToolCallBatchItem(
+                tool_call_id="call-missing",
+                tool_name="read_file",
+                args_preview='{"path":"missing.md"}',
+                index=1,
+            ),
+        ),
+    )
+    merge_tool_call_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-missing",
+        tool_name="read_file",
+        run_id=request.run_id,
+        session_id=request.session_id,
+        instance_id=request.instance_id,
+        role_id=request.role_id,
+        args_preview='{"path":"missing.md"}',
+        execution_status=ToolExecutionStatus.COMPLETED,
+        batch_id="batch-mixed",
+        batch_index=1,
+        batch_size=2,
+        result_envelope={
+            "ok": True,
+            "data": {"content": "missing"},
+            "meta": {"tool_result_event_published": True},
+        },
+    )
+    committed_history: list[ModelRequest | ModelResponse] = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read_file",
+                    args={"path": "committed.md"},
+                    tool_call_id="call-committed",
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="read_file",
+                    tool_call_id="call-committed",
+                    content={"ok": True, "data": {"content": "committed"}},
+                )
+            ]
+        ),
+    ]
+    committed_messages: list[ModelRequest | ModelResponse] = []
+
+    async def _commit_all_safe_messages_async(
+        *,
+        request: LLMRequest,
+        history: list[ModelRequest | ModelResponse],
+        pending_messages: list[ModelRequest | ModelResponse],
+    ) -> tuple[
+        list[ModelRequest | ModelResponse],
+        list[ModelRequest | ModelResponse],
+        list[int],
+        list[str],
+    ]:
+        _ = request
+        committed_messages.extend(pending_messages)
+        return [*history, *pending_messages], [], [], []
+
+    session.__dict__["_shared_store"] = shared_store
+    session.__dict__["_event_bus"] = _FakeEventLog(())
+    session.__dict__["_task_repo"] = None
+    session.__dict__["_message_repo"] = _FakeMessageRepo(committed_history)
+    session.__dict__["_commit_all_safe_messages_async"] = (
+        _commit_all_safe_messages_async
+    )
+
+    (
+        history,
+        recovered_count,
+    ) = await AgentLlmSession._recover_uncommitted_tool_batches_async(
+        session,
+        request=request,
+        history=committed_history,
+        deps=cast(ToolDeps, object()),
+        recover_ready_calls=False,
+    )
+
+    assert recovered_count == 1
+    assert history == [*committed_history, *committed_messages]
+    assert len(committed_messages) == 2
+    response = committed_messages[0]
+    result_request = committed_messages[1]
+    assert isinstance(response, ModelResponse)
+    assert isinstance(result_request, ModelRequest)
+    assert len(response.parts) == 1
+    assert len(result_request.parts) == 1
+    assert isinstance(response.parts[0], ToolCallPart)
+    assert isinstance(result_request.parts[0], ToolReturnPart)
+    assert response.parts[0].tool_call_id == "call-missing"
+    assert result_request.parts[0].tool_call_id == "call-missing"
+
+
+def test_subagent_record_helpers_cover_empty_and_background_paths() -> None:
+    session = object.__new__(AgentLlmSession)
+    request = _build_request()
+    state = PersistedToolCallState.model_construct(
+        tool_call_id="",
+        tool_name="spawn_subagent",
+        instance_id="inst-1",
+        role_id="writer",
+    )
+
+    class _WaitOnlyService:
+        async def wait_for_subagent_run(
+            self,
+            *,
+            parent_run_id: str,
+            subagent_run_id: str,
+        ) -> object:
+            return object()
+
+    assert (
+        AgentLlmSession._subagent_record_for_tool_state(
+            service=cast(
+                session_support_module._SubagentWaitService, _WaitOnlyService()
+            ),
+            request=request,
+            state=state,
+        )
+        is None
+    )
+    setattr(session, "_background_task_service", _WaitOnlyService())
+    assert (
+        AgentLlmSession._spawn_subagent_has_durable_launch(
+            session,
+            request=request,
+            state=state,
+        )
+        is False
+    )
+    durable = state.model_copy(
+        update={"call_state": {"subagent_run_id": "subagent-run-1"}}
+    )
+    assert AgentLlmSession._spawn_subagent_has_durable_launch(
+        session,
+        request=request,
+        state=durable,
+    )
+    assert AgentLlmSession._is_background_subagent_recovery(
+        call_state={"background": "true"},
+        record=None,
+    )
+
+
+@pytest.mark.asyncio
 async def test_restore_pending_tool_results_recovers_orphaned_subagent_from_args_preview(
     tmp_path: Path,
 ) -> None:
@@ -1278,6 +2341,34 @@ def test_superseded_tool_call_ids_scope_to_current_instance_and_role() -> None:
     )
 
     assert superseded_ids == {"call-current"}
+
+
+def test_best_effort_replay_lookups_ignore_sqlite_read_failures() -> None:
+    request = _build_request()
+    session = object.__new__(AgentLlmSession)
+
+    class _FailingEventBus:
+        def list_by_trace(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
+            _ = trace_id
+            raise sqlite3.OperationalError("database is locked")
+
+    class _FailingMessageRepo:
+        def get_history_for_conversation(
+            self,
+            conversation_id: str,
+        ) -> list[ModelRequest | ModelResponse]:
+            _ = conversation_id
+            raise sqlite3.DatabaseError("database is locked")
+
+    session.__dict__["_event_bus"] = _FailingEventBus()
+    session.__dict__["_message_repo"] = _FailingMessageRepo()
+
+    assert (
+        AgentLlmSession._superseded_tool_call_ids_for_request(session, request) == set()
+    )
+    assert (
+        AgentLlmSession._committed_tool_call_ids_for_request(session, request) == set()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/test_tool_call_history.py
+++ b/tests/unit_tests/agents/execution/test_tool_call_history.py
@@ -7,6 +7,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelRequestPart,
     ModelResponse,
+    RetryPromptPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
@@ -133,3 +134,75 @@ def test_normalize_replayed_messages_against_pending_keeps_request_fields() -> N
     assert request.timestamp == datetime(2026, 4, 2, 22, 44, 3, tzinfo=UTC)
     assert request.run_id == "run-123"
     assert request.metadata == {"source": "test"}
+
+
+def test_normalize_replayed_messages_drops_tool_result_name_mismatch() -> None:
+    messages = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="write",
+                    args={"content": "hello"},
+                    tool_call_id="call-real",
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="read",
+                    tool_call_id="call-real",
+                    content={"ok": True},
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="write",
+                    tool_call_id="call-real",
+                    content={"ok": True},
+                )
+            ]
+        ),
+    ]
+
+    sanitized = normalize_replayed_messages(messages)
+
+    assert len(sanitized) == 2
+    assert isinstance(sanitized[0], ModelResponse)
+    assert isinstance(sanitized[1], ModelRequest)
+    assert len(sanitized[1].parts) == 1
+    result_part = sanitized[1].parts[0]
+    assert isinstance(result_part, ToolReturnPart)
+    assert result_part.tool_name == "write"
+
+
+def test_normalize_replayed_messages_keeps_retry_prompt_without_tool_name() -> None:
+    messages = [
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="write",
+                    args={"content": "hello"},
+                    tool_call_id="call-real",
+                )
+            ]
+        ),
+        _request_with_metadata(
+            RetryPromptPart(
+                content="Input validation failed",
+                tool_call_id="call-real",
+            )
+        ),
+    ]
+
+    sanitized = normalize_replayed_messages(messages)
+
+    assert len(sanitized) == 2
+    request = sanitized[1]
+    assert isinstance(request, ModelRequest)
+    assert len(request.parts) == 1
+    retry_part = request.parts[0]
+    assert isinstance(retry_part, RetryPromptPart)
+    assert retry_part.tool_call_id == "call-real"

--- a/tests/unit_tests/agents/orchestration/test_task_execution_timeout.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_timeout.py
@@ -451,6 +451,61 @@ async def test_execute_applies_timeout_when_worker_cancel_wait_expires(
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_timeout_finalizer_applies_timeout_when_worker_cancel_wait_expires(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        task_execution_module,
+        "TIMEOUT_WORKER_CANCEL_GRACE_SECONDS",
+        0.01,
+    )
+    provider = _CancellationResistantProvider()
+    service, task_repo, agent_repo, message_repo = _build_service(
+        tmp_path / "task_execution_cancel_wait_timeout_finalizer.db",
+        provider,
+    )
+    task, instance_id = _seed_task(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+    )
+
+    async def _resistant_worker() -> TaskExecutionResult:
+        return TaskExecutionResult(output=await provider.generate(object()))
+
+    worker = asyncio.create_task(_resistant_worker())
+    timeout_cancellation = asyncio.Event()
+    await provider.started.wait()
+
+    try:
+        result = await service._complete_timeout_after_worker_cancel_async(
+            task=task,
+            instance_id=instance_id,
+            role_id="time",
+            timeout_seconds=0.05,
+            worker=worker,
+            timeout_cancellation=timeout_cancellation,
+        )
+    finally:
+        provider.release.set()
+
+    record = task_repo.get(task.task_id)
+    assert result.error_code == "task_timeout"
+    assert timeout_cancellation.is_set()
+    assert provider.cancelled.is_set()
+    assert record.status == TaskStatus.TIMEOUT
+    assert record.error_message is not None
+    assert "Task timed out after" in record.error_message
+    await asyncio.wait_for(provider.finished.wait(), timeout=1.0)
+    late_result = await asyncio.wait_for(worker, timeout=1.0)
+    assert late_result.output == "late"
+    await asyncio.sleep(0.01)
+    assert task_repo.get(task.task_id).status == TaskStatus.TIMEOUT
+
+
+@pytest.mark.asyncio
 async def test_timeout_finalizer_preserves_worker_result_if_cancel_returns_one(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/hooks/test_hook_service.py
+++ b/tests/unit_tests/hooks/test_hook_service.py
@@ -521,12 +521,13 @@ async def test_execute_publishes_hook_events_with_async_publisher(
             super().__init__()
             self.events: list[RunEvent] = []
 
-        def publish(self, event: RunEvent) -> None:
+        def publish(self, event: RunEvent) -> int:
             _ = event
             raise AssertionError("HookService must not call sync publish in async flow")
 
-        async def publish_async(self, event: RunEvent) -> None:
+        async def publish_async(self, event: RunEvent) -> int:
             self.events.append(event)
+            return 1
 
     class AllowCommandExecutor(CommandHookExecutor):
         async def execute(

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -19,6 +19,7 @@ from relay_teams.skills.discovery import SkillsDirectory
 from relay_teams.skills.skill_models import SkillSource
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.sessions.runs.background_tasks.models import (
+    BackgroundTaskKind,
     BackgroundTaskRecord,
     BackgroundTaskStatus,
 )
@@ -620,4 +621,72 @@ def test_container_preserves_background_task_rows_when_startup_kill_fails(
         "kill:3210",
         "kill:6543",
         "mark:('exec-killed',)",
+    ]
+
+
+def test_container_preserves_recoverable_foreground_subagent_records_on_startup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from relay_teams.interfaces.server import container as container_module
+
+    _clear_proxy_env(monkeypatch)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    lifecycle: list[str] = []
+    interruptible = (
+        BackgroundTaskRecord(
+            background_task_id="sync-subagent",
+            run_id="run-1",
+            session_id="session-1",
+            kind=BackgroundTaskKind.SUBAGENT,
+            instance_id="inst-1",
+            role_id="writer",
+            tool_call_id="call-subagent",
+            command="subagent:Explorer",
+            cwd=str(tmp_path),
+            execution_mode="foreground",
+            status=BackgroundTaskStatus.RUNNING,
+            log_path="",
+            subagent_role_id="Explorer",
+            subagent_run_id="subagent-run-1",
+            subagent_task_id="task-subagent-1",
+            subagent_instance_id="inst-subagent-1",
+        ),
+        BackgroundTaskRecord(
+            background_task_id="exec-running",
+            run_id="run-1",
+            session_id="session-1",
+            command="sleep 30",
+            cwd=str(tmp_path),
+            status=BackgroundTaskStatus.RUNNING,
+            pid=3210,
+            log_path="tmp/background_tasks/exec-running.log",
+        ),
+    )
+
+    monkeypatch.setattr(
+        container_module.BackgroundTaskRepository,
+        "list_interruptible",
+        lambda self: interruptible,
+    )
+    monkeypatch.setattr(
+        container_module,
+        "kill_process_tree_by_pid",
+        lambda pid: lifecycle.append(f"kill:{pid}") or True,
+    )
+    monkeypatch.setattr(
+        container_module.BackgroundTaskRepository,
+        "mark_transient_background_tasks_interrupted",
+        lambda self, *, background_task_ids=None: (
+            lifecycle.append(f"mark:{background_task_ids}")
+            or len(background_task_ids or ())
+        ),
+    )
+
+    _ = ServerContainer(config_dir=config_dir)
+
+    assert lifecycle == [
+        "kill:3210",
+        "mark:('exec-running',)",
     ]

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 from openai import APIError, APIStatusError
 from pydantic_ai.exceptions import ModelAPIError
+from pydantic_ai import Agent
 from pydantic_ai.messages import (
     ImageUrl,
     ModelRequest,
@@ -86,6 +87,7 @@ from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.tools.registry import ToolRegistry
+from relay_teams.tools.runtime.context import ToolContext, ToolDeps
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.workspace import WorkspaceManager, build_conversation_id
@@ -750,6 +752,7 @@ def _build_provider(
     run_control_manager: object | None = None,
     subagent_reflection_service: object | None = None,
     task_execution_service: object | None = None,
+    tool_registry: ToolRegistry | None = None,
 ) -> tuple[OpenAICompatibleProvider, MessageRepository]:
     registry = (
         cast(SkillRegistry, skill_registry)
@@ -815,7 +818,7 @@ def _build_provider(
             SubagentReflectionService | None,
             subagent_reflection_service,
         ),
-        tool_registry=cast(ToolRegistry, object()),
+        tool_registry=tool_registry or cast(ToolRegistry, object()),
         mcp_registry=resolved_mcp_registry,
         skill_registry=registry,
         allowed_tools=allowed_tools,
@@ -837,6 +840,22 @@ def _build_provider(
         tool_approval_policy=ToolApprovalPolicy(),
     )
     return provider, message_repo
+
+
+def _current_time_tool_registry() -> ToolRegistry:
+    def _register(agent: Agent[ToolDeps, str]) -> None:
+        @agent.tool(description="Return a fixed test timestamp.")
+        async def current_time(
+            ctx: ToolContext,
+            timezone: str,
+        ) -> dict[str, str]:
+            _ = ctx
+            return {
+                "time": "2026-03-07T10:00:00Z",
+                "timezone": timezone,
+            }
+
+    return ToolRegistry({"current_time": _register})
 
 
 @pytest.mark.asyncio
@@ -2751,7 +2770,11 @@ async def test_subagent_resume_after_tool_call_cancellation_replays_from_safe_bo
 ) -> None:
     db_path = tmp_path / "subagent_tool_call_cancel.db"
     cancel_hub = _FakeRunEventHub()
-    provider, message_repo = _build_provider(db_path, cancel_hub)
+    provider, message_repo = _build_provider(
+        db_path,
+        cancel_hub,
+        tool_registry=_current_time_tool_registry(),
+    )
     _seed_request(
         message_repo,
         session_id="session-sub",
@@ -2819,7 +2842,11 @@ async def test_subagent_resume_after_tool_call_cancellation_replays_from_safe_bo
     )
 
     resume_hub = _FakeRunEventHub()
-    resume_provider, resume_repo = _build_provider(db_path, resume_hub)
+    resume_provider, resume_repo = _build_provider(
+        db_path,
+        resume_hub,
+        tool_registry=_current_time_tool_registry(),
+    )
     resumed_agent = _SequentialAgent(
         [
             _ScriptedAgentRun(
@@ -2827,27 +2854,7 @@ async def test_subagent_resume_after_tool_call_cancellation_replays_from_safe_bo
                 messages_by_step=[],
                 result=_ScriptedResult(
                     response=ModelResponse(parts=[TextPart(content="done")]),
-                    messages=[
-                        ModelResponse(
-                            parts=[
-                                ToolCallPart(
-                                    tool_name="current_time",
-                                    args={"timezone": "UTC"},
-                                    tool_call_id="call-resume",
-                                )
-                            ]
-                        ),
-                        ModelRequest(
-                            parts=[
-                                ToolReturnPart(
-                                    tool_name="current_time",
-                                    tool_call_id="call-resume",
-                                    content={"time": "2026-03-07T10:00:00Z"},
-                                )
-                            ]
-                        ),
-                        ModelResponse(parts=[TextPart(content="done")]),
-                    ],
+                    messages=[ModelResponse(parts=[TextPart(content="done")])],
                 ),
             )
         ]
@@ -2876,8 +2883,154 @@ async def test_subagent_resume_after_tool_call_cancellation_replays_from_safe_bo
         for part in message.parts
         if isinstance(part, ToolReturnPart)
     ]
-    assert tool_calls == ["call-resume"]
-    assert tool_returns == ["call-resume"]
+    assert tool_calls == ["call-pre"]
+    assert tool_returns == ["call-pre"]
+    recovered_return = next(
+        part
+        for message in history_after_resume
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    )
+    assert isinstance(recovered_return.content, dict)
+    assert recovered_return.content["time"] == "2026-03-07T10:00:00Z"
+    assert recovered_return.content["timezone"] == "UTC"
+
+
+@pytest.mark.asyncio
+async def test_subagent_resume_recovers_parallel_tool_call_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "subagent_parallel_tool_call_cancel.db"
+    cancel_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        db_path,
+        cancel_hub,
+        tool_registry=_current_time_tool_registry(),
+    )
+    _seed_request(
+        message_repo,
+        session_id="session-sub",
+        instance_id="inst-sub",
+        task_id="task-sub",
+        trace_id="run-sub",
+        content="query time",
+        role_id="time",
+    )
+    cancelled_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[object()],
+                messages_by_step=[
+                    [
+                        ModelResponse(
+                            parts=[
+                                ToolCallPart(
+                                    tool_name="current_time",
+                                    args={"timezone": "UTC"},
+                                    tool_call_id="call-a",
+                                ),
+                                ToolCallPart(
+                                    tool_name="current_time",
+                                    args={"timezone": "Asia/Shanghai"},
+                                    tool_call_id="call-b",
+                                ),
+                            ]
+                        )
+                    ]
+                ],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=asyncio.CancelledError(),
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: cancelled_agent,
+    )
+    request = LLMRequest(
+        run_id="run-sub",
+        trace_id="run-sub",
+        task_id="task-sub",
+        session_id="session-sub",
+        workspace_id="default",
+        instance_id="inst-sub",
+        role_id="time",
+        system_prompt="system",
+        user_prompt=None,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider.generate(request)
+
+    assert len(message_repo.get_history("inst-sub")) == 1
+    sealed_batches = [
+        json.loads(event.payload_json)
+        for event in cancel_hub.events
+        if event.event_type == RunEventType.TOOL_CALL_BATCH_SEALED
+    ]
+    assert len(sealed_batches) == 1
+    assert [item["tool_call_id"] for item in sealed_batches[0]["tool_calls"]] == [
+        "call-a",
+        "call-b",
+    ]
+
+    resume_hub = _FakeRunEventHub()
+    resume_provider, resume_repo = _build_provider(
+        db_path,
+        resume_hub,
+        tool_registry=_current_time_tool_registry(),
+    )
+    resumed_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(parts=[TextPart(content="done")]),
+                    messages=[ModelResponse(parts=[TextPart(content="done")])],
+                ),
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: resumed_agent,
+    )
+
+    result = await resume_provider.generate(request)
+
+    assert result == "done"
+    history_after_resume = resume_repo.get_history("inst-sub")
+    recovered_call_message = history_after_resume[1]
+    recovered_result_message = history_after_resume[2]
+    assert isinstance(recovered_call_message, ModelResponse)
+    assert isinstance(recovered_result_message, ModelRequest)
+    recovered_call_ids = [
+        part.tool_call_id
+        for part in recovered_call_message.parts
+        if isinstance(part, ToolCallPart)
+    ]
+    recovered_return_ids = [
+        part.tool_call_id
+        for part in recovered_result_message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+    assert recovered_call_ids == ["call-a", "call-b"]
+    assert recovered_return_ids == ["call-a", "call-b"]
+
+    return_payloads = [
+        part.content
+        for part in recovered_result_message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+    assert return_payloads == [
+        {"time": "2026-03-07T10:00:00Z", "timezone": "UTC"},
+        {"time": "2026-03-07T10:00:00Z", "timezone": "Asia/Shanghai"},
+    ]
 
 
 @pytest.mark.asyncio
@@ -2887,7 +3040,11 @@ async def test_subagent_resume_after_tool_result_before_commit_retries_cleanly(
 ) -> None:
     db_path = tmp_path / "subagent_tool_result_commit_cancel.db"
     cancel_hub = _FakeRunEventHub()
-    provider, message_repo = _build_provider(db_path, cancel_hub)
+    provider, message_repo = _build_provider(
+        db_path,
+        cancel_hub,
+        tool_registry=_current_time_tool_registry(),
+    )
     _seed_request(
         message_repo,
         session_id="session-sub",
@@ -2960,7 +3117,11 @@ async def test_subagent_resume_after_tool_result_before_commit_retries_cleanly(
     assert len(history_after_cancel) == 1
 
     resume_hub = _FakeRunEventHub()
-    resume_provider, resume_repo = _build_provider(db_path, resume_hub)
+    resume_provider, resume_repo = _build_provider(
+        db_path,
+        resume_hub,
+        tool_registry=_current_time_tool_registry(),
+    )
     resumed_agent = _SequentialAgent(
         [
             _ScriptedAgentRun(
@@ -2968,7 +3129,7 @@ async def test_subagent_resume_after_tool_result_before_commit_retries_cleanly(
                 messages_by_step=[],
                 result=_ScriptedResult(
                     response=ModelResponse(parts=[TextPart(content="done")]),
-                    messages=scripted_messages,
+                    messages=[ModelResponse(parts=[TextPart(content="done")])],
                 ),
             )
         ]
@@ -2994,6 +3155,7 @@ async def test_subagent_resume_after_tool_result_before_commit_retries_cleanly(
     assert tool_returns[0].tool_call_id == "call-once"
     assert isinstance(tool_returns[0].content, dict)
     assert tool_returns[0].content.get("time") == "2026-03-07T10:00:00Z"
+    assert tool_returns[0].content.get("timezone") == "UTC"
 
 
 @pytest.mark.asyncio
@@ -3060,6 +3222,87 @@ async def test_generate_retries_retryable_status_error_before_side_effects(
     assert event_types.count(RunEventType.MODEL_STEP_STARTED) == 2
     assert RunEventType.LLM_RETRY_SCHEDULED in event_types
     history = message_repo.get_history("inst-retry-success")
+    assert len(history) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_retries_retryable_error_after_preflight_batch_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "retry_after_preflight_recovery.db",
+        fake_hub,
+    )
+    provider._session._retry_config.jitter = False
+    provider._session._retry_config.initial_delay_ms = 1
+
+    async def _fast_sleep(delay: float) -> None:
+        _ = delay
+
+    async def _recover_uncommitted_tool_batches_async(
+        **kwargs: object,
+    ) -> tuple[list[ModelRequest | ModelResponse], int]:
+        history = cast(list[ModelRequest | ModelResponse], kwargs["history"])
+        return history, 1
+
+    monkeypatch.setattr(llm_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(llm_retry_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(llm_module, "compute_retry_delay_ms", lambda **_: 0)
+    provider._session.__dict__["_recover_uncommitted_tool_batches_async"] = (
+        _recover_uncommitted_tool_batches_async
+    )
+    request_error = APIStatusError(
+        "lock timeout",
+        response=httpx.Response(
+            409,
+            request=httpx.Request("POST", "https://example.test/v1/chat/completions"),
+        ),
+        body={"error": {"code": "conflict", "message": "busy"}},
+    )
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(response="unused", messages=[]),
+                raise_on_exhaust=request_error,
+            ),
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=ModelResponse(parts=[TextPart(content="after retry")]),
+                    messages=[ModelResponse(parts=[TextPart(content="after retry")])],
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+    request = LLMRequest(
+        run_id="run-retry-after-preflight-recovery",
+        trace_id="run-retry-after-preflight-recovery",
+        task_id="task-retry-after-preflight-recovery",
+        session_id="session-retry-after-preflight-recovery",
+        workspace_id="default",
+        instance_id="inst-retry-after-preflight-recovery",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="retry me",
+    )
+
+    result = await provider.generate(request)
+
+    assert result == "after retry"
+    event_types = [event.event_type for event in fake_hub.events]
+    assert event_types.count(RunEventType.MODEL_STEP_STARTED) == 2
+    assert RunEventType.LLM_RETRY_SCHEDULED in event_types
+    history = message_repo.get_history("inst-retry-after-preflight-recovery")
     assert len(history) == 2
 
 

--- a/tests/unit_tests/providers/test_llm_tool_events.py
+++ b/tests/unit_tests/providers/test_llm_tool_events.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import cast
 
 import httpx
+import pytest
 from pydantic_ai.exceptions import ModelAPIError
 from pydantic_ai.messages import (
     ModelRequest,
@@ -33,6 +34,10 @@ from relay_teams.agents.instances.instance_repository import AgentInstanceReposi
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.agents.execution.event_publishing import (
+    EventPublishingService,
+    _args_preview,
+)
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )
@@ -42,7 +47,10 @@ from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.runtime.persisted_state import (
+    ToolCallBatchStatus,
     ToolExecutionStatus,
+    load_tool_call_batch_state,
+    load_tool_call_state,
     merge_tool_call_state,
 )
 from relay_teams.tools.registry import ToolRegistry
@@ -60,6 +68,11 @@ class _FakeRunEventHub:
         self.events = []
 
     def publish(self, event) -> None:
+        self.events.append(event)
+
+
+class _FakeAsyncRunEventHub(_FakeRunEventHub):
+    async def publish_async(self, event) -> None:
         self.events.append(event)
 
 
@@ -238,6 +251,7 @@ def test_publish_tool_events_emits_call_validation_failure_and_result() -> None:
     event_types = [event.event_type for event in hub.events]
     assert event_types == [
         RunEventType.TOOL_CALL,
+        RunEventType.TOOL_CALL_BATCH_SEALED,
         RunEventType.TOOL_INPUT_VALIDATION_FAILED,
         RunEventType.TOOL_RESULT,
     ]
@@ -245,8 +259,20 @@ def test_publish_tool_events_emits_call_validation_failure_and_result() -> None:
     tool_call_payload = json.loads(hub.events[0].payload_json)
     assert tool_call_payload["tool_name"] == "orch_create_tasks"
     assert tool_call_payload["tool_call_id"] == "call-1"
+    assert tool_call_payload["batch_index"] == 0
+    assert tool_call_payload["batch_size"] == 1
 
-    validation_payload = json.loads(hub.events[1].payload_json)
+    batch_payload = json.loads(hub.events[1].payload_json)
+    assert batch_payload["tool_calls"] == [
+        {
+            "tool_call_id": "call-1",
+            "tool_name": "orch_create_tasks",
+            "args": '{"objective": "x"}',
+            "index": 0,
+        }
+    ]
+
+    validation_payload = json.loads(hub.events[2].payload_json)
     assert validation_payload["tool_name"] == "orch_create_tasks"
     assert validation_payload["tool_call_id"] == "call-1"
     assert (
@@ -256,7 +282,7 @@ def test_publish_tool_events_emits_call_validation_failure_and_result() -> None:
         validation_payload["details"] == "Invalid arguments for tool orch_create_tasks"
     )
 
-    tool_result_payload = json.loads(hub.events[2].payload_json)
+    tool_result_payload = json.loads(hub.events[3].payload_json)
     assert tool_result_payload["tool_name"] == "orch_create_tasks"
     assert tool_result_payload["tool_call_id"] == "call-2"
     assert tool_result_payload["error"] is False
@@ -377,7 +403,290 @@ def test_publish_tool_call_events_deduplicates_published_tool_call_ids() -> None
 
     assert emitted_first is True
     assert emitted_second is False
-    assert [event.event_type for event in hub.events] == [RunEventType.TOOL_CALL]
+    assert [event.event_type for event in hub.events] == [
+        RunEventType.TOOL_CALL,
+        RunEventType.TOOL_CALL_BATCH_SEALED,
+    ]
+
+
+def test_publish_tool_call_events_persists_sealed_parallel_batch() -> None:
+    hub = _FakeRunEventHub()
+    provider = _provider_with_hub(hub)
+    request = _request()
+
+    emitted = provider._publish_tool_call_events_from_messages(
+        request=request,
+        messages=[
+            ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="read",
+                        args={"path": "a.txt"},
+                        tool_call_id="call-a",
+                    ),
+                    ToolCallPart(
+                        tool_name="read",
+                        args={"path": "b.txt"},
+                        tool_call_id="call-b",
+                    ),
+                ]
+            )
+        ],
+    )
+
+    assert emitted is True
+    batch_payloads = [
+        json.loads(event.payload_json)
+        for event in hub.events
+        if event.event_type == RunEventType.TOOL_CALL_BATCH_SEALED
+    ]
+    assert len(batch_payloads) == 1
+    batch_id = str(batch_payloads[0]["batch_id"])
+    batch_state = load_tool_call_batch_state(
+        shared_store=provider._session._shared_store,
+        task_id=request.task_id,
+        batch_id=batch_id,
+    )
+    assert batch_state is not None
+    assert batch_state.status == ToolCallBatchStatus.SEALED
+    assert [item.tool_call_id for item in batch_state.items] == ["call-a", "call-b"]
+
+    first_call_state = load_tool_call_state(
+        shared_store=provider._session._shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-a",
+    )
+    second_call_state = load_tool_call_state(
+        shared_store=provider._session._shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-b",
+    )
+    assert first_call_state is not None
+    assert second_call_state is not None
+    assert first_call_state.batch_id == batch_id
+    assert second_call_state.batch_id == batch_id
+    assert first_call_state.batch_index == 0
+    assert second_call_state.batch_index == 1
+    assert first_call_state.batch_size == 2
+    assert second_call_state.batch_size == 2
+
+
+def test_event_publishing_service_covers_sync_batch_edge_cases(
+    tmp_path: Path,
+) -> None:
+    hub = _FakeRunEventHub()
+    shared_store = SharedStateRepository(tmp_path / "event-publishing-sync.db")
+    service = EventPublishingService(
+        run_event_hub=cast(RunEventHub, cast(object, hub)),
+        shared_store=shared_store,
+    )
+    request = _request()
+
+    assert (
+        service.publish_tool_call_events_from_messages(
+            request=request,
+            messages=[ModelRequest(parts=[]), ModelResponse(parts=[])],
+        )
+        is False
+    )
+    assert (
+        service.publish_observed_tool_call_event(
+            request=request,
+            part=ToolCallPart(tool_name="", args={}, tool_call_id=""),
+            batch_id="batch-empty",
+            batch_index=0,
+            batch_size=1,
+        )
+        is False
+    )
+    service.seal_tool_call_batch(request=request, batch_id="batch-empty", tool_calls=[])
+    service.seal_tool_call_batch(
+        request=request,
+        batch_id="batch-invalid",
+        tool_calls=[(0, ToolCallPart(tool_name="", args={}, tool_call_id=""))],
+    )
+    emitted = service.publish_observed_tool_call_event(
+        request=request,
+        part=ToolCallPart(
+            tool_name="read", args={"path": "a.txt"}, tool_call_id="call-a"
+        ),
+        batch_id="batch-sealed",
+        batch_index=0,
+        batch_size=1,
+    )
+    service.seal_tool_call_batch(
+        request=request,
+        batch_id="batch-sealed",
+        tool_calls=[
+            (
+                0,
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-a",
+                ),
+            )
+        ],
+    )
+    event_count_after_first_seal = len(hub.events)
+    service.seal_tool_call_batch(
+        request=request,
+        batch_id="batch-sealed",
+        tool_calls=[
+            (
+                0,
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-a",
+                ),
+            )
+        ],
+    )
+    circular: list[object] = []
+    circular.append(circular)
+
+    assert emitted is True
+    assert len(hub.events) == event_count_after_first_seal
+    assert (
+        service._batch_id_for_tool_calls(
+            request=request,
+            tool_calls=[
+                (0, ToolCallPart(tool_name="read", args={}, tool_call_id="")),
+                (1, ToolCallPart(tool_name="read", args={}, tool_call_id="call-a")),
+            ],
+        )
+        == "batch-sealed"
+    )
+    assert _args_preview(circular).startswith("[[")
+
+
+@pytest.mark.asyncio
+async def test_event_publishing_service_covers_async_batch_edge_cases(
+    tmp_path: Path,
+) -> None:
+    hub = _FakeAsyncRunEventHub()
+    shared_store = SharedStateRepository(tmp_path / "event-publishing-async.db")
+    service = EventPublishingService(
+        run_event_hub=cast(RunEventHub, cast(object, hub)),
+        shared_store=shared_store,
+    )
+    request = _request()
+
+    assert (
+        await service.publish_observed_tool_call_event_async(
+            request=request,
+            part=ToolCallPart(tool_name="", args={}, tool_call_id=""),
+            batch_id="batch-empty",
+            batch_index=0,
+            batch_size=1,
+        )
+        is False
+    )
+    published = {"call-a"}
+    assert (
+        await service.publish_observed_tool_call_event_async(
+            request=request,
+            part=ToolCallPart(tool_name="read", args={}, tool_call_id="call-a"),
+            batch_id="batch-empty",
+            batch_index=0,
+            batch_size=1,
+            published_tool_call_ids=published,
+        )
+        is False
+    )
+    await service.seal_tool_call_batch_async(
+        request=request,
+        batch_id="batch-empty",
+        tool_calls=[],
+    )
+    await service.seal_tool_call_batch_async(
+        request=request,
+        batch_id="batch-invalid",
+        tool_calls=[(0, ToolCallPart(tool_name="", args={}, tool_call_id=""))],
+    )
+    await service.publish_observed_tool_call_event_async(
+        request=request,
+        part=ToolCallPart(
+            tool_name="read", args={"path": "a.txt"}, tool_call_id="call-b"
+        ),
+        batch_id="batch-async",
+        batch_index=0,
+        batch_size=1,
+    )
+    await service.seal_tool_call_batch_async(
+        request=request,
+        batch_id="batch-async",
+        tool_calls=[
+            (
+                0,
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-b",
+                ),
+            )
+        ],
+    )
+    event_count_after_first_seal = len(hub.events)
+    await service.seal_tool_call_batch_async(
+        request=request,
+        batch_id="batch-async",
+        tool_calls=[
+            (
+                0,
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-b",
+                ),
+            )
+        ],
+    )
+    service_without_store = EventPublishingService(
+        run_event_hub=cast(RunEventHub, cast(object, hub)),
+        shared_store=None,
+    )
+
+    assert len(hub.events) == event_count_after_first_seal
+    assert (
+        await service._batch_id_for_tool_calls_async(
+            request=request,
+            tool_calls=[
+                (0, ToolCallPart(tool_name="read", args={}, tool_call_id="")),
+                (1, ToolCallPart(tool_name="read", args={}, tool_call_id="call-b")),
+            ],
+        )
+        == "batch-async"
+    )
+    assert (
+        await service_without_store._tool_call_batch_is_sealed_async(
+            request=request,
+            batch_id="missing",
+        )
+        is False
+    )
+    assert (
+        await service_without_store._tool_call_batch_has_observed_items_async(
+            request=request,
+            batch_id="missing",
+        )
+        is False
+    )
+    await service_without_store.seal_tool_call_batch_async(
+        request=request,
+        batch_id="batch-no-store",
+        tool_calls=[
+            (
+                0,
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "z.txt"},
+                    tool_call_id="call-z",
+                ),
+            )
+        ],
+    )
 
 
 def test_publish_tool_events_skips_retry_without_tool_name() -> None:

--- a/tests/unit_tests/sessions/runs/background_tasks/test_repository.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_repository.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from relay_teams.sessions.runs.background_tasks.models import (
+    BackgroundTaskKind,
     BackgroundTaskRecord,
     BackgroundTaskStatus,
 )
@@ -155,6 +156,58 @@ def test_background_task_repository_lists_interruptible_records(tmp_path: Path) 
     )
 
 
+def test_background_task_repository_keeps_foreground_subagents_recoverable(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "background-subagent-recoverable.db"
+    repo = BackgroundTaskRepository(db_path)
+    foreground_subagent = BackgroundTaskRecord(
+        background_task_id="sync-subagent",
+        run_id="run-1",
+        session_id="session-1",
+        kind=BackgroundTaskKind.SUBAGENT,
+        instance_id="inst-1",
+        role_id="writer",
+        tool_call_id="call-subagent",
+        command="subagent:Explorer",
+        cwd="/tmp/project",
+        execution_mode="foreground",
+        status=BackgroundTaskStatus.RUNNING,
+        log_path="",
+        subagent_role_id="Explorer",
+        subagent_run_id="subagent-run-1",
+        subagent_task_id="task-subagent-1",
+        subagent_instance_id="inst-subagent-1",
+    )
+    running_command = BackgroundTaskRecord(
+        background_task_id="exec-running",
+        run_id="run-1",
+        session_id="session-1",
+        command="sleep 30",
+        cwd="/tmp/project",
+        status=BackgroundTaskStatus.RUNNING,
+        pid=111,
+        log_path="tmp/background_tasks/exec-running.log",
+    )
+    repo.upsert(foreground_subagent)
+    repo.upsert(running_command)
+
+    interruptible = repo.list_interruptible()
+    affected = repo.mark_transient_background_tasks_interrupted()
+
+    loaded_subagent = repo.get("sync-subagent")
+    loaded_command = repo.get("exec-running")
+    assert tuple(record.background_task_id for record in interruptible) == (
+        "exec-running",
+    )
+    assert affected == 1
+    assert loaded_subagent is not None
+    assert loaded_subagent.status == BackgroundTaskStatus.RUNNING
+    assert loaded_subagent.completed_at is None
+    assert loaded_command is not None
+    assert loaded_command.status == BackgroundTaskStatus.STOPPED
+
+
 def test_background_task_repository_can_interrupt_specific_records(
     tmp_path: Path,
 ) -> None:
@@ -235,10 +288,29 @@ async def test_background_task_repository_async_methods_match_sync_behavior(
         status=BackgroundTaskStatus.COMPLETED,
         log_path="tmp/background_tasks/exec-other.log",
     )
+    foreground_subagent = BackgroundTaskRecord(
+        background_task_id="sync-subagent",
+        run_id="run-1",
+        session_id="session-1",
+        kind=BackgroundTaskKind.SUBAGENT,
+        instance_id="inst-1",
+        role_id="writer",
+        tool_call_id="call-subagent",
+        command="subagent:Explorer",
+        cwd="/tmp/project",
+        execution_mode="foreground",
+        status=BackgroundTaskStatus.RUNNING,
+        log_path="",
+        subagent_role_id="Explorer",
+        subagent_run_id="subagent-run-1",
+        subagent_task_id="task-subagent-1",
+        subagent_instance_id="inst-subagent-1",
+    )
 
     persisted = await repo.upsert_async(running)
     _ = await repo.upsert_async(blocked)
     _ = await repo.upsert_async(other_session)
+    _ = await repo.upsert_async(foreground_subagent)
 
     loaded = await repo.get_async("exec-running")
     by_run = await repo.list_by_run_async("run-1")
@@ -257,14 +329,17 @@ async def test_background_task_repository_async_methods_match_sync_behavior(
     assert loaded is not None
     assert loaded.output_excerpt == "booting"
     assert tuple(record.background_task_id for record in by_run) == (
+        "sync-subagent",
         "exec-blocked",
         "exec-running",
     )
     assert tuple(record.background_task_id for record in by_session) == (
+        "sync-subagent",
         "exec-blocked",
         "exec-running",
     )
     assert tuple(record.background_task_id for record in all_records) == (
+        "sync-subagent",
         "exec-other",
         "exec-blocked",
         "exec-running",

--- a/tests/unit_tests/sessions/runs/background_tasks/test_service.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_service.py
@@ -13,7 +13,7 @@ import pytest
 
 from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.agents.tasks.enums import TaskStatus
-from relay_teams.agents.tasks.models import TaskEnvelope
+from relay_teams.agents.tasks.models import TaskEnvelope, TaskRecord, VerificationPlan
 from relay_teams.agents.orchestration.task_contracts import TaskExecutionResult
 from relay_teams.sessions.runs.background_tasks.command_runtime import (
     normalize_timeout,
@@ -311,6 +311,12 @@ class _FakeTaskRepo:
     def __init__(self) -> None:
         self.created: list[object] = []
         self.status_updates: list[dict[str, object]] = []
+
+    def get(self, task_id: str) -> object:
+        for task in self.created:
+            if isinstance(task, TaskEnvelope) and task.task_id == task_id:
+                return task
+        raise KeyError(task_id)
 
     def create(self, envelope: object) -> object:
         self.created.append(envelope)
@@ -1010,6 +1016,67 @@ async def test_background_task_service_start_subagent_publishes_start_event_asyn
 
 
 @pytest.mark.asyncio
+async def test_background_task_service_start_subagent_persists_launch_before_materialize(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-launch.db"
+    )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    task_repo = _FakeTaskRepo()
+    seen_records: list[BackgroundTaskRecord] = []
+
+    class _AssertingAgentRepo(_FakeAgentRepo):
+        def upsert_instance(self, **kwargs: object) -> None:
+            records = repo.list_by_run("run-1")
+            assert len(records) == 1
+            record = records[0]
+            assert record.status == BackgroundTaskStatus.RUNNING
+            assert record.input_text == "Inspect the failing tests."
+            assert record.tool_call_id == "call-subagent-1"
+            assert record.subagent_run_id == kwargs["run_id"]
+            assert task_repo.created == []
+            assert executor.calls == []
+            seen_records.append(record)
+            super().upsert_instance(**kwargs)
+
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=_AssertingAgentRepo(),
+        task_repo=task_repo,
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+    )
+
+    started = await service.start_subagent(
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="MainAgent",
+        tool_call_id="call-subagent-1",
+        workspace_id="workspace-1",
+        cwd=Path("C:/workspace"),
+        subagent_role_id="Crafter",
+        title="Investigate failures",
+        prompt="Inspect the failing tests.",
+    )
+    _, completed = await service.wait_for_run(
+        run_id="run-1",
+        background_task_id=started.background_task_id,
+    )
+
+    assert completed is True
+    assert len(seen_records) == 1
+
+
+@pytest.mark.asyncio
 async def test_background_task_service_start_subagent_cleans_up_when_start_event_fails(
     tmp_path: Path,
 ) -> None:
@@ -1061,6 +1128,265 @@ async def test_background_task_service_start_subagent_cleans_up_when_start_event
     assert run_control_manager.unregistered_run_ids == [
         subagent_run_id,
     ]
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_start_subagent_finalizes_record_when_launch_fails(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-launch-fails.db"
+    )
+
+    class _FailingAgentRepo(_FakeAgentRepo):
+        def upsert_instance(self, **kwargs: object) -> None:
+            _ = kwargs
+            raise RuntimeError("agent repo unavailable")
+
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=_FakeTaskExecutionService(
+            result=TaskExecutionResult(
+                output="unused",
+                completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+            )
+        ),
+        agent_repo=_FailingAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+    )
+
+    with pytest.raises(RuntimeError, match="agent repo unavailable"):
+        await service.start_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="MainAgent",
+            tool_call_id="call-subagent-1",
+            workspace_id="workspace-1",
+            cwd=Path("C:/workspace"),
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests.",
+        )
+
+    records = repo.list_by_run("run-1")
+    assert len(records) == 1
+    assert records[0].status == BackgroundTaskStatus.FAILED
+    assert records[0].output_excerpt == "agent repo unavailable"
+    assert records[0].completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_start_subagent_finalizes_when_launch_callback_fails(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-callback-fails.db"
+    )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="unused",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    agent_repo = _FakeAgentRepo()
+    task_repo = _FakeTaskRepo()
+    callback_records: list[BackgroundTaskRecord] = []
+
+    async def on_launch_prepared(record: BackgroundTaskRecord) -> None:
+        callback_records.append(record)
+        raise RuntimeError("call state persist failed")
+
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+    )
+
+    with pytest.raises(RuntimeError, match="call state persist failed"):
+        await service.start_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="MainAgent",
+            tool_call_id="call-subagent-1",
+            workspace_id="workspace-1",
+            cwd=Path("C:/workspace"),
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests.",
+            on_launch_prepared=on_launch_prepared,
+        )
+
+    records = repo.list_by_run("run-1")
+    assert len(callback_records) == 1
+    assert len(records) == 1
+    assert records[0].status == BackgroundTaskStatus.FAILED
+    assert records[0].output_excerpt == "call state persist failed"
+    assert records[0].completed_at is not None
+    assert executor.calls == []
+    assert agent_repo.calls == []
+    assert task_repo.created == []
+    assert task_repo.status_updates[-1]["error_message"] == "call state persist failed"
+    assert agent_repo.status_updates[-1]["status"] == InstanceStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_launch_cleanup_tolerates_status_update_failures(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-cleanup-failures.db"
+    )
+
+    class _FailingTaskRepo(_FakeTaskRepo):
+        def update_status(
+            self,
+            task_id: str,
+            status: object,
+            assigned_instance_id: str | None = None,
+            result: str | None = None,
+            error_message: str | None = None,
+        ) -> None:
+            _ = (task_id, status, assigned_instance_id, result, error_message)
+            raise RuntimeError("task status unavailable")
+
+    class _FailingAgentRepo(_FakeAgentRepo):
+        def mark_status(self, instance_id: str, status: InstanceStatus) -> None:
+            _ = (instance_id, status)
+            raise RuntimeError("agent status unavailable")
+
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=_FakeTaskExecutionService(
+            result=TaskExecutionResult(
+                output="unused",
+                completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+            )
+        ),
+        agent_repo=_FailingAgentRepo(),
+        task_repo=_FailingTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        hook_service=cast(HookService, _FailingSubagentStartHookService()),
+        run_event_hub=RunEventHub(),
+    )
+
+    with pytest.raises(RuntimeError, match="task status unavailable"):
+        await service.start_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="MainAgent",
+            tool_call_id="call-subagent-1",
+            workspace_id="workspace-1",
+            cwd=Path("C:/workspace"),
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests.",
+        )
+
+    records = repo.list_by_run("run-1")
+    assert len(records) == 1
+    assert records[0].status == BackgroundTaskStatus.FAILED
+    assert records[0].output_excerpt == "task status unavailable"
+
+
+def test_background_task_service_subagent_record_lookup_edge_cases(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(tmp_path / "background-task-subagent-lookup.db")
+    service = BackgroundTaskService(background_task_manager=None, repository=repo)
+    assert (
+        service.subagent_record_for_tool_call(parent_run_id="", tool_call_id="call-1")
+        is None
+    )
+    assert (
+        service.subagent_record_for_tool_call(parent_run_id="run-1", tool_call_id="")
+        is None
+    )
+    record = BackgroundTaskRecord(
+        background_task_id="subagent-lookup",
+        run_id="run-1",
+        session_id="session-1",
+        kind=BackgroundTaskKind.SUBAGENT,
+        instance_id="inst-1",
+        role_id="writer",
+        tool_call_id="call-1",
+        command="subagent:Crafter",
+        cwd="C:/workspace",
+        execution_mode="foreground",
+        status=BackgroundTaskStatus.RUNNING,
+    )
+    repo.upsert(record)
+
+    assert (
+        service.subagent_record_for_tool_call(
+            parent_run_id="run-1",
+            tool_call_id="call-1",
+        )
+        == record
+    )
+
+
+def test_background_task_service_prepared_launch_rejects_incomplete_sync_records() -> (
+    None
+):
+    missing_metadata = BackgroundTaskRecord(
+        background_task_id="sync-missing",
+        run_id="run-1",
+        session_id="session-1",
+        kind=BackgroundTaskKind.SUBAGENT,
+        instance_id="inst-1",
+        role_id="writer",
+        command="subagent:Crafter",
+        cwd="C:/workspace",
+        execution_mode="foreground",
+        status=BackgroundTaskStatus.RUNNING,
+    )
+    missing_workspace = missing_metadata.model_copy(
+        update={
+            "title": "",
+            "input_text": "Recover me",
+            "cwd": "",
+            "subagent_role_id": "Crafter",
+            "subagent_run_id": "subagent-run-1",
+            "subagent_task_id": "task-sub-1",
+            "subagent_instance_id": "inst-sub-1",
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="missing recovery metadata"):
+        BackgroundTaskService._prepared_launch_from_synchronous_record(missing_metadata)
+    with pytest.raises(RuntimeError, match="workspace is unavailable"):
+        BackgroundTaskService._prepared_launch_from_synchronous_record(
+            missing_workspace
+        )
+
+
+def test_background_task_service_subagent_task_exists_helper() -> None:
+    task_repo = _FakeTaskRepo()
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="trace-1",
+        role_id="writer",
+        title="Task",
+        objective="Do work",
+        verification=VerificationPlan(checklist=()),
+    )
+    task_repo.create(task)
+
+    assert BackgroundTaskService._subagent_task_exists(task_repo, "task-1")
+    assert not BackgroundTaskService._subagent_task_exists(task_repo, "missing")
 
 
 @pytest.mark.asyncio
@@ -1283,6 +1609,180 @@ async def test_background_task_service_run_subagent_injects_start_hook_context(
 
 
 @pytest.mark.asyncio
+async def test_background_task_service_run_subagent_persists_launch_before_execution(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-sync-launch.db"
+    )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    agent_repo = _FakeAgentRepo()
+    task_repo = _FakeTaskRepo()
+    seen_records: list[BackgroundTaskRecord] = []
+
+    async def on_launch_prepared(record: BackgroundTaskRecord) -> None:
+        persisted = repo.get(record.background_task_id)
+        assert persisted is not None
+        assert persisted.status == BackgroundTaskStatus.RUNNING
+        assert persisted.input_text == "Inspect the failing tests."
+        assert persisted.tool_call_id == "call-subagent-1"
+        assert agent_repo.calls == []
+        assert task_repo.created == []
+        assert executor.calls == []
+        seen_records.append(record)
+
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=RunRuntimeRepository(
+            tmp_path / "background-task-service-subagent-sync-launch.db"
+        ),
+    )
+
+    result = await service.run_subagent(
+        run_id="run-1",
+        session_id="session-1",
+        workspace_id="workspace-1",
+        tool_call_id="call-subagent-1",
+        parent_instance_id="inst-parent",
+        parent_role_id="writer",
+        subagent_role_id="Crafter",
+        title="Investigate failures",
+        prompt="Inspect the failing tests.",
+        on_launch_prepared=on_launch_prepared,
+    )
+
+    assert result.output == "analysis complete"
+    assert len(seen_records) == 1
+    persisted = repo.get(seen_records[0].background_task_id)
+    assert persisted is not None
+    assert persisted.status == BackgroundTaskStatus.COMPLETED
+    assert persisted.instance_id == "inst-parent"
+    assert persisted.role_id == "writer"
+    assert persisted.subagent_run_id == result.run_id
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_run_subagent_finalizes_record_when_launch_fails(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-sync-launch-fails.db"
+    )
+    seen_records: list[BackgroundTaskRecord] = []
+
+    class _FailingAgentRepo(_FakeAgentRepo):
+        def upsert_instance(self, **kwargs: object) -> None:
+            _ = kwargs
+            raise RuntimeError("agent repo unavailable")
+
+    async def on_launch_prepared(record: BackgroundTaskRecord) -> None:
+        seen_records.append(record)
+
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=_FakeTaskExecutionService(
+            result=TaskExecutionResult(
+                output="unused",
+                completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+            )
+        ),
+        agent_repo=_FailingAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=RunRuntimeRepository(
+            tmp_path / "background-task-service-subagent-sync-launch-fails.db"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="agent repo unavailable"):
+        await service.run_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            tool_call_id="call-subagent-1",
+            parent_instance_id="inst-parent",
+            parent_role_id="writer",
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests.",
+            on_launch_prepared=on_launch_prepared,
+        )
+
+    assert len(seen_records) == 1
+    persisted = repo.get(seen_records[0].background_task_id)
+    assert persisted is not None
+    assert persisted.status == BackgroundTaskStatus.FAILED
+    assert persisted.output_excerpt == "agent repo unavailable"
+    assert persisted.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_run_subagent_finalizes_when_launch_callback_fails(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-sync-callback-fails.db"
+    )
+    seen_records: list[BackgroundTaskRecord] = []
+
+    async def on_launch_prepared(record: BackgroundTaskRecord) -> None:
+        seen_records.append(record)
+        raise RuntimeError("tool state persistence failed")
+
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=_FakeTaskExecutionService(
+            result=TaskExecutionResult(
+                output="unused",
+                completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+            )
+        ),
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=RunRuntimeRepository(
+            tmp_path / "background-task-service-subagent-sync-callback-fails.db"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="tool state persistence failed"):
+        await service.run_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            tool_call_id="call-subagent-1",
+            parent_instance_id="inst-parent",
+            parent_role_id="writer",
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests.",
+            on_launch_prepared=on_launch_prepared,
+        )
+
+    assert len(seen_records) == 1
+    persisted = repo.get(seen_records[0].background_task_id)
+    assert persisted is not None
+    assert persisted.status == BackgroundTaskStatus.FAILED
+    assert persisted.output_excerpt == "tool state persistence failed"
+    assert persisted.completed_at is not None
+
+
+@pytest.mark.asyncio
 async def test_background_task_service_wait_for_subagent_run_reattaches_existing_sync_run(
     tmp_path: Path,
 ) -> None:
@@ -1398,6 +1898,251 @@ async def test_background_task_service_wait_for_subagent_run_recovers_persisted_
     assert persisted_records[0].execution_mode == "foreground"
     assert persisted_records[0].status == BackgroundTaskStatus.COMPLETED
     assert persisted_records[0].output_excerpt == "analysis complete"
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_wait_for_subagent_run_recovers_active_sync_record(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "background-task-service-subagent-sync-active.db"
+    repo = BackgroundTaskRepository(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    record = repo.upsert(
+        _build_record(
+            background_task_id="sync-subagent-active",
+            execution_mode="foreground",
+            status=BackgroundTaskStatus.RUNNING,
+        ).model_copy(
+            update={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "kind": BackgroundTaskKind.SUBAGENT,
+                "instance_id": "inst-parent",
+                "role_id": "writer",
+                "tool_call_id": "call-subagent-1",
+                "title": "Investigate failures",
+                "input_text": "Inspect the failing tests and summarize the cause.",
+                "command": "subagent:Crafter",
+                "cwd": "workspace-1",
+                "subagent_role_id": "Crafter",
+                "subagent_run_id": "subagent-run-recover",
+                "subagent_task_id": "task-sub-recover",
+                "subagent_instance_id": "inst-sub-recover",
+            }
+        )
+    )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="recovered analysis",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    agent_repo = _FakeAgentRepo()
+    task_repo = _FakeTaskRepo()
+    run_control_manager = _FakeRunControlManager()
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=run_control_manager,
+        run_runtime_repo=runtime_repo,
+    )
+
+    result = await service.wait_for_subagent_run(
+        parent_run_id="run-1",
+        subagent_run_id="subagent-run-recover",
+    )
+
+    assert result == SynchronousSubagentResult(
+        run_id="subagent-run-recover",
+        instance_id="inst-sub-recover",
+        role_id="Crafter",
+        task_id="task-sub-recover",
+        title="Investigate failures",
+        output="recovered analysis",
+    )
+    assert executor.calls == [
+        {
+            "instance_id": "inst-sub-recover",
+            "role_id": "Crafter",
+            "task": task_repo.created[0],
+            "user_prompt_override": "Inspect the failing tests and summarize the cause.",
+        }
+    ]
+    assert agent_repo.calls[0]["run_id"] == "subagent-run-recover"
+    assert run_control_manager.registered_run_ids == ["subagent-run-recover"]
+    assert run_control_manager.unregistered_run_ids == ["subagent-run-recover"]
+    persisted = repo.get(record.background_task_id)
+    assert persisted is not None
+    assert persisted.status == BackgroundTaskStatus.COMPLETED
+    assert persisted.output_excerpt == "recovered analysis"
+    runtime = runtime_repo.get("subagent-run-recover")
+    assert runtime is not None
+    assert runtime.status == RunRuntimeStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_wait_for_subagent_run_uses_terminal_task_without_rerun(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "background-task-service-subagent-sync-terminal-task.db"
+    repo = BackgroundTaskRepository(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    record = repo.upsert(
+        _build_record(
+            background_task_id="sync-subagent-terminal-task",
+            execution_mode="foreground",
+            status=BackgroundTaskStatus.RUNNING,
+        ).model_copy(
+            update={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "kind": BackgroundTaskKind.SUBAGENT,
+                "instance_id": "inst-parent",
+                "role_id": "writer",
+                "tool_call_id": "call-subagent-terminal",
+                "title": "Investigate failures",
+                "input_text": "Inspect the failing tests and summarize the cause.",
+                "command": "subagent:Crafter",
+                "cwd": "workspace-1",
+                "subagent_role_id": "Crafter",
+                "subagent_run_id": "subagent-run-terminal",
+                "subagent_task_id": "task-sub-terminal",
+                "subagent_instance_id": "inst-sub-terminal",
+            }
+        )
+    )
+    task_record = TaskRecord(
+        envelope=TaskEnvelope(
+            task_id="task-sub-terminal",
+            session_id="session-1",
+            trace_id="subagent-run-terminal",
+            role_id="Crafter",
+            title="Investigate failures",
+            objective="Inspect the failing tests and summarize the cause.",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        ),
+        status=TaskStatus.COMPLETED,
+        assigned_instance_id="inst-sub-terminal",
+        result="already completed",
+    )
+
+    class _TerminalTaskRepo(_FakeTaskRepo):
+        def get(self, task_id: str) -> object:
+            if task_id == task_record.envelope.task_id:
+                return task_record
+            raise KeyError(task_id)
+
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="should not execute",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    agent_repo = _FakeAgentRepo()
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=agent_repo,
+        task_repo=_TerminalTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=runtime_repo,
+    )
+
+    result = await service.wait_for_subagent_run(
+        parent_run_id="run-1",
+        subagent_run_id="subagent-run-terminal",
+    )
+
+    assert result == SynchronousSubagentResult(
+        run_id="subagent-run-terminal",
+        instance_id="inst-sub-terminal",
+        role_id="Crafter",
+        task_id="task-sub-terminal",
+        title="Investigate failures",
+        output="already completed",
+    )
+    assert executor.calls == []
+    assert agent_repo.calls == []
+    persisted = repo.get(record.background_task_id)
+    assert persisted is not None
+    assert persisted.status == BackgroundTaskStatus.COMPLETED
+    assert persisted.output_excerpt == "already completed"
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_recovers_parallel_active_sync_records(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "background-task-service-subagent-sync-parallel.db"
+    repo = BackgroundTaskRepository(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    record_count = 12
+    for index in range(record_count):
+        repo.upsert(
+            _build_record(
+                background_task_id=f"sync-subagent-active-{index}",
+                execution_mode="foreground",
+                status=BackgroundTaskStatus.RUNNING,
+            ).model_copy(
+                update={
+                    "run_id": "run-1",
+                    "session_id": "session-1",
+                    "kind": BackgroundTaskKind.SUBAGENT,
+                    "instance_id": "inst-parent",
+                    "role_id": "writer",
+                    "tool_call_id": f"call-subagent-{index}",
+                    "title": f"Investigate {index}",
+                    "input_text": f"Inspect item {index}.",
+                    "command": "subagent:Crafter",
+                    "cwd": "workspace-1",
+                    "subagent_role_id": "Crafter",
+                    "subagent_run_id": f"subagent-run-recover-{index}",
+                    "subagent_task_id": f"task-sub-recover-{index}",
+                    "subagent_instance_id": f"inst-sub-recover-{index}",
+                }
+            )
+        )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="recovered analysis",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=runtime_repo,
+    )
+
+    results = await asyncio.gather(
+        *(
+            service.wait_for_subagent_run(
+                parent_run_id="run-1",
+                subagent_run_id=f"subagent-run-recover-{index}",
+            )
+            for index in range(record_count)
+        )
+    )
+
+    assert [result.run_id for result in results] == [
+        f"subagent-run-recover-{index}" for index in range(record_count)
+    ]
+    assert len(executor.calls) == record_count
+    for index in range(record_count):
+        persisted = repo.get(f"sync-subagent-active-{index}")
+        assert persisted is not None
+        assert persisted.status == BackgroundTaskStatus.COMPLETED
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_event_stream.py
+++ b/tests/unit_tests/sessions/runs/test_event_stream.py
@@ -104,7 +104,7 @@ async def test_run_event_hub_publish_async_serializes_state_updates() -> None:
     )
     queue = hub.subscribe("run-1")
 
-    await asyncio.gather(
+    published_event_ids = await asyncio.gather(
         hub.publish_async(_event(RunEventType.RUN_STARTED)),
         hub.publish_async(_event(RunEventType.MODEL_STEP_STARTED)),
     )
@@ -114,6 +114,7 @@ async def test_run_event_hub_publish_async_serializes_state_updates() -> None:
 
     assert run_state_repo.max_active_updates == 1
     assert run_state_repo.applied_event_ids == [1, 2]
+    assert published_event_ids == [1, 2]
     assert first.event_id == 1
     assert second.event_id == 2
 
@@ -193,6 +194,22 @@ async def test_run_event_hub_publish_async_finishes_projection_when_cancelled() 
 
     assert run_state_repo.max_active_updates == 1
     assert run_state_repo.applied_event_ids == [1]
+    assert delivered.event_id == 1
+
+
+def test_run_event_hub_publish_returns_event_id() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    queue = hub.subscribe("run-1")
+
+    event_id = hub.publish(_event(RunEventType.RUN_STARTED))
+    delivered = queue.get_nowait()
+
+    assert event_id == 1
     assert delivered.event_id == 1
 
 

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -166,6 +166,157 @@ class _FakePolicy:
         return self.needs_approval
 
 
+def test_execute_tool_persists_terminal_state_before_publishing_result_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    order: list[tuple[str, bool, int]] = []
+
+    async def fake_persist_tool_record_async(**kwargs: object) -> None:
+        runtime_meta = cast(dict[str, JsonValue], kwargs["runtime_meta"])
+        result_event_id = cast(int, kwargs.get("result_event_id", 0))
+        order.append(
+            (
+                "persist",
+                runtime_meta.get("tool_result_event_published") is True,
+                result_event_id,
+            )
+        )
+
+    async def fake_publish_tool_result_event_async(**kwargs: object) -> int:
+        visible_envelope = cast(dict[str, JsonValue], kwargs["visible_envelope"])
+        meta = cast(dict[str, JsonValue], visible_envelope["meta"])
+        order.append(
+            (
+                "publish",
+                meta.get("tool_result_event_published") is True,
+                42,
+            )
+        )
+        return 42
+
+    monkeypatch.setattr(
+        execution_module,
+        "_persist_tool_record_async",
+        fake_persist_tool_record_async,
+    )
+    monkeypatch.setattr(
+        execution_module,
+        "_publish_tool_result_event_async",
+        fake_publish_tool_result_event_async,
+    )
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-order-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="search",
+            args_summary={"query": "relay"},
+            action=lambda: {"matches": 1},
+        )
+    )
+
+    assert cast(dict[str, JsonValue], result)["ok"] is True
+    assert order == [
+        ("persist", False, 0),
+        ("publish", True, 42),
+        ("persist", True, 42),
+    ]
+
+
+def test_execute_tool_ignores_post_publish_result_linkage_write_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    order: list[tuple[str, int]] = []
+
+    async def fake_persist_tool_record_async(**kwargs: object) -> None:
+        result_event_id = cast(int, kwargs.get("result_event_id", 0))
+        order.append(("persist", result_event_id))
+        if result_event_id == 42:
+            raise sqlite3.OperationalError("database is locked")
+
+    async def fake_publish_tool_result_event_async(**kwargs: object) -> int:
+        _ = kwargs
+        order.append(("publish", 42))
+        return 42
+
+    monkeypatch.setattr(
+        execution_module,
+        "_persist_tool_record_async",
+        fake_persist_tool_record_async,
+    )
+    monkeypatch.setattr(
+        execution_module,
+        "_publish_tool_result_event_async",
+        fake_publish_tool_result_event_async,
+    )
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-linkage-failure"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="search",
+            args_summary={"query": "relay"},
+            action=lambda: {"matches": 1},
+        )
+    )
+
+    assert cast(dict[str, JsonValue], result)["ok"] is True
+    assert order == [
+        ("persist", 0),
+        ("publish", 42),
+        ("persist", 42),
+    ]
+
+
+def test_execute_tool_runs_when_pre_run_state_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    action_calls: list[str] = []
+
+    async def fake_mark_tool_running_async(**kwargs: object) -> None:
+        _ = kwargs
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(
+        execution_module,
+        "_mark_tool_running_async",
+        fake_mark_tool_running_async,
+    )
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-running-state-failure"
+
+    def action() -> dict[str, int]:
+        action_calls.append("ran")
+        return {"matches": 1}
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="search",
+            args_summary={"query": "relay"},
+            action=action,
+        )
+    )
+
+    assert action_calls == ["ran"]
+    assert cast(dict[str, JsonValue], result)["ok"] is True
+    assert len(_tool_result_payloads(deps)) == 1
+
+
 class _FakeDeps:
     def __init__(
         self,

--- a/tests/unit_tests/tools/runtime/test_persisted_state.py
+++ b/tests/unit_tests/tools/runtime/test_persisted_state.py
@@ -1,0 +1,669 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pydantic import JsonValue
+
+from relay_teams.agents.execution.tool_result_state import ToolResultStateService
+from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.tools.runtime.persisted_state import (
+    ToolApprovalStatus,
+    ToolCallBatchStatus,
+    ToolExecutionStatus,
+    load_or_recover_tool_call_state,
+    load_tool_call_batch_state,
+    load_tool_call_batch_state_async,
+    load_tool_call_state,
+    merge_tool_call_state,
+    recover_tool_call_batches_from_event_log,
+    recover_tool_call_state_from_event_log,
+    update_tool_call_call_state_async,
+)
+
+
+def _event(
+    event_type: RunEventType,
+    *,
+    payload: dict[str, object],
+) -> RunEvent:
+    return RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="trace-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="time",
+        event_type=event_type,
+        payload_json=json.dumps(payload),
+    )
+
+
+def test_recover_tool_call_batch_and_result_from_event_log(tmp_path: Path) -> None:
+    db_path = tmp_path / "persisted_state_recovery.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-a",
+                "args": {"timezone": "UTC"},
+                "batch_id": "batch-1",
+                "batch_index": 0,
+                "batch_size": 2,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-b",
+                "args": {"timezone": "Asia/Shanghai"},
+                "batch_id": "batch-1",
+                "batch_index": 1,
+                "batch_size": 2,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL_BATCH_SEALED,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "batch_id": "batch-1",
+                "tool_calls": [
+                    {
+                        "tool_call_id": "call-a",
+                        "tool_name": "current_time",
+                        "args": {"timezone": "UTC"},
+                        "index": 0,
+                    },
+                    {
+                        "tool_call_id": "call-b",
+                        "tool_name": "current_time",
+                        "args": {"timezone": "Asia/Shanghai"},
+                        "index": 1,
+                    },
+                ],
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    result_event_id = event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_RESULT,
+            payload={
+                "tool_name": "current_time",
+                "tool_call_id": "call-a",
+                "result": {"time": "2026-03-07T10:00:00Z"},
+                "error": False,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    batches = recover_tool_call_batches_from_event_log(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+    )
+    recovered_call = recover_tool_call_state_from_event_log(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+        tool_call_id="call-a",
+    )
+
+    assert len(batches) == 1
+    assert batches[0].status == ToolCallBatchStatus.SEALED
+    assert [item.tool_call_id for item in batches[0].items] == ["call-a", "call-b"]
+    assert json.loads(batches[0].items[0].args_preview) == {"timezone": "UTC"}
+    assert json.loads(batches[0].items[1].args_preview) == {"timezone": "Asia/Shanghai"}
+    assert recovered_call is not None
+    assert recovered_call.execution_status == ToolExecutionStatus.COMPLETED
+    assert recovered_call.batch_id == "batch-1"
+    assert recovered_call.batch_index == 0
+    assert recovered_call.batch_size == 2
+    assert recovered_call.result_event_id == result_event_id
+    assert recovered_call.result_envelope == {"time": "2026-03-07T10:00:00Z"}
+    assert ToolResultStateService().visible_tool_result_from_state(
+        state=recovered_call,
+        expected_tool_name="current_time",
+        to_json_compatible=lambda value: cast(JsonValue, value),
+    ) == {"time": "2026-03-07T10:00:00Z"}
+
+
+def test_recover_open_tool_call_batch_preserves_json_args_preview(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_open_batch_recovery.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-open",
+                "args": {"timezone": "UTC"},
+                "batch_id": "batch-open",
+                "batch_index": 0,
+                "batch_size": 2,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    batches = recover_tool_call_batches_from_event_log(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+    )
+    recovered_call = recover_tool_call_state_from_event_log(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+        tool_call_id="call-open",
+    )
+
+    assert len(batches) == 1
+    assert batches[0].status == ToolCallBatchStatus.OPEN
+    assert json.loads(batches[0].items[0].args_preview) == {"timezone": "UTC"}
+    assert recovered_call is not None
+    assert json.loads(recovered_call.args_preview) == {"timezone": "UTC"}
+
+
+def test_tool_call_state_parallel_merges_do_not_corrupt_state(
+    tmp_path: Path,
+) -> None:
+    shared_store = SharedStateRepository(tmp_path / "persisted_state_parallel.db")
+
+    def _merge(i: int) -> None:
+        merge_tool_call_state(
+            shared_store=shared_store,
+            task_id="task-1",
+            tool_call_id=f"call-{i}",
+            tool_name="current_time",
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="time",
+            args_preview='{"timezone": "UTC"}',
+            execution_status=ToolExecutionStatus.READY,
+            batch_id=f"batch-{i // 5}",
+            batch_index=i % 5,
+            batch_size=5,
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(_merge, i) for i in range(100)]
+        for future in futures:
+            future.result()
+
+    snapshot = shared_store.snapshot(
+        ScopeRef(scope_type=ScopeType.TASK, scope_id="task-1")
+    )
+    tool_call_keys = [key for key, _value in snapshot if key.startswith("tool_call_")]
+    assert len(tool_call_keys) == 100
+    recovered = load_tool_call_state(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-42",
+    )
+    assert recovered is not None
+    assert recovered.batch_id == "batch-8"
+    assert recovered.batch_index == 2
+
+
+def test_load_or_recover_replays_result_event_over_stale_running_state(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_stale_running.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    merge_tool_call_state(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-a",
+        tool_name="current_time",
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="time",
+        args_preview='{"timezone":"UTC"}',
+        execution_status=ToolExecutionStatus.RUNNING,
+        call_state={"resume_token": "token-1"},
+    )
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-a",
+                "args": {"timezone": "UTC"},
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    result_event_id = event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_RESULT,
+            payload={
+                "tool_name": "current_time",
+                "tool_call_id": "call-a",
+                "result": {
+                    "ok": True,
+                    "data": {"time": "2026-03-07T10:00:00Z"},
+                    "meta": {"tool_result_event_published": True},
+                },
+                "error": False,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    recovered_call = load_or_recover_tool_call_state(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+        tool_call_id="call-a",
+    )
+
+    assert recovered_call is not None
+    assert recovered_call.execution_status == ToolExecutionStatus.COMPLETED
+    assert recovered_call.result_event_id == result_event_id
+    assert recovered_call.call_state == {"resume_token": "token-1"}
+    assert ToolResultStateService().visible_tool_result_from_state(
+        state=recovered_call,
+        expected_tool_name="current_time",
+        to_json_compatible=lambda value: cast(JsonValue, value),
+    ) == {
+        "ok": True,
+        "data": {"time": "2026-03-07T10:00:00Z"},
+        "meta": {"tool_result_event_published": True},
+    }
+
+
+def test_parallel_load_or_recover_replays_result_events_without_state_corruption(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_parallel_recovery.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    call_count = 50
+    for i in range(call_count):
+        tool_call_id = f"call-{i}"
+        merge_tool_call_state(
+            shared_store=shared_store,
+            task_id="task-1",
+            tool_call_id=tool_call_id,
+            tool_name="current_time",
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="time",
+            args_preview='{"timezone":"UTC"}',
+            execution_status=ToolExecutionStatus.RUNNING,
+            call_state={"resume_token": f"token-{i}"},
+        )
+        event_log.emit_run_event(
+            _event(
+                RunEventType.TOOL_RESULT,
+                payload={
+                    "tool_name": "current_time",
+                    "tool_call_id": tool_call_id,
+                    "result": {
+                        "ok": True,
+                        "data": {"index": i},
+                        "meta": {"tool_result_event_published": True},
+                    },
+                    "error": False,
+                    "role_id": "time",
+                    "instance_id": "inst-1",
+                },
+            )
+        )
+
+    def _recover(i: int) -> tuple[str, ToolExecutionStatus, dict[str, JsonValue]]:
+        recovered = load_or_recover_tool_call_state(
+            event_log=event_log,
+            shared_store=shared_store,
+            trace_id="trace-1",
+            task_id="task-1",
+            tool_call_id=f"call-{i}",
+        )
+        assert recovered is not None
+        return recovered.tool_call_id, recovered.execution_status, recovered.call_state
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(_recover, i) for i in range(call_count)]
+        recovered = [future.result() for future in futures]
+
+    assert len(recovered) == call_count
+    assert {item[0] for item in recovered} == {f"call-{i}" for i in range(call_count)}
+    assert all(item[1] == ToolExecutionStatus.COMPLETED for item in recovered)
+    assert all(
+        item[2]["resume_token"] == f"token-{index}"
+        for index, item in enumerate(recovered)
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_tool_call_batch_state_returns_none_for_sync_and_async(
+    tmp_path: Path,
+) -> None:
+    shared_store = SharedStateRepository(tmp_path / "persisted_state_invalid_batch.db")
+    shared_store.manage_state(
+        StateMutation(
+            scope=ScopeRef(scope_type=ScopeType.TASK, scope_id="task-1"),
+            key="tool_call_batch:batch-invalid",
+            value_json="{not-json",
+        )
+    )
+
+    assert (
+        load_tool_call_batch_state(
+            shared_store=shared_store,
+            task_id="task-1",
+            batch_id="batch-invalid",
+        )
+        is None
+    )
+    assert (
+        await load_tool_call_batch_state_async(
+            shared_store=shared_store,
+            task_id="task-1",
+            batch_id="batch-invalid",
+        )
+        is None
+    )
+
+
+def test_load_or_recover_returns_linked_terminal_state_without_event_log(
+    tmp_path: Path,
+) -> None:
+    shared_store = SharedStateRepository(
+        tmp_path / "persisted_state_linked_terminal.db"
+    )
+    current = merge_tool_call_state(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-linked",
+        tool_name="current_time",
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="time",
+        execution_status=ToolExecutionStatus.COMPLETED,
+        result_envelope={
+            "ok": True,
+            "runtime_meta": {"tool_result_event_published": True},
+        },
+    )
+
+    recovered = load_or_recover_tool_call_state(
+        shared_store=shared_store,
+        event_log=None,
+        trace_id="trace-1",
+        task_id="task-1",
+        tool_call_id="call-linked",
+    )
+
+    assert recovered == current
+
+
+def test_load_or_recover_preserves_current_state_when_no_recovery_event_exists(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_no_recovery.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    current = merge_tool_call_state(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-ready",
+        tool_name="current_time",
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="time",
+        execution_status=ToolExecutionStatus.READY,
+        call_state={"resume_token": "ready-token"},
+    )
+
+    assert (
+        load_or_recover_tool_call_state(
+            shared_store=shared_store,
+            event_log=None,
+            trace_id="trace-1",
+            task_id="task-1",
+            tool_call_id="call-ready",
+        )
+        == current
+    )
+    assert (
+        load_or_recover_tool_call_state(
+            shared_store=shared_store,
+            event_log=event_log,
+            trace_id="trace-1",
+            task_id="task-1",
+            tool_call_id="call-ready",
+        )
+        == current
+    )
+
+
+def test_load_or_recover_creates_state_from_tool_call_event_without_current_state(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_call_only_recovery.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-new",
+                "args": '{"timezone":"UTC"}',
+                "batch_id": "batch-new",
+                "batch_index": 3,
+                "batch_size": 4,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    recovered = load_or_recover_tool_call_state(
+        shared_store=shared_store,
+        event_log=event_log,
+        trace_id="trace-1",
+        task_id="task-1",
+        tool_call_id="call-new",
+    )
+
+    assert recovered is not None
+    assert recovered.execution_status == ToolExecutionStatus.READY
+    assert recovered.batch_id == "batch-new"
+    assert recovered.batch_index == 3
+    assert recovered.batch_size == 4
+
+
+def test_recover_tool_call_state_handles_denied_and_timed_out_approval_events(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_approval_resolution.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    for action in ("deny", "timeout"):
+        tool_call_id = f"call-{action}"
+        event_log.emit_run_event(
+            _event(
+                RunEventType.TOOL_APPROVAL_RESOLVED,
+                payload={
+                    "run_id": "run-1",
+                    "session_id": "session-1",
+                    "tool_name": "shell",
+                    "tool_call_id": tool_call_id,
+                    "action": action,
+                    "feedback": f"{action} feedback",
+                    "role_id": "time",
+                    "instance_id": "inst-1",
+                },
+            )
+        )
+
+        recovered = recover_tool_call_state_from_event_log(
+            event_log=event_log,
+            shared_store=shared_store,
+            trace_id="trace-1",
+            task_id="task-1",
+            tool_call_id=tool_call_id,
+        )
+
+        assert recovered is not None
+        assert recovered.execution_status == ToolExecutionStatus.FAILED
+        assert recovered.approval_status == (
+            ToolApprovalStatus.DENY if action == "deny" else ToolApprovalStatus.TIMEOUT
+        )
+
+
+def test_recover_tool_call_batches_skips_malformed_batch_payloads(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_malformed_batches.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="trace-1",
+            task_id="task-1",
+            instance_id="inst-1",
+            role_id="time",
+            event_type=RunEventType.TOOL_CALL,
+            payload_json="{not-json",
+        )
+    )
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "batch_id": "batch-bad-call",
+                "tool_call_id": "",
+                "tool_name": "current_time",
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL_BATCH_SEALED,
+            payload={
+                "batch_id": "batch-invalid-list",
+                "tool_calls": "not-a-list",
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    event_log.emit_run_event(
+        _event(
+            RunEventType.TOOL_CALL_BATCH_SEALED,
+            payload={
+                "batch_id": "batch-good",
+                "tool_calls": [
+                    "skip-me",
+                    {"tool_call_id": "", "tool_name": "current_time"},
+                    {"tool_call_id": "call-good", "tool_name": "current_time"},
+                ],
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    batches = recover_tool_call_batches_from_event_log(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+    )
+
+    assert len(batches) == 1
+    assert batches[0].batch_id == "batch-good"
+    assert [item.tool_call_id for item in batches[0].items] == ["call-good"]
+    assert batches[0].items[0].index == 2
+
+
+@pytest.mark.asyncio
+async def test_update_tool_call_call_state_async_merges_existing_call_state(
+    tmp_path: Path,
+) -> None:
+    shared_store = SharedStateRepository(tmp_path / "persisted_state_async_update.db")
+    merge_tool_call_state(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-state",
+        tool_name="spawn_subagent",
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="writer",
+        call_state={"existing": True},
+    )
+
+    updated = await update_tool_call_call_state_async(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-state",
+        tool_name="spawn_subagent",
+        instance_id="inst-1",
+        role_id="writer",
+        mutate=lambda current: {**current, "subagent_run_id": "subagent-run-1"},
+    )
+
+    assert updated.call_state == {
+        "existing": True,
+        "subagent_run_id": "subagent-run-1",
+    }

--- a/tests/unit_tests/tools/runtime/test_recoverable_invoker.py
+++ b/tests/unit_tests/tools/runtime/test_recoverable_invoker.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pydantic import JsonValue
+from pydantic_ai import Agent
+from pydantic_ai.messages import ToolReturn
+
+from relay_teams.tools.registry import ToolRegistry
+from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.recoverable_invoker import RecoverableToolInvoker
+
+
+def _deps() -> ToolDeps:
+    return cast(
+        ToolDeps,
+        SimpleNamespace(
+            run_id="run-1",
+            session_id="session-1",
+            role_registry=object(),
+        ),
+    )
+
+
+def _registry(register: Callable[[Agent[ToolDeps, str]], None]) -> ToolRegistry:
+    return ToolRegistry({"sample_tool": register})
+
+
+@pytest.mark.asyncio
+async def test_recoverable_invoker_returns_unavailable_error_for_missing_tool() -> None:
+    result = await RecoverableToolInvoker().invoke_async(
+        tool_registry=ToolRegistry({}),
+        deps=_deps(),
+        tool_name="missing_tool",
+        tool_call_id="call-1",
+        raw_args={},
+    )
+
+    assert result["ok"] is False
+    error = result["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "tool_recovery_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_recoverable_invoker_returns_unavailable_error_for_resolution_failure() -> (
+    None
+):
+    def register(agent: Agent[ToolDeps, str]) -> None:
+        if agent.__class__.__name__ == "_ToolFunctionCollector":
+            raise RuntimeError("registry drift")
+
+    result = await RecoverableToolInvoker().invoke_async(
+        tool_registry=_registry(register),
+        deps=_deps(),
+        tool_name="sample_tool",
+        tool_call_id="call-1",
+        raw_args={},
+    )
+
+    assert result["ok"] is False
+    error = result["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "tool_recovery_unavailable"
+    assert error["message"] == "registry drift"
+
+
+@pytest.mark.asyncio
+async def test_recoverable_invoker_replays_sync_tool_with_json_string_args() -> None:
+    def register(agent: Agent[ToolDeps, str]) -> None:
+        @agent.tool()
+        def sample_tool(ctx: object, value: str, count: int) -> dict[str, JsonValue]:
+            assert getattr(ctx, "tool_call_id") == "call-1"
+            return {"ok": True, "data": {"value": value, "count": count}}
+
+    result = await RecoverableToolInvoker().invoke_async(
+        tool_registry=_registry(register),
+        deps=_deps(),
+        tool_name="sample_tool",
+        tool_call_id="call-1",
+        raw_args='{"value":"restored","count":3}',
+    )
+
+    assert result == {"ok": True, "data": {"value": "restored", "count": 3}}
+
+
+@pytest.mark.asyncio
+async def test_recoverable_invoker_normalizes_mapping_args_and_dict_result() -> None:
+    def register(agent: Agent[ToolDeps, str]) -> None:
+        @agent.tool()
+        def sample_tool(ctx: object, **kwargs: JsonValue) -> dict[str, JsonValue]:
+            _ = ctx
+            return {"ok": True, "data": kwargs}
+
+    result = await RecoverableToolInvoker().invoke_async(
+        tool_registry=_registry(register),
+        deps=_deps(),
+        tool_name="sample_tool",
+        tool_call_id="call-1",
+        raw_args={1: ("tuple", "value")},
+    )
+
+    assert result == {"ok": True, "data": {"1": ["tuple", "value"]}}
+
+
+@pytest.mark.asyncio
+async def test_recoverable_invoker_wraps_tool_return_values() -> None:
+    def register(agent: Agent[ToolDeps, str]) -> None:
+        @agent.tool()
+        def sample_tool(ctx: object) -> ToolReturn:
+            _ = ctx
+            return ToolReturn(return_value=("subagent", "complete"))
+
+    result = await RecoverableToolInvoker().invoke_async(
+        tool_registry=_registry(register),
+        deps=_deps(),
+        tool_name="sample_tool",
+        tool_call_id="call-1",
+        raw_args="not-json",
+    )
+
+    assert result == {"ok": True, "data": ["subagent", "complete"]}
+
+
+@pytest.mark.asyncio
+async def test_recoverable_invoker_preserves_tool_return_dict_values() -> None:
+    def register(agent: Agent[ToolDeps, str]) -> None:
+        @agent.tool()
+        def sample_tool(ctx: object) -> ToolReturn:
+            _ = ctx
+            return ToolReturn(return_value={"ok": True, "data": {"done": True}})
+
+    result = await RecoverableToolInvoker().invoke_async(
+        tool_registry=_registry(register),
+        deps=_deps(),
+        tool_name="sample_tool",
+        tool_call_id="call-1",
+        raw_args=[],
+    )
+
+    assert result == {"ok": True, "data": {"done": True}}
+
+
+@pytest.mark.asyncio
+async def test_recoverable_invoker_returns_tool_error_when_replay_raises() -> None:
+    def register(agent: Agent[ToolDeps, str]) -> None:
+        @agent.tool()
+        async def sample_tool(ctx: object) -> dict[str, JsonValue]:
+            _ = ctx
+            raise OSError("boom")
+
+    result = await RecoverableToolInvoker().invoke_async(
+        tool_registry=_registry(register),
+        deps=_deps(),
+        tool_name="sample_tool",
+        tool_call_id="call-1",
+        raw_args={},
+    )
+
+    assert result["ok"] is False
+    error = result["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "tool_recovery_failed"
+    assert error["message"] == "boom"

--- a/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
+++ b/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
@@ -13,6 +13,7 @@ from pydantic_ai import Agent
 import relay_teams.tools.workspace_tools as workspace_tools_module
 from relay_teams.roles.role_models import RoleDefinition, RoleMode
 from relay_teams.roles.role_registry import RoleRegistry
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.sessions.runs.background_tasks.models import (
     BackgroundTaskKind,
     BackgroundTaskRecord,
@@ -24,6 +25,7 @@ from relay_teams.tools.runtime.models import (
     ToolResultProjection,
 )
 from relay_teams.tools.runtime.models import ToolApprovalRequest
+from relay_teams.tools.runtime.persisted_state import load_tool_call_state
 from relay_teams.tools.workspace_tools import (
     register_background_tasks,
     register_list_background_tasks,
@@ -99,7 +101,7 @@ class _CapturingBackgroundTaskService:
 
     async def start_subagent(self, **kwargs: object):
         self.calls.append(dict(kwargs))
-        return BackgroundTaskRecord(
+        record = BackgroundTaskRecord(
             background_task_id="subagent_123",
             run_id="run-1",
             session_id="session-1",
@@ -117,9 +119,40 @@ class _CapturingBackgroundTaskService:
             subagent_task_id="task-1",
             subagent_instance_id="subagent-inst-1",
         )
+        callback = kwargs.get("on_launch_prepared")
+        if callable(callback):
+            launch_callback = cast(
+                Callable[[BackgroundTaskRecord], Awaitable[None]], callback
+            )
+            await launch_callback(record)
+        return record
 
     async def run_subagent(self, **kwargs: object):
         self.calls.append(dict(kwargs))
+        callback = kwargs.get("on_launch_prepared")
+        if callable(callback):
+            launch_callback = cast(
+                Callable[[BackgroundTaskRecord], Awaitable[None]], callback
+            )
+            record = BackgroundTaskRecord(
+                background_task_id="subagent_123",
+                run_id="run-1",
+                session_id="session-1",
+                kind=BackgroundTaskKind.SUBAGENT,
+                instance_id="inst-1",
+                role_id="writer",
+                tool_call_id=cast(str | None, kwargs.get("tool_call_id")),
+                title=str(kwargs["title"]),
+                command="subagent:Crafter",
+                cwd="C:/workspace",
+                execution_mode="foreground",
+                status=BackgroundTaskStatus.RUNNING,
+                subagent_role_id=str(kwargs["subagent_role_id"]),
+                subagent_run_id="subagent-run-1",
+                subagent_task_id="task-1",
+                subagent_instance_id="subagent-inst-1",
+            )
+            await launch_callback(record)
         return SimpleNamespace(
             run_id="subagent-run-1",
             instance_id="subagent-inst-1",
@@ -239,11 +272,14 @@ async def test_spawn_subagent_runs_synchronously_by_default(
         fake_agent.tools["spawn_subagent"],
     )
     service = _CapturingBackgroundTaskService()
+    shared_store = SharedStateRepository(tmp_path / "spawn-subagent-state.db")
     workspace = _FakeWorkspace(tmp_path)
     role_registry = SimpleNamespace(resolve_subagent_role_id=lambda role_id: role_id)
     ctx = SimpleNamespace(
         tool_call_id="call-1",
         deps=SimpleNamespace(
+            shared_store=shared_store,
+            task_id="task-1",
             background_task_service=service,
             workspace=workspace,
             role_registry=role_registry,
@@ -281,10 +317,16 @@ async def test_spawn_subagent_runs_synchronously_by_default(
         prompt="Inspect the failing tests and summarize the root cause.",
     )
 
-    assert service.calls[0] == {
+    call = dict(service.calls[0])
+    on_launch_prepared = call.pop("on_launch_prepared")
+    assert callable(on_launch_prepared)
+    assert call == {
         "run_id": "run-1",
         "session_id": "session-1",
         "workspace_id": "workspace-1",
+        "tool_call_id": "call-1",
+        "parent_instance_id": "inst-1",
+        "parent_role_id": "writer",
         "subagent_role_id": "Crafter",
         "subagent_role": None,
         "title": "Investigate test failures",
@@ -294,6 +336,14 @@ async def test_spawn_subagent_runs_synchronously_by_default(
         "completed": True,
         "output": "root cause found",
     }
+    state = load_tool_call_state(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-1",
+    )
+    assert state is not None
+    assert state.call_state["kind"] == "spawn_subagent_sync"
+    assert state.call_state["subagent_run_id"] == "subagent-run-1"
 
 
 @pytest.mark.asyncio
@@ -507,11 +557,14 @@ async def test_spawn_subagent_starts_background_subagent_task_when_requested(
         fake_agent.tools["spawn_subagent"],
     )
     service = _CapturingBackgroundTaskService()
+    shared_store = SharedStateRepository(tmp_path / "spawn-background-state.db")
     workspace = _FakeWorkspace(tmp_path)
     role_registry = SimpleNamespace(resolve_subagent_role_id=lambda role_id: role_id)
     ctx = SimpleNamespace(
         tool_call_id="call-1",
         deps=SimpleNamespace(
+            shared_store=shared_store,
+            task_id="task-1",
             background_task_service=service,
             workspace=workspace,
             role_registry=role_registry,
@@ -550,10 +603,21 @@ async def test_spawn_subagent_starts_background_subagent_task_when_requested(
         background=True,
     )
 
-    assert service.calls[0]["subagent_role_id"] == "Crafter"
-    assert service.calls[0]["tool_call_id"] == "call-1"
+    call = service.calls[0]
+    assert callable(call["on_launch_prepared"])
+    assert call["subagent_role_id"] == "Crafter"
+    assert call["tool_call_id"] == "call-1"
     assert result["background_task_id"] == "subagent_123"
     assert result["completed"] is False
+    state = load_tool_call_state(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-1",
+    )
+    assert state is not None
+    assert state.call_state["kind"] == "spawn_subagent_background"
+    assert state.call_state["background_task_id"] == "subagent_123"
+    assert state.call_state["subagent_run_id"] == "subagent-run-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Persist sealed tool-call batches and per-call dispatch state so paused or killed runs can recover unfinished calls safely.
- Recover pending tool results, parallel tool-call batches, foreground/background subagent calls, and normal-mode subagent state after restart.
- Harden replay history against thinking-only assistant messages, orphaned/mismatched tool results, and invalid persisted rows.
- Persist subagent launch inputs before materialization and keep foreground subagents out of startup cleanup.

Fixes #524

## Validation
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev ruff check
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests --tb=short
- uv run --extra dev pytest -q tests/integration_tests --tb=short --timeout=120