### PR TITLE
Make async runtime paths concurrency-safe

### DIFF
--- a/src/relay_teams/agents/instances/instance_repository.py
+++ b/src/relay_teams/agents/instances/instance_repository.py
@@ -8,9 +8,12 @@ from typing import Optional
 
 from relay_teams.agents.instances.enums import InstanceLifecycle, InstanceStatus
 from relay_teams.agents.instances.models import AgentRuntimeRecord
-from relay_teams.persistence import async_fetchall, async_fetchone
+from relay_teams.persistence import (
+    SharedSqliteRepository,
+    async_fetchall,
+    async_fetchone,
+)
 from relay_teams.persistence.db import run_sqlite_write_with_retry
-from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.workspace import build_conversation_id
 
 _SQLITE_SAFE_VARIABLE_LIMIT = 900
@@ -495,26 +498,26 @@ class AgentInstanceRepository(SharedSqliteRepository):
         if len(session_ids) == 0:
             return {}
         subagent_counts: dict[str, int] = {}
-        for index in range(0, len(session_ids), _SQLITE_SAFE_VARIABLE_LIMIT):
-            session_id_chunk = session_ids[index : index + _SQLITE_SAFE_VARIABLE_LIMIT]
-            placeholders = ", ".join("?" for _ in session_id_chunk)
-            rows = await self._run_async_read(
-                lambda conn, query=placeholders, parameters=session_id_chunk: (
-                    async_fetchall(
-                        conn,
-                        f"""
+        async with self._async_lock_for_current_loop():
+            conn = await self._get_async_conn()
+            for index in range(0, len(session_ids), _SQLITE_SAFE_VARIABLE_LIMIT):
+                session_id_chunk = session_ids[
+                    index : index + _SQLITE_SAFE_VARIABLE_LIMIT
+                ]
+                placeholders = ", ".join("?" for _ in session_id_chunk)
+                rows = await async_fetchall(
+                    conn,
+                    f"""
                     SELECT session_id, COUNT(*) AS subagent_count
                     FROM agent_instances
-                    WHERE session_id IN ({query})
+                    WHERE session_id IN ({placeholders})
                       AND run_id GLOB 'subagent_run_*'
                     GROUP BY session_id
                     """,
-                        parameters,
-                    )
+                    session_id_chunk,
                 )
-            )
-            for row in rows:
-                subagent_counts[str(row["session_id"])] = int(row["subagent_count"])
+                for row in rows:
+                    subagent_counts[str(row["session_id"])] = int(row["subagent_count"])
         return subagent_counts
 
     def list_session_role_instances(

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -431,78 +431,17 @@ class TaskExecutionService(BaseModel):
                     },
                 )
                 raise
-            paused_subagent = False
-            if self.run_control_manager is not None:
-                run_stop_requested = self.run_control_manager.is_run_stop_requested(
-                    task.trace_id
-                )
-                subagent_stop_requested = (
-                    self.run_control_manager.is_subagent_stop_requested(
-                        run_id=task.trace_id,
-                        instance_id=instance_id,
-                    )
-                )
-                stopped = self.run_control_manager.handle_instance_cancelled(
+            cleanup_task = asyncio.create_task(
+                self._persist_cancelled_execution_async(
                     task=task,
                     instance_id=instance_id,
+                    role_id=role_id,
+                    is_coordinator=is_coordinator,
                 )
-                paused_subagent = (
-                    stopped
-                    and not is_coordinator
-                    and subagent_stop_requested
-                    and not run_stop_requested
-                )
-            else:
-                stopped = False
-                await self.task_repo.update_status_async(
-                    task.task_id,
-                    TaskStatus.FAILED,
-                    error_message="Task cancelled",
-                )
-                await self.agent_repo.mark_status_async(
-                    instance_id, InstanceStatus.FAILED
-                )
-                await self.event_bus.emit_async(
-                    EventEnvelope(
-                        event_type=EventType.TASK_FAILED,
-                        trace_id=task.trace_id,
-                        session_id=task.session_id,
-                        task_id=task.task_id,
-                        instance_id=instance_id,
-                        payload_json="{}",
-                    )
-                )
-            last_error = "Task stopped by user" if stopped else "Task cancelled"
-            if paused_subagent:
-                if not await self._promote_running_runtime_lane_async(
-                    run_id=task.trace_id,
-                    terminal_task_id=task.task_id,
-                    last_error=last_error,
-                ):
-                    await self.run_runtime_repo.update_async(
-                        task.trace_id,
-                        status=RunRuntimeStatus.STOPPED,
-                        phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
-                        active_instance_id=None,
-                        active_task_id=task.task_id,
-                        active_role_id=role_id,
-                        active_subagent_instance_id=instance_id,
-                        last_error=last_error,
-                    )
-            else:
-                await self._mark_runtime_after_terminal_task_update_async(
-                    run_id=task.trace_id,
-                    terminal_task_id=task.task_id,
-                    status=(
-                        RunRuntimeStatus.STOPPED if stopped else RunRuntimeStatus.FAILED
-                    ),
-                    phase=RunRuntimePhase.IDLE,
-                    active_instance_id=None,
-                    active_task_id=None,
-                    active_role_id=None,
-                    active_subagent_instance_id=None,
-                    last_error=last_error,
-                )
+            )
+            stopped, paused_subagent = await _await_cancellation_resistant_task(
+                cleanup_task
+            )
             log_event(
                 LOGGER,
                 logging.WARNING if stopped else logging.ERROR,
@@ -1369,6 +1308,84 @@ class TaskExecutionService(BaseModel):
             last_error=last_error,
         )
 
+    async def _persist_cancelled_execution_async(
+        self,
+        *,
+        task: TaskEnvelope,
+        instance_id: str,
+        role_id: str,
+        is_coordinator: bool,
+    ) -> tuple[bool, bool]:
+        paused_subagent = False
+        if self.run_control_manager is not None:
+            run_stop_requested = self.run_control_manager.is_run_stop_requested(
+                task.trace_id
+            )
+            subagent_stop_requested = (
+                self.run_control_manager.is_subagent_stop_requested(
+                    run_id=task.trace_id,
+                    instance_id=instance_id,
+                )
+            )
+            stopped = await self.run_control_manager.handle_instance_cancelled_async(
+                task=task,
+                instance_id=instance_id,
+            )
+            paused_subagent = (
+                stopped
+                and not is_coordinator
+                and subagent_stop_requested
+                and not run_stop_requested
+            )
+        else:
+            stopped = False
+            await self.task_repo.update_status_async(
+                task.task_id,
+                TaskStatus.FAILED,
+                error_message="Task cancelled",
+            )
+            await self.agent_repo.mark_status_async(instance_id, InstanceStatus.FAILED)
+            await self.event_bus.emit_async(
+                EventEnvelope(
+                    event_type=EventType.TASK_FAILED,
+                    trace_id=task.trace_id,
+                    session_id=task.session_id,
+                    task_id=task.task_id,
+                    instance_id=instance_id,
+                    payload_json="{}",
+                )
+            )
+        last_error = "Task stopped by user" if stopped else "Task cancelled"
+        if paused_subagent:
+            if not await self._promote_running_runtime_lane_async(
+                run_id=task.trace_id,
+                terminal_task_id=task.task_id,
+                last_error=last_error,
+            ):
+                await self.run_runtime_repo.update_async(
+                    task.trace_id,
+                    status=RunRuntimeStatus.STOPPED,
+                    phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
+                    active_instance_id=None,
+                    active_task_id=task.task_id,
+                    active_role_id=role_id,
+                    active_subagent_instance_id=instance_id,
+                    last_error=last_error,
+                )
+        else:
+            await self._mark_runtime_after_terminal_task_update_async(
+                run_id=task.trace_id,
+                terminal_task_id=task.task_id,
+                status=RunRuntimeStatus.STOPPED if stopped else RunRuntimeStatus.FAILED,
+                phase=RunRuntimePhase.IDLE,
+                active_instance_id=None,
+                active_task_id=None,
+                active_role_id=None,
+                active_subagent_instance_id=None,
+                last_error=last_error,
+            )
+        return stopped, paused_subagent
+
     def _promote_running_runtime_lane(
         self,
         *,
@@ -1634,6 +1651,25 @@ async def _cancel_and_wait(
             },
         )
         return None
+
+
+async def _await_cancellation_resistant_task(
+    task: asyncio.Task[TaskResultT],
+) -> TaskResultT:
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            _clear_current_task_cancellation_requests()
+    return task.result()
+
+
+def _clear_current_task_cancellation_requests() -> None:
+    current_task = asyncio.current_task()
+    if current_task is None:
+        return
+    while current_task.cancelling():
+        current_task.uncancel()
 
 
 def _raise_if_timeout_cancellation_requested(

--- a/src/relay_teams/gateway/acp_stdio.py
+++ b/src/relay_teams/gateway/acp_stdio.py
@@ -461,7 +461,7 @@ class AcpGatewayServer:
         if method == "session/resume":
             return await self._resume_session(params, observer=observer)
         if method == "session/cancel":
-            return self._cancel_session(params, observer=observer)
+            return await self._cancel_session(params, observer=observer)
         if method == "mcp/connect":
             return await self._mcp_connect(params, observer=observer)
         if method == "mcp/message":
@@ -477,7 +477,7 @@ class AcpGatewayServer:
         observer: _AcpRequestObserver | None = None,
     ) -> None:
         if method == "session/cancel":
-            _ = self._cancel_session(params, observer=observer)
+            _ = await self._cancel_session(params, observer=observer)
             return
         if method == "initialized":
             return
@@ -635,7 +635,7 @@ class AcpGatewayServer:
         )
         with self._mcp_relay.session_scope(gateway_session_id):
             try:
-                run_id = self._start_prompt_run(
+                run_id = await self._start_prompt_run(
                     intent,
                     force_attach_recoverable=recoverable_run_id is not None,
                 )
@@ -699,7 +699,7 @@ class AcpGatewayServer:
             "recoverable": result.recoverable,
         }
 
-    def _start_prompt_run(
+    async def _start_prompt_run(
         self,
         intent: IntentInput,
         *,
@@ -708,7 +708,7 @@ class AcpGatewayServer:
         # ACP follow-up prompts should be able to resume a recoverable run even
         # when the gateway ingress layer would otherwise treat the session as busy.
         if self._session_ingress_service is not None and not force_attach_recoverable:
-            result = self._session_ingress_service.require_started(
+            result = await self._session_ingress_service.require_started_async(
                 GatewaySessionIngressRequest(
                     intent=intent,
                     busy_policy=GatewaySessionIngressBusyPolicy.REJECT_IF_BUSY,
@@ -717,8 +717,8 @@ class AcpGatewayServer:
             if result.run_id is None:
                 raise RuntimeError("acp_run_not_started")
             return result.run_id
-        run_id, _ = self._run_service.create_run(intent)
-        self._run_service.ensure_run_started(run_id)
+        run_id, _ = await self._run_service.create_run_async(intent)
+        await self._run_service.ensure_run_started_async(run_id)
         return run_id
 
     async def _resume_session(
@@ -743,8 +743,8 @@ class AcpGatewayServer:
             run_id=run_id,
         )
         with self._mcp_relay.session_scope(gateway_session_id):
-            self._run_service.resume_run(run_id)
-            self._run_service.ensure_run_started(run_id)
+            await self._run_service.resume_run_async(run_id)
+            await self._run_service.ensure_run_started_async(run_id)
             self._active_runs[gateway_session_id] = run_id
             _ = self._gateway_session_service.bind_active_run(
                 gateway_session_id, run_id
@@ -1080,7 +1080,7 @@ class AcpGatewayServer:
             )
         return None
 
-    def _cancel_session(
+    async def _cancel_session(
         self,
         params: dict[str, JsonValue],
         *,
@@ -1098,7 +1098,7 @@ class AcpGatewayServer:
         if run_id is not None:
             if observer is not None:
                 observer.bind_run_id(run_id)
-            self._run_service.stop_run(run_id)
+            await self._run_service.stop_run_async(run_id)
         return {"status": "ok"}
 
     def _finalize_active_run_binding(

--- a/src/relay_teams/gateway/session_ingress_service.py
+++ b/src/relay_teams/gateway/session_ingress_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable
 from enum import Enum
 from typing import Protocol, cast
 
@@ -60,6 +61,16 @@ class _EnsureRunStarted(Protocol):
     def __call__(self, run_id: str) -> None: ...
 
 
+class _CreateDetachedRunAsync(Protocol):
+    def __call__(self, intent: IntentInput) -> Awaitable[tuple[str, str]]:
+        raise NotImplementedError
+
+
+class _EnsureRunStartedAsync(Protocol):
+    def __call__(self, run_id: str) -> Awaitable[None]:
+        raise NotImplementedError
+
+
 class GatewaySessionIngressService:
     def __init__(
         self,
@@ -113,14 +124,66 @@ class GatewaySessionIngressService:
             blocking_run_id=blocking_run_id,
         )
 
+    async def submit_async(
+        self,
+        request: GatewaySessionIngressRequest,
+    ) -> GatewaySessionIngressResult:
+        blocking_run_id = await self.active_run_id_async(request.intent.session_id)
+        if blocking_run_id is not None:
+            return self._busy_result(
+                session_id=request.intent.session_id,
+                blocking_run_id=blocking_run_id,
+                busy_policy=request.busy_policy,
+            )
+        safe_intent = request.intent.model_copy(deep=True)
+        try:
+            run_id, _ = await self._create_detached_run_async(safe_intent)
+            await self._ensure_run_started_async(run_id)
+        except RuntimeError as exc:
+            blocking_run_id = await self.active_run_id_async(request.intent.session_id)
+            if blocking_run_id is None or not _looks_like_session_busy_error(exc):
+                raise
+            return self._busy_result(
+                session_id=request.intent.session_id,
+                blocking_run_id=blocking_run_id,
+                busy_policy=request.busy_policy,
+            )
+        return GatewaySessionIngressResult(
+            status=GatewaySessionIngressStatus.STARTED,
+            session_id=request.intent.session_id,
+            run_id=run_id,
+        )
+
+    async def require_started_async(
+        self,
+        request: GatewaySessionIngressRequest,
+    ) -> GatewaySessionIngressResult:
+        result = await self.submit_async(request)
+        if result.status is GatewaySessionIngressStatus.STARTED:
+            return result
+        blocking_run_id = str(result.blocking_run_id or "").strip() or "unknown"
+        raise GatewaySessionBusyError(
+            session_id=request.intent.session_id,
+            blocking_run_id=blocking_run_id,
+        )
+
     def active_run_id(self, session_id: str) -> str | None:
         for runtime in self._list_session_runtimes(session_id):
             if self._is_busy_runtime(runtime):
                 return runtime.run_id
         return None
 
+    async def active_run_id_async(self, session_id: str) -> str | None:
+        for runtime in await self._list_session_runtimes_async(session_id):
+            if self._is_busy_runtime(runtime):
+                return runtime.run_id
+        return None
+
     def is_session_busy(self, session_id: str) -> bool:
         return self.active_run_id(session_id) is not None
+
+    async def is_session_busy_async(self, session_id: str) -> bool:
+        return await self.active_run_id_async(session_id) is not None
 
     def _busy_result(
         self,
@@ -150,6 +213,17 @@ class GatewaySessionIngressService:
             )
         )
 
+    async def _list_session_runtimes_async(
+        self, session_id: str
+    ) -> tuple[RunRuntimeRecord, ...]:
+        return tuple(
+            sorted(
+                await self._run_runtime_repo.list_by_session_async(session_id),
+                key=lambda item: item.updated_at,
+                reverse=True,
+            )
+        )
+
     @staticmethod
     def _is_busy_runtime(runtime: RunRuntimeRecord) -> bool:
         return runtime.status in {
@@ -170,11 +244,29 @@ class GatewaySessionIngressService:
             raise RuntimeError("Gateway session ingress run service is unavailable")
         return cast(_CreateDetachedRun, create_run)(intent)
 
+    async def _create_detached_run_async(self, intent: IntentInput) -> tuple[str, str]:
+        run_service = self._run_service
+        create_detached_run = getattr(run_service, "create_detached_run_async", None)
+        if callable(create_detached_run):
+            return await cast(_CreateDetachedRunAsync, create_detached_run)(intent)
+        create_run = getattr(run_service, "create_run_async", None)
+        if not callable(create_run):
+            raise RuntimeError("Gateway session ingress run service is unavailable")
+        return await cast(_CreateDetachedRunAsync, create_run)(intent)
+
     def _ensure_run_started(self, run_id: str) -> None:
         ensure_run_started = getattr(self._run_service, "ensure_run_started", None)
         if not callable(ensure_run_started):
             raise RuntimeError("Gateway session ingress run service is unavailable")
         cast(_EnsureRunStarted, ensure_run_started)(run_id)
+
+    async def _ensure_run_started_async(self, run_id: str) -> None:
+        ensure_run_started = getattr(
+            self._run_service, "ensure_run_started_async", None
+        )
+        if not callable(ensure_run_started):
+            raise RuntimeError("Gateway session ingress run service is unavailable")
+        await cast(_EnsureRunStartedAsync, ensure_run_started)(run_id)
 
 
 def _looks_like_session_busy_error(error: RuntimeError) -> bool:

--- a/src/relay_teams/hooks/hook_service.py
+++ b/src/relay_teams/hooks/hook_service.py
@@ -46,7 +46,7 @@ from relay_teams.hooks.hook_models import (
 from relay_teams.hooks.hook_runtime_state import HookRuntimeState
 from relay_teams.logger import get_logger, log_event
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
-from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
 
 LOGGER = get_logger(__name__)
@@ -197,7 +197,7 @@ class HookService:
         for resolved in snapshot.hooks.get(event_input.event_name, ()):
             if hook_matches_event(resolved.group, event_input, tool_name=tool_name):
                 matches.append(resolved)
-                _publish_hook_event(
+                await _publish_hook_event_async(
                     run_event_hub=run_event_hub,
                     event_input=event_input,
                     event_type=RunEventType.HOOK_MATCHED,
@@ -272,7 +272,7 @@ class HookService:
         if bundle.executions:
             conflicts = _decision_conflicts(bundle.executions)
             if conflicts:
-                _publish_hook_event(
+                await _publish_hook_event_async(
                     run_event_hub=run_event_hub,
                     event_input=event_input,
                     event_type=RunEventType.HOOK_CONFLICT,
@@ -282,7 +282,7 @@ class HookService:
                         "conflicts": list(conflicts),
                     },
                 )
-            _publish_hook_event(
+            await _publish_hook_event_async(
                 run_event_hub=run_event_hub,
                 event_input=event_input,
                 event_type=RunEventType.HOOK_DECISION_APPLIED,
@@ -311,7 +311,7 @@ class HookService:
                     source=source,
                     run_event_hub=run_event_hub,
                 )
-                self._apply_async_rewake(
+                await self._apply_async_rewake(
                     event_input=event_input,
                     handler=handler,
                     result=result,
@@ -334,7 +334,7 @@ class HookService:
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-    def _apply_async_rewake(
+    async def _apply_async_rewake(
         self,
         *,
         event_input: HookEventInput,
@@ -359,7 +359,7 @@ class HookService:
             source=InjectionSource.SYSTEM,
             content=content,
         )
-        _publish_hook_event(
+        await _publish_hook_event_async(
             run_event_hub=run_event_hub,
             event_input=event_input,
             event_type=RunEventType.HOOK_DEFERRED,
@@ -396,7 +396,7 @@ class HookService:
             )
             or handler.type.value
         )
-        _publish_hook_event(
+        await _publish_hook_event_async(
             run_event_hub=run_event_hub,
             event_input=event_input,
             event_type=RunEventType.HOOK_STARTED,
@@ -445,7 +445,7 @@ class HookService:
                 decision=decision,
                 duration_ms=int((time.perf_counter() - started) * 1000),
             )
-            _publish_hook_event(
+            await _publish_hook_event_async(
                 run_event_hub=run_event_hub,
                 event_input=event_input,
                 event_type=RunEventType.HOOK_COMPLETED,
@@ -462,7 +462,7 @@ class HookService:
             return result
         except NonBlockingHttpHookError as exc:
             duration_ms = int((time.perf_counter() - started) * 1000)
-            _publish_hook_event(
+            await _publish_hook_event_async(
                 run_event_hub=run_event_hub,
                 event_input=event_input,
                 event_type=RunEventType.HOOK_FAILED,
@@ -499,7 +499,7 @@ class HookService:
                 },
                 exc_info=exc,
             )
-            _publish_hook_event(
+            await _publish_hook_event_async(
                 run_event_hub=run_event_hub,
                 event_input=event_input,
                 event_type=RunEventType.HOOK_FAILED,
@@ -703,7 +703,7 @@ def _default_decision(event_name: HookEventName) -> HookDecisionType:
     return HookDecisionType.ALLOW
 
 
-def _publish_hook_event(
+async def _publish_hook_event_async(
     *,
     run_event_hub: RunEventHub | None,
     event_input: HookEventInput,
@@ -712,7 +712,8 @@ def _publish_hook_event(
 ) -> None:
     if run_event_hub is None:
         return
-    run_event_hub.publish(
+    await publish_run_event_async(
+        run_event_hub,
         RunEvent(
             session_id=event_input.session_id,
             run_id=event_input.run_id,
@@ -722,5 +723,5 @@ def _publish_hook_event(
             role_id=event_input.role_id,
             event_type=event_type,
             payload_json=dumps(payload, ensure_ascii=False),
-        )
+        ),
     )

--- a/src/relay_teams/persistence/__init__.py
+++ b/src/relay_teams/persistence/__init__.py
@@ -23,6 +23,7 @@ from relay_teams.persistence.sqlite_repository import (
     SharedSqliteRepository,
     async_fetchall,
     async_fetchone,
+    close_live_sqlite_repositories_async,
 )
 from relay_teams.persistence.shared_state_repo import (
     SharedStateRepository,
@@ -46,6 +47,7 @@ __all__ = [
     "async_sqlite_compile_options",
     "async_sqlite_supports_fts5",
     "build_global_scope_ref",
+    "close_live_sqlite_repositories_async",
     "is_retryable_sqlite_error",
     "open_async_sqlite",
     "run_async_blocking",

--- a/src/relay_teams/persistence/db.py
+++ b/src/relay_teams/persistence/db.py
@@ -114,7 +114,7 @@ class CrossModeWriteCoordinator:
         )
         initial_depth = self._owned_depth(token)
         try:
-            while not await asyncio.to_thread(self._try_acquire, token):
+            while not self._try_acquire(token):
                 await asyncio.sleep(0.001)
         except asyncio.CancelledError:
             self._release_cancelled_acquire(token, initial_depth)

--- a/src/relay_teams/persistence/sqlite_repository.py
+++ b/src/relay_teams/persistence/sqlite_repository.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable, Iterator
 from pathlib import Path
 from threading import RLock
 from typing import Awaitable, Callable, Optional, ParamSpec, TypeVar
-from weakref import WeakKeyDictionary
+from weakref import WeakKeyDictionary, WeakSet
 
 import aiosqlite
 
@@ -181,6 +181,24 @@ class SharedSqliteRepository:
             asyncio.AbstractEventLoop, asyncio.Lock
         ] = WeakKeyDictionary()
         self._repository_name = repository_name or type(self).__name__
+        _LIVE_REPOSITORIES.add(self)
+
+    def close(self) -> None:
+        try:
+            _ = asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "Cannot synchronously close SQLite repository from a running event "
+                "loop; use close_async instead."
+            )
+        close_task = self.close_async()
+        try:
+            run_async_blocking(close_task)
+        except Exception:
+            close_task.close()
+            raise
 
     # noinspection PyTypeHints
     def _run_read(self, operation: Callable[[], ResultT]) -> ResultT:
@@ -283,3 +301,11 @@ class SharedSqliteRepository:
         **kwargs: ParamT.kwargs,
     ) -> ResultT:
         return await asyncio.to_thread(function, *args, **kwargs)
+
+
+_LIVE_REPOSITORIES: WeakSet[SharedSqliteRepository] = WeakSet()
+
+
+async def close_live_sqlite_repositories_async() -> None:
+    for repository in tuple(_LIVE_REPOSITORIES):
+        await repository.close_async()

--- a/src/relay_teams/roles/runtime_role_resolver.py
+++ b/src/relay_teams/roles/runtime_role_resolver.py
@@ -111,6 +111,9 @@ class RuntimeRoleResolver:
     def cleanup_run(self, *, run_id: str) -> None:
         self._temporary_role_repository.delete_by_run(run_id)
 
+    async def cleanup_run_async(self, *, run_id: str) -> None:
+        await self._temporary_role_repository.delete_by_run_async(run_id)
+
     def _merge_with_template(
         self, *, run_id: str, role: TemporaryRoleSpec
     ) -> TemporaryRoleSpec:

--- a/src/relay_teams/roles/temporary_role_repository.py
+++ b/src/relay_teams/roles/temporary_role_repository.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
 from relay_teams.computer import ExecutionSurface
+from relay_teams.persistence import async_fetchall, async_fetchone
 from relay_teams.persistence.db import run_sqlite_write_with_retry
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.roles.memory_models import MemoryProfile
@@ -133,7 +135,65 @@ class TemporaryRoleRepository(SharedSqliteRepository):
         return self.get(run_id=record.run_id, role_id=record.role.role_id)
 
     async def upsert_async(self, record: TemporaryRoleRecord) -> TemporaryRoleRecord:
-        return await self._call_sync_async(self.upsert, record)
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO temporary_roles(
+                    run_id, session_id, role_id, source, name, description, version,
+                    tools_json, mcp_servers_json, skills_json, model_profile,
+                    bound_agent_id, execution_surface, memory_profile_json, system_prompt, template_role_id,
+                    created_at, updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id, role_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    source=excluded.source,
+                    name=excluded.name,
+                    description=excluded.description,
+                    version=excluded.version,
+                    tools_json=excluded.tools_json,
+                    mcp_servers_json=excluded.mcp_servers_json,
+                    skills_json=excluded.skills_json,
+                    model_profile=excluded.model_profile,
+                    bound_agent_id=excluded.bound_agent_id,
+                    execution_surface=excluded.execution_surface,
+                    memory_profile_json=excluded.memory_profile_json,
+                    system_prompt=excluded.system_prompt,
+                    template_role_id=excluded.template_role_id,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    record.run_id,
+                    record.session_id,
+                    record.role.role_id,
+                    record.source,
+                    record.role.name,
+                    record.role.description,
+                    record.role.version,
+                    _json_tuple(record.role.tools),
+                    _json_tuple(record.role.mcp_servers),
+                    _json_tuple(record.role.skills),
+                    record.role.model_profile,
+                    record.role.bound_agent_id,
+                    record.role.execution_surface.value,
+                    record.role.memory_profile.model_dump_json(),
+                    record.role.system_prompt,
+                    record.role.template_role_id,
+                    record.created_at.isoformat(),
+                    now,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="upsert_async",
+            operation=lambda _conn: operation(),
+        )
+        return await self.get_async(run_id=record.run_id, role_id=record.role.role_id)
 
     def get(self, *, run_id: str, role_id: str) -> TemporaryRoleRecord:
         with self._lock:
@@ -148,7 +208,18 @@ class TemporaryRoleRepository(SharedSqliteRepository):
         return self._to_record(row)
 
     async def get_async(self, *, run_id: str, role_id: str) -> TemporaryRoleRecord:
-        return await self._call_sync_async(self.get, run_id=run_id, role_id=role_id)
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT * FROM temporary_roles WHERE run_id=? AND role_id=?",
+                (run_id, role_id),
+            )
+        )
+        if row is None:
+            raise KeyError(
+                f"Unknown temporary role: run_id={run_id}, role_id={role_id}"
+            )
+        return self._to_record(row)
 
     def list_by_run(self, run_id: str) -> tuple[TemporaryRoleRecord, ...]:
         with self._lock:
@@ -159,7 +230,14 @@ class TemporaryRoleRepository(SharedSqliteRepository):
         return tuple(self._to_record(row) for row in rows)
 
     async def list_by_run_async(self, run_id: str) -> tuple[TemporaryRoleRecord, ...]:
-        return await self._call_sync_async(self.list_by_run, run_id)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM temporary_roles WHERE run_id=? ORDER BY created_at ASC",
+                (run_id,),
+            )
+        )
+        return tuple(self._to_record(row) for row in rows)
 
     def delete_by_run(self, run_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -174,7 +252,18 @@ class TemporaryRoleRepository(SharedSqliteRepository):
         )
 
     async def delete_by_run_async(self, run_id: str) -> None:
-        return await self._call_sync_async(self.delete_by_run, run_id)
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM temporary_roles WHERE run_id=?",
+                (run_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_run_async",
+            operation=lambda _conn: operation(),
+        )
 
     def _to_record(self, row: sqlite3.Row) -> TemporaryRoleRecord:
         return TemporaryRoleRecord(
@@ -214,14 +303,10 @@ class TemporaryRoleRepository(SharedSqliteRepository):
 
 
 def _json_tuple(values: tuple[str, ...]) -> str:
-    import json
-
     return json.dumps(list(values), ensure_ascii=False)
 
 
 def _json_load_tuple(raw: str) -> tuple[str, ...]:
-    import json
-
     loaded = json.loads(raw)
     if not isinstance(loaded, list):
         return ()
@@ -229,7 +314,5 @@ def _json_load_tuple(raw: str) -> tuple[str, ...]:
 
 
 def _memory_profile_from_json(raw: str) -> "MemoryProfile":
-    import json
-
     payload = json.loads(raw)
     return MemoryProfile.model_validate(payload)

--- a/src/relay_teams/sessions/runs/background_tasks/manager.py
+++ b/src/relay_teams/sessions/runs/background_tasks/manager.py
@@ -583,7 +583,7 @@ class BackgroundTaskManager:
             runtime.record = record
             persisted = False
             try:
-                runtime.record = self._repository.upsert(record)
+                runtime.record = await self._repository.upsert_async(record)
                 persisted = True
                 await self._publish_background_task_event_async(
                     event_type=RunEventType.BACKGROUND_TASK_STARTED,
@@ -596,7 +596,7 @@ class BackgroundTaskManager:
             except Exception:
                 self._runtimes.pop(background_task_id, None)
                 if persisted:
-                    self._repository.delete(background_task_id)
+                    await self._repository.delete_async(background_task_id)
                 await self._rollback_runtime(runtime)
                 raise
             runtime.supervisor_task = asyncio.create_task(self._supervise(runtime))
@@ -685,11 +685,14 @@ class BackgroundTaskManager:
         run_id: str,
         background_task_id: str,
     ) -> tuple[BackgroundTaskRecord, bool]:
-        record = self.get_for_run(run_id=run_id, background_task_id=background_task_id)
+        record = await self.get_for_run_async(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
         runtime = self._runtimes.get(background_task_id)
         if runtime is not None:
             await runtime.completed.wait()
-            return self._get_record(background_task_id), True
+            return await self._get_record_async(background_task_id), True
         if not record.is_active:
             return record, True
         return record, False
@@ -703,7 +706,10 @@ class BackgroundTaskManager:
         yield_time_ms: int | None,
         is_initial_poll: bool = False,
     ) -> tuple[BackgroundTaskRecord, bool]:
-        record = self.get_for_run(run_id=run_id, background_task_id=background_task_id)
+        record = await self.get_for_run_async(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
         runtime = self._runtimes.get(background_task_id)
         if not record.is_active:
             return record, True
@@ -722,7 +728,7 @@ class BackgroundTaskManager:
             before_version=before_version,
             timeout_ms=timeout_ms,
         )
-        updated = self._get_record(background_task_id)
+        updated = await self._get_record_async(background_task_id)
         return updated, not updated.is_active
 
     async def resize_for_run(
@@ -735,7 +741,10 @@ class BackgroundTaskManager:
     ) -> BackgroundTaskRecord:
         if columns < 1 or rows < 1:
             raise ValueError("columns and rows must both be >= 1")
-        record = self.get_for_run(run_id=run_id, background_task_id=background_task_id)
+        record = await self.get_for_run_async(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
         runtime = self._runtimes.get(background_task_id)
         if runtime is None or not record.is_active:
             return record
@@ -752,7 +761,10 @@ class BackgroundTaskManager:
         reason: str = "stopped_by_user",
     ) -> BackgroundTaskRecord:
         _ = reason
-        record = self.get_for_run(run_id=run_id, background_task_id=background_task_id)
+        record = await self.get_for_run_async(
+            run_id=run_id,
+            background_task_id=background_task_id,
+        )
         runtime = self._runtimes.get(background_task_id)
         if not record.is_active:
             return record
@@ -788,7 +800,7 @@ class BackgroundTaskManager:
                 timed_out=False,
                 wait_for_exit=False,
             )
-        return self._get_record(background_task_id)
+        return await self._get_record_async(background_task_id)
 
     async def _stop_persisted_record_without_runtime(
         self,
@@ -809,9 +821,9 @@ class BackgroundTaskManager:
                     "pid": record.pid,
                 },
             )
-            return self._get_record(record.background_task_id)
+            return await self._get_record_async(record.background_task_id)
         completed_at = datetime.now(tz=timezone.utc)
-        updated = self._repository.upsert(
+        updated = await self._repository.upsert_async(
             record.model_copy(
                 update={
                     "status": BackgroundTaskStatus.STOPPED,
@@ -840,7 +852,7 @@ class BackgroundTaskManager:
     ) -> None:
         active_ids = [
             record.background_task_id
-            for record in self._repository.list_by_run(run_id)
+            for record in await self._repository.list_by_run_async(run_id)
             if record.is_active
             and (execution_mode is None or record.execution_mode == execution_mode)
         ]
@@ -855,7 +867,7 @@ class BackgroundTaskManager:
     async def close(self) -> None:
         active_ids = list(self._runtimes.keys())
         for background_task_id in active_ids:
-            record = self._repository.get(background_task_id)
+            record = await self._repository.get_async(background_task_id)
             if record is None:
                 continue
             with contextlib.suppress(KeyError):
@@ -1332,15 +1344,14 @@ class BackgroundTaskManager:
         )
         runtime.recent_output.feed(chunk)
         runtime.output_buffer.append(chunk)
-        runtime.record = await self._run_blocking(
-            self._repository.upsert,
+        runtime.record = await self._repository.upsert_async(
             runtime.record.model_copy(
                 update={
                     "recent_output": runtime.recent_output.snapshot(),
                     "output_excerpt": runtime.output_buffer.render(),
                     "updated_at": datetime.now(tz=timezone.utc),
                 }
-            ),
+            )
         )
         await self._emit_monitor_lines_async(
             runtime,
@@ -1381,8 +1392,7 @@ class BackgroundTaskManager:
                 timed_out=timed_out,
             )
             completed_at = datetime.now(tz=timezone.utc)
-            runtime.record = await self._run_blocking(
-                self._repository.upsert,
+            runtime.record = await self._repository.upsert_async(
                 runtime.record.model_copy(
                     update={
                         "status": status,
@@ -1393,7 +1403,7 @@ class BackgroundTaskManager:
                         "updated_at": completed_at,
                         "completed_at": completed_at,
                     }
-                ),
+                )
             )
             runtime_id = runtime.record.background_task_id
             self._runtimes.pop(runtime_id, None)
@@ -1494,7 +1504,7 @@ class BackgroundTaskManager:
             runtime.change_condition.notify_all()
 
     async def _prune_sessions_if_needed(self) -> None:
-        records = list(self._repository.list_all())
+        records = list(await self._repository.list_all_async())
         if len(records) < MAX_BACKGROUND_TASKS:
             return
         required_slots = len(records) - MAX_BACKGROUND_TASKS + 1
@@ -1510,7 +1520,7 @@ class BackgroundTaskManager:
             if record.background_task_id not in protected and not record.is_active
         ]
         for record in reclaimable[:required_slots]:
-            self._repository.delete(record.background_task_id)
+            await self._repository.delete_async(record.background_task_id)
         required_slots -= min(required_slots, len(reclaimable))
         if required_slots <= 0:
             return
@@ -1529,7 +1539,7 @@ class BackgroundTaskManager:
                 )
             if stopped_record is None or stopped_record.is_active:
                 continue
-            self._repository.delete(record.background_task_id)
+            await self._repository.delete_async(record.background_task_id)
 
     async def _publish_background_task_event_async(
         self,

--- a/src/relay_teams/sessions/runs/background_tasks/repository.py
+++ b/src/relay_teams/sessions/runs/background_tasks/repository.py
@@ -7,6 +7,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
+import aiosqlite
+
+from relay_teams.persistence import async_fetchall, async_fetchone
 from relay_teams.persistence.db import run_sqlite_write_with_retry
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.runs.background_tasks.models import (
@@ -203,7 +206,82 @@ class BackgroundTaskRepository(SharedSqliteRepository):
         return persisted
 
     async def upsert_async(self, record: BackgroundTaskRecord) -> BackgroundTaskRecord:
-        return await self._call_sync_async(self.upsert, record)
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                """
+                INSERT INTO background_tasks(
+                    background_task_id,
+                    run_id,
+                    session_id,
+                    kind,
+                    instance_id,
+                    role_id,
+                    tool_call_id,
+                    title,
+                    command,
+                    cwd,
+                    execution_mode,
+                    status,
+                    tty,
+                    timeout_ms,
+                    pid,
+                    exit_code,
+                    recent_output_json,
+                    output_excerpt,
+                    log_path,
+                    subagent_role_id,
+                    subagent_run_id,
+                    subagent_task_id,
+                    subagent_instance_id,
+                    created_at,
+                    updated_at,
+                    completed_at,
+                    completion_notified_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(background_task_id)
+                DO UPDATE SET
+                    run_id=excluded.run_id,
+                    session_id=excluded.session_id,
+                    kind=excluded.kind,
+                    instance_id=excluded.instance_id,
+                    role_id=excluded.role_id,
+                    tool_call_id=excluded.tool_call_id,
+                    title=excluded.title,
+                    command=excluded.command,
+                    cwd=excluded.cwd,
+                    execution_mode=excluded.execution_mode,
+                    status=excluded.status,
+                    tty=excluded.tty,
+                    timeout_ms=excluded.timeout_ms,
+                    pid=excluded.pid,
+                    exit_code=excluded.exit_code,
+                    recent_output_json=excluded.recent_output_json,
+                    output_excerpt=excluded.output_excerpt,
+                    log_path=excluded.log_path,
+                    subagent_role_id=excluded.subagent_role_id,
+                    subagent_run_id=excluded.subagent_run_id,
+                    subagent_task_id=excluded.subagent_task_id,
+                    subagent_instance_id=excluded.subagent_instance_id,
+                    created_at=excluded.created_at,
+                    updated_at=excluded.updated_at,
+                    completed_at=excluded.completed_at,
+                    completion_notified_at=excluded.completion_notified_at
+                """,
+                _record_params(record),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="upsert_async",
+            operation=operation,
+        )
+        persisted = await self.get_async(record.background_task_id)
+        if persisted is None:
+            raise RuntimeError(
+                f"Failed to persist background task {record.background_task_id}"
+            )
+        return persisted
 
     def get(self, background_task_id: str) -> BackgroundTaskRecord | None:
         with self._lock:
@@ -220,7 +298,20 @@ class BackgroundTaskRepository(SharedSqliteRepository):
         return _row_to_record(row)
 
     async def get_async(self, background_task_id: str) -> BackgroundTaskRecord | None:
-        return await self._call_sync_async(self.get, background_task_id)
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                """
+                SELECT *
+                FROM background_tasks
+                WHERE background_task_id=?
+                """,
+                (background_task_id,),
+            )
+        )
+        if row is None:
+            return None
+        return _row_to_record(row)
 
     def list_by_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
         with self._lock:
@@ -236,7 +327,19 @@ class BackgroundTaskRepository(SharedSqliteRepository):
         return tuple(_row_to_record(row) for row in rows)
 
     async def list_by_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
-        return await self._call_sync_async(self.list_by_run, run_id)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT *
+                FROM background_tasks
+                WHERE run_id=?
+                ORDER BY updated_at DESC, created_at DESC
+                """,
+                (run_id,),
+            )
+        )
+        return tuple(_row_to_record(row) for row in rows)
 
     def list_by_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
         with self._lock:
@@ -254,7 +357,19 @@ class BackgroundTaskRepository(SharedSqliteRepository):
     async def list_by_session_async(
         self, session_id: str
     ) -> tuple[BackgroundTaskRecord, ...]:
-        return await self._call_sync_async(self.list_by_session, session_id)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT *
+                FROM background_tasks
+                WHERE session_id=?
+                ORDER BY updated_at DESC, created_at DESC
+                """,
+                (session_id,),
+            )
+        )
+        return tuple(_row_to_record(row) for row in rows)
 
     def list_all(self) -> tuple[BackgroundTaskRecord, ...]:
         with self._lock:
@@ -268,7 +383,17 @@ class BackgroundTaskRepository(SharedSqliteRepository):
         return tuple(_row_to_record(row) for row in rows)
 
     async def list_all_async(self) -> tuple[BackgroundTaskRecord, ...]:
-        return await self._call_sync_async(self.list_all)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT *
+                FROM background_tasks
+                ORDER BY updated_at DESC, created_at DESC
+                """,
+            )
+        )
+        return tuple(_row_to_record(row) for row in rows)
 
     def list_interruptible(self) -> tuple[BackgroundTaskRecord, ...]:
         with self._lock:
@@ -287,7 +412,22 @@ class BackgroundTaskRepository(SharedSqliteRepository):
         return tuple(_row_to_record(row) for row in rows)
 
     async def list_interruptible_async(self) -> tuple[BackgroundTaskRecord, ...]:
-        return await self._call_sync_async(self.list_interruptible)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT *
+                FROM background_tasks
+                WHERE status IN (?, ?)
+                ORDER BY updated_at DESC, created_at DESC
+                """,
+                (
+                    BackgroundTaskStatus.RUNNING.value,
+                    BackgroundTaskStatus.BLOCKED.value,
+                ),
+            )
+        )
+        return tuple(_row_to_record(row) for row in rows)
 
     def delete(self, background_task_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -303,7 +443,17 @@ class BackgroundTaskRepository(SharedSqliteRepository):
         )
 
     async def delete_async(self, background_task_id: str) -> None:
-        return await self._call_sync_async(self.delete, background_task_id)
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                "DELETE FROM background_tasks WHERE background_task_id=?",
+                (background_task_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_async",
+            operation=operation,
+        )
 
     def delete_by_session(self, session_id: str) -> None:
         run_sqlite_write_with_retry(
@@ -319,7 +469,17 @@ class BackgroundTaskRepository(SharedSqliteRepository):
         )
 
     async def delete_by_session_async(self, session_id: str) -> None:
-        return await self._call_sync_async(self.delete_by_session, session_id)
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                "DELETE FROM background_tasks WHERE session_id=?",
+                (session_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_by_session_async",
+            operation=operation,
+        )
 
     def mark_transient_background_tasks_interrupted(
         self,
@@ -381,9 +541,50 @@ class BackgroundTaskRepository(SharedSqliteRepository):
     async def mark_transient_background_tasks_interrupted_async(
         self, *, background_task_ids: tuple[str, ...] | None = None
     ) -> int:
-        return await self._call_sync_async(
-            self.mark_transient_background_tasks_interrupted,
-            background_task_ids=background_task_ids,
+        if background_task_ids is not None and not background_task_ids:
+            return 0
+
+        async def operation(conn: aiosqlite.Connection) -> int:
+            now = datetime.now(tz=timezone.utc).isoformat()
+            if background_task_ids is None:
+                cursor = await conn.execute(
+                    """
+                    UPDATE background_tasks
+                    SET status=?, updated_at=?, completed_at=COALESCE(completed_at, ?), pid=NULL
+                    WHERE status IN (?, ?)
+                    """,
+                    (
+                        BackgroundTaskStatus.STOPPED.value,
+                        now,
+                        now,
+                        BackgroundTaskStatus.RUNNING.value,
+                        BackgroundTaskStatus.BLOCKED.value,
+                    ),
+                )
+            else:
+                placeholders = ", ".join("?" for _ in background_task_ids)
+                cursor = await conn.execute(
+                    f"""
+                    UPDATE background_tasks
+                    SET status=?, updated_at=?, completed_at=COALESCE(completed_at, ?), pid=NULL
+                    WHERE background_task_id IN ({placeholders}) AND status IN (?, ?)
+                    """,
+                    (
+                        BackgroundTaskStatus.STOPPED.value,
+                        now,
+                        now,
+                        *background_task_ids,
+                        BackgroundTaskStatus.RUNNING.value,
+                        BackgroundTaskStatus.BLOCKED.value,
+                    ),
+                )
+            affected = int(cursor.rowcount or 0)
+            await cursor.close()
+            return affected
+
+        return await self._run_async_write(
+            operation_name="mark_transient_background_tasks_interrupted_async",
+            operation=operation,
         )
 
 

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -388,8 +388,7 @@ class BackgroundTaskService:
             title=title,
             prompt=prompt,
         )
-        record = await asyncio.to_thread(
-            self._repository.upsert,
+        record = await self._repository.upsert_async(
             BackgroundTaskRecord(
                 background_task_id=background_task_id,
                 run_id=run_id,
@@ -419,7 +418,7 @@ class BackgroundTaskService:
                 prepared=prepared,
             )
         except Exception as exc:
-            record = self._finalize_subagent_launch_failure(
+            record = await self._finalize_subagent_launch_failure(
                 background_task_id=background_task_id,
                 prepared=prepared,
                 output=str(exc),
@@ -485,14 +484,21 @@ class BackgroundTaskService:
             task=worker_task,
         )
         try:
-            await asyncio.to_thread(
-                self._publish_background_task_event,
+            await self._publish_background_task_event_async(
                 event_type=RunEventType.BACKGROUND_TASK_STARTED,
                 record=record,
             )
         except Exception:
             worker_task.cancel()
             await asyncio.gather(worker_task, return_exceptions=True)
+            current = await self._repository.get_async(background_task_id)
+            if current is not None and current.is_active:
+                await self._finalize_subagent_record(
+                    background_task_id=background_task_id,
+                    status=BackgroundTaskStatus.FAILED,
+                    exit_code=1,
+                    output="Task cancelled",
+                )
             raise
         worker_start_gate.set()
         return record
@@ -525,8 +531,7 @@ class BackgroundTaskService:
         if suppress_hooks:
             self._prime_subagent_hook_snapshot(subagent_run_id=prepared.subagent_run_id)
         background_task_id = f"sync_subagent_{uuid4().hex[:12]}"
-        _ = await asyncio.to_thread(
-            self._repository.upsert,
+        _ = await self._repository.upsert_async(
             self._build_synchronous_subagent_record(
                 background_task_id=background_task_id,
                 run_id=run_id,
@@ -542,7 +547,7 @@ class BackgroundTaskService:
                 prepared=prepared,
             )
         except Exception as exc:
-            self._finalize_subagent_launch_failure(
+            await self._finalize_subagent_launch_failure(
                 background_task_id=background_task_id,
                 prepared=prepared,
                 output=str(exc),
@@ -581,7 +586,7 @@ class BackgroundTaskService:
                     + "\n\n"
                     + f"Subagent stop hook failed: {stop_hook_error}"
                 ).strip()
-            self._finalize_synchronous_subagent_record(
+            await self._finalize_synchronous_subagent_record(
                 background_task_id=background_task_id,
                 status=final_status,
                 output=final_output,
@@ -692,8 +697,7 @@ class BackgroundTaskService:
             if result is None:
                 raise RuntimeError("Subagent completed without returning a result")
             return result
-        return await asyncio.to_thread(
-            self._synchronous_subagent_result_from_record,
+        return await self._synchronous_subagent_result_from_record(
             parent_run_id=normalized_parent_run_id,
             subagent_run_id=normalized_run_id,
         )
@@ -876,7 +880,7 @@ class BackgroundTaskService:
             await self._handle_background_task_completion(record)
         return record
 
-    def _finalize_subagent_launch_failure(
+    async def _finalize_subagent_launch_failure(
         self,
         *,
         background_task_id: str,
@@ -884,20 +888,24 @@ class BackgroundTaskService:
         output: str,
         synchronous: bool,
     ) -> BackgroundTaskRecord:
-        self._mark_subagent_launch_entities_failed(prepared=prepared, output=output)
+        await asyncio.to_thread(
+            self._mark_subagent_launch_entities_failed,
+            prepared=prepared,
+            output=output,
+        )
         if synchronous:
-            record = self._finalize_synchronous_subagent_record(
+            record = await self._finalize_synchronous_subagent_record(
                 background_task_id=background_task_id,
                 status=BackgroundTaskStatus.FAILED,
                 output=output,
             )
         else:
-            current = self._repository.get(background_task_id)
+            current = await self._repository.get_async(background_task_id)
             if current is None:
                 raise KeyError(f"Unknown background task: {background_task_id}")
             completed_at = datetime.now(tz=timezone.utc)
             summarized_output = output.strip()
-            record = self._repository.upsert(
+            record = await self._repository.upsert_async(
                 current.model_copy(
                     update={
                         "status": BackgroundTaskStatus.FAILED,
@@ -909,11 +917,12 @@ class BackgroundTaskService:
                     }
                 )
             )
-            self._publish_background_task_event(
+            await self._publish_background_task_event_async(
                 event_type=RunEventType.BACKGROUND_TASK_COMPLETED,
                 record=record,
             )
-        self._finalize_subagent_run_runtime(
+        await asyncio.to_thread(
+            self._finalize_subagent_run_runtime,
             subagent_run_id=prepared.subagent_run_id,
             status=BackgroundTaskStatus.FAILED,
             output=output,
@@ -968,19 +977,19 @@ class BackgroundTaskService:
             subagent_instance_id=prepared.subagent_instance.instance_id,
         )
 
-    def _finalize_synchronous_subagent_record(
+    async def _finalize_synchronous_subagent_record(
         self,
         *,
         background_task_id: str,
         status: BackgroundTaskStatus,
         output: str,
     ) -> BackgroundTaskRecord:
-        current = self._repository.get(background_task_id)
+        current = await self._repository.get_async(background_task_id)
         if current is None:
             raise KeyError(f"Unknown background task: {background_task_id}")
         completed_at = datetime.now(tz=timezone.utc)
         summarized_output = output.strip()
-        return self._repository.upsert(
+        return await self._repository.upsert_async(
             current.model_copy(
                 update={
                     "status": status,
@@ -994,13 +1003,13 @@ class BackgroundTaskService:
             )
         )
 
-    def _synchronous_subagent_result_from_record(
+    async def _synchronous_subagent_result_from_record(
         self,
         *,
         parent_run_id: str,
         subagent_run_id: str,
     ) -> SynchronousSubagentResult:
-        record = self._synchronous_subagent_record(
+        record = await self._synchronous_subagent_record(
             parent_run_id=parent_run_id,
             subagent_run_id=subagent_run_id,
         )
@@ -1017,13 +1026,13 @@ class BackgroundTaskService:
             output=record.output_excerpt,
         )
 
-    def _synchronous_subagent_record(
+    async def _synchronous_subagent_record(
         self,
         *,
         parent_run_id: str,
         subagent_run_id: str,
     ) -> BackgroundTaskRecord | None:
-        for record in self._repository.list_all():
+        for record in await self._repository.list_all_async():
             if (
                 record.kind == BackgroundTaskKind.SUBAGENT
                 and record.execution_mode == "foreground"
@@ -1044,7 +1053,7 @@ class BackgroundTaskService:
             self._schedule_completion_retry(record.background_task_id)
 
     async def _attempt_completion_delivery_async(self, background_task_id: str) -> bool:
-        current = await asyncio.to_thread(self._repository.get, background_task_id)
+        current = await self._repository.get_async(background_task_id)
         if current is None:
             return True
         if not self._should_notify_completion(current):
@@ -1074,7 +1083,7 @@ class BackgroundTaskService:
                 exc_info=exc,
             )
             return False
-        _ = await asyncio.to_thread(self._mark_completion_consumed, current)
+        _ = await self._mark_completion_consumed_async(current)
         return True
 
     def _attempt_completion_delivery(self, background_task_id: str) -> bool:

--- a/src/relay_teams/sessions/runs/media_run_executor.py
+++ b/src/relay_teams/sessions/runs/media_run_executor.py
@@ -74,7 +74,7 @@ class MediaRunExecutor:
         run_id: str,
         intent: IntentInput,
     ) -> RunResult:
-        session = self._session_repo.get(intent.session_id)
+        session = await self._session_repo.get_async(intent.session_id)
         role_id = self.resolve_generation_role_id(intent)
         role_registry = self._require_role_registry()
         role = role_registry.get(role_id)
@@ -97,7 +97,7 @@ class MediaRunExecutor:
         )
         agent_repo = self._require_agent_repo()
         task_repo = self._require_task_repo()
-        agent_repo.upsert_instance(
+        await agent_repo.upsert_instance_async(
             run_id=run_id,
             trace_id=run_id,
             session_id=intent.session_id,
@@ -107,13 +107,13 @@ class MediaRunExecutor:
             conversation_id=conversation_id,
             status=InstanceStatus.RUNNING,
         )
-        _ = task_repo.create(root_task)
-        task_repo.update_status(
+        _ = await task_repo.create_async(root_task)
+        await task_repo.update_status_async(
             root_task.task_id,
             TaskStatus.RUNNING,
             assigned_instance_id=instance.instance_id,
         )
-        self._event_publisher.safe_runtime_update(
+        await self._event_publisher.safe_runtime_update_async(
             run_id,
             root_task_id=root_task.task_id,
             status=RunRuntimeStatus.RUNNING,
@@ -217,13 +217,16 @@ class MediaRunExecutor:
                 ),
                 failure_event="run.event.publish_failed",
             )
-            task_repo.update_status(
+            await task_repo.update_status_async(
                 root_task.task_id,
                 TaskStatus.COMPLETED,
                 assigned_instance_id=instance.instance_id,
                 result=content_parts_to_text(output),
             )
-            agent_repo.mark_status(instance.instance_id, InstanceStatus.COMPLETED)
+            await agent_repo.mark_status_async(
+                instance.instance_id,
+                InstanceStatus.COMPLETED,
+            )
             return RunResult(
                 trace_id=run_id,
                 root_task_id=root_task.task_id,
@@ -243,14 +246,17 @@ class MediaRunExecutor:
                 error_code="native_generation_failed",
                 error_message=str(exc),
             )
-            task_repo.update_status(
+            await task_repo.update_status_async(
                 root_task.task_id,
                 TaskStatus.COMPLETED,
                 assigned_instance_id=instance.instance_id,
                 result=result.output_text,
                 error_message=result.error_message,
             )
-            agent_repo.mark_status(instance.instance_id, InstanceStatus.COMPLETED)
+            await agent_repo.mark_status_async(
+                instance.instance_id,
+                InstanceStatus.COMPLETED,
+            )
             await self.publish_generation_progress_async(
                 run_id=run_id,
                 session_id=intent.session_id,

--- a/src/relay_teams/sessions/runs/run_control_manager.py
+++ b/src/relay_teams/sessions/runs/run_control_manager.py
@@ -672,6 +672,63 @@ class RunControlManager:
             )
         return stopped
 
+    async def handle_instance_cancelled_async(
+        self,
+        *,
+        task: TaskEnvelope,
+        instance_id: str,
+    ) -> bool:
+        stopped = self.is_cancelled(run_id=task.trace_id, instance_id=instance_id)
+        if stopped:
+            await self._require_task_repo().update_status_async(
+                task.task_id,
+                TaskStatus.STOPPED,
+                error_message="Task stopped by user",
+            )
+            await self._require_agent_repo().mark_status_async(
+                instance_id, InstanceStatus.STOPPED
+            )
+            await self._require_event_bus().emit_async(
+                EventEnvelope(
+                    event_type=EventType.TASK_STOPPED,
+                    trace_id=task.trace_id,
+                    session_id=task.session_id,
+                    task_id=task.task_id,
+                    instance_id=instance_id,
+                    payload_json="{}",
+                )
+            )
+            await self._require_event_bus().emit_async(
+                EventEnvelope(
+                    event_type=EventType.INSTANCE_STOPPED,
+                    trace_id=task.trace_id,
+                    session_id=task.session_id,
+                    task_id=task.task_id,
+                    instance_id=instance_id,
+                    payload_json="{}",
+                )
+            )
+        else:
+            await self._require_task_repo().update_status_async(
+                task.task_id,
+                TaskStatus.FAILED,
+                error_message="Task cancelled",
+            )
+            await self._require_agent_repo().mark_status_async(
+                instance_id, InstanceStatus.FAILED
+            )
+            await self._require_event_bus().emit_async(
+                EventEnvelope(
+                    event_type=EventType.TASK_FAILED,
+                    trace_id=task.trace_id,
+                    session_id=task.session_id,
+                    task_id=task.task_id,
+                    instance_id=instance_id,
+                    payload_json="{}",
+                )
+            )
+        return stopped
+
     def request_subagent_stop(
         self, *, run_id: str, instance_id: str
     ) -> PausedSubagent | None:

--- a/src/relay_teams/sessions/runs/run_event_publisher.py
+++ b/src/relay_teams/sessions/runs/run_event_publisher.py
@@ -151,6 +151,30 @@ class RunEventPublisher:
                     exc_info=exc,
                 )
 
+    async def safe_runtime_update_async(self, run_id: str, **changes: object) -> None:
+        run_runtime_repo = self._get_run_runtime_repo()
+        if run_runtime_repo is None:
+            return
+        try:
+            await run_runtime_repo.update_async(run_id, **changes)
+        except Exception as exc:
+            with bind_trace_context(
+                trace_id=run_id,
+                run_id=run_id,
+                session_id="",
+            ):
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event="run.runtime.update_failed",
+                    message="Run runtime update failed",
+                    payload={
+                        "change_count": len(changes),
+                        "change_keys": ",".join(sorted(changes.keys())),
+                    },
+                    exc_info=exc,
+                )
+
     def safe_publish_run_event(
         self,
         event: RunEvent,

--- a/src/relay_teams/sessions/runs/run_intent_repo.py
+++ b/src/relay_teams/sessions/runs/run_intent_repo.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from sqlite3 import Row
 from typing import Literal, Optional
 
+import aiosqlite
 from pydantic import JsonValue, TypeAdapter, ValidationError
 
 from relay_teams.logger import get_logger, log_event
@@ -16,6 +17,7 @@ from relay_teams.media import (
     content_parts_to_text,
     text_part,
 )
+from relay_teams.persistence import async_fetchall, async_fetchone
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.runs.enums import ExecutionMode
 from relay_teams.sessions.runs.run_models import (
@@ -51,6 +53,49 @@ _RUN_INTENT_SELECT_COLUMNS = """
     session_mode,
     topology_json,
     conversation_context_json
+    """
+_RUN_INTENT_UPSERT_SQL = """
+    INSERT INTO run_intents(
+        run_id,
+        session_id,
+        intent,
+        input_json,
+        display_input_json,
+        run_kind,
+        generation_config_json,
+        execution_mode,
+        yolo,
+        reuse_root_instance,
+        thinking_enabled,
+        thinking_effort,
+        target_role_id,
+        skills_json,
+        session_mode,
+        topology_json,
+        conversation_context_json,
+        created_at,
+        updated_at
+    )
+    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(run_id)
+    DO UPDATE SET
+        session_id=excluded.session_id,
+        intent=excluded.intent,
+        input_json=excluded.input_json,
+        display_input_json=excluded.display_input_json,
+        run_kind=excluded.run_kind,
+        generation_config_json=excluded.generation_config_json,
+        execution_mode=excluded.execution_mode,
+        yolo=excluded.yolo,
+        reuse_root_instance=excluded.reuse_root_instance,
+        thinking_enabled=excluded.thinking_enabled,
+        thinking_effort=excluded.thinking_effort,
+        target_role_id=excluded.target_role_id,
+        skills_json=excluded.skills_json,
+        session_mode=excluded.session_mode,
+        topology_json=excluded.topology_json,
+        conversation_context_json=excluded.conversation_context_json,
+        updated_at=excluded.updated_at
 """
 
 
@@ -155,91 +200,12 @@ class RunIntentRepository(SharedSqliteRepository):
         self._run_write(
             operation_name="upsert",
             operation=lambda: self._conn.execute(
-                """
-                INSERT INTO run_intents(
-                    run_id,
-                    session_id,
-                    intent,
-                    input_json,
-                    display_input_json,
-                    run_kind,
-                    generation_config_json,
-                    execution_mode,
-                    yolo,
-                    reuse_root_instance,
-                    thinking_enabled,
-                    thinking_effort,
-                    target_role_id,
-                    skills_json,
-                    session_mode,
-                    topology_json,
-                    conversation_context_json,
-                    created_at,
-                    updated_at
-                )
-                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(run_id)
-                DO UPDATE SET
-                    session_id=excluded.session_id,
-                    intent=excluded.intent,
-                    input_json=excluded.input_json,
-                    display_input_json=excluded.display_input_json,
-                    run_kind=excluded.run_kind,
-                    generation_config_json=excluded.generation_config_json,
-                    execution_mode=excluded.execution_mode,
-                    yolo=excluded.yolo,
-                    reuse_root_instance=excluded.reuse_root_instance,
-                    thinking_enabled=excluded.thinking_enabled,
-                    thinking_effort=excluded.thinking_effort,
-                    target_role_id=excluded.target_role_id,
-                    skills_json=excluded.skills_json,
-                    session_mode=excluded.session_mode,
-                    topology_json=excluded.topology_json,
-                    conversation_context_json=excluded.conversation_context_json,
-                    updated_at=excluded.updated_at
-                """,
-                (
-                    run_id,
-                    session_id,
-                    intent.intent,
-                    ContentPartsAdapter.dump_json(intent.input).decode("utf-8"),
-                    (
-                        ContentPartsAdapter.dump_json(intent.display_input).decode(
-                            "utf-8"
-                        )
-                        if intent.display_input
-                        else None
-                    ),
-                    intent.run_kind.value,
-                    (
-                        intent.generation_config.model_dump_json()
-                        if intent.generation_config is not None
-                        else None
-                    ),
-                    intent.execution_mode.value,
-                    "true" if intent.yolo else "false",
-                    "true" if intent.reuse_root_instance else "false",
-                    "true" if intent.thinking.enabled else "false",
-                    intent.thinking.effort,
-                    intent.target_role_id,
-                    (
-                        json.dumps(tuple(intent.skills), ensure_ascii=False)
-                        if intent.skills is not None
-                        else None
-                    ),
-                    intent.session_mode.value,
-                    (
-                        intent.topology.model_dump_json()
-                        if intent.topology is not None
-                        else None
-                    ),
-                    (
-                        intent.conversation_context.model_dump_json()
-                        if intent.conversation_context is not None
-                        else None
-                    ),
-                    now,
-                    now,
+                _RUN_INTENT_UPSERT_SQL,
+                _run_intent_upsert_params(
+                    run_id=run_id,
+                    session_id=session_id,
+                    intent=intent,
+                    now=now,
                 ),
             ),
         )
@@ -247,8 +213,23 @@ class RunIntentRepository(SharedSqliteRepository):
     async def upsert_async(
         self, *, run_id: str, session_id: str, intent: IntentInput
     ) -> None:
-        return await self._call_sync_async(
-            self.upsert, run_id=run_id, session_id=session_id, intent=intent
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                _RUN_INTENT_UPSERT_SQL,
+                _run_intent_upsert_params(
+                    run_id=run_id,
+                    session_id=session_id,
+                    intent=intent,
+                    now=now,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="upsert_async",
+            operation=operation,
         )
 
     def append_followup(self, *, run_id: str, content: str) -> None:
@@ -282,8 +263,38 @@ class RunIntentRepository(SharedSqliteRepository):
         self._run_write(operation_name="append_followup", operation=operation)
 
     async def append_followup_async(self, *, run_id: str, content: str) -> None:
-        return await self._call_sync_async(
-            self.append_followup, run_id=run_id, content=content
+        async def operation(conn: aiosqlite.Connection) -> None:
+            row = await async_fetchone(
+                conn,
+                "SELECT intent, input_json FROM run_intents WHERE run_id=?",
+                (run_id,),
+            )
+            if row is None:
+                raise KeyError(f"Unknown run_id: {run_id}")
+            current_parts = _coerce_input_parts(row["input_json"], row["intent"])
+            next_part = text_part(content)
+            next_parts = (
+                current_parts if next_part is None else current_parts + (next_part,)
+            )
+            next_intent = content_parts_to_text(next_parts)
+            cursor = await conn.execute(
+                """
+                UPDATE run_intents
+                SET intent=?, input_json=?, display_input_json=NULL, updated_at=?
+                WHERE run_id=?
+                """,
+                (
+                    next_intent,
+                    ContentPartsAdapter.dump_json(next_parts).decode("utf-8"),
+                    datetime.now(tz=timezone.utc).isoformat(),
+                    run_id,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="append_followup_async",
+            operation=operation,
         )
 
     def get(
@@ -309,9 +320,20 @@ class RunIntentRepository(SharedSqliteRepository):
     async def get_async(
         self, run_id: str, *, fallback_session_id: str | None = None
     ) -> IntentInput:
-        return await self._call_sync_async(
-            self.get, run_id, fallback_session_id=fallback_session_id
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                f"""
+                SELECT {_RUN_INTENT_SELECT_COLUMNS}
+                FROM run_intents
+                WHERE run_id=?
+                """,
+                (run_id,),
+            )
         )
+        if row is None:
+            raise KeyError(f"Unknown run_id: {run_id}")
+        return _intent_input_from_row(row, fallback_session_id=fallback_session_id)
 
     def list_by_session(self, session_id: str) -> dict[str, IntentInput]:
         rows = self._run_read(
@@ -342,7 +364,79 @@ class RunIntentRepository(SharedSqliteRepository):
         return records
 
     async def list_by_session_async(self, session_id: str) -> dict[str, IntentInput]:
-        return await self._call_sync_async(self.list_by_session, session_id)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                f"""
+                SELECT
+                    run_id,
+                    {_RUN_INTENT_SELECT_COLUMNS}
+                FROM run_intents
+                WHERE session_id=?
+                ORDER BY created_at ASC
+                """,
+                (session_id,),
+            )
+        )
+        records: dict[str, IntentInput] = {}
+        for row in rows:
+            run_id = str(row["run_id"] or "").strip()
+            if not run_id:
+                continue
+            try:
+                records[run_id] = _intent_input_from_row(
+                    row,
+                    fallback_session_id=session_id,
+                )
+            except (KeyError, ValueError, ValidationError) as exc:
+                _log_invalid_run_intent_row(row=row, error=exc)
+        return records
+
+
+def _run_intent_upsert_params(
+    *,
+    run_id: str,
+    session_id: str,
+    intent: IntentInput,
+    now: str,
+) -> tuple[object, ...]:
+    return (
+        run_id,
+        session_id,
+        intent.intent,
+        ContentPartsAdapter.dump_json(intent.input).decode("utf-8"),
+        (
+            ContentPartsAdapter.dump_json(intent.display_input).decode("utf-8")
+            if intent.display_input
+            else None
+        ),
+        intent.run_kind.value,
+        (
+            intent.generation_config.model_dump_json()
+            if intent.generation_config is not None
+            else None
+        ),
+        intent.execution_mode.value,
+        "true" if intent.yolo else "false",
+        "true" if intent.reuse_root_instance else "false",
+        "true" if intent.thinking.enabled else "false",
+        intent.thinking.effort,
+        intent.target_role_id,
+        (
+            json.dumps(tuple(intent.skills), ensure_ascii=False)
+            if intent.skills is not None
+            else None
+        ),
+        intent.session_mode.value,
+        intent.topology.model_dump_json() if intent.topology is not None else None,
+        (
+            intent.conversation_context.model_dump_json()
+            if intent.conversation_context is not None
+            else None
+        ),
+        now,
+        now,
+    )
 
 
 def _intent_input_from_row(

--- a/src/relay_teams/sessions/runs/run_recovery.py
+++ b/src/relay_teams/sessions/runs/run_recovery.py
@@ -179,6 +179,7 @@ class RunRecoveryService:
         *,
         get_event_log: Callable[[], EventLog | None],
         get_runtime: Callable[[str], RunRuntimeRecord | None],
+        get_runtime_async: Callable[[str], Awaitable[RunRuntimeRecord | None]],
         event_publisher: RunEventPublisher,
         append_followup_to_instance: AppendFollowupToInstance,
         append_followup_to_coordinator: AppendFollowupToCoordinator,
@@ -186,6 +187,7 @@ class RunRecoveryService:
     ) -> None:
         self._get_event_log = get_event_log
         self._get_runtime = get_runtime
+        self._get_runtime_async = get_runtime_async
         self._event_publisher = event_publisher
         self._append_followup_to_instance = append_followup_to_instance
         self._append_followup_to_coordinator = append_followup_to_coordinator
@@ -219,7 +221,7 @@ class RunRecoveryService:
                     attempt=attempt,
                 )
                 self._queue_prompt(payload=exc.payload, policy=policy)
-                resume_payload = self.transition_run_to_resumed(
+                resume_payload = await self.transition_run_to_resumed_async(
                     run_id=run_id,
                     session_id=session_id,
                     reason=policy.reason,
@@ -286,6 +288,44 @@ class RunRecoveryService:
             max_attempts=max_attempts,
         )
         self._event_publisher.safe_publish_run_event(
+            RunEvent(
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=run_id,
+                task_id=None,
+                event_type=RunEventType.RUN_RESUMED,
+                payload_json=dumps(payload),
+            ),
+            failure_event="run.event.publish_failed",
+        )
+        return payload
+
+    async def transition_run_to_resumed_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        reason: str,
+        attempt: int | None = None,
+        max_attempts: int | None = None,
+    ) -> dict[str, JsonValue]:
+        runtime = await self._get_runtime_async(run_id)
+        phase = RunRuntimePhase.COORDINATOR_RUNNING
+        if runtime is not None and runtime.phase != RunRuntimePhase.TERMINAL:
+            phase = runtime.phase
+        await self._event_publisher.safe_runtime_update_async(
+            run_id,
+            status=RunRuntimeStatus.RUNNING,
+            phase=phase,
+            last_error=None,
+        )
+        payload = self._build_run_resumed_payload(
+            session_id=session_id,
+            reason=reason,
+            attempt=attempt,
+            max_attempts=max_attempts,
+        )
+        await self._event_publisher.safe_publish_run_event_async(
             RunEvent(
                 session_id=session_id,
                 run_id=run_id,

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 from concurrent.futures import Future as ThreadFuture
 from json import dumps
-from typing import Awaitable, Callable, TypeVar
+from typing import Awaitable, Callable, Coroutine, TypeVar
 
 from pydantic import JsonValue
 
@@ -104,6 +104,14 @@ def _is_run_already_running_conflict(*, run_id: str, error: RuntimeError) -> boo
     return str(error) == f"Run {run_id} is already running"
 
 
+def _clear_current_task_cancellation_requests() -> None:
+    current_task = asyncio.current_task()
+    if current_task is None:
+        return
+    while current_task.cancelling():
+        current_task.uncancel()
+
+
 class SessionRunService:
     def __init__(
         self,
@@ -189,6 +197,7 @@ class SessionRunService:
         self._recovery_service = RunRecoveryService(
             get_event_log=lambda: self._event_log,
             get_runtime=lambda run_id: self._runtime_for_run(run_id),
+            get_runtime_async=self._runtime_for_run_async,
             event_publisher=self._event_publisher,
             append_followup_to_instance=(
                 lambda **kwargs: self._append_followup_to_instance(**kwargs)
@@ -532,23 +541,23 @@ class SessionRunService:
         )
 
     async def run_intent(self, intent: IntentInput) -> RunResult:
-        session_id = self._ensure_session(intent.session_id)
+        session_id = await self._ensure_session_async(intent.session_id)
         intent.session_id = session_id
-        intent = self._prepare_intent(intent)
+        intent = await self._prepare_intent_async(intent)
         self._run_control_manager.assert_session_allows_main_input(session_id)
-        _ = self._session_repo.mark_started(session_id)
+        _ = await self._session_repo.mark_started_async(session_id)
         run_id = new_trace_id().value
         if self._hook_service is not None:
             self._hook_service.snapshot_run(run_id)
         if self._run_runtime_repo is not None:
-            self._run_runtime_repo.ensure(
+            await self._run_runtime_repo.ensure_async(
                 run_id=run_id,
                 session_id=session_id,
                 status=RunRuntimeStatus.RUNNING,
                 phase=RunRuntimePhase.COORDINATOR_RUNNING,
             )
         if self._run_intent_repo is not None:
-            self._run_intent_repo.upsert(
+            await self._run_intent_repo.upsert_async(
                 run_id=run_id,
                 session_id=session_id,
                 intent=intent,
@@ -588,7 +597,7 @@ class SessionRunService:
                     ),
                 )
                 if self._run_runtime_repo is not None:
-                    self._run_runtime_repo.update(
+                    await self._run_runtime_repo.update_async(
                         run_id,
                         root_task_id=result.root_task_id,
                         status=RunRuntimeStatus.COMPLETED,
@@ -619,7 +628,7 @@ class SessionRunService:
                 if isinstance(exc, RecoverableRunPauseError):
                     payload = exc.payload
                     if self._run_runtime_repo is not None:
-                        self._run_runtime_repo.update(
+                        await self._run_runtime_repo.update_async(
                             run_id,
                             root_task_id=payload.task_id,
                             status=RunRuntimeStatus.PAUSED,
@@ -642,7 +651,7 @@ class SessionRunService:
                     ),
                 )
                 if self._run_runtime_repo is not None:
-                    self._run_runtime_repo.update(
+                    await self._run_runtime_repo.update_async(
                         run_id,
                         root_task_id=result.root_task_id,
                         status=RunRuntimeStatus.COMPLETED,
@@ -663,7 +672,10 @@ class SessionRunService:
                 )
                 return result
             finally:
-                self._safe_finalize_run(run_id=run_id, session_id=session_id)
+                await self._safe_finalize_run_async(
+                    run_id=run_id,
+                    session_id=session_id,
+                )
 
     def create_run(
         self,
@@ -679,12 +691,15 @@ class SessionRunService:
         *,
         source: InjectionSource = InjectionSource.USER,
     ) -> tuple[str, str]:
-        if self._should_delegate_to_bound_loop():
-            delegated_intent = intent.model_copy(deep=True)
-            return await self._call_in_bound_loop_async(
-                lambda: self.create_run(delegated_intent, source=source)
-            )
         delegated_intent = intent.model_copy(deep=True)
+        if self._should_delegate_to_bound_loop():
+            return await self._call_coroutine_in_bound_loop_async(
+                lambda: self._create_run_local_async(
+                    delegated_intent,
+                    allow_active_run_attach=True,
+                    source=source,
+                )
+            )
         return await self._create_run_local_async(
             delegated_intent,
             allow_active_run_attach=True,
@@ -695,12 +710,15 @@ class SessionRunService:
         return self._scheduler.create_detached_run(intent)
 
     async def create_detached_run_async(self, intent: IntentInput) -> tuple[str, str]:
-        if self._should_delegate_to_bound_loop():
-            delegated_intent = intent.model_copy(deep=True)
-            return await self._call_in_bound_loop_async(
-                lambda: self.create_detached_run(delegated_intent)
-            )
         delegated_intent = intent.model_copy(deep=True)
+        if self._should_delegate_to_bound_loop():
+            return await self._call_coroutine_in_bound_loop_async(
+                lambda: self._create_run_local_async(
+                    delegated_intent,
+                    allow_active_run_attach=False,
+                    source=InjectionSource.USER,
+                )
+            )
         return await self._create_run_local_async(
             delegated_intent,
             allow_active_run_attach=False,
@@ -889,8 +907,8 @@ class SessionRunService:
 
     async def ensure_run_started_async(self, run_id: str) -> None:
         if self._should_delegate_to_bound_loop():
-            await self._call_in_bound_loop_async(
-                lambda: self.ensure_run_started(run_id)
+            await self._call_coroutine_in_bound_loop_async(
+                lambda: self._ensure_run_started_local_async(run_id)
             )
             return
         await self._ensure_run_started_local_async(run_id)
@@ -1004,7 +1022,7 @@ class SessionRunService:
             completion_reason="stopped_by_user",
             output_text="",
         )
-        self._safe_finalize_run(run_id=run_id, session_id=session_id)
+        await self._safe_finalize_run_async(run_id=run_id, session_id=session_id)
 
     async def _start_new_run_worker_async(self, run_id: str) -> None:
         intent = self._pending_runs.get(run_id)
@@ -1241,7 +1259,7 @@ class SessionRunService:
                 if runtime_intent is not None
                 else "conversation"
             )
-            self._safe_runtime_update(
+            await self._safe_runtime_update_async(
                 run_id,
                 root_task_id=result.root_task_id,
                 status=terminal_status,
@@ -1298,7 +1316,7 @@ class SessionRunService:
         except RecoverableRunPauseError as exc:
             payload = exc.payload
             paused_payload = self._recovery_service.build_run_paused_payload(payload)
-            self._safe_runtime_update(
+            await self._safe_runtime_update_async(
                 run_id,
                 root_task_id=payload.task_id,
                 status=RunRuntimeStatus.PAUSED,
@@ -1333,7 +1351,7 @@ class SessionRunService:
                     payload=paused_payload,
                 )
         except asyncio.CancelledError:
-            self._safe_runtime_update(
+            await self._safe_runtime_update_async(
                 run_id,
                 status=RunRuntimeStatus.STOPPED,
                 phase=RunRuntimePhase.IDLE,
@@ -1396,7 +1414,7 @@ class SessionRunService:
             )
             failed = result.status == "failed"
             output_text = result.output_text or str(result.error_message or "").strip()
-            self._safe_runtime_update(
+            await self._safe_runtime_update_async(
                 run_id,
                 root_task_id=result.root_task_id,
                 status=RunRuntimeStatus.FAILED
@@ -1486,7 +1504,10 @@ class SessionRunService:
                             message="Failed to clean up background tasks",
                             exc_info=exc,
                         )
-            self._safe_finalize_run(run_id=run_id, session_id=session_id)
+            await self._safe_finalize_run_async(
+                run_id=run_id,
+                session_id=session_id,
+            )
 
     def _finalize_run(self, *, run_id: str, session_id: str) -> None:
         self._injection_manager.deactivate(run_id)
@@ -1505,10 +1526,54 @@ class SessionRunService:
             self._runtime_role_resolver.cleanup_run(run_id=run_id)
         self._drop_active_run(session_id, run_id)
 
+    async def _finalize_run_async(self, *, run_id: str, session_id: str) -> None:
+        self._injection_manager.deactivate(run_id)
+        self._run_control_manager.unregister_run_task(run_id)
+        self._running_run_ids.discard(run_id)
+        _ = self._pending_runs.pop(run_id, None)
+        self._resume_requested_runs.discard(run_id)
+        runtime = await self._runtime_for_run_async(run_id)
+        if runtime is not None and runtime.is_recoverable:
+            self._remember_active_run(session_id, run_id)
+            return
+        if self._hook_service is not None:
+            self._hook_service.clear_run(run_id)
+        self._recovery_service.clear_attempts(run_id)
+        if self._runtime_role_resolver is not None:
+            await self._runtime_role_resolver.cleanup_run_async(run_id=run_id)
+        self._drop_active_run(session_id, run_id)
+
     def _safe_finalize_run(self, *, run_id: str, session_id: str) -> None:
         try:
             self._finalize_run(run_id=run_id, session_id=session_id)
         except Exception as exc:
+            with bind_trace_context(
+                trace_id=run_id,
+                run_id=run_id,
+                session_id=session_id,
+            ):
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event="run.finalize.failed",
+                    message="Run finalization failed",
+                    exc_info=exc,
+                )
+
+    async def _safe_finalize_run_async(self, *, run_id: str, session_id: str) -> None:
+        finalize_task = asyncio.create_task(
+            self._finalize_run_async(run_id=run_id, session_id=session_id)
+        )
+        cancellation_requested = False
+        try:
+            while not finalize_task.done():
+                try:
+                    await asyncio.shield(finalize_task)
+                except asyncio.CancelledError:
+                    cancellation_requested = True
+                    _clear_current_task_cancellation_requests()
+            finalize_task.result()
+        except (asyncio.CancelledError, Exception) as exc:
             with bind_trace_context(
                 trace_id=run_id,
                 run_id=run_id,
@@ -1526,6 +1591,8 @@ class SessionRunService:
             self._running_run_ids.discard(run_id)
             _ = self._pending_runs.pop(run_id, None)
             self._resume_requested_runs.discard(run_id)
+        if cancellation_requested:
+            raise asyncio.CancelledError
 
     async def stream_run_events(self, run_id: str, after_event_id: int = 0):
         queue = self._run_event_hub.subscribe(run_id)
@@ -1533,7 +1600,7 @@ class SessionRunService:
         try:
             replay_high_watermark = 0
             if after_event_id >= 0 and self._event_log is not None:
-                for row in self._event_log.list_by_trace_after_id(
+                for row in await self._event_log.list_by_trace_after_id_async(
                     run_id, after_event_id
                 ):
                     row_id = row.get("id")
@@ -1593,8 +1660,8 @@ class SessionRunService:
                 self._run_event_hub.unsubscribe_all(run_id)
 
     async def run_intent_stream(self, intent: IntentInput):
-        run_id, _ = self.create_run(intent)
-        self.ensure_run_started(run_id)
+        run_id, _ = await self.create_run_async(intent)
+        await self.ensure_run_started_async(run_id)
         async for event in self.stream_run_events(run_id):
             yield event
 
@@ -1618,8 +1685,8 @@ class SessionRunService:
         content: str,
     ):
         if self._should_delegate_to_bound_loop():
-            return await self._call_in_bound_loop_async(
-                lambda: self.inject_message(
+            return await self._call_coroutine_in_bound_loop_async(
+                lambda: self._run_control_manager.inject_to_running_agents_async(
                     run_id=run_id,
                     source=source,
                     content=content,
@@ -1679,7 +1746,9 @@ class SessionRunService:
 
     async def stop_run_async(self, run_id: str) -> None:
         if self._should_delegate_to_bound_loop():
-            await self._call_in_bound_loop_async(lambda: self.stop_run(run_id))
+            await self._call_coroutine_in_bound_loop_async(
+                lambda: self._stop_run_local_async(run_id)
+            )
             return
         await self._stop_run_local_async(run_id)
 
@@ -1832,27 +1901,30 @@ class SessionRunService:
         loop.call_soon_threadsafe(runner)
         return result.result(timeout=30)
 
-    async def _call_in_bound_loop_async(self, callback: Callable[[], _T]) -> _T:
+    async def _call_coroutine_in_bound_loop_async(
+        self,
+        callback: Callable[[], Coroutine[object, object, _T]],
+    ) -> _T:
         loop = self._event_loop
         if loop is None:
-            return callback()
-        result: ThreadFuture[_T] = ThreadFuture()
-
-        def runner() -> None:
-            try:
-                result.set_result(callback())
-            except Exception as exc:
-                result.set_exception(exc)
-
-        loop.call_soon_threadsafe(runner)
-        return await asyncio.wait_for(asyncio.wrap_future(result), timeout=30)
+            return await callback()
+        try:
+            if asyncio.get_running_loop() is loop:
+                return await callback()
+        except RuntimeError:
+            # No event loop is running in this thread, so dispatch to the bound loop.
+            pass
+        future = asyncio.run_coroutine_threadsafe(callback(), loop)
+        return await asyncio.wait_for(asyncio.wrap_future(future), timeout=30)
 
     def resume_run(self, run_id: str) -> str:
         return self._scheduler.resume_run(run_id)
 
     async def resume_run_async(self, run_id: str) -> str:
         if self._should_delegate_to_bound_loop():
-            return await self._call_in_bound_loop_async(lambda: self.resume_run(run_id))
+            return await self._call_coroutine_in_bound_loop_async(
+                lambda: self._resume_run_local_async(run_id)
+            )
         return await self._resume_run_local_async(run_id)
 
     async def _resume_run_local_async(self, run_id: str) -> str:
@@ -1912,8 +1984,10 @@ class SessionRunService:
         instance_id: str,
     ) -> dict[str, str]:
         if self._should_delegate_to_bound_loop():
-            return await self._call_in_bound_loop_async(
-                lambda: self.stop_subagent(run_id, instance_id)
+            return await self._call_coroutine_in_bound_loop_async(
+                lambda: self._interaction_service.stop_subagent_async(
+                    run_id, instance_id
+                )
             )
         return await self._interaction_service.stop_subagent_async(run_id, instance_id)
 
@@ -2123,8 +2197,8 @@ class SessionRunService:
         feedback: str = "",
     ) -> None:
         if self._should_delegate_to_bound_loop():
-            await self._call_in_bound_loop_async(
-                lambda: self.resolve_tool_approval(
+            await self._call_coroutine_in_bound_loop_async(
+                lambda: self._interaction_service.resolve_tool_approval_async(
                     run_id=run_id,
                     tool_call_id=tool_call_id,
                     action=action,
@@ -2441,6 +2515,9 @@ class SessionRunService:
 
     def _safe_runtime_update(self, run_id: str, **changes: object) -> None:
         self._event_publisher.safe_runtime_update(run_id, **changes)
+
+    async def _safe_runtime_update_async(self, run_id: str, **changes: object) -> None:
+        await self._event_publisher.safe_runtime_update_async(run_id, **changes)
 
     def _safe_publish_run_event(
         self,

--- a/src/relay_teams/sessions/session_repository.py
+++ b/src/relay_teams/sessions/session_repository.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from pydantic import JsonValue, ValidationError
 
 from relay_teams.logger import get_logger, log_event
+from relay_teams.persistence import async_fetchall, async_fetchone
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.sessions.session_models import ProjectKind, SessionMode, SessionRecord
 from relay_teams.validation import (
@@ -163,17 +164,62 @@ class SessionRepository(SharedSqliteRepository):
         normal_root_role_id: str | None = None,
         orchestration_preset_id: str | None = None,
     ) -> SessionRecord:
-        return await self._call_sync_async(
-            self.create,
+        now = datetime.now(tz=timezone.utc).isoformat()
+        metadata_dict = metadata or {}
+        resolved_project_id = (project_id or workspace_id).strip()
+        record = SessionRecord(
             session_id=session_id,
             workspace_id=workspace_id,
-            metadata=metadata,
             project_kind=project_kind,
-            project_id=project_id,
+            project_id=resolved_project_id,
+            metadata=metadata_dict,
             session_mode=session_mode,
             normal_root_role_id=normal_root_role_id,
             orchestration_preset_id=orchestration_preset_id,
+            created_at=datetime.fromisoformat(now),
+            updated_at=datetime.fromisoformat(now),
         )
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO sessions(
+                    session_id,
+                    workspace_id,
+                    project_kind,
+                    project_id,
+                    metadata,
+                    session_mode,
+                    normal_root_role_id,
+                    orchestration_preset_id,
+                    started_at,
+                    created_at,
+                    updated_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.session_id,
+                    record.workspace_id,
+                    record.project_kind.value,
+                    record.project_id,
+                    json.dumps(record.metadata),
+                    record.session_mode.value,
+                    record.normal_root_role_id,
+                    record.orchestration_preset_id,
+                    None,
+                    now,
+                    now,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="create_async",
+            operation=lambda _conn: operation(),
+        )
+        return record
 
     def update_topology(
         self,
@@ -217,13 +263,37 @@ class SessionRepository(SharedSqliteRepository):
         normal_root_role_id: str | None,
         orchestration_preset_id: str | None,
     ) -> None:
-        return await self._call_sync_async(
-            self.update_topology,
-            session_id,
-            session_mode=session_mode,
-            normal_root_role_id=normal_root_role_id,
-            orchestration_preset_id=orchestration_preset_id,
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation() -> int:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                UPDATE sessions
+                SET session_mode=?, normal_root_role_id=?, orchestration_preset_id=?, updated_at=?
+                WHERE session_id=? AND started_at IS NULL
+                """,
+                (
+                    session_mode.value,
+                    normal_root_role_id,
+                    orchestration_preset_id,
+                    now,
+                    session_id,
+                ),
+            )
+            affected_rows = cursor.rowcount
+            await cursor.close()
+            return affected_rows
+
+        updated_count = await self._run_async_write(
+            operation_name="update_topology_async",
+            operation=lambda _conn: operation(),
         )
+        if updated_count == 0:
+            existing = await self.get_async(session_id)
+            if existing.started_at is not None:
+                raise RuntimeError("Session mode can no longer be changed")
+            raise KeyError(f"Unknown session_id: {session_id}")
 
     def update_metadata(self, session_id: str, metadata: dict[str, str]) -> None:
         now = datetime.now(tz=timezone.utc).isoformat()
@@ -246,7 +316,28 @@ class SessionRepository(SharedSqliteRepository):
     async def update_metadata_async(
         self, session_id: str, metadata: dict[str, str]
     ) -> None:
-        return await self._call_sync_async(self.update_metadata, session_id, metadata)
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation() -> int:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                UPDATE sessions
+                SET metadata=?, updated_at=?
+                WHERE session_id=?
+                """,
+                (json.dumps(metadata), now, session_id),
+            )
+            affected_rows = cursor.rowcount
+            await cursor.close()
+            return affected_rows
+
+        updated_count = await self._run_async_write(
+            operation_name="update_metadata_async",
+            operation=lambda _conn: operation(),
+        )
+        if updated_count == 0:
+            raise KeyError(f"Unknown session_id: {session_id}")
 
     def update_workspace(
         self,
@@ -275,12 +366,28 @@ class SessionRepository(SharedSqliteRepository):
     async def update_workspace_async(
         self, session_id: str, *, workspace_id: str, project_id: str
     ) -> None:
-        return await self._call_sync_async(
-            self.update_workspace,
-            session_id,
-            workspace_id=workspace_id,
-            project_id=project_id,
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation() -> int:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                UPDATE sessions
+                SET workspace_id=?, project_id=?, updated_at=?
+                WHERE session_id=?
+                """,
+                (workspace_id, project_id, now, session_id),
+            )
+            affected_rows = cursor.rowcount
+            await cursor.close()
+            return affected_rows
+
+        updated_count = await self._run_async_write(
+            operation_name="update_workspace_async",
+            operation=lambda _conn: operation(),
         )
+        if updated_count == 0:
+            raise KeyError(f"Unknown session_id: {session_id}")
 
     def mark_started(self, session_id: str) -> SessionRecord:
         now = datetime.now(tz=timezone.utc).isoformat()
@@ -302,7 +409,29 @@ class SessionRepository(SharedSqliteRepository):
         return self.get(session_id)
 
     async def mark_started_async(self, session_id: str) -> SessionRecord:
-        return await self._call_sync_async(self.mark_started, session_id)
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation() -> int:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                UPDATE sessions
+                SET started_at=COALESCE(started_at, ?), updated_at=?
+                WHERE session_id=?
+                """,
+                (now, now, session_id),
+            )
+            affected_rows = cursor.rowcount
+            await cursor.close()
+            return affected_rows
+
+        updated_count = await self._run_async_write(
+            operation_name="mark_started_async",
+            operation=lambda _conn: operation(),
+        )
+        if updated_count == 0:
+            raise KeyError(f"Unknown session_id: {session_id}")
+        return await self.get_async(session_id)
 
     def reconcile_orchestration_presets(
         self,
@@ -359,11 +488,52 @@ class SessionRepository(SharedSqliteRepository):
     async def reconcile_orchestration_presets_async(
         self, *, valid_preset_ids: tuple[str, ...], default_preset_id: str | None
     ) -> None:
-        return await self._call_sync_async(
-            self.reconcile_orchestration_presets,
-            valid_preset_ids=valid_preset_ids,
-            default_preset_id=default_preset_id,
+        valid_ids = set(valid_preset_ids)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                """
+                SELECT session_id, session_mode, orchestration_preset_id, started_at
+                     , normal_root_role_id
+                FROM sessions
+                """,
+            )
         )
+        for row in rows:
+            try:
+                started_at = normalize_persisted_text(row["started_at"])
+                if started_at is not None:
+                    continue
+                session_id = require_persisted_identifier(
+                    row["session_id"],
+                    field_name="session_id",
+                )
+                session_mode = SessionMode(str(row["session_mode"] or "normal"))
+                normal_root_role_id = normalize_persisted_text(
+                    row["normal_root_role_id"]
+                )
+                preset_id = normalize_persisted_text(row["orchestration_preset_id"])
+            except (ValidationError, ValueError) as exc:
+                _log_invalid_session_row(row=row, error=exc)
+                continue
+            next_mode = session_mode
+            next_normal_root_role_id = normal_root_role_id
+            next_preset_id = preset_id
+            if preset_id and preset_id not in valid_ids:
+                next_preset_id = default_preset_id
+            if next_mode == SessionMode.ORCHESTRATION and next_preset_id is None:
+                next_mode = SessionMode.NORMAL
+            if (
+                next_mode != session_mode
+                or next_normal_root_role_id != normal_root_role_id
+                or next_preset_id != preset_id
+            ):
+                await self.update_topology_async(
+                    session_id,
+                    session_mode=next_mode,
+                    normal_root_role_id=next_normal_root_role_id,
+                    orchestration_preset_id=next_preset_id,
+                )
 
     def get(self, session_id: str) -> SessionRecord:
         row = self._run_read(
@@ -380,7 +550,20 @@ class SessionRepository(SharedSqliteRepository):
             raise KeyError(f"Unknown session_id: {session_id}") from exc
 
     async def get_async(self, session_id: str) -> SessionRecord:
-        return await self._call_sync_async(self.get, session_id)
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT * FROM sessions WHERE session_id=?",
+                (session_id,),
+            )
+        )
+        if row is None:
+            raise KeyError(f"Unknown session_id: {session_id}")
+        try:
+            return self._to_record(row)
+        except (ValidationError, ValueError) as exc:
+            _log_invalid_session_row(row=row, error=exc)
+            raise KeyError(f"Unknown session_id: {session_id}") from exc
 
     def list_all(self) -> tuple[SessionRecord, ...]:
         rows = self._run_read(
@@ -397,7 +580,19 @@ class SessionRepository(SharedSqliteRepository):
         return tuple(records)
 
     async def list_all_async(self) -> tuple[SessionRecord, ...]:
-        return await self._call_sync_async(self.list_all)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM sessions ORDER BY created_at DESC",
+            )
+        )
+        records: list[SessionRecord] = []
+        for row in rows:
+            try:
+                records.append(self._to_record(row))
+            except (ValidationError, ValueError) as exc:
+                _log_invalid_session_row(row=row, error=exc)
+        return tuple(records)
 
     def delete(self, session_id: str) -> None:
         self._run_write(
@@ -408,7 +603,18 @@ class SessionRepository(SharedSqliteRepository):
         )
 
     async def delete_async(self, session_id: str) -> None:
-        return await self._call_sync_async(self.delete, session_id)
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                "DELETE FROM sessions WHERE session_id=?",
+                (session_id,),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="delete_async",
+            operation=lambda _conn: operation(),
+        )
 
     def _to_record(self, row: sqlite3.Row) -> SessionRecord:
         session_id = require_persisted_identifier(
@@ -571,11 +777,11 @@ def _log_invalid_session_timestamp(
 
 def _log_invalid_session_row(*, row: sqlite3.Row, error: Exception) -> None:
     payload: dict[str, JsonValue] = {
-        "session_id": _persisted_value_preview(row["session_id"]),
-        "workspace_id": _persisted_value_preview(row["workspace_id"]),
-        "started_at": _persisted_value_preview(row["started_at"]),
-        "created_at": _persisted_value_preview(row["created_at"]),
-        "updated_at": _persisted_value_preview(row["updated_at"]),
+        "session_id": _persisted_value_preview(_row_value(row, "session_id")),
+        "workspace_id": _persisted_value_preview(_row_value(row, "workspace_id")),
+        "started_at": _persisted_value_preview(_row_value(row, "started_at")),
+        "created_at": _persisted_value_preview(_row_value(row, "created_at")),
+        "updated_at": _persisted_value_preview(_row_value(row, "updated_at")),
         "error_type": type(error).__name__,
         "error": str(error),
     }
@@ -586,3 +792,9 @@ def _log_invalid_session_row(*, row: sqlite3.Row, error: Exception) -> None:
         message="Skipping invalid persisted session row",
         payload=payload,
     )
+
+
+def _row_value(row: sqlite3.Row, key: str) -> object | None:
+    if key not in row.keys():
+        return None
+    return row[key]

--- a/tests/unit_tests/agents/instances/test_instance_repository.py
+++ b/tests/unit_tests/agents/instances/test_instance_repository.py
@@ -251,3 +251,73 @@ async def test_async_repository_methods_use_direct_sqlite_paths(
         assert await repository.list_all_async() == ()
     finally:
         await repository.close_async()
+
+
+@pytest.mark.asyncio
+async def test_async_methods_preserve_existing_instance_fields(
+    tmp_path: Path,
+) -> None:
+    repository = AgentInstanceRepository(tmp_path / "agent_instances_async.db")
+    try:
+        await repository.upsert_instance_async(
+            run_id="run-1",
+            trace_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+            workspace_id="workspace-1",
+            conversation_id="conversation-1",
+            status=InstanceStatus.IDLE,
+            lifecycle=InstanceLifecycle.EPHEMERAL,
+            parent_instance_id="parent-1",
+        )
+        await repository.upsert_instance_async(
+            run_id="run-1",
+            trace_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+            workspace_id="workspace-1",
+            conversation_id="conversation-1",
+            status=InstanceStatus.RUNNING,
+        )
+
+        record = await repository.get_instance_async("inst-1")
+        assert record.status == InstanceStatus.RUNNING
+        assert record.lifecycle == InstanceLifecycle.EPHEMERAL
+        assert record.parent_instance_id == "parent-1"
+
+        await repository.update_runtime_snapshot_async(
+            "inst-1",
+            runtime_system_prompt="system",
+            runtime_tools_json='{"tools":[]}',
+        )
+        await repository.upsert_instance_async(
+            run_id="run-2",
+            trace_id="run-2",
+            session_id="session-1",
+            instance_id="inst-2",
+            role_id="reviewer",
+            workspace_id="workspace-1",
+            conversation_id="conversation-2",
+            status=InstanceStatus.RUNNING,
+        )
+
+        assert (
+            await repository.get_session_role_instance_id_async("session-1", "reviewer")
+        ) == "inst-2"
+        assert len(await repository.list_by_run_async("run-1")) == 1
+        assert len(await repository.list_by_session_async("session-1")) == 2
+
+        failed_ids = await repository.mark_running_instances_failed_async()
+        assert failed_ids == ("inst-1", "inst-2")
+        assert (
+            await repository.get_instance_async("inst-2")
+        ).status == InstanceStatus.FAILED
+
+        await repository.delete_instance_async("inst-2")
+        assert len(await repository.list_all_async()) == 1
+        await repository.delete_by_session_async("session-1")
+        assert await repository.list_all_async() == ()
+    finally:
+        await repository.close_async()

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -133,6 +133,29 @@ class _InterruptingProvider:
         raise asyncio.CancelledError
 
 
+class _BlockingRunControlManager(RunControlManager):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.completed = False
+
+    async def handle_instance_cancelled_async(
+        self,
+        *,
+        task: TaskEnvelope,
+        instance_id: str,
+    ) -> bool:
+        self.started.set()
+        await self.release.wait()
+        stopped = await super().handle_instance_cancelled_async(
+            task=task,
+            instance_id=instance_id,
+        )
+        self.completed = True
+        return stopped
+
+
 class _ExplodingProvider:
     async def generate(self, request: object) -> str:
         _ = request
@@ -1067,6 +1090,67 @@ async def test_execute_marks_run_stop_as_stopped_idle_not_paused_followup(
     record = task_repo.get(task.task_id)
     assert record.status == TaskStatus.STOPPED
     assert record.error_message == "Task stopped by user"
+
+
+@pytest.mark.asyncio
+async def test_execute_finishes_cancelled_persistence_after_repeated_cancel(
+    tmp_path: Path,
+) -> None:
+    (
+        service,
+        task_repo,
+        agent_repo,
+        message_repo,
+        run_runtime_repo,
+        _run_control_manager,
+    ) = _build_service_with_control(
+        tmp_path / "task_execution_service_repeated_cancel.db",
+        _InterruptingProvider(),
+    )
+    control = _BlockingRunControlManager()
+    control.bind_runtime(
+        run_event_hub=RunEventHub(),
+        injection_manager=RunInjectionManager(),
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        message_repo=message_repo,
+        event_bus=service.event_bus,
+        run_runtime_repo=run_runtime_repo,
+    )
+    service.run_control_manager = control
+    task, instance_id = _seed_task(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+    )
+    _ = control.request_run_stop("run-1")
+
+    execution = asyncio.create_task(
+        service.execute(
+            instance_id=instance_id,
+            role_id="time",
+            task=task,
+        )
+    )
+    await control.started.wait()
+    execution.cancel()
+    await asyncio.sleep(0)
+    assert not execution.done()
+    execution.cancel()
+    await asyncio.sleep(0)
+    assert not execution.done()
+
+    control.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await execution
+
+    runtime = run_runtime_repo.get("run-1")
+    assert runtime is not None
+    assert runtime.status == RunRuntimeStatus.STOPPED
+    assert runtime.phase == RunRuntimePhase.IDLE
+    assert control.completed is True
+    assert task_repo.get(task.task_id).status == TaskStatus.STOPPED
+    assert agent_repo.get_instance(instance_id).status == InstanceStatus.STOPPED
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/orchestration/test_task_execution_timeout.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_timeout.py
@@ -356,6 +356,7 @@ async def test_execute_external_cancel_during_timeout_finalization_keeps_timeout
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(10)
 async def test_execute_applies_timeout_when_worker_cancel_wait_expires(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -377,9 +378,7 @@ async def test_execute_applies_timeout_when_worker_cancel_wait_expires(
     )
     task = task_repo.update_envelope(
         task.task_id,
-        task.model_copy(
-            update={"lifecycle": TaskLifecyclePolicy(timeout_seconds=0.05)}
-        ),
+        task.model_copy(update={"lifecycle": TaskLifecyclePolicy(timeout_seconds=2.0)}),
     ).envelope
 
     execution = asyncio.create_task(

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from os import environ
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 
+from relay_teams.persistence import close_live_sqlite_repositories_async
 from relay_teams.secrets import AppSecretStore
 
 _UNIT_TESTS_ROOT = Path(__file__).resolve().parent
@@ -22,6 +25,12 @@ def _disable_system_keyring_for_unit_tests(monkeypatch: pytest.MonkeyPatch) -> N
     import relay_teams.secrets.secret_store as secret_store
 
     monkeypatch.setattr(secret_store, "_SECRET_STORE", _UnitTestSecretStore())
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _close_sqlite_repositories_after_unit_test() -> AsyncIterator[None]:
+    yield
+    await close_live_sqlite_repositories_async()
 
 
 def pytest_collection_modifyitems(

--- a/tests/unit_tests/gateway/test_acp_stdio.py
+++ b/tests/unit_tests/gateway/test_acp_stdio.py
@@ -163,8 +163,14 @@ class FakeRunService:
         run_id = f"run-{self._counter}"
         return run_id, run_id
 
+    async def create_run_async(self, intent: IntentInput) -> tuple[str, str]:
+        return self.create_run(intent)
+
     def create_detached_run(self, intent: IntentInput) -> tuple[str, str]:
         return self.create_run(intent)
+
+    async def create_detached_run_async(self, intent: IntentInput) -> tuple[str, str]:
+        return self.create_detached_run(intent)
 
     async def stream_run_events(
         self,
@@ -184,12 +190,21 @@ class FakeRunService:
     def ensure_run_started(self, run_id: str) -> None:
         self.ensure_started_calls.append(run_id)
 
+    async def ensure_run_started_async(self, run_id: str) -> None:
+        self.ensure_run_started(run_id)
+
     def resume_run(self, run_id: str) -> str:
         self.resume_calls.append(run_id)
         return "session-1"
 
+    async def resume_run_async(self, run_id: str) -> str:
+        return self.resume_run(run_id)
+
     def stop_run(self, run_id: str) -> None:
         self.stop_calls.append(run_id)
+
+    async def stop_run_async(self, run_id: str) -> None:
+        self.stop_run(run_id)
 
 
 class FakeWorkspaceService:

--- a/tests/unit_tests/hooks/test_hook_service.py
+++ b/tests/unit_tests/hooks/test_hook_service.py
@@ -64,6 +64,7 @@ from relay_teams.hooks.hook_service import (
 from relay_teams.media import UserPromptContent
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.run_models import RunEvent
 
 
 def test_merge_decisions_retries_subagent_stop() -> None:
@@ -509,6 +510,89 @@ async def test_supported_events_dispatch_supported_handler_types(
     assert RunEventType.HOOK_MATCHED in published_event_types
     assert RunEventType.HOOK_COMPLETED in published_event_types
     assert RunEventType.HOOK_DECISION_APPLIED in published_event_types
+
+
+@pytest.mark.asyncio
+async def test_execute_publishes_hook_events_with_async_publisher(
+    tmp_path: Path,
+) -> None:
+    class AsyncOnlyRunEventHub(RunEventHub):
+        def __init__(self) -> None:
+            super().__init__()
+            self.events: list[RunEvent] = []
+
+        def publish(self, event: RunEvent) -> None:
+            _ = event
+            raise AssertionError("HookService must not call sync publish in async flow")
+
+        async def publish_async(self, event: RunEvent) -> None:
+            self.events.append(event)
+
+    class AllowCommandExecutor(CommandHookExecutor):
+        async def execute(
+            self,
+            *,
+            handler: HookHandlerConfig,
+            event_input: HookEventInput,
+        ) -> HookDecision:
+            _ = handler
+            _ = event_input
+            return HookDecision(decision=HookDecisionType.ALLOW)
+
+    source = HookSourceInfo(scope=HookSourceScope.USER, path=tmp_path / "hooks.json")
+    service = HookService(
+        loader=HookLoader(app_config_dir=tmp_path, project_root=None),
+        runtime_state=HookRuntimeState(),
+        command_executor=AllowCommandExecutor(),
+        http_executor=HttpHookExecutor(),
+    )
+    service.set_run_snapshot(
+        "run-1",
+        HookRuntimeSnapshot(
+            sources=(source,),
+            hooks={
+                HookEventName.TASK_CREATED: (
+                    ResolvedHookMatcherGroup(
+                        source=source,
+                        event_name=HookEventName.TASK_CREATED,
+                        group=HookMatcherGroup(
+                            matcher="*",
+                            hooks=(
+                                HookHandlerConfig(
+                                    type=HookHandlerType.COMMAND,
+                                    name="allow-task-created",
+                                    command="echo ok",
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+            },
+        ),
+    )
+    event_hub = AsyncOnlyRunEventHub()
+
+    _ = await service.execute(
+        event_input=TaskCreatedInput(
+            event_name=HookEventName.TASK_CREATED,
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            created_task_id="task-1",
+            parent_task_id="root-task",
+            title="Created task",
+            objective="Create a child task",
+        ),
+        run_event_hub=event_hub,
+    )
+
+    assert [event.event_type for event in event_hub.events] == [
+        RunEventType.HOOK_MATCHED,
+        RunEventType.HOOK_STARTED,
+        RunEventType.HOOK_COMPLETED,
+        RunEventType.HOOK_DECISION_APPLIED,
+    ]
 
 
 def test_runtime_view_prefers_group_name_for_loaded_hook_name(tmp_path: Path) -> None:

--- a/tests/unit_tests/interfaces/server/test_async_api_concurrency.py
+++ b/tests/unit_tests/interfaces/server/test_async_api_concurrency.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import FastAPI
+import httpx
+import pytest
+
+from relay_teams.interfaces.server.deps import (
+    get_run_service,
+    get_session_service,
+    get_skill_registry,
+)
+from relay_teams.interfaces.server.routers import runs, sessions
+from relay_teams.sessions.runs.enums import InjectionSource
+from relay_teams.sessions.runs.run_models import IntentInput
+from relay_teams.sessions.session_models import SessionRecord
+
+
+class _FakeSkillRegistry:
+    def resolve_known(
+        self,
+        values: tuple[str, ...],
+        *,
+        strict: bool,
+        consumer: str,
+    ) -> tuple[str, ...]:
+        _ = (strict, consumer)
+        return values
+
+
+class _AsyncSessionService:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._records: dict[str, SessionRecord] = {}
+
+    async def create_session(
+        self,
+        *,
+        session_id: str | None = None,
+        workspace_id: str,
+        metadata: dict[str, str] | None = None,
+    ) -> SessionRecord:
+        await asyncio.sleep(0.001)
+        async with self._lock:
+            resolved_session_id = session_id or f"session-{len(self._records) + 1}"
+            record = SessionRecord(
+                session_id=resolved_session_id,
+                workspace_id=workspace_id,
+                metadata={} if metadata is None else dict(metadata),
+            )
+            self._records[resolved_session_id] = record
+            return record
+
+    async def list_sessions(self) -> tuple[SessionRecord, ...]:
+        async with self._lock:
+            return tuple(self._records.values())
+
+
+class _InjectedRecord:
+    def __init__(self, *, run_id: str, source: InjectionSource, content: str) -> None:
+        self._payload = {
+            "run_id": run_id,
+            "source": source.value,
+            "content": content,
+        }
+
+    def model_dump(self) -> dict[str, object]:
+        return dict(self._payload)
+
+
+class _AsyncRunService:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._created_runs: dict[str, IntentInput] = {}
+        self.started_run_ids: list[str] = []
+        self.injected_messages: list[tuple[str, str, str]] = []
+        self.resolved_tool_approvals: list[tuple[str, str, str, str]] = []
+
+    def create_run(self, intent_input: IntentInput) -> tuple[str, str]:
+        _ = intent_input
+        raise AssertionError("create_run sync API must not be used by the run router")
+
+    def ensure_run_started(self, run_id: str) -> None:
+        _ = run_id
+        raise AssertionError(
+            "ensure_run_started sync API must not be used by the run router"
+        )
+
+    async def create_run_async(self, intent_input: IntentInput) -> tuple[str, str]:
+        await asyncio.sleep(0.001)
+        async with self._lock:
+            run_id = f"run-{len(self._created_runs) + 1}"
+            self._created_runs[run_id] = intent_input
+            if intent_input.session_id is None:
+                raise RuntimeError("session id is required")
+            return run_id, intent_input.session_id
+
+    async def ensure_run_started_async(self, run_id: str) -> None:
+        await asyncio.sleep(0.001)
+        async with self._lock:
+            self.started_run_ids.append(run_id)
+
+    async def inject_message_async(
+        self,
+        *,
+        run_id: str,
+        source: InjectionSource,
+        content: str,
+    ) -> _InjectedRecord:
+        await asyncio.sleep(0.001)
+        async with self._lock:
+            self.injected_messages.append((run_id, source.value, content))
+        return _InjectedRecord(run_id=run_id, source=source, content=content)
+
+    async def list_open_tool_approvals_async(
+        self,
+        run_id: str,
+    ) -> list[dict[str, str]]:
+        return [{"run_id": run_id, "tool_call_id": "call-open"}]
+
+    async def resolve_tool_approval_async(
+        self,
+        *,
+        run_id: str,
+        tool_call_id: str,
+        action: str,
+        feedback: str = "",
+    ) -> None:
+        await asyncio.sleep(0.001)
+        async with self._lock:
+            self.resolved_tool_approvals.append(
+                (run_id, tool_call_id, action, feedback)
+            )
+
+
+def _create_app(
+    *,
+    session_service: _AsyncSessionService,
+    run_service: _AsyncRunService,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(sessions.router, prefix="/api")
+    app.include_router(runs.router, prefix="/api")
+    app.dependency_overrides[get_session_service] = lambda: session_service
+    app.dependency_overrides[get_run_service] = lambda: run_service
+    app.dependency_overrides[get_skill_registry] = _FakeSkillRegistry
+    return app
+
+
+@pytest.mark.asyncio
+async def test_session_run_and_tool_call_routes_handle_concurrent_requests() -> None:
+    session_service = _AsyncSessionService()
+    run_service = _AsyncRunService()
+    app = _create_app(session_service=session_service, run_service=run_service)
+    transport = httpx.ASGITransport(app=app)
+    request_count = 24
+
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+        timeout=10.0,
+    ) as client:
+        session_responses = await asyncio.gather(
+            *(
+                client.post(
+                    "/api/sessions",
+                    json={
+                        "session_id": f"session-load-{index}",
+                        "workspace_id": "default",
+                    },
+                )
+                for index in range(request_count)
+            )
+        )
+        assert all(response.status_code == 200 for response in session_responses)
+
+        run_responses = await asyncio.gather(
+            *(
+                client.post(
+                    "/api/runs",
+                    json={
+                        "session_id": f"session-load-{index}",
+                        "input": [
+                            {
+                                "kind": "text",
+                                "text": f"load test run {index}",
+                            }
+                        ],
+                        "execution_mode": "manual",
+                    },
+                )
+                for index in range(request_count)
+            )
+        )
+        assert all(response.status_code == 200 for response in run_responses)
+        run_ids = [str(response.json()["run_id"]) for response in run_responses]
+
+        inject_responses = await asyncio.gather(
+            *(
+                client.post(
+                    f"/api/runs/{run_id}/inject",
+                    json={"source": "user", "content": f"follow-up {index}"},
+                )
+                for index, run_id in enumerate(run_ids)
+            )
+        )
+        assert all(response.status_code == 200 for response in inject_responses)
+
+        approval_responses = await asyncio.gather(
+            *(
+                client.post(
+                    f"/api/runs/{run_id}/tool-approvals/call-{index}/resolve",
+                    json={"action": "approve", "feedback": f"ok {index}"},
+                )
+                for index, run_id in enumerate(run_ids)
+            )
+        )
+        assert all(response.status_code == 200 for response in approval_responses)
+
+        list_response = await client.get("/api/sessions")
+        assert list_response.status_code == 200
+        assert len(list_response.json()) == request_count
+
+    assert sorted(run_service.started_run_ids) == sorted(run_ids)
+    assert len(run_service.injected_messages) == request_count
+    assert len(run_service.resolved_tool_approvals) == request_count

--- a/tests/unit_tests/persistence/test_db.py
+++ b/tests/unit_tests/persistence/test_db.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
-from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -193,15 +192,13 @@ async def test_cross_write_coordinator_releases_cancelled_async_acquire(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     coordinator = db_module.CrossModeWriteCoordinator()
+    original_try_acquire = coordinator._try_acquire
 
-    async def _cancel_after_acquire(
-        func: Callable[[tuple[str, int]], bool],
-        token: tuple[str, int],
-    ) -> bool:
-        assert func(token) is True
+    def _cancel_after_acquire(token: tuple[str, int]) -> bool:
+        assert original_try_acquire(token) is True
         raise asyncio.CancelledError
 
-    monkeypatch.setattr(db_module.asyncio, "to_thread", _cancel_after_acquire)
+    monkeypatch.setattr(coordinator, "_try_acquire", _cancel_after_acquire)
 
     with pytest.raises(asyncio.CancelledError):
         await coordinator.acquire_async()
@@ -216,15 +213,13 @@ async def test_cross_write_coordinator_cancelled_reentry_preserves_outer_lock(
 ) -> None:
     coordinator = db_module.CrossModeWriteCoordinator()
     first_token = await coordinator.acquire_async()
+    original_try_acquire = coordinator._try_acquire
 
-    async def _cancel_after_reentry(
-        func: Callable[[tuple[str, int]], bool],
-        token: tuple[str, int],
-    ) -> bool:
-        assert func(token) is True
+    def _cancel_after_reentry(token: tuple[str, int]) -> bool:
+        assert original_try_acquire(token) is True
         raise asyncio.CancelledError
 
-    monkeypatch.setattr(db_module.asyncio, "to_thread", _cancel_after_reentry)
+    monkeypatch.setattr(coordinator, "_try_acquire", _cancel_after_reentry)
 
     with pytest.raises(asyncio.CancelledError):
         await coordinator.acquire_async()
@@ -233,6 +228,24 @@ async def test_cross_write_coordinator_cancelled_reentry_preserves_outer_lock(
     assert coordinator._depth == 1
 
     coordinator.release(first_token)
+
+
+@pytest.mark.asyncio
+async def test_cross_write_coordinator_async_acquire_does_not_use_default_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = db_module.CrossModeWriteCoordinator()
+
+    async def _fail_to_thread(
+        function: object, /, *args: object, **kwargs: object
+    ) -> bool:
+        _ = (function, args, kwargs)
+        raise AssertionError("async coordinator acquire used the default executor")
+
+    monkeypatch.setattr(db_module.asyncio, "to_thread", _fail_to_thread)
+
+    token = await coordinator.acquire_async()
+    coordinator.release(token)
     assert coordinator._owner is None
     assert coordinator._depth == 0
 

--- a/tests/unit_tests/persistence/test_sqlite_repository.py
+++ b/tests/unit_tests/persistence/test_sqlite_repository.py
@@ -16,6 +16,7 @@ from relay_teams.persistence.sqlite_repository import (
     BlockingAsyncSqliteConnection,
     SharedSqliteRepository,
     async_fetchone,
+    close_live_sqlite_repositories_async,
 )
 from relay_teams.retrieval.sqlite_store import SqliteFts5RetrievalStore
 
@@ -97,6 +98,20 @@ def test_sqlite_retrieval_store_uses_stable_repository_name(tmp_path: Path) -> N
     store = SqliteFts5RetrievalStore(tmp_path / "retrieval.db")
 
     assert store._repository_name == "retrieval.sqlite"
+
+
+def test_shared_sqlite_repository_close_clears_cached_connections(
+    tmp_path: Path,
+) -> None:
+    repo = _DummyRepository(tmp_path / "shared_repo_close.db")
+    repo._conn.execute("CREATE TABLE items (value TEXT NOT NULL)")
+    repo._conn.commit()
+
+    assert repo._async_conns
+
+    repo.close()
+
+    assert not repo._async_conns
 
 
 @pytest.mark.asyncio
@@ -232,6 +247,20 @@ async def test_shared_sqlite_repository_sync_facade_writes_are_visible_to_async_
 
     assert row is not None
     assert row["value"] == "sync"
+
+
+@pytest.mark.asyncio
+async def test_close_live_sqlite_repositories_async_closes_registered_repositories(
+    tmp_path: Path,
+) -> None:
+    repo = _DummyRepository(tmp_path / "shared_repo_live_close.db")
+    await repo._run_async_read(lambda _conn: _async_value("ok"))
+
+    assert repo._async_conns
+
+    await close_live_sqlite_repositories_async()
+
+    assert not repo._async_conns
 
 
 async def _async_value(value: str) -> str:

--- a/tests/unit_tests/roles/test_temporary_role_repository.py
+++ b/tests/unit_tests/roles/test_temporary_role_repository.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from relay_teams.computer import ExecutionSurface
 from relay_teams.roles.temporary_role_models import (
     TemporaryRoleRecord,
@@ -43,3 +45,37 @@ def test_temporary_role_repository_roundtrip_and_cleanup(tmp_path: Path) -> None
 
     repo.delete_by_run("run-1")
     assert repo.list_by_run("run-1") == ()
+
+
+@pytest.mark.asyncio
+async def test_temporary_role_repository_async_roundtrip_and_cleanup(
+    tmp_path: Path,
+) -> None:
+    repo = TemporaryRoleRepository(tmp_path / "roles_async.db")
+    spec = TemporaryRoleSpec(
+        role_id="tmp_async_researcher",
+        name="Temporary Async Researcher",
+        description="Run scoped role",
+        system_prompt="You are temporary.",
+        tools=("shell",),
+        execution_surface=ExecutionSurface.API,
+    )
+
+    stored = await repo.upsert_async(
+        TemporaryRoleRecord(
+            run_id="run-async",
+            session_id="session-async",
+            source=TemporaryRoleSource.META_AGENT_GENERATED,
+            role=spec,
+        )
+    )
+    listed = await repo.list_by_run_async("run-async")
+
+    assert stored.role.role_id == "tmp_async_researcher"
+    assert [record.role.role_id for record in listed] == ["tmp_async_researcher"]
+    assert (
+        await repo.get_async(run_id="run-async", role_id="tmp_async_researcher")
+    ).role.tools == ("shell",)
+
+    await repo.delete_by_run_async("run-async")
+    assert await repo.list_by_run_async("run-async") == ()

--- a/tests/unit_tests/sessions/runs/background_tasks/test_manager.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_manager.py
@@ -1351,6 +1351,7 @@ async def test_background_task_manager_windows_tty_transport_supports_write_resi
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 async def test_background_task_manager_windows_tty_uses_dedicated_blocking_executor(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1597,11 +1598,12 @@ async def test_start_session_rolls_back_runtime_when_persistence_fails(
         )
 
     monkeypatch.setattr(manager, "_spawn_runtime", _fake_spawn_runtime)
-    monkeypatch.setattr(
-        repo,
-        "upsert",
-        lambda record: (_ for _ in ()).throw(RuntimeError("db write failed")),
-    )
+
+    async def _fail_upsert_async(record: BackgroundTaskRecord) -> BackgroundTaskRecord:
+        _ = record
+        raise RuntimeError("db write failed")
+
+    monkeypatch.setattr(repo, "upsert_async", _fail_upsert_async)
 
     with pytest.raises(RuntimeError, match="db write failed"):
         await manager.start_session(

--- a/tests/unit_tests/sessions/runs/background_tasks/test_repository.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_repository.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from pathlib import Path
 from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
 
 from relay_teams.sessions.runs.background_tasks.models import (
     BackgroundTaskRecord,
@@ -194,3 +196,87 @@ def test_background_task_repository_can_interrupt_specific_records(
     assert interrupted is not None
     assert interrupted.status == BackgroundTaskStatus.STOPPED
     assert interrupted.pid is None
+
+
+@pytest.mark.asyncio
+async def test_background_task_repository_async_methods_match_sync_behavior(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "background-terminals-async.db"
+    repo = BackgroundTaskRepository(db_path)
+    running = BackgroundTaskRecord(
+        background_task_id="exec-running",
+        run_id="run-1",
+        session_id="session-1",
+        command="sleep 30",
+        cwd="/tmp/project",
+        status=BackgroundTaskStatus.RUNNING,
+        recent_output=("booting",),
+        output_excerpt="booting",
+        pid=111,
+        log_path="tmp/background_tasks/exec-running.log",
+    )
+    blocked = BackgroundTaskRecord(
+        background_task_id="exec-blocked",
+        run_id="run-1",
+        session_id="session-1",
+        command="sleep 60",
+        cwd="/tmp/project",
+        status=BackgroundTaskStatus.BLOCKED,
+        pid=222,
+        log_path="tmp/background_tasks/exec-blocked.log",
+    )
+    other_session = BackgroundTaskRecord(
+        background_task_id="exec-other",
+        run_id="run-2",
+        session_id="session-2",
+        command="echo ok",
+        cwd="/tmp/project",
+        status=BackgroundTaskStatus.COMPLETED,
+        log_path="tmp/background_tasks/exec-other.log",
+    )
+
+    persisted = await repo.upsert_async(running)
+    _ = await repo.upsert_async(blocked)
+    _ = await repo.upsert_async(other_session)
+
+    loaded = await repo.get_async("exec-running")
+    by_run = await repo.list_by_run_async("run-1")
+    by_session = await repo.list_by_session_async("session-1")
+    all_records = await repo.list_all_async()
+    interruptible = await repo.list_interruptible_async()
+    affected = await repo.mark_transient_background_tasks_interrupted_async(
+        background_task_ids=("exec-blocked",)
+    )
+    still_running = await repo.get_async("exec-running")
+    interrupted = await repo.get_async("exec-blocked")
+    await repo.delete_async("exec-running")
+    await repo.delete_by_session_async("session-2")
+
+    assert persisted.background_task_id == "exec-running"
+    assert loaded is not None
+    assert loaded.output_excerpt == "booting"
+    assert tuple(record.background_task_id for record in by_run) == (
+        "exec-blocked",
+        "exec-running",
+    )
+    assert tuple(record.background_task_id for record in by_session) == (
+        "exec-blocked",
+        "exec-running",
+    )
+    assert tuple(record.background_task_id for record in all_records) == (
+        "exec-other",
+        "exec-blocked",
+        "exec-running",
+    )
+    assert tuple(record.background_task_id for record in interruptible) == (
+        "exec-blocked",
+        "exec-running",
+    )
+    assert affected == 1
+    assert still_running is not None
+    assert still_running.status == BackgroundTaskStatus.RUNNING
+    assert interrupted is not None
+    assert interrupted.status == BackgroundTaskStatus.STOPPED
+    assert await repo.get_async("exec-running") is None
+    assert await repo.list_by_session_async("session-2") == ()

--- a/tests/unit_tests/sessions/runs/background_tasks/test_service.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_service.py
@@ -410,6 +410,11 @@ class _FailingStartRunEventHub(_LoopGuardRunEventHub):
             raise RuntimeError("start publish failed")
         super().publish(event)
 
+    async def publish_async(self, event: RunEvent) -> None:
+        if event.event_type == RunEventType.BACKGROUND_TASK_STARTED:
+            raise RuntimeError("start publish failed")
+        await super().publish_async(event)
+
 
 class _LoopGuardRunRuntimeRepository:
     def __init__(self, wrapped: RunRuntimeRepository) -> None:

--- a/tests/unit_tests/sessions/runs/test_run_control_manager.py
+++ b/tests/unit_tests/sessions/runs/test_run_control_manager.py
@@ -301,6 +301,68 @@ async def test_inject_to_running_agents_async_publishes_event(
     assert events[-1]["event_type"] == RunEventType.INJECTION_ENQUEUED.value
 
 
+@pytest.mark.asyncio
+async def test_handle_instance_cancelled_async_persists_stop_without_sync_write(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_control_async_cancel.db"
+    event_log = EventLog(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    task_repo = TaskRepository(db_path)
+    mgr = RunControlManager()
+    mgr.bind_runtime(
+        run_event_hub=RunEventHub(),
+        injection_manager=RunInjectionManager(),
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        message_repo=MessageRepository(db_path),
+        event_bus=event_log,
+        run_runtime_repo=RunRuntimeRepository(db_path),
+    )
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        parent_task_id=None,
+        trace_id="run-1",
+        role_id="MainAgent",
+        objective="cancel me",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = await task_repo.create_async(task)
+    await agent_repo.upsert_instance_async(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="MainAgent",
+        workspace_id="workspace-1",
+        status=InstanceStatus.RUNNING,
+    )
+
+    async def _worker() -> None:
+        await asyncio.sleep(10)
+
+    run_task = asyncio.create_task(_worker())
+    mgr.register_run_task(run_id="run-1", session_id="session-1", task=run_task)
+    assert mgr.request_run_stop("run-1") is True
+    stopped = await mgr.handle_instance_cancelled_async(
+        task=task,
+        instance_id="inst-1",
+    )
+    await asyncio.gather(run_task, return_exceptions=True)
+
+    assert stopped is True
+    assert (await task_repo.get_async("task-1")).status == TaskStatus.STOPPED
+    assert (
+        await agent_repo.get_instance_async("inst-1")
+    ).status == InstanceStatus.STOPPED
+    events = await event_log.list_by_session_async("session-1")
+    assert [event["event_type"] for event in events] == [
+        "task_stopped",
+        "instance_stopped",
+    ]
+
+
 def test_context_raises_when_cancelled() -> None:
     mgr = RunControlManager()
     mgr.pause_subagent(

--- a/tests/unit_tests/sessions/runs/test_run_intent_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_intent_repo.py
@@ -91,6 +91,37 @@ def test_run_intent_repo_lists_intents_by_session(tmp_path: Path) -> None:
     assert records["run-1"].display_intent == "display first"
 
 
+@pytest.mark.asyncio
+async def test_run_intent_repo_async_methods_match_sync_behavior(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_intent_async.db"
+    repo = RunIntentRepository(db_path)
+
+    await repo.upsert_async(
+        run_id="run-1",
+        session_id="session-1",
+        intent=IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("first"),
+            display_input=content_parts_from_text("display first"),
+            execution_mode=ExecutionMode.AI,
+            yolo=True,
+        ),
+    )
+    await repo.append_followup_async(run_id="run-1", content="second")
+
+    record = await repo.get_async("run-1")
+    records = await repo.list_by_session_async("session-1")
+
+    assert record.execution_mode == ExecutionMode.AI
+    assert record.yolo is True
+    assert record.intent == "first\n\nsecond"
+    assert record.display_intent == "first\n\nsecond"
+    assert tuple(records) == ("run-1",)
+    assert records["run-1"].intent == "first\n\nsecond"
+
+
 def test_run_intent_repo_list_by_session_skips_invalid_rows(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -3927,7 +3927,11 @@ async def test_bound_loop_helpers_dispatch_callbacks_to_service_loop(
     manager = _build_manager(tmp_path / "run_bound_loop_helpers.db")
 
     assert manager._call_in_bound_loop(lambda: "local") == "local"
-    assert await manager._call_in_bound_loop_async(lambda: "local-async") == (
+
+    async def _local_async() -> str:
+        return "local-async"
+
+    assert await manager._call_coroutine_in_bound_loop_async(_local_async) == (
         "local-async"
     )
 
@@ -3950,30 +3954,35 @@ async def test_bound_loop_helpers_dispatch_callbacks_to_service_loop(
         callback_thread_ids.append(threading.get_ident())
         return "bound"
 
+    async def _capture_thread_async() -> str:
+        callback_thread_ids.append(threading.get_ident())
+        return "bound-async"
+
     def _sync_error() -> str:
         raise RuntimeError("sync bound failure")
 
-    def _async_error() -> str:
+    async def _async_error() -> str:
         raise RuntimeError("async bound failure")
 
     lifecycle_calls: list[str] = []
 
-    def _create_run(
+    async def _create_run_local_async(
         intent: IntentInput,
         *,
+        allow_active_run_attach: bool,
         source: InjectionSource = InjectionSource.USER,
     ) -> tuple[str, str]:
-        lifecycle_calls.append(f"create:{intent.intent}:{source.value}")
-        return "run-created", "session-1"
-
-    def _create_detached_run(intent: IntentInput) -> tuple[str, str]:
+        if allow_active_run_attach:
+            lifecycle_calls.append(f"create:{intent.intent}:{source.value}")
+            return "run-created", "session-1"
         lifecycle_calls.append(f"detached:{intent.intent}")
         return "run-detached", "session-1"
 
-    def _ensure_started(run_id: str) -> None:
+    async def _ensure_started(run_id: str) -> None:
         lifecycle_calls.append(f"ensure:{run_id}")
 
-    def _inject_message(
+    async def _inject_message(
+        *,
         run_id: str,
         source: InjectionSource,
         content: str,
@@ -3981,14 +3990,15 @@ async def test_bound_loop_helpers_dispatch_callbacks_to_service_loop(
         lifecycle_calls.append(f"inject:{run_id}:{source.value}:{content}")
         return run_id, source.value, content
 
-    def _stop_run(run_id: str) -> None:
+    async def _stop_run(run_id: str) -> None:
         lifecycle_calls.append(f"stop:{run_id}")
 
-    def _resume_run(run_id: str) -> str:
+    async def _resume_run(run_id: str) -> str:
         lifecycle_calls.append(f"resume:{run_id}")
         return "session-1"
 
-    def _resolve_tool_approval(
+    async def _resolve_tool_approval(
+        *,
         run_id: str,
         tool_call_id: str,
         action: str,
@@ -3996,25 +4006,32 @@ async def test_bound_loop_helpers_dispatch_callbacks_to_service_loop(
     ) -> None:
         lifecycle_calls.append(f"resolve:{run_id}:{tool_call_id}:{action}:{feedback}")
 
-    monkeypatch.setattr(manager, "create_run", _create_run)
-    monkeypatch.setattr(manager, "create_detached_run", _create_detached_run)
-    monkeypatch.setattr(manager, "ensure_run_started", _ensure_started)
-    monkeypatch.setattr(manager, "inject_message", _inject_message)
-    monkeypatch.setattr(manager, "stop_run", _stop_run)
-    monkeypatch.setattr(manager, "resume_run", _resume_run)
-    monkeypatch.setattr(manager, "resolve_tool_approval", _resolve_tool_approval)
+    monkeypatch.setattr(manager, "_create_run_local_async", _create_run_local_async)
+    monkeypatch.setattr(manager, "_ensure_run_started_local_async", _ensure_started)
+    monkeypatch.setattr(
+        manager._run_control_manager,
+        "inject_to_running_agents_async",
+        _inject_message,
+    )
+    monkeypatch.setattr(manager, "_stop_run_local_async", _stop_run)
+    monkeypatch.setattr(manager, "_resume_run_local_async", _resume_run)
+    monkeypatch.setattr(
+        manager._interaction_service,
+        "resolve_tool_approval_async",
+        _resolve_tool_approval,
+    )
 
     manager._event_loop = service_loop
     try:
         assert manager._should_delegate_to_bound_loop() is True
         assert manager._call_in_bound_loop(_capture_thread) == "bound"
-        assert await manager._call_in_bound_loop_async(lambda: "bound-async") == (
-            "bound-async"
-        )
+        assert await manager._call_coroutine_in_bound_loop_async(
+            _capture_thread_async
+        ) == ("bound-async")
         with pytest.raises(RuntimeError, match="sync bound failure"):
             manager._call_in_bound_loop(_sync_error)
         with pytest.raises(RuntimeError, match="async bound failure"):
-            await manager._call_in_bound_loop_async(_async_error)
+            await manager._call_coroutine_in_bound_loop_async(_async_error)
         assert await manager.create_run_async(
             IntentInput(
                 session_id="session-1",
@@ -4048,7 +4065,7 @@ async def test_bound_loop_helpers_dispatch_callbacks_to_service_loop(
         thread.join(timeout=5)
         service_loop.close()
 
-    assert callback_thread_ids == [thread_id]
+    assert callback_thread_ids == [thread_id, thread_id]
     assert lifecycle_calls == [
         "create:create through bound loop:system",
         "detached:detach through bound loop",
@@ -4068,11 +4085,11 @@ async def test_run_intent_stream_starts_run_before_streaming_events(
     manager = _build_manager(tmp_path / "run_intent_stream.db")
     calls: list[str] = []
 
-    def _create_run(intent: IntentInput) -> tuple[str, str]:
+    async def _create_run(intent: IntentInput) -> tuple[str, str]:
         calls.append(f"create:{intent.session_id}")
         return "run-stream", "session-1"
 
-    def _ensure_run_started(run_id: str) -> None:
+    async def _ensure_run_started(run_id: str) -> None:
         calls.append(f"ensure:{run_id}")
 
     async def _stream_run_events(run_id: str):
@@ -4085,8 +4102,8 @@ async def test_run_intent_stream_starts_run_before_streaming_events(
             payload_json="{}",
         )
 
-    monkeypatch.setattr(manager, "create_run", _create_run)
-    monkeypatch.setattr(manager, "ensure_run_started", _ensure_run_started)
+    monkeypatch.setattr(manager, "create_run_async", _create_run)
+    monkeypatch.setattr(manager, "ensure_run_started_async", _ensure_run_started)
     monkeypatch.setattr(manager, "stream_run_events", _stream_run_events)
 
     events = [

--- a/tests/unit_tests/sessions/runs/test_run_service_stop_semantics.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_stop_semantics.py
@@ -18,6 +18,7 @@ from relay_teams.sessions.runs.background_tasks.manager import BackgroundTaskMan
 from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
 from relay_teams.sessions.runs.run_service import SessionRunService
 from relay_teams.sessions.runs.run_models import IntentInput, RunResult
+from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.notifications import (
     NotificationChannel,
     NotificationConfig,
@@ -109,6 +110,18 @@ class _RunRuntimeRepo:
         return ()
 
 
+class _BlockingRuntimeRoleResolver:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.cleaned_runs: list[str] = []
+
+    async def cleanup_run_async(self, *, run_id: str) -> None:
+        self.started.set()
+        await self.release.wait()
+        self.cleaned_runs.append(run_id)
+
+
 class _FailingRunEventHub:
     def publish(self, event) -> None:
         _ = event
@@ -136,6 +149,9 @@ class _SessionRepo:
             workspace_id="default",
         )
 
+    async def get_async(self, session_id: str) -> SessionRecord:
+        return self.get(session_id)
+
     def create(
         self, session_id: str, metadata: dict[str, str] | None = None
     ) -> SessionRecord:
@@ -147,6 +163,9 @@ class _SessionRepo:
 
     def mark_started(self, session_id: str) -> SessionRecord:
         return self.get(session_id)
+
+    async def mark_started_async(self, session_id: str) -> SessionRecord:
+        return self.mark_started(session_id)
 
 
 def _make_run_service(
@@ -367,6 +386,41 @@ def test_stop_active_runs_for_shutdown_skips_missing_and_failed_stops(
 
     assert stopped_count == 1
     assert set(stopped_run_ids) == {"ok-run", "missing-run", "broken-run"}
+
+
+@pytest.mark.asyncio
+async def test_safe_finalize_run_async_finishes_after_repeated_cancellation() -> None:
+    control = RunControlManager()
+    manager = _make_run_service(control)
+    resolver = _BlockingRuntimeRoleResolver()
+    manager._runtime_role_resolver = cast(
+        RuntimeRoleResolver,
+        cast(object, resolver),
+    )
+    manager._running_run_ids.add("run-1")
+    manager._active_run_registry.remember_active_run(
+        session_id="session-1",
+        run_id="run-1",
+    )
+
+    finalizer = asyncio.create_task(
+        manager._safe_finalize_run_async(run_id="run-1", session_id="session-1")
+    )
+    await resolver.started.wait()
+    finalizer.cancel()
+    await asyncio.sleep(0)
+    assert not finalizer.done()
+    finalizer.cancel()
+    await asyncio.sleep(0)
+    assert not finalizer.done()
+
+    resolver.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        _ = await finalizer
+
+    assert resolver.cleaned_runs == ["run-1"]
+    assert "run-1" not in manager._running_run_ids
+    assert manager._active_run_registry.get_active_run_id("session-1") is None
 
 
 def test_completed_notification_uses_final_run_output() -> None:

--- a/tests/unit_tests/sessions/runs/test_run_split_helpers.py
+++ b/tests/unit_tests/sessions/runs/test_run_split_helpers.py
@@ -34,6 +34,7 @@ from relay_teams.sessions.runs.run_models import (
     RunKind,
     RunTopologySnapshot,
 )
+from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.sessions.runs.run_terminal_results import RunTerminalResultService
 from relay_teams.sessions.session_repository import SessionRepository
 from relay_teams.sessions.session_models import SessionMode
@@ -168,6 +169,32 @@ async def test_run_event_publisher_async_uses_async_notification_emit() -> None:
             run_kind="generate_image",
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_event_publisher_async_runtime_update_does_not_call_sync() -> None:
+    class _RuntimeRepo:
+        def __init__(self) -> None:
+            self.async_changes: dict[str, object] | None = None
+
+        def update(self, run_id: str, **changes: object) -> None:
+            _ = (run_id, changes)
+            raise AssertionError("sync update should not be called")
+
+        async def update_async(self, run_id: str, **changes: object) -> None:
+            self.async_changes = {"run_id": run_id, **changes}
+
+    runtime_repo = _RuntimeRepo()
+    publisher = RunEventPublisher(
+        run_event_hub=RunEventHub(),
+        get_runtime=lambda _run_id: None,
+        get_run_runtime_repo=lambda: cast(RunRuntimeRepository, runtime_repo),
+        get_notification_service=lambda: None,
+    )
+
+    await publisher.safe_runtime_update_async("run-1", phase="terminal")
+
+    assert runtime_repo.async_changes == {"run_id": "run-1", "phase": "terminal"}
 
 
 def test_execute_native_generation_rejects_inline_media_output() -> None:

--- a/tests/unit_tests/sessions/test_session_repository.py
+++ b/tests/unit_tests/sessions/test_session_repository.py
@@ -8,6 +8,7 @@ import time
 
 import pytest
 
+from relay_teams.sessions.session_models import SessionMode
 from relay_teams.sessions.session_repository import SessionRepository
 
 
@@ -163,6 +164,44 @@ def test_get_raises_key_error_for_invalid_persisted_row(tmp_path: Path) -> None:
         repository.get("None")
 
 
+@pytest.mark.asyncio
+async def test_get_async_raises_key_error_for_invalid_persisted_row(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_repository_invalid_get_async.db"
+    repository = SessionRepository(db_path)
+    _insert_session_row(
+        db_path,
+        session_id="None",
+        metadata_json="{}",
+    )
+
+    with pytest.raises(KeyError):
+        await repository.get_async("None")
+
+
+@pytest.mark.asyncio
+async def test_list_all_async_skips_rows_with_blank_session_id(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_repository_async_blank_session_id.db"
+    repository = SessionRepository(db_path)
+    _insert_session_row(
+        db_path,
+        session_id="session-valid",
+        metadata_json="{}",
+    )
+    _insert_session_row(
+        db_path,
+        session_id="",
+        metadata_json="{}",
+    )
+
+    records = await repository.list_all_async()
+
+    assert [record.session_id for record in records] == ["session-valid"]
+
+
 @pytest.mark.parametrize("started_at", ["", "None", "null"])
 def test_repository_init_normalizes_missing_or_none_like_started_at_for_mark_started(
     tmp_path: Path,
@@ -262,6 +301,155 @@ def test_mark_started_retries_transient_write_lock(tmp_path: Path) -> None:
     assert released.is_set()
     assert record.started_at is not None
     assert record.can_switch_mode is False
+
+
+@pytest.mark.asyncio
+async def test_async_methods_match_sync_session_repository_behavior(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_repository_async.db"
+    repository = SessionRepository(db_path)
+
+    created = await repository.create_async(
+        session_id="session-async",
+        workspace_id="workspace-1",
+        metadata={"title": "Async"},
+    )
+    await repository.update_topology_async(
+        "session-async",
+        session_mode=SessionMode.ORCHESTRATION,
+        normal_root_role_id=None,
+        orchestration_preset_id="preset-1",
+    )
+    await repository.update_metadata_async(
+        "session-async",
+        {"title": "Updated"},
+    )
+    await repository.update_workspace_async(
+        "session-async",
+        workspace_id="workspace-2",
+        project_id="project-2",
+    )
+    await repository.reconcile_orchestration_presets_async(
+        valid_preset_ids=("preset-1",),
+        default_preset_id=None,
+    )
+    started = await repository.mark_started_async("session-async")
+    records = await repository.list_all_async()
+
+    assert created.session_id == "session-async"
+    assert started.started_at is not None
+    assert started.can_switch_mode is False
+    assert started.workspace_id == "workspace-2"
+    assert started.project_id == "project-2"
+    assert started.metadata == {"title": "Updated"}
+    assert started.session_mode == SessionMode.ORCHESTRATION
+    assert [record.session_id for record in records] == ["session-async"]
+
+    with pytest.raises(RuntimeError, match="Session mode can no longer be changed"):
+        await repository.update_topology_async(
+            "session-async",
+            session_mode=SessionMode.NORMAL,
+            normal_root_role_id=None,
+            orchestration_preset_id=None,
+        )
+
+    await repository.delete_async("session-async")
+    with pytest.raises(KeyError):
+        await repository.get_async("session-async")
+
+
+@pytest.mark.asyncio
+async def test_async_mutations_raise_key_error_for_missing_session(
+    tmp_path: Path,
+) -> None:
+    repository = SessionRepository(tmp_path / "session_repository_async_missing.db")
+
+    with pytest.raises(KeyError):
+        await repository.update_topology_async(
+            "missing-session",
+            session_mode=SessionMode.ORCHESTRATION,
+            normal_root_role_id=None,
+            orchestration_preset_id="preset-1",
+        )
+    with pytest.raises(KeyError):
+        await repository.update_metadata_async(
+            "missing-session",
+            {"title": "Missing"},
+        )
+    with pytest.raises(KeyError):
+        await repository.update_workspace_async(
+            "missing-session",
+            workspace_id="workspace-2",
+            project_id="project-2",
+        )
+    with pytest.raises(KeyError):
+        await repository.mark_started_async("missing-session")
+
+
+@pytest.mark.asyncio
+async def test_reconcile_orchestration_presets_async_updates_dirty_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_repository_async_reconcile.db"
+    repository = SessionRepository(db_path)
+    _insert_session_row(
+        db_path,
+        session_id="",
+        metadata_json="{}",
+    )
+    await repository.create_async(
+        session_id="session-invalid-preset",
+        workspace_id="default",
+    )
+    await repository.update_topology_async(
+        "session-invalid-preset",
+        session_mode=SessionMode.ORCHESTRATION,
+        normal_root_role_id="MainAgent",
+        orchestration_preset_id="removed-preset",
+    )
+    await repository.create_async(
+        session_id="session-no-default",
+        workspace_id="default",
+    )
+    await repository.update_topology_async(
+        "session-no-default",
+        session_mode=SessionMode.ORCHESTRATION,
+        normal_root_role_id=None,
+        orchestration_preset_id="removed-preset",
+    )
+    await repository.create_async(
+        session_id="session-started",
+        workspace_id="default",
+    )
+    await repository.update_topology_async(
+        "session-started",
+        session_mode=SessionMode.ORCHESTRATION,
+        normal_root_role_id=None,
+        orchestration_preset_id="removed-preset",
+    )
+    await repository.mark_started_async("session-started")
+
+    await repository.reconcile_orchestration_presets_async(
+        valid_preset_ids=("fallback-preset",),
+        default_preset_id="fallback-preset",
+    )
+    await repository.reconcile_orchestration_presets_async(
+        valid_preset_ids=(),
+        default_preset_id=None,
+    )
+
+    invalid_preset = await repository.get_async("session-invalid-preset")
+    no_default = await repository.get_async("session-no-default")
+    started = await repository.get_async("session-started")
+
+    assert invalid_preset.session_mode == SessionMode.NORMAL
+    assert invalid_preset.normal_root_role_id == "MainAgent"
+    assert invalid_preset.orchestration_preset_id is None
+    assert no_default.session_mode == SessionMode.NORMAL
+    assert no_default.orchestration_preset_id is None
+    assert started.session_mode == SessionMode.ORCHESTRATION
+    assert started.orchestration_preset_id == "removed-preset"
 
 
 def _insert_session_row(

--- a/tests/unit_tests/test_async_wrapper_coverage.py
+++ b/tests/unit_tests/test_async_wrapper_coverage.py
@@ -20,130 +20,421 @@ class _WrapperSpec(NamedTuple):
     method_name: str
 
 
-class _AsyncWrapperReceiver:
-    def __init__(self) -> None:
-        self.calls: list[str] = []
-
-    def __getattr__(self, name: str) -> Callable[..., object]:
-        def sync_method(*args: object, **kwargs: object) -> object:
-            _ = (args, kwargs)
-            self.calls.append(name)
-            return {"called": name}
-
-        return sync_method
-
-    async def _call_sync_async(
-        self,
-        function: Callable[..., object],
-        /,
-        *args: object,
-        **kwargs: object,
-    ) -> object:
-        return function(*args, **kwargs)
-
-
-def _simple_call_sync_async_wrappers() -> tuple[_WrapperSpec, ...]:
-    project_root = Path(__file__).resolve().parents[2]
-    source_root = project_root / "src" / "relay_teams"
-    specs: list[_WrapperSpec] = []
-    for path in sorted(source_root.rglob("*.py")):
-        source = path.read_text(encoding="utf-8")
-        if "_call_sync_async" not in source:
-            continue
-        module_name = _module_name_for(path=path, source_root=source_root)
-        tree = ast.parse(source)
-        for node in tree.body:
-            if not isinstance(node, ast.ClassDef):
-                continue
-            for item in node.body:
-                if not isinstance(item, ast.AsyncFunctionDef):
-                    continue
-                if _is_simple_call_sync_async_wrapper(item):
-                    specs.append(
-                        _WrapperSpec(
-                            module_name=module_name,
-                            class_name=node.name,
-                            method_name=item.name,
-                        )
-                    )
-    return tuple(specs)
-
-
-def _is_simple_call_sync_async_wrapper(node: ast.AsyncFunctionDef) -> bool:
-    if len(node.body) != 1:
-        return False
-    statement = node.body[0]
-    if not isinstance(statement, ast.Return):
-        return False
-    value = statement.value
-    if not isinstance(value, ast.Await):
-        return False
-    call = value.value
-    if not isinstance(call, ast.Call):
-        return False
-    function = call.func
-    return isinstance(function, ast.Attribute) and function.attr == "_call_sync_async"
-
-
-def _module_name_for(*, path: Path, source_root: Path) -> str:
-    relative = path.relative_to(source_root.parent).with_suffix("")
-    return ".".join(relative.parts)
-
-
 def _module_class(*, module: ModuleType, class_name: str) -> type[object]:
     return cast(type[object], getattr(module, class_name))
 
 
-def _arguments_for(
-    signature: inspect.Signature,
-) -> tuple[list[object], dict[str, object]]:
-    args: list[object] = []
-    kwargs: dict[str, object] = {}
-    parameters = tuple(signature.parameters.values())
-    for parameter in parameters[1:]:
-        if parameter.default is not inspect.Parameter.empty:
-            continue
-        value = _value_for_parameter(parameter.name)
-        if parameter.kind in {
-            inspect.Parameter.POSITIONAL_ONLY,
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        }:
-            args.append(value)
-        elif parameter.kind == inspect.Parameter.KEYWORD_ONLY:
-            kwargs[parameter.name] = value
-    return args, kwargs
+_RUNTIME_LIFECYCLE_ASYNC_METHODS: tuple[_WrapperSpec, ...] = (
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service", "SessionRunService", "run_intent"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "create_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "create_detached_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "ensure_run_started_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "run_intent_stream",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "inject_message_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service", "SessionRunService", "stop_run_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service", "SessionRunService", "resume_run_async"
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "resolve_tool_approval_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_service",
+        "SessionRunService",
+        "stop_subagent_async",
+    ),
+)
+
+_BACKGROUND_TASK_REPOSITORY_ASYNC_METHODS: tuple[_WrapperSpec, ...] = (
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "upsert_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "get_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "list_by_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "list_by_session_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "list_all_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "list_interruptible_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "delete_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "delete_by_session_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.background_tasks.repository",
+        "BackgroundTaskRepository",
+        "mark_transient_background_tasks_interrupted_async",
+    ),
+)
+
+_RUN_INTENT_REPOSITORY_ASYNC_METHODS: tuple[_WrapperSpec, ...] = (
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_intent_repo",
+        "RunIntentRepository",
+        "upsert_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_intent_repo",
+        "RunIntentRepository",
+        "append_followup_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_intent_repo",
+        "RunIntentRepository",
+        "get_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_intent_repo",
+        "RunIntentRepository",
+        "list_by_session_async",
+    ),
+)
+
+_AGENT_INSTANCE_REPOSITORY_ASYNC_METHODS: tuple[_WrapperSpec, ...] = (
+    _WrapperSpec(
+        "relay_teams.agents.instances.instance_repository",
+        "AgentInstanceRepository",
+        "upsert_instance_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.instances.instance_repository",
+        "AgentInstanceRepository",
+        "update_runtime_snapshot_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.instances.instance_repository",
+        "AgentInstanceRepository",
+        "mark_status_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.instances.instance_repository",
+        "AgentInstanceRepository",
+        "list_by_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.instances.instance_repository",
+        "AgentInstanceRepository",
+        "get_instance_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.agents.instances.instance_repository",
+        "AgentInstanceRepository",
+        "get_session_role_instance_async",
+    ),
+)
+
+_SESSION_REPOSITORY_ASYNC_METHODS: tuple[_WrapperSpec, ...] = (
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "create_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "update_topology_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "update_metadata_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "update_workspace_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "mark_started_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "reconcile_orchestration_presets_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "get_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "list_all_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.session_repository",
+        "SessionRepository",
+        "delete_async",
+    ),
+)
+
+_RUN_EVENT_PUBLISHER_ASYNC_METHODS: tuple[_WrapperSpec, ...] = (
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_event_publisher",
+        "RunEventPublisher",
+        "safe_runtime_update_async",
+    ),
+)
+
+_TEMPORARY_ROLE_REPOSITORY_ASYNC_METHODS: tuple[_WrapperSpec, ...] = (
+    _WrapperSpec(
+        "relay_teams.roles.temporary_role_repository",
+        "TemporaryRoleRepository",
+        "upsert_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.roles.temporary_role_repository",
+        "TemporaryRoleRepository",
+        "get_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.roles.temporary_role_repository",
+        "TemporaryRoleRepository",
+        "list_by_run_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.roles.temporary_role_repository",
+        "TemporaryRoleRepository",
+        "delete_by_run_async",
+    ),
+)
+
+_SYNC_LIFECYCLE_METHOD_NAMES = frozenset(
+    {
+        "active_run_id",
+        "create_detached_run",
+        "create_run",
+        "ensure_run_started",
+        "is_session_busy",
+        "require_started",
+        "resume_run",
+        "start_run",
+        "stop_run",
+        "submit",
+    }
+)
+
+_SYNC_LIFECYCLE_TARGET_NAMES = frozenset(
+    {
+        "self",
+        "self._inbound_runtime",
+        "self._run_service",
+        "self._session_ingress_service",
+    }
+)
 
 
-def _value_for_parameter(name: str) -> object:
-    if name.endswith("_ids"):
-        return ("id-1",)
-    if name in {"limit", "timeout_ms", "yield_time_ms", "columns", "rows"}:
-        return 1
-    if name.startswith("is_") or name.startswith("include_"):
-        return False
-    if name in {"now", "created_at", "updated_at"}:
-        return "2026-04-25T00:00:00+00:00"
-    return f"{name}-value"
-
-
-@pytest.mark.asyncio
-@pytest.mark.timeout(10)
-@pytest.mark.parametrize("spec", _simple_call_sync_async_wrappers())
-async def test_simple_call_sync_async_wrappers_delegate_to_shared_helper(
+@pytest.mark.parametrize("spec", _RUNTIME_LIFECYCLE_ASYNC_METHODS)
+def test_runtime_lifecycle_async_methods_do_not_use_call_sync_async(
     spec: _WrapperSpec,
 ) -> None:
     module = importlib.import_module(spec.module_name)
     class_object = _module_class(module=module, class_name=spec.class_name)
-    method = cast(
-        Callable[..., Awaitable[object]],
-        getattr(class_object, spec.method_name),
+    method = getattr(class_object, spec.method_name)
+    source = inspect.getsource(method)
+
+    assert "_call_sync_async" not in source
+
+
+@pytest.mark.parametrize("spec", _BACKGROUND_TASK_REPOSITORY_ASYNC_METHODS)
+def test_background_task_repository_async_methods_do_not_use_call_sync_async(
+    spec: _WrapperSpec,
+) -> None:
+    module = importlib.import_module(spec.module_name)
+    class_object = _module_class(module=module, class_name=spec.class_name)
+    method = getattr(class_object, spec.method_name)
+    source = inspect.getsource(method)
+
+    assert "_call_sync_async" not in source
+
+
+@pytest.mark.parametrize("spec", _RUN_INTENT_REPOSITORY_ASYNC_METHODS)
+def test_run_intent_repository_async_methods_do_not_use_call_sync_async(
+    spec: _WrapperSpec,
+) -> None:
+    module = importlib.import_module(spec.module_name)
+    class_object = _module_class(module=module, class_name=spec.class_name)
+    method = getattr(class_object, spec.method_name)
+    source = inspect.getsource(method)
+
+    assert "_call_sync_async" not in source
+
+
+@pytest.mark.parametrize("spec", _AGENT_INSTANCE_REPOSITORY_ASYNC_METHODS)
+def test_agent_instance_repository_async_methods_do_not_use_call_sync_async(
+    spec: _WrapperSpec,
+) -> None:
+    module = importlib.import_module(spec.module_name)
+    class_object = _module_class(module=module, class_name=spec.class_name)
+    method = getattr(class_object, spec.method_name)
+    source = inspect.getsource(method)
+
+    assert "_call_sync_async" not in source
+
+
+@pytest.mark.parametrize("spec", _SESSION_REPOSITORY_ASYNC_METHODS)
+def test_session_repository_async_methods_do_not_use_call_sync_async(
+    spec: _WrapperSpec,
+) -> None:
+    module = importlib.import_module(spec.module_name)
+    class_object = _module_class(module=module, class_name=spec.class_name)
+    method = getattr(class_object, spec.method_name)
+    source = inspect.getsource(method)
+
+    assert "_call_sync_async" not in source
+
+
+@pytest.mark.parametrize("spec", _RUN_EVENT_PUBLISHER_ASYNC_METHODS)
+def test_run_event_publisher_async_methods_do_not_use_call_sync_async(
+    spec: _WrapperSpec,
+) -> None:
+    module = importlib.import_module(spec.module_name)
+    class_object = _module_class(module=module, class_name=spec.class_name)
+    method = getattr(class_object, spec.method_name)
+    source = inspect.getsource(method)
+
+    assert "_call_sync_async" not in source
+
+
+@pytest.mark.parametrize("spec", _TEMPORARY_ROLE_REPOSITORY_ASYNC_METHODS)
+def test_temporary_role_repository_async_methods_do_not_use_call_sync_async(
+    spec: _WrapperSpec,
+) -> None:
+    module = importlib.import_module(spec.module_name)
+    class_object = _module_class(module=module, class_name=spec.class_name)
+    method = getattr(class_object, spec.method_name)
+    source = inspect.getsource(method)
+
+    assert "_call_sync_async" not in source
+
+
+@pytest.mark.timeout(5)
+def test_async_runtime_entrypoints_do_not_call_sync_lifecycle_methods() -> None:
+    violations = _async_sync_lifecycle_calls()
+
+    assert violations == ()
+
+
+def _async_sync_lifecycle_calls() -> tuple[str, ...]:
+    project_root = Path(__file__).resolve().parents[2]
+    source_root = project_root / "src" / "relay_teams"
+    scoped_roots = (
+        source_root / "automation",
+        source_root / "gateway",
+        source_root / "interfaces" / "server",
+        source_root / "sessions" / "runs",
+        source_root / "triggers",
     )
-    receiver = _AsyncWrapperReceiver()
-    args, kwargs = _arguments_for(inspect.signature(method))
+    violations: list[str] = []
+    for scoped_root in scoped_roots:
+        for path in sorted(scoped_root.rglob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+            visitor = _AsyncSyncLifecycleVisitor(path=path, source_root=source_root)
+            visitor.visit(tree)
+            violations.extend(visitor.violations)
+    return tuple(violations)
 
-    _ = await method(receiver, *args, **kwargs)
 
-    assert receiver.calls
+class _AsyncSyncLifecycleVisitor(ast.NodeVisitor):
+    def __init__(self, *, path: Path, source_root: Path) -> None:
+        self._path = path
+        self._source_root = source_root
+        self._async_stack: list[str] = []
+        self.violations: list[str] = []
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._async_stack.append(node.name)
+        self.generic_visit(node)
+        _ = self._async_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if self._async_stack:
+            return
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._async_stack:
+            self._record_call_violation(node)
+        self.generic_visit(node)
+
+    def _record_call_violation(self, node: ast.Call) -> None:
+        function = node.func
+        if not isinstance(function, ast.Attribute):
+            return
+        if function.attr not in _SYNC_LIFECYCLE_METHOD_NAMES:
+            return
+        target = _attribute_name(function.value)
+        if target not in _SYNC_LIFECYCLE_TARGET_NAMES:
+            return
+        relative_path = self._path.relative_to(self._source_root.parent)
+        self.violations.append(
+            f"{relative_path}:{node.lineno}: "
+            f"async {self._async_stack[-1]} calls {target}.{function.attr}"
+        )
+
+
+def _attribute_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_attribute_name(node.value)}.{node.attr}"
+    return ""
 
 
 _PERMISSIVE_ASYNC_SPECS: tuple[_WrapperSpec, ...] = (
@@ -323,6 +614,11 @@ _PERMISSIVE_ASYNC_SPECS: tuple[_WrapperSpec, ...] = (
         "relay_teams.sessions.runs.run_control_manager",
         "RunControlManager",
         "publish_run_stopped_async",
+    ),
+    _WrapperSpec(
+        "relay_teams.sessions.runs.run_control_manager",
+        "RunControlManager",
+        "handle_instance_cancelled_async",
     ),
     _WrapperSpec(
         "relay_teams.sessions.runs.run_control_manager",
@@ -1171,6 +1467,10 @@ class _PermissiveAsyncReceiver:
         return None
 
     def is_run_stop_requested(self, *args: object, **kwargs: object) -> bool:
+        _ = (args, kwargs)
+        return False
+
+    def is_cancelled(self, *args: object, **kwargs: object) -> bool:
         _ = (args, kwargs)
         return False
 


### PR DESCRIPTION
## Summary
- Replace remaining fake async wrappers in runtime/session/tool-call paths with true async SQLite operations.
- Move run worker terminal updates, finalize cleanup, cancellation handling, media-run persistence, hook event publishing, and auto-recovery resume transitions onto async paths.
- Add regression coverage for async wrapper inventory, session/tool API concurrency, runtime cleanup, temporary roles, hook event publishing, and repository parity.

Fixes #547

## Verification
- `uv run --extra dev ruff check --fix` passed
- `uv run --extra dev ruff format --no-cache --force-exclude` passed
- `uv run --extra dev basedpyright` passed: 0 errors, 0 warnings, 0 notes
- `uv run --extra dev pytest -q tests/unit_tests` passed: 3930 passed, 5 skipped
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests` passed: 84 passed, 3 skipped
- SQLite mixed async/sync stress passed: 64 async workers + 16 thread workers, 12,000 records, about 48,000 operations, 6,000 running records marked failed, 6.37s