### PR TITLE
Fix async todo tool event publishing

### DIFF
--- a/src/relay_teams/tools/todo_tools/todo_read.py
+++ b/src/relay_teams/tools/todo_tools/todo_read.py
@@ -19,11 +19,11 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     async def todo_read(ctx: ToolContext) -> dict[str, JsonValue]:
         """Return the current run-scoped todo snapshot."""
 
-        def _action() -> dict[str, JsonValue]:
+        async def _action() -> dict[str, JsonValue]:
             service = ctx.deps.todo_service
             if service is None:
                 raise RuntimeError("Todo service is not configured")
-            snapshot = service.get_for_run(
+            snapshot = await service.get_for_run_async(
                 run_id=ctx.deps.run_id,
                 session_id=ctx.deps.session_id,
             )

--- a/src/relay_teams/tools/todo_tools/todo_write.py
+++ b/src/relay_teams/tools/todo_tools/todo_write.py
@@ -23,11 +23,11 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     ) -> dict[str, JsonValue]:
         """Replace the entire run-scoped todo list for the current run."""
 
-        def _action(items: list[TodoItem]) -> dict[str, JsonValue]:
+        async def _action(items: list[TodoItem]) -> dict[str, JsonValue]:
             service = ctx.deps.todo_service
             if service is None:
                 raise RuntimeError("Todo service is not configured")
-            snapshot = service.replace_for_run(
+            snapshot = await service.replace_for_run_async(
                 run_id=ctx.deps.run_id,
                 session_id=ctx.deps.session_id,
                 items=items,

--- a/tests/unit_tests/tools/todo_tools/test_todo_tools.py
+++ b/tests/unit_tests/tools/todo_tools/test_todo_tools.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Sequence
 from collections.abc import Awaitable, Callable
 from types import SimpleNamespace
 from typing import cast
@@ -36,6 +37,10 @@ class _FakeTodoService:
         self.get_calls: list[dict[str, object]] = []
 
     def get_for_run(self, *, run_id: str, session_id: str) -> TodoSnapshot:
+        _ = (run_id, session_id)
+        raise AssertionError("todo_read should use the async todo service path")
+
+    async def get_for_run_async(self, *, run_id: str, session_id: str) -> TodoSnapshot:
         self.get_calls.append({"run_id": run_id, "session_id": session_id})
         return TodoSnapshot(
             run_id=run_id,
@@ -49,7 +54,25 @@ class _FakeTodoService:
         *,
         run_id: str,
         session_id: str,
-        items,
+        items: Sequence[TodoItem],
+        updated_by_role_id: str | None = None,
+        updated_by_instance_id: str | None = None,
+    ) -> TodoSnapshot:
+        _ = (
+            run_id,
+            session_id,
+            items,
+            updated_by_role_id,
+            updated_by_instance_id,
+        )
+        raise AssertionError("todo_write should use the async todo service path")
+
+    async def replace_for_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        items: Sequence[TodoItem],
         updated_by_role_id: str | None = None,
         updated_by_instance_id: str | None = None,
     ) -> TodoSnapshot:
@@ -116,7 +139,7 @@ async def test_todo_write_calls_service_with_full_snapshot(
         *,
         tool_name: str,
         args_summary: dict[str, object],
-        action: Callable[..., Awaitable[dict[str, object]]],
+        action: Callable[..., object],
         raw_args: dict[str, object] | None = None,
         **_: object,
     ) -> dict[str, object]:
@@ -183,7 +206,10 @@ async def test_todo_read_returns_current_snapshot(
         **_: object,
     ) -> dict[str, object]:
         del ctx, tool_name, args_summary, raw_args
-        return cast(dict[str, object], action())
+        result = action()
+        if inspect.isawaitable(result):
+            return await result
+        return cast(dict[str, object], result)
 
     monkeypatch.setattr(todo_read_module, "execute_tool_call", _fake_execute_tool_call)
 


### PR DESCRIPTION
## Summary
- Route `todo_read` and `todo_write` through the async `TodoService` methods from async tool execution.
- Keep todo update events on the async `RunEventHub.publish_async` path, avoiding sync publish lock failures under concurrent session/tool runs.
- Update todo tool unit tests so the sync service methods fail if used by the async tools.

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests/api/test_http_run_flows.py::test_ai_run_persists_todo_snapshot_and_projects_it`
- Manual pressure verification: 16 concurrent session runs with 32 tool calls plus health/live polling, no health failures; browser backend status remained online.
- Post-fix todo pressure verification: 8 concurrent todo runs with 16 tool calls/results, 0 health failures, no `RunEventHub.publish` or `tool.call.failed` backend log markers.

Fixes #564