### PR TITLE
Fix webfetch event loop starvation

### DIFF
--- a/src/relay_teams/tools/web_tools/webfetch.py
+++ b/src/relay_teams/tools/web_tools/webfetch.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import re
 import shutil
 import tempfile
+import threading
+import weakref
 from urllib.parse import ParseResult, urljoin, urlparse
 from xml.etree.ElementTree import Element, ParseError
 
@@ -65,6 +67,8 @@ REDIRECT_REQUIRED_ERROR_TYPE = "redirect_required"
 WEBFETCH_FINAL_URL_EXTENSION_KEY = "agent_teams_final_url"
 MAX_REDIRECTS = 10
 MAX_REDIRECT_BODY_BYTES = 64 * 1024
+AUTOMATED_FETCH_BLOCK_SCAN_BYTES = 256 * 1024
+WEBFETCH_PROJECTION_WORKER_CONCURRENCY = 1
 BROWSER_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
@@ -113,6 +117,10 @@ ANCHOR_REDIRECT_PATTERN = re.compile(
     r"""<a[^>]+href\s*=\s*["']([^"']+)["']""",
     re.IGNORECASE,
 )
+_WEBFETCH_PROJECTION_SEMAPHORES: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Semaphore
+] = weakref.WeakKeyDictionary()
+_WEBFETCH_PROJECTION_SEMAPHORES_LOCK = threading.Lock()
 
 
 class WebFetchExtractMode(StrEnum):
@@ -397,14 +405,14 @@ async def fetch_webfetch_projection(
             )
         enforce_text_content_length_limit(response)
         body = await read_response_body(response)
-        return build_webfetch_projection(
+        return await build_webfetch_projection_in_worker(
             workspace_dir=workspace_dir,
             tool_call_id=tool_call_id,
             requested_url=requested_url,
             final_url=resolve_webfetch_response_url(response),
             response_format=response_format,
             content_type=content_type,
-            response_headers=response.headers,
+            response_headers=dict(response.headers),
             body=body,
             extract=extract,
             item_limit=item_limit,
@@ -674,10 +682,19 @@ async def is_textual_challenge_response(response: httpx.Response) -> bool:
         and response.status_code not in ANTI_BOT_STATUS_CODES
     ):
         return False
-    body_text = (await response.aread()).decode("utf-8", errors="replace").lower()
-    if any(marker in body_text for marker in ENTERPRISE_PROXY_BLOCK_MARKERS):
+    body = await response.aread()
+    return await asyncio.to_thread(body_has_automated_fetch_challenge_marker, body)
+
+
+def body_has_automated_fetch_challenge_marker(body: bytes) -> bool:
+    scan_text = (
+        body[:AUTOMATED_FETCH_BLOCK_SCAN_BYTES]
+        .decode("utf-8", errors="replace")
+        .lower()
+    )
+    if any(marker in scan_text for marker in ENTERPRISE_PROXY_BLOCK_MARKERS):
         return False
-    return any(marker in body_text for marker in ANTI_BOT_CHALLENGE_MARKERS)
+    return any(marker in scan_text for marker in ANTI_BOT_CHALLENGE_MARKERS)
 
 
 async def fetch_with_reader_fallback(
@@ -1089,6 +1106,83 @@ def build_webfetch_projection(
         output=rendered_output,
         metadata=build_text_result_metadata(response_headers),
     )
+
+
+async def build_webfetch_projection_in_worker(
+    *,
+    workspace_dir: Path,
+    tool_call_id: str,
+    requested_url: str,
+    final_url: str,
+    response_format: str,
+    content_type: str,
+    response_headers: Mapping[str, str] | None = None,
+    body: bytes,
+    extract: WebFetchExtractMode,
+    item_limit: int,
+) -> ToolResultProjection:
+    projection_semaphore = get_webfetch_projection_semaphore()
+    await projection_semaphore.acquire()
+    projection_task = asyncio.create_task(
+        asyncio.to_thread(
+            build_webfetch_projection,
+            workspace_dir=workspace_dir,
+            tool_call_id=tool_call_id,
+            requested_url=requested_url,
+            final_url=final_url,
+            response_format=response_format,
+            content_type=content_type,
+            response_headers=response_headers,
+            body=body,
+            extract=extract,
+            item_limit=item_limit,
+        )
+    )
+    try:
+        return await asyncio.shield(projection_task)
+    finally:
+        release_webfetch_projection_semaphore_when_done(
+            projection_task,
+            projection_semaphore,
+        )
+
+
+def get_webfetch_projection_semaphore() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    with _WEBFETCH_PROJECTION_SEMAPHORES_LOCK:
+        semaphore = _WEBFETCH_PROJECTION_SEMAPHORES.get(loop)
+        if semaphore is None:
+            semaphore = asyncio.Semaphore(WEBFETCH_PROJECTION_WORKER_CONCURRENCY)
+            _WEBFETCH_PROJECTION_SEMAPHORES[loop] = semaphore
+        return semaphore
+
+
+def release_webfetch_projection_semaphore_when_done(
+    projection_task: asyncio.Task[ToolResultProjection],
+    projection_semaphore: asyncio.Semaphore,
+) -> None:
+    # The shielded worker keeps running after caller cancellation; keep the
+    # permit until the CPU-heavy projection actually exits.
+    if projection_task.done():
+        projection_semaphore.release()
+        consume_webfetch_projection_task_exception(projection_task)
+        return
+
+    def release_projection_semaphore(
+        completed_task: asyncio.Future[ToolResultProjection],
+    ) -> None:
+        projection_semaphore.release()
+        consume_webfetch_projection_task_exception(completed_task)
+
+    projection_task.add_done_callback(release_projection_semaphore)
+
+
+def consume_webfetch_projection_task_exception(
+    projection_task: asyncio.Future[ToolResultProjection],
+) -> None:
+    if projection_task.cancelled():
+        return
+    projection_task.exception()
 
 
 def is_binary_response(content_type: str) -> bool:

--- a/tests/unit_tests/tools/web_tools/test_webfetch.py
+++ b/tests/unit_tests/tools/web_tools/test_webfetch.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import inspect
 from pathlib import Path
+import threading
+import time
 from types import SimpleNamespace
 from typing import Awaitable, Callable, cast
 
@@ -13,7 +16,7 @@ import pytest
 from relay_teams.computer import ComputerActionRisk
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.tools.runtime.context import ToolDeps
-from relay_teams.tools.runtime.models import ToolExecutionError
+from relay_teams.tools.runtime.models import ToolExecutionError, ToolResultProjection
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.web_tools import common, webfetch
 from relay_teams.tools.web_tools.preapproved import is_preapproved_webfetch_url
@@ -260,6 +263,17 @@ def _build_binary_transport(
         )
 
     return httpx.MockTransport(_handler)
+
+
+def test_body_has_automated_fetch_challenge_marker_scans_bounded_prefix() -> None:
+    marker = b"Enable JavaScript and cookies to continue"
+    assert webfetch.body_has_automated_fetch_challenge_marker(marker) is True
+    assert (
+        webfetch.body_has_automated_fetch_challenge_marker(
+            b"a" * (webfetch.AUTOMATED_FETCH_BLOCK_SCAN_BYTES + 1) + marker
+        )
+        is False
+    )
 
 
 def test_validate_web_url_rejects_non_http_scheme() -> None:
@@ -1096,6 +1110,175 @@ async def test_fetch_webfetch_projection_returns_redirect_result_for_cross_host_
     assert data["redirect_url"] == "https://docs.python.org/3/tutorial/"
     assert data["status_code"] == 302
     assert request_log == ["https://example.com/start"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_webfetch_projection_builds_projection_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    loop_thread_id = threading.get_ident()
+    projection_thread_ids: list[int] = []
+    projection_started = threading.Event()
+    projection_finished = threading.Event()
+    observed_projection_while_loop_was_live = False
+    heartbeat_done = False
+
+    def _fake_build_webfetch_projection(**kwargs: object) -> ToolResultProjection:
+        assert kwargs["body"] == b"ok"
+        projection_thread_ids.append(threading.get_ident())
+        projection_started.set()
+        time.sleep(0.05)
+        projection_finished.set()
+        return ToolResultProjection(
+            visible_data={"output": "ok"},
+            internal_data={"output": "ok"},
+        )
+
+    async def _heartbeat() -> None:
+        nonlocal observed_projection_while_loop_was_live
+        while not heartbeat_done:
+            await asyncio.sleep(0.001)
+            if projection_started.is_set() and not projection_finished.is_set():
+                observed_projection_while_loop_was_live = True
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            request=request,
+            headers={"content-type": "text/markdown", "content-length": "2"},
+            content=b"ok",
+        )
+
+    monkeypatch.setattr(
+        webfetch,
+        "build_webfetch_projection",
+        _fake_build_webfetch_projection,
+    )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    shared_store = _build_shared_store(tmp_path)
+    heartbeat_task = asyncio.create_task(_heartbeat())
+    try:
+        projection = await webfetch.fetch_webfetch_projection(
+            client=client,
+            requested_url="https://example.com/page",
+            response_format="markdown",
+            extract=webfetch.WebFetchExtractMode.NONE,
+            item_limit=webfetch.DEFAULT_ITEM_LIMIT,
+            workspace_dir=tmp_path,
+            workspace_id="workspace-1",
+            shared_store=shared_store,
+            tool_call_id="webfetch",
+            cancel_check=lambda: None,
+        )
+    finally:
+        heartbeat_done = True
+        await heartbeat_task
+        await client.aclose()
+
+    assert projection.visible_data == {"output": "ok"}
+    assert projection_thread_ids
+    assert projection_thread_ids[0] != loop_thread_id
+    assert observed_projection_while_loop_was_live is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_webfetch_projection_keeps_projection_limit_until_cancelled_worker_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    started_events = {
+        "first": threading.Event(),
+        "second": threading.Event(),
+    }
+    release_events = {
+        "first": threading.Event(),
+        "second": threading.Event(),
+    }
+    started_order: list[str] = []
+
+    async def _wait_for_event(event: threading.Event) -> None:
+        deadline = time.perf_counter() + 1.0
+        while not event.is_set():
+            if time.perf_counter() >= deadline:
+                raise AssertionError("Timed out waiting for projection worker")
+            await asyncio.sleep(0.001)
+
+    def _fake_build_webfetch_projection(**kwargs: object) -> ToolResultProjection:
+        tool_call_id = str(kwargs["tool_call_id"])
+        started_order.append(tool_call_id)
+        started_events[tool_call_id].set()
+        assert release_events[tool_call_id].wait(timeout=2.0)
+        return ToolResultProjection(
+            visible_data={"output": tool_call_id},
+            internal_data={"output": tool_call_id},
+        )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            request=request,
+            headers={"content-type": "text/markdown", "content-length": "2"},
+            content=b"ok",
+        )
+
+    monkeypatch.setattr(
+        webfetch,
+        "build_webfetch_projection",
+        _fake_build_webfetch_projection,
+    )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    shared_store = _build_shared_store(tmp_path)
+    try:
+        first_task = asyncio.create_task(
+            webfetch.fetch_webfetch_projection(
+                client=client,
+                requested_url="https://example.com/first",
+                response_format="markdown",
+                extract=webfetch.WebFetchExtractMode.NONE,
+                item_limit=webfetch.DEFAULT_ITEM_LIMIT,
+                workspace_dir=tmp_path,
+                workspace_id="workspace-1",
+                shared_store=shared_store,
+                tool_call_id="first",
+                cancel_check=lambda: None,
+            )
+        )
+        await _wait_for_event(started_events["first"])
+        first_task.cancel()
+        first_result = await asyncio.gather(first_task, return_exceptions=True)
+        assert isinstance(first_result[0], asyncio.CancelledError)
+
+        second_task = asyncio.create_task(
+            webfetch.fetch_webfetch_projection(
+                client=client,
+                requested_url="https://example.com/second",
+                response_format="markdown",
+                extract=webfetch.WebFetchExtractMode.NONE,
+                item_limit=webfetch.DEFAULT_ITEM_LIMIT,
+                workspace_dir=tmp_path,
+                workspace_id="workspace-1",
+                shared_store=shared_store,
+                tool_call_id="second",
+                cancel_check=lambda: None,
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert started_events["second"].is_set() is False
+
+        release_events["first"].set()
+        await _wait_for_event(started_events["second"])
+        release_events["second"].set()
+        second_projection = await second_task
+    finally:
+        release_events["first"].set()
+        release_events["second"].set()
+        await client.aclose()
+
+    assert second_projection.visible_data == {"output": "second"}
+    assert started_order == ["first", "second"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- bound anti-bot challenge scanning to the first 256KB of text bodies and move marker checks off the event loop
- build webfetch text projections in a worker and serialize the CPU-heavy projection stage so concurrent HTML conversions do not starve `/api/system/live`
- add unit coverage that projection work happens off the event loop and that challenge scans stay bounded

## Pressure Check
- Before fix: 6 concurrent 4.3MB HTML webfetch projections produced max loop lag about 5.72s, enough for the frontend 1.5s live probe timeout to show backend busy
- After fix: same pressure produced max loop lag about 0.109s and p95 about 0.013s
- websearch large JSON parsing check: 6 concurrent 3.4MB simulated SearXNG responses had max loop lag about 0.039s, so the reproduced busy symptom was in webfetch

## Tests
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/tools/web_tools/test_webfetch.py`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests`

Fixes #565