### PR TITLE
fix: avoid blocking event loop while recording tool read state

### DIFF
--- a/src/relay_teams/tools/web_tools/webfetch.py
+++ b/src/relay_teams/tools/web_tools/webfetch.py
@@ -1408,7 +1408,7 @@ async def download_binary_response(
                 probe=active_probe,
             )
         ):
-            save_binary_download_manifest(
+            await save_binary_download_manifest_async(
                 manifest=manifest,
                 manifest_path=manifest_path,
                 shared_store=shared_store,
@@ -1437,7 +1437,7 @@ async def download_binary_response(
                 probe=active_probe,
                 download_dir=download_dir,
             )
-            save_binary_download_manifest(
+            await save_binary_download_manifest_async(
                 manifest=manifest,
                 manifest_path=manifest_path,
                 shared_store=shared_store,
@@ -1498,7 +1498,7 @@ async def download_binary_response(
                     probe=active_probe,
                     download_dir=download_dir,
                 )
-                save_binary_download_manifest(
+                await save_binary_download_manifest_async(
                     manifest=active_manifest,
                     manifest_path=manifest_path,
                     shared_store=shared_store,
@@ -1725,7 +1725,7 @@ async def save_non_resumable_binary_response(
             size_bytes=bytes_written,
         )
         finalize_binary_temp_file(temp_path, Path(finalized_manifest.saved_path))
-        save_binary_download_manifest(
+        await save_binary_download_manifest_async(
             manifest=finalized_manifest,
             manifest_path=manifest_path,
             shared_store=shared_store,
@@ -1779,7 +1779,7 @@ async def download_binary_with_ranges(
             segment.downloaded_bytes = downloaded_bytes
             segment.complete = complete
             manifest.completed = all(current.complete for current in manifest.segments)
-            save_binary_download_manifest(
+            await save_binary_download_manifest_async(
                 manifest=manifest,
                 manifest_path=manifest_path,
                 shared_store=shared_store,
@@ -1847,7 +1847,7 @@ async def download_binary_with_ranges(
         probe=probe,
         download_dir=download_dir,
     )
-    save_binary_download_manifest(
+    await save_binary_download_manifest_async(
         manifest=finalized_manifest,
         manifest_path=manifest_path,
         shared_store=shared_store,
@@ -2318,6 +2318,25 @@ def save_binary_download_manifest(
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_text(manifest_path, manifest.model_dump_json(indent=2))
     shared_store.manage_state(
+        StateMutation(
+            scope=ScopeRef(scope_type=ScopeType.WORKSPACE, scope_id=workspace_id),
+            key=f"{WEBFETCH_DOWNLOAD_PREFIX}:{download_key}",
+            value_json=manifest.model_dump_json(),
+        )
+    )
+
+
+async def save_binary_download_manifest_async(
+    *,
+    manifest: BinaryDownloadManifest,
+    manifest_path: Path,
+    shared_store: SharedStateRepository,
+    workspace_id: str,
+    download_key: str,
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(manifest_path, manifest.model_dump_json(indent=2))
+    await shared_store.manage_state_async(
         StateMutation(
             scope=ScopeRef(scope_type=ScopeType.WORKSPACE, scope_id=workspace_id),
             key=f"{WEBFETCH_DOWNLOAD_PREFIX}:{download_key}",

--- a/src/relay_teams/tools/workspace_tools/edit.py
+++ b/src/relay_teams/tools/workspace_tools/edit.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from pydantic import JsonValue
-
 import re
 from pathlib import Path
 from typing import Generator
 
+from pydantic import JsonValue
 from pydantic_ai import Agent
 
 from relay_teams.paths import open_text_file, path_exists, path_is_dir
@@ -505,7 +504,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         new_string: str,
         replace_all: bool = False,
     ) -> dict[str, JsonValue]:
-        async def _action(
+        def _action(
             path: str,
             old_string: str,
             new_string: str,

--- a/src/relay_teams/tools/workspace_tools/edit_state.py
+++ b/src/relay_teams/tools/workspace_tools/edit_state.py
@@ -5,7 +5,7 @@ import json
 import os
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
@@ -52,6 +52,24 @@ def record_file_read(
     return state
 
 
+async def record_file_read_async(
+    *,
+    shared_store: SharedStateRepository,
+    session_id: str,
+    conversation_id: str,
+    path: Path,
+) -> FileReadState:
+    state = fingerprint_file(path)
+    await shared_store.manage_state_async(
+        StateMutation(
+            scope=_session_scope(session_id),
+            key=_state_key(conversation_id=conversation_id, path=path),
+            value_json=state.model_dump_json(),
+        )
+    )
+    return state
+
+
 def load_file_read_state(
     *,
     shared_store: SharedStateRepository,
@@ -73,7 +91,7 @@ def load_file_read_state(
         return None
     try:
         return FileReadState.model_validate(payload)
-    except Exception:
+    except ValidationError:
         return None
 
 

--- a/src/relay_teams/tools/workspace_tools/notebook_edit.py
+++ b/src/relay_teams/tools/workspace_tools/notebook_edit.py
@@ -41,7 +41,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     ) -> dict[str, JsonValue]:
         """Edit a Jupyter notebook cell without editing raw JSON."""
 
-        async def _action() -> ToolResultProjection:
+        def _action() -> ToolResultProjection:
             file_path = ctx.deps.workspace.resolve_path(path, write=True)
             result = notebook_edit_file_with_guard(
                 shared_store=ctx.deps.shared_store,

--- a/src/relay_teams/tools/workspace_tools/office_read_markdown.py
+++ b/src/relay_teams/tools/workspace_tools/office_read_markdown.py
@@ -20,7 +20,7 @@ from relay_teams.tools.runtime.context import (
 )
 from relay_teams.tools.runtime.execution import execute_tool_call
 from relay_teams.tools.runtime.models import ToolResultProjection
-from relay_teams.tools.workspace_tools.edit_state import record_file_read
+from relay_teams.tools.workspace_tools.edit_state import record_file_read_async
 from relay_teams.tools.workspace_tools.read_support import (
     DEFAULT_READ_LIMIT,
     MAX_BYTES_LABEL,
@@ -182,7 +182,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 output.append(f"\n\n(End of file - total {total_lines} lines)")
 
             output.append("</content>")
-            record_file_read(
+            await record_file_read_async(
                 shared_store=ctx.deps.shared_store,
                 session_id=ctx.deps.session_id,
                 conversation_id=ctx.deps.conversation_id,

--- a/src/relay_teams/tools/workspace_tools/read.py
+++ b/src/relay_teams/tools/workspace_tools/read.py
@@ -32,7 +32,7 @@ from relay_teams.tools.runtime.context import (
 )
 from relay_teams.tools.runtime.execution import execute_tool_call
 from relay_teams.tools.runtime.models import ToolResultProjection
-from relay_teams.tools.workspace_tools.edit_state import record_file_read
+from relay_teams.tools.workspace_tools.edit_state import record_file_read_async
 from relay_teams.tools.workspace_tools.notebook import (
     read_notebook_for_tool,
 )
@@ -255,7 +255,7 @@ def _image_support(ctx: ToolContext) -> bool | None:
     return ctx.deps.model_capabilities.input.image
 
 
-def _project_image_read_result(
+async def _project_image_read_result(
     *,
     ctx: ToolContext,
     file_path: Path,
@@ -291,7 +291,7 @@ def _project_image_read_result(
     )
     media_content_part = media_asset_service.to_content_part(record)
     media_part = media_content_part.model_dump(mode="json")
-    record_file_read(
+    await record_file_read_async(
         shared_store=ctx.deps.shared_store,
         session_id=ctx.deps.session_id,
         conversation_id=ctx.deps.conversation_id,
@@ -405,7 +405,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                     include_outputs=include_outputs,
                 )
                 output = _inject_instruction_sections(output, instruction_sections)
-                record_file_read(
+                await record_file_read_async(
                     shared_store=ctx.deps.shared_store,
                     session_id=ctx.deps.session_id,
                     conversation_id=ctx.deps.conversation_id,
@@ -428,7 +428,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             if is_binary_file(file_path, file_size):
                 image_mime_type = _detect_image_mime_type(file_path)
                 if image_mime_type is not None:
-                    return _project_image_read_result(
+                    return await _project_image_read_result(
                         ctx=ctx,
                         file_path=file_path,
                         path=path,
@@ -481,7 +481,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 output.append(f"\n\n(End of file - total {total_lines} lines)")
 
             output.append("</content>")
-            record_file_read(
+            await record_file_read_async(
                 shared_store=ctx.deps.shared_store,
                 session_id=ctx.deps.session_id,
                 conversation_id=ctx.deps.conversation_id,

--- a/tests/unit_tests/tools/workspace_tools/test_edit.py
+++ b/tests/unit_tests/tools/workspace_tools/test_edit.py
@@ -1,11 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+import inspect
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
+from pydantic import JsonValue
+from pydantic_ai import Agent
 
+from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.tools.runtime.context import ToolContext, ToolDeps
+from relay_teams.tools.runtime.models import ToolResultProjection
+from relay_teams.tools.workspace_tools import register_edit
 from relay_teams.tools.workspace_tools.edit import (
     _project_edit_result,
     apply_edit,
@@ -13,10 +23,40 @@ from relay_teams.tools.workspace_tools.edit import (
     replace_content,
 )
 from relay_teams.tools.workspace_tools.edit_state import (
+    READ_STATE_PREFIX,
     assert_file_was_read,
     load_file_read_state,
+    normalize_resolved_path,
     record_file_read,
+    record_file_read_async,
 )
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., object]] = {}
+
+    def tool(
+        self,
+        *,
+        description: str,
+    ) -> Callable[[Callable[..., object]], Callable[..., object]]:
+        del description
+
+        def decorator(func: Callable[..., object]) -> Callable[..., object]:
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+
+class _FakeWorkspace:
+    def __init__(self, root: Path) -> None:
+        self.scope_root = root
+
+    def resolve_path(self, relative_path: str, *, write: bool = False) -> Path:
+        _ = write
+        return (self.scope_root / relative_path).resolve()
 
 
 def test_replace_content_replaces_unique_exact_match() -> None:
@@ -186,6 +226,120 @@ def test_file_read_state_does_not_leak_between_conversations(tmp_path: Path) -> 
         )
         is None
     )
+
+
+def test_file_read_state_ignores_invalid_persisted_payload(tmp_path: Path) -> None:
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content", encoding="utf-8")
+    shared_store.manage_state(
+        StateMutation(
+            scope=ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-1"),
+            key=(
+                f"{READ_STATE_PREFIX}conversation-1:"
+                f"{normalize_resolved_path(file_path)}"
+            ),
+            value_json='{"path": "", "mtime_ns": -1, "size": -1}',
+        )
+    )
+
+    assert (
+        load_file_read_state(
+            shared_store=shared_store,
+            session_id="session-1",
+            conversation_id="conversation-1",
+            path=file_path,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_file_read_state_round_trips(tmp_path: Path) -> None:
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content", encoding="utf-8")
+
+    await record_file_read_async(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
+
+    state = load_file_read_state(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
+    assert state is not None
+    assert state.path.endswith("file.txt")
+
+
+@pytest.mark.asyncio
+async def test_edit_tool_runs_registered_sync_action(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import edit as edit_module
+
+    file_path = tmp_path / "demo.txt"
+    file_path.write_text("before\n", encoding="utf-8")
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
+    fake_agent = _FakeAgent()
+    register_edit(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, JsonValue]]],
+        fake_agent.tools["edit"],
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            workspace=_FakeWorkspace(tmp_path),
+            shared_store=shared_store,
+            session_id="session-1",
+            conversation_id="conversation-1",
+        )
+    )
+
+    async def _fake_execute_tool_call(
+        ctx: ToolContext,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., ToolResultProjection | Awaitable[ToolResultProjection]],
+        raw_args: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, JsonValue]:
+        del ctx, tool_name, args_summary, kwargs
+        parameter_names = set(inspect.signature(action).parameters)
+        action_args = {
+            key: value for key, value in raw_args.items() if key in parameter_names
+        }
+        maybe_projection = action(**action_args)
+        if inspect.isawaitable(maybe_projection):
+            projection = await maybe_projection
+        else:
+            projection = maybe_projection
+        return cast(dict[str, JsonValue], projection.internal_data)
+
+    monkeypatch.setattr(edit_module, "execute_tool_call", _fake_execute_tool_call)
+
+    result = await tool(
+        cast(ToolContext, cast(object, ctx)),
+        path="demo.txt",
+        old_string="before\n",
+        new_string="after\n",
+    )
+
+    assert "Edit applied successfully." in cast(str, result["output"])
+    assert file_path.read_text(encoding="utf-8") == "after\n"
 
 
 def test_edit_file_with_guard_rejects_external_change_after_read(

--- a/tests/unit_tests/tools/workspace_tools/test_notebook.py
+++ b/tests/unit_tests/tools/workspace_tools/test_notebook.py
@@ -1,13 +1,21 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+import inspect
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from pydantic import JsonValue
+from pydantic_ai import Agent
 
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.tools.runtime.context import ToolContext, ToolDeps
+from relay_teams.tools.runtime.models import ToolResultProjection
+from relay_teams.tools.workspace_tools import register_notebook_edit
 from relay_teams.tools.workspace_tools.edit_state import record_file_read
 from relay_teams.tools.workspace_tools.notebook import (
     apply_notebook_edit,
@@ -53,6 +61,33 @@ def _write_notebook(path: Path, notebook: dict[str, object] | None = None) -> No
         json.dumps(_notebook() if notebook is None else notebook, indent=1),
         encoding="utf-8",
     )
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., object]] = {}
+
+    def tool(
+        self,
+        *,
+        description: str,
+    ) -> Callable[[Callable[..., object]], Callable[..., object]]:
+        del description
+
+        def decorator(func: Callable[..., object]) -> Callable[..., object]:
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+
+class _FakeWorkspace:
+    def __init__(self, root: Path) -> None:
+        self.scope_root = root
+
+    def resolve_path(self, relative_path: str, *, write: bool = False) -> Path:
+        _ = write
+        return (self.scope_root / relative_path).resolve()
 
 
 def test_project_notebook_projects_cells_and_outputs(tmp_path: Path) -> None:
@@ -244,6 +279,67 @@ def test_notebook_edit_file_writes_cell_and_preserves_notebook_metadata(
     assert updated["metadata"] == {"language_info": {"name": "python"}}
     assert updated["cells"][1]["source"] == "print(2)\n"
     assert updated["cells"][1]["outputs"] == []
+
+
+@pytest.mark.asyncio
+async def test_notebook_edit_tool_runs_registered_sync_action(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import notebook_edit as notebook_edit_module
+
+    file_path = tmp_path / "demo.ipynb"
+    _write_notebook(file_path)
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    record_file_read(
+        shared_store=shared_store,
+        session_id="session-1",
+        conversation_id="conversation-1",
+        path=file_path,
+    )
+    fake_agent = _FakeAgent()
+    register_notebook_edit(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, JsonValue]]],
+        fake_agent.tools["notebook_edit"],
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            workspace=_FakeWorkspace(tmp_path),
+            shared_store=shared_store,
+            session_id="session-1",
+            conversation_id="conversation-1",
+        )
+    )
+
+    async def _fake_execute_tool(
+        ctx: ToolContext,
+        *,
+        tool_name: str,
+        args_summary: dict[str, JsonValue],
+        action: Callable[[], ToolResultProjection | Awaitable[ToolResultProjection]],
+        **kwargs: object,
+    ) -> dict[str, JsonValue]:
+        del ctx, tool_name, args_summary, kwargs
+        maybe_projection = action()
+        if inspect.isawaitable(maybe_projection):
+            projection = await maybe_projection
+        else:
+            projection = maybe_projection
+        return cast(dict[str, JsonValue], projection.internal_data)
+
+    monkeypatch.setattr(notebook_edit_module, "execute_tool", _fake_execute_tool)
+
+    result = await tool(
+        cast(ToolContext, cast(object, ctx)),
+        path="demo.ipynb",
+        cell_id="calc",
+        new_source="print(2)\n",
+    )
+
+    updated = json.loads(file_path.read_text(encoding="utf-8"))
+    assert "Notebook edit applied successfully" in cast(str, result["output"])
+    assert updated["cells"][1]["source"] == "print(2)\n"
 
 
 def test_load_notebook_empty_file_reports_empty_notebook(tmp_path: Path) -> None:

--- a/tests/unit_tests/tools/workspace_tools/test_read.py
+++ b/tests/unit_tests/tools/workspace_tools/test_read.py
@@ -211,7 +211,8 @@ def test_read_image_capability_error_allows_explicit_support() -> None:
     assert read_module._read_image_capability_error("src/diagram.png", True) == ""
 
 
-def test_project_image_read_result_rejects_missing_media_service_and_invalid_image(
+@pytest.mark.asyncio
+async def test_project_image_read_result_rejects_missing_media_service_and_invalid_image(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -232,7 +233,7 @@ def test_project_image_read_result_rejects_missing_media_service_and_invalid_ima
         ValueError,
         match="Cannot read image file without media asset support",
     ):
-        read_module._project_image_read_result(
+        await read_module._project_image_read_result(
             ctx=cast(ToolContext, cast(object, ctx_without_media)),
             file_path=file_path,
             path="src/diagram.png",
@@ -253,7 +254,7 @@ def test_project_image_read_result_rejects_missing_media_service_and_invalid_ima
     )
 
     with pytest.raises(ValueError, match="Cannot read binary file: src/diagram.png"):
-        read_module._project_image_read_result(
+        await read_module._project_image_read_result(
             ctx=cast(ToolContext, cast(object, ctx_with_media)),
             file_path=file_path,
             path="src/diagram.png",
@@ -550,6 +551,69 @@ async def test_read_tool_reads_notebook_cell_without_outputs(
             session_id="session-1",
             conversation_id="conversation-1",
             path=file_path,
+        )
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_tool_records_text_file_read_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from relay_teams.tools.workspace_tools import read as read_module
+
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    file_path = source_dir / "demo.txt"
+    file_path.write_text("alpha\nbeta\n", encoding="utf-8")
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    fake_agent = _FakeAgent()
+    register_read(cast(Agent[ToolDeps, str], fake_agent))
+    tool = cast(
+        Callable[..., Awaitable[dict[str, object]]],
+        fake_agent.tools["read"],
+    )
+    ctx = SimpleNamespace(
+        deps=SimpleNamespace(
+            workspace=_FakeWorkspace(tmp_path),
+            shared_store=shared_store,
+            task_id="task-1",
+            session_id="session-1",
+            conversation_id="conversation-1",
+        )
+    )
+
+    async def _fake_execute_tool(
+        ctx,
+        *,
+        tool_name: str,
+        args_summary: dict[str, object],
+        action: Callable[..., Awaitable[ToolResultProjection]],
+        approval_request=None,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        del ctx, tool_name, approval_request, kwargs
+        parameter_names = set(inspect.signature(action).parameters)
+        action_args = {
+            key: value for key, value in args_summary.items() if key in parameter_names
+        }
+        projected = await action(**action_args)
+        return cast(dict[str, object], projected.internal_data)
+
+    monkeypatch.setattr(read_module, "execute_tool_call", _fake_execute_tool)
+
+    result = await tool(ctx, path="src/demo.txt")
+
+    output = cast(str, result["output"])
+    assert "<type>file</type>" in output
+    assert "1: alpha" in output
+    assert (
+        load_file_read_state(
+            shared_store=shared_store,
+            session_id="session-1",
+            conversation_id="conversation-1",
+            path=file_path.resolve(),
         )
         is not None
     )


### PR DESCRIPTION
## Summary
- use async shared-state writes from async read, office_read_markdown, and webfetch paths so tool reads do not block the server event loop
- keep edit and notebook_edit guard/write work as synchronous tool actions, letting the shared tool runtime offload them through its action executor
- add focused coverage for read-state persistence, invalid persisted state tolerance, text/image/notebook read paths, and registered edit/notebook_edit execution

Fixes #567

## Verification
- `uv run --extra dev pytest -q tests/unit_tests/tools/workspace_tools/test_edit.py tests/unit_tests/tools/workspace_tools/test_read.py tests/unit_tests/tools/workspace_tools/test_notebook.py`
- `uv run --extra dev pytest -q tests/unit_tests/tools/workspace_tools/test_edit.py tests/unit_tests/tools/workspace_tools/test_read.py tests/unit_tests/tools/workspace_tools/test_notebook.py tests/unit_tests/tools/workspace_tools/test_office_read_markdown.py tests/unit_tests/tools/web_tools/test_webfetch.py --cov=src/relay_teams --cov=src/relay_teams_evals --cov-report=xml:coverage.xml`
- `uv run --extra dev diff-cover coverage.xml --config-file pyproject.toml --diff-file .tmp/diff-cover-copy-aware.diff` -> 100% changed-line coverage locally
- `uv run --extra dev ruff check --fix ...`
- `uv run --extra dev ruff format --no-cache --force-exclude ...`
- `uv run --extra dev basedpyright`
- `uv run --extra dev python .tmp/stress_builtin_tools.py --repetitions 3 --workers 24 --run-timeout 180`
  - runs: 90/90 completed
  - health: 0 failures, 0 busy responses, p95=169ms, max=447ms
  - page: 0 offline/busy/problem samples out of 115
  - tool errors: {}