### PR TITLE
Fix hooks settings delete persistence and actions

### DIFF
--- a/frontend/dist/css/components/feedback.css
+++ b/frontend/dist/css/components/feedback.css
@@ -236,8 +236,12 @@
 }
 
 .feedback-action-btn {
-    width: auto;
+    width: 88px;
     min-width: 88px;
+    min-height: 36px;
+    padding-left: 0.85rem;
+    padding-right: 0.85rem;
+    white-space: nowrap;
 }
 
 .feedback-tone-success {
@@ -250,4 +254,16 @@
 
 .feedback-tone-danger {
     border-color: color-mix(in srgb, var(--danger) 40%, var(--border-color));
+}
+
+@media (max-width: 480px) {
+    .feedback-dialog-actions {
+        justify-content: stretch;
+    }
+
+    .feedback-action-btn {
+        flex: 1 1 0;
+        width: auto;
+        min-width: 0;
+    }
 }

--- a/frontend/dist/css/components/interface.css
+++ b/frontend/dist/css/components/interface.css
@@ -24,6 +24,30 @@
     color: var(--button-primary-text);
 }
 
+.settings-modal .section-action-btn.primary-btn,
+.feedback-dialog .feedback-action-btn {
+    width: 88px;
+    min-width: 88px;
+}
+
+.settings-modal #save-hooks-btn,
+.feedback-dialog [data-feedback-confirm] {
+    width: 88px;
+    min-width: 88px;
+}
+
+.settings-modal #save-hooks-btn {
+    max-width: 88px;
+}
+
+@media (max-width: 480px) {
+    .feedback-dialog .feedback-action-btn {
+        flex: 1 1 0;
+        width: auto;
+        min-width: 0;
+    }
+}
+
 .primary-btn:hover {
     background: var(--button-primary-hover);
     border-color: var(--button-primary-hover);

--- a/frontend/dist/css/components/settings.css
+++ b/frontend/dist/css/components/settings.css
@@ -18,6 +18,12 @@
     padding: 2rem;
     background: var(--settings-overlay-bg);
     backdrop-filter: blur(8px);
+    --settings-action-btn-height: 36px;
+    --settings-action-btn-padding-x: 0.85rem;
+    --settings-action-btn-min-width: 88px;
+    --settings-list-action-height: 30px;
+    --settings-list-action-padding-x: 0.62rem;
+    --settings-list-action-min-width: 84px;
 }
 
 .modal-content {
@@ -298,10 +304,16 @@
 }
 
 .section-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: auto;
-    min-width: 0;
-    padding: 0.55rem 0.85rem;
+    height: var(--settings-action-btn-height);
+    min-height: var(--settings-action-btn-height);
+    min-width: var(--settings-action-btn-min-width);
+    padding: 0 var(--settings-action-btn-padding-x);
     font-size: 0.84rem;
+    line-height: 1;
     white-space: nowrap;
 }
 
@@ -655,8 +667,10 @@
 }
 
 .command-row-action {
-    min-height: 30px;
-    padding: 0.38rem 0.6rem;
+    height: var(--settings-action-btn-height);
+    min-height: var(--settings-action-btn-height);
+    min-width: var(--settings-action-btn-min-width);
+    padding: 0 var(--settings-action-btn-padding-x);
 }
 
 .commands-group-summary {
@@ -2963,6 +2977,7 @@
 
 .proxy-inline-test-btn {
     min-width: 128px;
+    height: var(--settings-action-btn-height);
     min-height: 42px;
     width: 100%;
     white-space: nowrap;
@@ -3413,12 +3428,18 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
 }
 
 .secondary-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     background-color: var(--settings-secondary-btn-bg);
     color: var(--text-primary);
     border: 1px solid var(--settings-border-default);
     border-radius: 6px;
-    padding: 0.65rem 1rem;
+    padding: 0 var(--settings-action-btn-padding-x);
+    min-height: var(--settings-action-btn-height);
+    min-width: var(--settings-action-btn-min-width);
     font-size: 0.875rem;
+    line-height: 1;
     font-weight: 500;
     cursor: pointer;
     transition: background-color 0.16s ease, border-color 0.16s ease;
@@ -3430,6 +3451,9 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
 }
 
 .settings-inline-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     background: none;
     border: 1px solid transparent;
     color: var(--text-secondary);
@@ -3452,15 +3476,17 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
 }
 
 .settings-list-action {
-    min-height: auto;
+    height: var(--settings-list-action-height);
+    min-height: var(--settings-list-action-height);
+    min-width: var(--settings-list-action-min-width);
     background: var(--button-secondary-bg);
     border-color: color-mix(in srgb, var(--settings-border-default) 82%, transparent);
     color: var(--text-secondary);
     border-radius: 6px;
-    padding: 0.28rem 0.58rem;
+    padding: 0 var(--settings-list-action-padding-x);
     font-size: 0.76rem;
     font-weight: 500;
-    line-height: 1.2;
+    line-height: 1;
 }
 
 .settings-list-action.codeagent-sso-login-btn {

--- a/frontend/dist/js/components/settings/hooksSettings.js
+++ b/frontend/dist/js/components/settings/hooksSettings.js
@@ -183,6 +183,7 @@ const PROMPT_PLACEHOLDERS = {
 
 let latestRuntimeView = null;
 let editorGroups = [];
+let lastSavedEditorGroups = [];
 let latestLoadErrorMessage = '';
 let latestRuntimeLoadErrorMessage = '';
 let latestConfigMessage = '';
@@ -193,9 +194,12 @@ let activeHooksLoadRequestId = 0;
 let nextGroupId = 1;
 let nextHandlerId = 1;
 let editingGroupId = null;
+let hooksConfigDirty = false;
 let groupEditSnapshots = new Map();
+let hooksPersistenceChain = Promise.resolve();
 const collapsedHandlerEditors = new Map();
 let agentRoleOptions = [];
+let pendingStaleDeleteSuccesses = [];
 
 export function bindHooksSettingsHandlers() {
     if (handlersBound || typeof document?.addEventListener !== 'function') {
@@ -213,6 +217,8 @@ export function bindHooksSettingsHandlers() {
             const group = createDefaultGroup();
             editorGroups = [...editorGroups, group];
             editingGroupId = group.id;
+            hooksConfigDirty = true;
+            latestLoadErrorMessage = '';
             latestConfigMessage = '';
             renderHooksPanel();
         });
@@ -232,12 +238,24 @@ export function bindHooksSettingsHandlers() {
     handlersBound = true;
 }
 
+export function syncHooksSettingsActions() {
+    if (!isHooksPanelActive()) {
+        return;
+    }
+    setActionDisplay('add-hook-btn', true);
+    const hasEditableHooks = !loadInFlight
+        && (editorGroups.length > 0 || editingGroupId !== null || hooksConfigDirty);
+    setActionDisplay('validate-hooks-btn', hasEditableHooks);
+    setActionDisplay('save-hooks-btn', hasEditableHooks);
+}
+
 export async function loadHooksSettingsPanel() {
     const requestId = ++activeHooksLoadRequestId;
     loadInFlight = true;
     latestLoadErrorMessage = '';
     latestRuntimeLoadErrorMessage = '';
     latestConfigMessage = '';
+    hooksConfigDirty = false;
     renderHooksPanel();
     const configPromise = fetchHooksConfig();
     const runtimeViewPromise = fetchHookRuntimeView();
@@ -248,6 +266,7 @@ export async function loadHooksSettingsPanel() {
             return;
         }
         editorGroups = deserializeHooksConfig(config);
+        lastSavedEditorGroups = cloneGroups(editorGroups);
         try {
             agentRoleOptions = normalizeAgentRoleOptions(await roleOptionsPromise);
         } catch (e) {
@@ -260,6 +279,7 @@ export async function loadHooksSettingsPanel() {
         }
         latestRuntimeLoadErrorMessage = '';
         editingGroupId = null;
+        hooksConfigDirty = false;
         groupEditSnapshots = new Map();
         collapsedHandlerEditors.clear();
         try {
@@ -291,7 +311,9 @@ export async function loadHooksSettingsPanel() {
         latestRuntimeLoadErrorMessage = '';
         latestRuntimeView = null;
         editorGroups = [];
+        lastSavedEditorGroups = [];
         editingGroupId = null;
+        hooksConfigDirty = false;
         groupEditSnapshots = new Map();
         collapsedHandlerEditors.clear();
         logError(
@@ -304,6 +326,7 @@ export async function loadHooksSettingsPanel() {
             return;
         }
         loadInFlight = false;
+        applyPendingStaleDeleteSuccesses();
         renderHooksPanel();
     }
 }
@@ -337,6 +360,7 @@ async function handleHooksClick(event) {
     }
     if (action === 'remove-group') {
         const groupId = Number(actionTarget.dataset.groupId || '0');
+        const deletedSavedGroups = lastSavedEditorGroups.filter(group => group.id === groupId);
         editorGroups = editorGroups.filter(group => group.id !== groupId);
         if (editingGroupId === groupId) {
             editingGroupId = null;
@@ -345,6 +369,10 @@ async function handleHooksClick(event) {
         clearCollapsedHandlersForGroup(groupId);
         latestConfigMessage = '';
         renderHooksPanel();
+        await queuePersistHooksAfterDelete({
+            deletedSavedGroups: cloneGroups(deletedSavedGroups),
+            requestId: activeHooksLoadRequestId,
+        });
         return;
     }
     if (action === 'add-handler') {
@@ -361,6 +389,7 @@ async function handleHooksClick(event) {
             };
         });
         collapsedHandlerEditors.set(getHandlerEditorKey(groupId, nextHandler.id), true);
+        hooksConfigDirty = true;
         latestConfigMessage = '';
         renderHooksPanel();
         return;
@@ -391,6 +420,7 @@ async function handleHooksClick(event) {
             };
         });
         collapsedHandlerEditors.delete(getHandlerEditorKey(groupId, handlerId));
+        hooksConfigDirty = true;
         latestConfigMessage = '';
         renderHooksPanel();
         return;
@@ -416,6 +446,7 @@ function handleHooksInput(event) {
     const groupId = Number(target.dataset.groupId || '0');
     const handlerId = Number(target.dataset.handlerId || '0');
     latestConfigMessage = '';
+    hooksConfigDirty = true;
     if (handlerId) {
         updateHandlerField(groupId, handlerId, field, readInputValue(target));
     } else {
@@ -459,16 +490,49 @@ async function validateCurrentHooksConfig() {
 }
 
 async function saveCurrentHooksConfig() {
+    let saveSnapshot;
     try {
-        const payload = serializeHooksConfig(editorGroups);
+        saveSnapshot = createHooksSaveSnapshot();
+    } catch (e) {
+        await handleHooksSaveFailure(e);
+        renderHooksPanel();
+        return;
+    }
+    hooksPersistenceChain = hooksPersistenceChain.then(() =>
+        persistCurrentHooksConfig(saveSnapshot),
+    );
+    await hooksPersistenceChain;
+}
+
+function createHooksSaveSnapshot() {
+    const groupsSnapshot = cloneGroups(editorGroups);
+    return {
+        requestId: activeHooksLoadRequestId,
+        previousSavedEditorGroups: cloneGroups(lastSavedEditorGroups),
+        savedEditorGroups: markGroupsSaved(groupsSnapshot),
+        payload: serializeHooksConfig(groupsSnapshot),
+    };
+}
+
+async function persistCurrentHooksConfig(saveSnapshot) {
+    const { payload, requestId, savedEditorGroups } = saveSnapshot;
+    try {
         validateHooksPayloadForEditor(payload);
         await validateHooksConfig(payload);
         await saveHooksConfig(payload);
+        if (requestId !== activeHooksLoadRequestId) {
+            reconcileStaleManualSaveSuccess(saveSnapshot);
+            return;
+        }
         latestConfigMessageTone = 'success';
         latestConfigMessage = t('settings.hooks.save_success');
-        editorGroups = editorGroups.map(group => ({ ...group, isNew: false }));
-        editingGroupId = null;
-        groupEditSnapshots = new Map();
+        editorGroups = mergeSavedStateIntoEditorGroups(editorGroups, savedEditorGroups);
+        lastSavedEditorGroups = savedEditorGroups;
+        reconcileHooksDirtyState();
+        if (!hooksConfigDirty) {
+            editingGroupId = null;
+            groupEditSnapshots = new Map();
+        }
         try {
             latestRuntimeView = await fetchHookRuntimeView();
             latestRuntimeLoadErrorMessage = '';
@@ -488,18 +552,195 @@ async function saveCurrentHooksConfig() {
             tone: 'success',
         });
     } catch (e) {
+        await handleHooksSaveFailure(e);
+    }
+    renderHooksPanel();
+}
+
+async function handleHooksSaveFailure(error) {
+    latestConfigMessageTone = 'error';
+    const errorReason = resolveHooksErrorReason(error);
+    latestConfigMessage = errorReason
+        ? formatMessage('settings.hooks.save_failed_detail', { error: errorReason })
+        : t('settings.hooks.save_failed');
+    logError(
+        'frontend.hooks_settings.save_failed',
+        'Failed to save hooks config',
+        errorToPayload(error),
+    );
+    await showAlertDialog({
+        title: t('settings.hooks.save_result_title'),
+        message: latestConfigMessage,
+        tone: 'error',
+    });
+}
+
+function reconcileStaleManualSaveSuccess(saveSnapshot) {
+    const currentSavedBaseline = cloneGroups(lastSavedEditorGroups);
+    lastSavedEditorGroups = mergeStaleManualSaveGroups(
+        lastSavedEditorGroups,
+        currentSavedBaseline,
+        saveSnapshot.previousSavedEditorGroups,
+        saveSnapshot.savedEditorGroups,
+        false,
+    );
+    editorGroups = mergeStaleManualSaveGroups(
+        editorGroups,
+        currentSavedBaseline,
+        saveSnapshot.previousSavedEditorGroups,
+        saveSnapshot.savedEditorGroups,
+        true,
+    );
+    clearRemovedGroupEditState(editorGroups);
+    reconcileHooksDirtyState();
+    renderHooksPanel();
+}
+
+function mergeStaleManualSaveGroups(
+    currentGroups,
+    currentSavedBaseline,
+    previousSavedGroups,
+    savedGroups,
+    preserveDirtyGroups,
+) {
+    const savedGroupsById = new Map(savedGroups.map(group => [group.id, group]));
+    const previousIds = new Set(previousSavedGroups.map(group => group.id));
+    const previousPairs = previousSavedGroups.map(previousGroup => ({
+        previousGroup,
+        savedGroup: savedGroupsById.get(previousGroup.id) || null,
+        used: false,
+    }));
+    const mergedGroups = [];
+    currentGroups.forEach(currentGroup => {
+        const previousPair = previousPairs.find(pair =>
+            !pair.used && groupsHaveSameSavedIdentity(currentGroup, pair.previousGroup),
+        );
+        if (!previousPair) {
+            mergedGroups.push(cloneGroup(currentGroup));
+            return;
+        }
+        previousPair.used = true;
+        if (
+            preserveDirtyGroups
+            && !groupMatchesCurrentSavedBaseline(currentGroup, currentSavedBaseline)
+        ) {
+            mergedGroups.push(cloneGroup(currentGroup));
+            return;
+        }
+        if (previousPair.savedGroup) {
+            mergedGroups.push(applySavedGroupToCurrentIds(currentGroup, previousPair.savedGroup));
+        }
+    });
+    savedGroups.forEach(savedGroup => {
+        if (!previousIds.has(savedGroup.id)) {
+            mergedGroups.push(assignFreshIdsToSavedGroup(savedGroup));
+        }
+    });
+    return mergedGroups;
+}
+
+function groupMatchesCurrentSavedBaseline(group, currentSavedBaseline) {
+    const savedGroup = currentSavedBaseline.find(candidate => candidate.id === group.id);
+    return savedGroup ? groupsHaveSameSerializedConfig([group], [savedGroup]) : false;
+}
+
+function applySavedGroupToCurrentIds(currentGroup, savedGroup) {
+    const nextGroup = cloneGroup(savedGroup);
+    return {
+        ...nextGroup,
+        id: currentGroup.id,
+        handlers: nextGroup.handlers.map((handler, index) => ({
+            ...handler,
+            id: currentGroup.handlers[index]?.id || handler.id,
+        })),
+    };
+}
+
+function assignFreshIdsToSavedGroup(savedGroup) {
+    const nextGroup = cloneGroup(savedGroup);
+    return {
+        ...nextGroup,
+        id: nextGroupId++,
+        handlers: nextGroup.handlers.map(handler => ({
+            ...handler,
+            id: nextHandlerId++,
+        })),
+    };
+}
+
+async function queuePersistHooksAfterDelete(deleteSnapshot) {
+    hooksPersistenceChain = hooksPersistenceChain.then(() =>
+        persistHooksAfterDelete(deleteSnapshot),
+    );
+    await hooksPersistenceChain;
+}
+
+async function persistHooksAfterDelete(deleteSnapshot) {
+    const { deletedSavedGroups, requestId } = deleteSnapshot;
+    const requestIsCurrent = requestId === activeHooksLoadRequestId;
+    const persistedGroups = removeDeletedSavedGroupsOnce(
+        lastSavedEditorGroups,
+        deletedSavedGroups,
+        requestIsCurrent,
+    );
+    if (persistedGroups.length === lastSavedEditorGroups.length) {
+        if (requestId !== activeHooksLoadRequestId) {
+            return;
+        }
+        reconcileHooksDirtyState();
+        renderHooksPanel();
+        return;
+    }
+    try {
+        const payload = serializeHooksConfig(persistedGroups);
+        validateHooksPayloadForEditor(payload);
+        await validateHooksConfig(payload);
+        await saveHooksConfig(payload);
+        if (requestId !== activeHooksLoadRequestId) {
+            handleStaleDeleteSuccess(deletedSavedGroups, persistedGroups);
+            return;
+        }
+        lastSavedEditorGroups = cloneGroups(persistedGroups);
+        reconcileHooksDirtyState();
+        latestConfigMessageTone = 'info';
+        latestConfigMessage = '';
+        try {
+            const runtimeView = await fetchHookRuntimeView();
+            if (requestId !== activeHooksLoadRequestId) {
+                return;
+            }
+            latestRuntimeView = runtimeView;
+            latestRuntimeLoadErrorMessage = '';
+        } catch (e) {
+            if (requestId !== activeHooksLoadRequestId) {
+                return;
+            }
+            latestRuntimeView = null;
+            latestRuntimeLoadErrorMessage =
+                e?.message || t('settings.hooks.runtime_load_failed');
+            logError(
+                'frontend.hooks_settings.runtime_load_failed',
+                'Failed to refresh hooks runtime view after delete',
+                errorToPayload(e),
+            );
+        }
+    } catch (e) {
+        if (requestId !== activeHooksLoadRequestId) {
+            return;
+        }
+        hooksConfigDirty = true;
         latestConfigMessageTone = 'error';
         const errorReason = resolveHooksErrorReason(e);
         latestConfigMessage = errorReason
-            ? formatMessage('settings.hooks.save_failed_detail', { error: errorReason })
-            : t('settings.hooks.save_failed');
+            ? formatMessage('settings.hooks.delete_failed_detail', { error: errorReason })
+            : t('settings.hooks.delete_failed');
         logError(
-            'frontend.hooks_settings.save_failed',
-            'Failed to save hooks config',
+            'frontend.hooks_settings.delete_save_failed',
+            'Failed to save hooks config after deleting hook group',
             errorToPayload(e),
         );
         await showAlertDialog({
-            title: t('settings.hooks.save_result_title'),
+            title: t('settings.hooks.delete_result_title'),
             message: latestConfigMessage,
             tone: 'error',
         });
@@ -507,7 +748,178 @@ async function saveCurrentHooksConfig() {
     renderHooksPanel();
 }
 
+function matchesDeletedSavedGroup(group, deletedSavedGroups, requestIsCurrent) {
+    return deletedSavedGroups.some(deletedGroup => {
+        if (requestIsCurrent) {
+            return group.id === deletedGroup.id;
+        }
+        return groupsHaveSameSavedIdentity(group, deletedGroup);
+    });
+}
+
+function removeDeletedSavedGroupsOnce(groups, deletedSavedGroups, requestIsCurrent) {
+    const remainingDeletedGroups = [...deletedSavedGroups];
+    return groups.filter(group => {
+        const deletedIndex = remainingDeletedGroups.findIndex(deletedGroup =>
+            matchesDeletedSavedGroup(group, [deletedGroup], requestIsCurrent),
+        );
+        if (deletedIndex < 0) {
+            return true;
+        }
+        remainingDeletedGroups.splice(deletedIndex, 1);
+        return false;
+    });
+}
+
+function handleStaleDeleteSuccess(deletedSavedGroups, persistedGroups) {
+    if (loadInFlight) {
+        pendingStaleDeleteSuccesses = [
+            ...pendingStaleDeleteSuccesses,
+            {
+                deletedSavedGroups: cloneGroups(deletedSavedGroups),
+                persistedGroups: cloneGroups(persistedGroups),
+            },
+        ];
+        return;
+    }
+    reconcileStaleDeleteSuccess(deletedSavedGroups, persistedGroups);
+}
+
+function applyPendingStaleDeleteSuccesses() {
+    if (pendingStaleDeleteSuccesses.length === 0) {
+        return;
+    }
+    const pendingSuccesses = pendingStaleDeleteSuccesses.map(success => ({
+        deletedSavedGroups: cloneGroups(success.deletedSavedGroups),
+        persistedGroups: cloneGroups(success.persistedGroups),
+    }));
+    pendingStaleDeleteSuccesses = [];
+    pendingSuccesses.forEach(success => {
+        reconcileStaleDeleteSuccess(success.deletedSavedGroups, success.persistedGroups);
+    });
+}
+
+function groupsHaveSameSavedIdentity(group, deletedGroup) {
+    const groupSavedIdentity = getGroupSavedIdentity(group);
+    const deletedGroupSavedIdentity = getGroupSavedIdentity(deletedGroup);
+    if (groupSavedIdentity && deletedGroupSavedIdentity) {
+        return groupSavedIdentity === deletedGroupSavedIdentity;
+    }
+    return group.event_name === deletedGroup.event_name
+        && group.name === deletedGroup.name
+        && group.matcher === deletedGroup.matcher
+        && JSON.stringify(group.role_ids) === JSON.stringify(deletedGroup.role_ids)
+        && JSON.stringify(group.session_modes) === JSON.stringify(deletedGroup.session_modes)
+        && JSON.stringify(group.run_kinds) === JSON.stringify(deletedGroup.run_kinds)
+        && JSON.stringify(normalizeHandlersForSavedIdentity(group.handlers))
+            === JSON.stringify(normalizeHandlersForSavedIdentity(deletedGroup.handlers));
+}
+
+function normalizeHandlersForSavedIdentity(handlers) {
+    if (!Array.isArray(handlers)) {
+        return [];
+    }
+    return handlers.map(handler => {
+        const savedFields = { ...(handler || {}) };
+        delete savedFields.id;
+        return savedFields;
+    });
+}
+
+function markGroupsSaved(groups) {
+    return cloneGroups(groups).map(group => {
+        const savedGroup = { ...group, isNew: false };
+        return {
+            ...savedGroup,
+            saved_identity: buildGroupSavedIdentity(savedGroup),
+        };
+    });
+}
+
+function mergeSavedStateIntoEditorGroups(groups, savedGroups) {
+    const savedGroupsById = new Map(savedGroups.map(group => [group.id, group]));
+    return cloneGroups(groups).map(group => {
+        const savedGroup = savedGroupsById.get(group.id);
+        if (!savedGroup) {
+            return group;
+        }
+        return {
+            ...group,
+            isNew: false,
+            saved_identity: savedGroup.saved_identity,
+        };
+    });
+}
+
+function getGroupSavedIdentity(group) {
+    if (typeof group?.saved_identity === 'string' && group.saved_identity) {
+        return group.saved_identity;
+    }
+    return buildGroupSavedIdentity(group);
+}
+
+function buildGroupSavedIdentity(group) {
+    return JSON.stringify({
+        event_name: group?.event_name,
+        name: group?.name,
+        matcher: group?.matcher,
+        role_ids: Array.isArray(group?.role_ids) ? group.role_ids : [],
+        session_modes: Array.isArray(group?.session_modes) ? group.session_modes : [],
+        run_kinds: Array.isArray(group?.run_kinds) ? group.run_kinds : [],
+        handlers: normalizeHandlersForSavedIdentity(group?.handlers),
+    });
+}
+
+function reconcileStaleDeleteSuccess(deletedSavedGroups, persistedGroups) {
+    if (groupsHaveSameSerializedConfig(lastSavedEditorGroups, persistedGroups)) {
+        return;
+    }
+    const nextLastSavedEditorGroups = removeDeletedSavedGroupsOnce(
+        lastSavedEditorGroups,
+        deletedSavedGroups,
+        false,
+    );
+    const nextEditorGroups = removeDeletedSavedGroupsOnce(
+        editorGroups,
+        deletedSavedGroups,
+        false,
+    );
+    const removedSavedGroup = nextLastSavedEditorGroups.length !== lastSavedEditorGroups.length;
+    const removedEditorGroup = nextEditorGroups.length !== editorGroups.length;
+    if (!removedSavedGroup && !removedEditorGroup) {
+        return;
+    }
+    lastSavedEditorGroups = cloneGroups(nextLastSavedEditorGroups);
+    editorGroups = cloneGroups(nextEditorGroups);
+    clearRemovedGroupEditState(editorGroups);
+    reconcileHooksDirtyState();
+    renderHooksPanel();
+}
+
+function groupsHaveSameSerializedConfig(groups, otherGroups) {
+    try {
+        return JSON.stringify(serializeHooksConfig(groups))
+            === JSON.stringify(serializeHooksConfig(otherGroups));
+    } catch {
+        return false;
+    }
+}
+
+function clearRemovedGroupEditState(groups) {
+    const retainedGroupIds = new Set(groups.map(group => group.id));
+    if (editingGroupId !== null && !retainedGroupIds.has(editingGroupId)) {
+        editingGroupId = null;
+    }
+    Array.from(groupEditSnapshots.keys()).forEach(groupId => {
+        if (!retainedGroupIds.has(groupId)) {
+            groupEditSnapshots.delete(groupId);
+            clearCollapsedHandlersForGroup(groupId);
+        }
+    });
+}
+
 function renderHooksPanel() {
+    syncHooksSettingsActions();
     const host = document.getElementById('hooks-runtime-status');
     if (!host) {
         return;
@@ -526,6 +938,18 @@ function renderHooksPanel() {
         return;
     }
     host.innerHTML = renderMergedHooksShell();
+}
+
+function isHooksPanelActive() {
+    const panel = document.getElementById('hooks-panel');
+    return !panel || panel.style.display !== 'none';
+}
+
+function setActionDisplay(id, visible) {
+    const element = document.getElementById(id);
+    if (element?.style) {
+        element.style.display = visible ? 'inline-flex' : 'none';
+    }
 }
 
 function startEditingGroup(groupId) {
@@ -549,6 +973,20 @@ function cancelEditingGroup(groupId) {
     if (editingGroupId === groupId) {
         editingGroupId = null;
     }
+    reconcileHooksDirtyState();
+}
+
+function reconcileHooksDirtyState() {
+    try {
+        hooksConfigDirty = JSON.stringify(serializeHooksConfig(editorGroups))
+            !== JSON.stringify(serializeHooksConfig(lastSavedEditorGroups));
+    } catch {
+        hooksConfigDirty = true;
+    }
+}
+
+function cloneGroups(groups) {
+    return groups.map(group => cloneGroup(group));
 }
 
 function renderMergedHooksShell() {
@@ -1143,7 +1581,7 @@ function deserializeHooksConfig(config) {
                 continue;
             }
             const handlers = Array.isArray(rawGroup.hooks) ? rawGroup.hooks : [];
-            groups.push({
+            const group = {
                 id: nextGroupId++,
                 isNew: false,
                 name: normalizeString(rawGroup.name),
@@ -1169,6 +1607,10 @@ function deserializeHooksConfig(config) {
                     model: normalizeString(rawHandler?.model),
                     role_id: normalizeString(rawHandler?.role_id),
                 })),
+            };
+            groups.push({
+                ...group,
+                saved_identity: buildGroupSavedIdentity(group),
             });
         }
     }
@@ -1392,6 +1834,7 @@ function createDefaultGroup() {
     return {
         id: nextGroupId++,
         isNew: true,
+        saved_identity: '',
         name: '',
         event_name: 'PreToolUse',
         matcher: '',

--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -8,7 +8,11 @@ import {
     loadCommandsSettingsPanel,
     syncCommandsSettingsActions,
 } from './commandsSettings.js';
-import { bindHooksSettingsHandlers, loadHooksSettingsPanel } from './hooksSettings.js';
+import {
+    bindHooksSettingsHandlers,
+    loadHooksSettingsPanel,
+    syncHooksSettingsActions,
+} from './hooksSettings.js';
 import { bindModelProfileHandlers, loadModelProfilesPanel } from './modelProfiles.js';
 import { renderModelProfilesPanelMarkup } from './modelProfiles/template.js';
 import {
@@ -818,7 +822,7 @@ function createModal() {
                             <button class="secondary-btn section-action-btn settings-action" id="cancel-command-btn" type="button" style="display:none;" data-i18n="settings.action.cancel">Cancel</button>
                         </div>
                         <div class="settings-panel-actions-group settings-panel-actions-group-end">
-                            <button class="secondary-btn section-action-btn settings-action" id="add-hook-btn" type="button" style="display:none;" data-i18n="settings.hooks.add_group">Add Hook</button>
+                            <button class="secondary-btn section-action-btn settings-action" id="add-hook-btn" type="button" style="display:none;" data-i18n="settings.hooks.add_group">新增 Hook</button>
                             <button class="secondary-btn section-action-btn settings-action" id="validate-hooks-btn" type="button" style="display:none;" data-i18n="settings.action.validate">Validate</button>
                             <button class="primary-btn section-action-btn settings-action" id="save-hooks-btn" type="button" style="display:none;" data-i18n="settings.action.save">Save</button>
                             <button class="secondary-btn section-action-btn settings-action" id="add-profile-btn" type="button" style="display:none;" data-i18n="settings.action.add_profile">Add Profile</button>
@@ -988,9 +992,7 @@ function renderPanelActions(tab) {
         return;
     }
     if (tab === 'hooks') {
-        document.getElementById('validate-hooks-btn').style.display = 'inline-flex';
-        document.getElementById('add-hook-btn').style.display = 'inline-flex';
-        document.getElementById('save-hooks-btn').style.display = 'inline-flex';
+        syncHooksSettingsActions();
         return;
     }
     if (tab === 'agents') {

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -422,6 +422,9 @@ const TRANSLATIONS = {
         'settings.hooks.save_failed': 'Failed to save hooks config.',
         'settings.hooks.save_failed_detail': 'Failed to save hooks config: {error}',
         'settings.hooks.save_result_title': 'Save Result',
+        'settings.hooks.delete_failed': 'Failed to delete hook.',
+        'settings.hooks.delete_failed_detail': 'Failed to delete hook: {error}',
+        'settings.hooks.delete_result_title': 'Delete Result',
         'settings.appearance.colors': 'Colors',
         'settings.appearance.accent': 'Accent',
         'settings.appearance.background': 'Background',
@@ -1490,7 +1493,6 @@ const TRANSLATIONS = {
         'settings.hooks.if_rule': 'If 规则',
         'settings.hooks.empty': '当前没有 Hook 配置',
         'settings.hooks.empty_copy': '添加一个 Hook 来开始构建当前页面展示的 Hooks。',
-        'settings.hooks.add_group': '添加 Hook',
         'settings.hooks.edit_group': '编辑',
         'settings.hooks.delete_group': '删除 Hook',
         'settings.hooks.handlers': '处理器',
@@ -1537,7 +1539,7 @@ const TRANSLATIONS = {
         'settings.hooks.runtime_section_copy': '查看当前运行时合并后实际生效的 Hook。',
         'settings.hooks.config_empty': '当前没有用户级 Hook 配置',
         'settings.hooks.config_empty_copy': '添加一个匹配组来开始构建用户级 Hook。',
-        'settings.hooks.add_group': '添加 Hook',
+        'settings.hooks.add_group': '新增 Hook',
         'settings.hooks.delete_group': '删除 Hook',
         'settings.hooks.handlers': '处理器',
         'settings.hooks.handlers_count_suffix': '个处理器',
@@ -4147,6 +4149,12 @@ function resolvePreferredLanguage() {
     }
     return DEFAULT_LANGUAGE;
 }
+
+Object.assign(TRANSLATIONS['zh-CN'], {
+    'settings.hooks.delete_failed': '\u5220\u9664 Hook \u5931\u8d25\u3002',
+    'settings.hooks.delete_failed_detail': '\u5220\u9664 Hook \u5931\u8d25\uff1a{error}',
+    'settings.hooks.delete_result_title': '\u5220\u9664\u7ed3\u679c',
+});
 
 function updateLanguageButton() {
     const button = document?.getElementById?.('language-toggle-btn');

--- a/tests/unit_tests/frontend/test_hooks_settings_ui.py
+++ b/tests/unit_tests/frontend/test_hooks_settings_ui.py
@@ -148,6 +148,70 @@ def test_hooks_settings_panel_renders_empty_and_error_states(tmp_path: Path) -> 
     assert "boom" in str(error_payload["html"])
 
 
+def test_hooks_settings_add_after_load_error_enables_save_actions(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+export async function fetchHooksConfig() {
+    throw new Error('broken config');
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig() {
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener(type, handler) { globalThis.__addHookClick = handler; } },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.document = {
+    addEventListener() {},
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const htmlAfterFailure = host.innerHTML;
+globalThis.__addHookClick();
+const htmlAfterAdd = host.innerHTML;
+console.log(JSON.stringify({
+    htmlAfterFailure,
+    htmlAfterAdd,
+    saveDisplay: buttons.save.style.display,
+    validateDisplay: buttons.validate.style.display,
+}));
+""",
+    )
+
+    assert "Load Failed" in cast(str, payload["htmlAfterFailure"])
+    assert "Load Failed" not in cast(str, payload["htmlAfterAdd"])
+    assert payload["saveDisplay"] == "inline-flex"
+    assert payload["validateDisplay"] == "inline-flex"
+
+
 def test_hooks_settings_panel_keeps_editor_when_runtime_view_load_fails(
     tmp_path: Path,
 ) -> None:
@@ -271,6 +335,1316 @@ console.log(JSON.stringify({ html: host.innerHTML }));
     assert "fresh hook" in html
     assert "stale hook" not in html
     assert "Loading loaded hooks..." not in html
+
+
+def test_hooks_settings_delete_autosave_ignores_stale_reload_result(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+let configCalls = 0;
+let runtimeCalls = 0;
+
+export async function fetchHooksConfig() {
+    configCalls += 1;
+    if (configCalls === 1) {
+        return {
+            hooks: {
+                PreToolUse: [
+                    {
+                        name: 'Python write guard',
+                        matcher: 'Write',
+                        hooks: [
+                            {
+                                type: 'command',
+                                name: 'lint changed files',
+                                command: 'python lint.py',
+                            },
+                        ],
+                    },
+                    {
+                        name: 'Shell guard',
+                        matcher: 'Bash',
+                        hooks: [
+                            {
+                                type: 'command',
+                                name: 'check shell',
+                                command: 'python shell_guard.py',
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+    }
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Fresh reload guard',
+                    matcher: 'Edit',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'fresh command',
+                            command: 'python fresh.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    runtimeCalls += 1;
+    if (runtimeCalls === 1) {
+        return {
+            sources: [{ scope: 'project', path: '/workspace/.relay-teams/hooks-first.json' }],
+            loaded_hooks: [{ name: 'first runtime hook', handler_type: 'command', event_name: 'PreToolUse', matcher: 'Write', source: { scope: 'project', path: '/workspace/.relay-teams/hooks-first.json' } }],
+        };
+    }
+    if (runtimeCalls === 2) {
+        return {
+            sources: [{ scope: 'project', path: '/workspace/.relay-teams/hooks-fresh.json' }],
+            loaded_hooks: [{ name: 'fresh runtime hook', handler_type: 'command', event_name: 'PreToolUse', matcher: 'Edit', source: { scope: 'project', path: '/workspace/.relay-teams/hooks-fresh.json' } }],
+        };
+    }
+    return {
+        sources: [{ scope: 'project', path: '/workspace/.relay-teams/hooks-stale-delete.json' }],
+        loaded_hooks: [{ name: 'stale delete runtime hook', handler_type: 'command', event_name: 'PreToolUse', matcher: 'Bash', source: { scope: 'project', path: '/workspace/.relay-teams/hooks-stale-delete.json' } }],
+    };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    await new Promise(resolve => {
+        globalThis.__resolveDeleteSave = resolve;
+    });
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+globalThis.__resolveDeleteSave();
+await deleteSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    html = cast(str, payload["html"])
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 1
+    assert "fresh runtime hook" in html
+    assert "Fresh reload guard" in html
+    assert "stale delete runtime hook" not in html
+    assert "Shell guard" not in html
+
+
+def test_hooks_settings_delete_autosave_persists_after_reload_during_validation(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Shell guard',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'check shell',
+                            command: 'python shell_guard.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    await new Promise(resolve => {
+        globalThis.__resolveDeleteValidation = resolve;
+    });
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+globalThis.__resolveDeleteValidation();
+await deleteSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({ savedPayloads: globalThis.__savedPayloads }));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 1
+    saved_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    saved_groups = cast(list[dict[str, object]], saved_hooks["PreToolUse"])
+    assert len(saved_groups) == 1
+    assert saved_groups[0]["name"] == "Shell guard"
+
+
+def test_hooks_settings_stale_delete_success_reconciles_reloaded_state(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Shell guard',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'check shell',
+                            command: 'python shell_guard.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (!globalThis.__deleteSaveBlocked) {
+        globalThis.__deleteSaveBlocked = true;
+        await new Promise(resolve => {
+            globalThis.__resolveDeleteSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+globalThis.__resolveDeleteSave();
+await deleteSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 1
+    saved_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    saved_groups = cast(list[dict[str, object]], saved_hooks["PreToolUse"])
+    assert len(saved_groups) == 1
+    assert saved_groups[0]["name"] == "Shell guard"
+    assert "Python write guard" not in cast(str, payload["html"])
+    assert "Shell guard" in cast(str, payload["html"])
+
+
+def test_hooks_settings_stale_delete_success_keeps_identical_sibling_group(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+export async function fetchHooksConfig() {
+    const duplicatedGroup = {
+        name: 'Duplicated guard',
+        matcher: 'Write',
+        hooks: [
+            {
+                type: 'command',
+                name: 'lint changed files',
+                command: 'python lint.py',
+            },
+        ],
+    };
+    return { hooks: { PreToolUse: [duplicatedGroup, duplicatedGroup] } };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (!globalThis.__deleteSaveBlocked) {
+        globalThis.__deleteSaveBlocked = true;
+        await new Promise(resolve => {
+            globalThis.__resolveDeleteSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+globalThis.__resolveDeleteSave();
+await deleteSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 1
+    saved_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    saved_groups = cast(list[dict[str, object]], saved_hooks["PreToolUse"])
+    assert len(saved_groups) == 1
+    assert saved_groups[0]["name"] == "Duplicated guard"
+    assert "Duplicated guard" in cast(str, payload["html"])
+
+
+def test_hooks_settings_stale_delete_success_waits_for_pending_reload(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+function duplicatedConfig() {
+    const duplicatedGroup = {
+        name: 'Duplicated guard',
+        matcher: 'Write',
+        hooks: [
+            {
+                type: 'command',
+                name: 'lint changed files',
+                command: 'python lint.py',
+            },
+        ],
+    };
+    return { hooks: { PreToolUse: [duplicatedGroup, duplicatedGroup] } };
+}
+
+export async function fetchHooksConfig() {
+    globalThis.__fetchCount += 1;
+    if (globalThis.__fetchCount === 2) {
+        await new Promise(resolve => {
+            globalThis.__resolveReload = resolve;
+        });
+    }
+    return duplicatedConfig();
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__fetchCount = 0;
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+const reload = loadHooksSettingsPanel();
+await deleteSave;
+globalThis.__resolveReload();
+await reload;
+await globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    manual_save_hooks = cast(dict[str, object], saved_payloads[1]["hooks"])
+    manual_save_groups = cast(list[dict[str, object]], manual_save_hooks["PreToolUse"])
+    assert len(manual_save_groups) == 1
+    assert manual_save_groups[0]["name"] == "Duplicated guard"
+    assert "Duplicated guard" in cast(str, payload["html"])
+
+
+def test_hooks_settings_stale_delete_success_skips_reload_with_deleted_group(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+function duplicatedGroup() {
+    return {
+        name: 'Duplicated guard',
+        matcher: 'Write',
+        hooks: [
+            {
+                type: 'command',
+                name: 'lint changed files',
+                command: 'python lint.py',
+            },
+        ],
+    };
+}
+
+export async function fetchHooksConfig() {
+    globalThis.__fetchCount += 1;
+    if (globalThis.__fetchCount === 1) {
+        return { hooks: { PreToolUse: [duplicatedGroup(), duplicatedGroup()] } };
+    }
+    return { hooks: { PreToolUse: [duplicatedGroup()] } };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (!globalThis.__deleteSaveBlocked) {
+        globalThis.__deleteSaveBlocked = true;
+        await new Promise(resolve => {
+            globalThis.__resolveDeleteSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__fetchCount = 0;
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+globalThis.__resolveDeleteSave();
+await deleteSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+await globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    first_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    first_groups = cast(list[dict[str, object]], first_hooks["PreToolUse"])
+    assert len(first_groups) == 1
+    second_hooks = cast(dict[str, object], saved_payloads[1]["hooks"])
+    second_groups = cast(list[dict[str, object]], second_hooks["PreToolUse"])
+    assert len(second_groups) == 1
+    assert second_groups[0]["name"] == "Duplicated guard"
+    assert "Duplicated guard" in cast(str, payload["html"])
+
+
+def test_hooks_settings_stale_delete_success_clears_removed_edit_state(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+function deletedConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Deleted guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHooksConfig() {
+    return deletedConfig();
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (!globalThis.__deleteSaveBlocked) {
+        globalThis.__deleteSaveBlocked = true;
+        await new Promise(resolve => {
+            globalThis.__resolveDeleteSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+globalThis.__resolveDeleteSave();
+await deleteSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    saveDisplay: buttons.save.style.display,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 1
+    assert payload["savedPayloads"] == [{"hooks": {}}]
+    assert payload["saveDisplay"] == "none"
+    assert "Deleted guard" not in cast(str, payload["html"])
+
+
+def test_hooks_settings_stale_delete_success_removes_edited_reloaded_group(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+function deletedConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Deleted guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHooksConfig() {
+    return deletedConfig();
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (!globalThis.__deleteSaveBlocked) {
+        globalThis.__deleteSaveBlocked = true;
+        await new Promise(resolve => {
+            globalThis.__resolveDeleteSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '2' },
+        value: 'Edited stale guard',
+    },
+});
+globalThis.__resolveDeleteSave();
+await deleteSave;
+await globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    assert saved_payloads[0] == {"hooks": {}}
+    assert saved_payloads[1] == {"hooks": {}}
+    assert "Deleted guard" not in cast(str, payload["html"])
+    assert "Edited stale guard" not in cast(str, payload["html"])
+
+
+def test_hooks_settings_manual_save_preserves_in_flight_edits(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Initial guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (globalThis.__savedPayloads.length === 1) {
+        await new Promise(resolve => {
+            globalThis.__resolveFirstSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '1' },
+        value: 'Saved guard',
+    },
+});
+const firstSave = globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '1' },
+        value: 'Post-save draft',
+    },
+});
+globalThis.__resolveFirstSave();
+await firstSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+const saveDisplayAfterFirstSave = buttons.save.style.display;
+await globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    saveDisplayAfterFirstSave,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    first_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    first_groups = cast(list[dict[str, object]], first_hooks["PreToolUse"])
+    assert first_groups[0]["name"] == "Saved guard"
+    second_hooks = cast(dict[str, object], saved_payloads[1]["hooks"])
+    second_groups = cast(list[dict[str, object]], second_hooks["PreToolUse"])
+    assert second_groups[0]["name"] == "Post-save draft"
+    assert payload["saveDisplayAfterFirstSave"] == "inline-flex"
+    assert "Post-save draft" in cast(str, payload["html"])
+
+
+def test_hooks_settings_stale_manual_save_does_not_break_delete_after_reload(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Reloaded guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (globalThis.__savedPayloads.length === 1) {
+        await new Promise(resolve => {
+            globalThis.__resolveFirstSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '1' },
+        value: 'Saved guard',
+    },
+});
+const manualSave = globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+globalThis.__resolveFirstSave();
+await manualSave;
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    first_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    first_groups = cast(list[dict[str, object]], first_hooks["PreToolUse"])
+    assert first_groups[0]["name"] == "Saved guard"
+    assert saved_payloads[1] == {"hooks": {}}
+    assert "Reloaded guard" not in cast(str, payload["html"])
+
+
+def test_hooks_settings_stale_manual_save_updates_delete_baseline_after_reload(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config=None,
+        runtime_view=None,
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Shell guard',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'check shell',
+                            command: 'python shell_guard.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (globalThis.__savedPayloads.length === 1) {
+        await new Promise(resolve => {
+            globalThis.__resolveFirstSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '2' },
+        value: 'Saved shell guard',
+    },
+});
+const manualSave = globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+await loadHooksSettingsPanel();
+globalThis.__resolveFirstSave();
+await manualSave;
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '3' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    first_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    first_groups = cast(list[dict[str, object]], first_hooks["PreToolUse"])
+    assert len(first_groups) == 2
+    assert first_groups[1]["name"] == "Saved shell guard"
+    second_hooks = cast(dict[str, object], saved_payloads[1]["hooks"])
+    second_groups = cast(list[dict[str, object]], second_hooks["PreToolUse"])
+    assert len(second_groups) == 1
+    assert second_groups[0]["name"] == "Saved shell guard"
+    assert "Python write guard" not in cast(str, payload["html"])
+    assert "Saved shell guard" in cast(str, payload["html"])
 
 
 def test_hooks_settings_panel_switches_card_into_edit_mode(tmp_path: Path) -> None:
@@ -1137,6 +2511,1381 @@ console.log(JSON.stringify({ savedPayload: globalThis.__savedPayload }));
             "prompt": "review the final answer",
         }
     ]
+
+
+def test_hooks_settings_saves_empty_config_after_deleting_last_group(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayload = payload;
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+const saveDisplayAfterDelete = buttons.save.style.display;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    savedPayload: globalThis.__savedPayload,
+    feedbackCalls: globalThis.__feedbackCalls || [],
+    saveDisplayAfterDelete,
+    saveDisplayAfterDeleteSave: buttons.save.style.display,
+}));
+""",
+    )
+
+    assert payload["savedPayload"] == {"hooks": {}}
+    assert payload["feedbackCalls"] == []
+    assert payload["saveDisplayAfterDelete"] == "none"
+    assert payload["saveDisplayAfterDeleteSave"] == "none"
+
+
+def test_hooks_settings_delete_keeps_identical_sibling_group(tmp_path: Path) -> None:
+    duplicated_group = {
+        "name": "Duplicated guard",
+        "matcher": "Write",
+        "hooks": [
+            {
+                "type": "command",
+                "name": "lint changed files",
+                "command": "python lint.py",
+            }
+        ],
+    }
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={"hooks": {"PreToolUse": [duplicated_group, duplicated_group]}},
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    const duplicatedGroup = {
+        name: 'Duplicated guard',
+        matcher: 'Write',
+        hooks: [
+            {
+                type: 'command',
+                name: 'lint changed files',
+                command: 'python lint.py',
+            },
+        ],
+    };
+    return { hooks: { PreToolUse: [duplicatedGroup, duplicatedGroup] } };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayload = payload;
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({ savedPayload: globalThis.__savedPayload }));
+""",
+    )
+
+    saved_payload = cast(dict[str, object], payload["savedPayload"])
+    saved_hooks = cast(dict[str, object], saved_payload["hooks"])
+    saved_groups = cast(list[dict[str, object]], saved_hooks["PreToolUse"])
+    assert len(saved_groups) == 1
+    assert saved_groups[0]["name"] == "Duplicated guard"
+
+
+def test_hooks_settings_delete_does_not_persist_other_group_drafts(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "Shell guard",
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "check shell",
+                                "command": "python shell_guard.py",
+                            }
+                        ],
+                    },
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Shell guard',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'check shell',
+                            command: 'python shell_guard.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayload = payload;
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '2', handlerId: '0' },
+        value: 'Draft shell guard',
+    },
+});
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    savedPayload: globalThis.__savedPayload,
+    saveDisplay: buttons.save.style.display,
+    html: host.innerHTML,
+}));
+""",
+    )
+
+    saved_payload = cast(dict[str, object], payload["savedPayload"])
+    saved_hooks = cast(dict[str, object], saved_payload["hooks"])
+    groups = cast(list[dict[str, object]], saved_hooks["PreToolUse"])
+    assert len(groups) == 1
+    assert groups[0]["name"] == "Shell guard"
+    assert payload["saveDisplay"] == "inline-flex"
+    assert "Draft shell guard" in cast(str, payload["html"])
+
+
+def test_hooks_settings_delete_failure_shows_delete_result_dialog(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig() {
+    throw new Error('write denied');
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    feedbackCalls: globalThis.__feedbackCalls || [],
+    saveDisplay: buttons.save.style.display,
+    validateDisplay: buttons.validate.style.display,
+}));
+""",
+    )
+
+    assert payload["feedbackCalls"] == [
+        {
+            "title": "Delete Result",
+            "message": "Failed to delete hook: write denied",
+            "tone": "error",
+        }
+    ]
+    assert payload["saveDisplay"] == "inline-flex"
+    assert payload["validateDisplay"] == "inline-flex"
+
+
+def test_hooks_settings_serializes_concurrent_delete_saves(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "Shell guard",
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "check shell",
+                                "command": "python shell_guard.py",
+                            }
+                        ],
+                    },
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Shell guard',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'check shell',
+                            command: 'python shell_guard.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (globalThis.__savedPayloads.length === 1) {
+        await new Promise(resolve => {
+            globalThis.__resolveFirstSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+function removeGroup(groupId) {
+    return listeners.click({
+        target: {
+            closest(selector) {
+                if (selector === '[data-hooks-action]') {
+                    return { dataset: { hooksAction: 'remove-group', groupId } };
+                }
+                return null;
+            },
+        },
+    });
+}
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const firstDelete = removeGroup('1');
+await new Promise(resolve => setTimeout(resolve, 0));
+const secondDelete = removeGroup('2');
+await new Promise(resolve => setTimeout(resolve, 0));
+globalThis.__resolveFirstSave();
+await firstDelete;
+await secondDelete;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({ savedPayloads: globalThis.__savedPayloads }));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    first_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    first_groups = cast(list[dict[str, object]], first_hooks["PreToolUse"])
+    assert len(first_groups) == 1
+    assert first_groups[0]["name"] == "Shell guard"
+    assert saved_payloads[1] == {"hooks": {}}
+
+
+def test_hooks_settings_queues_manual_save_after_delete_autosave(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "Shell guard",
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "check shell",
+                                "command": "python shell_guard.py",
+                            }
+                        ],
+                    },
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Shell guard',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'check shell',
+                            command: 'python shell_guard.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (globalThis.__savedPayloads.length === 1) {
+        await new Promise(resolve => {
+            globalThis.__resolveFirstSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '2', handlerId: '0' },
+        value: 'Draft shell guard',
+    },
+});
+const manualSave = globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+globalThis.__resolveFirstSave();
+await deleteSave;
+await manualSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({ savedPayloads: globalThis.__savedPayloads }));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    first_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    first_groups = cast(list[dict[str, object]], first_hooks["PreToolUse"])
+    assert len(first_groups) == 1
+    assert first_groups[0]["name"] == "Shell guard"
+    second_hooks = cast(dict[str, object], saved_payloads[1]["hooks"])
+    second_groups = cast(list[dict[str, object]], second_hooks["PreToolUse"])
+    assert len(second_groups) == 1
+    assert second_groups[0]["name"] == "Draft shell guard"
+
+
+def test_hooks_settings_queued_manual_save_uses_click_snapshot(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "Shell guard",
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "check shell",
+                                "command": "python shell_guard.py",
+                            }
+                        ],
+                    },
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Shell guard',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'check shell',
+                            command: 'python shell_guard.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (globalThis.__savedPayloads.length === 1) {
+        await new Promise(resolve => {
+            globalThis.__resolveDeleteSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '2', handlerId: '0' },
+        value: 'Clicked shell guard',
+    },
+});
+const manualSave = globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '2', handlerId: '0' },
+        value: 'Post-click draft',
+    },
+});
+globalThis.__resolveDeleteSave();
+await deleteSave;
+await manualSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    html: host.innerHTML,
+    savedPayloads: globalThis.__savedPayloads,
+}));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    first_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    first_groups = cast(list[dict[str, object]], first_hooks["PreToolUse"])
+    assert len(first_groups) == 1
+    assert first_groups[0]["name"] == "Shell guard"
+    second_hooks = cast(dict[str, object], saved_payloads[1]["hooks"])
+    second_groups = cast(list[dict[str, object]], second_hooks["PreToolUse"])
+    assert len(second_groups) == 1
+    assert second_groups[0]["name"] == "Clicked shell guard"
+    assert "Post-click draft" in cast(str, payload["html"])
+
+
+def test_hooks_settings_delete_after_in_flight_manual_save_persists_delete(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "Shell guard",
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "check shell",
+                                "command": "python shell_guard.py",
+                            }
+                        ],
+                    },
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Shell guard',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'check shell',
+                            command: 'python shell_guard.py',
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayloads.push(payload);
+    if (globalThis.__savedPayloads.length === 1) {
+        await new Promise(resolve => {
+            globalThis.__resolveFirstSave = resolve;
+        });
+    }
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener(type, handler) { globalThis.__saveClick = handler; } },
+};
+globalThis.__savedPayloads = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'name', groupId: '2', handlerId: '0' },
+        value: 'Saved shell guard',
+    },
+});
+const manualSave = globalThis.__saveClick();
+await new Promise(resolve => setTimeout(resolve, 0));
+const deleteSave = listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+globalThis.__resolveFirstSave();
+await manualSave;
+await deleteSave;
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({ savedPayloads: globalThis.__savedPayloads }));
+""",
+    )
+
+    saved_payloads = cast(list[dict[str, object]], payload["savedPayloads"])
+    assert len(saved_payloads) == 2
+    first_hooks = cast(dict[str, object], saved_payloads[0]["hooks"])
+    first_groups = cast(list[dict[str, object]], first_hooks["PreToolUse"])
+    assert len(first_groups) == 2
+    assert first_groups[1]["name"] == "Saved shell guard"
+    second_hooks = cast(dict[str, object], saved_payloads[1]["hooks"])
+    second_groups = cast(list[dict[str, object]], second_hooks["PreToolUse"])
+    assert len(second_groups) == 1
+    assert second_groups[0]["name"] == "Saved shell guard"
+
+
+def test_hooks_settings_delete_success_ignores_invalid_unrelated_draft(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "HTTP audit",
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "http",
+                                "name": "notify audit",
+                                "url": "https://hooks.example.test/audit",
+                                "headers": {"Authorization": "Bearer $HOOK_TOKEN"},
+                            }
+                        ],
+                    },
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'HTTP audit',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'http',
+                            name: 'notify audit',
+                            url: 'https://hooks.example.test/audit',
+                            headers: { Authorization: 'Bearer $HOOK_TOKEN' },
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayload = payload;
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.__feedbackCalls = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'edit-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+listeners.input({
+    target: {
+        dataset: { hooksField: 'headers', groupId: '2', handlerId: '2' },
+        value: '{"Authorization":',
+    },
+});
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '1' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    feedbackCalls: globalThis.__feedbackCalls,
+    savedPayload: globalThis.__savedPayload,
+    saveDisplay: buttons.save.style.display,
+}));
+""",
+    )
+
+    assert payload["feedbackCalls"] == []
+    saved_payload = cast(dict[str, object], payload["savedPayload"])
+    saved_hooks = cast(dict[str, object], saved_payload["hooks"])
+    saved_groups = cast(list[dict[str, object]], saved_hooks["PreToolUse"])
+    assert len(saved_groups) == 1
+    assert saved_groups[0]["name"] == "HTTP audit"
+    assert payload["saveDisplay"] == "inline-flex"
+
+
+def test_hooks_settings_delete_bad_saved_headers_group_recovers_config(
+    tmp_path: Path,
+) -> None:
+    payload = _run_hooks_settings_script(
+        tmp_path=tmp_path,
+        hooks_config={
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "name": "Python write guard",
+                        "matcher": "Write",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "name": "lint changed files",
+                                "command": "python lint.py",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "Bad HTTP audit",
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "http",
+                                "name": "notify audit",
+                                "url": "https://hooks.example.test/audit",
+                                "headers": {"Authorization": 123},
+                            }
+                        ],
+                    },
+                ]
+            }
+        },
+        runtime_view={"sources": [], "loaded_hooks": []},
+        api_source="""
+export async function fetchHooksConfig() {
+    return {
+        hooks: {
+            PreToolUse: [
+                {
+                    name: 'Python write guard',
+                    matcher: 'Write',
+                    hooks: [
+                        {
+                            type: 'command',
+                            name: 'lint changed files',
+                            command: 'python lint.py',
+                        },
+                    ],
+                },
+                {
+                    name: 'Bad HTTP audit',
+                    matcher: 'Bash',
+                    hooks: [
+                        {
+                            type: 'http',
+                            name: 'notify audit',
+                            url: 'https://hooks.example.test/audit',
+                            headers: { Authorization: 123 },
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+}
+
+export async function fetchHookRuntimeView() {
+    return { sources: [], loaded_hooks: [] };
+}
+
+export async function saveHooksConfig(payload) {
+    globalThis.__savedPayload = payload;
+    return { status: 'ok' };
+}
+
+export async function validateHooksConfig() {
+    return { status: 'ok' };
+}
+""",
+        runner_source="""
+const listeners = {};
+const host = { innerHTML: '' };
+const buttons = {
+    add: { style: {}, addEventListener() {} },
+    validate: { style: {}, addEventListener() {} },
+    save: { style: {}, addEventListener() {} },
+};
+globalThis.__feedbackCalls = [];
+globalThis.document = {
+    addEventListener(name, handler) {
+        listeners[name] = handler;
+    },
+    getElementById(id) {
+        if (id === 'hooks-runtime-status') return host;
+        if (id === 'add-hook-btn') return buttons.add;
+        if (id === 'validate-hooks-btn') return buttons.validate;
+        if (id === 'save-hooks-btn') return buttons.save;
+        if (id === 'hooks-panel') return { style: { display: 'block' } };
+        return null;
+    },
+};
+
+const { bindHooksSettingsHandlers, loadHooksSettingsPanel } = await import('./hooksSettings.mjs');
+bindHooksSettingsHandlers();
+await loadHooksSettingsPanel();
+await listeners.click({
+    target: {
+        closest(selector) {
+            if (selector === '[data-hooks-action]') {
+                return { dataset: { hooksAction: 'remove-group', groupId: '2' } };
+            }
+            return null;
+        },
+    },
+});
+await new Promise(resolve => setTimeout(resolve, 0));
+console.log(JSON.stringify({
+    feedbackCalls: globalThis.__feedbackCalls,
+    savedPayload: globalThis.__savedPayload,
+}));
+""",
+    )
+
+    assert payload["feedbackCalls"] == []
+    saved_payload = cast(dict[str, object], payload["savedPayload"])
+    saved_hooks = cast(dict[str, object], saved_payload["hooks"])
+    saved_groups = cast(list[dict[str, object]], saved_hooks["PreToolUse"])
+    assert len(saved_groups) == 1
+    assert saved_groups[0]["name"] == "Python write guard"
 
 
 def test_hooks_settings_blocks_empty_agent_role_on_save(tmp_path: Path) -> None:
@@ -2504,6 +5253,11 @@ export async function showAlertDialog({ title = '', message = '', tone = 'info' 
     globalThis.__feedbackCalls.push({ title, message, tone });
     return true;
 }
+
+export function showToast({ title = '', message = '', tone = 'info' } = {}) {
+    globalThis.__feedbackCalls = globalThis.__feedbackCalls || [];
+    globalThis.__feedbackCalls.push({ title, message, tone });
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -2595,6 +5349,9 @@ const STRINGS = {
     'settings.hooks.save_failed': 'Failed to save hooks config.',
     'settings.hooks.save_failed_detail': 'Failed to save hooks config: {error}',
     'settings.hooks.save_result_title': 'Save Result',
+    'settings.hooks.delete_failed': 'Failed to delete hook.',
+    'settings.hooks.delete_failed_detail': 'Failed to delete hook: {error}',
+    'settings.hooks.delete_result_title': 'Delete Result',
     'settings.panel.hooks.title': 'Hooks',
     'settings.panel.hooks.description': 'View currently loaded hooks and provide custom editing.',
     'settings.action.validate': 'Validate',

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -566,6 +566,12 @@ export function bindHooksSettingsHandlers() {
 export async function loadHooksSettingsPanel() {
     globalThis.__loadCalls.hooks += 1;
 }
+
+export function syncHooksSettingsActions() {
+    document.getElementById('add-hook-btn').style.display = 'inline-flex';
+    document.getElementById('validate-hooks-btn').style.display = 'inline-flex';
+    document.getElementById('save-hooks-btn').style.display = 'inline-flex';
+}
 """.strip(),
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary
- hide hooks validate/save actions when there is no editable hook config
- persist hook deletions immediately, including saving an empty hooks config after deleting the last hook
- keep successful deletes silent and show delete failures through the same dialog pattern as validation/save failures
- align hooks/settings and feedback dialog button sizing, including the hooks save button override for the global primary button width

Fixes #570

## Tests
- `node --check frontend\\dist\\js\\components\\settings\\hooksSettings.js`
- `node --check frontend\\dist\\js\\components\\settings\\index.js`
- `node --check frontend\\dist\\js\\utils\\i18n.js`
- `uv run --extra dev pytest -q tests\\unit_tests\\frontend\\test_hooks_settings_ui.py --assert=plain --tb=line`