### PR TITLE
fix: expand MCP env variable templates

### DIFF
--- a/src/relay_teams/mcp/mcp_registry.py
+++ b/src/relay_teams/mcp/mcp_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 import logging
 import os
+import re
 from typing import Protocol, cast
 
 from pydantic import JsonValue
@@ -21,6 +22,12 @@ from relay_teams.trace import trace_span
 LOGGER = get_logger(__name__)
 _DEFAULT_STDIO_MCP_TIMEOUT_SECONDS = 15.0
 _CAPABILITY_WILDCARD = "*"
+_ENV_REFERENCE_PATTERN = re.compile(
+    r"\{\{(?P<template>[A-Za-z_][A-Za-z0-9_]*)}}"
+    r"|\$\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)}"
+    r"|\$(?P<plain>[A-Za-z_][A-Za-z0-9_]*)"
+    r"|%(?P<windows>[^%\s]+)%"
+)
 
 
 class _ListedMcpTool(Protocol):
@@ -314,5 +321,24 @@ def _string_dict(value: JsonValue) -> dict[str, str] | None:
 def _build_stdio_env(server_config: Mapping[str, JsonValue]) -> dict[str, str]:
     merged_env = dict(os.environ)
     explicit_env = _string_dict(server_config.get("env")) or {}
+    explicit_env = {
+        key: _expand_env_references(value, merged_env)
+        for key, value in explicit_env.items()
+    }
     merged_env.update(explicit_env)
     return merged_env
+
+
+def _expand_env_references(value: str, env_values: Mapping[str, str]) -> str:
+    def replace_match(match: re.Match[str]) -> str:
+        env_key = (
+            match.group("template")
+            or match.group("braced")
+            or match.group("plain")
+            or match.group("windows")
+        )
+        if env_key is None:
+            return match.group(0)
+        return env_values.get(env_key, match.group(0))
+
+    return _ENV_REFERENCE_PATTERN.sub(replace_match, value)

--- a/tests/unit_tests/mcp/test_mcp_config_manager.py
+++ b/tests/unit_tests/mcp/test_mcp_config_manager.py
@@ -646,6 +646,42 @@ def test_load_registry_syncs_app_environment_for_stdio_mcp(tmp_path: Path) -> No
     assert server.env[env_key] == "from-app"
 
 
+def test_stdio_mcp_env_templates_resolve_from_app_environment(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir(parents=True)
+    env_key = "MCP_APP_ENV_TEMPLATE_TEST"
+    monkeypatch.delenv(env_key, raising=False)
+    (app_config_dir / ".env").write_text(f"{env_key}=from-app\n", encoding="utf-8")
+    (app_config_dir / "mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "time-mcp": {
+                        "command": "npx",
+                        "args": ["-y", "@upstash/context7-mcp"],
+                        "env": {
+                            env_key: f"{{{{{env_key}}}}}",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    manager = config_manager.McpConfigManager(app_config_dir=app_config_dir)
+
+    registry = manager.load_registry()
+    server = build_mcp_server(registry.get_spec("time-mcp"))
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert os.environ[env_key] == "from-app"
+    assert server.env[env_key] == "from-app"
+
+
 def test_get_mcp_file_paths_follow_scope_conventions(
     monkeypatch,
 ) -> None:

--- a/tests/unit_tests/mcp/test_mcp_service.py
+++ b/tests/unit_tests/mcp/test_mcp_service.py
@@ -444,6 +444,44 @@ def test_build_mcp_server_stdio_inherits_process_env_and_prefers_explicit_env(
     assert server.env["MCP_SPEC_ONLY"] == "from-spec"
 
 
+def test_build_mcp_server_stdio_expands_explicit_env_references(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MCP_TOKEN", "token-from-process")
+    monkeypatch.setenv("MCP_HOME", "C:/Users/tester")
+    monkeypatch.setenv("MCP_MODE", "stdio")
+    monkeypatch.setenv("TOKEN", "same-name-token")
+
+    server = build_mcp_server(
+        McpServerSpec(
+            name="context7",
+            config={"mcpServers": {"context7": {"command": "npx"}}},
+            server_config={
+                "command": "npx",
+                "args": ["-y", "@upstash/context7-mcp"],
+                "env": {
+                    "TOKEN": "{{MCP_TOKEN}}",
+                    "SAME_NAME_TOKEN": "{{TOKEN}}",
+                    "CACHE_DIR": "%MCP_HOME%/.cache/context7",
+                    "MODE": "$MCP_MODE",
+                    "MISSING": "${MCP_MISSING}",
+                    "TEMPLATE_MISSING": "{{MCP_MISSING}}",
+                },
+            },
+            source=McpConfigScope.SESSION,
+        )
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert server.env["TOKEN"] == "token-from-process"
+    assert server.env["SAME_NAME_TOKEN"] == "same-name-token"
+    assert server.env["CACHE_DIR"] == "C:/Users/tester/.cache/context7"
+    assert server.env["MODE"] == "stdio"
+    assert server.env["MISSING"] == "${MCP_MISSING}"
+    assert server.env["TEMPLATE_MISSING"] == "{{MCP_MISSING}}"
+
+
 def test_registry_resolve_server_names_ignores_unknown_servers_when_not_strict() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- expand MCP stdio env values from process/app environment variables
- support `{{VAR}}` placeholders while preserving `$VAR`, `${VAR}`, and `%VAR%` compatibility
- cover same-name app env references and unresolved placeholders with regression tests

Fixes #569.

## Tests
- `uv run pytest tests/unit_tests/mcp/test_mcp_service.py tests/unit_tests/mcp/test_mcp_config_manager.py`
- pre-push hooks: `ruff-check`, `ruff-format`, `basedpyright-check`