### PR TITLE
Fix final-answer system reminder handling

### DIFF
--- a/docs/system-reminders-design.md
+++ b/docs/system-reminders-design.md
@@ -71,7 +71,7 @@ Tool failure:
 
 Read-only streak:
 
-- triggered after five consecutive known read-only tools
+- triggered after fifty consecutive known read-only tools
 - unknown tools are neutral and do not count
 - `shell` is not considered read-only in v1
 

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -16,6 +16,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
+    TextPart,
     ToolCallPart,
     ToolCallPartDelta,
     ToolReturnPart,
@@ -42,6 +43,12 @@ from relay_teams.providers.llm_retry import extract_retry_error_info
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_stream import publish_run_event_async
+from relay_teams.sessions.runs.injection_classification import (
+    INJECTION_CLASSIFIER,
+    InjectionBoundaryContext,
+    InjectionDisposition,
+    public_injection_payload_json,
+)
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
@@ -452,7 +459,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                             instance_id=request.instance_id,
                             role_id=request.role_id,
                             event_type=RunEventType.INJECTION_APPLIED,
-                            payload_json=msg.model_dump_json(),
+                            payload_json=public_injection_payload_json(msg),
                         ),
                     )
                     appended = (
@@ -713,7 +720,22 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                 request.run_id, request.instance_id
                             )
                             if injections:
-                                for msg in injections:
+                                boundary_context = InjectionBoundaryContext(
+                                    final_answer_ready=_messages_include_final_answer(
+                                        new_to_process
+                                    ),
+                                )
+                                applied_injections = [
+                                    msg
+                                    for msg in injections
+                                    if INJECTION_CLASSIFIER.disposition(
+                                        msg, context=boundary_context
+                                    )
+                                    == InjectionDisposition.APPLY
+                                ]
+                                if not applied_injections:
+                                    continue
+                                for msg in applied_injections:
                                     await publish_run_event_async(
                                         self._run_event_hub,
                                         RunEvent(
@@ -724,7 +746,9 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                             instance_id=request.instance_id,
                                             role_id=request.role_id,
                                             event_type=RunEventType.INJECTION_APPLIED,
-                                            payload_json=msg.model_dump_json(),
+                                            payload_json=public_injection_payload_json(
+                                                msg
+                                            ),
                                         ),
                                     )
                                     await self._message_repo.append_user_prompt_if_missing_async(
@@ -1044,3 +1068,16 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
             return text
         finally:
             await self._close_run_scoped_llm_http_client(request=request)
+
+
+def _messages_include_final_answer(
+    messages: Sequence[ModelRequest | ModelResponse],
+) -> bool:
+    for message in messages:
+        if not isinstance(message, ModelResponse):
+            continue
+        if any(isinstance(part, ToolCallPart) for part in message.parts):
+            continue
+        if any(isinstance(part, TextPart) for part in message.parts):
+            return True
+    return False

--- a/src/relay_teams/reminders/__init__.py
+++ b/src/relay_teams/reminders/__init__.py
@@ -14,6 +14,7 @@ from relay_teams.reminders.renderer import render_system_reminder
 from relay_teams.reminders.service import SystemReminderService
 from relay_teams.reminders.state import ReminderStateRepository, ReminderRunState
 from relay_teams.reminders.tool_effects import classify_tool_effect
+from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
 from relay_teams.system_reminder_text import is_rendered_system_reminder_text
 
 __all__ = [
@@ -27,6 +28,7 @@ __all__ = [
     "ReminderStateRepository",
     "SystemReminderPolicy",
     "SystemReminderService",
+    "SystemReminderDeliveryMode",
     "ToolEffect",
     "ToolResultObservation",
     "classify_tool_effect",

--- a/src/relay_teams/reminders/models.py
+++ b/src/relay_teams/reminders/models.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
+from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
+
 
 class ReminderKind(str, Enum):
     TOOL_FAILURE = "tool_failure"
@@ -84,6 +86,7 @@ class ReminderDecision(BaseModel):
 
     issue: bool = False
     kind: Optional[ReminderKind] = None
+    delivery_mode: SystemReminderDeliveryMode = SystemReminderDeliveryMode.GUIDANCE
     issue_key: str = ""
     content: str = ""
     retry_completion: bool = False

--- a/src/relay_teams/reminders/policy.py
+++ b/src/relay_teams/reminders/policy.py
@@ -12,13 +12,14 @@ from relay_teams.reminders.models import (
 from relay_teams.reminders.state import ReminderRunState, can_issue
 from relay_teams.reminders.tool_effects import classify_tool_effect
 from relay_teams.reminders.models import ToolEffect
+from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
 
 
 class ReminderPolicyConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     tool_failure_cooldown_seconds: int = Field(default=60, ge=0)
-    read_only_streak_threshold: int = Field(default=5, ge=1)
+    read_only_streak_threshold: int = Field(default=50, ge=1)
     read_only_streak_cooldown_seconds: int = Field(default=600, ge=0)
     context_pressure_cooldown_seconds: int = Field(default=900, ge=0)
     completion_max_retries: int = Field(default=3, ge=0)
@@ -53,6 +54,7 @@ class SystemReminderPolicy:
                 ReminderDecision(
                     issue=True,
                     kind=ReminderKind.TOOL_FAILURE,
+                    delivery_mode=SystemReminderDeliveryMode.GUIDANCE,
                     issue_key=issue_key,
                     content=(
                         f"The `{observation.tool_name}` tool failed with `{error_type}`: "
@@ -85,6 +87,7 @@ class SystemReminderPolicy:
             ReminderDecision(
                 issue=True,
                 kind=ReminderKind.READ_ONLY_STREAK,
+                delivery_mode=SystemReminderDeliveryMode.GUIDANCE,
                 issue_key=issue_key,
                 content=(
                     f"You have used {next_streak} read-only tools in a row. If you "
@@ -124,6 +127,7 @@ class SystemReminderPolicy:
                 ReminderDecision(
                     issue=True,
                     kind=ReminderKind.INCOMPLETE_TODOS,
+                    delivery_mode=SystemReminderDeliveryMode.COMPLETION_GUARD,
                     issue_key="incomplete_todos:failed_completion",
                     content=content,
                     fail_completion=True,
@@ -135,6 +139,7 @@ class SystemReminderPolicy:
             ReminderDecision(
                 issue=True,
                 kind=ReminderKind.INCOMPLETE_TODOS,
+                delivery_mode=SystemReminderDeliveryMode.COMPLETION_GUARD,
                 issue_key=f"incomplete_todos:retry:{retry_count}",
                 content=content,
                 retry_completion=True,
@@ -172,6 +177,7 @@ class SystemReminderPolicy:
             ReminderDecision(
                 issue=True,
                 kind=observation.kind,
+                delivery_mode=SystemReminderDeliveryMode.GUIDANCE,
                 issue_key=issue_key,
                 content=content,
                 reason=observation.kind.value,

--- a/src/relay_teams/reminders/service.py
+++ b/src/relay_teams/reminders/service.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
+from threading import Lock
 
 from relay_teams.logger import get_logger, log_event
 from relay_teams.reminders.models import (
@@ -35,12 +39,24 @@ class SystemReminderService:
         self._fallback_states: dict[tuple[str, str], ReminderRunState] = {}
         self._read_degraded_keys: set[tuple[str, str]] = set()
         self._write_degraded_keys: set[tuple[str, str]] = set()
+        self._state_locks = _RunStateLockRegistry()
+        self._async_state_locks = _AsyncRunStateLockRegistry()
 
     @property
     def policy(self) -> SystemReminderPolicy:
         return self._policy
 
     def observe_tool_result(
+        self,
+        observation: ToolResultObservation,
+    ) -> ReminderDecision:
+        with self._state_locks.hold(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        ):
+            return self._observe_tool_result_locked(observation)
+
+    def _observe_tool_result_locked(
         self,
         observation: ToolResultObservation,
     ) -> ReminderDecision:
@@ -64,6 +80,10 @@ class SystemReminderService:
                     instance_id=observation.instance_id,
                     role_id=observation.role_id,
                     content=content,
+                    visibility="internal",
+                    internal_kind=_decision_kind(decision),
+                    internal_delivery_mode=decision.delivery_mode.value,
+                    internal_issue_key=decision.issue_key,
                 )
         self._save_state(
             session_id=observation.session_id,
@@ -76,35 +96,53 @@ class SystemReminderService:
         self,
         observation: ToolResultObservation,
     ) -> ReminderDecision:
-        state = await self._load_state_async(
+        async with self._async_state_locks.hold(
             session_id=observation.session_id,
             run_id=observation.run_id,
-        )
-        decision, next_state = self._policy.evaluate_tool_result(
-            observation=observation,
-            state=state,
-        )
-        if decision.issue:
-            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
-            content = render_system_reminder(decision.content)
-            if content:
-                _ = await self._injection_sink.enqueue_only_async(
-                    session_id=observation.session_id,
-                    run_id=observation.run_id,
-                    trace_id=observation.trace_id,
-                    task_id=observation.task_id,
-                    instance_id=observation.instance_id,
-                    role_id=observation.role_id,
-                    content=content,
-                )
-        await self._save_state_async(
-            session_id=observation.session_id,
-            run_id=observation.run_id,
-            state=next_state,
-        )
-        return decision
+        ):
+            state = await self._load_state_async(
+                session_id=observation.session_id,
+                run_id=observation.run_id,
+            )
+            decision, next_state = self._policy.evaluate_tool_result(
+                observation=observation,
+                state=state,
+            )
+            if decision.issue:
+                next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+                content = render_system_reminder(decision.content)
+                if content:
+                    _ = await self._injection_sink.enqueue_only_async(
+                        session_id=observation.session_id,
+                        run_id=observation.run_id,
+                        trace_id=observation.trace_id,
+                        task_id=observation.task_id,
+                        instance_id=observation.instance_id,
+                        role_id=observation.role_id,
+                        content=content,
+                        visibility="internal",
+                        internal_kind=_decision_kind(decision),
+                        internal_delivery_mode=decision.delivery_mode.value,
+                        internal_issue_key=decision.issue_key,
+                    )
+            await self._save_state_async(
+                session_id=observation.session_id,
+                run_id=observation.run_id,
+                state=next_state,
+            )
+            return decision
 
     def evaluate_completion_attempt(
+        self,
+        observation: CompletionAttemptObservation,
+    ) -> ReminderDecision:
+        with self._state_locks.hold(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        ):
+            return self._evaluate_completion_attempt_locked(observation)
+
+    def _evaluate_completion_attempt_locked(
         self,
         observation: CompletionAttemptObservation,
     ) -> ReminderDecision:
@@ -130,6 +168,10 @@ class SystemReminderService:
                     workspace_id=observation.workspace_id,
                     conversation_id=observation.conversation_id,
                     content=content,
+                    visibility="internal",
+                    internal_kind=_decision_kind(decision),
+                    internal_delivery_mode=decision.delivery_mode.value,
+                    internal_issue_key=decision.issue_key,
                 )
         self._save_state(
             session_id=observation.session_id,
@@ -142,37 +184,55 @@ class SystemReminderService:
         self,
         observation: CompletionAttemptObservation,
     ) -> ReminderDecision:
-        state = await self._load_state_async(
+        async with self._async_state_locks.hold(
             session_id=observation.session_id,
             run_id=observation.run_id,
-        )
-        decision, next_state = self._policy.evaluate_completion_attempt(
-            observation=observation,
-            state=state,
-        )
-        if decision.issue and decision.retry_completion:
-            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
-            content = render_system_reminder(decision.content)
-            if content:
-                _ = await self._injection_sink.append_and_enqueue_async(
-                    session_id=observation.session_id,
-                    run_id=observation.run_id,
-                    trace_id=observation.trace_id,
-                    task_id=observation.task_id,
-                    instance_id=observation.instance_id,
-                    role_id=observation.role_id,
-                    workspace_id=observation.workspace_id,
-                    conversation_id=observation.conversation_id,
-                    content=content,
-                )
-        await self._save_state_async(
-            session_id=observation.session_id,
-            run_id=observation.run_id,
-            state=next_state,
-        )
-        return decision
+        ):
+            state = await self._load_state_async(
+                session_id=observation.session_id,
+                run_id=observation.run_id,
+            )
+            decision, next_state = self._policy.evaluate_completion_attempt(
+                observation=observation,
+                state=state,
+            )
+            if decision.issue and decision.retry_completion:
+                next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+                content = render_system_reminder(decision.content)
+                if content:
+                    _ = await self._injection_sink.append_and_enqueue_async(
+                        session_id=observation.session_id,
+                        run_id=observation.run_id,
+                        trace_id=observation.trace_id,
+                        task_id=observation.task_id,
+                        instance_id=observation.instance_id,
+                        role_id=observation.role_id,
+                        workspace_id=observation.workspace_id,
+                        conversation_id=observation.conversation_id,
+                        content=content,
+                        visibility="internal",
+                        internal_kind=_decision_kind(decision),
+                        internal_delivery_mode=decision.delivery_mode.value,
+                        internal_issue_key=decision.issue_key,
+                    )
+            await self._save_state_async(
+                session_id=observation.session_id,
+                run_id=observation.run_id,
+                state=next_state,
+            )
+            return decision
 
     def observe_context_pressure(
+        self,
+        observation: ContextPressureObservation,
+    ) -> ReminderDecision:
+        with self._state_locks.hold(
+            session_id=observation.session_id,
+            run_id=observation.run_id,
+        ):
+            return self._observe_context_pressure_locked(observation)
+
+    def _observe_context_pressure_locked(
         self,
         observation: ContextPressureObservation,
     ) -> ReminderDecision:
@@ -196,6 +256,10 @@ class SystemReminderService:
                     instance_id=observation.instance_id,
                     role_id=observation.role_id,
                     content=content,
+                    visibility="internal",
+                    internal_kind=_decision_kind(decision),
+                    internal_delivery_mode=decision.delivery_mode.value,
+                    internal_issue_key=decision.issue_key,
                 )
         self._save_state(
             session_id=observation.session_id,
@@ -208,33 +272,41 @@ class SystemReminderService:
         self,
         observation: ContextPressureObservation,
     ) -> ReminderDecision:
-        state = await self._load_state_async(
+        async with self._async_state_locks.hold(
             session_id=observation.session_id,
             run_id=observation.run_id,
-        )
-        decision, next_state = self._policy.evaluate_context_pressure(
-            observation=observation,
-            state=state,
-        )
-        if decision.issue:
-            next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
-            content = render_system_reminder(decision.content)
-            if content:
-                _ = await self._injection_sink.enqueue_only_async(
-                    session_id=observation.session_id,
-                    run_id=observation.run_id,
-                    trace_id=observation.trace_id,
-                    task_id=observation.task_id,
-                    instance_id=observation.instance_id,
-                    role_id=observation.role_id,
-                    content=content,
-                )
-        await self._save_state_async(
-            session_id=observation.session_id,
-            run_id=observation.run_id,
-            state=next_state,
-        )
-        return decision
+        ):
+            state = await self._load_state_async(
+                session_id=observation.session_id,
+                run_id=observation.run_id,
+            )
+            decision, next_state = self._policy.evaluate_context_pressure(
+                observation=observation,
+                state=state,
+            )
+            if decision.issue:
+                next_state = mark_issued(state=next_state, issue_key=decision.issue_key)
+                content = render_system_reminder(decision.content)
+                if content:
+                    _ = await self._injection_sink.enqueue_only_async(
+                        session_id=observation.session_id,
+                        run_id=observation.run_id,
+                        trace_id=observation.trace_id,
+                        task_id=observation.task_id,
+                        instance_id=observation.instance_id,
+                        role_id=observation.role_id,
+                        content=content,
+                        visibility="internal",
+                        internal_kind=_decision_kind(decision),
+                        internal_delivery_mode=decision.delivery_mode.value,
+                        internal_issue_key=decision.issue_key,
+                    )
+            await self._save_state_async(
+                session_id=observation.session_id,
+                run_id=observation.run_id,
+                state=next_state,
+            )
+            return decision
 
     def _load_state(self, *, session_id: str, run_id: str) -> ReminderRunState:
         key = _state_cache_key(session_id=session_id, run_id=run_id)
@@ -363,3 +435,108 @@ class SystemReminderService:
 
 def _state_cache_key(*, session_id: str, run_id: str) -> tuple[str, str]:
     return session_id, run_id
+
+
+class _RunStateLockSlot:
+    def __init__(self) -> None:
+        self.lock = Lock()
+        self.references = 0
+
+
+class _AsyncRunStateLockSlot:
+    def __init__(self) -> None:
+        self.lock = asyncio.Lock()
+        self.references = 0
+
+
+class _RunStateLockRegistry:
+    def __init__(self) -> None:
+        self._guard = Lock()
+        self._slots: dict[tuple[str, str], _RunStateLockSlot] = {}
+
+    @contextmanager
+    def hold(self, *, session_id: str, run_id: str) -> Iterator[None]:
+        key = _state_cache_key(session_id=session_id, run_id=run_id)
+        slot = self._retain(key)
+        slot.lock.acquire()
+        try:
+            yield
+        finally:
+            slot.lock.release()
+            self._release(key=key, slot=slot)
+
+    def _retain(self, key: tuple[str, str]) -> _RunStateLockSlot:
+        with self._guard:
+            slot = self._slots.get(key)
+            if slot is None:
+                slot = _RunStateLockSlot()
+                self._slots[key] = slot
+            slot.references += 1
+            return slot
+
+    def _release(self, *, key: tuple[str, str], slot: _RunStateLockSlot) -> None:
+        with self._guard:
+            slot.references -= 1
+            if slot.references == 0 and self._slots.get(key) is slot:
+                del self._slots[key]
+
+    @property
+    def active_lock_count(self) -> int:
+        with self._guard:
+            return len(self._slots)
+
+    @property
+    def active_reference_count(self) -> int:
+        with self._guard:
+            return sum(slot.references for slot in self._slots.values())
+
+
+class _AsyncRunStateLockRegistry:
+    def __init__(self) -> None:
+        self._guard = Lock()
+        self._slots: dict[tuple[str, str], _AsyncRunStateLockSlot] = {}
+
+    @asynccontextmanager
+    async def hold(self, *, session_id: str, run_id: str) -> AsyncIterator[None]:
+        key = _state_cache_key(session_id=session_id, run_id=run_id)
+        slot = self._retain(key)
+        acquired = False
+        try:
+            await slot.lock.acquire()
+            acquired = True
+            yield
+        finally:
+            if acquired:
+                slot.lock.release()
+            self._release(key=key, slot=slot)
+
+    def _retain(self, key: tuple[str, str]) -> _AsyncRunStateLockSlot:
+        with self._guard:
+            slot = self._slots.get(key)
+            if slot is None:
+                slot = _AsyncRunStateLockSlot()
+                self._slots[key] = slot
+            slot.references += 1
+            return slot
+
+    def _release(self, *, key: tuple[str, str], slot: _AsyncRunStateLockSlot) -> None:
+        with self._guard:
+            slot.references -= 1
+            if slot.references == 0 and self._slots.get(key) is slot:
+                del self._slots[key]
+
+    @property
+    def active_lock_count(self) -> int:
+        with self._guard:
+            return len(self._slots)
+
+    @property
+    def active_reference_count(self) -> int:
+        with self._guard:
+            return sum(slot.references for slot in self._slots.values())
+
+
+def _decision_kind(decision: ReminderDecision) -> str:
+    if decision.kind is None:
+        return ""
+    return decision.kind.value

--- a/src/relay_teams/sessions/runs/injection_classification.py
+++ b/src/relay_teams/sessions/runs/injection_classification.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from enum import Enum
+from json import dumps
+
+from relay_teams.media import user_prompt_content_to_text
+from relay_teams.sessions.runs.enums import InjectionSource
+from relay_teams.sessions.runs.run_models import InjectionMessage
+from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
+from relay_teams.system_reminder_text import is_rendered_system_reminder_text
+
+
+class InjectionDisposition(str, Enum):
+    APPLY = "apply"
+    DISCARD = "discard"
+
+
+class InjectionBoundaryContext:
+    def __init__(self, *, final_answer_ready: bool = False) -> None:
+        self.final_answer_ready = final_answer_ready
+
+
+class RunInjectionClassifier:
+    def disposition(
+        self,
+        message: InjectionMessage,
+        *,
+        context: InjectionBoundaryContext,
+    ) -> InjectionDisposition:
+        if (
+            context.final_answer_ready
+            and self.is_internal_system_reminder(message)
+            and self.delivery_mode(message) == SystemReminderDeliveryMode.GUIDANCE
+        ):
+            return InjectionDisposition.DISCARD
+        return InjectionDisposition.APPLY
+
+    @staticmethod
+    def is_internal_system_reminder(message: InjectionMessage) -> bool:
+        if message.source != InjectionSource.SYSTEM:
+            return False
+        text = user_prompt_content_to_text(message.content).strip()
+        return is_rendered_system_reminder_text(text)
+
+    @staticmethod
+    def delivery_mode(message: InjectionMessage) -> SystemReminderDeliveryMode:
+        try:
+            return SystemReminderDeliveryMode(message.internal_delivery_mode)
+        except ValueError:
+            return SystemReminderDeliveryMode.GUIDANCE
+
+
+INJECTION_CLASSIFIER = RunInjectionClassifier()
+
+
+def public_injection_payload_json(message: InjectionMessage) -> str:
+    if not INJECTION_CLASSIFIER.is_internal_system_reminder(message):
+        return message.model_dump_json()
+    text = user_prompt_content_to_text(message.content)
+    payload: dict[str, object] = {
+        "run_id": message.run_id,
+        "recipient_instance_id": message.recipient_instance_id,
+        "source": message.source.value,
+        "visibility": message.visibility,
+        "internal_kind": message.internal_kind,
+        "internal_delivery_mode": message.internal_delivery_mode,
+        "internal_issue_key": message.internal_issue_key,
+        "content_redacted": True,
+        "content_length": len(text),
+        "sender_instance_id": message.sender_instance_id,
+        "sender_role_id": message.sender_role_id,
+        "priority": message.priority,
+        "created_at": message.created_at.isoformat(),
+    }
+    return dumps(payload, ensure_ascii=False)

--- a/src/relay_teams/sessions/runs/injection_queue.py
+++ b/src/relay_teams/sessions/runs/injection_queue.py
@@ -37,12 +37,20 @@ class RunInjectionManager:
         content: UserPromptContent,
         sender_instance_id: str | None = None,
         sender_role_id: str | None = None,
+        visibility: str = "public",
+        internal_kind: str = "",
+        internal_delivery_mode: str = "",
+        internal_issue_key: str = "",
     ) -> InjectionMessage:
         priority = _priority_for(source)
         message = InjectionMessage(
             run_id=run_id,
             recipient_instance_id=recipient_instance_id,
             source=source,
+            visibility="internal" if visibility == "internal" else "public",
+            internal_kind=internal_kind,
+            internal_delivery_mode=internal_delivery_mode,
+            internal_issue_key=internal_issue_key,
             content=content,
             sender_instance_id=sender_instance_id,
             sender_role_id=sender_role_id,

--- a/src/relay_teams/sessions/runs/run_models.py
+++ b/src/relay_teams/sessions/runs/run_models.py
@@ -172,6 +172,10 @@ class InjectionMessage(BaseModel):
     run_id: RequiredIdentifierStr
     recipient_instance_id: RequiredIdentifierStr
     source: InjectionSource
+    visibility: Literal["public", "internal"] = "public"
+    internal_kind: str = ""
+    internal_delivery_mode: str = ""
+    internal_issue_key: str = ""
     # noinspection PyTypeHints
     content: UserPromptContent
     sender_instance_id: OptionalIdentifierStr = None

--- a/src/relay_teams/sessions/runs/system_injection.py
+++ b/src/relay_teams/sessions/runs/system_injection.py
@@ -7,6 +7,9 @@ from pydantic import BaseModel, ConfigDict
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
+from relay_teams.sessions.runs.injection_classification import (
+    public_injection_payload_json,
+)
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_models import InjectionMessage, RunEvent
 
@@ -41,6 +44,10 @@ class SystemInjectionSink:
         role_id: str,
         content: str,
         source: InjectionSource = InjectionSource.SYSTEM,
+        visibility: str = "public",
+        internal_kind: str = "",
+        internal_delivery_mode: str = "",
+        internal_issue_key: str = "",
     ) -> SystemInjectionResult:
         record = self._enqueue(
             session_id=session_id,
@@ -51,6 +58,10 @@ class SystemInjectionSink:
             role_id=role_id,
             content=content,
             source=source,
+            visibility=visibility,
+            internal_kind=internal_kind,
+            internal_delivery_mode=internal_delivery_mode,
+            internal_issue_key=internal_issue_key,
         )
         return SystemInjectionResult(enqueued=record is not None)
 
@@ -65,6 +76,10 @@ class SystemInjectionSink:
         role_id: str,
         content: str,
         source: InjectionSource = InjectionSource.SYSTEM,
+        visibility: str = "public",
+        internal_kind: str = "",
+        internal_delivery_mode: str = "",
+        internal_issue_key: str = "",
     ) -> SystemInjectionResult:
         record = await self._enqueue_async(
             session_id=session_id,
@@ -75,6 +90,10 @@ class SystemInjectionSink:
             role_id=role_id,
             content=content,
             source=source,
+            visibility=visibility,
+            internal_kind=internal_kind,
+            internal_delivery_mode=internal_delivery_mode,
+            internal_issue_key=internal_issue_key,
         )
         return SystemInjectionResult(enqueued=record is not None)
 
@@ -91,6 +110,10 @@ class SystemInjectionSink:
         conversation_id: str,
         content: str,
         source: InjectionSource = InjectionSource.SYSTEM,
+        visibility: str = "public",
+        internal_kind: str = "",
+        internal_delivery_mode: str = "",
+        internal_issue_key: str = "",
     ) -> SystemInjectionResult:
         appended = self._append(
             session_id=session_id,
@@ -111,6 +134,10 @@ class SystemInjectionSink:
             role_id=role_id,
             content=content,
             source=source,
+            visibility=visibility,
+            internal_kind=internal_kind,
+            internal_delivery_mode=internal_delivery_mode,
+            internal_issue_key=internal_issue_key,
         )
         return SystemInjectionResult(appended=appended, enqueued=record is not None)
 
@@ -127,6 +154,10 @@ class SystemInjectionSink:
         conversation_id: str,
         content: str,
         source: InjectionSource = InjectionSource.SYSTEM,
+        visibility: str = "public",
+        internal_kind: str = "",
+        internal_delivery_mode: str = "",
+        internal_issue_key: str = "",
     ) -> SystemInjectionResult:
         appended = await self._append_async(
             session_id=session_id,
@@ -147,6 +178,10 @@ class SystemInjectionSink:
             role_id=role_id,
             content=content,
             source=source,
+            visibility=visibility,
+            internal_kind=internal_kind,
+            internal_delivery_mode=internal_delivery_mode,
+            internal_issue_key=internal_issue_key,
         )
         return SystemInjectionResult(appended=appended, enqueued=record is not None)
 
@@ -259,6 +294,10 @@ class SystemInjectionSink:
         role_id: str,
         content: str,
         source: InjectionSource,
+        visibility: str,
+        internal_kind: str,
+        internal_delivery_mode: str,
+        internal_issue_key: str,
     ) -> Optional[InjectionMessage]:
         if not self._injection_manager.is_active(run_id):
             return None
@@ -268,6 +307,10 @@ class SystemInjectionSink:
                 recipient_instance_id=instance_id,
                 source=source,
                 content=content,
+                visibility=visibility,
+                internal_kind=internal_kind,
+                internal_delivery_mode=internal_delivery_mode,
+                internal_issue_key=internal_issue_key,
             )
         except KeyError:
             return None
@@ -280,7 +323,7 @@ class SystemInjectionSink:
                 instance_id=instance_id,
                 role_id=role_id,
                 event_type=RunEventType.INJECTION_ENQUEUED,
-                payload_json=record.model_dump_json(),
+                payload_json=public_injection_payload_json(record),
             )
         )
         return record
@@ -296,6 +339,10 @@ class SystemInjectionSink:
         role_id: str,
         content: str,
         source: InjectionSource,
+        visibility: str,
+        internal_kind: str,
+        internal_delivery_mode: str,
+        internal_issue_key: str,
     ) -> Optional[InjectionMessage]:
         if not self._injection_manager.is_active(run_id):
             return None
@@ -305,6 +352,10 @@ class SystemInjectionSink:
                 recipient_instance_id=instance_id,
                 source=source,
                 content=content,
+                visibility=visibility,
+                internal_kind=internal_kind,
+                internal_delivery_mode=internal_delivery_mode,
+                internal_issue_key=internal_issue_key,
             )
         except KeyError:
             return None
@@ -318,7 +369,7 @@ class SystemInjectionSink:
                 instance_id=instance_id,
                 role_id=role_id,
                 event_type=RunEventType.INJECTION_ENQUEUED,
-                payload_json=record.model_dump_json(),
+                payload_json=public_injection_payload_json(record),
             ),
         )
         return record

--- a/src/relay_teams/system_reminder_delivery.py
+++ b/src/relay_teams/system_reminder_delivery.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class SystemReminderDeliveryMode(str, Enum):
+    GUIDANCE = "guidance"
+    COMPLETION_GUARD = "completion_guard"

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -69,9 +69,10 @@ from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
-from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.runs.run_models import InjectionMessage, RunEvent
 from relay_teams.sessions.runs.run_models import RunThinkingConfig
 from relay_teams.sessions.runs.assistant_errors import AssistantRunError
+from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )
@@ -1042,23 +1043,26 @@ async def test_generate_recomputes_budget_after_injection_restart(
     provider._config_ref = updated_config
     provider._session._config = updated_config
 
-    class _InjectedMessage:
-        def __init__(self, content: str) -> None:
-            self.content = content
-
-        def model_dump_json(self) -> str:
-            return json.dumps({"content": self.content})
-
     class _OneShotInjectionManager:
         def __init__(self) -> None:
             self._drained = False
 
-        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
+        def drain_at_boundary(
+            self, run_id: str, instance_id: str
+        ) -> list[InjectionMessage]:
             _ = (run_id, instance_id)
             if self._drained:
                 return []
             self._drained = True
-            return [_InjectedMessage("y" * 124_200)]
+            return [
+                InjectionMessage(
+                    run_id=run_id,
+                    recipient_instance_id=instance_id,
+                    source=InjectionSource.SYSTEM,
+                    content="y" * 124_200,
+                    priority=0,
+                )
+            ]
 
     provider._session._injection_manager = cast(
         RunInjectionManager,
@@ -1225,22 +1229,24 @@ async def test_generate_defers_injection_restart_until_pending_tool_call_complet
         fake_hub,
     )
 
-    class _InjectedMessage:
-        def __init__(self, content: str) -> None:
-            self.content = content
-
-        def model_dump_json(self) -> str:
-            return json.dumps({"content": self.content})
-
     class _DeferredInjectionManager:
         def __init__(self) -> None:
             self.calls = 0
 
-        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
-            _ = (run_id, instance_id)
+        def drain_at_boundary(
+            self, run_id: str, instance_id: str
+        ) -> list[InjectionMessage]:
             self.calls += 1
             if self.calls == 1:
-                return [_InjectedMessage("background follow-up")]
+                return [
+                    InjectionMessage(
+                        run_id=run_id,
+                        recipient_instance_id=instance_id,
+                        source=InjectionSource.SYSTEM,
+                        content="background follow-up",
+                        priority=0,
+                    )
+                ]
             return []
 
     injection_manager = _DeferredInjectionManager()
@@ -1396,6 +1402,215 @@ async def test_generate_defers_injection_restart_until_pending_tool_call_complet
         )
         == 1
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_discards_guidance_reminder_after_final_answer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "final_answer_guidance_reminder.db",
+        fake_hub,
+    )
+
+    class _FinalAnswerReminderManager:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def drain_at_boundary(
+            self, run_id: str, recipient_instance_id: str
+        ) -> tuple[InjectionMessage, ...]:
+            self.calls += 1
+            if self.calls != 1:
+                return ()
+            return (
+                InjectionMessage(
+                    run_id=run_id,
+                    recipient_instance_id=recipient_instance_id,
+                    source=InjectionSource.SYSTEM,
+                    visibility="internal",
+                    internal_kind="read_only_streak",
+                    internal_delivery_mode=SystemReminderDeliveryMode.GUIDANCE.value,
+                    internal_issue_key="read_only_streak",
+                    content=render_system_reminder("Stop inspecting and answer."),
+                    priority=0,
+                ),
+            )
+
+    injection_manager = _FinalAnswerReminderManager()
+    provider._session._injection_manager = cast(
+        RunInjectionManager,
+        cast(object, injection_manager),
+    )
+
+    final_response = ModelResponse(parts=[TextPart(content="done")])
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[
+                    _FakeModelRequestNode(
+                        SimpleNamespace(
+                            input_tokens=0,
+                            output_tokens=0,
+                            total_tokens=0,
+                            requests=1,
+                            tool_calls=0,
+                        )
+                    )
+                ],
+                messages_by_step=[[final_response]],
+                result=_ScriptedResult(
+                    response=final_response, messages=[final_response]
+                ),
+            )
+        ]
+    )
+    monkeypatch.setattr(llm_module, "ModelRequestNode", _FakeModelRequestNode)
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+
+    request = LLMRequest(
+        run_id="run-final-guidance",
+        trace_id="run-final-guidance",
+        task_id="task-final-guidance",
+        session_id="session-final-guidance",
+        workspace_id="default",
+        conversation_id=build_conversation_id("session-final-guidance", "Coordinator"),
+        instance_id="inst-final-guidance",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="answer",
+    )
+
+    response = await provider.generate(request)
+    history = message_repo.get_history_for_conversation(request.conversation_id or "")
+
+    assert response == "done"
+    assert injection_manager.calls == 1
+    assert len(scripted_agent.histories) == 1
+    assert RunEventType.INJECTION_APPLIED not in [
+        event.event_type for event in fake_hub.events
+    ]
+    assert "<system-reminder>" not in "\n".join(str(item) for item in history)
+
+
+@pytest.mark.asyncio
+async def test_generate_applies_completion_guard_reminder_after_final_answer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_hub = _FakeRunEventHub()
+    provider, message_repo = _build_provider(
+        tmp_path / "final_answer_completion_guard.db",
+        fake_hub,
+    )
+
+    class _CompletionGuardReminderManager:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def drain_at_boundary(
+            self, run_id: str, recipient_instance_id: str
+        ) -> tuple[InjectionMessage, ...]:
+            self.calls += 1
+            if self.calls != 1:
+                return ()
+            return (
+                InjectionMessage(
+                    run_id=run_id,
+                    recipient_instance_id=recipient_instance_id,
+                    source=InjectionSource.SYSTEM,
+                    visibility="internal",
+                    internal_kind="incomplete_todos",
+                    internal_delivery_mode=(
+                        SystemReminderDeliveryMode.COMPLETION_GUARD.value
+                    ),
+                    internal_issue_key="incomplete_todos:retry:1",
+                    content=render_system_reminder("Finish the pending todo first."),
+                    priority=0,
+                ),
+            )
+
+    injection_manager = _CompletionGuardReminderManager()
+    provider._session._injection_manager = cast(
+        RunInjectionManager,
+        cast(object, injection_manager),
+    )
+
+    first_response = ModelResponse(parts=[TextPart(content="premature done")])
+    second_response = ModelResponse(parts=[TextPart(content="done")])
+    scripted_agent = _SequentialAgent(
+        [
+            _ScriptedAgentRun(
+                nodes=[
+                    _FakeModelRequestNode(
+                        SimpleNamespace(
+                            input_tokens=0,
+                            output_tokens=0,
+                            total_tokens=0,
+                            requests=1,
+                            tool_calls=0,
+                        )
+                    )
+                ],
+                messages_by_step=[[first_response]],
+                result=_ScriptedResult(
+                    response=first_response,
+                    messages=[first_response],
+                ),
+            ),
+            _ScriptedAgentRun(
+                nodes=[],
+                messages_by_step=[],
+                result=_ScriptedResult(
+                    response=second_response,
+                    messages=[second_response],
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(llm_module, "ModelRequestNode", _FakeModelRequestNode)
+    monkeypatch.setattr(
+        llm_module,
+        "build_coordination_agent",
+        lambda **kwargs: scripted_agent,
+    )
+
+    request = LLMRequest(
+        run_id="run-final-completion-guard",
+        trace_id="run-final-completion-guard",
+        task_id="task-final-completion-guard",
+        session_id="session-final-completion-guard",
+        workspace_id="default",
+        conversation_id=build_conversation_id(
+            "session-final-completion-guard",
+            "Coordinator",
+        ),
+        instance_id="inst-final-completion-guard",
+        role_id="Coordinator",
+        system_prompt="system",
+        user_prompt="answer",
+    )
+
+    response = await provider.generate(request)
+    history = message_repo.get_history_for_conversation(request.conversation_id or "")
+
+    assert response == "done"
+    assert len(scripted_agent.histories) == 2
+    applied_events = [
+        event
+        for event in fake_hub.events
+        if event.event_type == RunEventType.INJECTION_APPLIED
+    ]
+    assert applied_events
+    assert "Finish the pending todo first" not in applied_events[0].payload_json
+    assert "<system-reminder>" not in applied_events[0].payload_json
+    assert any("<system-reminder>" in str(message) for message in history)
 
 
 @pytest.mark.asyncio
@@ -1558,23 +1773,26 @@ async def test_generate_rebuilds_agent_when_restart_updates_compaction_summary(
         fake_hub,
     )
 
-    class _InjectedMessage:
-        def __init__(self, content: str) -> None:
-            self.content = content
-
-        def model_dump_json(self) -> str:
-            return json.dumps({"content": self.content})
-
     class _OneShotInjectionManager:
         def __init__(self) -> None:
             self._drained = False
 
-        def drain_at_boundary(self, run_id: str, instance_id: str) -> list[object]:
+        def drain_at_boundary(
+            self, run_id: str, instance_id: str
+        ) -> list[InjectionMessage]:
             _ = (run_id, instance_id)
             if self._drained:
                 return []
             self._drained = True
-            return [_InjectedMessage("restart with compaction summary")]
+            return [
+                InjectionMessage(
+                    run_id=run_id,
+                    recipient_instance_id=instance_id,
+                    source=InjectionSource.SYSTEM,
+                    content="restart with compaction summary",
+                    priority=0,
+                )
+            ]
 
     provider._session._injection_manager = cast(
         RunInjectionManager,

--- a/tests/unit_tests/reminders/test_policy.py
+++ b/tests/unit_tests/reminders/test_policy.py
@@ -30,6 +30,27 @@ def test_policy_reminds_after_read_only_streak_threshold() -> None:
     assert state.read_only_streak == 2
 
 
+def test_policy_default_read_only_streak_threshold_is_fifty() -> None:
+    policy = SystemReminderPolicy()
+    state = ReminderRunState()
+
+    for index in range(49):
+        decision, state = policy.evaluate_tool_result(
+            observation=_tool_result("read", call_id=f"call-read-{index}"),
+            state=state,
+        )
+        assert decision.issue is False
+
+    decision, state = policy.evaluate_tool_result(
+        observation=_tool_result("read", call_id="call-read-49"),
+        state=state,
+    )
+
+    assert decision.issue is True
+    assert decision.kind == ReminderKind.READ_ONLY_STREAK
+    assert state.read_only_streak == 50
+
+
 def test_policy_resets_read_only_streak_after_mutating_tool() -> None:
     policy = SystemReminderPolicy(ReminderPolicyConfig(read_only_streak_threshold=2))
     state = ReminderRunState(read_only_streak=1)
@@ -102,6 +123,7 @@ def test_policy_fails_completion_after_retry_limit() -> None:
 def _tool_result(
     tool_name: str,
     *,
+    call_id: str = "",
     ok: bool = True,
     error_type: str = "",
     error_message: str = "",
@@ -114,7 +136,7 @@ def _tool_result(
         instance_id="inst-1",
         role_id="role-1",
         tool_name=tool_name,
-        tool_call_id=f"call-{tool_name}",
+        tool_call_id=call_id or f"call-{tool_name}",
         ok=ok,
         error_type=error_type,
         error_message=error_message,

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import cast
@@ -127,6 +128,7 @@ def test_service_enqueues_tool_failure_reminder_once(tmp_path: Path) -> None:
     assert len(sink.enqueued) == 1
     assert "<system-reminder>" in sink.enqueued[0]
     assert "No such file" in sink.enqueued[0]
+    assert service._state_locks.active_lock_count == 0
 
 
 def test_service_appends_completion_retry_reminder(tmp_path: Path) -> None:
@@ -311,6 +313,72 @@ def test_service_preserves_completion_retry_limit_when_state_load_fails() -> Non
     assert second.fail_completion is True
     assert len(sink.appended) == 1
     assert [state.completion_retry_count for state in repository.saved_states] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_service_async_serializes_concurrent_tool_result_reminders(
+    tmp_path: Path,
+) -> None:
+    sink = _CapturingSink()
+    service = _service(
+        tmp_path,
+        sink,
+        policy=SystemReminderPolicy(ReminderPolicyConfig(read_only_streak_threshold=1)),
+    )
+    observation = ToolResultObservation(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        tool_name="read",
+        tool_call_id="call-1",
+        ok=True,
+    )
+
+    first, second = await asyncio.gather(
+        service.observe_tool_result_async(observation),
+        service.observe_tool_result_async(observation),
+    )
+
+    assert [first.issue, second.issue].count(True) == 1
+    assert len(sink.enqueued) == 1
+    assert service._async_state_locks.active_lock_count == 0
+
+
+@pytest.mark.asyncio
+async def test_service_async_lock_releases_reference_when_waiter_is_cancelled(
+    tmp_path: Path,
+) -> None:
+    sink = _CapturingSink()
+    service = _service(tmp_path, sink)
+
+    async def wait_for_lock() -> None:
+        async with service._async_state_locks.hold(
+            session_id="session-1",
+            run_id="run-1",
+        ):
+            pass
+
+    async with service._async_state_locks.hold(
+        session_id="session-1",
+        run_id="run-1",
+    ):
+        task = asyncio.create_task(wait_for_lock())
+        for _ in range(10):
+            if service._async_state_locks.active_reference_count == 2:
+                break
+            await asyncio.sleep(0)
+        assert service._async_state_locks.active_reference_count == 2
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError) as exc_info:
+            await task
+        assert isinstance(exc_info.value, asyncio.CancelledError)
+        assert service._async_state_locks.active_reference_count == 1
+
+    assert service._async_state_locks.active_lock_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_system_injection_sink.py
+++ b/tests/unit_tests/sessions/runs/test_system_injection_sink.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 from typing import cast
 
 from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.reminders import render_system_reminder
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.enums import InjectionSource
+from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.system_injection import SystemInjectionSink
+from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
+
+
+class _CapturingRunEventHub:
+    def __init__(self) -> None:
+        self.events: list[RunEvent] = []
+
+    def publish(self, event: RunEvent) -> None:
+        self.events.append(event)
 
 
 def test_append_and_enqueue_persists_message_and_queues_injection(
@@ -138,8 +150,21 @@ def test_enqueue_only_degrades_when_active_run_disappears() -> None:
             recipient_instance_id: str,
             source: InjectionSource,
             content: object,
+            visibility: str = "public",
+            internal_kind: str = "",
+            internal_delivery_mode: str = "",
+            internal_issue_key: str = "",
         ) -> object:
-            _ = (run_id, recipient_instance_id, source, content)
+            _ = (
+                run_id,
+                recipient_instance_id,
+                source,
+                content,
+                visibility,
+                internal_kind,
+                internal_delivery_mode,
+                internal_issue_key,
+            )
             raise KeyError("run disappeared")
 
     sink = SystemInjectionSink(
@@ -159,3 +184,35 @@ def test_enqueue_only_degrades_when_active_run_disappears() -> None:
     )
 
     assert result.enqueued is False
+
+
+def test_enqueue_only_redacts_internal_system_reminder_events() -> None:
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    event_hub = _CapturingRunEventHub()
+    sink = SystemInjectionSink(
+        injection_manager=injection_manager,
+        run_event_hub=cast(RunEventHub, event_hub),
+        message_repo=None,
+    )
+
+    result = sink.enqueue_only(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        content=render_system_reminder("Do not leak this body."),
+        visibility="internal",
+        internal_kind="read_only_streak",
+        internal_delivery_mode=SystemReminderDeliveryMode.GUIDANCE.value,
+        internal_issue_key="read_only_streak",
+    )
+
+    payload = json.loads(event_hub.events[0].payload_json)
+    assert result.enqueued is True
+    assert payload["content_redacted"] is True
+    assert payload["internal_kind"] == "read_only_streak"
+    assert "<system-reminder>" not in event_hub.events[0].payload_json
+    assert "Do not leak this body" not in event_hub.events[0].payload_json

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -103,8 +103,19 @@ class _FakeInjectionManager:
         *,
         source: InjectionSource,
         content: UserPromptContent,
+        visibility: str = "public",
+        internal_kind: str = "",
+        internal_delivery_mode: str = "",
+        internal_issue_key: str = "",
     ) -> _FakeInjectionRecord:
-        _ = (run_id, recipient_instance_id)
+        _ = (
+            run_id,
+            recipient_instance_id,
+            visibility,
+            internal_kind,
+            internal_delivery_mode,
+            internal_issue_key,
+        )
         record = _FakeInjectionRecord(source=source, content=content)
         self.records.append(record)
         return record


### PR DESCRIPTION
Fixes #529.

## Summary
- classify system reminders by delivery mode so guidance can be dropped at the final-answer boundary while completion guards still restart the model
- mark reminder injections as internal and redact reminder bodies from injection events
- serialize reminder state updates per run to avoid duplicate reminder issues under concurrent observations

## Validation
- uv run --extra dev pytest -q tests/unit_tests/reminders tests/unit_tests/sessions/runs/test_injection_queue.py tests/unit_tests/sessions/runs/test_system_injection_sink.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_recomputes_budget_after_injection_restart tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_persists_startup_system_reminders_before_first_agent_turn tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_defers_injection_restart_until_pending_tool_call_completes tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_discards_guidance_reminder_after_final_answer tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_applies_completion_guard_reminder_after_final_answer tests/unit_tests/providers/test_llm_multi_turn_prompt.py::test_generate_rebuilds_agent_when_restart_updates_compaction_summary tests/unit_tests/agents/execution/test_message_repository.py
- uv run --extra dev ruff check src/relay_teams/reminders src/relay_teams/sessions/runs src/relay_teams/agents/execution/session_runtime.py tests/unit_tests/reminders/test_service.py tests/unit_tests/sessions/runs/test_system_injection_sink.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py
- uv run --extra dev basedpyright src/relay_teams/reminders src/relay_teams/sessions/runs src/relay_teams/agents/execution/session_runtime.py tests/unit_tests/reminders/test_service.py tests/unit_tests/sessions/runs/test_system_injection_sink.py tests/unit_tests/providers/test_llm_multi_turn_prompt.py

Note: full `tests/unit_tests` was attempted, but the repository-level pytest run timed out in existing background-thread cleanup/reporting around 56%; the focused coverage above passed.