### PR TITLE
fix: reduce session rounds and probe route latency

### DIFF
--- a/src/relay_teams/agents/execution/message_repository.py
+++ b/src/relay_teams/agents/execution/message_repository.py
@@ -118,6 +118,9 @@ class MessageRepository(SharedSqliteRepository):
                 "CREATE INDEX IF NOT EXISTS idx_messages_session_role_id ON messages(session_id, role, id)"
             )
             self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_messages_session_trace_id ON messages(session_id, trace_id, id)"
+            )
+            self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_messages_instance ON messages(instance_id)"
             )
             self._conn.execute(
@@ -263,6 +266,55 @@ class MessageRepository(SharedSqliteRepository):
             )
         return _dedupe_duplicate_objective_messages(results)
 
+    def get_messages_by_session_run_ids(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+        *,
+        include_cleared: bool = False,
+        include_hidden_from_context: bool = False,
+    ) -> list[dict[str, JsonValue]]:
+        normalized_run_ids = tuple(
+            dict.fromkeys(run_id.strip() for run_id in run_ids if run_id.strip())
+        )
+        if not normalized_run_ids:
+            return []
+        rows: list[sqlite3.Row] = []
+        chunk_size = _SQLITE_SAFE_VARIABLE_LIMIT - 1
+        with self._lock:
+            for index in range(0, len(normalized_run_ids), chunk_size):
+                run_id_chunk = normalized_run_ids[index : index + chunk_size]
+                placeholders = ", ".join("?" for _ in run_id_chunk)
+                rows.extend(
+                    self._conn.execute(
+                        "SELECT id, session_id, conversation_id, agent_role_id, instance_id, task_id, trace_id, role, message_json, created_at, hidden_from_context, hidden_reason, hidden_at, hidden_marker_id "
+                        f"FROM messages WHERE session_id=? AND trace_id IN ({placeholders}) ORDER BY id ASC",
+                        (session_id, *run_id_chunk),
+                    ).fetchall()
+                )
+        rows.sort(key=lambda row: int(row["id"]) if isinstance(row["id"], int) else 0)
+        return self._project_message_rows(
+            rows,
+            include_cleared=include_cleared,
+            include_hidden_from_context=include_hidden_from_context,
+        )
+
+    async def get_messages_by_session_run_ids_async(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+        *,
+        include_cleared: bool = False,
+        include_hidden_from_context: bool = False,
+    ) -> list[dict[str, JsonValue]]:
+        return await self._call_sync_async(
+            self.get_messages_by_session_run_ids,
+            session_id,
+            run_ids,
+            include_cleared=include_cleared,
+            include_hidden_from_context=include_hidden_from_context,
+        )
+
     def first_user_messages_by_session_ids(
         self,
         session_ids: tuple[str, ...],
@@ -364,6 +416,45 @@ class MessageRepository(SharedSqliteRepository):
 
         results: list[dict[str, JsonValue]] = []
         for row in rows:
+            msg_list = _load_message_list(str(row["message_json"]))
+            msg = msg_list[0] if msg_list and isinstance(msg_list[0], dict) else {}
+            if _is_system_reminder_projection_message(msg):
+                continue
+            results.append(
+                {
+                    "conversation_id": str(row["conversation_id"] or ""),
+                    "agent_role_id": str(row["agent_role_id"] or ""),
+                    "instance_id": str(row["instance_id"]),
+                    "task_id": str(row["task_id"]),
+                    "trace_id": str(row["trace_id"]),
+                    "role": str(row["role"]),
+                    "created_at": str(row["created_at"]),
+                    "hidden_from_context": bool(int(row["hidden_from_context"] or 0)),
+                    "hidden_reason": str(row["hidden_reason"] or ""),
+                    "hidden_at": str(row["hidden_at"] or ""),
+                    "hidden_marker_id": str(row["hidden_marker_id"] or ""),
+                    "message": msg,
+                }
+            )
+        return _dedupe_duplicate_objective_messages(results)
+
+    def _project_message_rows(
+        self,
+        rows: Sequence[sqlite3.Row],
+        *,
+        include_cleared: bool,
+        include_hidden_from_context: bool,
+    ) -> list[dict[str, JsonValue]]:
+        filtered_rows = self._filter_rows_for_read(
+            rows,
+            include_cleared=include_cleared,
+            include_hidden_from_context=include_hidden_from_context,
+        )
+        if not include_hidden_from_context:
+            filtered_rows = _truncate_message_rows_to_safe_boundary(filtered_rows)
+
+        results: list[dict[str, JsonValue]] = []
+        for row in filtered_rows:
             msg_list = _load_message_list(str(row["message_json"]))
             msg = msg_list[0] if msg_list and isinstance(msg_list[0], dict) else {}
             if _is_system_reminder_projection_message(msg):

--- a/src/relay_teams/agents/tasks/task_repository.py
+++ b/src/relay_teams/agents/tasks/task_repository.py
@@ -10,6 +10,8 @@ from relay_teams.agents.tasks.models import TaskEnvelope, TaskRecord
 from relay_teams.persistence import async_fetchall, async_fetchone
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
+_SQLITE_SAFE_VARIABLE_LIMIT = 900
+
 
 class TaskRepository(SharedSqliteRepository):
     def __init__(self, db_path: Path) -> None:
@@ -40,6 +42,9 @@ class TaskRepository(SharedSqliteRepository):
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tasks_session_trace ON tasks(session_id, trace_id, created_at)"
             )
 
         self._run_write(
@@ -72,6 +77,9 @@ class TaskRepository(SharedSqliteRepository):
             )
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tasks_session_trace ON tasks(session_id, trace_id, created_at)"
             )
 
         await self._run_async_write(
@@ -450,6 +458,42 @@ class TaskRepository(SharedSqliteRepository):
                 (session_id,),
             ).fetchall()
         return tuple(self._to_record(row) for row in rows)
+
+    def list_by_session_run_ids(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+    ) -> tuple[TaskRecord, ...]:
+        normalized_run_ids = tuple(
+            dict.fromkeys(run_id.strip() for run_id in run_ids if run_id.strip())
+        )
+        if not normalized_run_ids:
+            return ()
+        rows: list[sqlite3.Row] = []
+        chunk_size = _SQLITE_SAFE_VARIABLE_LIMIT - 1
+        with self._lock:
+            for index in range(0, len(normalized_run_ids), chunk_size):
+                run_id_chunk = normalized_run_ids[index : index + chunk_size]
+                placeholders = ", ".join("?" for _ in run_id_chunk)
+                rows.extend(
+                    self._conn.execute(
+                        f"SELECT * FROM tasks WHERE session_id=? AND trace_id IN ({placeholders}) ORDER BY created_at ASC",
+                        (session_id, *run_id_chunk),
+                    ).fetchall()
+                )
+        rows.sort(key=lambda row: str(row["created_at"] or ""))
+        return tuple(self._to_record(row) for row in rows)
+
+    async def list_by_session_run_ids_async(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+    ) -> tuple[TaskRecord, ...]:
+        return await self._call_sync_async(
+            self.list_by_session_run_ids,
+            session_id,
+            run_ids,
+        )
 
     async def list_by_session_async(self, session_id: str) -> tuple[TaskRecord, ...]:
         rows = await self._run_async_read(

--- a/src/relay_teams/interfaces/server/async_call.py
+++ b/src/relay_teams/interfaces/server/async_call.py
@@ -22,6 +22,7 @@ SETTINGS_ADMIN_THREAD_WORKER_COUNT = 4
 LOGS_INGEST_THREAD_WORKER_COUNT = 2
 FILE_MEDIA_THREAD_WORKER_COUNT = 4
 RUNTIME_BACKGROUND_THREAD_WORKER_COUNT = 4
+NETWORK_PROBE_THREAD_WORKER_COUNT = 4
 SLOW_SERVER_CALL_SECONDS = 1.0
 DEFAULT_ROUTE_WORK_QUEUE_TIMEOUT_SECONDS = 4.0
 LOGGER = get_logger(__name__)
@@ -35,6 +36,7 @@ class RouteWorkClass(str, Enum):
     LOGS_INGEST = "logs_ingest"
     FILE_MEDIA = "file_media"
     RUNTIME_BACKGROUND = "runtime_background"
+    NETWORK_PROBE = "network_probe"
 
 
 class RouteWorkRejectedError(RuntimeError):
@@ -49,6 +51,7 @@ _ROUTE_WORKER_COUNTS = {
     RouteWorkClass.LOGS_INGEST: LOGS_INGEST_THREAD_WORKER_COUNT,
     RouteWorkClass.FILE_MEDIA: FILE_MEDIA_THREAD_WORKER_COUNT,
     RouteWorkClass.RUNTIME_BACKGROUND: RUNTIME_BACKGROUND_THREAD_WORKER_COUNT,
+    RouteWorkClass.NETWORK_PROBE: NETWORK_PROBE_THREAD_WORKER_COUNT,
 }
 _ROUTE_QUEUE_LIMITS = {
     RouteWorkClass.CRITICAL_CONTROL: ISOLATED_THREAD_WORKER_COUNT * 2,
@@ -58,6 +61,7 @@ _ROUTE_QUEUE_LIMITS = {
     RouteWorkClass.LOGS_INGEST: LOGS_INGEST_THREAD_WORKER_COUNT * 2,
     RouteWorkClass.FILE_MEDIA: FILE_MEDIA_THREAD_WORKER_COUNT * 2,
     RouteWorkClass.RUNTIME_BACKGROUND: RUNTIME_BACKGROUND_THREAD_WORKER_COUNT * 2,
+    RouteWorkClass.NETWORK_PROBE: NETWORK_PROBE_THREAD_WORKER_COUNT * 2,
 }
 _ROUTE_EXECUTORS = {
     work_class: ThreadPoolExecutor(
@@ -229,6 +233,22 @@ async def call_maybe_async_in_session_read_thread(
 ) -> ResultT:
     return await call_route_work(
         RouteWorkClass.SESSION_READ,
+        operation,
+        function,
+        *args,
+        **kwargs,
+    )
+
+
+async def call_maybe_async_in_network_probe_thread(
+    operation: str,
+    function: Callable[ParamT, ResultT | Awaitable[ResultT]],
+    /,
+    *args: ParamT.args,
+    **kwargs: ParamT.kwargs,
+) -> ResultT:
+    return await call_route_work(
+        RouteWorkClass.NETWORK_PROBE,
         operation,
         function,
         *args,

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, JsonValue
 from relay_teams.interfaces.server.async_call import (
     call_maybe_async,
     call_maybe_async_in_isolated_thread,
+    call_maybe_async_in_network_probe_thread,
 )
 from relay_teams.env.clawhub_config_models import ClawHubConfig
 from relay_teams.env.clawhub_config_service import ClawHubConfigService
@@ -291,7 +292,11 @@ async def probe_ssh_profile_connectivity(
     service: SshProfileService = Depends(get_ssh_profile_service),
 ) -> SshProfileConnectivityProbeResult:
     try:
-        return await call_maybe_async(service.probe_connectivity, req)
+        return await call_maybe_async_in_network_probe_thread(
+            "ssh.probe_connectivity",
+            service.probe_connectivity,
+            req,
+        )
     except Exception as exc:
         _raise_system_http_error(
             exc,
@@ -663,7 +668,11 @@ async def probe_model_connectivity(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelConnectivityProbeResult:
     try:
-        return await call_maybe_async(service.probe_connectivity, req)
+        return await call_maybe_async_in_network_probe_thread(
+            "model.probe_connectivity",
+            service.probe_connectivity,
+            req,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -674,7 +683,11 @@ async def discover_model_catalog(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelDiscoveryResult:
     try:
-        return await call_maybe_async(service.discover_models, req)
+        return await call_maybe_async_in_network_probe_thread(
+            "model.discover_models",
+            service.discover_models,
+            req,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/relay_teams/sessions/runs/event_log.py
+++ b/src/relay_teams/sessions/runs/event_log.py
@@ -15,6 +15,8 @@ from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.agents.tasks.events import EventEnvelope
 
+_SQLITE_SAFE_VARIABLE_LIMIT = 900
+
 
 class EventLog(SharedSqliteRepository):
     """Append-only business event log backed by SQLite."""
@@ -47,6 +49,12 @@ class EventLog(SharedSqliteRepository):
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_events_session_id_trace ON events(session_id, id, trace_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_session_event_type_id ON events(session_id, event_type, id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_session_trace_event_id ON events(session_id, trace_id, event_type, id)"
             )
 
         self._run_write(
@@ -82,6 +90,14 @@ class EventLog(SharedSqliteRepository):
             await cursor.close()
             cursor = await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_events_session_id_trace ON events(session_id, id, trace_id)"
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_session_event_type_id ON events(session_id, event_type, id)"
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_session_trace_event_id ON events(session_id, trace_id, event_type, id)"
             )
             await cursor.close()
 
@@ -266,6 +282,88 @@ class EventLog(SharedSqliteRepository):
                 (session_id,),
             ).fetchall()
         return tuple(self._row_to_dict(row) for row in rows)
+
+    def list_by_session_event_types(
+        self,
+        session_id: str,
+        event_types: tuple[str, ...],
+    ) -> tuple[dict[str, JsonValue], ...]:
+        normalized_event_types = tuple(
+            dict.fromkeys(
+                event_type.strip() for event_type in event_types if event_type.strip()
+            )
+        )
+        if not normalized_event_types:
+            return ()
+        placeholders = ", ".join("?" for _ in normalized_event_types)
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                f"FROM events WHERE session_id=? AND event_type IN ({placeholders}) ORDER BY id ASC",
+                (session_id, *normalized_event_types),
+            ).fetchall()
+        return tuple(self._row_to_dict(row) for row in rows)
+
+    async def list_by_session_event_types_async(
+        self,
+        session_id: str,
+        event_types: tuple[str, ...],
+    ) -> tuple[dict[str, JsonValue], ...]:
+        return await self._call_sync_async(
+            self.list_by_session_event_types,
+            session_id,
+            event_types,
+        )
+
+    def list_by_session_run_ids_event_types(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+        event_types: tuple[str, ...],
+    ) -> tuple[dict[str, JsonValue], ...]:
+        normalized_run_ids = tuple(
+            dict.fromkeys(run_id.strip() for run_id in run_ids if run_id.strip())
+        )
+        normalized_event_types = tuple(
+            dict.fromkeys(
+                event_type.strip() for event_type in event_types if event_type.strip()
+            )
+        )
+        if not normalized_run_ids or not normalized_event_types:
+            return ()
+        event_placeholders = ", ".join("?" for _ in normalized_event_types)
+        chunk_size = max(
+            1,
+            _SQLITE_SAFE_VARIABLE_LIMIT - len(normalized_event_types) - 1,
+        )
+        rows: list[sqlite3.Row] = []
+        with self._lock:
+            for index in range(0, len(normalized_run_ids), chunk_size):
+                run_id_chunk = normalized_run_ids[index : index + chunk_size]
+                run_placeholders = ", ".join("?" for _ in run_id_chunk)
+                rows.extend(
+                    self._conn.execute(
+                        "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                        f"FROM events WHERE session_id=? AND trace_id IN ({run_placeholders}) "
+                        f"AND event_type IN ({event_placeholders}) ORDER BY id ASC",
+                        (session_id, *run_id_chunk, *normalized_event_types),
+                    ).fetchall()
+                )
+        rows.sort(key=lambda row: int(row["id"]) if isinstance(row["id"], int) else 0)
+        return tuple(self._row_to_dict(row) for row in rows)
+
+    async def list_by_session_run_ids_event_types_async(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+        event_types: tuple[str, ...],
+    ) -> tuple[dict[str, JsonValue], ...]:
+        return await self._call_sync_async(
+            self.list_by_session_run_ids_event_types,
+            session_id,
+            run_ids,
+            event_types,
+        )
 
     async def list_by_session_async(
         self, session_id: str

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -26,6 +26,18 @@ from relay_teams.sessions.session_history_marker_models import (
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.workspace import build_conversation_id
 
+ROUND_PROJECTION_EVENT_TYPES = (
+    RunEventType.LLM_RETRY_SCHEDULED.value,
+    RunEventType.LLM_RETRY_EXHAUSTED.value,
+    RunEventType.LLM_FALLBACK_ACTIVATED.value,
+    RunEventType.LLM_FALLBACK_EXHAUSTED.value,
+    RunEventType.MODEL_STEP_STARTED.value,
+    RunEventType.MODEL_STEP_FINISHED.value,
+    RunEventType.RUN_COMPLETED.value,
+    RunEventType.RUN_FAILED.value,
+    RunEventType.RUN_STOPPED.value,
+)
+
 
 def build_session_rounds(
     *,
@@ -39,9 +51,14 @@ def build_session_rounds(
     get_session_history_markers: Callable[[str], list[dict[str, object]]] | None = None,
     get_session_events: Callable[[str], list[dict[str, object]]] | None = None,
     excluded_run_ids: set[str] | None = None,
+    included_run_ids: set[str] | None = None,
     run_runtime_by_run: dict[str, RunRuntimeRecord] | None = None,
 ) -> list[dict[str, object]]:
-    session_tasks = task_repo.list_by_session(session_id)
+    session_tasks = (
+        task_repo.list_by_session_run_ids(session_id, tuple(included_run_ids))
+        if included_run_ids is not None
+        else task_repo.list_by_session(session_id)
+    )
     session_agents = agent_repo.list_session_role_instances(session_id)
     session_messages = get_session_messages(session_id)
     session_markers = (
@@ -250,6 +267,8 @@ def build_session_rounds(
     run_ids.update(run_runtime.keys())
     if excluded_run_ids:
         run_ids.difference_update(excluded_run_ids)
+    if included_run_ids is not None:
+        run_ids.intersection_update(included_run_ids)
 
     rounds: list[dict[str, object]] = []
     for run_id in run_ids:
@@ -344,9 +363,14 @@ def build_session_timeline_rounds(
     get_session_history_markers: Callable[[str], list[dict[str, object]]] | None = None,
     get_session_events: Callable[[str], list[dict[str, object]]] | None = None,
     excluded_run_ids: set[str] | None = None,
+    included_run_ids: set[str] | None = None,
     run_runtime_by_run: dict[str, RunRuntimeRecord] | None = None,
 ) -> list[dict[str, object]]:
-    session_tasks = task_repo.list_by_session(session_id)
+    session_tasks = (
+        task_repo.list_by_session_run_ids(session_id, tuple(included_run_ids))
+        if included_run_ids is not None
+        else task_repo.list_by_session(session_id)
+    )
     session_messages = get_session_user_messages(session_id)
     session_markers = (
         get_session_history_markers(session_id) if get_session_history_markers else []
@@ -388,6 +412,8 @@ def build_session_timeline_rounds(
     run_ids.update(run_runtime.keys())
     if excluded_run_ids:
         run_ids.difference_update(excluded_run_ids)
+    if included_run_ids is not None:
+        run_ids.intersection_update(included_run_ids)
 
     rounds: list[dict[str, object]] = []
     for run_id in run_ids:

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -28,6 +28,7 @@ from relay_teams.sessions.runs.active_run_registry import ActiveSessionRunRegist
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.runtime_config import RuntimeConfig
 from relay_teams.sessions.session_rounds_projection import (
+    ROUND_PROJECTION_EVENT_TYPES,
     approvals_to_projection,
     build_session_rounds,
     build_session_timeline_rounds,
@@ -1238,6 +1239,29 @@ class SessionService:
         events = self._event_log.list_by_session(session_id)
         return cast(list[dict[str, object]], list(events))
 
+    def _get_round_projection_events(self, session_id: str) -> list[dict[str, object]]:
+        if self._event_log is None:
+            return []
+        events = self._event_log.list_by_session_event_types(
+            session_id,
+            ROUND_PROJECTION_EVENT_TYPES,
+        )
+        return cast(list[dict[str, object]], list(events))
+
+    def _get_round_projection_events_for_runs(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+    ) -> list[dict[str, object]]:
+        if self._event_log is None:
+            return []
+        events = self._event_log.list_by_session_run_ids_event_types(
+            session_id,
+            run_ids,
+            ROUND_PROJECTION_EVENT_TYPES,
+        )
+        return cast(list[dict[str, object]], list(events))
+
     def get_session_messages(self, session_id: str) -> list[dict[str, object]]:
         return cast(
             list[dict[str, object]],
@@ -1263,40 +1287,89 @@ class SessionService:
             if record.envelope.parent_task_id is not None
         ]
 
-    def build_session_rounds(self, session_id: str) -> list[dict[str, object]]:
+    def build_session_rounds(
+        self,
+        session_id: str,
+        *,
+        included_run_ids: set[str] | None = None,
+        include_history_markers: bool = True,
+    ) -> list[dict[str, object]]:
         excluded_run_ids = self._subagent_run_ids(session_id)
+        selected_run_ids = (
+            tuple(sorted(included_run_ids)) if included_run_ids is not None else None
+        )
         todos_by_run_id = (
             {
                 snapshot.run_id: snapshot.model_dump(mode="json")
                 for snapshot in self._todo_service.list_for_session(session_id)
+                if included_run_ids is None or snapshot.run_id in included_run_ids
             }
             if self._todo_service is not None
             else {}
         )
-        intent_input_parts_by_run = self._session_run_intent_input_parts_by_run(
-            session_id
+        intent_input_parts_by_run = (
+            self._session_run_intent_input_parts_by_run(session_id)
+            if included_run_ids is None
+            else {
+                run_id: parts
+                for run_id, parts in self._session_run_intent_input_parts_by_run(
+                    session_id
+                ).items()
+                if run_id in included_run_ids
+            }
         )
-        runtime_by_run = self._session_run_runtime_by_run(session_id)
+        runtime_by_run = {
+            run_id: runtime
+            for run_id, runtime in self._session_run_runtime_by_run(session_id).items()
+            if included_run_ids is None or run_id in included_run_ids
+        }
         rounds = build_session_rounds(
             session_id=session_id,
             agent_repo=self._agent_repo,
             task_repo=self._task_repo,
             approval_tickets_by_run=approvals_to_projection(
-                self._approval_ticket_repo.list_open_by_session(session_id)
+                [
+                    record
+                    for record in self._approval_ticket_repo.list_open_by_session(
+                        session_id
+                    )
+                    if included_run_ids is None or record.run_id in included_run_ids
+                ]
             ),
             run_runtime_repo=self._run_runtime_repo,
             get_session_messages=lambda current_session_id: cast(
                 list[dict[str, object]],
-                self._message_repo.get_messages_by_session(
-                    current_session_id,
-                    include_cleared=True,
-                    include_hidden_from_context=True,
+                (
+                    self._message_repo.get_messages_by_session(
+                        current_session_id,
+                        include_cleared=True,
+                        include_hidden_from_context=True,
+                    )
+                    if selected_run_ids is None
+                    else self._message_repo.get_messages_by_session_run_ids(
+                        current_session_id,
+                        selected_run_ids,
+                        include_cleared=True,
+                        include_hidden_from_context=True,
+                    )
                 ),
             ),
             get_run_intent_input=intent_input_parts_by_run.get,
-            get_session_history_markers=self._get_session_history_markers,
-            get_session_events=self.get_global_events,
+            get_session_history_markers=(
+                self._get_session_history_markers if include_history_markers else None
+            ),
+            get_session_events=(
+                self._get_round_projection_events
+                if selected_run_ids is None
+                else lambda current_session_id: (
+                    self._get_round_projection_events_for_runs(
+                        current_session_id,
+                        selected_run_ids,
+                    )
+                )
+            ),
             excluded_run_ids=excluded_run_ids,
+            included_run_ids=included_run_ids,
             run_runtime_by_run=runtime_by_run,
         )
         question_counts_by_run = self._pending_user_question_counts_by_run(session_id)
@@ -1352,7 +1425,7 @@ class SessionService:
             ),
             get_run_intent_input=intent_input_parts_by_run.get,
             get_session_history_markers=self._get_session_history_markers,
-            get_session_events=self.get_global_events,
+            get_session_events=self._get_round_projection_events,
             excluded_run_ids=excluded_run_ids,
             run_runtime_by_run=runtime_by_run,
         )
@@ -1426,8 +1499,52 @@ class SessionService:
         if timeline:
             rounds = self.build_session_timeline_rounds(session_id)
             return timeline_rounds(rounds)
-        rounds = self.build_session_rounds(session_id)
-        return paginate_rounds(rounds, limit=limit, cursor_run_id=cursor_run_id)
+        timeline_items = self.build_session_timeline_rounds(session_id)
+        page = paginate_rounds(
+            timeline_items,
+            limit=limit,
+            cursor_run_id=cursor_run_id,
+        )
+        page_items = page.get("items")
+        if not isinstance(page_items, list) or not page_items:
+            return page
+        page_run_ids = tuple(
+            str(item.get("run_id") or "")
+            for item in page_items
+            if isinstance(item, dict) and str(item.get("run_id") or "")
+        )
+        if not page_run_ids:
+            return page
+        full_rounds = self.build_session_rounds(
+            session_id,
+            included_run_ids=set(page_run_ids),
+            include_history_markers=False,
+        )
+        full_round_by_run = {
+            str(round_item.get("run_id") or ""): round_item
+            for round_item in full_rounds
+        }
+        page_marker_by_run = {
+            str(item.get("run_id") or ""): {
+                "clear_marker_before": item.get("clear_marker_before"),
+                "compaction_marker_before": item.get("compaction_marker_before"),
+            }
+            for item in page_items
+            if isinstance(item, dict) and str(item.get("run_id") or "")
+        }
+        resolved_items: list[dict[str, object]] = []
+        for run_id in page_run_ids:
+            full_round = full_round_by_run.get(run_id)
+            if full_round is None:
+                continue
+            markers = page_marker_by_run.get(run_id, {})
+            full_round["clear_marker_before"] = markers.get("clear_marker_before")
+            full_round["compaction_marker_before"] = markers.get(
+                "compaction_marker_before"
+            )
+            resolved_items.append(full_round)
+        page["items"] = resolved_items
+        return page
 
     def get_round(self, session_id: str, run_id: str) -> dict[str, object]:
         rounds = self.build_session_rounds(session_id)

--- a/tests/integration_tests/api/test_session_tool_call_pressure.py
+++ b/tests/integration_tests/api/test_session_tool_call_pressure.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from integration_tests.support.api_helpers import (
+    create_session,
+    new_session_id,
+)
+from integration_tests.support.environment import IntegrationEnvironment
+from integration_tests.support.session_tool_pressure import (
+    assert_backend_probes_stayed_responsive,
+    run_pressure_scenario,
+)
+
+
+@pytest.mark.timeout(140)
+def test_normal_mode_session_concurrent_tool_calls_do_not_starve_backend(
+    api_client: httpx.Client,
+    integration_env: IntegrationEnvironment,
+) -> None:
+    session_ids = [
+        create_session(
+            api_client,
+            session_id=new_session_id(f"normal-tool-pressure-{index:02d}"),
+        )
+        for index in range(10)
+    ]
+
+    result = run_pressure_scenario(
+        integration_env=integration_env,
+        session_ids=session_ids,
+        intent_template=(
+            "[normal-tool-pressure count=4 delay=320 tag=normal{index}] "
+            "run concurrent shell pressure in normal mode."
+        ),
+        timeout_seconds=90.0,
+    )
+
+    assert {run.terminal_event_type for run in result.runs} == {"run_completed"}
+    assert sum(run.event_counts.get("tool_call", 0) for run in result.runs) >= 40
+    assert sum(run.event_counts.get("tool_result", 0) for run in result.runs) >= 40
+    assert all(
+        "[fake-llm] normal tool pressure completed" in run.output_text
+        for run in result.runs
+    )
+    assert_backend_probes_stayed_responsive(result.probes)
+
+
+@pytest.mark.timeout(180)
+def test_orchestration_mode_session_concurrent_tool_calls_do_not_starve_backend(
+    api_client: httpx.Client,
+    integration_env: IntegrationEnvironment,
+) -> None:
+    session_ids = [
+        create_session(
+            api_client,
+            session_id=new_session_id(f"orch-tool-pressure-{index:02d}"),
+        )
+        for index in range(3)
+    ]
+    for session_id in session_ids:
+        response = api_client.patch(
+            f"/api/sessions/{session_id}/topology",
+            json={"session_mode": "orchestration"},
+        )
+        response.raise_for_status()
+
+    result = run_pressure_scenario(
+        integration_env=integration_env,
+        session_ids=session_ids,
+        intent_template=(
+            "[orch-tool-pressure count=4 tools=3 delay=260] "
+            "dispatch tool-heavy workers in orchestrated mode."
+        ),
+        timeout_seconds=140.0,
+    )
+
+    assert {run.terminal_event_type for run in result.runs} == {"run_completed"}
+    assert sum(run.event_counts.get("tool_call", 0) for run in result.runs) >= 12
+    assert sum(run.event_counts.get("tool_result", 0) for run in result.runs) >= 12
+    assert all(
+        "[fake-llm] orchestration tool pressure completed" in run.output_text
+        for run in result.runs
+    )
+    assert_backend_probes_stayed_responsive(result.probes)

--- a/tests/integration_tests/browser/test_backend_status_pressure.py
+++ b/tests/integration_tests/browser/test_backend_status_pressure.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from concurrent.futures import Future, ThreadPoolExecutor
+import os
+import time
+
+import httpx
+from playwright.sync_api import Locator, Page, expect, sync_playwright
+import pytest
+
+from integration_tests.browser.test_browser_smoke import (
+    _CONNECTED_LABEL,
+    _WAIT_TIMEOUT_MS,
+    _resolve_playwright_browser_root,
+)
+from integration_tests.support.api_helpers import create_session, new_session_id
+from integration_tests.support.environment import IntegrationEnvironment
+from integration_tests.support.session_tool_pressure import (
+    PressureScenarioResult,
+    assert_backend_probes_stayed_responsive,
+    run_pressure_scenario,
+)
+
+
+@pytest.fixture()
+def browser_page() -> Iterator[Page]:
+    browser_root = _resolve_playwright_browser_root()
+    previous_browser_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_root)
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            context = browser.new_context(
+                viewport={"width": 1600, "height": 1200},
+                color_scheme="dark",
+            )
+            page = context.new_page()
+            try:
+                yield page
+            finally:
+                context.close()
+                browser.close()
+    finally:
+        if previous_browser_root is None:
+            os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
+        else:
+            os.environ["PLAYWRIGHT_BROWSERS_PATH"] = previous_browser_root
+
+
+@pytest.mark.timeout(180)
+def test_browser_backend_status_stays_connected_during_tool_pressure(
+    browser_page: Page,
+    api_client: httpx.Client,
+    integration_env: IntegrationEnvironment,
+) -> None:
+    normal_session_ids = [
+        create_session(
+            api_client,
+            session_id=new_session_id(f"browser-normal-pressure-{index:02d}"),
+        )
+        for index in range(6)
+    ]
+    orchestration_session_ids = [
+        create_session(
+            api_client,
+            session_id=new_session_id(f"browser-orch-pressure-{index:02d}"),
+        )
+        for index in range(3)
+    ]
+    for session_id in orchestration_session_ids:
+        response = api_client.patch(
+            f"/api/sessions/{session_id}/topology",
+            json={"session_mode": "orchestration"},
+        )
+        response.raise_for_status()
+
+    page = browser_page
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        normal_future = executor.submit(
+            run_pressure_scenario,
+            integration_env=integration_env,
+            session_ids=normal_session_ids,
+            intent_template=(
+                "[normal-tool-pressure count=4 delay=700 tag=browsernormal{index}] "
+                "run browser-observed normal pressure."
+            ),
+            timeout_seconds=120.0,
+        )
+        orchestration_future = executor.submit(
+            run_pressure_scenario,
+            integration_env=integration_env,
+            session_ids=orchestration_session_ids,
+            intent_template=(
+                "[orch-tool-pressure count=3 tools=3 delay=620] "
+                "run browser-observed orchestrated pressure."
+            ),
+            timeout_seconds=140.0,
+        )
+
+        page.goto(integration_env.api_base_url, wait_until="domcontentloaded")
+        status = page.locator("#backend-status")
+        expect(page.locator("#backend-status-label")).to_contain_text(
+            _CONNECTED_LABEL,
+            timeout=_WAIT_TIMEOUT_MS,
+        )
+        observed_statuses = _observe_backend_status_until_done(
+            page,
+            status,
+            normal_future,
+            orchestration_future,
+        )
+        normal_result = normal_future.result(timeout=130.0)
+        orchestration_result = orchestration_future.result(timeout=150.0)
+
+    assert "online" in observed_statuses
+    assert "busy" not in observed_statuses
+    assert "offline" not in observed_statuses
+    _assert_pressure_completed(normal_result, expected_text="normal tool pressure")
+    _assert_pressure_completed(
+        orchestration_result,
+        expected_text="orchestration tool pressure",
+    )
+    assert_backend_probes_stayed_responsive(normal_result.probes)
+    assert_backend_probes_stayed_responsive(orchestration_result.probes)
+
+
+def _observe_backend_status_until_done(
+    page: Page,
+    status: Locator,
+    normal_future: Future[PressureScenarioResult],
+    orchestration_future: Future[PressureScenarioResult],
+) -> set[str]:
+    observed_statuses: set[str] = set()
+    deadline = time.monotonic() + 25.0
+    while time.monotonic() < deadline:
+        current_status = str(status.get_attribute("data-status") or "").strip()
+        if current_status:
+            observed_statuses.add(current_status)
+        assert current_status not in {"busy", "offline"}
+        if normal_future.done() and orchestration_future.done():
+            break
+        page.wait_for_timeout(250)
+    return observed_statuses
+
+
+def _assert_pressure_completed(
+    result: PressureScenarioResult,
+    *,
+    expected_text: str,
+) -> None:
+    assert {run.terminal_event_type for run in result.runs} == {"run_completed"}
+    assert all(expected_text in run.output_text for run in result.runs)

--- a/tests/integration_tests/support/fake_llm_server.py
+++ b/tests/integration_tests/support/fake_llm_server.py
@@ -257,10 +257,14 @@ def plan_fake_response(payload: object) -> dict[str, object]:
     messages = payload.get("messages")
     if not isinstance(messages, list):
         return {"kind": "text", "content": "fake-response"}
+    if _normal_tool_pressure_mode(messages):
+        return _plan_normal_tool_pressure_response(payload, messages)
     if _orch_clone_worker_mode(messages):
         return _plan_orch_clone_worker_response(messages)
     if _orch_clone_benchmark_mode(messages):
         return _plan_orch_clone_benchmark_response(messages)
+    if _orch_tool_pressure_mode(messages):
+        return _plan_orch_tool_pressure_response(messages)
     if _rolling_summary_compaction_mode(messages):
         return _plan_rolling_summary_compaction_response(messages)
     if _rolling_summary_phase_mode(messages):
@@ -444,6 +448,198 @@ def _plan_orch_clone_worker_response(messages: list[object]) -> dict[str, object
         "delay_before_ms": max(0, min(2_000, delay_ms)),
         "content": "[fake-llm] clone worker completed",
     }
+
+
+def _normal_tool_pressure_mode(messages: list[object]) -> bool:
+    return _messages_contain_user_text(messages, "[normal-tool-pressure")
+
+
+def _plan_normal_tool_pressure_response(
+    payload: dict[str, object],
+    messages: list[object],
+) -> dict[str, object]:
+    available_tools = _extract_available_tools(payload)
+    if "shell" not in available_tools:
+        return {
+            "kind": "text",
+            "content": "[fake-llm] shell is not available for tool pressure.",
+        }
+    config = _extract_normal_tool_pressure_config(messages)
+    completed_call_ids = _extract_tool_call_ids(
+        messages,
+        prefix=config.tool_call_prefix,
+    )
+    if len(completed_call_ids) >= config.tool_count:
+        return {
+            "kind": "text",
+            "content": (
+                "[fake-llm] normal tool pressure completed "
+                f"{config.tool_count} shell calls."
+            ),
+        }
+    return {
+        "kind": "tool_calls",
+        "tool_calls": [
+            {
+                "tool_name": "shell",
+                "tool_call_id": f"{config.tool_call_prefix}{index + 1}",
+                "arguments": {
+                    "command": _build_tool_pressure_shell_command(
+                        index=index + 1,
+                        delay_ms=config.delay_ms,
+                    ),
+                    "background": False,
+                    "timeout_ms": max(5_000, config.delay_ms + 5_000),
+                },
+            }
+            for index in range(config.tool_count)
+        ],
+    }
+
+
+class _NormalToolPressureConfig:
+    def __init__(
+        self,
+        *,
+        tool_count: int,
+        delay_ms: int,
+        tool_call_prefix: str,
+    ) -> None:
+        self.tool_count = tool_count
+        self.delay_ms = delay_ms
+        self.tool_call_prefix = tool_call_prefix
+
+
+def _extract_normal_tool_pressure_config(
+    messages: list[object],
+) -> _NormalToolPressureConfig:
+    user_text = _extract_last_user_text(messages)
+    match = re.search(
+        r"\[normal-tool-pressure\s+count=(\d+)\s+delay=(\d+)(?:\s+tag=([A-Za-z0-9_-]+))?\]",
+        user_text,
+    )
+    if match is None:
+        return _NormalToolPressureConfig(
+            tool_count=4,
+            delay_ms=100,
+            tool_call_prefix="call-normal-tool-pressure-",
+        )
+    tag = match.group(3) or ""
+    prefix_tag = f"{tag}-" if tag else ""
+    return _NormalToolPressureConfig(
+        tool_count=max(1, min(16, int(match.group(1)))),
+        delay_ms=max(0, min(2_000, int(match.group(2)))),
+        tool_call_prefix=f"call-normal-tool-pressure-{prefix_tag}",
+    )
+
+
+def _build_tool_pressure_shell_command(*, index: int, delay_ms: int) -> str:
+    sleep_seconds = max(0.0, min(2.0, delay_ms / 1000))
+    script = (
+        f"import time; time.sleep({sleep_seconds:.3f}); print('tool-pressure-{index}')"
+    )
+    if sys.platform.startswith("win"):
+        return f'& "{sys.executable}" -c "{script}"'
+    return f'"{sys.executable}" -c "{script}"'
+
+
+def _orch_tool_pressure_mode(messages: list[object]) -> bool:
+    return _messages_contain_user_text(messages, "[orch-tool-pressure")
+
+
+def _plan_orch_tool_pressure_response(messages: list[object]) -> dict[str, object]:
+    config = _extract_orch_tool_pressure_config(messages)
+    task_ids = _extract_task_ids_from_tool_result(
+        messages,
+        tool_call_id="call-orch-tool-pressure-create",
+    )
+    dispatched_call_ids = _extract_tool_call_ids(
+        messages,
+        prefix="call-orch-tool-pressure-dispatch-",
+    )
+    cleared_todos = bool(
+        _extract_tool_call_ids(
+            messages,
+            prefix="call-orch-tool-pressure-clear-todos",
+        )
+    )
+    if not task_ids:
+        return {
+            "kind": "tool_call",
+            "tool_name": "orch_create_tasks",
+            "tool_call_id": "call-orch-tool-pressure-create",
+            "arguments": {
+                "tasks": [
+                    {
+                        "title": f"tool pressure worker {index + 1}",
+                        "objective": (
+                            f"[normal-tool-pressure count={config.tool_count} "
+                            f"delay={config.delay_ms} tag=orch{index + 1}] "
+                            f"complete tool pressure worker {index + 1}."
+                        ),
+                    }
+                    for index in range(config.task_count)
+                ]
+            },
+        }
+    if len(dispatched_call_ids) >= len(task_ids) and not cleared_todos:
+        return {
+            "kind": "tool_call",
+            "tool_name": "todo_write",
+            "tool_call_id": "call-orch-tool-pressure-clear-todos",
+            "arguments": {"items": []},
+        }
+    if len(dispatched_call_ids) >= len(task_ids):
+        return {
+            "kind": "text",
+            "content": (
+                "[fake-llm] orchestration tool pressure completed "
+                f"{len(task_ids)} tasks."
+            ),
+        }
+    return {
+        "kind": "tool_calls",
+        "tool_calls": [
+            {
+                "tool_name": "orch_dispatch_task",
+                "tool_call_id": f"call-orch-tool-pressure-dispatch-{index + 1}",
+                "arguments": {
+                    "task_id": task_id,
+                    "role_id": "Crafter",
+                    "prompt": (
+                        f"[normal-tool-pressure count={config.tool_count} "
+                        f"delay={config.delay_ms} tag=orch{index + 1}] "
+                        f"complete dispatched tool pressure worker {index + 1}."
+                    ),
+                },
+            }
+            for index, task_id in enumerate(task_ids)
+        ],
+    }
+
+
+class _OrchToolPressureConfig:
+    def __init__(self, *, task_count: int, tool_count: int, delay_ms: int) -> None:
+        self.task_count = task_count
+        self.tool_count = tool_count
+        self.delay_ms = delay_ms
+
+
+def _extract_orch_tool_pressure_config(
+    messages: list[object],
+) -> _OrchToolPressureConfig:
+    user_text = _extract_last_user_text(messages)
+    match = re.search(
+        r"\[orch-tool-pressure\s+count=(\d+)\s+tools=(\d+)\s+delay=(\d+)\]",
+        user_text,
+    )
+    if match is None:
+        return _OrchToolPressureConfig(task_count=3, tool_count=3, delay_ms=100)
+    return _OrchToolPressureConfig(
+        task_count=max(1, min(8, int(match.group(1)))),
+        tool_count=max(1, min(8, int(match.group(2)))),
+        delay_ms=max(0, min(2_000, int(match.group(3)))),
+    )
 
 
 def _rolling_summary_compaction_mode(messages: list[object]) -> bool:

--- a/tests/integration_tests/support/session_tool_pressure.py
+++ b/tests/integration_tests/support/session_tool_pressure.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Event
+import json
+import time
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from integration_tests.support.api_helpers import (
+    create_run,
+    stream_run_until_terminal,
+)
+from integration_tests.support.environment import IntegrationEnvironment
+
+
+class RunPressureResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    run_id: str
+    duration_ms: int
+    terminal_event_type: str
+    event_counts: dict[str, int]
+    output_text: str
+
+
+class BackendProbeResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    path: str
+    status_code: int
+    duration_ms: int
+    error: str = ""
+
+
+class PressureScenarioResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    runs: tuple[RunPressureResult, ...]
+    probes: tuple[BackendProbeResult, ...] = Field(default_factory=tuple)
+
+
+def run_pressure_scenario(
+    *,
+    integration_env: IntegrationEnvironment,
+    session_ids: list[str],
+    intent_template: str,
+    timeout_seconds: float,
+) -> PressureScenarioResult:
+    stop_probes = Event()
+    probe_results: list[BackendProbeResult] = []
+    started_at = time.monotonic()
+    with ThreadPoolExecutor(max_workers=len(session_ids) + 2) as executor:
+        probe_future = executor.submit(
+            _probe_backend_until_stopped,
+            integration_env.api_base_url,
+            tuple(session_ids),
+            stop_probes,
+            probe_results,
+        )
+        futures = [
+            executor.submit(
+                _run_single_pressure_session,
+                integration_env.api_base_url,
+                session_id,
+                intent_template.format(index=index + 1),
+                timeout_seconds,
+            )
+            for index, session_id in enumerate(session_ids)
+        ]
+        run_results: list[RunPressureResult] = []
+        try:
+            remaining_timeout = max(
+                1.0,
+                timeout_seconds - (time.monotonic() - started_at),
+            )
+            for future in as_completed(futures, timeout=remaining_timeout):
+                run_results.append(future.result())
+        finally:
+            stop_probes.set()
+            probe_future.result(timeout=10.0)
+
+    if len(run_results) != len(session_ids):
+        raise AssertionError(
+            f"Expected {len(session_ids)} completed pressure runs, got {len(run_results)}"
+        )
+    return PressureScenarioResult(
+        runs=tuple(run_results),
+        probes=tuple(probe_results),
+    )
+
+
+def assert_backend_probes_stayed_responsive(
+    probes: tuple[BackendProbeResult, ...],
+) -> None:
+    assert len(probes) >= 10
+    failures = [
+        probe
+        for probe in probes
+        if probe.status_code == 0
+        or probe.status_code >= 500
+        or probe.status_code == 429
+    ]
+    assert failures == []
+    live_durations = sorted(
+        probe.duration_ms for probe in probes if probe.path == "/api/system/live"
+    )
+    assert live_durations
+    assert live_durations[-1] < 1500
+    durations = sorted(probe.duration_ms for probe in probes)
+    p95_index = max(0, int(len(durations) * 0.95) - 1)
+    assert durations[p95_index] < 1500
+
+
+def _run_single_pressure_session(
+    base_url: str,
+    session_id: str,
+    intent: str,
+    timeout_seconds: float,
+) -> RunPressureResult:
+    with httpx.Client(
+        base_url=base_url, timeout=timeout_seconds, trust_env=False
+    ) as client:
+        started_at = time.perf_counter()
+        run_id = create_run(
+            client,
+            session_id=session_id,
+            intent=intent,
+            execution_mode="ai",
+            yolo=True,
+        )
+        events = stream_run_until_terminal(
+            client,
+            run_id=run_id,
+            timeout_seconds=timeout_seconds,
+        )
+        return RunPressureResult(
+            session_id=session_id,
+            run_id=run_id,
+            duration_ms=int((time.perf_counter() - started_at) * 1000),
+            terminal_event_type=str(events[-1].get("event_type") or ""),
+            event_counts=_event_counts(events),
+            output_text=_text_output(events),
+        )
+
+
+def _probe_backend_until_stopped(
+    base_url: str,
+    session_ids: tuple[str, ...],
+    stop_event: Event,
+    results: list[BackendProbeResult],
+) -> None:
+    paths = _probe_paths(session_ids)
+    index = 0
+    with httpx.Client(base_url=base_url, timeout=1.5, trust_env=False) as client:
+        while not stop_event.is_set():
+            path = paths[index % len(paths)]
+            index += 1
+            results.append(_send_backend_probe(client, path))
+            time.sleep(0.03)
+
+
+def _probe_paths(session_ids: tuple[str, ...]) -> tuple[str, ...]:
+    paths = ["/api/system/live", "/api/system/health", "/api/sessions"]
+    for session_id in session_ids[:6]:
+        paths.extend(
+            [
+                f"/api/sessions/{session_id}",
+                f"/api/sessions/{session_id}/rounds?limit=4",
+                f"/api/sessions/{session_id}/recovery",
+                f"/api/sessions/{session_id}/token-usage",
+            ]
+        )
+    return tuple(paths)
+
+
+def _send_backend_probe(
+    client: httpx.Client,
+    path: str,
+) -> BackendProbeResult:
+    started_at = time.perf_counter()
+    try:
+        response = client.get(path)
+        _consume_response(response)
+        return BackendProbeResult(
+            path=path,
+            status_code=response.status_code,
+            duration_ms=int((time.perf_counter() - started_at) * 1000),
+        )
+    except Exception as exc:
+        return BackendProbeResult(
+            path=path,
+            status_code=0,
+            duration_ms=int((time.perf_counter() - started_at) * 1000),
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _consume_response(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "")
+    if "application/json" in content_type:
+        _ = response.json()
+        return
+    _ = response.text
+
+
+def _event_counts(events: list[dict[str, object]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for event in events:
+        event_type = str(event.get("event_type") or "")
+        if event_type:
+            counts[event_type] += 1
+    return dict(counts)
+
+
+def _text_output(events: list[dict[str, object]]) -> str:
+    parts: list[str] = []
+    for event in events:
+        if str(event.get("event_type") or "") != "text_delta":
+            continue
+        payload = json.loads(str(event.get("payload_json") or "{}"))
+        parts.append(str(payload.get("text") or ""))
+    return "".join(parts)

--- a/tests/unit_tests/agents/execution/test_message_repository.py
+++ b/tests/unit_tests/agents/execution/test_message_repository.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import cast
 
+import pytest
 from pydantic_ai.messages import (
     ImageUrl,
     ModelRequest,
@@ -125,6 +126,59 @@ def test_message_repo_hides_duplicate_task_objective_messages(tmp_path: Path) ->
     messages = repo.get_messages_by_session("session-1")
 
     assert len(messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_message_repo_lists_messages_by_session_run_ids(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "message_repo_session_run_ids.db"
+    repo = MessageRepository(db_path)
+    reminder = render_system_reminder("Check todos.")
+
+    repo.append(
+        session_id="session-1",
+        workspace_id="default",
+        conversation_id="conversation-1",
+        agent_role_id="time",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        messages=[ModelRequest(parts=[UserPromptPart(content="query time")])],
+    )
+    repo.append_user_prompt_if_missing(
+        session_id="session-1",
+        workspace_id="default",
+        conversation_id="conversation-1",
+        agent_role_id="time",
+        instance_id="inst-1",
+        task_id="task-2",
+        trace_id="run-2",
+        content=reminder,
+    )
+    repo.append(
+        session_id="session-2",
+        workspace_id="default",
+        instance_id="inst-2",
+        task_id="task-3",
+        trace_id="run-1",
+        messages=[ModelRequest(parts=[UserPromptPart(content="other session")])],
+    )
+
+    empty_messages = repo.get_messages_by_session_run_ids(
+        "session-1",
+        ("", "   "),
+    )
+    messages = await repo.get_messages_by_session_run_ids_async(
+        "session-1",
+        ("run-1", "run-2", "run-1"),
+    )
+
+    assert empty_messages == []
+    assert [message["trace_id"] for message in messages] == ["run-1"]
+    payload = cast(dict[str, object], messages[0]["message"])
+    parts = cast(list[dict[str, object]], payload["parts"])
+    assert parts[0]["content"] == "query time"
 
 
 def test_message_repo_filters_system_reminders_from_public_message_reads(

--- a/tests/unit_tests/agents/tasks/test_task_repository.py
+++ b/tests/unit_tests/agents/tasks/test_task_repository.py
@@ -9,13 +9,19 @@ from relay_teams.agents.tasks.enums import TaskStatus
 from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
 
 
-def _create_task(repo: TaskRepository, task_id: str = "task-1") -> None:
+def _create_task(
+    repo: TaskRepository,
+    task_id: str = "task-1",
+    *,
+    session_id: str = "session-1",
+    trace_id: str = "run-1",
+) -> None:
     _ = repo.create(
         TaskEnvelope(
             task_id=task_id,
-            session_id="session-1",
+            session_id=session_id,
             parent_task_id=None,
-            trace_id="run-1",
+            trace_id=trace_id,
             objective="demo",
             verification=VerificationPlan(checklist=("non_empty_response",)),
         )
@@ -99,6 +105,29 @@ async def test_async_task_repository_methods_share_persisted_state(
     assert fetched.status == TaskStatus.COMPLETED
     assert fetched.assigned_instance_id == "inst-1"
     assert fetched.result == "done"
+
+
+@pytest.mark.asyncio
+async def test_task_repository_lists_session_run_ids(tmp_path: Path) -> None:
+    repo = TaskRepository(tmp_path / "task_repo_session_run_ids.db")
+    _create_task(repo, "task-run-2", trace_id="run-2")
+    _create_task(repo, "task-run-1", trace_id="run-1")
+    _create_task(repo, "task-other-session", session_id="session-2", trace_id="run-1")
+
+    try:
+        empty_records = repo.list_by_session_run_ids("session-1", ("", "   "))
+        records = await repo.list_by_session_run_ids_async(
+            "session-1",
+            ("run-1", "run-2", "run-1"),
+        )
+    finally:
+        await repo.close_async()
+
+    assert empty_records == ()
+    assert tuple(record.envelope.task_id for record in records) == (
+        "task-run-2",
+        "task-run-1",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/interfaces/server/test_async_call.py
+++ b/tests/unit_tests/interfaces/server/test_async_call.py
@@ -13,6 +13,7 @@ from relay_teams.interfaces.server import async_call
 from relay_teams.interfaces.server.async_call import (
     call_maybe_async,
     call_maybe_async_in_isolated_thread,
+    call_maybe_async_in_network_probe_thread,
     call_maybe_async_in_session_read_thread,
     call_route_work,
     RouteWorkClass,
@@ -181,6 +182,57 @@ async def test_session_read_thread_is_not_blocked_by_default_executor() -> None:
         release_default_worker.set()
         completed = await blocking_task
         assert completed is None
+
+
+@pytest.mark.asyncio
+async def test_network_probe_thread_isolated_from_critical_control(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = ThreadPoolExecutor(max_workers=1)
+    release_worker = threading.Event()
+    worker_started = threading.Event()
+
+    monkeypatch.setitem(
+        async_call._ROUTE_EXECUTORS,
+        RouteWorkClass.CRITICAL_CONTROL,
+        executor,
+    )
+    monkeypatch.setitem(
+        async_call._ROUTE_SEMAPHORES,
+        RouteWorkClass.CRITICAL_CONTROL,
+        asyncio.Semaphore(1),
+    )
+
+    def block_critical_control() -> str:
+        worker_started.set()
+        _ = release_worker.wait(timeout=5.0)
+        return "done"
+
+    blocking_task = asyncio.create_task(
+        call_route_work(
+            RouteWorkClass.CRITICAL_CONTROL,
+            "test.blocking_critical",
+            block_critical_control,
+        )
+    )
+    try:
+        started = await asyncio.to_thread(worker_started.wait, 1.0)
+        assert started is True
+
+        def load_probe_value() -> str:
+            return "probe-ok"
+
+        result = await asyncio.wait_for(
+            call_maybe_async_in_network_probe_thread(
+                "test.network_probe",
+                load_probe_value,
+            ),
+            timeout=1.0,
+        )
+        assert result == "probe-ok"
+    finally:
+        release_worker.set()
+        assert await blocking_task == "done"
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -1115,16 +1115,22 @@ def test_probe_ssh_profile_connectivity_runs_service_call_in_threadpool(
     calls: list[SshProfileConnectivityProbeRequest] = []
 
     async def fake_to_thread(
+        operation: str,
         func: Callable[
             [SshProfileConnectivityProbeRequest],
             SshProfileConnectivityProbeResult,
         ],
         request: SshProfileConnectivityProbeRequest,
     ) -> SshProfileConnectivityProbeResult:
+        assert operation == "ssh.probe_connectivity"
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
+    monkeypatch.setattr(
+        system,
+        "call_maybe_async_in_network_probe_thread",
+        fake_to_thread,
+    )
     client = _create_test_client(_FakeSystemService())
 
     response = client.post(
@@ -2326,16 +2332,22 @@ def test_probe_model_connectivity_runs_service_call_in_threadpool(
     calls: list[ModelConnectivityProbeRequest] = []
 
     async def fake_to_thread(
+        operation: str,
         func: Callable[
             [ModelConnectivityProbeRequest],
             ModelConnectivityProbeResult,
         ],
         request: ModelConnectivityProbeRequest,
     ) -> ModelConnectivityProbeResult:
+        assert operation == "model.probe_connectivity"
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
+    monkeypatch.setattr(
+        system,
+        "call_maybe_async_in_network_probe_thread",
+        fake_to_thread,
+    )
     client = _create_test_client(_FakeSystemService())
 
     response = client.post(
@@ -2373,13 +2385,19 @@ def test_discover_model_catalog_runs_service_call_in_threadpool(
     calls: list[ModelDiscoveryRequest] = []
 
     async def fake_to_thread(
+        operation: str,
         func: Callable[[ModelDiscoveryRequest], ModelDiscoveryResult],
         request: ModelDiscoveryRequest,
     ) -> ModelDiscoveryResult:
+        assert operation == "model.discover_models"
         calls.append(request)
         return func(request)
 
-    monkeypatch.setattr(system, "call_maybe_async", fake_to_thread)
+    monkeypatch.setattr(
+        system,
+        "call_maybe_async_in_network_probe_thread",
+        fake_to_thread,
+    )
     client = _create_test_client(_FakeSystemService())
 
     response = client.post(

--- a/tests/unit_tests/sessions/runs/test_event_log.py
+++ b/tests/unit_tests/sessions/runs/test_event_log.py
@@ -72,6 +72,70 @@ async def test_event_log_async_hot_paths_do_not_reinitialize_schema(
 
 
 @pytest.mark.asyncio
+async def test_event_log_lists_session_run_events_by_type(
+    tmp_path: Path,
+) -> None:
+    event_log = EventLog(tmp_path / "event_log_session_run_event_types.db")
+    run_started_id = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            instance_id="instance-1",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"started": true}',
+        )
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-2",
+            trace_id="run-2",
+            task_id="task-2",
+            instance_id="instance-2",
+            event_type=RunEventType.MODEL_STEP_STARTED,
+            payload_json="{}",
+        )
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-2",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-3",
+            instance_id="instance-3",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json="{}",
+        )
+    )
+
+    try:
+        empty_by_type = event_log.list_by_session_event_types("session-1", ("", "  "))
+        by_type = await event_log.list_by_session_event_types_async(
+            "session-1",
+            (RunEventType.RUN_STARTED.value,),
+        )
+        empty_by_run_and_type = event_log.list_by_session_run_ids_event_types(
+            "session-1",
+            (),
+            (RunEventType.RUN_STARTED.value,),
+        )
+        by_run_and_type = await event_log.list_by_session_run_ids_event_types_async(
+            "session-1",
+            ("run-1", "run-2", "run-1"),
+            (RunEventType.RUN_STARTED.value,),
+        )
+    finally:
+        await event_log.close_async()
+
+    assert empty_by_type == ()
+    assert empty_by_run_and_type == ()
+    assert tuple(row["trace_id"] for row in by_type) == ("run-1",)
+    assert tuple(row["id"] for row in by_run_and_type) == (run_started_id,)
+
+
+@pytest.mark.asyncio
 async def test_event_log_lists_session_events_after_id_and_filters_subagent_runs(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py
+++ b/tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from pydantic import JsonValue
 
 from relay_teams.media import InlineMediaContentPart
 from relay_teams.media import MediaModality
@@ -21,6 +22,7 @@ from relay_teams.sessions.runs.user_question_models import UserQuestionOption
 from relay_teams.sessions.runs.user_question_models import UserQuestionPrompt
 from relay_teams.sessions.runs.user_question_repository import UserQuestionRepository
 from relay_teams.sessions.session_service import SessionService
+from relay_teams.sessions.session_rounds_projection import build_session_timeline_rounds
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.sessions.runs.event_log import EventLog
@@ -239,6 +241,172 @@ def test_session_rounds_timeline_bypasses_full_round_projection(
     assert first.get("run_id") == "run-1"
     assert first.get("intent") == "timeline only"
     assert "coordinator_messages" not in first
+
+
+def test_session_rounds_page_targets_only_visible_run_messages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "rounds_page_targeted_messages.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    task_repo = TaskRepository(db_path)
+    for index in range(3):
+        _ = task_repo.create(
+            TaskEnvelope(
+                task_id=f"task-root-{index}",
+                session_id="session-1",
+                parent_task_id=None,
+                trace_id=f"run-{index}",
+                objective=f"work {index}",
+                verification=VerificationPlan(checklist=("non_empty_response",)),
+            )
+        )
+
+    def fail_full_session_message_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("paged rounds should not load every session message")
+
+    captured_run_ids: list[tuple[str, ...]] = []
+    original_targeted_load = service._message_repo.get_messages_by_session_run_ids
+
+    def capture_targeted_load(
+        session_id: str,
+        run_ids: tuple[str, ...],
+        *,
+        include_cleared: bool = False,
+        include_hidden_from_context: bool = False,
+    ) -> list[dict[str, JsonValue]]:
+        captured_run_ids.append(run_ids)
+        return original_targeted_load(
+            session_id,
+            run_ids,
+            include_cleared=include_cleared,
+            include_hidden_from_context=include_hidden_from_context,
+        )
+
+    monkeypatch.setattr(
+        service._message_repo,
+        "get_messages_by_session",
+        fail_full_session_message_load,
+    )
+    monkeypatch.setattr(
+        service._message_repo,
+        "get_messages_by_session_run_ids",
+        capture_targeted_load,
+    )
+
+    page = service.get_session_rounds("session-1", limit=1)
+    items = page.get("items")
+
+    assert isinstance(items, list)
+    assert len(items) == 1
+    assert page.get("has_more") is True
+    assert captured_run_ids == [(str(items[0].get("run_id") or ""),)]
+
+
+def test_build_session_timeline_rounds_filters_included_run_ids(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "timeline_rounds_included_runs.db"
+    task_repo = TaskRepository(db_path)
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id="task-root-1",
+            session_id="session-1",
+            parent_task_id=None,
+            trace_id="run-1",
+            objective="first run",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id="task-root-2",
+            session_id="session-1",
+            parent_task_id=None,
+            trace_id="run-2",
+            objective="second run",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+
+    rounds = build_session_timeline_rounds(
+        session_id="session-1",
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=RunRuntimeRepository(db_path),
+        get_session_user_messages=lambda _session_id: [],
+        included_run_ids={"run-2"},
+    )
+
+    assert [round_item["run_id"] for round_item in rounds] == ["run-2"]
+
+
+def test_round_projection_events_return_empty_without_event_log(tmp_path: Path) -> None:
+    service = _build_service(tmp_path / "round_events_without_log.db")
+    service._event_log = None
+
+    assert service._get_round_projection_events("session-1") == []
+    assert service._get_round_projection_events_for_runs("session-1", ("run-1",)) == []
+
+
+def test_get_session_rounds_returns_empty_page_without_timeline_items(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path / "rounds_empty_page.db")
+
+    page = service.get_session_rounds("session-1")
+
+    assert page.get("items") == []
+
+
+def test_get_session_rounds_keeps_page_when_timeline_items_have_no_run_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _build_service(tmp_path / "rounds_page_without_run_ids.db")
+    page_items: list[dict[str, object]] = [{"intent": "missing run id"}]
+
+    def timeline_without_run_ids(_session_id: str) -> list[dict[str, object]]:
+        return list(page_items)
+
+    monkeypatch.setattr(
+        service,
+        "build_session_timeline_rounds",
+        timeline_without_run_ids,
+    )
+
+    page = service.get_session_rounds("session-1")
+
+    assert page.get("items") == page_items
+
+
+def test_get_session_rounds_skips_timeline_items_missing_full_rounds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _build_service(tmp_path / "rounds_missing_full_round.db")
+
+    def timeline_rounds(_session_id: str) -> list[dict[str, object]]:
+        return [{"run_id": "run-1", "intent": "missing full round"}]
+
+    def no_full_rounds(
+        _session_id: str,
+        *,
+        included_run_ids: set[str] | None = None,
+        include_history_markers: bool = True,
+    ) -> list[dict[str, object]]:
+        assert included_run_ids == {"run-1"}
+        assert include_history_markers is False
+        return []
+
+    monkeypatch.setattr(service, "build_session_timeline_rounds", timeline_rounds)
+    monkeypatch.setattr(service, "build_session_rounds", no_full_rounds)
+
+    page = service.get_session_rounds("session-1")
+
+    assert page.get("items") == []
 
 
 def test_session_rounds_timeline_applies_runtime_phase_and_todo_overlay(


### PR DESCRIPTION
## Summary
- page session rounds by lightweight timeline first, then load full details only for visible run ids
- add targeted message/task/event queries with supporting SQLite indexes
- isolate model/SSH probe and discovery work into a dedicated network_probe route worker lane
- add API and real-browser pressure coverage for concurrent tool calls and backend status responsiveness

## Tests
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests/interfaces/server/test_async_call.py tests/unit_tests/interfaces/server/test_system_router.py tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py tests/unit_tests/persistence/test_sqlite_write_inventory.py::test_sqlite_repository_public_methods_have_async_interfaces
- uv run --extra dev pytest -q tests/integration_tests/api/test_session_http_pressure.py tests/integration_tests/api/test_session_tool_call_pressure.py
- uv run --extra dev pytest -q tests/integration_tests/browser/test_backend_status_pressure.py

Closes #567