### PR TITLE
Add CodeAgent dual auth flow

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -78,37 +78,6 @@ Response fields:
 Notes:
 - Health stays `200 ok` for a reachable server even when builtin roles or local
   tools are degraded; inspect the `*_sanity` fields for diagnosis.
-- This endpoint is a diagnostic/readiness contract. UI liveness should use the
-  control-plane endpoints below so high task or tool concurrency cannot make the
-  browser misclassify a busy server as offline.
-
-### `GET /system/live`
-
-Returns a lightweight liveness payload from the main API process:
-
-- `status`: `alive`
-- `version`
-- `pid`
-- `uptime_seconds`
-- `main_base_url`
-
-This route intentionally avoids registry, filesystem, provider, and tool checks.
-
-### `GET /system/control-plane`
-
-Returns the out-of-band liveness endpoint published by `relay-teams server start`.
-
-Response fields:
-- `enabled`
-- `live_url`
-- `host`
-- `port`
-- `main_base_url`
-
-When `enabled` is true, `live_url` points at the sidecar control-plane HTTP
-server. The browser status indicator probes that endpoint first. If the sidecar
-is alive but the main API liveness probe times out, the UI reports the backend as
-busy rather than offline.
 
 ### `GET /system/commands`
 
@@ -214,7 +183,7 @@ The response body is a root object whose keys are profile ids and whose values u
 Returns normalized model profiles.
 Each profile includes `has_api_key`, the currently stored `api_key` value so the web UI can mask it by default and reveal it on demand, `headers[]` for additional request headers, `is_default` to mark the runtime default profile, optional `context_window` for next-send context preview UI, optional `fallback_policy_id` to bind that profile to a fallback policy, `fallback_priority` to rank it as a fallback candidate, structured `capabilities.input/output.*`, and a derived `input_modalities[]` compatibility field so the UI can label profiles that accept direct media input.
 Profiles created from the shared model directory may also include optional `catalog_provider_id`, `catalog_provider_name`, and `catalog_model_name` metadata. These fields are descriptive and do not change provider transport selection.
-`provider` currently supports `openai_compatible`, `bigmodel`, `minimax`, `maas`, and the internal/testing-only `echo`. MAAS profiles also return `maas_auth` with `username` and `has_password` so the web UI can preserve the stored password without echoing it back. The MAAS login endpoint and `app-id` are fixed by the backend.
+`provider` currently supports `openai_compatible`, `bigmodel`, `minimax`, `maas`, `codeagent`, and the internal/testing-only `echo`. MAAS profiles return `maas_auth` with `username` and `has_password` so the web UI can preserve the stored password without echoing it back. CodeAgent profiles return `codeagent_auth`; `auth_method = "sso"` exposes `has_access_token` and `has_refresh_token`, while `auth_method = "password"` exposes `username` and `has_password`. The MaaS login endpoint and `app-id`, and the CodeAgent OAuth/login endpoints and inference base URL, are fixed by the backend.
 When no profile is explicitly marked default, the backend resolves the default in this order: a profile named `default`, the only configured profile, then the first profile by name.
 
 ### `GET /system/configs/model/catalog`
@@ -247,15 +216,16 @@ Selecting a catalog model in the UI only pre-fills the add-profile editor; persi
 Upserts a model profile.
 Request body may include optional `source_name` to rename an existing profile while preserving its stored API key and secret headers when `api_key` and `headers` are omitted.
 If `source_name` does not exist, the backend returns `404`. Profile-level semantic validation failures that occur after request parsing, such as invalid secret-header state or missing MAAS password on first configuration, return `400`.
-`provider` accepts `openai_compatible`, `bigmodel`, `minimax`, `maas`, and `echo`.
+`provider` accepts `openai_compatible`, `bigmodel`, `minimax`, `maas`, `codeagent`, and `echo`.
 Profiles may also include optional `ssl_verify` to override the global outbound TLS verification default for that model only.
 Profiles may include `is_default` to promote that profile to the runtime default; saving one default clears the flag from all others.
 Profiles may include optional `context_window` to declare the total model context limit separately from `max_tokens`, which remains the output-token cap when explicitly set. If `max_tokens` is omitted, the backend preserves that unset state and lets the provider decide the default output cap for primary LLM requests.
 Profiles may include optional `fallback_policy_id` to enable quota/rate-limit fallback for that profile. The referenced policy id must exist in `model-fallback.json`. Profiles may also include `fallback_priority`; higher values are preferred when the profile is selected as a fallback candidate.
 Profiles may include optional `catalog_provider_id`, `catalog_provider_name`, and `catalog_model_name` metadata when the UI prefilled the draft from `GET /system/configs/model/catalog`.
 Profiles may include `headers[]`, where each item has `name`, optional `value`, optional `secret`, and optional `configured`.
-Profiles must provide at least one auth source: `api_key`, one configured header, or `maas_auth` for `provider = "maas"`.
-When `provider = "maas"`, `maas_auth` must include `username`; `password` is accepted on write but persisted only in the unified secret store. The backend always authenticates against `http://rnd-idea-api.huawei.com/ideaclientservice/login/v4/secureLogin`, always sends `app-id: RelayTeams`, and always uses `http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/` as the MAAS inference base URL. When `context_window` is omitted and the backend recognizes the provider/model pair, it may auto-fill a known context limit during save and runtime load.
+Profiles must provide at least one auth source: `api_key`, one configured header, `maas_auth` for `provider = "maas"`, or `codeagent_auth` for `provider = "codeagent"`.
+When `provider = "maas"`, `maas_auth` must include `username`; `password` is accepted on write but persisted only in the unified secret store. The backend always authenticates against `http://rnd-idea-api.huawei.com/ideaclientservice/login/v4/secureLogin`, always sends `app-id: RelayTeams`, and always uses `http://snapengine.cida.cce.prod-szv-g.dragon.tools.huawei.com/api/v2/` as the MAAS inference base URL.
+When `provider = "codeagent"`, `codeagent_auth.auth_method` must be either `sso` or `password`. `sso` accepts the saved-token flags plus an optional `oauth_session_id`; the backend persists the resulting CodeAgent tokens in the unified secret store. `password` accepts `username` and `password`; `username` remains in the profile, while `password` is persisted only in the unified secret store. CodeAgent password login reuses the MaaS secure-login endpoint and request/response contract, but it remains a CodeAgent-only auth flow under `codeagent_auth`. The backend always uses `https://codeagentcli.rnd.huawei.com/codeAgentPro` as the CodeAgent inference base URL. When `context_window` is omitted and the backend recognizes the provider/model pair, it may auto-fill a known context limit during save and runtime load.
 
 ### `GET /system/configs/model-fallback`
 
@@ -293,16 +263,16 @@ Unknown profile fields and invalid profile ids are rejected at request validatio
 
 Tests model connectivity for a saved profile and/or draft override.
 Draft overrides may include optional `ssl_verify`; effective TLS verification resolves as `override.ssl_verify` -> global `SSL_VERIFY` -> default `false`.
-Draft overrides may include `headers[]` and may omit `api_key` when headers are provided. MAAS draft overrides use `maas_auth` instead of `api_key` and perform a login before probing `/chat/completions`.
+Draft overrides may include `headers[]` and may omit `api_key` when headers are provided. MAAS draft overrides use `maas_auth` instead of `api_key` and perform a login before probing `/chat/completions`. CodeAgent draft overrides use `codeagent_auth`; `sso` reuses the saved OAuth session/tokens, while `password` logs in with username/password before probing.
 If `timeout_ms` is omitted, the backend uses the resolved profile `connect_timeout_seconds` value, or `15s` when no saved profile is involved.
 
 ### `POST /system/configs/model:discover`
 
 Fetches the available model catalog for a saved profile and/or draft override.
-Draft overrides may omit `model`, but must provide `base_url` and `api_key` or `headers` when `profile_name` is omitted. For `provider = "maas"`, the override must provide `base_url` and `maas_auth`.
+Draft overrides may omit `model`, but must provide `base_url` and `api_key` or `headers` when `profile_name` is omitted. For `provider = "maas"`, the override must provide `base_url` and `maas_auth`. For `provider = "codeagent"`, the override must provide `codeagent_auth`; the backend still forces the fixed CodeAgent base URL.
 When `profile_name` is provided, the request may override `base_url`, `api_key`, `headers`, and `ssl_verify` while reusing the saved credentials for any omitted fields.
 If `timeout_ms` is omitted, the backend uses the resolved profile `connect_timeout_seconds` value, or `15s` when no saved profile is involved.
-`openai_compatible`, `bigmodel`, and `minimax` map this call to `GET {base_url}/models` and return the normalized `models` list sorted and deduplicated. `maas` maps this call to the fixed PromptCenter discovery endpoint after MAAS login, using the returned `X-Auth-Token` plus department info from `userInfo` to build the discovery request payload.
+`openai_compatible`, `bigmodel`, and `minimax` map this call to `GET {base_url}/models` and return the normalized `models` list sorted and deduplicated. `maas` maps this call to the fixed PromptCenter discovery endpoint after MAAS login, using the returned `X-Auth-Token` plus department info from `userInfo` to build the discovery request payload. `codeagent` resolves a CodeAgent token through either saved SSO credentials or username/password login, then calls the fixed CodeAgent model-discovery endpoint.
 For `maas`, the backend merges model ids from top-level `user_model_list` and nested `plugin_config[].config` payloads, filters invalid ids, then returns sorted deduplicated ids in `models[]` and `model_entries[]`.
 When the provider exposes per-model context-limit metadata in the catalog payload, the response also includes `model_entries[]` with:
 - `model`
@@ -315,9 +285,9 @@ For a small set of known provider/model pairs, the backend also applies a built-
 
 ### `POST /system/configs/model/codeagent/auth:verify`
 
-Verifies whether a saved CodeAgent profile still has a usable SSO session.
+Verifies whether a saved CodeAgent profile still has usable auth state.
 The request body is `{ "profile_name": "<saved profile name>" }`.
-The backend only accepts saved `codeagent` profiles for this endpoint. It validates the saved session by making a lightweight authenticated CodeAgent request with the currently available token, and only forces a refresh when the first authenticated request comes back `401/403`.
+The backend only accepts saved `codeagent` profiles for this endpoint. It validates the saved auth state by making a lightweight authenticated CodeAgent request with the currently available token. For SSO profiles it retries once through the refresh path after `401/403`. For password profiles it retries once by logging in again with the saved username/password.
 
 The response shape is:
 
@@ -325,7 +295,7 @@ The response shape is:
 - `checked_at`
 - optional `detail`
 
-`reauth_required` means the saved session can no longer complete an authenticated CodeAgent request, including one retry through the refresh path, and the user must sign in again. The persisted `codeagent_auth.has_refresh_token` flag still means saved credentials exist; it does not mean the current session has already been verified.
+`reauth_required` means the saved CodeAgent credentials can no longer complete an authenticated CodeAgent request, including one retry through refresh or password re-login, and the user must authenticate again. The persisted `codeagent_auth.has_refresh_token` or `codeagent_auth.has_password` flags still mean saved credentials exist; they do not mean the current auth state has already been verified.
 
 ### `POST /system/configs/model:reload`
 
@@ -890,8 +860,6 @@ Notes:
 
 Lists sessions.
 
-Each item uses the same `SessionRecord` response shape as `GET /sessions/{session_id}`.
-
 ### `GET /sessions/{session_id}`
 
 Gets one session.
@@ -902,13 +870,6 @@ Response fields also include:
 - `orchestration_preset_id`
 - `started_at`
 - `can_switch_mode`
-- `last_viewed_terminal_run_id`
-- `latest_terminal_run_id`
-- `latest_terminal_run_status`
-- `latest_terminal_run_updated_at`
-- `has_unread_terminal_run`
-
-`latest_terminal_run_*` projects the most recent top-level run whose status is `completed`, `failed`, or `stopped`. `has_unread_terminal_run` is `true` when that run is newer than the last terminal run the user has viewed.
 
 ### `PATCH /sessions/{session_id}`
 
@@ -936,18 +897,6 @@ Rules:
 - `custom_metadata` replaces only the caller-managed custom metadata subset. System-managed metadata keys remain intact.
 - `custom_metadata` keys must be non-empty and cannot overwrite reserved keys such as `title`, `title_source`, `source_label`, `source_icon`, `source_kind`, `source_provider`, or any key with the `feishu_` prefix.
 - `custom_metadata` values must be non-empty strings.
-
-### `POST /sessions/{session_id}/terminal-view`
-
-Marks the latest terminal top-level run for a session as viewed.
-
-Response:
-
-```json
-{"status": "ok"}
-```
-
-If the session has no terminal top-level run yet, the endpoint is a no-op. Missing sessions return `404`.
 
 ### `PATCH /sessions/{session_id}/topology`
 
@@ -1205,16 +1154,6 @@ Response fields include:
 - `reflection_updated_at`
 - `runtime_system_prompt`
 - `runtime_tools_json`
-
-### `GET /sessions/{session_id}/subagents/events`
-
-Streams persisted and live normal-mode subagent run events for a session through SSE.
-
-Notes:
-- The stream is session-scoped and includes only synthetic `subagent_run_*` run events.
-- Clients may pass `after_event_id` to replay events after a known persisted event id before receiving live events.
-- One session-level connection replaces one EventSource per subagent run, so sidebar and subagent views should use this endpoint to avoid request fan-out when a session has many child runs.
-- Event payloads use the same run-event JSON shape as `/api/runs/{run_id}/events`.
 
 ### `DELETE /sessions/{session_id}/subagents/{instance_id}`
 
@@ -2451,52 +2390,11 @@ Response:
 
 ### `GET /mcp/servers`
 
-Lists effective MCP servers from app scope, including disabled servers for
-management views.
-
-### `POST /mcp/servers`
-
-Adds an app-scoped MCP server and reloads the runtime registry.
-
-Request:
-```json
-{
-  "name": "filesystem",
-  "config": {
-    "transport": "stdio",
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-filesystem"]
-  },
-  "overwrite": false
-}
-```
-
-The backend also accepts opencode-style local/remote config shapes, including
-`{"type": "local", "command": ["npx", "-y", "package"]}` and
-`{"type": "remote", "url": "https://example.com/mcp"}`.
-
-### `PUT /mcp/servers/{server_name}/enabled`
-
-Enables or disables an app-scoped MCP server without deleting its config, then
-reloads the runtime registry. Disabled servers remain visible in management APIs
-but are not expanded by `*` role bindings or injected as runtime MCP tools.
-
-Request:
-```json
-{
-  "enabled": false
-}
-```
+Lists effective MCP servers from app scope.
 
 ### `GET /mcp/servers/{server_name}/tools`
 
 Lists tools exposed by one MCP server. Returned tool names are the effective callable names registered at runtime in the form `<server_name>_<tool_name>` so tools from different MCP servers cannot collide.
-
-### `POST /mcp/servers/{server_name}/test`
-
-Connects to one MCP server, lists its tools, and returns `{ "ok": true }` with
-tool metadata on success or `{ "ok": false, "error": "..." }` on connection
-failure.
 
 ## Gateway APIs
 
@@ -2921,6 +2819,3 @@ Returns sessions generated for one automation project.
 `GET /sessions` and `GET /sessions/{session_id}` now also include:
 - `project_kind`: `workspace` or `automation`
 - `project_id`: workspace id or automation project id used by the sidebar grouping logic
-- `latest_terminal_run_id`, `latest_terminal_run_status`, and `latest_terminal_run_updated_at`: latest terminal top-level run projection
-- `last_viewed_terminal_run_id`: last terminal top-level run opened by the user
-- `has_unread_terminal_run`: whether the latest terminal top-level run has not been viewed

--- a/docs/codeagent-provider-design.md
+++ b/docs/codeagent-provider-design.md
@@ -1,15 +1,22 @@
-# CodeAgent Provider 设计
+# CodeAgent Provider Design
 
-CodeAgent 已作为一等模型提供商注册，`provider` 值为 `"codeagent"`。
-它沿用常规模型配置中的模型名和采样参数，并通过 `codeagent_auth`
-保存 SSO 登录后得到的认证状态。CodeAgent 的 API 端点和 OAuth 应用参数
-均由代码写死，不对用户暴露配置入口。
+## Overview
 
-## 常量
+CodeAgent is a first-class model provider with `provider = "codeagent"`.
+Its inference endpoint, OAuth client parameters, and password-login endpoint are fixed by the backend.
+The user does not configure a separate CodeAgent login URL.
 
-后端在 `relay_teams.providers.model_config` 中维护以下常量：
+CodeAgent profile auth always lives under `codeagent_auth`.
+There are two supported auth modes:
 
-| 名称 | 值 |
+- `sso`: CodeAgent OAuth / refresh-token flow
+- `password`: username/password login that reuses the MaaS secure-login endpoint and payload contract
+
+## Fixed Endpoints And OAuth Constants
+
+The backend enforces these constants:
+
+| Name | Value |
 | --- | --- |
 | `DEFAULT_CODEAGENT_BASE_URL` | `https://codeagentcli.rnd.huawei.com/codeAgentPro` |
 | `DEFAULT_CODEAGENT_SSO_BASE_URL` | `https://ssoproxysvr.cd-cloud-ssoproxysvr.szv.dragon.tools.huawei.com/ssoproxysvr` |
@@ -17,61 +24,56 @@ CodeAgent 已作为一等模型提供商注册，`provider` 值为 `"codeagent"`
 | `DEFAULT_CODEAGENT_SCOPE` | `1000:1002` |
 | `DEFAULT_CODEAGENT_SCOPE_RESOURCE` | `devuc` |
 
-`ModelEndpointConfig` 会强制 CodeAgent 配置使用
-`DEFAULT_CODEAGENT_BASE_URL`。`CodeAgentAuthConfig` 也会强制覆盖
-`client_id`、`scope` 和 `scope_resource`，即使调用方提交了其他值也不会生效。
+`ModelEndpointConfig` always rewrites CodeAgent `base_url` to `DEFAULT_CODEAGENT_BASE_URL`.
+`CodeAgentAuthConfig` also enforces the fixed OAuth client values even if callers submit different ones.
 
-## OAuth 流程
+For password auth, the backend reuses the MaaS secure-login endpoint and request/response shape:
 
-CodeAgent 使用 issue #461 描述的 `client_code` OAuth 轮询流程。前端通过以下
-接口启动和查询登录：
+- `POST http://rnd-idea-api.huawei.com/ideaclientservice/login/v4/secureLogin`
+- request headers include `app-id: RelayTeams`
+
+The returned token is then used as the CodeAgent `X-Auth-Token`.
+
+## Auth Modes
+
+### SSO Mode
+
+`codeagent_auth.auth_method = "sso"` uses the existing OAuth flow:
 
 - `POST /api/system/configs/model/codeagent/oauth:start`
 - `GET /api/system/configs/model/codeagent/oauth/{auth_session_id}`
 
-本地回调路由已删除。SSO 完成后，前端只轮询
-`GET /api/system/configs/model/codeagent/oauth/{auth_session_id}`，后端在该接口中向
-CodeAgent `getToken` 接口查询 token 状态。
+The frontend starts OAuth, opens the returned authorization URL, and polls for completion.
+Completed OAuth sessions yield CodeAgent `access_token` and `refresh_token`.
 
-启动接口不接收用户提供的 provider 配置。后端会生成 32 位 `client_code`，
-并构造：
+At runtime:
 
-- 回调地址：
-  `https://codeagentcli.rnd.huawei.com/codeAgentPro/codeAgent/oauth/callback?client_code={client_code}`
-- 授权地址：
-  `https://ssoproxysvr.cd-cloud-ssoproxysvr.szv.dragon.tools.huawei.com/ssoproxysvr/oauth2/authorize`
+- the current `access_token` is used first when present
+- `401` or `403` triggers one refresh attempt through `refresh_token`
+- refreshed tokens are persisted back to the secret store
 
-授权地址查询参数如下：
+### Password Mode
 
-| 参数 | 值 |
-| --- | --- |
-| `client_id` | `com.huawei.devmind.codebot.apibot` |
-| `redirect_uri` | 上面的回调地址 |
-| `scope` | `1000:1002` |
-| `response_type` | `code` |
-| `scope_resource` | `devuc` |
+`codeagent_auth.auth_method = "password"` requires:
 
-前端打开授权地址后，会轮询登录状态接口。每次状态查询会由后端向 CodeAgent
-轮询 token：
+- `username`
+- `password`
 
-- `POST https://codeagentcli.rnd.huawei.com/codeAgentPro/codeAgent/oauth/getToken`
-- 请求头：`Content-Type: application/json`
-- 请求体：
+The login exchange does not use OAuth sessions or refresh tokens.
+Instead, the CodeAgent token service logs in with the MaaS-compatible secure-login API and caches the returned token for a short TTL.
 
-```json
-{
-  "clientCode": "{client_code}",
-  "redirectUrl": "https://codeagentcli.rnd.huawei.com/codeAgentPro/codeAgent/oauth/callback?client_code={client_code}"
-}
-```
+At runtime:
 
-如果 CodeAgent 尚未返回 `access_token`，会话保持 pending。CodeAgent 返回
-`access_token` 和 `refresh_token` 后，内存中的 OAuth 会话会被标记为完成。
-前端最长轮询 30 分钟。
+- if no cached token is available, the provider logs in with the saved username/password
+- if a CodeAgent request returns `401` or `403`, the provider logs in again and retries once
+- password-mode tokens are not persisted as refreshable CodeAgent credentials
 
-## 配置存储
+## Persisted Profile Shape
 
-保存后的 profile JSON 不包含明文 token，只保存能力标记和 OAuth 状态信息：
+Saved CodeAgent profiles keep auth state in `codeagent_auth`.
+The backend never stores raw CodeAgent password credentials or OAuth tokens in `model.json`.
+
+### Stored SSO Profile
 
 ```json
 {
@@ -79,107 +81,127 @@ CodeAgent `getToken` 接口查询 token 状态。
   "model": "codeagent-chat",
   "base_url": "https://codeagentcli.rnd.huawei.com/codeAgentPro",
   "codeagent_auth": {
+    "auth_method": "sso",
     "has_access_token": true,
     "has_refresh_token": true
   }
 }
 ```
 
-保存 CodeAgent profile 时，服务端会消费已完成的 OAuth 会话，并把 token 写入
-secret store。运行时配置会从 secret store 解析 token，再注入到
-`codeagent_auth` 中用于构建 provider client。
+### Stored Password Profile
 
-## Token 使用
+```json
+{
+  "provider": "codeagent",
+  "model": "codeagent-chat",
+  "base_url": "https://codeagentcli.rnd.huawei.com/codeAgentPro",
+  "codeagent_auth": {
+    "auth_method": "password",
+    "username": "relay-user",
+    "has_password": true
+  }
+}
+```
 
-CodeAgent API 使用 `X-Auth-Token` 认证。
+Persistence rules:
 
-SSO 完成后的首个请求会直接使用 OAuth 返回的 `access_token`。如果运行时配置中
-同时存在 `access_token` 和 `refresh_token`，token service 会先用该
-`access_token` 初始化缓存，不会立刻调用 refresh 接口。
+- SSO `access_token` and `refresh_token` are stored in the unified secret store.
+- Password-mode `password` is stored in the unified secret store.
+- Password-mode `username` stays in the profile JSON.
+- Editing a saved password profile with an empty password field preserves the stored password secret.
+- Switching from SSO to password removes saved SSO tokens.
+- Switching from password to SSO removes the saved password secret.
 
-当请求返回 `401` 或 `403` 时，provider 会调用 refresh 接口刷新一次 token：
+## Runtime Config Resolution
 
-- `POST https://codeagentcli.rnd.huawei.com/codeAgentPro/codeAgent/oauth/refreshToken`
+Runtime profile loading resolves `codeagent_auth` differently by mode:
 
-随后使用刷新后的 access token 重试原请求。
+- `sso`: requires a saved `refresh_token` or an in-progress `oauth_session_id`
+- `password`: requires `username` plus a password from the secret store or inline override
 
-## API 传输
+This keeps `codeagent_auth` as the single CodeAgent auth contract.
+CodeAgent does not reuse top-level `maas_auth`.
 
-CodeAgent chat 请求保留 OpenAI-compatible 的请求体和流式语义，但实际 URL 会被
-重写为：
+## Model Discovery And Chat Requests
 
-- `POST https://codeagentcli.rnd.huawei.com/codeAgentPro/chat/completions`
+CodeAgent model discovery and chat requests use the same provider auth resolver as save-time verification and runtime execution.
 
-chat 请求必需请求头：
+### Model Discovery
 
-| Header | 值 |
+- `GET {DEFAULT_CODEAGENT_BASE_URL}/chat/modles?checkUserPermission=TRUE`
+
+Required request headers:
+
+| Header | Value |
 | --- | --- |
-| `X-Auth-Token` | 当前 OAuth access token |
+| `X-Auth-Token` | resolved CodeAgent token |
+| `app-id` | `CodeAgent2.0` |
+| `User-Agent` | `AgentKernel/1.0` |
+| `gray` | `false` |
+| `oc-heartbeat` | `1` |
+| `X-snap-traceid` | generated UUID |
+| `X-session-id` | generated `ses_...` id |
+
+The discovery parser accepts a bare JSON list or objects with `data` / `models`.
+Model ids are normalized from `name`, `id`, or `model` and deduplicated.
+
+### Chat
+
+- `POST {DEFAULT_CODEAGENT_BASE_URL}/chat/completions`
+
+Required request headers:
+
+| Header | Value |
+| --- | --- |
+| `X-Auth-Token` | resolved CodeAgent token |
 | `app-id` | `CodeAgent2.0` |
 | `Content-Type` | `application/json` |
 | `Accept` | `text/event-stream` |
 | `User-Agent` | `AgentKernel/1.0` |
 | `gray` | `false` |
 | `oc-heartbeat` | `1` |
-| `X-snap-traceid` | 生成的 UUID |
-| `X-session-id` | `ses_` 加生成 UUID 去连字符后的前 20 位 |
+| `X-snap-traceid` | generated UUID |
+| `X-session-id` | generated `ses_...` id |
 
-请求认证层会先移除 OpenAI SDK 请求中已有的 `Authorization`、`X-Auth-Token`
-以及 CodeAgent 专用请求头，再注入上表中的值。
+The provider strips any preexisting OpenAI `Authorization`, `X-Auth-Token`, and CodeAgent-specific headers before injecting the resolved CodeAgent headers.
 
-模型发现使用：
+## Frontend Behavior
 
-- `GET https://codeagentcli.rnd.huawei.com/codeAgentPro/chat/modles?checkUserPermission=TRUE`
+When the user selects `codeagent` in Settings:
 
-模型发现必需请求头：
+- the UI hides API-key auth
+- the UI shows an auth-method selector
+- `sso` shows the existing SSO button and status
+- `password` shows username and password inputs
 
-| Header | 值 |
-| --- | --- |
-| `X-Auth-Token` | 当前 OAuth access token |
-| `app-id` | `CodeAgent2.0` |
-| `User-Agent` | `AgentKernel/1.0` |
-| `gray` | `false` |
-| `oc-heartbeat` | `1` |
-| `X-snap-traceid` | 生成的 UUID |
-| `X-session-id` | `ses_` 加生成 UUID 去连字符后的前 20 位 |
+The draft flow is:
 
-模型发现解析器支持 JSON 数组，也支持带 `data` 或 `models` 字段的包装对象。
-模型 ID 会从 `name`、`id` 或 `model` 字段读取，并进行去重。
+1. select `CodeAgent`
+2. choose `SSO` or `Username and Password`
+3. either complete SSO or enter username/password
+4. fetch the model list using the resolved CodeAgent token
 
-## 前端行为
+For saved password profiles, the password field remains masked by default and the UI preserves the stored secret unless the user enters a new password.
 
-当用户选择 `codeagent` provider 时，设置页会隐藏 API Key 和 Base URL 输入框，
-改为显示 CodeAgent SSO 控件。前端向 OAuth 启动接口发送空请求体，所有
-CodeAgent OAuth 和 API 参数均由后端硬编码值决定。
+## Auth Verification API
 
-前端在准备 profile payload 时也会使用硬编码的 CodeAgent base URL，用户输入的
-端点值不会覆盖后端常量。
-
-## 验证
-
-当前已做的聚焦检查：
-
-- `node --check frontend\dist\js\components\settings\modelProfiles.js`
-- `.venv\Scripts\ruff.exe check` 检查 CodeAgent provider 和相关测试
-- CodeAgent 单元测试覆盖 OAuth、token 缓存初始化、模型发现和 chat probe 行为
-- 使用 DevTools 验证选择 `codeagent` 后会打开 SSO URL，且 URL 中包含硬编码
-  client ID、scope、scope resource 和带 `client_code` 的回调地址
-
-外部 CodeAgent 网络连通性依赖运行环境，因此浏览器验证只要求前端流程和本地 API
-请求/响应结构正确。
-
-## 持久化登录态与校验
-
-保存后的 `codeagent_auth.has_refresh_token` 仅表示本地已保存过 CodeAgent SSO 凭据，不表示当前登录态已经过实时校验。
-
-设置页编辑已保存的 CodeAgent profile 时，前端会调用：
+The settings page uses:
 
 - `POST /api/system/configs/model/codeagent/auth:verify`
 
-该接口只接受已保存的 CodeAgent profile 名称，并强制执行一次 refresh 校验：
+The request body only includes the saved profile name.
+The backend validates the saved CodeAgent auth state for either mode:
 
-- `status = "valid"`：refresh 仍可用，可显示为已登录
-- `status = "reauth_required"`：refresh 已被上游拒绝，需要重新 SSO 登录
-- `status = "error"`：网络或上游异常，无法确认当前登录状态
+- `status = "valid"`: the profile can still obtain or use a CodeAgent token
+- `status = "reauth_required"`: SSO refresh failed or password re-login failed with an auth-invalid result
+- `status = "error"`: transport or upstream failure prevented verification
 
-运行时 chat / model discovery 仍保持原有的按需 refresh 机制；新增接口只用于设置页区分“保存过凭据”和“当前鉴权已验证”这两个状态。
+This endpoint distinguishes “saved credentials exist” from “the credentials were verified successfully right now”.
+
+## Validation Notes
+
+- CodeAgent profiles always require `codeagent_auth`.
+- `sso` mode requires a saved refresh path or OAuth session id.
+- `password` mode requires `username` and `password` for new drafts.
+- The backend always forces the default CodeAgent inference base URL.
+- Password login is a CodeAgent-only auth mode even though it reuses the MaaS login endpoint.

--- a/frontend/dist/css/components/settings.css
+++ b/frontend/dist/css/components/settings.css
@@ -2373,13 +2373,39 @@
     margin-bottom: 0;
 }
 
+.profile-maas-credentials-row {
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+}
+
 .profile-codeagent-credentials-row {
-    grid-template-columns: minmax(0, 1fr);
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
     gap: 0.85rem;
 }
 
+.profile-codeagent-auth-method-row {
+    width: 100%;
+    max-width: 16rem;
+}
+
+.profile-codeagent-auth-method-row select {
+    width: min(100%, 14rem);
+}
+
+.profile-codeagent-auth-detail-row {
+    display: grid;
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    align-items: start;
+}
+
 .profile-codeagent-sso-group {
-    max-width: 560px;
+    grid-column: 1 / -1;
+    max-width: none;
 }
 
 .codeagent-sso-control {
@@ -2392,7 +2418,9 @@
     min-width: 0;
     min-height: 42px;
     max-width: 100%;
-    white-space: nowrap;
+    white-space: normal;
+    line-height: 1.35;
+    text-align: left;
 }
 
 .codeagent-sso-login-btn:disabled {
@@ -2402,7 +2430,7 @@
 
 .codeagent-sso-status-message {
     margin-top: 0.55rem;
-    max-width: 560px;
+    max-width: none;
 }
 
 .profile-editor-subsection {
@@ -3432,6 +3460,9 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
 
 .settings-list-action.codeagent-sso-login-btn {
     min-height: 42px;
+    width: fit-content;
+    max-width: 100%;
+    padding: 0.5rem 0.75rem;
 }
 
 .settings-list-action:hover {
@@ -3577,6 +3608,19 @@ body.dark-theme .notification-toggle input[type="checkbox"]:checked + .notificat
     }
 
     .profile-credentials-row {
+        grid-template-columns: 1fr;
+    }
+
+    .profile-codeagent-auth-method-row {
+        max-width: none;
+    }
+
+    .profile-codeagent-auth-method-row select,
+    .profile-codeagent-auth-detail-row {
+        width: 100%;
+    }
+
+    .profile-codeagent-auth-detail-row {
         grid-template-columns: 1fr;
     }
 

--- a/frontend/dist/js/components/settings/modelProfiles.js
+++ b/frontend/dist/js/components/settings/modelProfiles.js
@@ -30,6 +30,7 @@ let draftDiscoveredModels = [];
 let draftModelDiscoveryState = null;
 let draftApiKeyState = createDraftSecretState();
 let draftMaasPasswordState = createDraftSecretState();
+let draftCodeAgentPasswordState = createDraftSecretState();
 let draftCatalogSelection = null;
 let modelCatalogProviders = [];
 let selectedCatalogProviderId = '';
@@ -65,6 +66,10 @@ const PROVIDER_MODES = {
     MAAS: 'maas',
     CODEAGENT: 'codeagent',
     CUSTOM: 'custom',
+};
+const CODEAGENT_AUTH_METHODS = {
+    SSO: 'sso',
+    PASSWORD: 'password',
 };
 const FALLBACK_POLICY_TRANSLATION_KEYS = {
     same_provider_then_other_provider: 'settings.model.fallback_policy_same_provider_then_other_provider',
@@ -176,6 +181,25 @@ export function bindModelProfileHandlers() {
         codeagentLoginBtn.onclick = handleCodeAgentLogin;
     }
 
+    const codeagentAuthMethodInput = document.getElementById('profile-codeagent-auth-method');
+    if (codeagentAuthMethodInput) {
+        codeagentAuthMethodInput.onchange = handleDraftCodeAgentAuthMethodChanged;
+    }
+
+    const codeagentUsernameInput = document.getElementById('profile-codeagent-username');
+    if (codeagentUsernameInput) {
+        codeagentUsernameInput.oninput = handleDraftEndpointChanged;
+    }
+
+    const codeagentPasswordInput = document.getElementById('profile-codeagent-password');
+    if (codeagentPasswordInput) {
+        codeagentPasswordInput.oninput = handleDraftCodeAgentPasswordInput;
+        codeagentPasswordInput.onfocus = armDraftCodeAgentPasswordInput;
+        codeagentPasswordInput.onpointerdown = armDraftCodeAgentPasswordInput;
+        codeagentPasswordInput.onkeydown = armDraftCodeAgentPasswordInput;
+        codeagentPasswordInput.onblur = disarmDraftCodeAgentPasswordInput;
+    }
+
     const toggleApiKeyBtn = document.getElementById('toggle-profile-api-key-btn');
     if (toggleApiKeyBtn) {
         toggleApiKeyBtn.onclick = toggleDraftApiKeyVisibility;
@@ -184,6 +208,11 @@ export function bindModelProfileHandlers() {
     const toggleMaasPasswordBtn = document.getElementById('toggle-profile-maas-password-btn');
     if (toggleMaasPasswordBtn) {
         toggleMaasPasswordBtn.onclick = toggleDraftMaasPasswordVisibility;
+    }
+
+    const toggleCodeAgentPasswordBtn = document.getElementById('toggle-profile-codeagent-password-btn');
+    if (toggleCodeAgentPasswordBtn) {
+        toggleCodeAgentPasswordBtn.onclick = toggleDraftCodeAgentPasswordVisibility;
     }
 
     const sslVerifyInput = document.getElementById('profile-ssl-verify');
@@ -918,9 +947,13 @@ function handleAddProfile() {
     delete document.getElementById('profile-base-url').dataset.defaultSourceProvider;
     draftApiKeyState = createDraftSecretState();
     draftMaasPasswordState = createDraftSecretState();
-    draftCodeAgentAuthState = createDraftCodeAgentAuthState();
+    draftCodeAgentPasswordState = createDraftSecretState();
+    draftCodeAgentAuthState = createDraftCodeAgentAuthState(CODEAGENT_AUTH_METHODS.SSO);
     document.getElementById('profile-maas-username').value = '';
     document.getElementById('profile-maas-password').value = '';
+    document.getElementById('profile-codeagent-auth-method').value = CODEAGENT_AUTH_METHODS.SSO;
+    document.getElementById('profile-codeagent-username').value = '';
+    document.getElementById('profile-codeagent-password').value = '';
     document.getElementById('profile-is-default').checked = Object.keys(profiles).length === 0;
     document.getElementById('profile-temperature').value = '0.7';
     document.getElementById('profile-top-p').value = '1.0';
@@ -980,20 +1013,44 @@ function handleEditProfile(name) {
     document.getElementById('profile-maas-username').value = profile.maas_auth?.username || '';
     document.getElementById('profile-maas-password').value = '';
     const codeagentAuth = profile.codeagent_auth || {};
+    const codeagentAuthMethod = String(
+        codeagentAuth.auth_method || CODEAGENT_AUTH_METHODS.SSO,
+    ).trim() || CODEAGENT_AUTH_METHODS.SSO;
+    draftCodeAgentPasswordState = {
+        persistedValue: typeof codeagentAuth.password === 'string' ? codeagentAuth.password : '',
+        draftValue: '',
+        hasPersistedValue: Boolean(codeagentAuth.has_password),
+        isDirty: false,
+        hasExplicitEntry: false,
+        armedForInput: false,
+        revealed: false,
+    };
+    document.getElementById('profile-codeagent-auth-method').value = codeagentAuthMethod;
+    document.getElementById('profile-codeagent-username').value = codeagentAuth.username || '';
+    document.getElementById('profile-codeagent-password').value = '';
     draftCodeAgentAuthState = {
+        authMethod: codeagentAuthMethod,
+        persistedUsername: codeagentAuthMethod === CODEAGENT_AUTH_METHODS.PASSWORD
+            ? String(codeagentAuth.username || '').trim()
+            : '',
         authSessionId: '',
         completed: false,
         verified: false,
         verifying: false,
         reauthRequired: false,
-        hasPersistedAccessToken: Boolean(codeagentAuth.has_access_token),
-        hasPersistedRefreshToken: Boolean(codeagentAuth.has_refresh_token),
+        hasPersistedAccessToken: codeagentAuthMethod === CODEAGENT_AUTH_METHODS.SSO && Boolean(codeagentAuth.has_access_token),
+        hasPersistedRefreshToken: codeagentAuthMethod === CODEAGENT_AUTH_METHODS.SSO && Boolean(codeagentAuth.has_refresh_token),
+        hasPersistedPassword: codeagentAuthMethod === CODEAGENT_AUTH_METHODS.PASSWORD && Boolean(codeagentAuth.has_password),
         loginInProgress: false,
         pendingAuthorizationUrl: '',
         verificationScopeId: nextDraftCodeAgentVerificationScopeId++,
         verificationRequestId: 0,
-        statusMessage: Boolean(codeagentAuth.has_refresh_token)
-            ? 'Saved sign-in requires verification'
+        statusMessage: (
+            codeagentAuthMethod === CODEAGENT_AUTH_METHODS.PASSWORD
+                ? Boolean(codeagentAuth.has_password)
+                : Boolean(codeagentAuth.has_refresh_token)
+        )
+            ? 'Saved credentials require verification'
             : 'Not signed in',
     };
     document.getElementById('profile-is-default').checked = profile.is_default === true;
@@ -1034,7 +1091,13 @@ function handleEditProfile(name) {
     if (draftProviderMode === PROVIDER_MODES.EXTERNAL) {
         void loadModelCatalogForNewProfile();
     }
-    if (isCodeAgentProvider(profile.provider) && Boolean(codeagentAuth.has_refresh_token)) {
+    if (
+        isCodeAgentProvider(profile.provider)
+        && (
+            (codeagentAuthMethod === CODEAGENT_AUTH_METHODS.SSO && Boolean(codeagentAuth.has_refresh_token))
+            || (codeagentAuthMethod === CODEAGENT_AUTH_METHODS.PASSWORD && Boolean(codeagentAuth.has_password))
+        )
+    ) {
         void verifyPersistedCodeAgentAuth(name);
     }
 }
@@ -1105,10 +1168,20 @@ async function handleSaveProfile() {
             return;
         }
     } else if (isCodeAgentProvider(provider)) {
+        if (requiresDraftCodeAgentPasswordReentry()) {
+            showToast({
+                title: t('settings.model.save_failed_title'),
+                message: 'Re-enter the CodeAgent password after changing the username.',
+                tone: 'warning',
+            });
+            return;
+        }
         if (!hasDraftCodeAgentAuth()) {
             showToast({
                 title: t('settings.model.save_failed_title'),
-                message: 'CodeAgent profiles require SSO login before saving.',
+                message: getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+                    ? 'CodeAgent password login requires username and password before saving.'
+                    : 'CodeAgent profiles require SSO login before saving.',
                 tone: 'warning',
             });
             return;
@@ -1156,11 +1229,19 @@ async function handleSaveProfile() {
         }
     } else if (isCodeAgentProvider(provider)) {
         profile.codeagent_auth = {
-            has_access_token: codeagentAuth.has_access_token,
-            has_refresh_token: codeagentAuth.has_refresh_token,
+            auth_method: codeagentAuth.auth_method,
         };
-        if (codeagentAuth.oauth_session_id) {
-            profile.codeagent_auth.oauth_session_id = codeagentAuth.oauth_session_id;
+        if (codeagentAuth.auth_method === CODEAGENT_AUTH_METHODS.PASSWORD) {
+            profile.codeagent_auth.username = codeagentAuth.username;
+            if (codeagentAuth.password) {
+                profile.codeagent_auth.password = codeagentAuth.password;
+            }
+        } else {
+            profile.codeagent_auth.has_access_token = codeagentAuth.has_access_token;
+            profile.codeagent_auth.has_refresh_token = codeagentAuth.has_refresh_token;
+            if (codeagentAuth.oauth_session_id) {
+                profile.codeagent_auth.oauth_session_id = codeagentAuth.oauth_session_id;
+            }
         }
     } else if (apiKey) {
         profile.api_key = apiKey;
@@ -1371,7 +1452,10 @@ async function handleDiscoverDraftModels() {
 
 async function handleCodeAgentLogin() {
     const provider = getDraftProvider();
-    if (!isCodeAgentProvider(provider)) {
+    if (
+        !isCodeAgentProvider(provider)
+        || getDraftCodeAgentAuthMethod() !== CODEAGENT_AUTH_METHODS.SSO
+    ) {
         return;
     }
     if (draftCodeAgentAuthState.pendingAuthorizationUrl) {
@@ -1421,6 +1505,9 @@ async function handleCodeAgentLogin() {
 }
 
 async function continueCodeAgentLogin() {
+    if (getDraftCodeAgentAuthMethod() !== CODEAGENT_AUTH_METHODS.SSO) {
+        return;
+    }
     const authSessionId = String(draftCodeAgentAuthState.authSessionId || '').trim();
     const authorizationUrl = String(
         draftCodeAgentAuthState.pendingAuthorizationUrl || '',
@@ -1521,7 +1608,10 @@ async function verifyPersistedCodeAgentAuth(profileName) {
     if (!normalizedProfileName || !isCodeAgentProvider(getDraftProvider())) {
         return;
     }
-    if (editingProfile !== normalizedProfileName || !draftCodeAgentAuthState.hasPersistedRefreshToken) {
+    if (
+        editingProfile !== normalizedProfileName
+        || !hasPersistedCodeAgentCredentials()
+    ) {
         return;
     }
     const verificationScopeId = Number(draftCodeAgentAuthState.verificationScopeId || 0);
@@ -1530,7 +1620,9 @@ async function verifyPersistedCodeAgentAuth(profileName) {
     draftCodeAgentAuthState.verified = false;
     draftCodeAgentAuthState.verifying = true;
     draftCodeAgentAuthState.reauthRequired = false;
-    draftCodeAgentAuthState.statusMessage = 'Verifying saved sign-in';
+    draftCodeAgentAuthState.statusMessage = getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+        ? 'Verifying saved credentials'
+        : 'Verifying saved sign-in';
     renderDraftCodeAgentAuthState();
 
     try {
@@ -1542,7 +1634,9 @@ async function verifyPersistedCodeAgentAuth(profileName) {
         if (result.status === 'valid') {
             draftCodeAgentAuthState.verified = true;
             draftCodeAgentAuthState.reauthRequired = false;
-            draftCodeAgentAuthState.statusMessage = 'Signed in';
+            draftCodeAgentAuthState.statusMessage = getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+                ? 'Credentials verified'
+                : 'Signed in';
             renderDraftCodeAgentAuthState();
             return;
         }
@@ -1574,7 +1668,9 @@ function markCodeAgentAuthReauthRequired() {
     draftCodeAgentAuthState.verified = false;
     draftCodeAgentAuthState.verifying = false;
     draftCodeAgentAuthState.reauthRequired = true;
-    draftCodeAgentAuthState.statusMessage = 'Saved sign-in expired. Sign in with SSO again';
+    draftCodeAgentAuthState.statusMessage = getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+        ? 'Saved credentials expired. Update username or password'
+        : 'Saved sign-in expired. Sign in with SSO again';
     renderDraftCodeAgentAuthState();
 }
 
@@ -1615,10 +1711,20 @@ function buildDraftProbePayload() {
             return null;
         }
     } else if (isCodeAgentProvider(provider)) {
-        if (draftCodeAgentAuthState.reauthRequired) {
+        if (shouldBlockDraftCodeAgentReauth()) {
             draftProbeState = {
                 status: 'failed',
-                message: 'SSO login expired. Sign in with SSO again before testing a CodeAgent profile.',
+                message: getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+                    ? 'Saved CodeAgent credentials expired. Update username or password before testing.'
+                    : 'SSO login expired. Sign in with SSO again before testing a CodeAgent profile.',
+            };
+            renderDraftProbeState();
+            return null;
+        }
+        if (requiresDraftCodeAgentPasswordReentry()) {
+            draftProbeState = {
+                status: 'failed',
+                message: 'Re-enter the CodeAgent password after changing the username.',
             };
             renderDraftProbeState();
             return null;
@@ -1626,7 +1732,9 @@ function buildDraftProbePayload() {
         if (!hasDraftCodeAgentAuth()) {
             draftProbeState = {
                 status: 'failed',
-                message: 'Model and SSO login are required before testing a CodeAgent profile.',
+                message: getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+                    ? 'Model, username, and password are required before testing a CodeAgent profile.'
+                    : 'Model and SSO login are required before testing a CodeAgent profile.',
             };
             renderDraftProbeState();
             return null;
@@ -1662,11 +1770,17 @@ function buildDraftProbePayload() {
             override.maas_auth.password = maasAuth.password;
         }
     } else if (isCodeAgentProvider(provider)) {
-        override.codeagent_auth = {
-            oauth_session_id: codeagentAuth.oauth_session_id,
-            has_access_token: codeagentAuth.has_access_token,
-            has_refresh_token: codeagentAuth.has_refresh_token,
-        };
+        override.codeagent_auth = { auth_method: codeagentAuth.auth_method };
+        if (codeagentAuth.auth_method === CODEAGENT_AUTH_METHODS.PASSWORD) {
+            override.codeagent_auth.username = codeagentAuth.username;
+            if (codeagentAuth.password) {
+                override.codeagent_auth.password = codeagentAuth.password;
+            }
+        } else {
+            override.codeagent_auth.oauth_session_id = codeagentAuth.oauth_session_id;
+            override.codeagent_auth.has_access_token = codeagentAuth.has_access_token;
+            override.codeagent_auth.has_refresh_token = codeagentAuth.has_refresh_token;
+        }
     } else if (apiKey) {
         override.api_key = apiKey;
     }
@@ -1702,11 +1816,23 @@ function buildDraftModelDiscoveryPayload() {
             return null;
         }
     } else if (isCodeAgentProvider(provider)) {
-        if (draftCodeAgentAuthState.reauthRequired) {
+        if (shouldBlockDraftCodeAgentReauth()) {
             draftDiscoveredModels = [];
             draftModelDiscoveryState = {
                 status: 'failed',
-                message: 'SSO login expired. Sign in with SSO again before fetching CodeAgent models.',
+                message: getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+                    ? 'Saved CodeAgent credentials expired. Update username or password before fetching models.'
+                    : 'SSO login expired. Sign in with SSO again before fetching CodeAgent models.',
+            };
+            renderDiscoveredModels();
+            renderDraftModelDiscoveryState();
+            return null;
+        }
+        if (requiresDraftCodeAgentPasswordReentry()) {
+            draftDiscoveredModels = [];
+            draftModelDiscoveryState = {
+                status: 'failed',
+                message: 'Re-enter the CodeAgent password after changing the username.',
             };
             renderDiscoveredModels();
             renderDraftModelDiscoveryState();
@@ -1716,7 +1842,9 @@ function buildDraftModelDiscoveryPayload() {
             draftDiscoveredModels = [];
             draftModelDiscoveryState = {
                 status: 'failed',
-                message: 'SSO login is required before fetching CodeAgent models.',
+                message: getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+                    ? 'Username and password are required before fetching CodeAgent models.'
+                    : 'SSO login is required before fetching CodeAgent models.',
             };
             renderDiscoveredModels();
             renderDraftModelDiscoveryState();
@@ -1748,11 +1876,17 @@ function buildDraftModelDiscoveryPayload() {
             override.maas_auth.password = maasAuth.password;
         }
     } else if (isCodeAgentProvider(provider)) {
-        override.codeagent_auth = {
-            oauth_session_id: codeagentAuth.oauth_session_id,
-            has_access_token: codeagentAuth.has_access_token,
-            has_refresh_token: codeagentAuth.has_refresh_token,
-        };
+        override.codeagent_auth = { auth_method: codeagentAuth.auth_method };
+        if (codeagentAuth.auth_method === CODEAGENT_AUTH_METHODS.PASSWORD) {
+            override.codeagent_auth.username = codeagentAuth.username;
+            if (codeagentAuth.password) {
+                override.codeagent_auth.password = codeagentAuth.password;
+            }
+        } else {
+            override.codeagent_auth.oauth_session_id = codeagentAuth.oauth_session_id;
+            override.codeagent_auth.has_access_token = codeagentAuth.has_access_token;
+            override.codeagent_auth.has_refresh_token = codeagentAuth.has_refresh_token;
+        }
     } else if (apiKey) {
         override.api_key = apiKey;
     }
@@ -1939,6 +2073,7 @@ function handleDraftEndpointChanged() {
     ) {
         draftModelInputExpanded = false;
     }
+    syncDraftCodeAgentAuthStatusMessage();
     renderDraftProviderFields();
     renderProfileEditorState();
     draftDiscoveredModels = [];
@@ -2044,6 +2179,48 @@ function handleDraftMaasPasswordInput() {
     renderDraftMaaSPasswordToggle();
 }
 
+function handleDraftCodeAgentAuthMethodChanged() {
+    const nextMethod = getDraftCodeAgentAuthMethod();
+    const nextState = createDraftCodeAgentAuthState(nextMethod);
+    nextState.persistedUsername = nextMethod === CODEAGENT_AUTH_METHODS.PASSWORD
+        ? String(draftCodeAgentAuthState.persistedUsername || '').trim()
+        : '';
+    nextState.hasPersistedAccessToken = draftCodeAgentAuthState.hasPersistedAccessToken;
+    nextState.hasPersistedRefreshToken = draftCodeAgentAuthState.hasPersistedRefreshToken;
+    nextState.hasPersistedPassword = draftCodeAgentPasswordState.hasPersistedValue;
+    draftCodeAgentAuthState = nextState;
+    handleDraftEndpointChanged();
+    renderDraftCodeAgentAuthState();
+}
+
+function handleDraftCodeAgentPasswordInput() {
+    const codeagentPasswordInput = document.getElementById('profile-codeagent-password');
+    if (!codeagentPasswordInput) {
+        return;
+    }
+    if (
+        draftCodeAgentPasswordState.hasPersistedValue
+        && !draftCodeAgentPasswordState.revealed
+        && !canAcceptDraftCodeAgentPasswordInput(codeagentPasswordInput)
+    ) {
+        draftCodeAgentPasswordState.draftValue = '';
+        draftCodeAgentPasswordState.isDirty = false;
+        draftCodeAgentPasswordState.hasExplicitEntry = false;
+        draftCodeAgentPasswordState.armedForInput = false;
+        draftCodeAgentPasswordState.revealed = false;
+        renderDraftCodeAgentPasswordField();
+        return;
+    }
+
+    draftCodeAgentPasswordState.draftValue = codeagentPasswordInput.value;
+    draftCodeAgentPasswordState.isDirty = draftCodeAgentPasswordState.draftValue !== draftCodeAgentPasswordState.persistedValue;
+    draftCodeAgentPasswordState.hasExplicitEntry = Boolean(
+        codeagentPasswordInput.value.trim(),
+    );
+    handleDraftEndpointChanged();
+    renderDraftCodeAgentPasswordToggle();
+}
+
 function toggleDraftApiKeyVisibility() {
     if (!draftApiKeyState.hasPersistedValue && !draftApiKeyState.draftValue.trim()) {
         return;
@@ -2058,6 +2235,14 @@ function toggleDraftMaasPasswordVisibility() {
     }
     draftMaasPasswordState.revealed = !draftMaasPasswordState.revealed;
     renderDraftMaaSPasswordField();
+}
+
+function toggleDraftCodeAgentPasswordVisibility() {
+    if (!draftCodeAgentPasswordState.hasPersistedValue && !draftCodeAgentPasswordState.draftValue.trim()) {
+        return;
+    }
+    draftCodeAgentPasswordState.revealed = !draftCodeAgentPasswordState.revealed;
+    renderDraftCodeAgentPasswordField();
 }
 
 function applyDiscoveredModelSelection() {
@@ -2218,6 +2403,7 @@ function resetDraftEditorState() {
     draftModelDiscoveryState = null;
     draftApiKeyState = createDraftSecretState();
     draftMaasPasswordState = createDraftSecretState();
+    draftCodeAgentPasswordState = createDraftSecretState();
     draftCodeAgentAuthState = createDraftCodeAgentAuthState();
     draftCatalogSelection = null;
     draftImageCapabilityMode = IMAGE_CAPABILITY_MODES.FOLLOW_DETECTION;
@@ -2662,11 +2848,74 @@ function readDraftMaasAuth() {
     };
 }
 
+function getDraftCodeAgentAuthMethod() {
+    const authMethodInput = document.getElementById('profile-codeagent-auth-method');
+    const normalized = String(authMethodInput?.value || draftCodeAgentAuthState.authMethod || '').trim();
+    return normalized === CODEAGENT_AUTH_METHODS.PASSWORD
+        ? CODEAGENT_AUTH_METHODS.PASSWORD
+        : CODEAGENT_AUTH_METHODS.SSO;
+}
+
+function syncDraftCodeAgentAuthStatusMessage() {
+    if (!isCodeAgentProvider(getDraftProvider())) {
+        return;
+    }
+    const authMethod = getDraftCodeAgentAuthMethod();
+    draftCodeAgentAuthState.authMethod = authMethod;
+    if (draftCodeAgentAuthState.loginInProgress || draftCodeAgentAuthState.verifying) {
+        return;
+    }
+    if (shouldBlockDraftCodeAgentReauth()) {
+        draftCodeAgentAuthState.statusMessage = authMethod === CODEAGENT_AUTH_METHODS.PASSWORD
+            ? 'Saved credentials expired. Update username or password'
+            : 'Saved sign-in expired. Sign in with SSO again';
+        return;
+    }
+    if (authMethod === CODEAGENT_AUTH_METHODS.PASSWORD) {
+        if (requiresDraftCodeAgentPasswordReentry()) {
+            draftCodeAgentAuthState.statusMessage = 'Re-enter password after changing username';
+            return;
+        }
+        if (draftCodeAgentAuthState.verified) {
+            draftCodeAgentAuthState.statusMessage = 'Credentials verified';
+            return;
+        }
+        if (
+            draftCodeAgentPasswordState.hasPersistedValue
+            && !draftCodeAgentPasswordState.isDirty
+            && !draftCodeAgentPasswordState.hasExplicitEntry
+        ) {
+            draftCodeAgentAuthState.statusMessage = 'Saved credentials require verification';
+            return;
+        }
+        draftCodeAgentAuthState.statusMessage = hasDraftCodeAgentAuth()
+            ? 'Credentials ready'
+            : 'Not signed in';
+        return;
+    }
+    if (draftCodeAgentAuthState.completed || draftCodeAgentAuthState.verified) {
+        draftCodeAgentAuthState.statusMessage = 'Signed in';
+        return;
+    }
+    draftCodeAgentAuthState.statusMessage = draftCodeAgentAuthState.hasPersistedRefreshToken
+        ? 'Saved credentials require verification'
+        : 'Not signed in';
+}
+
 function readDraftCodeAgentAuth() {
+    const authMethod = getDraftCodeAgentAuthMethod();
+    if (authMethod === CODEAGENT_AUTH_METHODS.PASSWORD) {
+        return {
+            auth_method: authMethod,
+            username: document.getElementById('profile-codeagent-username').value.trim(),
+            password: readDraftCodeAgentPasswordValue(),
+        };
+    }
     const completedSessionId = draftCodeAgentAuthState.completed
         ? draftCodeAgentAuthState.authSessionId || null
         : null;
     return {
+        auth_method: authMethod,
         oauth_session_id: completedSessionId,
         has_access_token: draftCodeAgentAuthState.completed || draftCodeAgentAuthState.hasPersistedAccessToken,
         has_refresh_token: draftCodeAgentAuthState.completed || draftCodeAgentAuthState.hasPersistedRefreshToken,
@@ -2674,33 +2923,101 @@ function readDraftCodeAgentAuth() {
 }
 
 function hasDraftCodeAgentAuth() {
+    if (getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD) {
+        if (requiresDraftCodeAgentPasswordReentry()) {
+            return false;
+        }
+        const username = document.getElementById('profile-codeagent-username').value.trim();
+        return Boolean(username && hasDraftCodeAgentPassword());
+    }
     return draftCodeAgentAuthState.completed || draftCodeAgentAuthState.hasPersistedRefreshToken;
+}
+
+function hasPersistedCodeAgentCredentials() {
+    return getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+        ? draftCodeAgentAuthState.hasPersistedPassword
+        : draftCodeAgentAuthState.hasPersistedRefreshToken;
+}
+
+function hasFreshDraftCodeAgentPasswordEntry() {
+    return getDraftCodeAgentAuthMethod() === CODEAGENT_AUTH_METHODS.PASSWORD
+        && Boolean(readDraftCodeAgentPasswordValue());
+}
+
+function shouldBlockDraftCodeAgentReauth() {
+    return draftCodeAgentAuthState.reauthRequired && !hasFreshDraftCodeAgentPasswordEntry();
+}
+
+function hasDraftCodeAgentPassword() {
+    return Boolean(readDraftCodeAgentPasswordValue()) || draftCodeAgentPasswordState.hasPersistedValue;
+}
+
+function requiresDraftCodeAgentPasswordReentry() {
+    if (getDraftCodeAgentAuthMethod() !== CODEAGENT_AUTH_METHODS.PASSWORD) {
+        return false;
+    }
+    if (!draftCodeAgentPasswordState.hasPersistedValue) {
+        return false;
+    }
+    const persistedUsername = String(
+        draftCodeAgentAuthState.persistedUsername || '',
+    ).trim();
+    if (!persistedUsername) {
+        return false;
+    }
+    const username = document.getElementById('profile-codeagent-username').value.trim();
+    if (!username || username === persistedUsername) {
+        return false;
+    }
+    return !Boolean(readDraftCodeAgentPasswordValue());
 }
 
 function renderDraftCodeAgentAuthState() {
     const loginBtn = document.getElementById('profile-codeagent-login-status');
     const statusMessageEl = document.getElementById('profile-codeagent-login-status-message');
+    const authMethodInput = document.getElementById('profile-codeagent-auth-method');
+    const ssoGroup = document.getElementById('profile-codeagent-sso-group');
+    const usernameGroup = document.getElementById('profile-codeagent-username-group');
+    const passwordGroup = document.getElementById('profile-codeagent-password-group');
     const provider = getDraftProvider();
     const isCodeAgent = isCodeAgentProvider(provider);
+    const authMethod = getDraftCodeAgentAuthMethod();
     const hasAuth = hasDraftCodeAgentAuth();
     const authVerified = Boolean(draftCodeAgentAuthState.verified || draftCodeAgentAuthState.completed);
     const statusMessage = draftCodeAgentAuthState.statusMessage
         || (
-            draftCodeAgentAuthState.hasPersistedRefreshToken
-                ? 'Saved sign-in requires verification'
+            hasPersistedCodeAgentCredentials()
+                ? 'Saved credentials require verification'
                 : hasAuth
-                    ? 'Signed in'
+                    ? authMethod === CODEAGENT_AUTH_METHODS.PASSWORD
+                        ? 'Credentials ready'
+                        : 'Signed in'
                     : 'Not signed in'
         );
     const loginLabel = t('settings.model.codeagent_sign_in_sso');
     const showStatus = isCodeAgent && statusMessage && statusMessage !== 'Not signed in';
     const statusTone = getCodeAgentAuthStatusTone(statusMessage, authVerified);
 
+    if (authMethodInput) {
+        authMethodInput.value = authMethod;
+    }
+    if (ssoGroup) {
+        ssoGroup.style.display = isCodeAgent && authMethod === CODEAGENT_AUTH_METHODS.SSO ? 'block' : 'none';
+    }
+    if (usernameGroup) {
+        usernameGroup.style.display = isCodeAgent && authMethod === CODEAGENT_AUTH_METHODS.PASSWORD ? 'block' : 'none';
+    }
+    if (passwordGroup) {
+        passwordGroup.style.display = isCodeAgent && authMethod === CODEAGENT_AUTH_METHODS.PASSWORD ? 'block' : 'none';
+    }
     if (loginBtn) {
         loginBtn.textContent = loginLabel;
         loginBtn.title = loginLabel;
         loginBtn.setAttribute('aria-label', loginLabel);
-        loginBtn.disabled = !isCodeAgent || draftCodeAgentAuthState.loginInProgress || draftCodeAgentAuthState.verifying;
+        loginBtn.disabled = !isCodeAgent
+            || authMethod !== CODEAGENT_AUTH_METHODS.SSO
+            || draftCodeAgentAuthState.loginInProgress
+            || draftCodeAgentAuthState.verifying;
     }
     if (statusMessageEl) {
         statusMessageEl.textContent = showStatus ? localizeCodeAgentAuthStatusMessage(statusMessage) : '';
@@ -2709,6 +3026,7 @@ function renderDraftCodeAgentAuthState() {
             ? `codeagent-sso-status-message probe-status probe-status-${statusTone}`
             : 'codeagent-sso-status-message';
     }
+    renderDraftCodeAgentPasswordField();
 }
 
 function localizeCodeAgentAuthStatusMessage(statusMessage) {
@@ -2716,11 +3034,14 @@ function localizeCodeAgentAuthStatusMessage(statusMessage) {
     if (message === 'Starting SSO login') {
         return t('settings.model.codeagent_sso_starting');
     }
-    if (message === 'Saved sign-in requires verification') {
-        return t('settings.model.codeagent_sso_saved');
+    if (message === 'Saved credentials require verification') {
+        return t('settings.model.codeagent_credentials_saved');
     }
     if (message === 'Verifying saved sign-in') {
         return t('settings.model.codeagent_sso_verifying');
+    }
+    if (message === 'Verifying saved credentials') {
+        return t('settings.model.codeagent_credentials_verifying');
     }
     if (message === 'Waiting for SSO callback') {
         return t('settings.model.codeagent_sso_waiting');
@@ -2730,6 +3051,18 @@ function localizeCodeAgentAuthStatusMessage(statusMessage) {
     }
     if (message === 'Saved sign-in expired. Sign in with SSO again') {
         return t('settings.model.codeagent_sso_reauth_required');
+    }
+    if (message === 'Saved credentials expired. Update username or password') {
+        return t('settings.model.codeagent_credentials_expired');
+    }
+    if (message === 'Re-enter password after changing username') {
+        return t('settings.model.codeagent_password_reenter');
+    }
+    if (message === 'Credentials ready') {
+        return t('settings.model.codeagent_credentials_ready');
+    }
+    if (message === 'Credentials verified') {
+        return t('settings.model.codeagent_credentials_verified');
     }
     if (message === 'SSO popup blocked') {
         return t('settings.model.codeagent_sso_popup_blocked');
@@ -2751,6 +3084,7 @@ function getCodeAgentAuthStatusTone(statusMessage, hasAuth) {
         normalizedMessage.includes('failed')
         || normalizedMessage.includes('timed out')
         || normalizedMessage.includes('expired')
+        || normalizedMessage.includes('re-enter password')
     ) {
         return 'failed';
     }
@@ -2814,7 +3148,7 @@ function renderDraftProviderFields() {
         maasFields.style.display = maasProvider ? 'grid' : 'none';
     }
     if (codeagentFields) {
-        codeagentFields.style.display = codeagentProvider ? 'grid' : 'none';
+        codeagentFields.style.display = codeagentProvider ? 'flex' : 'none';
     }
     if (passwordInput) {
         renderDraftMaaSPasswordField();
@@ -2865,7 +3199,7 @@ function renderDraftMaaSPasswordField() {
     } else {
         maasPasswordInput.type = 'password';
         maasPasswordInput.value = draftMaasPasswordState.draftValue;
-        maasPasswordInput.placeholder = 'password';
+        maasPasswordInput.placeholder = t('settings.model.password_placeholder');
     }
 
     renderDraftMaaSPasswordToggle();
@@ -2892,19 +3226,82 @@ function renderDraftMaaSPasswordToggle() {
     }
 }
 
+function readDraftCodeAgentPasswordValue() {
+    const codeagentPasswordInput = document.getElementById('profile-codeagent-password');
+    const inputValue = codeagentPasswordInput ? codeagentPasswordInput.value.trim() : '';
+    if (!draftCodeAgentPasswordState.hasPersistedValue) {
+        return inputValue || draftCodeAgentPasswordState.draftValue.trim();
+    }
+    if (draftCodeAgentPasswordState.isDirty || draftCodeAgentPasswordState.hasExplicitEntry) {
+        return inputValue || draftCodeAgentPasswordState.draftValue.trim();
+    }
+    return '';
+}
+
+function renderDraftCodeAgentPasswordField() {
+    const codeagentPasswordInput = document.getElementById('profile-codeagent-password');
+    if (!codeagentPasswordInput) {
+        return;
+    }
+
+    if (draftCodeAgentPasswordState.revealed) {
+        codeagentPasswordInput.type = 'text';
+        codeagentPasswordInput.value = draftCodeAgentPasswordState.isDirty
+            ? draftCodeAgentPasswordState.draftValue
+            : draftCodeAgentPasswordState.persistedValue;
+        codeagentPasswordInput.placeholder = '';
+    } else if (draftCodeAgentPasswordState.hasPersistedValue && !draftCodeAgentPasswordState.isDirty) {
+        codeagentPasswordInput.type = 'password';
+        codeagentPasswordInput.value = '';
+        codeagentPasswordInput.placeholder = '************';
+    } else {
+        codeagentPasswordInput.type = 'password';
+        codeagentPasswordInput.value = draftCodeAgentPasswordState.draftValue;
+        codeagentPasswordInput.placeholder = t('settings.model.codeagent_password_placeholder');
+    }
+
+    renderDraftCodeAgentPasswordToggle();
+}
+
+function renderDraftCodeAgentPasswordToggle() {
+    const toggleCodeAgentPasswordBtn = document.getElementById('toggle-profile-codeagent-password-btn');
+    const codeagentPasswordInput = document.getElementById('profile-codeagent-password');
+    if (!toggleCodeAgentPasswordBtn) {
+        return;
+    }
+
+    const inputValue = codeagentPasswordInput ? codeagentPasswordInput.value.trim() : '';
+    const hasValue = draftCodeAgentPasswordState.hasPersistedValue
+        || Boolean(draftCodeAgentPasswordState.draftValue.trim())
+        || Boolean(inputValue);
+    toggleCodeAgentPasswordBtn.style.display = hasValue ? 'inline-flex' : 'none';
+    toggleCodeAgentPasswordBtn.className = draftCodeAgentPasswordState.revealed ? 'secure-input-btn is-active' : 'secure-input-btn';
+    toggleCodeAgentPasswordBtn.title = draftCodeAgentPasswordState.revealed
+        ? t('settings.model.hide_password')
+        : t('settings.model.show_password');
+    if (typeof toggleCodeAgentPasswordBtn.setAttribute === 'function') {
+        toggleCodeAgentPasswordBtn.setAttribute('aria-label', toggleCodeAgentPasswordBtn.title);
+    } else {
+        toggleCodeAgentPasswordBtn.ariaLabel = toggleCodeAgentPasswordBtn.title;
+    }
+}
+
 function createDraftSecretState() {
     return {
         persistedValue: '',
         draftValue: '',
         hasPersistedValue: false,
         isDirty: false,
+        hasExplicitEntry: false,
         armedForInput: false,
         revealed: false,
     };
 }
 
-function createDraftCodeAgentAuthState() {
+function createDraftCodeAgentAuthState(authMethod = 'sso') {
     return {
+        authMethod,
+        persistedUsername: '',
         authSessionId: '',
         completed: false,
         verified: false,
@@ -2912,6 +3309,7 @@ function createDraftCodeAgentAuthState() {
         reauthRequired: false,
         hasPersistedAccessToken: false,
         hasPersistedRefreshToken: false,
+        hasPersistedPassword: false,
         loginInProgress: false,
         pendingAuthorizationUrl: '',
         verificationScopeId: nextDraftCodeAgentVerificationScopeId++,
@@ -2969,6 +3367,30 @@ function canAcceptDraftMaasPasswordInput(secretInput) {
         return false;
     }
     if (draftMaasPasswordState.armedForInput) {
+        return true;
+    }
+    if (typeof document !== 'object' || document === null) {
+        return false;
+    }
+    if (!('activeElement' in document)) {
+        return true;
+    }
+    return document.activeElement === secretInput;
+}
+
+function armDraftCodeAgentPasswordInput() {
+    draftCodeAgentPasswordState.armedForInput = true;
+}
+
+function disarmDraftCodeAgentPasswordInput() {
+    draftCodeAgentPasswordState.armedForInput = false;
+}
+
+function canAcceptDraftCodeAgentPasswordInput(secretInput) {
+    if (!secretInput) {
+        return false;
+    }
+    if (draftCodeAgentPasswordState.armedForInput) {
         return true;
     }
     if (typeof document !== 'object' || document === null) {

--- a/frontend/dist/js/components/settings/modelProfiles/template.js
+++ b/frontend/dist/js/components/settings/modelProfiles/template.js
@@ -63,7 +63,7 @@ export function renderModelProfilesPanelMarkup() {
                                             </span>
                                             <span>
                                                 <strong data-i18n="settings.model.provider_codeagent">CodeAgent Model</strong>
-                                                <span data-i18n="settings.model.provider_codeagent_copy">Use CodeAgent models with SSO sign-in</span>
+                                                <span data-i18n="settings.model.provider_codeagent_copy">Use CodeAgent models with SSO or username/password sign-in</span>
                                             </span>
                                         </button>
                                         <button class="model-provider-choice" id="profile-provider-custom-btn" type="button" data-provider-mode="custom" data-provider-value="openai_compatible">
@@ -159,15 +159,15 @@ export function renderModelProfilesPanelMarkup() {
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="profile-credentials-row" id="profile-maas-auth-fields" style="display:none;">
+                                    <div class="profile-credentials-row profile-maas-credentials-row" id="profile-maas-auth-fields" style="display:none;">
                                         <div class="form-group">
-                                            <label for="profile-maas-username">MAAS Username</label>
-                                            <input type="text" id="profile-maas-username" placeholder="username" autocomplete="username">
+                                            <label for="profile-maas-username" data-i18n="settings.model.username">Username</label>
+                                            <input type="text" id="profile-maas-username" placeholder="username" data-i18n-placeholder="settings.model.username_placeholder" autocomplete="username">
                                         </div>
                                         <div class="form-group">
-                                            <label for="profile-maas-password">MAAS Password</label>
+                                            <label for="profile-maas-password" data-i18n="settings.model.password">Password</label>
                                             <div class="secure-input-row">
-                                                <input type="password" id="profile-maas-password" placeholder="password" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
+                                                <input type="password" id="profile-maas-password" placeholder="password" data-i18n-placeholder="settings.model.password_placeholder" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
                                                 <button class="secure-input-btn" id="toggle-profile-maas-password-btn" type="button" title="Show password" aria-label="Show password" style="display:none;">
                                                     <svg viewBox="0 0 24 24" fill="none" class="icon-sm" aria-hidden="true">
                                                         <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
@@ -179,12 +179,37 @@ export function renderModelProfilesPanelMarkup() {
                                         <div class="form-group-span-2" id="profile-maas-model-slot"></div>
                                     </div>
                                     <div class="profile-credentials-row profile-codeagent-credentials-row" id="profile-codeagent-auth-fields" style="display:none;">
-                                        <div class="form-group form-group-inline-action profile-codeagent-sso-group">
-                                            <label for="profile-codeagent-login-status">CodeAgent SSO</label>
-                                            <div class="codeagent-sso-control">
-                                                <button class="settings-inline-action settings-list-action codeagent-sso-login-btn" type="button" id="profile-codeagent-login-status" data-i18n="settings.model.codeagent_sign_in_sso" data-i18n-title="settings.model.codeagent_sign_in_sso" data-i18n-aria-label="settings.model.codeagent_sign_in_sso" aria-controls="profile-codeagent-login-status-message">Sign in with SSO</button>
+                                        <div class="form-group profile-codeagent-auth-method-row">
+                                            <label for="profile-codeagent-auth-method" data-i18n="settings.model.codeagent_auth_method">CodeAgent Auth Method</label>
+                                            <select id="profile-codeagent-auth-method">
+                                                <option value="sso" data-i18n="settings.model.codeagent_auth_method_sso">SSO Sign-In</option>
+                                                <option value="password" data-i18n="settings.model.codeagent_auth_method_password">Username and Password</option>
+                                            </select>
+                                        </div>
+                                        <div class="profile-codeagent-auth-detail-row">
+                                            <div class="form-group form-group-inline-action profile-codeagent-sso-group" id="profile-codeagent-sso-group">
+                                                <label for="profile-codeagent-login-status" data-i18n="settings.model.codeagent_sso_field">SSO Sign-In</label>
+                                                <div class="codeagent-sso-control">
+                                                    <button class="settings-inline-action settings-list-action codeagent-sso-login-btn" type="button" id="profile-codeagent-login-status" data-i18n="settings.model.codeagent_sign_in_sso" data-i18n-title="settings.model.codeagent_sign_in_sso" data-i18n-aria-label="settings.model.codeagent_sign_in_sso" aria-controls="profile-codeagent-login-status-message">Sign in with SSO</button>
+                                                </div>
+                                                <div class="codeagent-sso-status-message" id="profile-codeagent-login-status-message" role="status" aria-live="polite" style="display:none;"></div>
                                             </div>
-                                            <div class="codeagent-sso-status-message" id="profile-codeagent-login-status-message" role="status" aria-live="polite" style="display:none;"></div>
+                                            <div class="form-group" id="profile-codeagent-username-group" style="display:none;">
+                                                <label for="profile-codeagent-username" data-i18n="settings.model.codeagent_username">CodeAgent Username</label>
+                                                <input type="text" id="profile-codeagent-username" placeholder="username" data-i18n-placeholder="settings.model.codeagent_username_placeholder" autocomplete="username">
+                                            </div>
+                                            <div class="form-group" id="profile-codeagent-password-group" style="display:none;">
+                                                <label for="profile-codeagent-password" data-i18n="settings.model.codeagent_password">CodeAgent Password</label>
+                                                <div class="secure-input-row">
+                                                    <input type="password" id="profile-codeagent-password" placeholder="password" data-i18n-placeholder="settings.model.codeagent_password_placeholder" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false">
+                                                    <button class="secure-input-btn" id="toggle-profile-codeagent-password-btn" type="button" title="Show password" aria-label="Show password" style="display:none;">
+                                                    <svg viewBox="0 0 24 24" fill="none" class="icon-sm" aria-hidden="true">
+                                                        <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"></path>
+                                                        <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.8"></circle>
+                                                    </svg>
+                                                    </button>
+                                                </div>
+                                            </div>
                                         </div>
                                         <div class="form-group-span-2" id="profile-codeagent-model-slot"></div>
                                     </div>

--- a/frontend/dist/js/core/api/system.js
+++ b/frontend/dist/js/core/api/system.js
@@ -424,7 +424,7 @@ export async function verifyCodeAgentAuth(profileName) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ profile_name: profileName }),
         },
-        'Failed to verify CodeAgent SSO status',
+        'Failed to verify CodeAgent auth status',
     );
 }
 

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -3888,7 +3888,27 @@ Object.assign(TRANSLATIONS['zh-CN'], {
     'settings.hooks.error_handler_index': '第 {index} 个处理器',
 });
 
+Object.assign(TRANSLATIONS['zh-CN'], {
+    'settings.model.username': '\u7528\u6237\u540d',
+    'settings.model.username_placeholder': '\u7528\u6237\u540d',
+    'settings.model.password': '\u5bc6\u7801',
+    'settings.model.password_placeholder': '\u5bc6\u7801',
+});
+
 Object.assign(TRANSLATIONS['en-US'], {
+    'settings.model.provider_codeagent_copy': 'Use CodeAgent models with SSO or username/password sign-in',
+    'settings.model.username': 'Username',
+    'settings.model.username_placeholder': 'username',
+    'settings.model.password': 'Password',
+    'settings.model.password_placeholder': 'password',
+    'settings.model.codeagent_auth_method': 'Authentication Method',
+    'settings.model.codeagent_auth_method_sso': 'SSO Sign-In',
+    'settings.model.codeagent_auth_method_password': 'Username and Password',
+    'settings.model.codeagent_sso_field': 'SSO Sign-In',
+    'settings.model.codeagent_username': 'Username',
+    'settings.model.codeagent_username_placeholder': 'username',
+    'settings.model.codeagent_password': 'Password',
+    'settings.model.codeagent_password_placeholder': 'password',
     'settings.model.codeagent_sign_in_sso': 'Sign in with SSO',
     'settings.model.codeagent_sso_starting': 'Starting SSO login...',
     'settings.model.codeagent_sso_saved': 'Saved sign-in requires verification',
@@ -3899,9 +3919,28 @@ Object.assign(TRANSLATIONS['en-US'], {
     'settings.model.codeagent_sso_popup_blocked': 'SSO popup was blocked. Click Sign in with SSO again to continue.',
     'settings.model.codeagent_sso_timed_out': 'SSO login timed out',
     'settings.model.codeagent_sso_failed': 'SSO failed: {error}',
+    'settings.model.codeagent_credentials_saved': 'Saved credentials require verification',
+    'settings.model.codeagent_credentials_verifying': 'Verifying saved credentials',
+    'settings.model.codeagent_credentials_expired': 'Saved credentials expired. Update username or password.',
+    'settings.model.codeagent_password_reenter': 'Re-enter password after changing username.',
+    'settings.model.codeagent_credentials_ready': 'Credentials ready',
+    'settings.model.codeagent_credentials_verified': 'Credentials verified',
 });
 
 Object.assign(TRANSLATIONS['zh-CN'], {
+    'settings.model.username': '用户名',
+    'settings.model.username_placeholder': '用户名',
+    'settings.model.password': '密码',
+    'settings.model.password_placeholder': '密码',
+    'settings.model.provider_codeagent_copy': '使用 CodeAgent 模型，支持 SSO 或用户名密码登录',
+    'settings.model.codeagent_auth_method': '认证方式',
+    'settings.model.codeagent_auth_method_sso': 'SSO 登录',
+    'settings.model.codeagent_auth_method_password': '用户名和密码',
+    'settings.model.codeagent_sso_field': 'SSO 登录',
+    'settings.model.codeagent_username': '用户名',
+    'settings.model.codeagent_username_placeholder': '用户名',
+    'settings.model.codeagent_password': '密码',
+    'settings.model.codeagent_password_placeholder': '密码',
     'settings.model.codeagent_sign_in_sso': '使用 SSO 登录',
     'settings.model.codeagent_sso_starting': '正在启动 SSO 登录...',
     'settings.model.codeagent_sso_saved': '已保存登录，需校验状态',
@@ -3912,6 +3951,12 @@ Object.assign(TRANSLATIONS['zh-CN'], {
     'settings.model.codeagent_sso_popup_blocked': 'SSO 弹窗被拦截，请再次点击“使用 SSO 登录”继续。',
     'settings.model.codeagent_sso_timed_out': 'SSO 登录超时',
     'settings.model.codeagent_sso_failed': 'SSO 登录失败：{error}',
+    'settings.model.codeagent_credentials_saved': '已保存凭据，需校验状态',
+    'settings.model.codeagent_credentials_verifying': '正在校验已保存的凭据',
+    'settings.model.codeagent_credentials_expired': '已保存凭据已失效，请更新用户名或密码。',
+    'settings.model.codeagent_password_reenter': '修改用户名后请重新输入密码。',
+    'settings.model.codeagent_credentials_ready': '凭据已就绪',
+    'settings.model.codeagent_credentials_verified': '凭据已验证',
 });
 
 Object.assign(TRANSLATIONS['en-US'], {

--- a/src/relay_teams/providers/codeagent_auth.py
+++ b/src/relay_teams/providers/codeagent_auth.py
@@ -16,7 +16,13 @@ from openai import AsyncOpenAI
 from pydantic import BaseModel, ConfigDict, Field
 
 from relay_teams.net.clients import create_async_http_client, create_sync_http_client
+from relay_teams.providers.maas_auth import (
+    MaaSAuthConfig,
+    MaaSLoginError,
+    get_maas_token_service,
+)
 from relay_teams.providers.model_config import (
+    CodeAgentAuthMethod,
     CodeAgentAuthConfig,
     DEFAULT_CODEAGENT_SSO_BASE_URL,
 )
@@ -24,6 +30,7 @@ from relay_teams.secrets import get_secret_store
 
 __all__ = [
     "CODEAGENT_ACCESS_TOKEN_SECRET_FIELD",
+    "CODEAGENT_PASSWORD_SECRET_FIELD",
     "CODEAGENT_REFRESH_TOKEN_SECRET_FIELD",
     "CodeAgentOAuthError",
     "CodeAgentOAuthSession",
@@ -35,6 +42,7 @@ __all__ = [
     "clear_codeagent_oauth_session_store",
     "clear_codeagent_token_service_cache",
     "codeagent_access_token_secret_field_name",
+    "codeagent_password_secret_field_name",
     "codeagent_refresh_token_secret_field_name",
     "consume_codeagent_oauth_tokens",
     "create_codeagent_oauth_session",
@@ -48,6 +56,7 @@ __all__ = [
 ]
 
 CODEAGENT_ACCESS_TOKEN_SECRET_FIELD = "codeagent_access_token"
+CODEAGENT_PASSWORD_SECRET_FIELD = "codeagent_password"
 CODEAGENT_REFRESH_TOKEN_SECRET_FIELD = "codeagent_refresh_token"
 _CODEAGENT_TOKEN_TTL = timedelta(hours=1)
 _CODEAGENT_REFRESH_SKEW = timedelta(minutes=5)
@@ -166,6 +175,19 @@ class CodeAgentTokenService:
                 and not self._should_refresh(cached.token_result)
             ):
                 return cached.token_result
+            if auth_config.auth_method == CodeAgentAuthMethod.PASSWORD:
+                result = self._login_with_password_sync(
+                    auth_config=auth_config,
+                    ssl_verify=ssl_verify,
+                    connect_timeout_seconds=connect_timeout_seconds,
+                    force_refresh=force_refresh,
+                )
+                self._store_token_result(
+                    cache_key=cache_key,
+                    auth_config=auth_config,
+                    token_result=result,
+                )
+                return result
             config_token_result = self._token_result_from_config(auth_config)
             if not force_refresh and config_token_result is not None:
                 self._tokens[cache_key] = _CodeAgentTokenRecord(
@@ -233,6 +255,19 @@ class CodeAgentTokenService:
                 and not self._should_refresh(cached.token_result)
             ):
                 return cached.token_result
+            if auth_config.auth_method == CodeAgentAuthMethod.PASSWORD:
+                result = await self._login_with_password(
+                    auth_config=auth_config,
+                    ssl_verify=ssl_verify,
+                    connect_timeout_seconds=connect_timeout_seconds,
+                    force_refresh=force_refresh,
+                )
+                self._store_token_result(
+                    cache_key=cache_key,
+                    auth_config=auth_config,
+                    token_result=result,
+                )
+                return result
             config_token_result = self._token_result_from_config(auth_config)
             if not force_refresh and config_token_result is not None:
                 self._tokens[cache_key] = _CodeAgentTokenRecord(
@@ -333,19 +368,93 @@ class CodeAgentTokenService:
 
     def _cache_key(self, *, base_url: str, auth_config: CodeAgentAuthConfig) -> str:
         cache_discriminator = (
-            auth_config.secret_owner_id or auth_config.oauth_session_id or ""
+            auth_config.secret_owner_id
+            or auth_config.oauth_session_id
+            or auth_config.username
+            or ""
         )
         raw = "\0".join(
             (
                 base_url.strip(),
+                auth_config.auth_method.value,
                 auth_config.client_id,
                 auth_config.scope,
                 auth_config.scope_resource,
                 cache_discriminator,
+                auth_config.username or "",
+                auth_config.password or "",
                 auth_config.refresh_token or "",
             )
         )
         return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _login_with_password_sync(
+        *,
+        auth_config: CodeAgentAuthConfig,
+        ssl_verify: bool | None,
+        connect_timeout_seconds: float,
+        force_refresh: bool,
+    ) -> CodeAgentOAuthTokenResult:
+        if auth_config.username is None or auth_config.password is None:
+            raise CodeAgentOAuthError(
+                "CodeAgent username/password is not configured.",
+                status_code=None,
+            )
+        try:
+            auth_context = get_maas_token_service().get_auth_context_sync(
+                auth_config=MaaSAuthConfig(
+                    username=auth_config.username,
+                    password=auth_config.password,
+                ),
+                ssl_verify=ssl_verify,
+                connect_timeout_seconds=connect_timeout_seconds,
+                force_refresh=force_refresh,
+            )
+        except MaaSLoginError as exc:
+            raise CodeAgentOAuthError(
+                str(exc) or "CodeAgent password login failed.",
+                status_code=exc.status_code,
+            ) from exc
+        return CodeAgentOAuthTokenResult(
+            access_token=auth_context.token,
+            refresh_token=auth_context.token,
+            expires_at=datetime.now(UTC) + _CODEAGENT_TOKEN_TTL,
+        )
+
+    @staticmethod
+    async def _login_with_password(
+        *,
+        auth_config: CodeAgentAuthConfig,
+        ssl_verify: bool | None,
+        connect_timeout_seconds: float,
+        force_refresh: bool,
+    ) -> CodeAgentOAuthTokenResult:
+        if auth_config.username is None or auth_config.password is None:
+            raise CodeAgentOAuthError(
+                "CodeAgent username/password is not configured.",
+                status_code=None,
+            )
+        try:
+            auth_context = await get_maas_token_service().get_auth_context(
+                auth_config=MaaSAuthConfig(
+                    username=auth_config.username,
+                    password=auth_config.password,
+                ),
+                ssl_verify=ssl_verify,
+                connect_timeout_seconds=connect_timeout_seconds,
+                force_refresh=force_refresh,
+            )
+        except MaaSLoginError as exc:
+            raise CodeAgentOAuthError(
+                str(exc) or "CodeAgent password login failed.",
+                status_code=exc.status_code,
+            ) from exc
+        return CodeAgentOAuthTokenResult(
+            access_token=auth_context.token,
+            refresh_token=auth_context.token,
+            expires_at=datetime.now(UTC) + _CODEAGENT_TOKEN_TTL,
+        )
 
     def _should_refresh(self, token_result: CodeAgentOAuthTokenResult) -> bool:
         return datetime.now(UTC) + _CODEAGENT_REFRESH_SKEW >= token_result.expires_at
@@ -373,6 +482,8 @@ class CodeAgentTokenService:
         token_result: CodeAgentOAuthTokenResult,
     ) -> None:
         self._tokens[cache_key] = _CodeAgentTokenRecord(token_result=token_result)
+        if auth_config.auth_method == CodeAgentAuthMethod.PASSWORD:
+            return
         oauth_session_id = auth_config.oauth_session_id
         if oauth_session_id is None:
             _persist_codeagent_profile_tokens(
@@ -400,6 +511,8 @@ class CodeAgentTokenService:
         self,
         auth_config: CodeAgentAuthConfig,
     ) -> CodeAgentOAuthTokenResult | None:
+        if auth_config.auth_method == CodeAgentAuthMethod.PASSWORD:
+            return None
         if auth_config.access_token is None or auth_config.refresh_token is None:
             return None
         return CodeAgentOAuthTokenResult(
@@ -653,6 +766,10 @@ def clear_codeagent_token_service_cache() -> None:
 
 def codeagent_access_token_secret_field_name() -> str:
     return CODEAGENT_ACCESS_TOKEN_SECRET_FIELD
+
+
+def codeagent_password_secret_field_name() -> str:
+    return CODEAGENT_PASSWORD_SECRET_FIELD
 
 
 def codeagent_refresh_token_secret_field_name() -> str:

--- a/src/relay_teams/providers/maas_auth.py
+++ b/src/relay_teams/providers/maas_auth.py
@@ -21,6 +21,7 @@ from relay_teams.providers.model_config import (
 
 __all__ = [
     "MAAS_PASSWORD_SECRET_FIELD",
+    "MaaSAuthConfig",
     "build_maas_openai_client",
     "clear_maas_token_service_cache",
     "get_maas_token_service",

--- a/src/relay_teams/providers/model_config.py
+++ b/src/relay_teams/providers/model_config.py
@@ -34,6 +34,11 @@ class ProviderType(StrEnum):
     ECHO = "echo"
 
 
+class CodeAgentAuthMethod(StrEnum):
+    SSO = "sso"
+    PASSWORD = "password"
+
+
 class ModelFallbackTrigger(StrEnum):
     RATE_LIMIT_AFTER_RETRIES = "rate_limit_after_retries"
 
@@ -74,12 +79,16 @@ class CodeAgentAuthConfig(BaseModel):
     _secret_config_dir: Path | None = PrivateAttr(default=None)
     _secret_owner_id: str | None = PrivateAttr(default=None)
 
+    auth_method: CodeAgentAuthMethod = CodeAgentAuthMethod.SSO
     client_id: str = Field(default=DEFAULT_CODEAGENT_CLIENT_ID, min_length=1)
     scope: str = Field(default=DEFAULT_CODEAGENT_SCOPE, min_length=1)
     scope_resource: str = Field(
         default=DEFAULT_CODEAGENT_SCOPE_RESOURCE,
         min_length=1,
     )
+    username: str | None = Field(default=None, min_length=1)
+    password: str | None = Field(default=None, min_length=1)
+    has_password: bool = False
     access_token: str | None = Field(default=None, min_length=1)
     refresh_token: str | None = Field(default=None, min_length=1)
     has_access_token: bool = False
@@ -90,6 +99,8 @@ class CodeAgentAuthConfig(BaseModel):
         "client_id",
         "scope",
         "scope_resource",
+        "username",
+        "password",
         "access_token",
         "refresh_token",
         "oauth_session_id",
@@ -107,6 +118,8 @@ class CodeAgentAuthConfig(BaseModel):
         self.client_id = DEFAULT_CODEAGENT_CLIENT_ID
         self.scope = DEFAULT_CODEAGENT_SCOPE
         self.scope_resource = DEFAULT_CODEAGENT_SCOPE_RESOURCE
+        if self.password is not None:
+            self.has_password = True
         if self.access_token is not None:
             self.has_access_token = True
         if self.refresh_token is not None:
@@ -291,6 +304,15 @@ class ModelEndpointConfig(BaseModel):
                 raise ValueError(
                     "CodeAgent model endpoint config requires codeagent_auth configuration."
                 )
+            if self.codeagent_auth.auth_method == CodeAgentAuthMethod.PASSWORD:
+                if (
+                    self.codeagent_auth.username is None
+                    or self.codeagent_auth.password is None
+                ):
+                    raise ValueError(
+                        "CodeAgent model endpoint config requires codeagent_auth.username and codeagent_auth.password for password auth."
+                    )
+                return self
             if (
                 self.codeagent_auth.refresh_token is None
                 and self.codeagent_auth.oauth_session_id is None

--- a/src/relay_teams/providers/model_config_manager.py
+++ b/src/relay_teams/providers/model_config_manager.py
@@ -9,6 +9,7 @@ from typing import cast
 
 from relay_teams.providers.codeagent_auth import (
     codeagent_access_token_secret_field_name,
+    codeagent_password_secret_field_name,
     codeagent_refresh_token_secret_field_name,
     consume_codeagent_oauth_tokens,
     get_codeagent_oauth_tokens,
@@ -16,6 +17,7 @@ from relay_teams.providers.codeagent_auth import (
 from relay_teams.providers.maas_auth import maas_password_secret_field_name
 from relay_teams.providers.model_capabilities import resolve_model_capabilities
 from relay_teams.providers.model_config import (
+    CodeAgentAuthMethod,
     CodeAgentAuthConfig,
     DEFAULT_CODEAGENT_BASE_URL,
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
@@ -37,6 +39,7 @@ _MODEL_PROFILE_SECRET_NAMESPACE = "model_profile"
 _MODEL_PROFILE_SECRET_FIELD = "api_key"
 _MODEL_PROFILE_MAAS_PASSWORD_FIELD = maas_password_secret_field_name()
 _MODEL_PROFILE_CODEAGENT_ACCESS_TOKEN_FIELD = codeagent_access_token_secret_field_name()
+_MODEL_PROFILE_CODEAGENT_PASSWORD_FIELD = codeagent_password_secret_field_name()
 _MODEL_PROFILE_CODEAGENT_REFRESH_TOKEN_FIELD = (
     codeagent_refresh_token_secret_field_name()
 )
@@ -178,6 +181,15 @@ class ModelConfigManager:
             if codeagent_storage_relevant
             else None
         )
+        current_codeagent_password = (
+            (
+                self._get_profile_codeagent_password(source_name)
+                if source_name is not None and source_name != name
+                else self._get_profile_codeagent_password(name)
+            )
+            if codeagent_storage_relevant
+            else None
+        )
         current_codeagent_refresh_token = (
             (
                 self._get_profile_codeagent_refresh_token(source_name)
@@ -233,7 +245,9 @@ class ModelConfigManager:
             config[name],
             next_codeagent_access_token,
             next_codeagent_refresh_token,
+            next_codeagent_password,
             preserve_codeagent_tokens,
+            preserve_codeagent_password,
             _pending_oauth_session_id,
         ) = self._prepare_profile_codeagent_auth_for_storage(
             profile_name=name,
@@ -241,6 +255,7 @@ class ModelConfigManager:
             next_profile=cast(dict[str, JsonValue], config[name]),
             source_name=source_name,
             current_access_token=current_codeagent_access_token,
+            current_password=current_codeagent_password,
             current_refresh_token=current_codeagent_refresh_token,
         )
         if cast(dict[str, JsonValue], config[name]).get("max_tokens") is None:
@@ -267,6 +282,12 @@ class ModelConfigManager:
             next_access_token=next_codeagent_access_token,
             next_refresh_token=next_codeagent_refresh_token,
             preserve_tokens=preserve_codeagent_tokens,
+        )
+        self._apply_profile_codeagent_password_update(
+            name=name,
+            source_name=source_name,
+            next_password=next_codeagent_password,
+            preserve_password=preserve_codeagent_password,
         )
         self._sync_profile_header_secrets(
             profile_name=name,
@@ -300,6 +321,7 @@ class ModelConfigManager:
         next_config: dict[str, JsonValue] = {}
         secret_updates: dict[str, tuple[str | None, bool]] = {}
         maas_password_updates: dict[str, tuple[str | None, bool]] = {}
+        codeagent_password_updates: dict[str, tuple[str | None, bool]] = {}
         codeagent_token_updates: dict[str, tuple[str | None, str | None, bool]] = {}
         header_secret_sync_profiles: dict[str, dict[str, JsonValue]] = {}
         pending_codeagent_oauth_sessions: dict[str, str] = {}
@@ -312,6 +334,7 @@ class ModelConfigManager:
             current_codeagent_access_token = self._get_profile_codeagent_access_token(
                 name
             )
+            current_codeagent_password = self._get_profile_codeagent_password(name)
             current_codeagent_refresh_token = self._get_profile_codeagent_refresh_token(
                 name
             )
@@ -361,7 +384,9 @@ class ModelConfigManager:
                 next_profile,
                 next_codeagent_access_token,
                 next_codeagent_refresh_token,
+                next_codeagent_password,
                 preserve_codeagent_tokens,
+                preserve_codeagent_password,
                 pending_oauth_session_id,
             ) = self._prepare_profile_codeagent_auth_for_storage(
                 profile_name=name,
@@ -369,6 +394,7 @@ class ModelConfigManager:
                 next_profile=next_profile,
                 source_name=None,
                 current_access_token=current_codeagent_access_token,
+                current_password=current_codeagent_password,
                 current_refresh_token=current_codeagent_refresh_token,
                 consume_oauth_session=False,
             )
@@ -382,6 +408,10 @@ class ModelConfigManager:
                 next_codeagent_access_token,
                 next_codeagent_refresh_token,
                 preserve_codeagent_tokens,
+            )
+            codeagent_password_updates[name] = (
+                next_codeagent_password,
+                preserve_codeagent_password,
             )
             header_secret_sync_profiles[name] = header_secret_sync_profile
             if pending_oauth_session_id is not None:
@@ -424,12 +454,21 @@ class ModelConfigManager:
                 next_codeagent_refresh_token,
                 preserve_codeagent_tokens,
             ) = codeagent_token_updates.get(profile_name, (None, None, False))
+            next_codeagent_password, preserve_codeagent_password = (
+                codeagent_password_updates.get(profile_name, (None, False))
+            )
             self._apply_profile_codeagent_token_update(
                 name=profile_name,
                 source_name=None,
                 next_access_token=next_codeagent_access_token,
                 next_refresh_token=next_codeagent_refresh_token,
                 preserve_tokens=preserve_codeagent_tokens,
+            )
+            self._apply_profile_codeagent_password_update(
+                name=profile_name,
+                source_name=None,
+                next_password=next_codeagent_password,
+                preserve_password=preserve_codeagent_password,
             )
             next_profile = next_config.get(profile_name)
             if isinstance(next_profile, dict) and isinstance(
@@ -551,6 +590,38 @@ class ModelConfigManager:
         if not isinstance(raw_codeagent_auth, dict):
             raise ValueError("codeagent_auth must be an object")
         resolved_payload: dict[str, str | bool] = {}
+        auth_method_raw = raw_codeagent_auth.get("auth_method")
+        if isinstance(auth_method_raw, str) and auth_method_raw.strip():
+            resolved_payload["auth_method"] = auth_method_raw.strip()
+        resolved_auth_method = (
+            CodeAgentAuthMethod.PASSWORD
+            if resolved_payload.get("auth_method") == CodeAgentAuthMethod.PASSWORD.value
+            else CodeAgentAuthMethod.SSO
+        )
+        username = raw_codeagent_auth.get("username")
+        if isinstance(username, str) and username.strip():
+            resolved_payload["username"] = username.strip()
+        if resolved_auth_method == CodeAgentAuthMethod.PASSWORD:
+            password = raw_codeagent_auth.get("password")
+            if isinstance(password, str) and password.strip():
+                resolved_payload["password"] = password.strip()
+            else:
+                secret_value = self._secret_store.get_secret(
+                    self._config_dir,
+                    namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                    owner_id=profile_name,
+                    field_name=_MODEL_PROFILE_CODEAGENT_PASSWORD_FIELD,
+                )
+                if secret_value is not None:
+                    resolved_payload["password"] = secret_value
+            if raw_codeagent_auth.get("has_password"):
+                resolved_payload["has_password"] = True
+            return CodeAgentAuthConfig.model_validate(
+                resolved_payload
+            ).with_secret_owner(
+                config_dir=self._config_dir,
+                owner_id=profile_name,
+            )
         oauth_session_id = raw_codeagent_auth.get("oauth_session_id")
         if isinstance(oauth_session_id, str) and oauth_session_id.strip():
             resolved_payload["oauth_session_id"] = oauth_session_id.strip()
@@ -901,10 +972,24 @@ class ModelConfigManager:
         next_profile: dict[str, JsonValue],
         source_name: str | None,
         current_access_token: str | None,
+        current_password: str | None,
         current_refresh_token: str | None,
         consume_oauth_session: bool = True,
-    ) -> tuple[dict[str, JsonValue], str | None, str | None, bool, str | None]:
+    ) -> tuple[
+        dict[str, JsonValue],
+        str | None,
+        str | None,
+        str | None,
+        bool,
+        bool,
+        str | None,
+    ]:
         merged_profile = dict(next_profile)
+        current_owner = (
+            source_name
+            if source_name is not None and source_name != profile_name
+            else profile_name
+        )
         provider_raw = merged_profile.get(
             "provider", ProviderType.OPENAI_COMPATIBLE.value
         )
@@ -914,6 +999,8 @@ class ModelConfigManager:
                 merged_profile,
                 None,
                 None,
+                None,
+                False,
                 False,
                 None,
             )
@@ -923,11 +1010,26 @@ class ModelConfigManager:
                 and "codeagent_auth" in existing_profile
             ):
                 merged_profile["codeagent_auth"] = existing_profile["codeagent_auth"]
+                preserved_auth = (
+                    self._resolve_codeagent_auth(current_owner, existing_profile)
+                    if isinstance(existing_profile, dict)
+                    else None
+                )
                 return (
                     merged_profile,
                     None,
                     None,
-                    current_refresh_token is not None,
+                    None,
+                    (
+                        preserved_auth is not None
+                        and preserved_auth.auth_method == CodeAgentAuthMethod.SSO
+                        and current_refresh_token is not None
+                    ),
+                    (
+                        preserved_auth is not None
+                        and preserved_auth.auth_method == CodeAgentAuthMethod.PASSWORD
+                        and current_password is not None
+                    ),
                     None,
                 )
             raise ValueError(
@@ -936,16 +1038,97 @@ class ModelConfigManager:
         raw_codeagent_auth = merged_profile.get("codeagent_auth")
         if not isinstance(raw_codeagent_auth, dict):
             raise ValueError("codeagent_auth must be an object")
-        current_owner = (
-            source_name
-            if source_name is not None and source_name != profile_name
-            else profile_name
-        )
         existing_codeagent_auth = (
             self._resolve_codeagent_auth(current_owner, existing_profile)
             if isinstance(existing_profile, dict)
             else None
         )
+        auth_method_raw = raw_codeagent_auth.get("auth_method")
+        normalized_auth_method = (
+            auth_method_raw.strip()
+            if isinstance(auth_method_raw, str) and auth_method_raw.strip()
+            else None
+        )
+        if normalized_auth_method not in (
+            None,
+            CodeAgentAuthMethod.SSO.value,
+            CodeAgentAuthMethod.PASSWORD.value,
+        ):
+            raise ValueError("CodeAgent auth auth_method must be 'sso' or 'password'.")
+        resolved_auth_method = (
+            CodeAgentAuthMethod.PASSWORD
+            if normalized_auth_method == CodeAgentAuthMethod.PASSWORD.value
+            else CodeAgentAuthMethod.SSO
+        )
+        if resolved_auth_method == CodeAgentAuthMethod.PASSWORD:
+            password = raw_codeagent_auth.get("password")
+            next_password = (
+                password.strip()
+                if isinstance(password, str) and password.strip()
+                else None
+            )
+            next_username = raw_codeagent_auth.get("username")
+            normalized_username = (
+                next_username.strip()
+                if isinstance(next_username, str) and next_username.strip()
+                else None
+            )
+            current_username = (
+                existing_codeagent_auth.username
+                if existing_codeagent_auth is not None
+                else None
+            )
+            existing_password = (
+                existing_codeagent_auth.password
+                if existing_codeagent_auth is not None
+                else None
+            )
+            stored_password = self._get_profile_codeagent_password(current_owner)
+            if normalized_username is None:
+                raise ValueError(
+                    "CodeAgent auth username requires a value for password auth."
+                )
+            preserve_password = False
+            if next_password is None:
+                if (
+                    current_username is not None
+                    and normalized_username != current_username.strip()
+                ):
+                    raise ValueError(
+                        "CodeAgent auth password must be re-entered after changing the username."
+                    )
+                if existing_password is not None:
+                    if stored_password is not None:
+                        preserve_password = True
+                    else:
+                        next_password = existing_password
+                elif current_password is not None:
+                    preserve_password = True
+                else:
+                    raise ValueError(
+                        "CodeAgent auth password requires a value the first time it is configured."
+                    )
+            validated = CodeAgentAuthConfig.model_validate(
+                {
+                    "auth_method": CodeAgentAuthMethod.PASSWORD.value,
+                    "username": normalized_username,
+                    "password": next_password or current_password or existing_password,
+                }
+            )
+            merged_profile["codeagent_auth"] = {
+                "auth_method": validated.auth_method.value,
+                "username": validated.username,
+                "has_password": True,
+            }
+            return (
+                merged_profile,
+                None,
+                None,
+                next_password,
+                False,
+                preserve_password,
+                None,
+            )
         token_result = None
         pending_oauth_session_id = None
         oauth_session_id = raw_codeagent_auth.get("oauth_session_id")
@@ -1012,6 +1195,7 @@ class ModelConfigManager:
         merged_profile["codeagent_auth"] = cast(
             JsonValue,
             {
+                "auth_method": CodeAgentAuthMethod.SSO.value,
                 "has_access_token": bool(
                     next_access_token
                     or current_access_token
@@ -1028,7 +1212,9 @@ class ModelConfigManager:
             merged_profile,
             next_access_token,
             next_refresh_token,
+            None,
             preserve_tokens,
+            False,
             pending_oauth_session_id if not consume_oauth_session else None,
         )
 
@@ -1128,6 +1314,16 @@ class ModelConfigManager:
             field_name=_MODEL_PROFILE_CODEAGENT_ACCESS_TOKEN_FIELD,
         )
 
+    def _get_profile_codeagent_password(self, profile_name: str | None) -> str | None:
+        if profile_name is None:
+            return None
+        return self._secret_store.get_secret(
+            self._config_dir,
+            namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+            owner_id=profile_name,
+            field_name=_MODEL_PROFILE_CODEAGENT_PASSWORD_FIELD,
+        )
+
     def _get_profile_codeagent_refresh_token(
         self,
         profile_name: str | None,
@@ -1152,6 +1348,19 @@ class ModelConfigManager:
             owner_id=profile_name,
             field_name=_MODEL_PROFILE_CODEAGENT_ACCESS_TOKEN_FIELD,
             value=access_token,
+        )
+
+    def _set_profile_codeagent_password(
+        self,
+        profile_name: str,
+        password: str,
+    ) -> None:
+        self._secret_store.set_secret(
+            self._config_dir,
+            namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+            owner_id=profile_name,
+            field_name=_MODEL_PROFILE_CODEAGENT_PASSWORD_FIELD,
+            value=password,
         )
 
     def _set_profile_codeagent_refresh_token(
@@ -1179,6 +1388,14 @@ class ModelConfigManager:
             namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
             owner_id=profile_name,
             field_name=_MODEL_PROFILE_CODEAGENT_REFRESH_TOKEN_FIELD,
+        )
+
+    def _delete_profile_codeagent_password(self, profile_name: str) -> None:
+        self._secret_store.delete_secret(
+            self._config_dir,
+            namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+            owner_id=profile_name,
+            field_name=_MODEL_PROFILE_CODEAGENT_PASSWORD_FIELD,
         )
 
     def _delete_profile_secret_owner(self, profile_name: str) -> None:
@@ -1247,6 +1464,35 @@ class ModelConfigManager:
         if preserve_password:
             return
         self._delete_profile_maas_password(name)
+
+    def _apply_profile_codeagent_password_update(
+        self,
+        *,
+        name: str,
+        source_name: str | None,
+        next_password: str | None,
+        preserve_password: bool,
+    ) -> None:
+        if source_name is not None and source_name != name:
+            if next_password is not None:
+                self._set_profile_codeagent_password(name, next_password)
+                self._delete_profile_codeagent_password(source_name)
+                return
+            if preserve_password:
+                existing_password = self._get_profile_codeagent_password(source_name)
+                if existing_password is not None:
+                    self._set_profile_codeagent_password(name, existing_password)
+                self._delete_profile_codeagent_password(source_name)
+                return
+            self._delete_profile_codeagent_password(source_name)
+            self._delete_profile_codeagent_password(name)
+            return
+        if next_password is not None:
+            self._set_profile_codeagent_password(name, next_password)
+            return
+        if preserve_password:
+            return
+        self._delete_profile_codeagent_password(name)
 
     def _apply_profile_codeagent_token_update(
         self,
@@ -1505,7 +1751,18 @@ def _build_maas_auth_profile_payload(
 def _build_codeagent_auth_profile_payload(
     codeagent_auth: CodeAgentAuthConfig,
 ) -> dict[str, JsonValue]:
+    if codeagent_auth.auth_method == CodeAgentAuthMethod.PASSWORD:
+        return {
+            "auth_method": codeagent_auth.auth_method.value,
+            "username": codeagent_auth.username or "",
+            "password": codeagent_auth.password or "",
+            "has_password": codeagent_auth.password is not None
+            or codeagent_auth.has_password,
+            "has_access_token": False,
+            "has_refresh_token": False,
+        }
     return {
+        "auth_method": codeagent_auth.auth_method.value,
         "has_access_token": codeagent_auth.access_token is not None
         or codeagent_auth.has_access_token,
         "has_refresh_token": codeagent_auth.refresh_token is not None

--- a/src/relay_teams/providers/model_connectivity.py
+++ b/src/relay_teams/providers/model_connectivity.py
@@ -28,6 +28,7 @@ from relay_teams.providers.known_model_context_windows import (
     infer_known_context_window,
 )
 from relay_teams.providers.model_config import (
+    CodeAgentAuthMethod,
     CodeAgentAuthConfig,
     DEFAULT_CODEAGENT_BASE_URL,
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
@@ -671,8 +672,44 @@ class ModelConnectivityProbeService:
             return base_codeagent_auth
         if base_codeagent_auth is None:
             return override_codeagent_auth
+        if override_codeagent_auth.auth_method == CodeAgentAuthMethod.PASSWORD:
+            if (
+                override_codeagent_auth.password is None
+                and override_codeagent_auth.username is not None
+                and base_codeagent_auth.username is not None
+                and override_codeagent_auth.username != base_codeagent_auth.username
+                and base_codeagent_auth.password is not None
+            ):
+                raise ValueError(
+                    "CodeAgent password must be re-entered after changing the username."
+                )
+            merged_auth = CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.PASSWORD,
+                client_id=override_codeagent_auth.client_id
+                or base_codeagent_auth.client_id,
+                scope=override_codeagent_auth.scope or base_codeagent_auth.scope,
+                scope_resource=override_codeagent_auth.scope_resource
+                or base_codeagent_auth.scope_resource,
+                username=override_codeagent_auth.username
+                or base_codeagent_auth.username,
+                password=(
+                    override_codeagent_auth.password
+                    if override_codeagent_auth.password is not None
+                    else base_codeagent_auth.password
+                ),
+                has_password=(
+                    override_codeagent_auth.has_password
+                    or base_codeagent_auth.has_password
+                ),
+            )
+            return self._with_codeagent_secret_owner(
+                merged_auth,
+                preferred=override_codeagent_auth,
+                fallback=base_codeagent_auth,
+            )
         if override_codeagent_auth.oauth_session_id is not None:
             merged_auth = CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.SSO,
                 client_id=override_codeagent_auth.client_id
                 or base_codeagent_auth.client_id,
                 scope=override_codeagent_auth.scope or base_codeagent_auth.scope,
@@ -690,6 +727,7 @@ class ModelConnectivityProbeService:
                 fallback=base_codeagent_auth,
             )
         merged_auth = CodeAgentAuthConfig(
+            auth_method=override_codeagent_auth.auth_method,
             client_id=override_codeagent_auth.client_id
             or base_codeagent_auth.client_id,
             scope=override_codeagent_auth.scope or base_codeagent_auth.scope,
@@ -1776,10 +1814,18 @@ class ModelConnectivityProbeService:
         self,
         auth_config: CodeAgentAuthConfig,
     ) -> CodeAgentAuthConfig:
+        if auth_config.auth_method == CodeAgentAuthMethod.PASSWORD:
+            if auth_config.username is not None and auth_config.password is not None:
+                return auth_config
+            raise CodeAgentOAuthError(
+                "CodeAgent username/password is not configured.",
+                status_code=None,
+            )
         if auth_config.oauth_session_id is not None:
             token_result = get_codeagent_oauth_tokens(auth_config.oauth_session_id)
             if token_result is not None:
                 resolved_auth = CodeAgentAuthConfig(
+                    auth_method=CodeAgentAuthMethod.SSO,
                     client_id=auth_config.client_id,
                     scope=auth_config.scope,
                     scope_resource=auth_config.scope_resource,

--- a/src/relay_teams/sessions/runs/runtime_config.py
+++ b/src/relay_teams/sessions/runs/runtime_config.py
@@ -21,10 +21,12 @@ from relay_teams.paths import (
 )
 from relay_teams.providers.codeagent_auth import (
     codeagent_access_token_secret_field_name,
+    codeagent_password_secret_field_name,
     codeagent_refresh_token_secret_field_name,
 )
 from relay_teams.providers.maas_auth import maas_password_secret_field_name
 from relay_teams.providers.model_config import (
+    CodeAgentAuthMethod,
     CodeAgentAuthConfig,
     DEFAULT_LLM_CONNECT_TIMEOUT_SECONDS,
     DEFAULT_MAAS_BASE_URL,
@@ -54,6 +56,7 @@ _MODEL_PROFILE_SECRET_NAMESPACE = "model_profile"
 _MODEL_PROFILE_SECRET_FIELD = "api_key"
 _MODEL_PROFILE_MAAS_PASSWORD_FIELD = maas_password_secret_field_name()
 _MODEL_PROFILE_CODEAGENT_ACCESS_TOKEN_FIELD = codeagent_access_token_secret_field_name()
+_MODEL_PROFILE_CODEAGENT_PASSWORD_FIELD = codeagent_password_secret_field_name()
 _MODEL_PROFILE_CODEAGENT_REFRESH_TOKEN_FIELD = (
     codeagent_refresh_token_secret_field_name()
 )
@@ -256,7 +259,16 @@ def load_llm_profile_state(
                     f"Invalid profile '{name}': MAAS profiles require maas_auth with a password."
                 )
         elif provider == ProviderType.CODEAGENT:
-            if codeagent_auth is None or codeagent_auth.refresh_token is None:
+            if codeagent_auth is None:
+                raise ValueError(
+                    f"Invalid profile '{name}': CodeAgent profiles require codeagent_auth configuration."
+                )
+            if codeagent_auth.auth_method == CodeAgentAuthMethod.PASSWORD:
+                if codeagent_auth.username is None or codeagent_auth.password is None:
+                    raise ValueError(
+                        f"Invalid profile '{name}': CodeAgent password profiles require codeagent_auth.username and password."
+                    )
+            elif codeagent_auth.refresh_token is None:
                 raise ValueError(
                     f"Invalid profile '{name}': CodeAgent profiles require codeagent_auth from completed SSO login."
                 )
@@ -556,6 +568,48 @@ def _resolve_profile_codeagent_auth(
         )
     payload = dict(raw_value)
     normalized_payload: dict[str, str | bool] = {}
+    auth_method_raw = payload.get("auth_method")
+    if isinstance(auth_method_raw, str) and auth_method_raw.strip():
+        normalized_payload["auth_method"] = auth_method_raw.strip()
+    resolved_auth_method = (
+        CodeAgentAuthMethod.PASSWORD
+        if normalized_payload.get("auth_method") == CodeAgentAuthMethod.PASSWORD.value
+        else CodeAgentAuthMethod.SSO
+    )
+
+    username = payload.get("username")
+    if isinstance(username, str) and username.strip():
+        normalized_payload["username"] = username.strip()
+
+    password = payload.get("password")
+    if resolved_auth_method == CodeAgentAuthMethod.PASSWORD:
+        if isinstance(password, str) and password.strip():
+            normalized_payload["password"] = _resolve_required_config_value(
+                password,
+                env_values,
+                profile_name=profile_name,
+                field_name="codeagent_auth.password",
+            )
+        else:
+            secret_value = get_secret_store().get_secret(
+                config_dir,
+                namespace=_MODEL_PROFILE_SECRET_NAMESPACE,
+                owner_id=profile_name,
+                field_name=_MODEL_PROFILE_CODEAGENT_PASSWORD_FIELD,
+            )
+            if secret_value is not None:
+                normalized_payload["password"] = _resolve_required_config_value(
+                    secret_value,
+                    env_values,
+                    profile_name=profile_name,
+                    field_name="codeagent_auth.password",
+                )
+        if payload.get("has_password"):
+            normalized_payload["has_password"] = True
+        return CodeAgentAuthConfig.model_validate(normalized_payload).with_secret_owner(
+            config_dir=config_dir,
+            owner_id=profile_name,
+        )
 
     access_token = _resolve_profile_codeagent_token(
         config_dir=config_dir,

--- a/tests/unit_tests/frontend/test_i18n_ui.py
+++ b/tests/unit_tests/frontend/test_i18n_ui.py
@@ -63,10 +63,10 @@ globalThis.localStorage = {
         this._values.set(key, String(value));
     },
 };
-    Object.defineProperty(globalThis, 'navigator', {
-        value: { language: 'en-US' },
-        configurable: true,
-    });
+Object.defineProperty(globalThis, 'navigator', {
+    value: { language: 'en-US' },
+    configurable: true,
+});
 globalThis.CustomEvent = class CustomEvent {
     constructor(type, init = {}) {
         this.type = type;
@@ -172,4 +172,110 @@ console.log(JSON.stringify({ afterInit, afterToggle }));
         "computerToolGroup": "Computer Use",
         "webToolGroup": "Web",
         "savedPayloads": [{"language": "en-US"}],
+    }
+
+
+def test_i18n_module_exposes_readable_model_auth_labels_in_chinese(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "utils" / "i18n.js"
+    mock_api_path = tmp_path / "mockApi.mjs"
+    module_under_test_path = tmp_path / "i18n.mjs"
+    runner_path = tmp_path / "runner.mjs"
+
+    mock_api_path.write_text(
+        """
+export async function fetchUiLanguageSettings() {
+    return { language: "zh-CN" };
+}
+
+export async function saveUiLanguageSettings(payload) {
+    globalThis.__savedPayloads.push(payload);
+    return { status: "ok" };
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    module_under_test_path.write_text(
+        source_path.read_text(encoding="utf-8").replace(
+            "../core/api.js", "./mockApi.mjs"
+        ),
+        encoding="utf-8",
+    )
+
+    runner_path.write_text(
+        """
+globalThis.__savedPayloads = [];
+globalThis.localStorage = {
+    _values: new Map(),
+    getItem(key) {
+        return this._values.has(key) ? this._values.get(key) : null;
+    },
+    setItem(key, value) {
+        this._values.set(key, String(value));
+    },
+};
+Object.defineProperty(globalThis, 'navigator', {
+    value: { language: 'zh-CN' },
+    configurable: true,
+});
+globalThis.CustomEvent = class CustomEvent {
+    constructor(type, init = {}) {
+        this.type = type;
+        this.detail = init.detail || null;
+    }
+};
+globalThis.document = {
+    documentElement: { lang: 'zh-CN' },
+    getElementById() {
+        return null;
+    },
+    querySelectorAll() {
+        return [];
+    },
+    dispatchEvent() {
+        return true;
+    },
+};
+
+const { initializeLanguage, t } = await import('./i18n.mjs');
+
+await initializeLanguage();
+
+console.log(JSON.stringify({
+    username: t('settings.model.username'),
+    usernamePlaceholder: t('settings.model.username_placeholder'),
+    password: t('settings.model.password'),
+    passwordPlaceholder: t('settings.model.password_placeholder'),
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+    assert payload == {
+        "username": "用户名",
+        "usernamePlaceholder": "用户名",
+        "password": "密码",
+        "passwordPlaceholder": "密码",
     }

--- a/tests/unit_tests/frontend/test_model_profiles_ui.py
+++ b/tests/unit_tests/frontend/test_model_profiles_ui.py
@@ -200,7 +200,272 @@ def test_codeagent_sso_button_uses_shared_form_control_height() -> None:
     override_rule = components_css[override_rule_start:override_rule_end]
 
     assert "min-height: 42px;" in button_rule
+    assert "white-space: normal;" in button_rule
     assert "min-height: 42px;" in override_rule
+    assert "width: fit-content;" in override_rule
+    assert (
+        "display: flex;"
+        in components_css[
+            components_css.index(
+                ".profile-codeagent-credentials-row {"
+            ) : components_css.index(".profile-codeagent-auth-method-row {")
+        ]
+    )
+    maas_rule_start = components_css.index(".profile-maas-credentials-row {")
+    maas_rule_end = components_css.index(
+        ".profile-codeagent-credentials-row {", maas_rule_start
+    )
+    maas_rule = components_css[maas_rule_start:maas_rule_end]
+    assert "grid-template-columns: repeat(2, minmax(0, 1fr));" in maas_rule
+
+
+def test_codeagent_auth_fields_use_split_rows_and_i18n_markup() -> None:
+    template_source = (
+        Path(__file__).resolve().parents[3]
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "settings"
+        / "modelProfiles"
+        / "template.js"
+    ).read_text(encoding="utf-8")
+
+    assert "profile-codeagent-auth-method-row" in template_source
+    assert "profile-codeagent-auth-detail-row" in template_source
+    assert 'data-i18n="settings.model.codeagent_auth_method"' in template_source
+    assert 'data-i18n="settings.model.codeagent_sso_field"' in template_source
+    assert 'data-i18n="settings.model.codeagent_username"' in template_source
+    assert 'data-i18n="settings.model.codeagent_password"' in template_source
+    assert (
+        'data-i18n-placeholder="settings.model.codeagent_username_placeholder"'
+        in template_source
+    )
+    assert (
+        'data-i18n-placeholder="settings.model.codeagent_password_placeholder"'
+        in template_source
+    )
+
+
+def test_maas_auth_fields_use_i18n_markup() -> None:
+    template_source = Path(
+        "frontend/dist/js/components/settings/modelProfiles/template.js"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        'class="profile-credentials-row profile-maas-credentials-row"'
+        in template_source
+    )
+    assert (
+        'for="profile-maas-username" data-i18n="settings.model.username"'
+        in template_source
+    )
+    assert (
+        'id="profile-maas-username" placeholder="username" '
+        'data-i18n-placeholder="settings.model.username_placeholder"' in template_source
+    )
+    assert (
+        'for="profile-maas-password" data-i18n="settings.model.password"'
+        in template_source
+    )
+    assert (
+        'id="profile-maas-password" placeholder="password" '
+        'data-i18n-placeholder="settings.model.password_placeholder"' in template_source
+    )
+
+
+def test_codeagent_password_field_runtime_placeholder_uses_i18n(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+document.getElementById("add-profile-btn").onclick();
+document.getElementById("profile-provider-codeagent-btn").onclick();
+document.getElementById("profile-codeagent-auth-method").value = "password";
+document.getElementById("profile-codeagent-auth-method").onchange();
+
+console.log(JSON.stringify({
+    placeholder: document.getElementById("profile-codeagent-password").placeholder,
+}));
+""".strip(),
+        mock_i18n_source="""
+const translations = {
+    "settings.model.profile_name": "Profile Name",
+    "settings.model.profile_name_placeholder": "profile",
+    "settings.model.default_model_action": "Set as default model",
+    "settings.model.step_provider_model": "Model Provider and Model",
+    "settings.model.provider_external": "Model Marketplace",
+    "settings.model.provider_external_copy": "Choose provider and model from the marketplace",
+    "settings.model.provider_maas": "MaaS Model",
+    "settings.model.provider_maas_copy": "Hosted model service platform",
+    "settings.model.provider_codeagent": "CodeAgent Model",
+    "settings.model.provider_codeagent_copy": "Use CodeAgent models with SSO or username/password sign-in",
+    "settings.model.provider_custom": "Custom Model",
+    "settings.model.provider_custom_copy": "Enter endpoint and model id manually",
+    "settings.model.base_url": "Base URL",
+    "settings.model.custom_base_url_placeholder": "Base URL",
+    "settings.model.catalog_title": "Model Catalog",
+    "settings.model.catalog_loading": "Loading model catalog...",
+    "settings.model.catalog_refresh": "Refresh",
+    "settings.model.provider": "Provider",
+    "settings.model.catalog_provider_search": "Search providers",
+    "settings.model.model": "Model",
+    "settings.model.catalog_model_search": "Search models",
+    "settings.model.custom_model_placeholder": "Model placeholder",
+    "settings.model.api_key": "API Key",
+    "settings.model.codeagent_auth_method": "Authentication Method",
+    "settings.model.codeagent_auth_method_sso": "SSO Sign-In",
+    "settings.model.codeagent_auth_method_password": "Username and Password",
+    "settings.model.codeagent_sso_field": "SSO Sign-In",
+    "settings.model.codeagent_sign_in_sso": "Sign in with SSO",
+    "settings.model.codeagent_username": "Username",
+    "settings.model.codeagent_username_placeholder": "localized username",
+    "settings.model.codeagent_password": "Password",
+    "settings.model.codeagent_password_placeholder": "localized password",
+    "settings.model.temperature": "Temperature",
+    "settings.model.top_p": "Top P",
+    "settings.model.max_output_tokens": "Max Output Tokens",
+    "settings.model.optional": "Optional",
+    "settings.model.context_window": "Context Window",
+    "settings.model.connect_timeout": "Connect Timeout",
+    "settings.proxy.default_ssl": "SSL Verification",
+    "settings.proxy.inherit_default": "Inherit Default",
+    "settings.proxy.verify": "Verify",
+    "settings.proxy.skip_verify": "Skip Verify",
+    "settings.model.step_advanced": "Advanced Options",
+    "settings.model.image_capability": "Image Input",
+    "settings.model.image_capability_follow": "Follow detection",
+    "settings.model.image_capability_supported": "Supports image input",
+    "settings.model.image_capability_unsupported": "Text only",
+    "settings.model.step_fallback": "Fallback Strategy",
+    "settings.model.fallback_strategy": "Fallback Strategy",
+    "settings.model.fallback_priority": "Fallback Priority",
+    "settings.model.codeagent_credentials_ready": "Credentials ready",
+    "settings.model.show_password": "Show password",
+    "settings.model.hide_password": "Hide password",
+    "settings.model.catalog_select_provider_first": "Select a provider first.",
+    "settings.model.catalog_empty": "No providers match the search.",
+    "settings.model.catalog_no_models": "No models match the search.",
+    "settings.model.catalog_loaded": "{providers} providers, {models} models",
+    "settings.model.catalog_cache_current": "just updated",
+};
+
+export function t(key) {
+    return translations[key] || key;
+}
+""".strip(),
+    )
+
+    assert payload["placeholder"] == "localized password"
+
+
+def test_maas_password_field_runtime_placeholder_uses_i18n(tmp_path: Path) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+document.getElementById("add-profile-btn").onclick();
+document.getElementById("profile-provider-maas-btn").onclick();
+
+console.log(JSON.stringify({
+    placeholder: document.getElementById("profile-maas-password").placeholder,
+}));
+""".strip(),
+        mock_i18n_source="""
+const translations = {
+    "settings.model.profile_name": "Profile Name",
+    "settings.model.profile_name_placeholder": "profile",
+    "settings.model.default_model_action": "Set as default model",
+    "settings.model.step_provider_model": "Model Provider and Model",
+    "settings.model.provider_external": "Model Marketplace",
+    "settings.model.provider_external_copy": "Choose provider and model from the marketplace",
+    "settings.model.provider_maas": "MaaS Model",
+    "settings.model.provider_maas_copy": "Hosted model service platform",
+    "settings.model.provider_codeagent": "CodeAgent Model",
+    "settings.model.provider_codeagent_copy": "Use CodeAgent models with SSO or username/password sign-in",
+    "settings.model.provider_custom": "Custom Model",
+    "settings.model.provider_custom_copy": "Enter endpoint and model id manually",
+    "settings.model.base_url": "Base URL",
+    "settings.model.custom_base_url_placeholder": "Base URL",
+    "settings.model.catalog_title": "Model Catalog",
+    "settings.model.catalog_loading": "Loading model catalog...",
+    "settings.model.catalog_refresh": "Refresh",
+    "settings.model.provider": "Provider",
+    "settings.model.catalog_provider_search": "Search providers",
+    "settings.model.model": "Model",
+    "settings.model.catalog_model_search": "Search models",
+    "settings.model.custom_model_placeholder": "Model placeholder",
+    "settings.model.api_key": "API Key",
+    "settings.model.username": "Username",
+    "settings.model.username_placeholder": "localized username",
+    "settings.model.password": "Password",
+    "settings.model.password_placeholder": "localized password",
+    "settings.model.temperature": "Temperature",
+    "settings.model.top_p": "Top P",
+    "settings.model.max_output_tokens": "Max Output Tokens",
+    "settings.model.optional": "Optional",
+    "settings.model.context_window": "Context Window",
+    "settings.model.connect_timeout": "Connect Timeout",
+    "settings.proxy.default_ssl": "SSL Verification",
+    "settings.proxy.inherit_default": "Inherit Default",
+    "settings.proxy.verify": "Verify",
+    "settings.proxy.skip_verify": "Skip Verify",
+    "settings.model.step_advanced": "Advanced Options",
+    "settings.model.image_capability": "Image Input",
+    "settings.model.image_capability_follow": "Follow detection",
+    "settings.model.image_capability_supported": "Supports image input",
+    "settings.model.image_capability_unsupported": "Text only",
+    "settings.model.show_password": "Show password",
+    "settings.model.hide_password": "Hide password",
+    "settings.model.catalog_select_provider_first": "Select a provider first.",
+    "settings.model.catalog_empty": "No providers match the search.",
+    "settings.model.catalog_no_models": "No models match the search.",
+    "settings.model.catalog_loaded": "{providers} providers, {models} models",
+    "settings.model.catalog_cache_current": "just updated",
+    "settings.model.catalog_cache_age": "{seconds}s old",
+    "settings.model.catalog_reasoning": "reasoning",
+    "settings.model.catalog_tools": "tools",
+    "settings.model.capability_section": "Capabilities",
+    "settings.model.show_api_key": "Show API key",
+    "settings.model.hide_api_key": "Hide API key",
+    "settings.model.advanced_summary": "Temperature {temperature}",
+    "settings.model.catalog_selected": "Selected Model",
+    "settings.model.catalog_selected_empty": "Choose a model from the catalog.",
+    "settings.model.capability_image_input": "Image input",
+    "settings.model.capability_text_only": "Text only",
+    "settings.model.capability_unknown": "Capability unknown",
+    "settings.model.no_model": "No model",
+    "settings.model.no_endpoint": "No endpoint",
+    "settings.model.fallback_policy_same_provider_then_other_provider": "Same Provider Then Other Provider",
+    "settings.model.fallback_policy_other_provider_only": "Other Provider Only",
+    "settings.model.unknown": "Unknown",
+    "settings.action.test": "Test",
+    "settings.action.edit": "Edit",
+    "settings.action.delete": "Delete",
+    "settings.action.cancel": "Cancel"
+};
+
+export function t(key) {
+    return translations[key] || key;
+}
+""".strip(),
+    )
+
+    assert payload["placeholder"] == "localized password"
 
 
 def test_saving_model_profile_restores_profile_list_visibility(
@@ -2491,7 +2756,7 @@ console.log(JSON.stringify({
     assert codeagent_state["baseUrlDisabled"] is True
     assert codeagent_state["baseUrlGroupDisplay"] == "none"
     assert codeagent_state["apiKeyDisplay"] == "none"
-    assert codeagent_state["codeagentDisplay"] == "grid"
+    assert codeagent_state["codeagentDisplay"] == "flex"
     assert codeagent_state["summary"] == "CodeAgent Model · No model"
     assert custom_state["providerValue"] == "openai_compatible"
     assert custom_state["baseUrlValue"] == ""
@@ -3918,6 +4183,312 @@ export async function discoverModelCatalog(payload) {
     )
 
 
+def test_saved_codeagent_password_profile_allows_probe_and_discovery_with_new_password_after_reauth_required(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+await loadModelProfilesPanel();
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "codeagent-profile").onclick();
+await Promise.resolve();
+await Promise.resolve();
+
+document.getElementById("profile-codeagent-password").value = "fresh-password";
+document.getElementById("profile-codeagent-password").oninput();
+await document.getElementById("test-profile-btn").onclick();
+await document.getElementById("fetch-profile-models-btn").onclick();
+
+console.log(JSON.stringify({
+    probePayload: globalThis.__probePayload || null,
+    discoverPayload: globalThis.__discoverPayload || null,
+    authStatus: document.getElementById("profile-codeagent-login-status-message").textContent,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "codeagent-profile": {
+            provider: "codeagent",
+            model: "codeagent-chat",
+            base_url: "https://codeagentcli.rnd.huawei.com/codeAgentPro",
+            codeagent_auth: {
+                auth_method: "password",
+                username: "saved-user",
+                has_password: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function fetchModelFallbackConfig() {
+    return { policies: [] };
+}
+
+export async function verifyCodeAgentAuth(profileName) {
+    globalThis.__codeAgentAuthVerifyCalls = globalThis.__codeAgentAuthVerifyCalls || [];
+    globalThis.__codeAgentAuthVerifyCalls.push(profileName);
+    return {
+        status: "reauth_required",
+        checked_at: "2026-04-27T02:00:00Z",
+        detail: "expired credentials",
+    };
+}
+
+export async function probeModelConnection(payload) {
+    globalThis.__probePayload = payload;
+    return { ok: true, latency_ms: 42, token_usage: { total_tokens: 9 } };
+}
+
+export async function discoverModelCatalog(payload) {
+    globalThis.__discoverPayload = payload;
+    return { ok: true, latency_ms: 37, models: ["codeagent-chat"] };
+}
+""".strip(),
+    )
+
+    probe_payload = cast(dict[str, JsonValue], payload["probePayload"])
+    discover_payload = cast(dict[str, JsonValue], payload["discoverPayload"])
+    probe_override = cast(dict[str, JsonValue], probe_payload["override"])
+    discover_override = cast(dict[str, JsonValue], discover_payload["override"])
+
+    assert cast(dict[str, JsonValue], probe_override["codeagent_auth"]) == {
+        "auth_method": "password",
+        "username": "saved-user",
+        "password": "fresh-password",
+    }
+    assert cast(dict[str, JsonValue], discover_override["codeagent_auth"]) == {
+        "auth_method": "password",
+        "username": "saved-user",
+        "password": "fresh-password",
+    }
+    assert payload["authStatus"] == "Credentials ready"
+
+
+def test_saved_codeagent_password_profile_accepts_same_password_reentry_after_reauth_required(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+await loadModelProfilesPanel();
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "codeagent-profile").onclick();
+await Promise.resolve();
+await Promise.resolve();
+
+document.getElementById("profile-codeagent-password").value = "same-password";
+document.getElementById("profile-codeagent-password").oninput();
+await document.getElementById("test-profile-btn").onclick();
+await document.getElementById("fetch-profile-models-btn").onclick();
+
+console.log(JSON.stringify({
+    probePayload: globalThis.__probePayload || null,
+    discoverPayload: globalThis.__discoverPayload || null,
+    authStatus: document.getElementById("profile-codeagent-login-status-message").textContent,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "codeagent-profile": {
+            provider: "codeagent",
+            model: "codeagent-chat",
+            base_url: "https://codeagentcli.rnd.huawei.com/codeAgentPro",
+            codeagent_auth: {
+                auth_method: "password",
+                username: "saved-user",
+                password: "same-password",
+                has_password: true,
+            },
+            is_default: false,
+            temperature: 0.7,
+            top_p: 1.0,
+            connect_timeout_seconds: 15,
+        },
+    };
+}
+
+export async function fetchModelFallbackConfig() {
+    return { policies: [] };
+}
+
+export async function verifyCodeAgentAuth(profileName) {
+    globalThis.__codeAgentAuthVerifyCalls = globalThis.__codeAgentAuthVerifyCalls || [];
+    globalThis.__codeAgentAuthVerifyCalls.push(profileName);
+    return {
+        status: "reauth_required",
+        checked_at: "2026-04-27T02:00:00Z",
+        detail: "expired credentials",
+    };
+}
+
+export async function probeModelConnection(payload) {
+    globalThis.__probePayload = payload;
+    return { ok: true, latency_ms: 42, token_usage: { total_tokens: 9 } };
+}
+
+export async function discoverModelCatalog(payload) {
+    globalThis.__discoverPayload = payload;
+    return { ok: true, latency_ms: 37, models: ["codeagent-chat"] };
+}
+""".strip(),
+    )
+
+    probe_payload = cast(dict[str, JsonValue], payload["probePayload"])
+    discover_payload = cast(dict[str, JsonValue], payload["discoverPayload"])
+    probe_override = cast(dict[str, JsonValue], probe_payload["override"])
+    discover_override = cast(dict[str, JsonValue], discover_payload["override"])
+
+    assert cast(dict[str, JsonValue], probe_override["codeagent_auth"]) == {
+        "auth_method": "password",
+        "username": "saved-user",
+        "password": "same-password",
+    }
+    assert cast(dict[str, JsonValue], discover_override["codeagent_auth"]) == {
+        "auth_method": "password",
+        "username": "saved-user",
+        "password": "same-password",
+    }
+    assert payload["authStatus"] == "Credentials ready"
+
+
+def test_codeagent_password_auth_discovery_uses_username_and_password(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+document.getElementById("add-profile-btn").onclick();
+document.getElementById("profile-provider").value = "codeagent";
+document.getElementById("profile-provider").onchange();
+document.getElementById("profile-codeagent-auth-method").value = "password";
+document.getElementById("profile-codeagent-auth-method").onchange();
+document.getElementById("profile-codeagent-username").value = "relay-user";
+document.getElementById("profile-codeagent-username").oninput();
+document.getElementById("profile-codeagent-password").onfocus();
+document.getElementById("profile-codeagent-password").value = "relay-password";
+document.getElementById("profile-codeagent-password").oninput();
+document.getElementById("profile-model").value = "codeagent-chat";
+document.getElementById("profile-model").oninput();
+
+await document.getElementById("fetch-profile-models-btn").onclick();
+
+console.log(JSON.stringify({
+    discoverPayload: globalThis.__discoverPayload,
+    authStatus: document.getElementById("profile-codeagent-login-status-message").textContent,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {};
+}
+
+export async function fetchModelFallbackConfig() {
+    return { policies: [] };
+}
+
+export async function discoverModelCatalog(payload) {
+    globalThis.__discoverPayload = payload;
+    return { ok: true, latency_ms: 37, models: ["codeagent-chat"] };
+}
+""".strip(),
+    )
+
+    discover_payload = cast(dict[str, JsonValue], payload["discoverPayload"])
+    override = cast(dict[str, JsonValue], discover_payload["override"])
+    codeagent_auth = cast(dict[str, JsonValue], override["codeagent_auth"])
+
+    assert codeagent_auth == {
+        "auth_method": "password",
+        "username": "relay-user",
+        "password": "relay-password",
+    }
+    assert payload["authStatus"] == "Credentials ready"
+
+
+def test_editing_saved_codeagent_password_profile_requires_new_password_after_username_change(
+    tmp_path: Path,
+) -> None:
+    payload = _run_model_profiles_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { bindModelProfileHandlers, loadModelProfilesPanel } from "./modelProfiles.mjs";
+
+const notifications = [];
+const elements = createElements();
+installGlobals(elements, notifications);
+bindModelProfileHandlers();
+
+await loadModelProfilesPanel();
+document.getElementById("profiles-list").querySelectorAll(".edit-profile-btn").find(btn => btn.dataset.name === "codeagent-profile").onclick();
+document.getElementById("profile-codeagent-username").value = "new-user";
+document.getElementById("profile-codeagent-username").oninput();
+await document.getElementById("save-profile-btn").onclick();
+
+console.log(JSON.stringify({
+    notifications,
+    savedProfile: globalThis.__savedProfile || null,
+}));
+""".strip(),
+        mock_api_source="""
+export async function fetchModelProfiles() {
+    return {
+        "codeagent-profile": {
+            provider: "codeagent",
+            model: "codeagent-chat",
+            base_url: "https://codeagentcli.rnd.huawei.com/codeAgentPro",
+            codeagent_auth: {
+                auth_method: "password",
+                username: "old-user",
+                has_password: true,
+            },
+        },
+    };
+}
+
+export async function fetchModelFallbackConfig() {
+    return { policies: [] };
+}
+""".strip(),
+    )
+
+    notifications = cast(list[dict[str, JsonValue]], payload["notifications"])
+
+    assert payload["savedProfile"] is None
+    assert notifications == [
+        {
+            "title": "Save Failed",
+            "message": "Re-enter the CodeAgent password after changing the username.",
+            "tone": "warning",
+        }
+    ]
+
+
 def test_codeagent_sso_polling_stops_when_auth_session_changes(
     tmp_path: Path,
 ) -> None:
@@ -4391,6 +4962,18 @@ const translations = {
     "settings.model.image_capability_follow": "Follow detection",
     "settings.model.image_capability_supported": "Supports image input",
     "settings.model.image_capability_unsupported": "Text only",
+    "settings.model.username": "Username",
+    "settings.model.username_placeholder": "username",
+    "settings.model.password": "Password",
+    "settings.model.password_placeholder": "password",
+    "settings.model.codeagent_auth_method": "Authentication Method",
+    "settings.model.codeagent_auth_method_sso": "SSO Sign-In",
+    "settings.model.codeagent_auth_method_password": "Username and Password",
+    "settings.model.codeagent_sso_field": "SSO Sign-In",
+    "settings.model.codeagent_username": "Username",
+    "settings.model.codeagent_username_placeholder": "username",
+    "settings.model.codeagent_password": "Password",
+    "settings.model.codeagent_password_placeholder": "password",
     "settings.model.codeagent_sign_in_sso": "Sign in with SSO",
     "settings.model.codeagent_sso_starting": "Starting SSO login",
     "settings.model.codeagent_sso_saved": "Saved sign-in requires verification",
@@ -4401,6 +4984,12 @@ const translations = {
     "settings.model.codeagent_sso_popup_blocked": "SSO popup was blocked. Click Sign in with SSO again to continue.",
     "settings.model.codeagent_sso_timed_out": "SSO login timed out",
     "settings.model.codeagent_sso_failed": "SSO failed: {error}",
+    "settings.model.codeagent_credentials_saved": "Saved credentials require verification",
+    "settings.model.codeagent_credentials_verifying": "Verifying saved credentials",
+    "settings.model.codeagent_credentials_expired": "Saved credentials expired. Update username or password.",
+    "settings.model.codeagent_password_reenter": "Re-enter password after changing username.",
+    "settings.model.codeagent_credentials_ready": "Credentials ready",
+    "settings.model.codeagent_credentials_verified": "Credentials verified",
     "settings.model.show_api_key": "Show API key",
     "settings.model.hide_api_key": "Hide API key",
     "settings.model.show_password": "Show password",
@@ -4412,7 +5001,7 @@ const translations = {
     "settings.model.default_saved_message": "{name} is now the default model.",
     "settings.model.provider_external": "Model Marketplace",
     "settings.model.provider_maas": "MaaS Model",
-    "settings.model.provider_codeagent_copy": "Use CodeAgent models with SSO sign-in",
+    "settings.model.provider_codeagent_copy": "Use CodeAgent models with SSO or username/password sign-in",
     "settings.model.provider_codeagent": "CodeAgent Model",
     "settings.model.provider_custom": "Custom Model",
     "settings.model.custom_model": "Custom model",
@@ -4606,8 +5195,15 @@ function createElements() {{
             ["profile-maas-model-slot", createElement("block", "profile-maas-model-slot")],
             ["profile-codeagent-auth-fields", createElement("none", "profile-codeagent-auth-fields")],
             ["profile-codeagent-model-slot", createElement("block", "profile-codeagent-model-slot")],
+            ["profile-codeagent-auth-method", createElement("block", "profile-codeagent-auth-method")],
+            ["profile-codeagent-sso-group", createElement("block", "profile-codeagent-sso-group")],
             ["profile-codeagent-login-status", createElement("block", "profile-codeagent-login-status")],
             ["profile-codeagent-login-status-message", createElement("none", "profile-codeagent-login-status-message")],
+            ["profile-codeagent-username-group", createElement("none", "profile-codeagent-username-group")],
+            ["profile-codeagent-username", createElement("block", "profile-codeagent-username")],
+            ["profile-codeagent-password-group", createElement("none", "profile-codeagent-password-group")],
+            ["profile-codeagent-password", createElement("block", "profile-codeagent-password")],
+            ["toggle-profile-codeagent-password-btn", createElement("none", "toggle-profile-codeagent-password-btn")],
             ["profile-maas-username", createElement("block", "profile-maas-username")],
             ["profile-maas-password", createElement("block", "profile-maas-password")],
             ["toggle-profile-maas-password-btn", createElement("none", "toggle-profile-maas-password-btn")],
@@ -4639,8 +5235,15 @@ function createElements() {{
         elements.get("profile-model-field-home")?.appendChild(elements.get("profile-model-group"));
         elements.get("profile-maas-auth-fields")?.appendChild(elements.get("profile-maas-model-slot"));
         elements.get("profile-codeagent-auth-fields")?.appendChild(elements.get("profile-codeagent-model-slot"));
-        elements.get("profile-codeagent-auth-fields")?.appendChild(elements.get("profile-codeagent-login-status"));
-        elements.get("profile-codeagent-auth-fields")?.appendChild(elements.get("profile-codeagent-login-status-message"));
+        elements.get("profile-codeagent-auth-fields")?.appendChild(elements.get("profile-codeagent-auth-method"));
+        elements.get("profile-codeagent-auth-fields")?.appendChild(elements.get("profile-codeagent-sso-group"));
+        elements.get("profile-codeagent-auth-fields")?.appendChild(elements.get("profile-codeagent-username-group"));
+        elements.get("profile-codeagent-auth-fields")?.appendChild(elements.get("profile-codeagent-password-group"));
+        elements.get("profile-codeagent-sso-group")?.appendChild(elements.get("profile-codeagent-login-status"));
+        elements.get("profile-codeagent-sso-group")?.appendChild(elements.get("profile-codeagent-login-status-message"));
+        elements.get("profile-codeagent-username-group")?.appendChild(elements.get("profile-codeagent-username"));
+        elements.get("profile-codeagent-password-group")?.appendChild(elements.get("profile-codeagent-password"));
+        elements.get("profile-codeagent-password-group")?.appendChild(elements.get("toggle-profile-codeagent-password-btn"));
         elements.get("profile-base-url").closestElements = {{ ".form-group": baseUrlGroup }};
         return elements;
     }}

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -341,7 +341,7 @@ console.log(JSON.stringify({
     assert 'id="profile-maas-username"' in modal_html
     assert 'id="profile-maas-password"' in modal_html
     assert (
-        'id="profile-maas-password" placeholder="password" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false"'
+        'id="profile-maas-password" placeholder="password" data-i18n-placeholder="settings.model.password_placeholder" autocomplete="new-password" autocapitalize="off" autocorrect="off" spellcheck="false"'
         in modal_html
     )
     assert 'id="profile-maas-model-slot"' in modal_html
@@ -350,7 +350,7 @@ console.log(JSON.stringify({
     assert 'data-i18n="settings.model.provider_codeagent"' in modal_html
     assert 'data-i18n="settings.model.provider_codeagent_copy"' in modal_html
     assert "CodeAgent Model" in modal_html
-    assert "Use CodeAgent models with SSO sign-in" in modal_html
+    assert "Use CodeAgent models with SSO or username/password sign-in" in modal_html
     assert 'id="profile-codeagent-auth-fields"' in modal_html
     assert 'id="profile-codeagent-login-status"' in modal_html
     assert 'id="profile-codeagent-login-status-message"' in modal_html

--- a/tests/unit_tests/providers/test_codeagent_auth.py
+++ b/tests/unit_tests/providers/test_codeagent_auth.py
@@ -25,7 +25,13 @@ from relay_teams.providers.codeagent_auth import (
     is_codeagent_chat_completion_request,
     save_codeagent_oauth_tokens,
 )
+from relay_teams.providers.maas_auth import (
+    MaaSAuthConfig,
+    MaaSAuthContext,
+    MaaSLoginError,
+)
 from relay_teams.providers.model_config import (
+    CodeAgentAuthMethod,
     CodeAgentAuthConfig,
     DEFAULT_CODEAGENT_BASE_URL,
     DEFAULT_CODEAGENT_CLIENT_ID,
@@ -253,6 +259,106 @@ def test_codeagent_token_service_uses_configured_access_token_first(
     assert token == "fresh-access-token"
 
 
+def test_codeagent_token_service_password_login_reuses_maas_token_service(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeMaaSTokenService:
+        def get_auth_context_sync(
+            self,
+            *,
+            auth_config: object,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> MaaSAuthContext:
+            captured["auth_config"] = auth_config
+            captured["ssl_verify"] = ssl_verify
+            captured["connect_timeout_seconds"] = connect_timeout_seconds
+            captured["force_refresh"] = force_refresh
+            return MaaSAuthContext(token="maas-issued-token", department=None)
+
+    monkeypatch.setattr(
+        codeagent_auth_module,
+        "get_maas_token_service",
+        lambda: _FakeMaaSTokenService(),
+    )
+
+    token = CodeAgentTokenService().get_token_sync(
+        base_url=DEFAULT_CODEAGENT_BASE_URL,
+        auth_config=CodeAgentAuthConfig(
+            auth_method=CodeAgentAuthMethod.PASSWORD,
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=False,
+        connect_timeout_seconds=12.0,
+    )
+
+    assert token == "maas-issued-token"
+    auth_config = cast(MaaSAuthConfig, captured["auth_config"])
+    assert auth_config.username == "relay-user"
+    assert auth_config.password == "relay-password"
+    assert captured["ssl_verify"] is False
+    assert captured["connect_timeout_seconds"] == pytest.approx(12.0)
+    assert captured["force_refresh"] is False
+
+
+def test_codeagent_token_service_password_login_sync_requires_username_and_password() -> (
+    None
+):
+    with pytest.raises(
+        CodeAgentOAuthError,
+        match="CodeAgent username/password is not configured.",
+    ):
+        CodeAgentTokenService().get_token_result_sync(
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            auth_config=CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.PASSWORD,
+                username="relay-user",
+            ),
+            ssl_verify=None,
+            connect_timeout_seconds=15.0,
+        )
+
+
+def test_codeagent_token_service_password_login_sync_maps_maas_login_error(
+    monkeypatch,
+) -> None:
+    class _FailingMaaSTokenService:
+        def get_auth_context_sync(
+            self,
+            *,
+            auth_config: object,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> MaaSAuthContext:
+            _ = auth_config, ssl_verify, connect_timeout_seconds, force_refresh
+            raise MaaSLoginError("password login denied", status_code=401)
+
+    monkeypatch.setattr(
+        codeagent_auth_module,
+        "get_maas_token_service",
+        lambda: _FailingMaaSTokenService(),
+    )
+
+    with pytest.raises(CodeAgentOAuthError, match="password login denied") as exc_info:
+        CodeAgentTokenService().get_token_result_sync(
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            auth_config=CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.PASSWORD,
+                username="relay-user",
+                password="relay-password",
+            ),
+            ssl_verify=None,
+            connect_timeout_seconds=15.0,
+        )
+
+    assert exc_info.value.status_code == 401
+
+
 def test_codeagent_token_service_get_token_result_sync_uses_cached_result() -> None:
     service = CodeAgentTokenService()
     auth_config = CodeAgentAuthConfig(refresh_token="refresh-token")
@@ -277,6 +383,21 @@ def test_codeagent_token_service_get_token_result_sync_uses_cached_result() -> N
     )
 
     assert result == token_result
+
+
+def test_codeagent_token_service_token_result_from_config_skips_password_auth() -> None:
+    service = CodeAgentTokenService()
+
+    assert (
+        service._token_result_from_config(
+            CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.PASSWORD,
+                username="relay-user",
+                password="relay-password",
+            )
+        )
+        is None
+    )
 
 
 def test_codeagent_token_service_get_token_result_sync_rechecks_cache_inside_lock(
@@ -637,6 +758,109 @@ async def test_codeagent_token_service_get_token_uses_cached_async_result() -> N
     )
 
     assert token == "cached-access-token"
+
+
+@pytest.mark.asyncio
+async def test_codeagent_token_service_password_login_async_reuses_maas_token_service(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeMaaSTokenService:
+        async def get_auth_context(
+            self,
+            *,
+            auth_config: object,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> MaaSAuthContext:
+            captured["auth_config"] = auth_config
+            captured["ssl_verify"] = ssl_verify
+            captured["connect_timeout_seconds"] = connect_timeout_seconds
+            captured["force_refresh"] = force_refresh
+            return MaaSAuthContext(token="maas-issued-token", department=None)
+
+    monkeypatch.setattr(
+        codeagent_auth_module,
+        "get_maas_token_service",
+        lambda: _FakeMaaSTokenService(),
+    )
+
+    token = await CodeAgentTokenService().get_token(
+        base_url=DEFAULT_CODEAGENT_BASE_URL,
+        auth_config=CodeAgentAuthConfig(
+            auth_method=CodeAgentAuthMethod.PASSWORD,
+            username="relay-user",
+            password="relay-password",
+        ),
+        ssl_verify=False,
+        connect_timeout_seconds=12.0,
+    )
+
+    assert token == "maas-issued-token"
+    auth_config = cast(MaaSAuthConfig, captured["auth_config"])
+    assert auth_config.username == "relay-user"
+    assert auth_config.password == "relay-password"
+    assert captured["ssl_verify"] is False
+    assert captured["connect_timeout_seconds"] == pytest.approx(12.0)
+    assert captured["force_refresh"] is False
+
+
+@pytest.mark.asyncio
+async def test_codeagent_token_service_password_login_async_requires_username_and_password() -> (
+    None
+):
+    with pytest.raises(
+        CodeAgentOAuthError,
+        match="CodeAgent username/password is not configured.",
+    ):
+        await CodeAgentTokenService().get_token_result(
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            auth_config=CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.PASSWORD,
+                username="relay-user",
+            ),
+            ssl_verify=None,
+            connect_timeout_seconds=15.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_codeagent_token_service_password_login_async_maps_maas_login_error(
+    monkeypatch,
+) -> None:
+    class _FailingMaaSTokenService:
+        async def get_auth_context(
+            self,
+            *,
+            auth_config: object,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> MaaSAuthContext:
+            _ = auth_config, ssl_verify, connect_timeout_seconds, force_refresh
+            raise MaaSLoginError("password login denied", status_code=401)
+
+    monkeypatch.setattr(
+        codeagent_auth_module,
+        "get_maas_token_service",
+        lambda: _FailingMaaSTokenService(),
+    )
+
+    with pytest.raises(CodeAgentOAuthError, match="password login denied") as exc_info:
+        await CodeAgentTokenService().get_token_result(
+            base_url=DEFAULT_CODEAGENT_BASE_URL,
+            auth_config=CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.PASSWORD,
+                username="relay-user",
+                password="relay-password",
+            ),
+            ssl_verify=None,
+            connect_timeout_seconds=15.0,
+        )
+
+    assert exc_info.value.status_code == 401
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_model_config.py
+++ b/tests/unit_tests/providers/test_model_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from relay_teams.providers.model_config import (
+    CodeAgentAuthMethod,
     CodeAgentAuthConfig,
     MaaSAuthConfig,
     ModelEndpointConfig,
@@ -49,4 +50,20 @@ def test_model_endpoint_config_requires_maas_password() -> None:
             model="maas-chat",
             base_url="https://maas.example/api/v2",
             maas_auth=MaaSAuthConfig(username="relay-user"),
+        )
+
+
+def test_model_endpoint_config_requires_codeagent_password_fields() -> None:
+    with pytest.raises(
+        ValueError,
+        match="CodeAgent model endpoint config requires codeagent_auth.username and codeagent_auth.password for password auth.",
+    ):
+        ModelEndpointConfig(
+            provider=ProviderType.CODEAGENT,
+            model="codeagent-chat",
+            base_url="https://codeagent.example/codeAgentPro",
+            codeagent_auth=CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.PASSWORD,
+                username="relay-user",
+            ),
         )

--- a/tests/unit_tests/providers/test_model_config_manager.py
+++ b/tests/unit_tests/providers/test_model_config_manager.py
@@ -14,6 +14,7 @@ from relay_teams.providers.codeagent_auth import (
     CodeAgentOAuthTokenResult,
     clear_codeagent_oauth_session_store,
     codeagent_access_token_secret_field_name,
+    codeagent_password_secret_field_name,
     codeagent_refresh_token_secret_field_name,
     create_codeagent_oauth_session,
     get_codeagent_oauth_tokens,
@@ -772,6 +773,7 @@ def test_save_model_profile_stores_codeagent_tokens_from_oauth_session(
     assert codeagent_auth["has_refresh_token"] is True
     assert model_payload["codeagent-profile"]["base_url"] == DEFAULT_CODEAGENT_BASE_URL
     assert model_payload["codeagent-profile"]["codeagent_auth"] == {
+        "auth_method": "sso",
         "has_access_token": True,
         "has_refresh_token": True,
     }
@@ -1018,6 +1020,7 @@ def test_save_model_config_stores_codeagent_profiles_and_hydrates_auth(
     hydrated_auth = cast(dict[str, JsonValue], hydrated_profile["codeagent_auth"])
 
     assert raw_config["raw-note"] == "keep-me"
+    assert raw_auth["auth_method"] == "sso"
     assert raw_auth["has_access_token"] is True
     assert raw_auth["has_refresh_token"] is True
     assert "access_token" not in raw_auth
@@ -1155,33 +1158,44 @@ def test_prepare_profile_codeagent_auth_reuses_existing_config_when_omitted(
         secret_store=_FileOnlySecretStore(),
     )
 
-    merged_profile, next_access_token, next_refresh_token, preserve_tokens, _pending = (
-        manager._prepare_profile_codeagent_auth_for_storage(
-            profile_name="codeagent-profile",
-            existing_profile={
-                "provider": "codeagent",
-                "codeagent_auth": {
-                    "has_access_token": True,
-                    "has_refresh_token": True,
-                },
+    (
+        merged_profile,
+        next_access_token,
+        next_refresh_token,
+        next_password,
+        preserve_tokens,
+        preserve_password,
+        _pending,
+    ) = manager._prepare_profile_codeagent_auth_for_storage(
+        profile_name="codeagent-profile",
+        existing_profile={
+            "provider": "codeagent",
+            "codeagent_auth": {
+                "auth_method": "sso",
+                "has_access_token": True,
+                "has_refresh_token": True,
             },
-            next_profile={
-                "provider": "codeagent",
-                "model": "codeagent-chat",
-            },
-            source_name=None,
-            current_access_token=None,
-            current_refresh_token="saved-refresh-token",
-        )
+        },
+        next_profile={
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+        },
+        source_name=None,
+        current_access_token=None,
+        current_password=None,
+        current_refresh_token="saved-refresh-token",
     )
 
     assert merged_profile["codeagent_auth"] == {
+        "auth_method": "sso",
         "has_access_token": True,
         "has_refresh_token": True,
     }
     assert next_access_token is None
     assert next_refresh_token is None
+    assert next_password is None
     assert preserve_tokens is True
+    assert preserve_password is False
 
 
 def test_prepare_profile_codeagent_auth_requires_config_for_codeagent_profiles(
@@ -1205,6 +1219,7 @@ def test_prepare_profile_codeagent_auth_requires_config_for_codeagent_profiles(
             },
             source_name=None,
             current_access_token=None,
+            current_password=None,
             current_refresh_token=None,
         )
 
@@ -1228,6 +1243,7 @@ def test_prepare_profile_codeagent_auth_rejects_non_object_payload(
             },
             source_name=None,
             current_access_token=None,
+            current_password=None,
             current_refresh_token=None,
         )
 
@@ -1257,6 +1273,7 @@ def test_prepare_profile_codeagent_auth_rejects_missing_oauth_session(
             },
             source_name=None,
             current_access_token=None,
+            current_password=None,
             current_refresh_token=None,
         )
 
@@ -1283,6 +1300,7 @@ def test_prepare_profile_codeagent_auth_requires_completed_login_without_saved_t
             },
             source_name=None,
             current_access_token=None,
+            current_password=None,
             current_refresh_token=None,
         )
 
@@ -1292,30 +1310,39 @@ def test_prepare_profile_codeagent_auth_preserves_existing_refresh_token(
 ) -> None:
     manager = ModelConfigManager(config_dir=tmp_path)
 
-    next_profile, next_access_token, next_refresh_token, preserve_tokens, _pending = (
-        manager._prepare_profile_codeagent_auth_for_storage(
-            profile_name="codeagent-profile",
-            existing_profile={
-                "provider": "codeagent",
-                "model": "codeagent-chat",
-                "codeagent_auth": {
-                    "refresh_token": "saved-refresh-token",
-                },
+    (
+        next_profile,
+        next_access_token,
+        next_refresh_token,
+        next_password,
+        preserve_tokens,
+        preserve_password,
+        _pending,
+    ) = manager._prepare_profile_codeagent_auth_for_storage(
+        profile_name="codeagent-profile",
+        existing_profile={
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "codeagent_auth": {
+                "refresh_token": "saved-refresh-token",
             },
-            next_profile={
-                "provider": "codeagent",
-                "model": "codeagent-chat",
-                "codeagent_auth": {},
-            },
-            source_name=None,
-            current_access_token=None,
-            current_refresh_token=None,
-        )
+        },
+        next_profile={
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "codeagent_auth": {},
+        },
+        source_name=None,
+        current_access_token=None,
+        current_password=None,
+        current_refresh_token=None,
     )
 
     assert preserve_tokens is True
     assert next_access_token is None
     assert next_refresh_token is None
+    assert next_password is None
+    assert preserve_password is False
     assert "codeagent_auth" in next_profile
 
 
@@ -1324,24 +1351,147 @@ def test_prepare_profile_codeagent_auth_preserves_current_refresh_token(
 ) -> None:
     manager = ModelConfigManager(config_dir=tmp_path)
 
-    _next_profile, next_access_token, next_refresh_token, preserve_tokens, _pending = (
+    (
+        _next_profile,
+        next_access_token,
+        next_refresh_token,
+        next_password,
+        preserve_tokens,
+        preserve_password,
+        _pending,
+    ) = manager._prepare_profile_codeagent_auth_for_storage(
+        profile_name="codeagent-profile",
+        existing_profile=None,
+        next_profile={
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "codeagent_auth": {},
+        },
+        source_name=None,
+        current_access_token=None,
+        current_password=None,
+        current_refresh_token="current-refresh-token",
+    )
+
+    assert preserve_tokens is True
+    assert next_access_token is None
+    assert next_refresh_token is None
+    assert next_password is None
+    assert preserve_password is False
+
+
+def test_prepare_profile_codeagent_auth_preserves_existing_password_for_password_auth(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+    manager._set_profile_codeagent_password("codeagent-profile", "saved-password")
+
+    (
+        next_profile,
+        _next_access_token,
+        _next_refresh_token,
+        next_password,
+        preserve_tokens,
+        preserve_password,
+        _pending,
+    ) = manager._prepare_profile_codeagent_auth_for_storage(
+        profile_name="codeagent-profile",
+        existing_profile={
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "codeagent_auth": {
+                "auth_method": "password",
+                "username": "relay-user",
+                "has_password": True,
+            },
+        },
+        next_profile={
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "codeagent_auth": {
+                "auth_method": "password",
+                "username": "relay-user",
+            },
+        },
+        source_name=None,
+        current_access_token=None,
+        current_password=None,
+        current_refresh_token=None,
+    )
+
+    assert next_profile["codeagent_auth"] == {
+        "auth_method": "password",
+        "username": "relay-user",
+        "has_password": True,
+    }
+    assert next_password is None
+    assert preserve_tokens is False
+    assert preserve_password is True
+
+
+def test_prepare_profile_codeagent_auth_preserves_current_password_for_password_auth(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(config_dir=tmp_path)
+
+    (
+        _next_profile,
+        _next_access_token,
+        _next_refresh_token,
+        next_password,
+        preserve_tokens,
+        preserve_password,
+        _pending,
+    ) = manager._prepare_profile_codeagent_auth_for_storage(
+        profile_name="codeagent-profile",
+        existing_profile=None,
+        next_profile={
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "codeagent_auth": {
+                "auth_method": "password",
+                "username": "relay-user",
+            },
+        },
+        source_name=None,
+        current_access_token=None,
+        current_password="current-password",
+        current_refresh_token=None,
+    )
+
+    assert next_password is None
+    assert preserve_tokens is False
+    assert preserve_password is True
+
+
+def test_prepare_profile_codeagent_auth_requires_password_for_first_password_auth(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(config_dir=tmp_path)
+
+    with pytest.raises(
+        ValueError,
+        match="CodeAgent auth password requires a value the first time it is configured.",
+    ):
         manager._prepare_profile_codeagent_auth_for_storage(
             profile_name="codeagent-profile",
             existing_profile=None,
             next_profile={
                 "provider": "codeagent",
                 "model": "codeagent-chat",
-                "codeagent_auth": {},
+                "codeagent_auth": {
+                    "auth_method": "password",
+                    "username": "relay-user",
+                },
             },
             source_name=None,
             current_access_token=None,
-            current_refresh_token="current-refresh-token",
+            current_password=None,
+            current_refresh_token=None,
         )
-    )
-
-    assert preserve_tokens is True
-    assert next_access_token is None
-    assert next_refresh_token is None
 
 
 def test_save_model_config_does_not_consume_codeagent_session_before_full_validation(
@@ -1423,10 +1573,217 @@ def test_resolve_codeagent_auth_prefers_inline_tokens_and_session_id(
     )
 
     assert resolved is not None
+    assert resolved.auth_method.value == "sso"
     assert resolved.oauth_session_id == "session-id"
     assert resolved.access_token == "access-token"
     assert resolved.refresh_token == "refresh-token"
     assert resolved._secret_owner_id == "codeagent-profile"
+
+
+def test_save_model_profile_stores_codeagent_password_in_secret_store(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+
+    manager.save_model_profile(
+        "codeagent-password",
+        {
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "codeagent_auth": {
+                "auth_method": "password",
+                "username": "relay-user",
+                "password": "relay-password",
+            },
+        },
+    )
+
+    profiles = manager.get_model_profiles()
+    saved_auth = cast(
+        dict[str, JsonValue],
+        profiles["codeagent-password"]["codeagent_auth"],
+    )
+    raw_config = json.loads((tmp_path / "model.json").read_text(encoding="utf-8"))
+    secrets_payload = json.loads(
+        (tmp_path / "secrets.json").read_text(encoding="utf-8")
+    )
+
+    assert saved_auth["auth_method"] == "password"
+    assert saved_auth["username"] == "relay-user"
+    assert saved_auth["has_password"] is True
+    assert raw_config["codeagent-password"]["codeagent_auth"] == {
+        "auth_method": "password",
+        "username": "relay-user",
+        "has_password": True,
+    }
+    assert {
+        "namespace": "model_profile",
+        "owner_id": "codeagent-password",
+        "field_name": codeagent_password_secret_field_name(),
+        "storage": "file",
+        "value": "relay-password",
+    } in secrets_payload["entries"]
+
+
+def test_save_model_profile_rejects_codeagent_username_change_without_new_password(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+
+    manager.save_model_profile(
+        "codeagent-password",
+        {
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "codeagent_auth": {
+                "auth_method": "password",
+                "username": "old-user",
+                "password": "relay-password",
+            },
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="CodeAgent auth password must be re-entered after changing the username.",
+    ):
+        manager.save_model_profile(
+            "codeagent-password",
+            {
+                "provider": "codeagent",
+                "model": "codeagent-chat",
+                "base_url": DEFAULT_CODEAGENT_BASE_URL,
+                "codeagent_auth": {
+                    "auth_method": "password",
+                    "username": "new-user",
+                },
+            },
+        )
+
+
+def test_save_model_profile_rejects_codeagent_password_auth_without_username(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="CodeAgent auth username requires a value for password auth.",
+    ):
+        manager.save_model_profile(
+            "codeagent-password",
+            {
+                "provider": "codeagent",
+                "model": "codeagent-chat",
+                "base_url": DEFAULT_CODEAGENT_BASE_URL,
+                "codeagent_auth": {
+                    "auth_method": "password",
+                    "password": "relay-password",
+                },
+            },
+        )
+
+
+def test_save_model_profile_rejects_invalid_codeagent_auth_method(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="CodeAgent auth auth_method must be 'sso' or 'password'.",
+    ):
+        manager.save_model_profile(
+            "codeagent-password",
+            {
+                "provider": "codeagent",
+                "model": "codeagent-chat",
+                "base_url": DEFAULT_CODEAGENT_BASE_URL,
+                "codeagent_auth": {
+                    "auth_method": "Password",
+                    "username": "relay-user",
+                    "password": "relay-password",
+                },
+            },
+        )
+
+
+def test_save_model_profile_migrates_inline_codeagent_password_into_secret_store(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+    (tmp_path / "model.json").write_text(
+        json.dumps(
+            {
+                "codeagent-profile": {
+                    "provider": "codeagent",
+                    "model": "codeagent-chat",
+                    "base_url": DEFAULT_CODEAGENT_BASE_URL,
+                    "codeagent_auth": {
+                        "auth_method": "password",
+                        "username": "relay-user",
+                        "password": "inline-password",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager.save_model_profile(
+        "codeagent-profile",
+        {
+            "provider": "codeagent",
+            "model": "codeagent-chat",
+            "base_url": DEFAULT_CODEAGENT_BASE_URL,
+            "codeagent_auth": {
+                "auth_method": "password",
+                "username": "relay-user",
+            },
+        },
+    )
+
+    profiles = manager.get_model_profiles()
+    saved_profile = cast(dict[str, JsonValue], profiles["codeagent-profile"])
+    saved_auth = cast(dict[str, JsonValue], saved_profile["codeagent_auth"])
+    raw_config = json.loads((tmp_path / "model.json").read_text(encoding="utf-8"))
+    secrets_payload = json.loads(
+        (tmp_path / "secrets.json").read_text(encoding="utf-8")
+    )
+
+    assert saved_auth["auth_method"] == "password"
+    assert saved_auth["username"] == "relay-user"
+    assert saved_auth["password"] == "inline-password"
+    assert saved_auth["has_password"] is True
+    assert raw_config["codeagent-profile"]["codeagent_auth"] == {
+        "auth_method": "password",
+        "username": "relay-user",
+        "has_password": True,
+    }
+    assert {
+        "namespace": "model_profile",
+        "owner_id": "codeagent-profile",
+        "field_name": codeagent_password_secret_field_name(),
+        "storage": "file",
+        "value": "inline-password",
+    } in secrets_payload["entries"]
 
 
 def test_profile_codeagent_secret_accessors_return_none_for_missing_profile_name(
@@ -1439,6 +1796,42 @@ def test_profile_codeagent_secret_accessors_return_none_for_missing_profile_name
 
     assert manager._get_profile_codeagent_access_token(None) is None
     assert manager._get_profile_codeagent_refresh_token(None) is None
+
+
+def test_get_profile_codeagent_password_returns_saved_secret(tmp_path: Path) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+    manager._set_profile_codeagent_password("codeagent-profile", "saved-password")
+
+    assert (
+        manager._get_profile_codeagent_password("codeagent-profile") == "saved-password"
+    )
+
+
+def test_resolve_codeagent_auth_reads_inline_password_for_dirty_profile(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(config_dir=tmp_path)
+
+    resolved = manager._resolve_codeagent_auth(
+        "codeagent-profile",
+        {
+            "codeagent_auth": {
+                "auth_method": "password",
+                "username": "relay-user",
+                "password": " inline-password ",
+                "has_password": True,
+            }
+        },
+    )
+
+    assert resolved is not None
+    assert resolved.auth_method.value == "password"
+    assert resolved.username == "relay-user"
+    assert resolved.password == "inline-password"
+    assert resolved.has_password is True
 
 
 def test_apply_profile_codeagent_token_update_moves_explicit_tokens_on_rename(
@@ -1505,3 +1898,65 @@ def test_apply_profile_codeagent_token_update_copies_source_tokens_when_preservi
     )
     assert manager._get_profile_codeagent_access_token("source-profile") is None
     assert manager._get_profile_codeagent_refresh_token("source-profile") is None
+
+
+def test_apply_profile_codeagent_password_update_moves_saved_password_on_rename(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+    manager._set_profile_codeagent_password("source-profile", "saved-password")
+
+    manager._apply_profile_codeagent_password_update(
+        name="target-profile",
+        source_name="source-profile",
+        next_password=None,
+        preserve_password=True,
+    )
+
+    assert manager._get_profile_codeagent_password("source-profile") is None
+    assert manager._get_profile_codeagent_password("target-profile") == "saved-password"
+
+
+def test_apply_profile_codeagent_password_update_clears_passwords_on_rename_without_preserve(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+    manager._set_profile_codeagent_password("source-profile", "saved-password")
+    manager._set_profile_codeagent_password("target-profile", "stale-password")
+
+    manager._apply_profile_codeagent_password_update(
+        name="target-profile",
+        source_name="source-profile",
+        next_password=None,
+        preserve_password=False,
+    )
+
+    assert manager._get_profile_codeagent_password("source-profile") is None
+    assert manager._get_profile_codeagent_password("target-profile") is None
+
+
+def test_apply_profile_codeagent_password_update_keeps_password_when_preserved(
+    tmp_path: Path,
+) -> None:
+    manager = ModelConfigManager(
+        config_dir=tmp_path,
+        secret_store=_FileOnlySecretStore(),
+    )
+    manager._set_profile_codeagent_password("codeagent-profile", "saved-password")
+
+    manager._apply_profile_codeagent_password_update(
+        name="codeagent-profile",
+        source_name=None,
+        next_password=None,
+        preserve_password=True,
+    )
+
+    assert (
+        manager._get_profile_codeagent_password("codeagent-profile") == "saved-password"
+    )

--- a/tests/unit_tests/providers/test_model_connectivity.py
+++ b/tests/unit_tests/providers/test_model_connectivity.py
@@ -18,6 +18,7 @@ from relay_teams.providers.codeagent_auth import (
 )
 from relay_teams.providers.maas_auth import MaaSAuthContext, MaaSLoginError
 from relay_teams.providers.model_config import (
+    CodeAgentAuthMethod,
     CodeAgentAuthConfig,
     DEFAULT_CODEAGENT_BASE_URL,
     MaaSAuthConfig,
@@ -203,7 +204,7 @@ class _FakeCodeAgentTokenService:
 
 def test_probe_uses_saved_profile_and_returns_usage(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -248,7 +249,7 @@ def test_probe_uses_profile_connect_timeout_when_request_timeout_omitted(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -268,7 +269,7 @@ def test_probe_uses_profile_connect_timeout_when_request_timeout_omitted(
 
 def test_probe_merges_override_with_saved_profile(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -301,7 +302,7 @@ def test_probe_merges_override_with_saved_profile(monkeypatch) -> None:
 
 def test_probe_uses_model_ssl_override_before_global_default(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -325,7 +326,7 @@ def test_probe_uses_model_ssl_override_before_global_default(monkeypatch) -> Non
 
 
 def test_probe_returns_timeout_error(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -343,7 +344,7 @@ def test_probe_returns_timeout_error(monkeypatch) -> None:
 
 
 def test_probe_returns_auth_error_for_unauthorized_response(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -366,7 +367,7 @@ def test_probe_returns_auth_error_for_unauthorized_response(monkeypatch) -> None
 
 def test_probe_accepts_editor_default_timeout(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -395,7 +396,7 @@ def test_probe_accepts_editor_default_timeout(monkeypatch) -> None:
 
 
 def test_probe_requires_base_url_for_openai_override() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="base_url"):
         service.probe(
@@ -410,7 +411,7 @@ def test_probe_requires_base_url_for_openai_override() -> None:
 
 
 def test_probe_requires_codeagent_auth_for_codeagent_override() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="codeagent_auth"):
         service.probe(
@@ -424,7 +425,7 @@ def test_probe_requires_codeagent_auth_for_codeagent_override() -> None:
 
 
 def test_probe_codeagent_override_reports_all_missing_required_fields() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="model, codeagent_auth"):
         service.probe(
@@ -436,7 +437,7 @@ def test_probe_codeagent_override_reports_all_missing_required_fields() -> None:
 
 def test_probe_supports_bigmodel_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -469,7 +470,7 @@ def test_probe_supports_bigmodel_provider(monkeypatch) -> None:
 
 def test_probe_allows_header_only_override(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -503,7 +504,7 @@ def test_probe_allows_header_only_override(monkeypatch) -> None:
 
 def test_probe_supports_maas_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_maas_token_service",
@@ -562,7 +563,7 @@ def test_probe_supports_codeagent_provider_with_oauth_session(
         ),
     )
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -616,7 +617,7 @@ def test_probe_supports_codeagent_provider_with_oauth_session(
 
 def test_probe_codeagent_accepts_event_stream_success_without_json(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -655,7 +656,7 @@ def test_probe_codeagent_accepts_event_stream_success_without_json(monkeypatch) 
 
 def test_probe_codeagent_rejects_event_stream_error_payload(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -696,7 +697,7 @@ def test_probe_codeagent_rejects_event_stream_error_payload(monkeypatch) -> None
 def test_probe_codeagent_rejects_event_stream_top_level_message_payload(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -731,7 +732,7 @@ def test_probe_codeagent_rejects_event_stream_top_level_message_payload(
 
 
 def test_probe_codeagent_rejects_invalid_event_stream_payload(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -768,7 +769,7 @@ def test_probe_codeagent_rejects_invalid_event_stream_payload(monkeypatch) -> No
 def test_probe_codeagent_rejects_plain_text_event_stream_heartbeat(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -914,7 +915,7 @@ def test_probe_merges_saved_maas_password_when_override_omits_it(monkeypatch) ->
 
 
 def test_probe_returns_maas_auth_error_for_invalid_credentials(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _InvalidCredentialsTokenService:
         def get_token_sync(
@@ -956,7 +957,7 @@ def test_probe_returns_maas_auth_error_for_invalid_credentials(monkeypatch) -> N
 
 
 def test_probe_returns_retryable_maas_login_service_error(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _UnavailableTokenService:
         def get_token_sync(
@@ -1003,7 +1004,7 @@ def test_probe_refreshes_maas_token_after_unauthorized_response(monkeypatch) -> 
         httpx.Response(401, json={"error": {"message": "expired"}}),
         httpx.Response(200, json={"usage": {"total_tokens": 1}}),
     ]
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     token_service = _FakeMaaSTokenService(["expired-token", "fresh-token"], captured)
     monkeypatch.setattr(
@@ -1049,7 +1050,7 @@ def test_probe_refreshes_maas_token_after_unauthorized_response(monkeypatch) -> 
 
 def test_discover_models_supports_maas_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_maas_token_service",
@@ -1142,7 +1143,7 @@ def test_discover_models_supports_codeagent_provider_with_oauth_session(
         ),
     )
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -1198,7 +1199,7 @@ def test_discover_models_supports_codeagent_provider_with_oauth_session(
 
 
 def test_discover_models_requires_base_url_for_openai_override() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="base_url"):
         service.discover_models(
@@ -1213,7 +1214,7 @@ def test_discover_models_requires_base_url_for_openai_override() -> None:
 
 
 def test_discover_models_requires_codeagent_auth_for_codeagent_override() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="codeagent_auth"):
         service.discover_models(
@@ -1227,7 +1228,7 @@ def test_discover_models_requires_codeagent_auth_for_codeagent_override() -> Non
 
 
 def test_discover_models_codeagent_override_reports_missing_codeagent_auth() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="codeagent_auth"):
         service.discover_models(
@@ -1244,7 +1245,7 @@ def test_probe_codeagent_returns_network_error_for_request_exception(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -1281,7 +1282,7 @@ def test_probe_codeagent_returns_network_error_for_request_exception(
 def test_probe_codeagent_returns_invalid_response_for_oauth_error_without_http_status(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
         def get_token_sync(
@@ -1382,7 +1383,7 @@ def test_discover_models_codeagent_returns_timeout_for_request_exception(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_codeagent_token_service",
@@ -1419,7 +1420,7 @@ def test_discover_models_codeagent_returns_timeout_for_request_exception(
 def test_discover_models_codeagent_returns_invalid_response_for_oauth_error(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
         def get_token_sync(
@@ -2011,7 +2012,7 @@ def test_verify_codeagent_auth_returns_reauth_required_after_refresh_denied(
 def test_discover_models_codeagent_oauth_http_error_is_retryable_for_server_errors(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
         def get_token_sync(
@@ -2061,7 +2062,7 @@ def test_discover_models_codeagent_oauth_http_error_is_retryable_for_server_erro
 def test_get_codeagent_token_for_probe_returns_timeout_when_token_service_times_out(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _TimeoutingCodeAgentTokenService:
         def get_token_sync(
@@ -2107,7 +2108,7 @@ def test_get_codeagent_token_for_probe_returns_timeout_when_token_service_times_
 def test_get_codeagent_token_for_discovery_returns_network_error_when_token_service_fails(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
         def get_token_sync(
@@ -2166,7 +2167,7 @@ def test_resolve_codeagent_auth_for_request_preserves_secret_owner_metadata() ->
             expires_at=datetime.now(UTC) + timedelta(hours=1),
         ),
     )
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     resolved = service._resolve_codeagent_auth_for_request(
         CodeAgentAuthConfig(
@@ -2187,7 +2188,7 @@ def test_resolve_codeagent_auth_for_request_preserves_secret_owner_metadata() ->
 def test_resolve_codeagent_auth_for_request_rejects_consumed_session_without_refresh_token() -> (
     None
 ):
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(
         CodeAgentOAuthError,
@@ -2201,7 +2202,7 @@ def test_resolve_codeagent_auth_for_request_rejects_consumed_session_without_ref
 def test_resolve_codeagent_auth_for_request_rejects_missing_refresh_token_without_session() -> (
     None
 ):
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(
         CodeAgentOAuthError,
@@ -2211,7 +2212,7 @@ def test_resolve_codeagent_auth_for_request_rejects_missing_refresh_token_withou
 
 
 def test_resolve_codeagent_auth_for_request_returns_existing_refresh_token() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
     auth_config = CodeAgentAuthConfig(refresh_token="refresh-token")
 
     resolved = service._resolve_codeagent_auth_for_request(auth_config)
@@ -2219,8 +2220,39 @@ def test_resolve_codeagent_auth_for_request_returns_existing_refresh_token() -> 
     assert resolved == auth_config
 
 
+def test_resolve_codeagent_auth_for_request_returns_password_auth_config() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+    auth_config = CodeAgentAuthConfig(
+        auth_method=CodeAgentAuthMethod.PASSWORD,
+        username="relay-user",
+        password="relay-password",
+    ).with_secret_owner(
+        config_dir=Path("D:/tmp/.agent_teams"),
+        owner_id="codeagent-profile",
+    )
+
+    resolved = service._resolve_codeagent_auth_for_request(auth_config)
+
+    assert resolved == auth_config
+
+
+def test_resolve_codeagent_auth_for_request_rejects_incomplete_password_auth() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    with pytest.raises(
+        CodeAgentOAuthError,
+        match="CodeAgent username/password is not configured.",
+    ):
+        service._resolve_codeagent_auth_for_request(
+            CodeAgentAuthConfig(
+                auth_method=CodeAgentAuthMethod.PASSWORD,
+                username="relay-user",
+            )
+        )
+
+
 def test_merge_codeagent_auth_returns_override_when_base_is_missing() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
     override_auth = CodeAgentAuthConfig(refresh_token="refresh-token")
 
     merged = service._merge_codeagent_auth(
@@ -2234,7 +2266,7 @@ def test_merge_codeagent_auth_returns_override_when_base_is_missing() -> None:
 def test_merge_codeagent_auth_with_session_override_drops_stale_base_refresh_token() -> (
     None
 ):
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
     base_auth = CodeAgentAuthConfig(
         refresh_token="stale-refresh-token",
         access_token="stale-access-token",
@@ -2260,7 +2292,7 @@ def test_merge_codeagent_auth_with_session_override_drops_stale_base_refresh_tok
 
 
 def test_merge_codeagent_auth_without_session_override_preserves_secret_owner() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
     base_auth = CodeAgentAuthConfig(
         access_token="saved-access-token",
         refresh_token="saved-refresh-token",
@@ -2282,10 +2314,61 @@ def test_merge_codeagent_auth_without_session_override_preserves_secret_owner() 
     assert merged._secret_owner_id == "saved-profile"
 
 
+def test_merge_codeagent_auth_password_override_drops_stale_sso_tokens() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+    base_auth = CodeAgentAuthConfig(
+        access_token="saved-access-token",
+        refresh_token="saved-refresh-token",
+    ).with_secret_owner(
+        config_dir=Path("D:/tmp/.agent_teams"),
+        owner_id="saved-profile",
+    )
+    override_auth = CodeAgentAuthConfig(
+        auth_method=CodeAgentAuthMethod.PASSWORD,
+        username="relay-user",
+        password="relay-password",
+    )
+
+    merged = service._merge_codeagent_auth(
+        base_codeagent_auth=base_auth,
+        override_codeagent_auth=override_auth,
+    )
+
+    assert merged is not None
+    assert merged.auth_method == CodeAgentAuthMethod.PASSWORD
+    assert merged.username == "relay-user"
+    assert merged.password == "relay-password"
+    assert merged.access_token is None
+    assert merged.refresh_token is None
+    assert merged._secret_owner_id == "saved-profile"
+
+
+def test_merge_codeagent_auth_rejects_username_change_without_new_password() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+    base_auth = CodeAgentAuthConfig(
+        auth_method=CodeAgentAuthMethod.PASSWORD,
+        username="old-user",
+        password="saved-password",
+    )
+    override_auth = CodeAgentAuthConfig(
+        auth_method=CodeAgentAuthMethod.PASSWORD,
+        username="new-user",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="CodeAgent password must be re-entered after changing the username.",
+    ):
+        service._merge_codeagent_auth(
+            base_codeagent_auth=base_auth,
+            override_codeagent_auth=override_auth,
+        )
+
+
 def test_build_maas_login_error_result_without_http_status_returns_invalid_response() -> (
     None
 ):
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     result = service._build_maas_login_error_result(
         config=ModelEndpointConfig(
@@ -2308,7 +2391,7 @@ def test_build_maas_login_error_result_without_http_status_returns_invalid_respo
 
 
 def test_build_model_discovery_maas_login_error_result_maps_auth_failure() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     result = service._build_model_discovery_maas_login_error_result(
         config=ModelDiscoveryResolvedConfig(
@@ -2332,7 +2415,7 @@ def test_build_model_discovery_maas_login_error_result_maps_auth_failure() -> No
 
 
 def test_extract_openai_model_entries_skips_invalid_and_duplicate_items() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     entries = service._extract_model_entries(
         payload={
@@ -2353,7 +2436,7 @@ def test_extract_openai_model_entries_skips_invalid_and_duplicate_items() -> Non
 
 
 def test_extract_model_entries_returns_none_for_non_mapping_payload() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     entries = service._extract_model_entries(
         payload=["gpt-4.1"],
@@ -2364,7 +2447,7 @@ def test_extract_model_entries_returns_none_for_non_mapping_payload() -> None:
 
 
 def test_extract_codeagent_model_entries_reads_models_field() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     entries = service._extract_codeagent_model_entries(
         {
@@ -2383,7 +2466,7 @@ def test_extract_codeagent_model_entries_reads_models_field() -> None:
 
 
 def test_extract_codeagent_model_entries_skips_blank_model_ids() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     entries = service._extract_codeagent_model_entries(
         {
@@ -2458,7 +2541,7 @@ def test_discover_models_refreshes_maas_token_after_unauthorized_response(
         httpx.Response(401, json={"error": {"message": "expired"}}),
         httpx.Response(200, json={"user_model_list": [{"model_id": "maas-chat"}]}),
     ]
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     token_service = _FakeMaaSTokenService(["expired-token", "fresh-token"], captured)
     monkeypatch.setattr(
@@ -2505,7 +2588,7 @@ def test_discover_models_refreshes_maas_auth_when_department_missing(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     token_service = _FakeMaaSTokenService(
         ["stale-token", "fresh-token"],
@@ -2555,7 +2638,7 @@ def test_discover_models_returns_invalid_response_when_maas_department_missing(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_maas_token_service",
@@ -2591,7 +2674,7 @@ def test_discover_models_returns_invalid_response_when_maas_department_missing(
 
 def test_discover_models_uses_saved_profile_and_parses_catalog(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -2633,7 +2716,7 @@ def test_discover_models_uses_saved_profile_and_parses_catalog(monkeypatch) -> N
 
 
 def test_discover_models_projects_input_modalities_from_catalog(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -2668,7 +2751,7 @@ def test_discover_models_projects_input_modalities_from_catalog(monkeypatch) -> 
 def test_discover_models_extracts_context_window_when_provider_returns_it(
     monkeypatch,
 ) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -2705,7 +2788,7 @@ def test_discover_models_extracts_context_window_when_provider_returns_it(
 
 
 def test_discover_models_falls_back_to_known_context_window_rules(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -2735,7 +2818,7 @@ def test_discover_models_allows_saved_api_key_with_override_base_url(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -2765,7 +2848,7 @@ def test_discover_models_allows_saved_api_key_with_override_base_url(
 
 def test_discover_models_supports_bigmodel_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -2796,7 +2879,7 @@ def test_discover_models_supports_bigmodel_provider(monkeypatch) -> None:
 
 def test_discover_models_allows_header_only_override(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -2829,7 +2912,7 @@ def test_discover_models_allows_header_only_override(monkeypatch) -> None:
 
 
 def test_discover_models_returns_invalid_response_error(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.create_sync_http_client",
@@ -2847,7 +2930,7 @@ def test_discover_models_returns_invalid_response_error(monkeypatch) -> None:
 
 def test_probe_maas_supports_event_stream_wrapped_json(monkeypatch) -> None:
     captured: dict[str, object] = {}
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
         "relay_teams.providers.model_connectivity.get_maas_token_service",
@@ -2891,14 +2974,14 @@ def test_probe_maas_supports_event_stream_wrapped_json(monkeypatch) -> None:
 
 
 def test_probe_requires_source_config() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="Provide profile_name, override, or both."):
         service.probe(ModelConnectivityProbeRequest())
 
 
 def test_discover_models_requires_source_config() -> None:
-    service = ModelConnectivityProbeService(get_runtime=lambda: _runtime_config())
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="Provide profile_name, override, or both."):
         service.discover_models(ModelDiscoveryRequest())

--- a/tests/unit_tests/sessions/runs/test_runtime_config.py
+++ b/tests/unit_tests/sessions/runs/test_runtime_config.py
@@ -8,6 +8,7 @@ import pytest
 
 from relay_teams.providers.codeagent_auth import (
     codeagent_access_token_secret_field_name,
+    codeagent_password_secret_field_name,
     codeagent_refresh_token_secret_field_name,
 )
 from relay_teams.providers.model_header_utils import model_header_secret_field_name
@@ -599,6 +600,58 @@ def test_load_llm_configs_rejects_codeagent_profile_without_completed_auth(
         runtime_config.load_llm_configs(tmp_path, {})
 
 
+def test_load_llm_configs_rejects_codeagent_profile_without_codeagent_auth(
+    tmp_path: Path,
+) -> None:
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "codeagent-profile": {
+                    "provider": "codeagent",
+                    "model": "codeagent-chat",
+                    "base_url": "https://codeagent.example/codeAgentPro",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="CodeAgent profiles require codeagent_auth configuration.",
+    ):
+        runtime_config.load_llm_configs(tmp_path, {})
+
+
+def test_load_llm_configs_rejects_codeagent_password_auth_without_password(
+    tmp_path: Path,
+) -> None:
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "codeagent-profile": {
+                    "provider": "codeagent",
+                    "model": "codeagent-chat",
+                    "base_url": "https://codeagent.example/codeAgentPro",
+                    "codeagent_auth": {
+                        "auth_method": "password",
+                        "username": "relay-user",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="CodeAgent password profiles require codeagent_auth.username and password.",
+    ):
+        runtime_config.load_llm_configs(tmp_path, {})
+
+
 def test_load_llm_configs_rejects_non_object_codeagent_auth(tmp_path: Path) -> None:
     model_file = tmp_path / "model.json"
     model_file.write_text(
@@ -659,6 +712,118 @@ def test_load_llm_configs_resolves_codeagent_tokens_from_env_placeholders(
     assert (
         profiles["codeagent-profile"].codeagent_auth.refresh_token
         == "env-codeagent-refresh-token"
+    )
+
+
+def test_load_llm_configs_accepts_codeagent_password_auth(
+    tmp_path: Path,
+) -> None:
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "codeagent-profile": {
+                    "provider": "codeagent",
+                    "model": "codeagent-chat",
+                    "base_url": "https://codeagent.example/codeAgentPro",
+                    "codeagent_auth": {
+                        "auth_method": "password",
+                        "username": "relay-user",
+                        "has_password": True,
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    get_secret_store().set_secret(
+        tmp_path,
+        namespace="model_profile",
+        owner_id="codeagent-profile",
+        field_name=codeagent_password_secret_field_name(),
+        value="relay-password",
+    )
+
+    profiles = runtime_config.load_llm_configs(tmp_path, {})
+
+    assert profiles["codeagent-profile"].codeagent_auth is not None
+    assert profiles["codeagent-profile"].codeagent_auth.auth_method.value == "password"
+    assert profiles["codeagent-profile"].codeagent_auth.username == "relay-user"
+    assert profiles["codeagent-profile"].codeagent_auth.password == "relay-password"
+
+
+def test_load_llm_configs_resolves_codeagent_password_env_placeholder(
+    tmp_path: Path,
+) -> None:
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "codeagent-profile": {
+                    "provider": "codeagent",
+                    "model": "codeagent-chat",
+                    "base_url": "https://codeagent.example/codeAgentPro",
+                    "codeagent_auth": {
+                        "auth_method": "password",
+                        "username": "relay-user",
+                        "password": "${CODEAGENT_PASSWORD}",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    profiles = runtime_config.load_llm_configs(
+        tmp_path,
+        {"CODEAGENT_PASSWORD": "env-codeagent-password"},
+    )
+
+    assert profiles["codeagent-profile"].codeagent_auth is not None
+    assert (
+        profiles["codeagent-profile"].codeagent_auth.password
+        == "env-codeagent-password"
+    )
+
+
+def test_load_llm_configs_resolves_secret_backed_codeagent_password_env_placeholder(
+    tmp_path: Path,
+) -> None:
+    model_file = tmp_path / "model.json"
+    model_file.write_text(
+        json.dumps(
+            {
+                "codeagent-profile": {
+                    "provider": "codeagent",
+                    "model": "codeagent-chat",
+                    "base_url": "https://codeagent.example/codeAgentPro",
+                    "codeagent_auth": {
+                        "auth_method": "password",
+                        "username": "relay-user",
+                        "has_password": True,
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    get_secret_store().set_secret(
+        tmp_path,
+        namespace="model_profile",
+        owner_id="codeagent-profile",
+        field_name=codeagent_password_secret_field_name(),
+        value="${CODEAGENT_PASSWORD}",
+    )
+
+    profiles = runtime_config.load_llm_configs(
+        tmp_path,
+        {"CODEAGENT_PASSWORD": "env-codeagent-password"},
+    )
+
+    assert profiles["codeagent-profile"].codeagent_auth is not None
+    assert (
+        profiles["codeagent-profile"].codeagent_auth.password
+        == "env-codeagent-password"
     )
 
 


### PR DESCRIPTION
Add CodeAgent dual auth flow

Fixes #578

## Summary
- add CodeAgent dual auth support for SSO and username/password flows
- align CodeAgent and MaaS credential forms with i18n labels and placeholders
- restore system model API managed request caching and MCP system exports

## Validation
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_i18n_ui.py::test_i18n_module_exposes_readable_model_auth_labels_in_chinese tests/unit_tests/frontend/test_model_profiles_ui.py::test_maas_auth_fields_use_i18n_markup tests/unit_tests/frontend/test_model_profiles_ui.py::test_maas_password_field_runtime_placeholder_uses_i18n tests/unit_tests/frontend/test_model_profiles_ui.py::test_codeagent_sso_button_uses_shared_form_control_height
- pre-commit hooks on commit: ruff-check, ruff-format, basedpyright-check
