### PR TITLE
feat: parse MCP server JSON in settings

### DIFF
--- a/frontend/dist/css/components/settings.css
+++ b/frontend/dist/css/components/settings.css
@@ -1513,6 +1513,11 @@
     min-height: 92px;
 }
 
+.mcp-editor-json-textarea {
+    min-height: 132px;
+    font-family: var(--font-mono);
+}
+
 .mcp-overwrite-toggle {
     grid-column: 1 / -1;
 }

--- a/frontend/dist/js/components/settings/systemStatus.js
+++ b/frontend/dist/js/components/settings/systemStatus.js
@@ -557,6 +557,10 @@ function renderMcpEditor() {
     return `
         <section class="mcp-editor-panel">
             <div class="mcp-editor-grid">
+                <div class="form-group form-group-span-2">
+                    <label for="mcp-server-json-input">${escapeHtml(t('settings.mcp.json_config'))}</label>
+                    <textarea id="mcp-server-json-input" class="config-textarea mcp-editor-textarea mcp-editor-json-textarea" placeholder="${escapeHtml(t('settings.mcp.json_placeholder'))}" spellcheck="false"></textarea>
+                </div>
                 <div class="form-group">
                     <label for="mcp-server-name-input">${escapeHtml(t('settings.mcp.name'))}</label>
                     <input type="text" id="mcp-server-name-input" placeholder="${escapeHtml(t('settings.mcp.name_placeholder'))}" autocomplete="off" value="${escapeHtml(name)}" ${mcpEditorMode === 'edit' ? 'disabled' : ''}>
@@ -601,6 +605,13 @@ function bindMcpEditorHandlers() {
     if (transportInput) {
         transportInput.onchange = syncMcpEditorTransportFields;
         syncMcpEditorTransportFields();
+    }
+    const jsonInput = safeGetElementById('mcp-server-json-input');
+    if (jsonInput) {
+        jsonInput.oninput = applyMcpJsonConfigFromInput;
+        jsonInput.onpaste = () => {
+            setTimeout(applyMcpJsonConfigFromInput, 0);
+        };
     }
 }
 
@@ -671,27 +682,125 @@ function buildMcpServerPayloadFromForm() {
     };
 }
 
+function applyMcpJsonConfigFromInput() {
+    const parsed = parseMcpJsonConfig(getInputValue('mcp-server-json-input'));
+    if (!parsed) {
+        return;
+    }
+    const config = normalizeEditableMcpConfig(parsed.config);
+    setInputValue('mcp-server-name-input', parsed.name, { overwriteDisabled: false });
+    setInputValue('mcp-server-transport-input', normalizeEditableTransport(config));
+    syncMcpEditorTransportFields();
+    setInputValue('mcp-server-command-input', config.command || '');
+    setInputValue('mcp-server-args-input', formatLineList(config.args));
+    setInputValue('mcp-server-url-input', config.url || '');
+    const extra = normalizeEditableTransport(config) === 'stdio'
+        ? formatKeyValueLines(config.env)
+        : formatKeyValueLines(config.headers);
+    setInputValue('mcp-server-extra-input', extra);
+}
+
+function parseMcpJsonConfig(raw) {
+    const text = String(raw || '').trim();
+    if (!text) {
+        return null;
+    }
+    let payload;
+    try {
+        payload = JSON.parse(text);
+    } catch (_) {
+        return null;
+    }
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        return null;
+    }
+
+    const mcpServers = payload.mcpServers;
+    if (mcpServers && typeof mcpServers === 'object' && !Array.isArray(mcpServers)) {
+        const firstServer = Object.entries(mcpServers).find(([, config]) => (
+            config && typeof config === 'object' && !Array.isArray(config)
+        ));
+        if (firstServer) {
+            return {
+                name: String(firstServer[0] || ''),
+                config: { ...firstServer[1] },
+            };
+        }
+    }
+
+    if (typeof payload.name === 'string' && payload.config && typeof payload.config === 'object' && !Array.isArray(payload.config)) {
+        return {
+            name: payload.name,
+            config: { ...payload.config },
+        };
+    }
+
+    return null;
+}
+
 function normalizeEditableMcpConfig(config) {
     const normalized = { ...config };
     normalized.transport = normalizeEditableTransport(normalized);
+    if (Array.isArray(normalized.command)) {
+        const commandParts = normalized.command
+            .map(item => String(item).trim())
+            .filter(Boolean);
+        if (commandParts.length > 0) {
+            normalized.command = commandParts[0];
+            if (!Array.isArray(normalized.args)) {
+                normalized.args = commandParts.slice(1);
+            }
+        }
+    }
     return normalized;
 }
 
 function normalizeEditableTransport(config) {
     const rawTransport = String(config?.transport || '').trim();
-    if (rawTransport) {
-        return rawTransport;
+    const transport = normalizeMcpTransportValue(rawTransport);
+    if (transport) {
+        return transport;
+    }
+    const rawType = String(config?.type || '').trim();
+    const configType = normalizeMcpTransportValue(rawType);
+    if (configType === 'local') {
+        return 'stdio';
+    }
+    if (configType === 'remote') {
+        return detectRemoteMcpTransport(config);
+    }
+    if (configType) {
+        return configType;
     }
     if (typeof config?.command === 'string' && config.command.trim()) {
         return 'stdio';
     }
-    if (typeof config?.url === 'string' && config.url.includes('/sse')) {
-        return 'sse';
-    }
     if (typeof config?.url === 'string' && config.url.trim()) {
-        return 'http';
+        return detectRemoteMcpTransport(config);
     }
     return 'stdio';
+}
+
+function normalizeMcpTransportValue(value) {
+    const normalized = String(value || '').trim().toLowerCase().replaceAll('_', '-');
+    if (!normalized) {
+        return '';
+    }
+    if (normalized === 'streamablehttp' || normalized === 'streamable-http') {
+        return 'streamable-http';
+    }
+    if (normalized === 'stdio' || normalized === 'http' || normalized === 'sse') {
+        return normalized;
+    }
+    if (normalized === 'local' || normalized === 'remote') {
+        return normalized;
+    }
+    return normalized;
+}
+
+function detectRemoteMcpTransport(config) {
+    const url = typeof config?.url === 'string' ? config.url : '';
+    return url.includes('/sse') ? 'sse' : 'http';
 }
 
 function formatLineList(value) {
@@ -713,6 +822,14 @@ function formatKeyValueLines(value) {
 function getInputValue(id) {
     const input = safeGetElementById(id);
     return input ? input.value || '' : '';
+}
+
+function setInputValue(id, value, options = {}) {
+    const input = safeGetElementById(id);
+    if (!input || (input.disabled && options.overwriteDisabled !== true)) {
+        return;
+    }
+    input.value = String(value || '');
 }
 
 function setActionDisplay(id, visible) {

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -3916,6 +3916,8 @@ Object.assign(TRANSLATIONS['zh-CN'], {
 
 Object.assign(TRANSLATIONS['en-US'], {
     'settings.mcp.add_server': 'Add Server',
+    'settings.mcp.json_config': 'JSON config',
+    'settings.mcp.json_placeholder': '{\n  "mcpServers": {\n    "playwright": {\n      "command": "npx",\n      "args": ["@playwright/mcp@latest"]\n    }\n  }\n}',
     'settings.mcp.name': 'Server name',
     'settings.mcp.name_placeholder': 'e.g. filesystem',
     'settings.mcp.transport': 'Transport',
@@ -3947,6 +3949,8 @@ Object.assign(TRANSLATIONS['en-US'], {
 
 Object.assign(TRANSLATIONS['zh-CN'], {
     'settings.mcp.add_server': '\u6dfb\u52a0\u670d\u52a1',
+    'settings.mcp.json_config': 'JSON \u914d\u7f6e',
+    'settings.mcp.json_placeholder': '{\n  "mcpServers": {\n    "playwright": {\n      "command": "npx",\n      "args": ["@playwright/mcp@latest"]\n    }\n  }\n}',
     'settings.mcp.name': '\u670d\u52a1\u540d\u79f0',
     'settings.mcp.name_placeholder': '\u4f8b\u5982 filesystem',
     'settings.mcp.transport': '\u4f20\u8f93\u65b9\u5f0f',

--- a/tests/unit_tests/frontend/test_system_status_ui.py
+++ b/tests/unit_tests/frontend/test_system_status_ui.py
@@ -519,6 +519,257 @@ console.log(JSON.stringify({
     assert config["read_timeout"] == 300
 
 
+def test_mcp_editor_populates_fields_from_mcp_servers_json(
+    tmp_path: Path,
+) -> None:
+    payload = _run_system_status_script(
+        tmp_path=tmp_path,
+        runner_source=r"""
+const { bindSystemStatusHandlers } = await import('./systemStatus.mjs');
+
+const elements = createElements();
+[
+    'add-mcp-server-btn',
+    'save-mcp-server-btn',
+    'cancel-mcp-server-btn',
+    'mcp-server-json-input',
+    'mcp-server-name-input',
+    'mcp-server-transport-input',
+    'mcp-server-command-input',
+    'mcp-server-args-input',
+    'mcp-server-extra-input',
+    'mcp-server-url-input',
+    'mcp-server-overwrite-input',
+].forEach(id => elements.set(id, createElement('block')));
+installGlobals(elements);
+
+bindSystemStatusHandlers();
+document.getElementById('add-mcp-server-btn').onclick();
+
+document.getElementById('mcp-server-json-input').value = JSON.stringify({
+    mcpServers: {
+        playwright: {
+            command: 'npx',
+            args: ['@playwright/mcp@latest'],
+            env: { DEBUG: 'pw:mcp' },
+        },
+    },
+});
+document.getElementById('mcp-server-json-input').oninput();
+await document.getElementById('save-mcp-server-btn').onclick();
+
+console.log(JSON.stringify({
+    name: document.getElementById('mcp-server-name-input').value,
+    transport: document.getElementById('mcp-server-transport-input').value,
+    command: document.getElementById('mcp-server-command-input').value,
+    args: document.getElementById('mcp-server-args-input').value,
+    extra: document.getElementById('mcp-server-extra-input').value,
+    addCalls: globalThis.__addMcpServerCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["name"] == "playwright"
+    assert payload["transport"] == "stdio"
+    assert payload["command"] == "npx"
+    assert payload["args"] == "@playwright/mcp@latest"
+    assert payload["extra"] == "DEBUG=pw:mcp"
+    add_calls = cast(list[dict[str, JsonValue]], payload["addCalls"])
+    assert add_calls == [
+        {
+            "name": "playwright",
+            "config": {
+                "transport": "stdio",
+                "command": "npx",
+                "args": ["@playwright/mcp@latest"],
+                "env": {"DEBUG": "pw:mcp"},
+            },
+            "overwrite": False,
+        }
+    ]
+
+
+def test_mcp_editor_populates_remote_fields_from_json_config(
+    tmp_path: Path,
+) -> None:
+    payload = _run_system_status_script(
+        tmp_path=tmp_path,
+        runner_source=r"""
+const { bindSystemStatusHandlers } = await import('./systemStatus.mjs');
+
+const elements = createElements();
+[
+    'add-mcp-server-btn',
+    'save-mcp-server-btn',
+    'cancel-mcp-server-btn',
+    'mcp-server-json-input',
+    'mcp-server-name-input',
+    'mcp-server-transport-input',
+    'mcp-server-command-input',
+    'mcp-server-args-input',
+    'mcp-server-extra-input',
+    'mcp-server-url-input',
+    'mcp-server-overwrite-input',
+].forEach(id => elements.set(id, createElement('block')));
+installGlobals(elements);
+
+bindSystemStatusHandlers();
+document.getElementById('add-mcp-server-btn').onclick();
+
+document.getElementById('mcp-server-json-input').value = JSON.stringify({
+    mcpServers: {
+        docs: {
+            type: 'streamablehttp',
+            url: 'https://example.com/mcp',
+            headers: { Authorization: 'Bearer token' },
+        },
+    },
+});
+document.getElementById('mcp-server-json-input').oninput();
+await document.getElementById('save-mcp-server-btn').onclick();
+
+console.log(JSON.stringify({
+    name: document.getElementById('mcp-server-name-input').value,
+    transport: document.getElementById('mcp-server-transport-input').value,
+    url: document.getElementById('mcp-server-url-input').value,
+    extra: document.getElementById('mcp-server-extra-input').value,
+    addCalls: globalThis.__addMcpServerCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["name"] == "docs"
+    assert payload["transport"] == "streamable-http"
+    assert payload["url"] == "https://example.com/mcp"
+    assert payload["extra"] == "Authorization=Bearer token"
+    add_calls = cast(list[dict[str, JsonValue]], payload["addCalls"])
+    config = cast(dict[str, JsonValue], add_calls[0]["config"])
+    assert config == {
+        "transport": "streamable-http",
+        "url": "https://example.com/mcp",
+        "headers": {"Authorization": "Bearer token"},
+    }
+
+
+def test_mcp_editor_maps_local_and_remote_json_types_to_transports(
+    tmp_path: Path,
+) -> None:
+    payload = _run_system_status_script(
+        tmp_path=tmp_path,
+        runner_source=r"""
+const { bindSystemStatusHandlers } = await import('./systemStatus.mjs');
+
+const elements = createElements();
+[
+    'add-mcp-server-btn',
+    'save-mcp-server-btn',
+    'cancel-mcp-server-btn',
+    'mcp-server-json-input',
+    'mcp-server-name-input',
+    'mcp-server-transport-input',
+    'mcp-server-command-input',
+    'mcp-server-args-input',
+    'mcp-server-extra-input',
+    'mcp-server-url-input',
+    'mcp-server-overwrite-input',
+].forEach(id => elements.set(id, createElement('block')));
+installGlobals(elements);
+
+bindSystemStatusHandlers();
+document.getElementById('add-mcp-server-btn').onclick();
+
+document.getElementById('mcp-server-json-input').value = JSON.stringify({
+    mcpServers: {
+        localDocs: {
+            type: 'local',
+            command: 'npx',
+            args: ['docs-mcp'],
+        },
+    },
+});
+document.getElementById('mcp-server-json-input').oninput();
+const localTransport = document.getElementById('mcp-server-transport-input').value;
+
+document.getElementById('mcp-server-json-input').value = JSON.stringify({
+    mcpServers: {
+        remoteDocs: {
+            type: 'remote',
+            url: 'https://example.com/sse',
+        },
+    },
+});
+document.getElementById('mcp-server-json-input').oninput();
+const remoteTransport = document.getElementById('mcp-server-transport-input').value;
+
+console.log(JSON.stringify({
+    localTransport,
+    remoteTransport,
+    name: document.getElementById('mcp-server-name-input').value,
+    url: document.getElementById('mcp-server-url-input').value,
+}));
+""".strip(),
+    )
+
+    assert payload["localTransport"] == "stdio"
+    assert payload["remoteTransport"] == "sse"
+    assert payload["name"] == "remoteDocs"
+    assert payload["url"] == "https://example.com/sse"
+
+
+def test_mcp_editor_splits_array_command_from_json_config(
+    tmp_path: Path,
+) -> None:
+    payload = _run_system_status_script(
+        tmp_path=tmp_path,
+        runner_source=r"""
+const { bindSystemStatusHandlers } = await import('./systemStatus.mjs');
+
+const elements = createElements();
+[
+    'add-mcp-server-btn',
+    'save-mcp-server-btn',
+    'cancel-mcp-server-btn',
+    'mcp-server-json-input',
+    'mcp-server-name-input',
+    'mcp-server-transport-input',
+    'mcp-server-command-input',
+    'mcp-server-args-input',
+    'mcp-server-extra-input',
+    'mcp-server-url-input',
+    'mcp-server-overwrite-input',
+].forEach(id => elements.set(id, createElement('block')));
+installGlobals(elements);
+
+bindSystemStatusHandlers();
+document.getElementById('add-mcp-server-btn').onclick();
+
+document.getElementById('mcp-server-json-input').value = JSON.stringify({
+    mcpServers: {
+        docs: {
+            type: 'local',
+            command: ['npx', '-y', 'docs-mcp'],
+        },
+    },
+});
+document.getElementById('mcp-server-json-input').oninput();
+await document.getElementById('save-mcp-server-btn').onclick();
+
+console.log(JSON.stringify({
+    command: document.getElementById('mcp-server-command-input').value,
+    args: document.getElementById('mcp-server-args-input').value,
+    addCalls: globalThis.__addMcpServerCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["command"] == "npx"
+    assert payload["args"] == "-y\ndocs-mcp"
+    add_calls = cast(list[dict[str, JsonValue]], payload["addCalls"])
+    config = cast(dict[str, JsonValue], add_calls[0]["config"])
+    assert config["command"] == "npx"
+    assert config["args"] == ["-y", "docs-mcp"]
+
+
 def test_skills_status_panel_accepts_new_source_field_and_bare_refs(
     tmp_path: Path,
 ) -> None:
@@ -595,6 +846,7 @@ def test_system_status_styles_include_mcp_tool_list_tokens() -> None:
     assert ".mcp-tools-error {" in components_css
     assert ".status-list-copy {" in components_css
     assert ".status-list-description {" in components_css
+    assert ".mcp-editor-json-textarea {" in components_css
 
 
 def _run_system_status_script(
@@ -661,6 +913,8 @@ const translations = {
     "settings.system.server_count_loading": "{count} servers, {loading} loading.",
     "settings.system.server_count_loaded": "{count} servers loaded.",
     "settings.mcp.testing": "Testing...",
+    "settings.mcp.json_config": "JSON config",
+    "settings.mcp.json_placeholder": "{}",
     "settings.mcp.test_ok": "Connection succeeded. {count} tools loaded.",
     "settings.mcp.test_failed_message": "Connection test failed.",
     "settings.mcp.disabled_state": "This MCP server is disabled.",


### PR DESCRIPTION
## Summary
- Add a JSON config textarea to the MCP server editor.
- Parse `mcpServers` JSON and auto-fill the existing server fields.
- Normalize MCP transport/type aliases such as `streamablehttp` to `streamable-http`.

## Tests
- `uv run pytest tests\unit_tests\frontend\test_system_status_ui.py`
- pre-push hooks: `ruff-check`, `ruff-format`, `basedpyright-check`

Closes #574