### PR TITLE
feat(gateway): add xiaoluban im interactive commands and session switching

### DIFF
--- a/docs/xiaoluban-integration.md
+++ b/docs/xiaoluban-integration.md
@@ -16,6 +16,8 @@ Current scope:
 - Xiaoluban IM forwarding for the current token owner
 - inbound WeLink messages forwarded through Xiaoluban's manual forwarding mode
 - Xiaoluban-triggered Relay task execution with a final-result reply
+- interactive session management via `/new`, `/resume`, `/help` commands
+- instant acknowledgement on every received message
 
 Current non-goals for this phase:
 
@@ -94,16 +96,29 @@ The IM settings are separate from notification delivery settings.
 The first version exposes:
 
 - IM workspace, required for inbound IM-triggered tasks
-- read-only forwarding command, for example `http://10.88.1.23:9009/{account_id}?auth=... g`
+- read-only forwarding command, for example `http://10.88.1.23:9009/{account_id} g`
 
 Forwarding uses the dedicated Xiaoluban IM listener, not the main Relay Teams
 web port. The listener binds to `0.0.0.0:9009` by default and generates a
-forwarding URL with the machine's detected local IPv4 address and a per-account
-auth token, for example `http://10.88.1.23:9009/{account_id}?auth=...`. The user sends
-`http://10.88.1.23:9009/{account_id}?auth=... g` to Xiaoluban in WeLink to enter
+forwarding URL with the machine's detected local IPv4 address, for example
+`http://10.88.1.23:9009/{account_id}`. The user sends
+`http://10.88.1.23:9009/{account_id} g` to Xiaoluban in WeLink to enter
 message forwarding mode, and sends `q` to exit that mode. The default
 `relay-teams server start` command remains loopback-only for the main web UI and
 still shows `http://127.0.0.1:8000`.
+
+Once in forwarding mode, the following interactive commands are available:
+
+- `/new` -- create a new session (becomes the active session for the IM conversation)
+- `/new <task>` -- create a new session and immediately submit a task
+- `/resume` -- list up to 15 most recently active sessions in the workspace, with session IDs, relative timestamps, and titles
+- `/resume {session_id}` -- switch to a previously created session (supports exact ID, prefix match, or list index)
+- `/resume {index}` -- switch to a session by its list index (e.g. `/resume 3`)
+- `/help` -- display available commands
+
+Every non-command message receives an instant acknowledgement ("收到，正在处理中...")
+before the task runs, confirming the connection is alive. The session ID shown in
+the acknowledgement header matches the `internal_session_id` used by `/resume`.
 
 The listener can be adjusted with:
 
@@ -163,7 +178,7 @@ Workspace completion behavior:
 Xiaoluban calls the dedicated IM listener callback at:
 
 ```text
-POST http://{detected-local-ip}:9009/{account_id}?auth=...
+POST http://{detected-local-ip}:9009/{account_id}
 ```
 
 The route returns immediately with:
@@ -175,13 +190,43 @@ The route returns immediately with:
 Processing continues in the background:
 
 - the account must exist and be enabled
-- the request must include the account-specific auth token in the callback URL
 - the IM workspace must exist
 - the stored personal token is reused for Xiaoluban replies
 - `keep_alive` is attempted when a Xiaoluban `session_id` is present
 - empty content sends a short usage hint through the shared Xiaoluban notification formatter
-- gateway sessions use the Xiaoluban channel and an external key of `xiaoluban:{account_id}:{session_id}` when a session id is present
+
+### Message Routing
+
+Normal messages (not starting with `/`) are routed to the active session for the
+IM conversation. By default, the first message in an IM conversation creates a
+gateway session keyed by `xiaoluban:{account_id}:{workspace_id}:{session_id}`.
+When the user switches sessions via `/new` or `/resume`, subsequent messages are
+routed to the chosen session through an in-memory active-session mapping.
+
+### Session Management
+
+An in-memory mapping tracks which gateway session is active for each IM
+conversation. The mapping is keyed by `{account_id}:{xiaoluban_session_id}`.
+
+| Command | Behaviour |
+|---------|-----------|
+| `/new` | Creates a new gateway session (external key suffixed with a UUID), sets it as active for this IM conversation, and replies with the created `internal_session_id`. |
+| `/new <task>` | Same as `/new` but also submits the given task text immediately in the new session. |
+| `/resume` | Lists up to 15 most recently active sessions in the workspace. Each entry shows `internal_session_id`, relative timestamp, and the session title (auto-generated from the first user message, or `新会话`). Over 15 sessions, a `...(N more)` line is appended. |
+| `/resume {id}` | Switches the IM conversation's active session to the matched one. Matching order: exact `internal_session_id`, prefix match, list index. If the target session has no gateway session record yet (e.g. a web-created session), one is created on the fly. |
+| `/help` | Displays available commands. |
+
+### Acknowledgement
+
+Every non-command message that successfully starts a run receives an instant
+acknowledgement (`收到，正在处理中...`). Busy sessions are rejected before the
+acknowledgement, so the user does not receive a misleading "processing" message.
+
+### Run Execution
+
+- gateway sessions use the Xiaoluban channel and an external key of `xiaoluban:{account_id}:{workspace_id}:{session_id}` when a session id is present
 - if no `session_id` is present, the key falls back to `xiaoluban:{account_id}:{sender}:{receiver}`
+- sessions created by `/new` append an additional `:{uuid_suffix}` to the external key
 - busy sessions are rejected with a short "try again later" message through the shared Xiaoluban notification formatter
 - the task runs through the shared gateway session ingress path
 - only the terminal result is sent back to Xiaoluban through the shared Xiaoluban notification formatter

--- a/src/relay_teams/gateway/gateway_session_service.py
+++ b/src/relay_teams/gateway/gateway_session_service.py
@@ -180,6 +180,63 @@ class GatewaySessionService:
         )
         return self._repository.update(updated)
 
+    def resolve_or_bind_internal_session(
+        self,
+        *,
+        channel_type: GatewayChannelType,
+        external_session_id: str,
+        internal_session_id: str,
+        workspace_id: str,
+        capabilities: dict[str, JsonValue] | None = None,
+        channel_state: dict[str, JsonValue] | None = None,
+        peer_user_id: str | None = None,
+        peer_chat_id: str | None = None,
+    ) -> GatewaySessionRecord:
+        internal_session = self._session_service.get_session(internal_session_id)
+        if internal_session.workspace_id != workspace_id:
+            raise ValueError("internal session does not belong to workspace")
+        existing = self._repository.get_by_external(
+            channel_type=channel_type,
+            external_session_id=external_session_id,
+        )
+        now = self._utcnow()
+        normalized_capabilities = capabilities or {}
+        normalized_channel_state = channel_state or {}
+        if existing is not None:
+            active_run_id = (
+                existing.active_run_id
+                if existing.internal_session_id == internal_session_id
+                else None
+            )
+            updated = existing.model_copy(
+                update={
+                    "internal_session_id": internal_session_id,
+                    "active_run_id": active_run_id,
+                    "peer_user_id": peer_user_id or existing.peer_user_id,
+                    "peer_chat_id": peer_chat_id or existing.peer_chat_id,
+                    "capabilities": normalized_capabilities or existing.capabilities,
+                    "channel_state": {
+                        **existing.channel_state,
+                        **normalized_channel_state,
+                    },
+                    "updated_at": now,
+                }
+            )
+            return self._repository.update(updated)
+        record = GatewaySessionRecord(
+            gateway_session_id=f"gws_{uuid4().hex[:12]}",
+            channel_type=channel_type,
+            external_session_id=external_session_id,
+            internal_session_id=internal_session_id,
+            peer_user_id=peer_user_id,
+            peer_chat_id=peer_chat_id,
+            capabilities=normalized_capabilities,
+            channel_state=normalized_channel_state,
+            created_at=now,
+            updated_at=now,
+        )
+        return self._repository.create(record)
+
     def _create_internal_session(
         self,
         *,
@@ -232,6 +289,18 @@ class GatewaySessionService:
         internal_session_id: str,
     ) -> GatewaySessionRecord | None:
         return self._repository.get_by_internal_session_id(internal_session_id)
+
+    def list_all(self) -> tuple[GatewaySessionRecord, ...]:
+        return self._repository.list_all()
+
+    def list_internal_by_workspace(
+        self, workspace_id: str
+    ) -> tuple[SessionRecord, ...]:
+        return tuple(
+            s
+            for s in self._session_service.list_sessions()
+            if s.workspace_id == workspace_id
+        )
 
     def bind_active_run(
         self,

--- a/src/relay_teams/gateway/xiaoluban/notification_format.py
+++ b/src/relay_teams/gateway/xiaoluban/notification_format.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import unicodedata
+from datetime import datetime, timezone
+
 _HEADER = "【relay-teams】"
 _SEPARATOR = "────────────────────"
+_MAX_LIST_DISPLAY = 15
+_TITLE_DISPLAY_WIDTH = 30
 
 
 def format_xiaoluban_notification_text(
@@ -25,4 +30,128 @@ def format_xiaoluban_notification_text(
     return "\n".join(lines)
 
 
-__all__ = ["format_xiaoluban_notification_text"]
+def format_im_command_reply(
+    *,
+    body: str,
+    session_id: str = "",
+) -> str:
+    lines = [_HEADER]
+    normalized_session_id = str(session_id or "").strip()
+    if normalized_session_id:
+        lines.append(normalized_session_id)
+    lines.append(_SEPARATOR)
+    normalized_body = str(body or "").strip()
+    if normalized_body:
+        lines.append(normalized_body)
+    return "\n".join(lines)
+
+
+def format_session_list_text(
+    *,
+    sessions: tuple[_SessionListItem, ...],
+    total_count: int,
+) -> str:
+    now = datetime.now(tz=timezone.utc)
+    lines = ["当前workspace会话列表", _SEPARATOR]
+    displayed = sessions[:_MAX_LIST_DISPLAY]
+    for idx, item in enumerate(displayed, start=1):
+        relative = _format_relative_time(item.last_active_at, now)
+        title = item.title.strip() if item.title else "新会话"
+        title_display = _truncate_display_width(title, _TITLE_DISPLAY_WIDTH)
+        if title_display:
+            lines.append(
+                f"[{idx}] {item.internal_session_id}  {relative}  {title_display}"
+            )
+        else:
+            lines.append(f"[{idx}] {item.internal_session_id}  {relative}")
+    if total_count > _MAX_LIST_DISPLAY:
+        remaining = total_count - _MAX_LIST_DISPLAY
+        lines.append(f"...({remaining} more)")
+    lines.append(_SEPARATOR)
+    lines.append("使用 /resume {编号或session_id} 切换会话")
+    return "\n".join(lines)
+
+
+def format_help_text() -> str:
+    lines = [
+        "可用命令",
+        _SEPARATOR,
+        "/new [任务内容]  创建新会话，可选附带任务",
+        "/resume          列出当前workspace会话列表",
+        "/resume {id}     切换到指定会话",
+        "/help            显示此帮助",
+        "",
+        "输入 q 退出转发，回到小鲁班对话",
+    ]
+    return "\n".join(lines)
+
+
+class _SessionListItem:
+    __slots__ = ("internal_session_id", "last_active_at", "title")
+
+    def __init__(
+        self, internal_session_id: str, last_active_at: datetime, title: str = ""
+    ) -> None:
+        self.internal_session_id = internal_session_id
+        self.last_active_at = last_active_at
+        self.title = title
+
+
+def make_session_list_item(
+    internal_session_id: str, last_active_at: datetime, title: str = ""
+) -> _SessionListItem:
+    return _SessionListItem(internal_session_id, last_active_at, title)
+
+
+def _format_relative_time(dt: datetime, now: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    diff = (now - dt).total_seconds()
+    if diff < 60:
+        return "刚刚"
+    minutes = int(diff / 60)
+    if minutes < 60:
+        return f"{minutes}分钟前"
+    hours = int(diff / 3600)
+    if hours < 24:
+        return f"{hours}小时前"
+    days = int(diff / 86400)
+    if days < 7:
+        return f"{days}天前"
+    return dt.astimezone().strftime("%m-%d %H:%M")
+
+
+def _display_width(text: str) -> int:
+    width = 0
+    for char in text:
+        if unicodedata.east_asian_width(char) in ("W", "F", "A"):
+            width += 2
+        else:
+            width += 1
+    return width
+
+
+def _truncate_display_width(text: str, max_width: int) -> str:
+    if _display_width(text) <= max_width:
+        return text
+    result: list[str] = []
+    current = 0
+    suffix = "..."
+    suffix_width = _display_width(suffix)
+    limit = max_width - suffix_width
+    for char in text:
+        char_width = 2 if unicodedata.east_asian_width(char) in ("W", "F", "A") else 1
+        if current + char_width > limit:
+            break
+        result.append(char)
+        current += char_width
+    return "".join(result) + suffix
+
+
+__all__ = [
+    "format_xiaoluban_notification_text",
+    "format_im_command_reply",
+    "format_session_list_text",
+    "format_help_text",
+    "make_session_list_item",
+]

--- a/src/relay_teams/gateway/xiaoluban/service.py
+++ b/src/relay_teams/gateway/xiaoluban/service.py
@@ -9,7 +9,9 @@ from pathlib import Path
 from typing import NamedTuple, Optional, Protocol, Tuple, cast
 from uuid import uuid4
 
-from relay_teams.gateway.gateway_models import GatewayChannelType
+from pydantic import JsonValue
+
+from relay_teams.gateway.gateway_models import GatewayChannelType, GatewaySessionRecord
 from relay_teams.gateway.gateway_session_service import GatewaySessionService
 from relay_teams.gateway.session_ingress_service import (
     GatewaySessionIngressBusyPolicy,
@@ -31,7 +33,11 @@ from relay_teams.gateway.xiaoluban.models import (
     XiaolubanSecretStatus,
 )
 from relay_teams.gateway.xiaoluban.notification_format import (
+    format_help_text,
+    format_im_command_reply,
+    format_session_list_text,
     format_xiaoluban_notification_text,
+    make_session_list_item,
 )
 from relay_teams.gateway.xiaoluban.secret_store import (
     XiaolubanSecretStore,
@@ -51,6 +57,7 @@ from relay_teams.sessions.runs.terminal_payload import (
     extract_terminal_output,
     parse_terminal_payload_json,
 )
+from relay_teams.sessions.session_models import SessionRecord
 from relay_teams.validation import require_force_delete
 
 LOGGER = get_logger(__name__)
@@ -92,6 +99,8 @@ class XiaolubanGatewayService:
         self._pending_im_replies: dict[str, _IMReplyContext] = {}
         self._pending_im_replies_lock = threading.Lock()
         self._im_poller_started = False
+        self._im_active_session: dict[str, str] = {}
+        self._im_active_session_lock = threading.Lock()
 
     def list_accounts(self) -> Tuple[XiaolubanAccountRecord, ...]:
         return tuple(
@@ -430,6 +439,392 @@ class XiaolubanGatewayService:
         self._validate_im_workspace(workspace_id)
         return request_im_config.model_copy(update={"workspace_id": workspace_id})
 
+    @staticmethod
+    def _im_conversation_key(
+        *,
+        account_id: str,
+        workspace_id: str,
+        message: XiaolubanInboundMessage,
+    ) -> str:
+        return _external_session_id(
+            account_id=account_id,
+            workspace_id=workspace_id,
+            message=message,
+        )
+
+    def _resolve_effective_external_session_id(
+        self,
+        account_id: str,
+        message: XiaolubanInboundMessage,
+        workspace_id: str,
+    ) -> str:
+        conversation_key = self._im_conversation_key(
+            account_id=account_id,
+            workspace_id=workspace_id,
+            message=message,
+        )
+        with self._im_active_session_lock:
+            active_gws_id = self._im_active_session.get(conversation_key)
+        if active_gws_id and self._gateway_session_service is not None:
+            try:
+                mapped = self._gateway_session_service.get_session(active_gws_id)
+                return mapped.external_session_id
+            except KeyError:
+                with self._im_active_session_lock:
+                    self._im_active_session.pop(conversation_key, None)
+        return _external_session_id(
+            account_id=account_id,
+            workspace_id=workspace_id,
+            message=message,
+        )
+
+    def _try_handle_command(
+        self,
+        *,
+        account_id: str,
+        message: XiaolubanInboundMessage,
+        text: str,
+        workspace_id: str,
+        reply_target: str,
+    ) -> str | None:
+        normalized_command_text = text.lstrip("/").strip()
+        if not normalized_command_text:
+            self._handle_help_command(
+                account_id=account_id,
+                message=message,
+                reply_target=reply_target,
+            )
+            return None
+        command_text = normalized_command_text.split(None, 1)
+        command = command_text[0].lower()
+        arg = command_text[1] if len(command_text) > 1 else ""
+        if command == "new":
+            return self._handle_new_command(
+                account_id=account_id,
+                message=message,
+                workspace_id=workspace_id,
+                reply_target=reply_target,
+                task_text=arg,
+            )
+        if command == "resume":
+            return self._handle_resume_command(
+                account_id=account_id,
+                message=message,
+                workspace_id=workspace_id,
+                reply_target=reply_target,
+                arg=arg,
+            )
+        if command == "help":
+            self._handle_help_command(
+                account_id=account_id,
+                message=message,
+                reply_target=reply_target,
+            )
+            return None
+        return text
+
+    def _handle_new_command(
+        self,
+        *,
+        account_id: str,
+        message: XiaolubanInboundMessage,
+        workspace_id: str,
+        reply_target: str,
+        task_text: str,
+    ) -> str | None:
+        if self._gateway_session_service is None:
+            self._send_im_reply(
+                account_id=account_id,
+                message=message,
+                reply_target=reply_target,
+                text="服务暂不可用，请稍后重试",
+            )
+            return None
+        new_external_id = (
+            _external_session_id(
+                account_id=account_id,
+                workspace_id=workspace_id,
+                message=message,
+            )
+            + f":{uuid4().hex[:8]}"
+        )
+        gateway_session = self._gateway_session_service.resolve_or_create_session(
+            channel_type=GatewayChannelType.XIAOLUBAN,
+            external_session_id=new_external_id,
+            workspace_id=workspace_id,
+            metadata={
+                "source_provider": XIAOLUBAN_PLATFORM,
+                "source_kind": "im",
+                "xiaoluban_account_id": account_id,
+            },
+            cwd=None,
+            capabilities={},
+            channel_state={
+                "account_id": account_id,
+                "receiver": message.receiver,
+                "sender": message.sender,
+                "xiaoluban_session_id": message.session_id,
+            },
+            peer_user_id=message.sender or None,
+            peer_chat_id=message.receiver or None,
+        )
+        conversation_key = self._im_conversation_key(
+            account_id=account_id,
+            workspace_id=workspace_id,
+            message=message,
+        )
+        with self._im_active_session_lock:
+            self._im_active_session[conversation_key] = (
+                gateway_session.gateway_session_id
+            )
+        short_id = gateway_session.internal_session_id
+        if task_text:
+            return task_text
+        self._send_im_reply(
+            account_id=account_id,
+            message=message,
+            reply_target=reply_target,
+            text=f"已创建新会话: {short_id}",
+            session_id=gateway_session.internal_session_id,
+        )
+        return None
+
+    def _handle_resume_command(
+        self,
+        *,
+        account_id: str,
+        message: XiaolubanInboundMessage,
+        workspace_id: str,
+        reply_target: str,
+        arg: str,
+    ) -> str | None:
+        if self._gateway_session_service is None:
+            self._send_im_reply(
+                account_id=account_id,
+                message=message,
+                reply_target=reply_target,
+                text="服务暂不可用，请稍后重试",
+            )
+            return None
+        gateway_sessions, internal_sessions = self._list_workspace_sessions(
+            account_id, workspace_id
+        )
+        if not arg:
+            combined = _merge_and_sort_session_list(gateway_sessions, internal_sessions)
+            items = tuple(
+                make_session_list_item(
+                    internal_session_id=s_id,
+                    last_active_at=ts,
+                    title=title,
+                )
+                for s_id, ts, title in combined
+            )
+            body = format_session_list_text(
+                sessions=items,
+                total_count=len(items),
+            )
+            self._send_im_reply(
+                account_id=account_id,
+                message=message,
+                reply_target=reply_target,
+                text=body,
+            )
+            return None
+        matched = self._find_session_for_resume(
+            arg,
+            gateway_sessions,
+            internal_sessions,
+            account_id=account_id,
+            workspace_id=workspace_id,
+            message=message,
+        )
+        if matched is None:
+            self._send_im_reply(
+                account_id=account_id,
+                message=message,
+                reply_target=reply_target,
+                text=f"未找到会话: {arg}",
+            )
+            return None
+        conversation_key = self._im_conversation_key(
+            account_id=account_id,
+            workspace_id=workspace_id,
+            message=message,
+        )
+        with self._im_active_session_lock:
+            self._im_active_session[conversation_key] = matched.gateway_session_id
+        self._send_im_reply(
+            account_id=account_id,
+            message=message,
+            reply_target=reply_target,
+            text=f"已切换到会话: {matched.internal_session_id}",
+            session_id=matched.internal_session_id,
+        )
+        return None
+
+    def _handle_help_command(
+        self,
+        *,
+        account_id: str,
+        message: XiaolubanInboundMessage,
+        reply_target: str,
+    ) -> None:
+        self._send_im_reply(
+            account_id=account_id,
+            message=message,
+            reply_target=reply_target,
+            text=format_help_text(),
+        )
+
+    def _find_session_for_resume(
+        self,
+        arg: str,
+        gateway_sessions: tuple[GatewaySessionRecord, ...],
+        internal_sessions: tuple[SessionRecord, ...],
+        *,
+        account_id: str,
+        workspace_id: str,
+        message: XiaolubanInboundMessage,
+    ) -> GatewaySessionRecord | None:
+        if not arg:
+            return None
+        sorted_tuples = _merge_and_sort_session_list(
+            gateway_sessions, internal_sessions
+        )
+        sorted_ids: list[str] = [s_id for s_id, _c, _t in sorted_tuples]
+        try:
+            idx = int(arg)
+            if 1 <= idx <= len(sorted_ids):
+                target_id = sorted_ids[idx - 1]
+                return self._ensure_gateway_session_for_internal_id(
+                    target_id,
+                    account_id=account_id,
+                    workspace_id=workspace_id,
+                    message=message,
+                )
+        except ValueError:
+            # Non-integer input is valid; fall through to id and prefix matching.
+            pass
+        for session_id in sorted_ids:
+            if session_id == arg:
+                return self._ensure_gateway_session_for_internal_id(
+                    session_id,
+                    account_id=account_id,
+                    workspace_id=workspace_id,
+                    message=message,
+                )
+        for session_id in sorted_ids:
+            if session_id.startswith(arg):
+                return self._ensure_gateway_session_for_internal_id(
+                    session_id,
+                    account_id=account_id,
+                    workspace_id=workspace_id,
+                    message=message,
+                )
+        return None
+
+    def _ensure_gateway_session_for_internal_id(
+        self,
+        internal_session_id: str,
+        *,
+        account_id: str,
+        workspace_id: str,
+        message: XiaolubanInboundMessage,
+    ) -> GatewaySessionRecord | None:
+        if self._gateway_session_service is None:
+            raise RuntimeError("xiaoluban_im_runtime_unavailable")
+        existing = self._gateway_session_service.get_by_internal_session_id(
+            internal_session_id
+        )
+        xlb_prefix = f"xiaoluban:{account_id}:{workspace_id}:"
+        channel_state: dict[str, JsonValue] = {
+            "account_id": account_id,
+            "receiver": message.receiver,
+            "sender": message.sender,
+            "xiaoluban_session_id": message.session_id,
+        }
+        if (
+            existing is not None
+            and existing.channel_type == GatewayChannelType.XIAOLUBAN
+        ):
+            if existing.external_session_id.startswith(xlb_prefix):
+                try:
+                    return (
+                        self._gateway_session_service.resolve_or_bind_internal_session(
+                            channel_type=GatewayChannelType.XIAOLUBAN,
+                            external_session_id=existing.external_session_id,
+                            internal_session_id=internal_session_id,
+                            workspace_id=workspace_id,
+                            channel_state=channel_state,
+                            capabilities={},
+                            peer_user_id=message.sender or None,
+                            peer_chat_id=message.receiver or None,
+                        )
+                    )
+                except (KeyError, ValueError):
+                    return None
+        external_id = f"{xlb_prefix}internal:{internal_session_id}"
+        return self._gateway_session_service.resolve_or_bind_internal_session(
+            channel_type=GatewayChannelType.XIAOLUBAN,
+            external_session_id=external_id,
+            internal_session_id=internal_session_id,
+            workspace_id=workspace_id,
+            channel_state=channel_state,
+            capabilities={},
+            peer_user_id=message.sender or None,
+            peer_chat_id=message.receiver or None,
+        )
+
+    def _list_workspace_sessions(
+        self,
+        account_id: str,
+        workspace_id: str,
+    ) -> tuple[
+        tuple[GatewaySessionRecord, ...],
+        tuple[SessionRecord, ...],
+    ]:
+        internal_sessions: tuple[SessionRecord, ...] = ()
+        internal_session_ids: set[str] = set()
+        if self._gateway_session_service is not None:
+            internal_sessions = (
+                self._gateway_session_service.list_internal_by_workspace(workspace_id)
+            )
+            internal_session_ids = {s.session_id for s in internal_sessions}
+
+        gateway_sessions: list[GatewaySessionRecord] = []
+        if self._gateway_session_service is not None:
+            xlb_prefix = f"xiaoluban:{account_id}:{workspace_id}:"
+            for s in self._gateway_session_service.list_all():
+                if s.channel_type != GatewayChannelType.XIAOLUBAN:
+                    continue
+                if not s.external_session_id.startswith(xlb_prefix):
+                    continue
+                if s.internal_session_id not in internal_session_ids:
+                    continue
+                gateway_sessions.append(s)
+            gateway_sessions.sort(key=lambda item: item.created_at, reverse=True)
+
+        return tuple(gateway_sessions), internal_sessions
+
+    def _send_im_reply(
+        self,
+        *,
+        account_id: str,
+        message: XiaolubanInboundMessage,
+        reply_target: str,
+        text: str,
+        session_id: str = "",
+    ) -> None:
+        effective_session_id = str(session_id or "").strip() or message.session_id
+        self.send_text_message(
+            account_id=account_id,
+            text=format_im_command_reply(
+                body=text,
+                session_id=effective_session_id,
+            ),
+            receiver_uid=reply_target,
+        )
+
     def _handle_im_inbound(
         self,
         account_id: str,
@@ -467,10 +862,21 @@ class XiaolubanGatewayService:
                 receiver_uid=reply_target,
             )
             return
-        external_session_id = _external_session_id(
+        if text.startswith("/"):
+            result = self._try_handle_command(
+                account_id=account_id,
+                message=message,
+                text=text,
+                workspace_id=workspace_id,
+                reply_target=reply_target,
+            )
+            if result is None:
+                return
+            text = result
+        external_session_id = self._resolve_effective_external_session_id(
             account_id=account_id,
-            workspace_id=workspace_id,
             message=message,
+            workspace_id=workspace_id,
         )
         log_event(
             LOGGER,
@@ -559,6 +965,15 @@ class XiaolubanGatewayService:
             gateway_session.gateway_session_id,
             run_id,
         )
+        self._register_im_reply(
+            account_id=account_id,
+            gateway_session_id=gateway_session.gateway_session_id,
+            workspace_id=workspace_id,
+            session_id=gateway_session.internal_session_id,
+            run_id=run_id,
+            reply_target=reply_target,
+        )
+        self._ensure_poller_started()
         log_event(
             LOGGER,
             logging.INFO,
@@ -575,15 +990,27 @@ class XiaolubanGatewayService:
                 "workspace_id": workspace_id,
             },
         )
-        self._ensure_poller_started()
-        self._register_im_reply(
-            account_id=account_id,
-            gateway_session_id=gateway_session.gateway_session_id,
-            workspace_id=workspace_id,
-            session_id=gateway_session.internal_session_id,
-            run_id=run_id,
-            reply_target=reply_target,
-        )
+        try:
+            self._send_im_reply(
+                account_id=account_id,
+                message=message,
+                reply_target=reply_target,
+                text="收到，正在处理中...",
+                session_id=gateway_session.internal_session_id,
+            )
+        except (RuntimeError, OSError, KeyError, ValueError) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="gateway.xiaoluban.im_inbound.ack_failed",
+                message="Failed to send Xiaoluban IM processing acknowledgement",
+                payload={
+                    "account_id": account_id,
+                    "run_id": run_id,
+                    "session_id": gateway_session.internal_session_id,
+                    "error": str(exc),
+                },
+            )
 
     def _keep_alive_if_possible(
         self,
@@ -820,6 +1247,30 @@ def _normalize_base_url(value: Optional[str]) -> str:
     if not normalized:
         return DEFAULT_XIAOLUBAN_BASE_URL
     return normalized
+
+
+def _merge_and_sort_session_list(
+    gateway_sessions: tuple[GatewaySessionRecord, ...],
+    internal_sessions: tuple[SessionRecord, ...],
+) -> list[tuple[str, datetime, str]]:
+    isess_by_id: dict[str, SessionRecord] = {s.session_id: s for s in internal_sessions}
+    seen: set[str] = set()
+    result: list[tuple[str, datetime, str]] = []
+    for gws in gateway_sessions:
+        if gws.internal_session_id not in seen:
+            seen.add(gws.internal_session_id)
+            matched = isess_by_id.get(gws.internal_session_id)
+            last_active = matched.updated_at if matched is not None else gws.updated_at
+            title = ""
+            if matched is not None:
+                title = (matched.metadata or {}).get("title", "")
+            result.append((gws.internal_session_id, last_active, title))
+    for isess in internal_sessions:
+        if isess.session_id not in seen:
+            title = (isess.metadata or {}).get("title", "")
+            result.append((isess.session_id, isess.updated_at, title))
+    result.sort(key=lambda item: item[1], reverse=True)
+    return result
 
 
 def _validate_token(token: str) -> str:

--- a/src/relay_teams/sessions/session_repository.py
+++ b/src/relay_teams/sessions/session_repository.py
@@ -612,6 +612,39 @@ class SessionRepository(SharedSqliteRepository):
                 _log_invalid_session_row(row=row, error=exc)
         return tuple(records)
 
+    def list_by_workspace(self, workspace_id: str) -> tuple[SessionRecord, ...]:
+        rows = self._run_read(
+            lambda: self._conn.execute(
+                "SELECT * FROM sessions WHERE workspace_id=? ORDER BY created_at DESC",
+                (workspace_id,),
+            ).fetchall()
+        )
+        records: list[SessionRecord] = []
+        for row in rows:
+            try:
+                records.append(self._to_record(row))
+            except (ValidationError, ValueError) as exc:
+                _log_invalid_session_row(row=row, error=exc)
+        return tuple(records)
+
+    async def list_by_workspace_async(
+        self, workspace_id: str
+    ) -> tuple[SessionRecord, ...]:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT * FROM sessions WHERE workspace_id=? ORDER BY created_at DESC",
+                (workspace_id,),
+            )
+        )
+        records: list[SessionRecord] = []
+        for row in rows:
+            try:
+                records.append(self._to_record(row))
+            except (ValidationError, ValueError) as exc:
+                _log_invalid_session_row(row=row, error=exc)
+        return tuple(records)
+
     async def list_all_async(self) -> tuple[SessionRecord, ...]:
         rows = await self._run_async_read(
             lambda conn: async_fetchall(

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -997,6 +997,11 @@ class SessionService:
         )
         self._invalidate_list_sessions_cache()
 
+    def list_sessions_by_workspace(
+        self, workspace_id: str
+    ) -> tuple[SessionRecord, ...]:
+        return self._session_repo.list_by_workspace(workspace_id)
+
     def list_sessions_by_project(
         self,
         *,

--- a/tests/unit_tests/gateway/test_gateway_session_service.py
+++ b/tests/unit_tests/gateway/test_gateway_session_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import cast
 
+import pytest
+
 from relay_teams.gateway.gateway_models import GatewayChannelType, GatewaySessionRecord
 from relay_teams.gateway.gateway_model_profile_override import (
     GatewayModelProfileOverride,
@@ -85,6 +87,103 @@ def test_resolve_or_create_session_preserves_model_profile_override_on_rebind() 
     assert profile_store.get(second.internal_session_id) == previous_profile
 
 
+def test_resolve_or_bind_internal_session_uses_existing_session() -> None:
+    repository = _FakeGatewaySessionRepository()
+    session_service = _FakeSessionService()
+    service = GatewaySessionService(
+        repository=cast(GatewaySessionRepository, repository),
+        session_service=cast(SessionService, session_service),
+    )
+    internal_session = session_service.create_session(workspace_id="workspace-1")
+
+    gateway_session = service.resolve_or_bind_internal_session(
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id="xiaoluban:account:workspace-1:internal:session-1",
+        internal_session_id=internal_session.session_id,
+        workspace_id="workspace-1",
+        channel_state={"sender": "uid"},
+    )
+
+    assert gateway_session.internal_session_id == internal_session.session_id
+    assert len(session_service.sessions) == 1
+    assert gateway_session.channel_state == {"sender": "uid"}
+
+
+def test_resolve_or_bind_internal_session_updates_existing_mapping() -> None:
+    repository = _FakeGatewaySessionRepository()
+    session_service = _FakeSessionService()
+    service = GatewaySessionService(
+        repository=cast(GatewaySessionRepository, repository),
+        session_service=cast(SessionService, session_service),
+    )
+    first = session_service.create_session(workspace_id="workspace-1")
+    second = session_service.create_session(workspace_id="workspace-1")
+    existing = GatewaySessionRecord(
+        gateway_session_id="gws-existing",
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id="xiaoluban:account:workspace-1:internal:session",
+        internal_session_id=first.session_id,
+        active_run_id="run-active",
+        channel_state={"receiver": "old"},
+    )
+    repository.create(existing)
+
+    gateway_session = service.resolve_or_bind_internal_session(
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id=existing.external_session_id,
+        internal_session_id=second.session_id,
+        workspace_id="workspace-1",
+        channel_state={"sender": "new"},
+        peer_user_id="sender",
+    )
+
+    assert gateway_session.gateway_session_id == "gws-existing"
+    assert gateway_session.internal_session_id == second.session_id
+    assert gateway_session.active_run_id is None
+    assert gateway_session.peer_user_id == "sender"
+    assert gateway_session.channel_state == {"receiver": "old", "sender": "new"}
+
+
+def test_gateway_session_service_list_helpers_delegate() -> None:
+    repository = _FakeGatewaySessionRepository()
+    session_service = _FakeSessionService()
+    service = GatewaySessionService(
+        repository=cast(GatewaySessionRepository, repository),
+        session_service=cast(SessionService, session_service),
+    )
+    workspace_1 = session_service.create_session(workspace_id="workspace-1")
+    _ = session_service.create_session(workspace_id="workspace-2")
+    record = GatewaySessionRecord(
+        gateway_session_id="gws-existing",
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id="xiaoluban:account:workspace-1:session",
+        internal_session_id=workspace_1.session_id,
+    )
+    repository.create(record)
+
+    assert service.get_by_internal_session_id(workspace_1.session_id) == record
+    assert service.list_all() == (record,)
+    assert service.list_internal_by_workspace("workspace-1") == (workspace_1,)
+
+
+def test_resolve_or_bind_internal_session_rejects_workspace_mismatch() -> None:
+    repository = _FakeGatewaySessionRepository()
+    session_service = _FakeSessionService()
+    service = GatewaySessionService(
+        repository=cast(GatewaySessionRepository, repository),
+        session_service=cast(SessionService, session_service),
+    )
+    internal_session = session_service.create_session(workspace_id="workspace-1")
+
+    with pytest.raises(ValueError, match="does not belong to workspace"):
+        service.resolve_or_bind_internal_session(
+            channel_type=GatewayChannelType.XIAOLUBAN,
+            external_session_id="xiaoluban:account:workspace-2:internal:session-1",
+            internal_session_id=internal_session.session_id,
+            workspace_id="workspace-2",
+        )
+
+
 class _FakeGatewaySessionRepository:
     def __init__(self) -> None:
         self.records: dict[str, GatewaySessionRecord] = {}
@@ -110,6 +209,18 @@ class _FakeGatewaySessionRepository:
     def update(self, record: GatewaySessionRecord) -> GatewaySessionRecord:
         self.records[record.gateway_session_id] = record
         return record
+
+    def get_by_internal_session_id(
+        self,
+        internal_session_id: str,
+    ) -> GatewaySessionRecord | None:
+        for record in self.records.values():
+            if record.internal_session_id == internal_session_id:
+                return record
+        return None
+
+    def list_all(self) -> tuple[GatewaySessionRecord, ...]:
+        return tuple(self.records.values())
 
 
 class _FakeSessionService:
@@ -145,3 +256,6 @@ class _FakeSessionService:
 
     def delete(self, session_id: str) -> None:
         self.sessions.pop(session_id, None)
+
+    def list_sessions(self) -> tuple[SessionRecord, ...]:
+        return tuple(self.sessions.values())

--- a/tests/unit_tests/gateway/test_xiaoluban_im.py
+++ b/tests/unit_tests/gateway/test_xiaoluban_im.py
@@ -33,6 +33,7 @@ from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.run_models import IntentInput
 from relay_teams.sessions.runs.run_service import SessionRunService
+from relay_teams.sessions.session_models import SessionRecord
 
 
 class _ResolvedGatewaySessionCall(BaseModel):
@@ -401,9 +402,10 @@ class _FakeWorkspaceLookup:
 
 
 class _FakeXiaolubanClient:
-    def __init__(self) -> None:
+    def __init__(self, fail_send_when_contains: str | None = None) -> None:
         self.keep_alive_calls: list[tuple[str, str]] = []
         self.sent_messages: list[tuple[str, str]] = []
+        self._fail_send_when_contains = fail_send_when_contains
 
     def keep_alive(
         self,
@@ -428,6 +430,11 @@ class _FakeXiaolubanClient:
         sender: str | None = None,
     ) -> object:
         _ = (auth_token, base_url, sender)
+        if (
+            self._fail_send_when_contains is not None
+            and self._fail_send_when_contains in text
+        ):
+            raise RuntimeError("simulated xiaoluban send failure")
         self.sent_messages.append((text, receiver_uid))
         return _FakeSendResponse()
 
@@ -440,8 +447,11 @@ class _FakeGatewaySessionService:
     def __init__(self) -> None:
         self.last_external_session_id = ""
         self.resolved_calls: list[_ResolvedGatewaySessionCall] = []
+        self.bound_internal_calls: list[_ResolvedGatewaySessionCall] = []
         self._internal_session_ids: dict[str, str] = {}
         self.bound_runs: list[tuple[str, str | None]] = []
+        self._records: dict[str, GatewaySessionRecord] = {}
+        self.internal_sessions: list[SessionRecord] = []
 
     def resolve_or_create_session(
         self,
@@ -467,6 +477,19 @@ class _FakeGatewaySessionService:
             kwargs,
         )
         self.last_external_session_id = external_session_id
+        for record in self._records.values():
+            if (
+                record.channel_type == channel_type
+                and record.external_session_id == external_session_id
+            ):
+                self.resolved_calls.append(
+                    _ResolvedGatewaySessionCall(
+                        external_session_id=external_session_id,
+                        workspace_id=workspace_id,
+                        internal_session_id=record.internal_session_id,
+                    )
+                )
+                return record
         internal_session_id = self._internal_session_ids.setdefault(
             external_session_id,
             f"session-{len(self._internal_session_ids) + 1}",
@@ -478,13 +501,73 @@ class _FakeGatewaySessionService:
                 internal_session_id=internal_session_id,
             )
         )
-        return GatewaySessionRecord(
+        record = GatewaySessionRecord(
             gateway_session_id=f"gws-{internal_session_id}",
             channel_type=channel_type,
             external_session_id=external_session_id,
             internal_session_id=internal_session_id,
             cwd=None,
         )
+        self._records[record.gateway_session_id] = record
+        if not any(
+            session.session_id == internal_session_id
+            for session in self.internal_sessions
+        ):
+            self.internal_sessions.append(
+                SessionRecord(
+                    session_id=internal_session_id,
+                    workspace_id=workspace_id,
+                )
+            )
+        return record
+
+    def resolve_or_bind_internal_session(
+        self,
+        *,
+        channel_type: GatewayChannelType,
+        external_session_id: str,
+        internal_session_id: str,
+        workspace_id: str,
+        capabilities: dict[str, JsonValue] | None = None,
+        channel_state: dict[str, JsonValue] | None = None,
+        peer_user_id: str | None = None,
+        peer_chat_id: str | None = None,
+    ) -> GatewaySessionRecord:
+        _ = (capabilities, channel_state, peer_user_id, peer_chat_id)
+        session = next(
+            (
+                item
+                for item in self.internal_sessions
+                if item.session_id == internal_session_id
+            ),
+            None,
+        )
+        if session is None:
+            raise KeyError(f"Unknown session_id: {internal_session_id}")
+        if session.workspace_id != workspace_id:
+            raise ValueError("internal session does not belong to workspace")
+        for record in self._records.values():
+            if (
+                record.channel_type == channel_type
+                and record.external_session_id == external_session_id
+            ):
+                return record
+        self.bound_internal_calls.append(
+            _ResolvedGatewaySessionCall(
+                external_session_id=external_session_id,
+                workspace_id=workspace_id,
+                internal_session_id=internal_session_id,
+            )
+        )
+        record = GatewaySessionRecord(
+            gateway_session_id=f"gws-bound-{internal_session_id}",
+            channel_type=channel_type,
+            external_session_id=external_session_id,
+            internal_session_id=internal_session_id,
+            cwd=None,
+        )
+        self._records[record.gateway_session_id] = record
+        return record
 
     def bind_active_run(
         self,
@@ -497,6 +580,32 @@ class _FakeGatewaySessionService:
             channel_type=GatewayChannelType.XIAOLUBAN,
             external_session_id="external-1",
             internal_session_id="session-1",
+        )
+
+    def get_session(self, gateway_session_id: str) -> GatewaySessionRecord:
+        record = self._records.get(gateway_session_id)
+        if record is None:
+            raise KeyError(f"Unknown gateway_session_id: {gateway_session_id}")
+        return record
+
+    def get_by_internal_session_id(
+        self, internal_session_id: str
+    ) -> GatewaySessionRecord | None:
+        for record in self._records.values():
+            if record.internal_session_id == internal_session_id:
+                return record
+        return None
+
+    def list_all(self) -> tuple[GatewaySessionRecord, ...]:
+        return tuple(self._records.values())
+
+    def list_internal_by_workspace(
+        self, workspace_id: str
+    ) -> tuple[SessionRecord, ...]:
+        return tuple(
+            session
+            for session in self.internal_sessions
+            if session.workspace_id == workspace_id
         )
 
 
@@ -961,6 +1070,711 @@ def test_start_im_run_via_create_detached_run(tmp_path: Path) -> None:
     )
 
     assert run_service.detached_run_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# 命令处理 & 会话切换 测试
+# ---------------------------------------------------------------------------
+
+
+def test_command_new_creates_session_and_sends_reply(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/new",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert fake_ingress.requests == []
+    assert fake_client.sent_messages[-1][1] == "uidself"
+    assert "已创建新会话" in fake_client.sent_messages[-1][0]
+    resolved_ids = [c.external_session_id for c in fake_gateway_sessions.resolved_calls]
+    assert len(resolved_ids) == 1
+    base_id = f"xiaoluban:{account.account_id}:im-workspace:welink-session-1"
+    assert resolved_ids[0].startswith(base_id + ":")
+
+
+def test_command_new_with_task_creates_session_and_starts_run(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/new 帮我看一下这个项目",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert len(fake_ingress.requests) == 1
+    assert fake_ingress.requests[0].intent.intent == "帮我看一下这个项目"
+    assert len(fake_client.sent_messages) >= 1
+    assert "处理中" in fake_client.sent_messages[0][0]
+    resolved_ids = [c.external_session_id for c in fake_gateway_sessions.resolved_calls]
+    base_id = f"xiaoluban:{account.account_id}:im-workspace:welink-session-1"
+    assert resolved_ids[0].startswith(base_id + ":")
+
+
+def test_command_new_routes_subsequent_messages(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/new",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="继续做任务",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    resolved_ids = [c.external_session_id for c in fake_gateway_sessions.resolved_calls]
+    assert len(resolved_ids) == 2
+    base_id = f"xiaoluban:{account.account_id}:im-workspace:welink-session-1"
+    new_session_id = resolved_ids[0]
+    assert new_session_id.startswith(base_id + ":")
+    assert resolved_ids[1] == new_session_id
+    assert fake_ingress.requests[0].intent.intent == "继续做任务"
+
+
+def test_command_resume_lists_sessions(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/new",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/resume",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    list_message = fake_client.sent_messages[-1][0]
+    assert "会话列表" in list_message
+    assert "/resume" in list_message
+
+
+def test_command_resume_by_session_id_switches_session(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/new",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+    new_call = fake_gateway_sessions.resolved_calls[0]
+    target_internal_id = new_call.internal_session_id
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content=f"/resume {target_internal_id}",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    switch_reply = fake_client.sent_messages[-1][0]
+    assert "已切换到会话" in switch_reply
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="在旧会话继续",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+    assert fake_ingress.requests[0].intent.session_id == target_internal_id
+
+
+def test_command_resume_by_index_switches_session(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/new",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/resume 1",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert "已切换到会话" in fake_client.sent_messages[-1][0]
+
+
+def test_command_resume_binds_existing_internal_session(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_gateway_sessions.internal_sessions.append(
+        SessionRecord(
+            session_id="session-existing",
+            workspace_id="im-workspace",
+            metadata={"title": "Existing session"},
+        )
+    )
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/resume session-existing",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="继续这个会话",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert fake_gateway_sessions.bound_internal_calls == [
+        _ResolvedGatewaySessionCall(
+            external_session_id=(
+                f"xiaoluban:{account.account_id}:im-workspace:internal:session-existing"
+            ),
+            workspace_id="im-workspace",
+            internal_session_id="session-existing",
+        )
+    ]
+    assert fake_ingress.requests[0].intent.session_id == "session-existing"
+
+
+def test_command_resume_ignores_stale_gateway_session(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+    fake_gateway_sessions._records["gws-stale"] = GatewaySessionRecord(
+        gateway_session_id="gws-stale",
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id=(
+            f"xiaoluban:{account.account_id}:im-workspace:internal:session-stale"
+        ),
+        internal_session_id="session-stale",
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/resume session-stale",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert "未找到会话" in fake_client.sent_messages[-1][0]
+    assert fake_gateway_sessions.bound_internal_calls == []
+
+
+def test_command_resume_rejects_stale_existing_gateway_binding(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+    fake_gateway_sessions._records["gws-stale"] = GatewaySessionRecord(
+        gateway_session_id="gws-stale",
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id=(
+            f"xiaoluban:{account.account_id}:im-workspace:internal:session-stale"
+        ),
+        internal_session_id="session-stale",
+    )
+
+    result = service._ensure_gateway_session_for_internal_id(
+        "session-stale",
+        account_id=account.account_id,
+        workspace_id="im-workspace",
+        message=XiaolubanInboundMessage(
+            content="/resume session-stale",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert result is None
+
+
+def test_command_resume_invalid_session_shows_error(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/resume nonexistent",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert "未找到会话" in fake_client.sent_messages[-1][0]
+
+
+def test_command_help_shows_help_text(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/help",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    help_message = fake_client.sent_messages[-1][0]
+    assert "/new" in help_message
+    assert "/resume" in help_message
+    assert "/help" in help_message
+
+
+def test_slash_only_command_shows_help(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/   ",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    help_message = fake_client.sent_messages[-1][0]
+    assert "/new" in help_message
+    assert "/resume" in help_message
+    assert fake_ingress.requests == []
+
+
+def test_normal_message_sends_ack_after_run_submit(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="帮我分析一下",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert len(fake_client.sent_messages) >= 1
+    ack_message = fake_client.sent_messages[0][0]
+    assert "处理中" in ack_message
+    assert len(fake_ingress.requests) == 1
+
+
+def test_processing_ack_failure_keeps_terminal_reply_registered(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient(fail_send_when_contains="处理中")
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="帮我分析一下",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert len(fake_ingress.requests) == 1
+    assert fake_gateway_sessions.bound_runs == [("gws-session-1", "run-1")]
+    assert fake_client.sent_messages == []
+    service._drain_im_replies()
+    assert fake_client.sent_messages[-1] == (
+        _formatted_xiaoluban_text(
+            session_id="session-1",
+            body="done from run",
+            status="completed",
+        ),
+        "uidself",
+    )
+
+
+def test_submit_rejection_sends_busy_without_processing_ack(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService(reject_submit=True)
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="帮我分析一下",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert len(fake_ingress.requests) == 1
+    assert len(fake_client.sent_messages) == 1
+    assert "当前会话已有任务运行" in fake_client.sent_messages[-1][0]
+    assert "处理中" not in fake_client.sent_messages[-1][0]
+
+
+def test_non_slash_text_not_treated_as_command(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="用 /new 语法 ...",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert len(fake_ingress.requests) == 1
+    assert fake_ingress.requests[0].intent.intent == "用 /new 语法 ..."
+    base_id = f"xiaoluban:{account.account_id}:im-workspace:welink-session-1"
+    assert fake_gateway_sessions.resolved_calls[0].external_session_id == base_id
+
+
+def test_command_new_without_platform_session_id_isolated_by_peer(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/new",
+            receiver="recv_uid",
+            sender="sender-a",
+            session_id="",
+        ),
+    )
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="sender b task",
+            receiver="recv_uid",
+            sender="sender-b",
+            session_id="",
+        ),
+    )
+
+    base_a = f"xiaoluban:{account.account_id}:im-workspace:sender-a:recv_uid"
+    base_b = f"xiaoluban:{account.account_id}:im-workspace:sender-b:recv_uid"
+    assert fake_gateway_sessions.resolved_calls[0].external_session_id.startswith(
+        base_a + ":"
+    )
+    assert fake_gateway_sessions.resolved_calls[1].external_session_id == base_b
+    assert fake_ingress.requests[0].intent.intent == "sender b task"
+
+
+def test_command_resume_without_existing_sessions(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/resume",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert "会话列表" in fake_client.sent_messages[-1][0]
+
+
+def test_command_resume_by_prefix_match(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/new",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+    target_internal_id = fake_gateway_sessions.resolved_calls[0].internal_session_id
+    prefix = target_internal_id[:6]
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content=f"/resume {prefix}",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert "已切换到会话" in fake_client.sent_messages[-1][0]
+
+
+def test_handle_im_inbound_unknown_command_routes_as_task(
+    tmp_path: Path,
+) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService()
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="/some-unknown-command 参数",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert len(fake_ingress.requests) == 1
+    assert fake_ingress.requests[0].intent.intent == "/some-unknown-command 参数"
+
+
+def test_handle_im_inbound_busy_does_not_send_ack(tmp_path: Path) -> None:
+    fake_client = _FakeXiaolubanClient()
+    fake_gateway_sessions = _FakeGatewaySessionService()
+    fake_ingress = _FakeIngressService(active_run_id="run-active")
+    service, account = _build_ready_im_service(
+        tmp_path,
+        client=fake_client,
+        gateway_session_service=fake_gateway_sessions,
+        session_ingress_service=fake_ingress,
+    )
+
+    service.handle_im_inbound(
+        account_id=account.account_id,
+        message=XiaolubanInboundMessage(
+            content="帮我分析一下",
+            receiver="uidself",
+            sender="uidself",
+            session_id="welink-session-1",
+        ),
+    )
+
+    assert len(fake_client.sent_messages) == 1
+    assert (
+        "繁忙" in fake_client.sent_messages[-1][0]
+        or "任务" in fake_client.sent_messages[-1][0]
+    )
+    assert "处理中" not in fake_client.sent_messages[-1][0]
 
 
 class _FakeRunService:

--- a/tests/unit_tests/gateway/test_xiaoluban_notification_format.py
+++ b/tests/unit_tests/gateway/test_xiaoluban_notification_format.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from relay_teams.gateway.xiaoluban.notification_format import (
+    format_help_text,
+    format_im_command_reply,
+    format_session_list_text,
+    format_xiaoluban_notification_text,
+    make_session_list_item,
+)
+
+
+def test_format_im_command_reply_includes_optional_session_id() -> None:
+    text = format_im_command_reply(body="处理中", session_id="session-1")
+
+    assert "【relay-teams】" in text
+    assert "session-1" in text
+    assert "处理中" in text
+
+
+def test_format_xiaoluban_notification_text_omits_blank_body() -> None:
+    text = format_xiaoluban_notification_text(
+        workspace_id="workspace-1",
+        session_id="session-1",
+        status="completed",
+        body="",
+    )
+
+    assert text.endswith("────────────────────")
+
+
+def test_format_session_list_text_covers_relative_times_and_truncation() -> None:
+    now = datetime.now(tz=timezone.utc)
+    sessions = (
+        make_session_list_item("session-now", now - timedelta(seconds=5), "短标题"),
+        make_session_list_item(
+            "session-minute",
+            now - timedelta(minutes=3),
+            "这是一个很长很长很长很长的中文标题",
+        ),
+        make_session_list_item("session-hour", now - timedelta(hours=2), "hour"),
+        make_session_list_item("session-day", now - timedelta(days=3), "day"),
+        make_session_list_item("session-old", now - timedelta(days=9), "old"),
+        make_session_list_item("session-blank-title", now, "   "),
+    )
+
+    text = format_session_list_text(sessions=sessions, total_count=20)
+
+    assert "刚刚" in text
+    assert "分钟前" in text
+    assert "小时前" in text
+    assert "天前" in text
+    assert "..." in text
+    assert "...(5 more)" in text
+    assert (
+        f"session-old  {(now - timedelta(days=9)).astimezone().strftime('%m-%d')}"
+        in text
+    )
+    assert "[6] session-blank-title" in text
+
+
+def test_format_session_list_text_treats_naive_datetime_as_utc() -> None:
+    naive = datetime.now(tz=timezone.utc).replace(tzinfo=None) - timedelta(minutes=2)
+
+    text = format_session_list_text(
+        sessions=(make_session_list_item("session-naive", naive, "naive"),),
+        total_count=1,
+    )
+
+    assert "session-naive" in text
+    assert "分钟前" in text
+
+
+def test_format_help_text_lists_commands() -> None:
+    text = format_help_text()
+
+    assert "/new" in text
+    assert "/resume" in text
+    assert "/help" in text

--- a/tests/unit_tests/sessions/test_session_list_status.py
+++ b/tests/unit_tests/sessions/test_session_list_status.py
@@ -94,6 +94,23 @@ def test_list_sessions_includes_active_run_overlay(tmp_path: Path) -> None:
     assert idle.pending_tool_approval_count == 0
 
 
+def test_list_sessions_by_workspace_filters_sessions(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_list_by_workspace.db"
+    service = _build_service(db_path)
+    _ = service.create_session(
+        session_id="session-workspace-1",
+        workspace_id="workspace-1",
+    )
+    _ = service.create_session(
+        session_id="session-workspace-2",
+        workspace_id="workspace-2",
+    )
+
+    sessions = service.list_sessions_by_workspace("workspace-1")
+
+    assert [session.session_id for session in sessions] == ["session-workspace-1"]
+
+
 def test_list_sessions_uses_runtime_overlay_for_running_subagent(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/sessions/test_session_repository.py
+++ b/tests/unit_tests/sessions/test_session_repository.py
@@ -128,6 +128,44 @@ def test_list_all_skips_rows_with_blank_session_id(tmp_path: Path) -> None:
     assert [record.session_id for record in records] == ["session-valid"]
 
 
+def test_list_by_workspace_filters_sessions(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_repository_list_by_workspace.db"
+    repository = SessionRepository(db_path)
+    repository.create(
+        session_id="session-workspace-1",
+        workspace_id="workspace-1",
+        metadata={"title": "Workspace 1"},
+    )
+    repository.create(
+        session_id="session-workspace-2",
+        workspace_id="workspace-2",
+    )
+
+    records = repository.list_by_workspace("workspace-1")
+
+    assert [record.session_id for record in records] == ["session-workspace-1"]
+    assert records[0].metadata == {"title": "Workspace 1"}
+
+
+def test_list_by_workspace_skips_invalid_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_repository_list_by_workspace_invalid.db"
+    repository = SessionRepository(db_path)
+    _insert_session_row(
+        db_path,
+        session_id="session-valid",
+        metadata_json="{}",
+    )
+    _insert_session_row(
+        db_path,
+        session_id="",
+        metadata_json="{}",
+    )
+
+    records = repository.list_by_workspace("default")
+
+    assert [record.session_id for record in records] == ["session-valid"]
+
+
 @pytest.mark.parametrize("session_id", ["None", "null"])
 def test_list_all_skips_rows_with_none_like_session_id(
     tmp_path: Path,
@@ -198,6 +236,46 @@ async def test_list_all_async_skips_rows_with_blank_session_id(
     )
 
     records = await repository.list_all_async()
+
+    assert [record.session_id for record in records] == ["session-valid"]
+
+
+@pytest.mark.asyncio
+async def test_list_by_workspace_async_filters_sessions(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_repository_list_by_workspace_async.db"
+    repository = SessionRepository(db_path)
+    await repository.create_async(
+        session_id="session-workspace-1",
+        workspace_id="workspace-1",
+        metadata={"title": "Workspace 1"},
+    )
+    await repository.create_async(
+        session_id="session-workspace-2",
+        workspace_id="workspace-2",
+    )
+
+    records = await repository.list_by_workspace_async("workspace-1")
+
+    assert [record.session_id for record in records] == ["session-workspace-1"]
+    assert records[0].metadata == {"title": "Workspace 1"}
+
+
+@pytest.mark.asyncio
+async def test_list_by_workspace_async_skips_invalid_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_repository_list_by_workspace_async_invalid.db"
+    repository = SessionRepository(db_path)
+    _insert_session_row(
+        db_path,
+        session_id="session-valid",
+        metadata_json="{}",
+    )
+    _insert_session_row(
+        db_path,
+        session_id="",
+        metadata_json="{}",
+    )
+
+    records = await repository.list_by_workspace_async("default")
 
     assert [record.session_id for record in records] == ["session-valid"]
 


### PR DESCRIPTION
## Summary

- Add Xiaoluban IM interactive commands: `/new`, `/resume`, and `/help`.
- Support switching an IM conversation to an existing workspace session.
- Add formatted IM command replies and session list output.
- Add safe binding from gateway sessions to existing internal sessions with workspace validation.
- Fix active IM session tracking so messages without a platform session id are isolated by account/workspace/sender/receiver.
- Update Xiaoluban integration docs and focused gateway tests.

## Validation

- `uv run --extra dev pytest -q tests/unit_tests/gateway/test_xiaoluban_im.py tests/unit_tests/gateway/test_gateway_session_service.py`
- `uv run --extra dev pytest -q tests/unit_tests/gateway`
- `uv run --extra dev basedpyright`
- pre-commit amend hooks passed: `ruff-check`, `ruff-format`, `basedpyright-check`

Closes #580 