### PR TITLE
fix: reconcile incomplete todo completion guard

### DIFF
--- a/docs/system-reminders-design.md
+++ b/docs/system-reminders-design.md
@@ -79,9 +79,14 @@ Incomplete todos:
 
 - evaluated only for root task completion attempts
 - pending or in-progress todos block successful completion
-- the reminder is appended to history and the agent gets another turn
-- after three reminder retries, the task returns an assistant error instead of being
-  marked complete
+- the reminder is appended to history and the agent gets another turn to reconcile
+  persisted todo state with actual progress
+- if the work is already complete, the agent should update the run-scoped todo list
+  with `todo_write` before finalizing, not repeat completed work just to satisfy the
+  guard
+- after three reminder retries, the task returns a completion-guard assistant error
+  instead of being marked complete; this reflects persisted todo state, not a
+  provider/API execution failure
 
 Context pressure:
 

--- a/src/relay_teams/reminders/policy.py
+++ b/src/relay_teams/reminders/policy.py
@@ -119,8 +119,12 @@ class SystemReminderPolicy:
         content = (
             "You attempted to finish while run-scoped todos are still incomplete.\n\n"
             f"{formatted_todos}\n\n"
-            "Before completing, either finish the pending work or update the todo list "
-            "to accurately reflect what remains."
+            "Before completing, reconcile the persisted todo list with the work "
+            "already done. If these items are already complete, call `todo_write` "
+            "to mark them completed or clear the list, then provide the final "
+            "answer. If work remains, continue the remaining work and update the "
+            "todo list accurately. Do not repeat completed work only to satisfy "
+            "this reminder."
         )
         if retry_count > self._config.completion_max_retries:
             return (

--- a/src/relay_teams/sessions/runs/assistant_errors.py
+++ b/src/relay_teams/sessions/runs/assistant_errors.py
@@ -108,6 +108,15 @@ def build_assistant_error_message(
     recovery_guidance = _build_recovery_guidance_message(code, detail=detail)
     if recovery_guidance is not None:
         return recovery_guidance
+    if code == "incomplete_todos":
+        return _append_error_detail(
+            "The previous request could not be marked complete because "
+            "run-scoped todos are still incomplete. Continue from the latest "
+            "successful conversation state already persisted. Do not repeat "
+            "already successful tool calls. Reconcile the persisted todo list "
+            "with actual progress before finalizing.",
+            detail,
+        )
     lowered = detail.lower()
     if "prompt is too long" in lowered:
         return (

--- a/tests/unit_tests/reminders/test_policy.py
+++ b/tests/unit_tests/reminders/test_policy.py
@@ -116,7 +116,12 @@ def test_policy_fails_completion_after_retry_limit() -> None:
     )
 
     assert first.retry_completion is True
+    assert "`todo_write`" in first.content
+    assert "reconcile the persisted todo list" in first.content
+    assert "Do not repeat completed work" in first.content
     assert second.fail_completion is True
+    assert "`todo_write`" in second.content
+    assert "reconcile the persisted todo list" in second.content
     assert state.completion_retry_count == 2
 
 

--- a/tests/unit_tests/sessions/runs/test_assistant_errors.py
+++ b/tests/unit_tests/sessions/runs/test_assistant_errors.py
@@ -73,3 +73,16 @@ def test_build_assistant_error_message_uses_auth_invalid_code() -> None:
     )
 
     assert "API key is invalid" in message
+
+
+def test_build_assistant_error_message_uses_incomplete_todos_guidance() -> None:
+    message = build_assistant_error_message(
+        error_code="incomplete_todos",
+        error_message="You attempted to finish while run-scoped todos are still incomplete.",
+    )
+
+    assert "could not be marked complete" in message
+    assert "run-scoped todos are still incomplete" in message
+    assert "Reconcile the persisted todo list" in message
+    assert "Do not repeat already successful tool calls" in message
+    assert "API or execution error" not in message


### PR DESCRIPTION
## Summary
- clarify incomplete-todo completion guard guidance so agents reconcile persisted todo state with actual progress instead of repeating completed work
- add a dedicated incomplete_todos assistant-error message instead of the generic API/execution error text
- document the completion-guard semantics and cover the new wording with focused tests

Closes #582

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests
- Manual validation on existing session session-2a22fb36 with run a16205dd-facf-451b-98f7-ae27a422469d: guard injected for an in_progress todo, agent reconciled it with todo_write, and run completed with assistant_response.