### PR TITLE
fix: limit shared LLM HTTP concurrency

### DIFF
--- a/docs/llm-concurrency-incident-2026-04-28.md
+++ b/docs/llm-concurrency-incident-2026-04-28.md
@@ -1,0 +1,50 @@
+# LLM Concurrency Incident Record
+
+Date: 2026-04-28
+Issue: #588
+
+## Summary
+
+Two sessions overlapped and pushed several `glm-5.1` requests to BigModel at the same time:
+
+- `session-65525b35`: normal run started at 2026-04-28 08:31:01 UTC.
+- `session-45c27856`: orchestration run started at 2026-04-28 08:31:29 UTC.
+- At about 2026-04-28 08:33:46 UTC, the orchestration run dispatched four `Crafter` subagents while the other session was still active.
+- BigModel returned 429 responses with `code=1305` and message `the model is currently overloaded`.
+- The backend process later became unresponsive from the UI perspective and was restarted at about 2026-04-28 08:45:42 UTC. The restart marked both runs as `interrupted_by_process_restart`.
+
+## Root Cause
+
+The orchestration layer had a per-run delegated task limit, but the LLM HTTP path had no shared provider-level concurrency budget. Multiple sessions could therefore exceed the upstream model capacity even when each individual orchestration run stayed within its local limit.
+
+Async execution kept network waits non-blocking, but it did not provide admission control. Each incoming run still allocated a worker task, event stream state, persistence work, retry state, and logging work. When many runs are allowed to start and then wait or retry deep inside the LLM transport path, the service can remain alive but become slow or unresponsive to health and UI requests.
+
+## Fix In This Change
+
+The LLM HTTP client now shares a concurrency limiter per event loop and URL origin. The default limit is four concurrent requests per LLM origin and can be configured with:
+
+```text
+RELAY_TEAMS_LLM_HTTP_MAX_CONCURRENCY
+```
+
+Setting the value to `0` disables the limiter.
+
+The limiter is held for the full response stream lifetime, so streaming responses still count against the provider budget until the stream is closed.
+
+## Validation
+
+Fake LLM regression coverage:
+
+- One slow session plus one orchestration session with five delegated tasks.
+- The fake LLM observed at most four concurrent chat completions.
+- Both runs completed and backend health remained OK.
+
+Real BigModel pressure test:
+
+- 60 concurrent real BigModel runs: 60/60 completed, 140/140 health probes returned 200.
+- 120 concurrent real BigModel runs: 120/120 completed, 404/404 health probes returned 200.
+- BigModel still produced upstream 429 responses during the high-load run, but the backend stayed responsive and the retry path completed successfully.
+
+## Follow-Up
+
+This change protects the upstream model and prevents unbounded provider concurrency. It does not yet provide full server admission control. A separate run-level capacity guard should cap started and queued runs and return 429 or 503 before too many worker tasks, SSE queues, persistence writes, and retry states accumulate.

--- a/src/relay_teams/net/clients.py
+++ b/src/relay_teams/net/clients.py
@@ -17,6 +17,7 @@ from relay_teams.env.runtime_env import load_merged_env_vars
 from relay_teams.env.hook_runtime_env import merge_tool_hook_runtime_env
 from relay_teams.net.constants import DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
 from relay_teams.net.proxy_transports import (
+    AsyncRequestLimiter,
     AsyncProxyRoutingTransport,
     SyncProxyRoutingTransport,
 )
@@ -76,6 +77,7 @@ def create_async_http_client(
     timeout_seconds: float = DEFAULT_HTTP_TIMEOUT,
     connect_timeout_seconds: float = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS,
     follow_redirects: bool = False,
+    request_limiter: AsyncRequestLimiter | None = None,
 ) -> httpx.AsyncClient:
     resolved_proxy_config = _resolve_proxy_config(
         merged_env=merged_env,
@@ -93,6 +95,7 @@ def create_async_http_client(
         transport=AsyncProxyRoutingTransport(
             proxy_config=resolved_proxy_config,
             ssl_verify=resolved_ssl_verify,
+            request_limiter=request_limiter,
         ),
         follow_redirects=follow_redirects,
     )

--- a/src/relay_teams/net/llm_client.py
+++ b/src/relay_teams/net/llm_client.py
@@ -14,6 +14,11 @@ from relay_teams.env.proxy_env import (
 )
 from relay_teams.net.clients import create_async_http_client
 from relay_teams.net.constants import DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS
+from relay_teams.net.llm_http_concurrency import (
+    clear_llm_http_concurrency_limiters,
+    get_llm_http_concurrency_limiter,
+    resolve_llm_http_max_concurrency,
+)
 
 __all__ = [
     "build_llm_http_client",
@@ -33,7 +38,9 @@ _PROXY_CACHE_KEYS = (
     "no_proxy",
 )
 _LLM_HTTP_CLIENT_CACHE_MAXSIZE = 32
-type _LlmHttpClientCacheKey = tuple[frozenset[tuple[str, str]], bool, float, str | None]
+type _LlmHttpClientCacheKey = tuple[
+    frozenset[tuple[str, str]], bool, float, int | None, str | None
+]
 _SHARED_LLM_HTTP_CLIENT_CACHE: OrderedDict[
     _LlmHttpClientCacheKey, httpx.AsyncClient
 ] = OrderedDict()
@@ -51,10 +58,12 @@ def build_llm_http_client(
         merged_env=merged_env,
         ssl_verify=ssl_verify,
     )
+    max_concurrency = resolve_llm_http_max_concurrency()
     cache_key = _build_llm_http_client_cache_key(
         merged_env=resolved_env,
         ssl_verify=effective_ssl_verify,
         connect_timeout_seconds=connect_timeout_seconds,
+        max_concurrency=max_concurrency,
         cache_scope=cache_scope,
     )
     cache = _select_llm_http_client_cache(cache_scope=cache_scope)
@@ -67,6 +76,7 @@ def build_llm_http_client(
             merged_env=dict(cache_key[0]),
             connect_timeout_seconds=connect_timeout_seconds,
             ssl_verify=effective_ssl_verify,
+            request_limiter=get_llm_http_concurrency_limiter(max_concurrency),
         )
         cache[cache_key] = client
         if cache_scope is None:
@@ -84,6 +94,7 @@ def clear_llm_http_client_cache() -> None:
     )
     _SHARED_LLM_HTTP_CLIENT_CACHE.clear()
     _SCOPED_LLM_HTTP_CLIENT_CACHE.clear()
+    clear_llm_http_concurrency_limiters()
     _close_llm_http_clients(clients)
 
 
@@ -93,6 +104,7 @@ async def clear_llm_http_client_cache_async() -> None:
     )
     _SHARED_LLM_HTTP_CLIENT_CACHE.clear()
     _SCOPED_LLM_HTTP_CLIENT_CACHE.clear()
+    clear_llm_http_concurrency_limiters()
     await _close_llm_http_clients_async(clients)
 
 
@@ -107,10 +119,12 @@ async def reset_llm_http_client_cache_entry(
         merged_env=merged_env,
         ssl_verify=ssl_verify,
     )
+    max_concurrency = resolve_llm_http_max_concurrency()
     cache_key = _build_llm_http_client_cache_key(
         merged_env=resolved_env,
         ssl_verify=effective_ssl_verify,
         connect_timeout_seconds=connect_timeout_seconds,
+        max_concurrency=max_concurrency,
         cache_scope=cache_scope,
     )
     cache = _select_llm_http_client_cache(cache_scope=cache_scope)
@@ -131,12 +145,14 @@ def _build_llm_http_client_cache_key(
     merged_env: Mapping[str, str],
     ssl_verify: bool,
     connect_timeout_seconds: float,
+    max_concurrency: int | None,
     cache_scope: str | None,
 ) -> _LlmHttpClientCacheKey:
     return (
         _proxy_cache_key(merged_env),
         ssl_verify,
         connect_timeout_seconds,
+        max_concurrency,
         cache_scope,
     )
 

--- a/src/relay_teams/net/llm_http_concurrency.py
+++ b/src/relay_teams/net/llm_http_concurrency.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from threading import Lock
+
+from relay_teams.logger import get_logger, log_event
+
+LOGGER = get_logger(__name__)
+DEFAULT_LLM_HTTP_MAX_CONCURRENCY = 4
+LLM_HTTP_MAX_CONCURRENCY_ENV = "RELAY_TEAMS_LLM_HTTP_MAX_CONCURRENCY"
+
+_LIMITER_LOCK = Lock()
+_LIMITERS: dict[int, LlmHttpConcurrencyLimiter] = {}
+
+
+class LlmHttpConcurrencyLimiter:
+    def __init__(self, *, max_concurrency: int) -> None:
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be greater than zero")
+        self._max_concurrency = max_concurrency
+        self._semaphores: dict[tuple[int, str], asyncio.Semaphore] = {}
+        self._lock = Lock()
+
+    async def acquire(self, url: str) -> "LlmHttpConcurrencyLease":
+        scope = _concurrency_scope_for_url(url)
+        loop_id = id(asyncio.get_running_loop())
+        semaphore_key = (loop_id, scope)
+        with self._lock:
+            semaphore = self._semaphores.get(semaphore_key)
+            if semaphore is None:
+                semaphore = asyncio.Semaphore(self._max_concurrency)
+                self._semaphores[semaphore_key] = semaphore
+        await semaphore.acquire()
+        return LlmHttpConcurrencyLease(semaphore=semaphore)
+
+
+class LlmHttpConcurrencyLease:
+    def __init__(self, *, semaphore: asyncio.Semaphore) -> None:
+        self._semaphore = semaphore
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._semaphore.release()
+
+
+def resolve_llm_http_max_concurrency() -> int | None:
+    raw_value = os.environ.get(LLM_HTTP_MAX_CONCURRENCY_ENV)
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_LLM_HTTP_MAX_CONCURRENCY
+    try:
+        resolved = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="llm.http_concurrency.invalid_env",
+            message="Ignoring invalid LLM HTTP concurrency limit",
+            payload={LLM_HTTP_MAX_CONCURRENCY_ENV: raw_value},
+        )
+        return DEFAULT_LLM_HTTP_MAX_CONCURRENCY
+    if resolved <= 0:
+        return None
+    return resolved
+
+
+def get_llm_http_concurrency_limiter(
+    max_concurrency: int | None,
+) -> LlmHttpConcurrencyLimiter | None:
+    if max_concurrency is None:
+        return None
+    with _LIMITER_LOCK:
+        limiter = _LIMITERS.get(max_concurrency)
+        if limiter is None:
+            limiter = LlmHttpConcurrencyLimiter(max_concurrency=max_concurrency)
+            _LIMITERS[max_concurrency] = limiter
+        return limiter
+
+
+def clear_llm_http_concurrency_limiters() -> None:
+    with _LIMITER_LOCK:
+        _LIMITERS.clear()
+
+
+def _concurrency_scope_for_url(url: str) -> str:
+    split = url.split("://", 1)
+    if len(split) != 2:
+        return url
+    scheme, remainder = split
+    authority = remainder.split("/", 1)[0]
+    return f"{scheme}://{authority}".casefold()

--- a/src/relay_teams/net/llm_http_concurrency.py
+++ b/src/relay_teams/net/llm_http_concurrency.py
@@ -64,8 +64,17 @@ def resolve_llm_http_max_concurrency() -> int | None:
             payload={LLM_HTTP_MAX_CONCURRENCY_ENV: raw_value},
         )
         return DEFAULT_LLM_HTTP_MAX_CONCURRENCY
-    if resolved <= 0:
+    if resolved == 0:
         return None
+    if resolved < 0:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="llm.http_concurrency.invalid_env",
+            message="Ignoring invalid LLM HTTP concurrency limit",
+            payload={LLM_HTTP_MAX_CONCURRENCY_ENV: raw_value},
+        )
+        return DEFAULT_LLM_HTTP_MAX_CONCURRENCY
     return resolved
 
 

--- a/src/relay_teams/net/proxy_transports.py
+++ b/src/relay_teams/net/proxy_transports.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Protocol, cast
+from typing import Protocol
 
 import httpx
 
@@ -101,13 +101,16 @@ class AsyncProxyRoutingTransport(httpx.AsyncBaseTransport):
         except BaseException:
             lease.release()
             raise
+        stream = response.stream
+        if not isinstance(stream, httpx.AsyncByteStream):
+            lease.release()
+            raise TypeError(
+                "Async proxy transport received a non-async response stream"
+            )
         return httpx.Response(
             response.status_code,
             headers=response.headers,
-            stream=_ReleasingAsyncByteStream(
-                cast(httpx.AsyncByteStream, response.stream),
-                lease,
-            ),
+            stream=_ReleasingAsyncByteStream(stream, lease),
             request=request,
             extensions=response.extensions,
             default_encoding=response.default_encoding,

--- a/src/relay_teams/net/proxy_transports.py
+++ b/src/relay_teams/net/proxy_transports.py
@@ -1,9 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from typing import Protocol, cast
+
 import httpx
 
 from relay_teams.env.proxy_env import ProxyEnvConfig, proxy_applies_to_url
+
+
+class AsyncRequestLimitLease(Protocol):
+    def release(self) -> None: ...
+
+
+class AsyncRequestLimiter(Protocol):
+    async def acquire(self, url: str) -> AsyncRequestLimitLease: ...
 
 
 class SyncProxyRoutingTransport(httpx.BaseTransport):
@@ -60,8 +71,10 @@ class AsyncProxyRoutingTransport(httpx.AsyncBaseTransport):
         proxy_config: ProxyEnvConfig,
         *,
         ssl_verify: bool,
+        request_limiter: AsyncRequestLimiter | None = None,
     ) -> None:
         self._proxy_config = proxy_config
+        self._request_limiter = request_limiter
         self._direct_transport = httpx.AsyncHTTPTransport(
             trust_env=False,
             verify=ssl_verify,
@@ -80,7 +93,25 @@ class AsyncProxyRoutingTransport(httpx.AsyncBaseTransport):
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         transport = self._select_transport(str(request.url))
-        return await transport.handle_async_request(request)
+        if self._request_limiter is None:
+            return await transport.handle_async_request(request)
+        lease = await self._request_limiter.acquire(str(request.url))
+        try:
+            response = await transport.handle_async_request(request)
+        except BaseException:
+            lease.release()
+            raise
+        return httpx.Response(
+            response.status_code,
+            headers=response.headers,
+            stream=_ReleasingAsyncByteStream(
+                cast(httpx.AsyncByteStream, response.stream),
+                lease,
+            ),
+            request=request,
+            extensions=response.extensions,
+            default_encoding=response.default_encoding,
+        )
 
     async def aclose(self) -> None:
         await self._direct_transport.aclose()
@@ -130,3 +161,33 @@ def _build_async_proxy_transport(
         trust_env=False,
         verify=ssl_verify,
     )
+
+
+class _ReleasingAsyncByteStream(httpx.AsyncByteStream):
+    def __init__(
+        self,
+        stream: httpx.AsyncByteStream,
+        lease: AsyncRequestLimitLease,
+    ) -> None:
+        self._stream = stream
+        self._lease = lease
+        self._released = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in self._stream:
+                yield chunk
+        finally:
+            self._release()
+
+    async def aclose(self) -> None:
+        try:
+            await self._stream.aclose()
+        finally:
+            self._release()
+
+    def _release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._lease.release()

--- a/src/relay_teams/net/proxy_transports.py
+++ b/src/relay_teams/net/proxy_transports.py
@@ -10,11 +10,15 @@ from relay_teams.env.proxy_env import ProxyEnvConfig, proxy_applies_to_url
 
 
 class AsyncRequestLimitLease(Protocol):
-    def release(self) -> None: ...
+    def release(self) -> None:
+        """Release an acquired request slot."""
+        raise NotImplementedError  # pragma: no cover
 
 
 class AsyncRequestLimiter(Protocol):
-    async def acquire(self, url: str) -> AsyncRequestLimitLease: ...
+    async def acquire(self, url: str) -> AsyncRequestLimitLease:
+        """Acquire a request slot for the target URL."""
+        raise NotImplementedError  # pragma: no cover
 
 
 class SyncProxyRoutingTransport(httpx.BaseTransport):

--- a/tests/integration_tests/api/test_orchestration_async_performance.py
+++ b/tests/integration_tests/api/test_orchestration_async_performance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import json
 import time
 
@@ -13,6 +14,7 @@ from integration_tests.support.api_helpers import (
     new_session_id,
     stream_run_until_terminal,
 )
+from integration_tests.support.environment import IntegrationEnvironment
 
 
 class _BenchmarkResult(BaseModel):
@@ -39,6 +41,48 @@ def test_orchestration_parallel_same_role_clone_completes_via_api(
     assert "[fake-llm] orchestration clone benchmark completed" in str(
         result.output_text
     )
+
+
+@pytest.mark.timeout(120)
+def test_concurrent_sessions_share_llm_http_concurrency_budget(
+    api_client: httpx.Client,
+    integration_env: IntegrationEnvironment,
+) -> None:
+    slow_session_id = create_session(
+        api_client,
+        session_id=new_session_id("concurrent-slow-session"),
+    )
+    slow_run_id = create_run(
+        api_client,
+        session_id=slow_session_id,
+        execution_mode="ai",
+        intent="[slow-stream-hold ms=10000] keep one primary run active.",
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        slow_future = executor.submit(
+            _stream_run_with_new_client,
+            integration_env.api_base_url,
+            slow_run_id,
+        )
+        _wait_for_fake_llm_active(integration_env, minimum_active=1)
+        result = _run_orchestration_clone_benchmark(
+            api_client,
+            mode="parallel",
+            task_count=5,
+            delay_ms=900,
+        )
+        slow_events = slow_future.result(timeout=60.0)
+
+    health_response = api_client.get("/api/system/health")
+    health_response.raise_for_status()
+    metrics = _get_fake_llm_metrics(integration_env)
+    max_active = _metric_int(metrics, "max_active_chat_completions")
+
+    assert result.terminal_event_type == "run_completed"
+    assert result.completed_tasks == 5
+    assert str(slow_events[-1].get("event_type") or "") == "run_completed"
+    assert max_active == 4
 
 
 @pytest.mark.timeout(90)
@@ -128,3 +172,55 @@ def _text_output(events: list[dict[str, object]]) -> str:
         payload = json.loads(str(event.get("payload_json") or "{}"))
         parts.append(str(payload.get("text") or ""))
     return "".join(parts)
+
+
+def _stream_run_with_new_client(
+    base_url: str,
+    run_id: str,
+) -> list[dict[str, object]]:
+    with httpx.Client(base_url=base_url, timeout=120.0, trust_env=False) as client:
+        return stream_run_until_terminal(
+            client,
+            run_id=run_id,
+            timeout_seconds=120.0,
+        )
+
+
+def _wait_for_fake_llm_active(
+    integration_env: IntegrationEnvironment,
+    *,
+    minimum_active: int,
+    timeout_seconds: float = 15.0,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        metrics = _get_fake_llm_metrics(integration_env)
+        active = _metric_int(metrics, "active_chat_completions")
+        if active >= minimum_active:
+            return
+        time.sleep(0.05)
+    raise AssertionError("Timed out waiting for fake LLM active request")
+
+
+def _get_fake_llm_metrics(
+    integration_env: IntegrationEnvironment,
+) -> dict[str, object]:
+    response = httpx.get(
+        f"{integration_env.fake_llm_admin_url}/metrics",
+        timeout=5.0,
+        trust_env=False,
+    )
+    response.raise_for_status()
+    body = response.json()
+    if not isinstance(body, dict):
+        raise AssertionError(f"Invalid fake LLM metrics response: {body}")
+    return body
+
+
+def _metric_int(metrics: dict[str, object], key: str) -> int:
+    value = metrics.get(key)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value)
+    raise AssertionError(f"Invalid fake LLM metric {key}: {value}")

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -105,6 +105,7 @@ def integration_env(
         python_paths.append(existing_pythonpath)
     shared_env["PYTHONPATH"] = os.pathsep.join(python_paths)
     shared_env["AGENT_TEAMS_COMPUTER_RUNTIME"] = "fake"
+    shared_env["RELAY_TEAMS_LLM_HTTP_MAX_CONCURRENCY"] = "4"
 
     fake_llm_log_file = runtime_root / "fake-llm.log"
     backend_log_file = runtime_root / "backend.log"

--- a/tests/integration_tests/support/fake_llm_server.py
+++ b/tests/integration_tests/support/fake_llm_server.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 import json
 import re
 import sys
+from threading import Lock
 import time
 
 from fastapi import FastAPI, Request
@@ -13,6 +14,9 @@ app = FastAPI(title="Fake OpenAI-Compatible LLM")
 
 _chat_completions_calls = 0
 _scenario_attempts: dict[str, int] = {}
+_active_chat_completions = 0
+_max_active_chat_completions = 0
+_metrics_lock = Lock()
 
 
 @app.get("/health")
@@ -22,17 +26,24 @@ def health() -> dict[str, str]:
 
 @app.get("/metrics")
 def metrics() -> dict[str, object]:
-    return {
-        "chat_completions_calls": _chat_completions_calls,
-        "scenario_attempts": dict(_scenario_attempts),
-    }
+    with _metrics_lock:
+        return {
+            "chat_completions_calls": _chat_completions_calls,
+            "active_chat_completions": _active_chat_completions,
+            "max_active_chat_completions": _max_active_chat_completions,
+            "scenario_attempts": dict(_scenario_attempts),
+        }
 
 
 @app.post("/admin/reset")
 def reset() -> dict[str, str]:
-    global _chat_completions_calls
-    _chat_completions_calls = 0
-    _scenario_attempts.clear()
+    global _active_chat_completions, _chat_completions_calls
+    global _max_active_chat_completions
+    with _metrics_lock:
+        _chat_completions_calls = 0
+        _active_chat_completions = 0
+        _max_active_chat_completions = 0
+        _scenario_attempts.clear()
     return {"status": "ok"}
 
 
@@ -53,20 +64,22 @@ def list_models() -> dict[str, object]:
 
 @app.post("/v1/chat/completions")
 async def chat_completions(request: Request):
-    global _chat_completions_calls
-    _chat_completions_calls += 1
     payload = await request.json()
+    _begin_chat_completion()
     model = str(payload.get("model") or "fake-chat-model")
     response_spec = plan_fake_response(payload)
     stream = bool(payload.get("stream"))
     if str(response_spec.get("kind") or "") == "error_status":
-        _sleep_ms(response_spec.get("delay_before_ms"))
-        return JSONResponse(
-            status_code=_coerce_int(response_spec.get("status_code"), default=500),
-            content=response_spec.get("body")
-            or {"error": {"code": "fake_error", "message": "fake error"}},
-            headers=_normalize_headers(response_spec.get("headers")),
-        )
+        try:
+            _sleep_ms(response_spec.get("delay_before_ms"))
+            return JSONResponse(
+                status_code=_coerce_int(response_spec.get("status_code"), default=500),
+                content=response_spec.get("body")
+                or {"error": {"code": "fake_error", "message": "fake error"}},
+                headers=_normalize_headers(response_spec.get("headers")),
+            )
+        finally:
+            _end_chat_completion()
 
     if stream:
         return StreamingResponse(
@@ -74,9 +87,30 @@ async def chat_completions(request: Request):
             media_type="text/event-stream",
         )
 
-    return JSONResponse(
-        build_chat_completion_response(model=model, response_spec=response_spec)
-    )
+    try:
+        return JSONResponse(
+            build_chat_completion_response(model=model, response_spec=response_spec)
+        )
+    finally:
+        _end_chat_completion()
+
+
+def _begin_chat_completion() -> None:
+    global _active_chat_completions, _chat_completions_calls
+    global _max_active_chat_completions
+    with _metrics_lock:
+        _chat_completions_calls += 1
+        _active_chat_completions += 1
+        _max_active_chat_completions = max(
+            _max_active_chat_completions,
+            _active_chat_completions,
+        )
+
+
+def _end_chat_completion() -> None:
+    global _active_chat_completions
+    with _metrics_lock:
+        _active_chat_completions = max(0, _active_chat_completions - 1)
 
 
 def stream_chat_completions(
@@ -84,87 +118,93 @@ def stream_chat_completions(
     model: str,
     response_spec: dict[str, object],
 ) -> Iterator[bytes]:
-    created = int(time.time())
-    completion_id = f"chatcmpl-{_chat_completions_calls}"
-    _sleep_ms(response_spec.get("delay_before_ms"))
+    try:
+        created = int(time.time())
+        completion_id = f"chatcmpl-{_chat_completions_calls}"
+        _sleep_ms(response_spec.get("delay_before_ms"))
 
-    response_kind = str(response_spec.get("kind") or "")
-    if response_kind in {"tool_call", "invalid_tool_call", "tool_calls"}:
-        tool_calls: list[dict[str, object]] = []
-        for index, call_spec in enumerate(_response_tool_call_specs(response_spec)):
-            tool_calls.append(
-                {
-                    "index": index,
-                    "id": str(call_spec.get("tool_call_id") or ""),
-                    "type": "function",
-                    "function": {
-                        "name": str(call_spec.get("tool_name") or ""),
-                        "arguments": _response_tool_call_arguments(
-                            response_kind=response_kind,
-                            response_spec=response_spec,
-                            call_spec=call_spec,
-                        ),
-                    },
-                }
+        response_kind = str(response_spec.get("kind") or "")
+        if response_kind in {"tool_call", "invalid_tool_call", "tool_calls"}:
+            tool_calls: list[dict[str, object]] = []
+            for index, call_spec in enumerate(_response_tool_call_specs(response_spec)):
+                tool_calls.append(
+                    {
+                        "index": index,
+                        "id": str(call_spec.get("tool_call_id") or ""),
+                        "type": "function",
+                        "function": {
+                            "name": str(call_spec.get("tool_name") or ""),
+                            "arguments": _response_tool_call_arguments(
+                                response_kind=response_kind,
+                                response_spec=response_spec,
+                                call_spec=call_spec,
+                            ),
+                        },
+                    }
+                )
+            chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "tool_calls": tool_calls,
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8")
+            _maybe_abort_stream(response_spec, emitted_chunk_count=1)
+            _sleep_ms(response_spec.get("delay_between_chunks_ms"))
+            final_chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            }
+            yield f"data: {json.dumps(final_chunk, ensure_ascii=False)}\n\n".encode(
+                "utf-8"
             )
-        chunk = {
-            "id": completion_id,
-            "object": "chat.completion.chunk",
-            "created": created,
-            "model": model,
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {
-                        "role": "assistant",
-                        "tool_calls": tool_calls,
-                    },
-                    "finish_reason": None,
-                }
-            ],
-        }
-        yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8")
-        _maybe_abort_stream(response_spec, emitted_chunk_count=1)
-        _sleep_ms(response_spec.get("delay_between_chunks_ms"))
+            yield b"data: [DONE]\n\n"
+            return
+
+        content = str(response_spec.get("content") or "")
+        chunk_size = max(1, _coerce_int(response_spec.get("chunk_size"), default=12))
+        chunks = split_text(content, size=chunk_size)
+
+        for index, part in enumerate(chunks):
+            delta: dict[str, str] = {"content": part}
+            if index == 0:
+                delta["role"] = "assistant"
+            chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+            }
+            yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8")
+            _maybe_abort_stream(response_spec, emitted_chunk_count=index + 1)
+            _sleep_ms(response_spec.get("delay_between_chunks_ms"))
+
+        _sleep_ms(response_spec.get("delay_after_content_ms"))
         final_chunk = {
             "id": completion_id,
             "object": "chat.completion.chunk",
             "created": created,
             "model": model,
-            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
         }
         yield f"data: {json.dumps(final_chunk, ensure_ascii=False)}\n\n".encode("utf-8")
         yield b"data: [DONE]\n\n"
-        return
-
-    content = str(response_spec.get("content") or "")
-    chunk_size = max(1, _coerce_int(response_spec.get("chunk_size"), default=12))
-    chunks = split_text(content, size=chunk_size)
-
-    for index, part in enumerate(chunks):
-        delta: dict[str, str] = {"content": part}
-        if index == 0:
-            delta["role"] = "assistant"
-        chunk = {
-            "id": completion_id,
-            "object": "chat.completion.chunk",
-            "created": created,
-            "model": model,
-            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
-        }
-        yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8")
-        _maybe_abort_stream(response_spec, emitted_chunk_count=index + 1)
-        _sleep_ms(response_spec.get("delay_between_chunks_ms"))
-
-    final_chunk = {
-        "id": completion_id,
-        "object": "chat.completion.chunk",
-        "created": created,
-        "model": model,
-        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-    }
-    yield f"data: {json.dumps(final_chunk, ensure_ascii=False)}\n\n".encode("utf-8")
-    yield b"data: [DONE]\n\n"
+    finally:
+        _end_chat_completion()
 
 
 def build_chat_completion_response(
@@ -297,6 +337,8 @@ def plan_fake_response(payload: object) -> dict[str, object]:
         return _plan_rate_limit_retry_response(messages)
     if _stream_drop_retry_mode(messages):
         return _plan_stream_drop_retry_response(messages)
+    if _slow_stream_hold_mode(messages):
+        return _plan_slow_stream_hold_response(messages)
     if _slow_stream_mode(messages):
         return _plan_slow_stream_response()
     if _webfetch_approval_validation_mode(messages):
@@ -1130,6 +1172,22 @@ def _plan_stream_drop_retry_response(messages: list[object]) -> dict[str, object
 
 def _slow_stream_mode(messages: list[object]) -> bool:
     return _messages_contain_user_text(messages, "[slow-stream]")
+
+
+def _slow_stream_hold_mode(messages: list[object]) -> bool:
+    return _messages_contain_user_text(messages, "[slow-stream-hold")
+
+
+def _plan_slow_stream_hold_response(messages: list[object]) -> dict[str, object]:
+    user_text = _extract_last_user_text(messages)
+    match = re.search(r"\[slow-stream-hold\s+ms=(\d+)\]", user_text)
+    hold_ms = int(match.group(1)) if match is not None else 5_000
+    return {
+        "kind": "text",
+        "content": "[fake-llm] Holding slow stream for concurrency validation.",
+        "delay_before_ms": 100,
+        "delay_after_content_ms": max(0, min(15_000, hold_ms)),
+    }
 
 
 def _plan_slow_stream_response() -> dict[str, object]:

--- a/tests/unit_tests/net/test_llm_client.py
+++ b/tests/unit_tests/net/test_llm_client.py
@@ -78,7 +78,8 @@ def test_build_llm_http_client_loads_saved_proxy_settings_when_env_not_provided(
     client = llm_client.build_llm_http_client()
 
     assert isinstance(client, _FakeAsyncClient)
-    assert captured_kwargs.pop("request_limiter") is not None
+    request_limiter = captured_kwargs.pop("request_limiter")
+    assert request_limiter is not None
     assert captured_kwargs == {
         "merged_env": {
             "HTTPS_PROXY": "http://alice:secret@proxy.internal:8443",

--- a/tests/unit_tests/net/test_llm_client.py
+++ b/tests/unit_tests/net/test_llm_client.py
@@ -78,6 +78,7 @@ def test_build_llm_http_client_loads_saved_proxy_settings_when_env_not_provided(
     client = llm_client.build_llm_http_client()
 
     assert isinstance(client, _FakeAsyncClient)
+    assert captured_kwargs.pop("request_limiter") is not None
     assert captured_kwargs == {
         "merged_env": {
             "HTTPS_PROXY": "http://alice:secret@proxy.internal:8443",

--- a/tests/unit_tests/net/test_llm_http_concurrency.py
+++ b/tests/unit_tests/net/test_llm_http_concurrency.py
@@ -13,6 +13,11 @@ from relay_teams.net.llm_http_concurrency import (
 )
 
 
+def test_limiter_rejects_non_positive_concurrency() -> None:
+    with pytest.raises(ValueError, match="greater than zero"):
+        LlmHttpConcurrencyLimiter(max_concurrency=0)
+
+
 @pytest.mark.asyncio
 async def test_limiter_blocks_same_origin_until_lease_released() -> None:
     limiter = LlmHttpConcurrencyLimiter(max_concurrency=1)
@@ -47,10 +52,47 @@ async def test_limiter_allows_different_origins_independently() -> None:
     first_lease.release()
 
 
+@pytest.mark.asyncio
+async def test_limiter_lease_release_is_idempotent() -> None:
+    limiter = LlmHttpConcurrencyLimiter(max_concurrency=1)
+    first_lease = await limiter.acquire("https://provider.example/v1/chat/completions")
+
+    first_lease.release()
+    first_lease.release()
+
+    second_lease = await limiter.acquire("https://provider.example/v1/models")
+    waiter = asyncio.create_task(
+        limiter.acquire("https://provider.example/v1/chat/completions"),
+    )
+    await asyncio.sleep(0)
+
+    assert waiter.done() is False
+
+    second_lease.release()
+    third_lease = await asyncio.wait_for(waiter, timeout=1.0)
+    third_lease.release()
+
+
 def test_resolve_llm_http_max_concurrency_defaults_when_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(LLM_HTTP_MAX_CONCURRENCY_ENV, raising=False)
+
+    assert resolve_llm_http_max_concurrency() == DEFAULT_LLM_HTTP_MAX_CONCURRENCY
+
+
+def test_resolve_llm_http_max_concurrency_defaults_when_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(LLM_HTTP_MAX_CONCURRENCY_ENV, " ")
+
+    assert resolve_llm_http_max_concurrency() == DEFAULT_LLM_HTTP_MAX_CONCURRENCY
+
+
+def test_resolve_llm_http_max_concurrency_defaults_when_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(LLM_HTTP_MAX_CONCURRENCY_ENV, "not-a-number")
 
     assert resolve_llm_http_max_concurrency() == DEFAULT_LLM_HTTP_MAX_CONCURRENCY
 
@@ -61,3 +103,25 @@ def test_resolve_llm_http_max_concurrency_allows_disable(
     monkeypatch.setenv(LLM_HTTP_MAX_CONCURRENCY_ENV, "0")
 
     assert resolve_llm_http_max_concurrency() is None
+
+
+def test_resolve_llm_http_max_concurrency_uses_positive_env_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(LLM_HTTP_MAX_CONCURRENCY_ENV, "7")
+
+    assert resolve_llm_http_max_concurrency() == 7
+
+
+@pytest.mark.asyncio
+async def test_limiter_keeps_urls_without_scheme_as_exact_scope() -> None:
+    limiter = LlmHttpConcurrencyLimiter(max_concurrency=1)
+    first_lease = await limiter.acquire("provider.example/v1/chat/completions")
+
+    second_lease = await asyncio.wait_for(
+        limiter.acquire("provider.example/v1/models"),
+        timeout=1.0,
+    )
+
+    second_lease.release()
+    first_lease.release()

--- a/tests/unit_tests/net/test_llm_http_concurrency.py
+++ b/tests/unit_tests/net/test_llm_http_concurrency.py
@@ -105,6 +105,14 @@ def test_resolve_llm_http_max_concurrency_allows_disable(
     assert resolve_llm_http_max_concurrency() is None
 
 
+def test_resolve_llm_http_max_concurrency_defaults_when_negative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(LLM_HTTP_MAX_CONCURRENCY_ENV, "-1")
+
+    assert resolve_llm_http_max_concurrency() == DEFAULT_LLM_HTTP_MAX_CONCURRENCY
+
+
 def test_resolve_llm_http_max_concurrency_uses_positive_env_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/net/test_llm_http_concurrency.py
+++ b/tests/unit_tests/net/test_llm_http_concurrency.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from relay_teams.net.llm_http_concurrency import (
+    DEFAULT_LLM_HTTP_MAX_CONCURRENCY,
+    LLM_HTTP_MAX_CONCURRENCY_ENV,
+    LlmHttpConcurrencyLimiter,
+    resolve_llm_http_max_concurrency,
+)
+
+
+@pytest.mark.asyncio
+async def test_limiter_blocks_same_origin_until_lease_released() -> None:
+    limiter = LlmHttpConcurrencyLimiter(max_concurrency=1)
+    first_lease = await limiter.acquire("https://provider.example/v1/chat/completions")
+    waiter = asyncio.create_task(
+        limiter.acquire("https://provider.example/v1/models"),
+    )
+
+    await asyncio.sleep(0)
+
+    assert waiter.done() is False
+
+    first_lease.release()
+    second_lease = await asyncio.wait_for(waiter, timeout=1.0)
+
+    second_lease.release()
+
+
+@pytest.mark.asyncio
+async def test_limiter_allows_different_origins_independently() -> None:
+    limiter = LlmHttpConcurrencyLimiter(max_concurrency=1)
+    first_lease = await limiter.acquire(
+        "https://provider-a.example/v1/chat/completions"
+    )
+
+    second_lease = await asyncio.wait_for(
+        limiter.acquire("https://provider-b.example/v1/chat/completions"),
+        timeout=1.0,
+    )
+
+    second_lease.release()
+    first_lease.release()
+
+
+def test_resolve_llm_http_max_concurrency_defaults_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(LLM_HTTP_MAX_CONCURRENCY_ENV, raising=False)
+
+    assert resolve_llm_http_max_concurrency() == DEFAULT_LLM_HTTP_MAX_CONCURRENCY
+
+
+def test_resolve_llm_http_max_concurrency_allows_disable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(LLM_HTTP_MAX_CONCURRENCY_ENV, "0")
+
+    assert resolve_llm_http_max_concurrency() is None

--- a/tests/unit_tests/net/test_proxy_transports.py
+++ b/tests/unit_tests/net/test_proxy_transports.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+
+import httpx
+import pytest
+
+from relay_teams.env.proxy_env import ProxyEnvConfig
+from relay_teams.net.proxy_transports import AsyncProxyRoutingTransport
+
+
+class _FakeLease:
+    def __init__(self) -> None:
+        self.release_count = 0
+
+    def release(self) -> None:
+        self.release_count += 1
+
+
+class _FakeLimiter:
+    def __init__(self) -> None:
+        self.lease = _FakeLease()
+        self.acquired_urls: list[str] = []
+
+    async def acquire(self, url: str) -> _FakeLease:
+        self.acquired_urls.append(url)
+        return self.lease
+
+
+class _ChunkStream(httpx.AsyncByteStream):
+    def __init__(
+        self,
+        chunks: tuple[bytes, ...] = (b"ok",),
+        *,
+        fail_after_first_chunk: bool = False,
+    ) -> None:
+        self._chunks = chunks
+        self._fail_after_first_chunk = fail_after_first_chunk
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for index, chunk in enumerate(self._chunks):
+            yield chunk
+            if self._fail_after_first_chunk and index == 0:
+                raise RuntimeError("stream failed")
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _SyncStream(httpx.SyncByteStream):
+    def __iter__(self) -> Iterator[bytes]:
+        yield b"ok"
+
+
+class _FakeTransport(httpx.AsyncBaseTransport):
+    def __init__(
+        self,
+        *,
+        stream: httpx.AsyncByteStream | httpx.SyncByteStream | None = None,
+        raise_on_request: bool = False,
+    ) -> None:
+        self.stream = stream
+        self.raise_on_request = raise_on_request
+        self.closed = False
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if self.raise_on_request:
+            raise RuntimeError("request failed")
+        return httpx.Response(
+            200,
+            stream=self.stream or _ChunkStream(),
+            request=request,
+        )
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _build_transport(
+    *,
+    limiter: _FakeLimiter | None = None,
+    direct_transport: _FakeTransport | None = None,
+) -> tuple[AsyncProxyRoutingTransport, _FakeTransport]:
+    transport = AsyncProxyRoutingTransport(
+        ProxyEnvConfig(),
+        ssl_verify=False,
+        request_limiter=limiter,
+    )
+    fake_transport = direct_transport or _FakeTransport()
+    setattr(transport, "_direct_transport", fake_transport)
+    return transport, fake_transport
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_after_stream_consumed() -> None:
+    limiter = _FakeLimiter()
+    stream = _ChunkStream(chunks=(b"o", b"k"))
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=stream),
+    )
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+
+    assert limiter.acquired_urls == ["https://provider.example/v1/chat/completions"]
+    assert limiter.lease.release_count == 0
+    assert await response.aread() == b"ok"
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_when_response_closed() -> None:
+    limiter = _FakeLimiter()
+    stream = _ChunkStream()
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=stream),
+    )
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+    await response.aclose()
+    await response.aclose()
+
+    assert stream.closed is True
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_when_delegate_raises() -> None:
+    limiter = _FakeLimiter()
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(raise_on_request=True),
+    )
+
+    with pytest.raises(RuntimeError, match="request failed"):
+        await transport.handle_async_request(
+            httpx.Request("GET", "https://provider.example/v1/chat/completions")
+        )
+
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_for_invalid_stream_type() -> None:
+    limiter = _FakeLimiter()
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=_SyncStream()),
+    )
+
+    with pytest.raises(TypeError, match="non-async response stream"):
+        await transport.handle_async_request(
+            httpx.Request("GET", "https://provider.example/v1/chat/completions")
+        )
+
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_when_stream_iteration_fails() -> (
+    None
+):
+    limiter = _FakeLimiter()
+    stream = _ChunkStream(fail_after_first_chunk=True)
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=stream),
+    )
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+
+    with pytest.raises(RuntimeError, match="stream failed"):
+        await response.aread()
+
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_without_limiter_delegates_directly() -> None:
+    transport, fake_transport = _build_transport()
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+
+    assert await response.aread() == b"ok"
+    assert len(fake_transport.requests) == 1


### PR DESCRIPTION
## Summary

Closes #588.

This PR adds a shared LLM HTTP concurrency budget so multiple active sessions cannot independently saturate the same upstream provider/model endpoint.

Changes:

- Add a per-event-loop, per-origin LLM HTTP concurrency limiter, defaulting to 4 concurrent requests per origin.
- Configure the limit through `RELAY_TEAMS_LLM_HTTP_MAX_CONCURRENCY`; `0` disables it.
- Hold the limiter lease for the full streaming response lifetime.
- Extend the fake LLM server with active/max concurrency metrics and slow stream hold scenarios.
- Add regression coverage for concurrent sessions sharing one LLM HTTP budget.
- Record the 2026-04-28 incident and follow-up run-level admission-control gap in docs.

## Real BigModel Pressure Test

Ran against an isolated backend using the real `bigmodel` profile:

- 60 concurrent real BigModel runs: 60/60 completed, 140/140 health probes returned 200.
- 120 concurrent real BigModel runs: 120/120 completed, 404/404 health probes returned 200.
- BigModel returned upstream 429 under pressure, but backend health stayed OK and retries completed.

## Local Verification

- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/opt/workspace/agent-teams-main/.playwright-browsers uv run --extra dev pytest -q tests/integration_tests`

Results:

- Unit tests: 4270 passed, 5 skipped.
- Integration tests: 89 passed, 3 skipped.
