### PR TITLE
Add Block AI sources to research prompts

### DIFF
--- a/src/relay_teams/builtin/roles/daily-ai-report.md
+++ b/src/relay_teams/builtin/roles/daily-ai-report.md
@@ -138,6 +138,8 @@ skills:
 - [AI Brief 中文](https://ai-brief.liziran.com/zh/)
 - [a16z news](https://www.a16z.news/)
 - [alphaxiv](https://www.alphaxiv.org/)
+- [Block AI](https://block.xyz/ai)
+- [Block AI News](https://block.xyz/news/ai)
 
 ## X 账号信源
 
@@ -167,6 +169,7 @@ skills:
 - `Hailuo_AI`
 - `MIT_CSAIL`
 - `IBMData`
+- `blocks`
 
 ### 个人 / 观点账号
 
@@ -224,6 +227,9 @@ skills:
 - `a16z.news`  
   RSS: <https://www.a16z.news/feed>  
   Site: <https://www.a16z.news>
+- `engineering.block.xyz`
+  RSS: <https://engineering.block.xyz/blog/rss.xml>
+  Site: <https://engineering.block.xyz>
 - `simonwillison.net`  
   RSS: <https://simonwillison.net/atom/everything/>  
   Site: <https://simonwillison.net>

--- a/src/relay_teams/builtin/skills/deepresearch/news_source.md
+++ b/src/relay_teams/builtin/skills/deepresearch/news_source.md
@@ -2,11 +2,16 @@
 
 - [AI Digest 中文](https://ai-digest.liziran.com/zh/)
 - [AI Brief 中文](https://ai-brief.liziran.com/zh/)
+- [Block AI](https://block.xyz/ai)
+- [Block AI News](https://block.xyz/news/ai)
 
 ## RSS 博客池
 
 ### Blogs
 
+- `engineering.block.xyz`
+  RSS: <https://engineering.block.xyz/blog/rss.xml>
+  Site: <https://engineering.block.xyz>
 - `simonwillison.net`  
   RSS: <https://simonwillison.net/atom/everything/>  
   Site: <https://simonwillison.net>

--- a/tests/unit_tests/builtin/test_resources.py
+++ b/tests/unit_tests/builtin/test_resources.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from relay_teams.builtin.resources import (
     ensure_app_config_bootstrap,
     get_builtin_roles_dir,
+    get_builtin_skills_dir,
 )
 from relay_teams.roles.role_registry import RoleLoader
 
@@ -30,3 +31,13 @@ def test_primary_builtin_runtime_roles_allow_all_mcp_servers_and_skills() -> Non
         role = registry.get(role_id)
         assert role.mcp_servers == ("*",)
         assert role.skills == ("*",)
+
+
+def test_deepresearch_news_sources_include_block_ai_source_entries() -> None:
+    news_source_path = get_builtin_skills_dir() / "deepresearch" / "news_source.md"
+
+    content = news_source_path.read_text(encoding="utf-8")
+
+    assert "- [Block AI](https://block.xyz/ai)" in content
+    assert "- [Block AI News](https://block.xyz/news/ai)" in content
+    assert "RSS: <https://engineering.block.xyz/blog/rss.xml>" in content

--- a/tests/unit_tests/roles/test_daily_ai_report_role_content.py
+++ b/tests/unit_tests/roles/test_daily_ai_report_role_content.py
@@ -14,3 +14,14 @@ def test_daily_ai_report_role_includes_x_account_sources() -> None:
     assert "- `AnthropicAI`" in content
     assert "- `karpathy`" in content
     assert "- `AndrewYNg`" in content
+
+
+def test_daily_ai_report_role_includes_block_ai_sources() -> None:
+    role_path = get_builtin_roles_dir() / "daily-ai-report.md"
+
+    content = role_path.read_text(encoding="utf-8")
+
+    assert "- [Block AI](https://block.xyz/ai)" in content
+    assert "- [Block AI News](https://block.xyz/news/ai)" in content
+    assert "RSS: <https://engineering.block.xyz/blog/rss.xml>" in content
+    assert "- `blocks`" in content


### PR DESCRIPTION
## Summary
- add Block AI and Block AI News as source-level entries for deepresearch and daily AI report prompts
- add Block Engineering Blog RSS and the official blocks X account to daily AI report discovery
- add tests covering the new source entries

Fixes #583

## Tests
- uv run --extra dev pytest -q tests/unit_tests/builtin/test_resources.py tests/unit_tests/roles/test_daily_ai_report_role_content.py tests/unit_tests/tools/test_package_data.py
- uv run --extra dev ruff check tests/unit_tests/builtin/test_resources.py tests/unit_tests/roles/test_daily_ai_report_role_content.py
- git diff --check