### PR TITLE
Fix settings action races and cache warmup

### DIFF
--- a/frontend/dist/css/components/settings.css
+++ b/frontend/dist/css/components/settings.css
@@ -187,6 +187,22 @@
     justify-content: center;
 }
 
+.settings-actions-bar[data-active-tab="appearance"] [data-settings-action-tab]:not([data-settings-action-tab="appearance"]),
+.settings-actions-bar[data-active-tab="model"] [data-settings-action-tab]:not([data-settings-action-tab="model"]),
+.settings-actions-bar[data-active-tab="mcp"] [data-settings-action-tab]:not([data-settings-action-tab="mcp"]),
+.settings-actions-bar[data-active-tab="commands"] [data-settings-action-tab]:not([data-settings-action-tab="commands"]),
+.settings-actions-bar[data-active-tab="hooks"] [data-settings-action-tab]:not([data-settings-action-tab="hooks"]),
+.settings-actions-bar[data-active-tab="agents"] [data-settings-action-tab]:not([data-settings-action-tab="agents"]),
+.settings-actions-bar[data-active-tab="roles"] [data-settings-action-tab]:not([data-settings-action-tab="roles"]),
+.settings-actions-bar[data-active-tab="orchestration"] [data-settings-action-tab]:not([data-settings-action-tab="orchestration"]),
+.settings-actions-bar[data-active-tab="notifications"] [data-settings-action-tab]:not([data-settings-action-tab="notifications"]),
+.settings-actions-bar[data-active-tab="web"] [data-settings-action-tab]:not([data-settings-action-tab="web"]),
+.settings-actions-bar[data-active-tab="proxy"] [data-settings-action-tab]:not([data-settings-action-tab="proxy"]),
+.settings-actions-bar[data-active-tab="workspace"] [data-settings-action-tab]:not([data-settings-action-tab="workspace"]),
+.settings-actions-bar[data-active-tab="environment"] [data-settings-action-tab]:not([data-settings-action-tab="environment"]) {
+    display: none !important;
+}
+
 .modal-header h2 {
     margin: 0;
     font-size: 1.15rem;

--- a/frontend/dist/js/components/settings/index.js
+++ b/frontend/dist/js/components/settings/index.js
@@ -30,12 +30,22 @@ import { bindWorkspaceSettingsHandlers, loadWorkspaceSettingsPanel } from './wor
 import { bindWebSettingsHandlers, loadWebSettingsPanel } from './webSettings.js';
 import { bindSystemStatusHandlers, loadMcpStatusPanel, loadSkillsStatusPanel } from './systemStatus.js';
 import { bindAppearanceHandlers, loadAppearancePanel, initAppearanceOnStartup } from './appearanceSettings.js';
+import {
+    fetchModelProfiles,
+    fetchOrchestrationConfig,
+    fetchRoleConfigOptions,
+    fetchRoleConfigs,
+} from '../../core/api.js';
 import { t, translateDocument } from '../../utils/i18n.js';
+import { errorToPayload, logError } from '../../utils/logger.js';
 
 let settingsModal = null;
 let currentTab = 'appearance';
 let initialized = false;
 let overlayPointerDown = false;
+let actionOwnershipObserver = null;
+let panelLoadRequestId = 0;
+let settingsWarmupPromise = null;
 
 const TAB_METADATA = {
     appearance: {
@@ -90,6 +100,49 @@ const TAB_METADATA = {
         titleKey: 'settings.panel.environment.title',
         descriptionKey: 'settings.panel.environment.description',
     },
+};
+
+const ACTION_TAB_OWNERS = {
+    'add-profile-btn': 'model',
+    'save-profile-btn': 'model',
+    'cancel-profile-btn': 'model',
+    'test-profile-btn': 'model',
+    'profile-probe-inline-status': 'model',
+    'add-ssh-profile-btn': 'workspace',
+    'save-ssh-profile-btn': 'workspace',
+    'cancel-ssh-profile-btn': 'workspace',
+    'test-ssh-profile-btn': 'workspace',
+    'delete-ssh-profile-btn': 'workspace',
+    'test-agent-btn': 'agents',
+    'add-agent-btn': 'agents',
+    'save-agent-btn': 'agents',
+    'delete-agent-btn': 'agents',
+    'cancel-agent-btn': 'agents',
+    'add-command-btn': 'commands',
+    'preview-command-btn': 'commands',
+    'save-command-btn': 'commands',
+    'cancel-command-btn': 'commands',
+    'add-hook-btn': 'hooks',
+    'validate-hooks-btn': 'hooks',
+    'save-hooks-btn': 'hooks',
+    'add-role-btn': 'roles',
+    'validate-role-btn': 'roles',
+    'save-role-btn': 'roles',
+    'cancel-role-btn': 'roles',
+    'add-orchestration-preset-btn': 'orchestration',
+    'save-orchestration-btn': 'orchestration',
+    'cancel-orchestration-btn': 'orchestration',
+    'add-env-btn': 'environment',
+    'save-env-btn': 'environment',
+    'cancel-env-btn': 'environment',
+    'save-notifications-btn': 'notifications',
+    'save-web-btn': 'web',
+    'save-proxy-btn': 'proxy',
+    'add-mcp-server-btn': 'mcp',
+    'save-mcp-server-btn': 'mcp',
+    'cancel-mcp-server-btn': 'mcp',
+    'reload-mcp-btn': 'mcp',
+    'reset-appearance-btn': 'appearance',
 };
 
 export function initSettings() {
@@ -864,6 +917,7 @@ function createModal() {
     `;
     document.body.appendChild(settingsModal);
     translateDocument(settingsModal);
+    setupSettingsActionOwnership();
 }
 
 function setupEventListeners() {
@@ -887,7 +941,7 @@ function setupEventListeners() {
     document.querySelectorAll('.settings-tab').forEach(tab => {
         tab.onclick = () => {
             currentTab = tab.dataset.tab;
-            showPanel(currentTab);
+            return showPanel(currentTab);
         };
     });
 
@@ -916,6 +970,7 @@ function setupEventListeners() {
 }
 
 async function showPanel(tab) {
+    const requestId = ++panelLoadRequestId;
     document.querySelectorAll('.settings-tab').forEach(button => {
         button.classList.toggle('active', button.dataset.tab === tab);
     });
@@ -927,7 +982,7 @@ async function showPanel(tab) {
     });
 
     updatePanelHeading(tab);
-    renderPanelActions(tab);
+    clearPanelActions(tab);
     bindModelProfileHandlers();
     bindCommandsSettingsHandlers();
     bindHooksSettingsHandlers();
@@ -940,6 +995,14 @@ async function showPanel(tab) {
     bindWorkspaceSettingsHandlers();
     bindSystemStatusHandlers();
 
+    await loadSettingsPanel(tab);
+    if (requestId !== panelLoadRequestId || currentTab !== tab) {
+        return;
+    }
+    renderPanelActions(tab);
+}
+
+async function loadSettingsPanel(tab) {
     if (tab === 'model') {
         await loadModelProfilesPanel();
     } else if (tab === 'hooks') {
@@ -977,70 +1040,174 @@ function updatePanelHeading(tab) {
     document.getElementById('settings-panel-description').textContent = t(meta.descriptionKey);
 }
 
+function clearPanelActions(tab) {
+    const actions = document.getElementById('settings-panel-actions');
+    const actionsBar = document.getElementById('settings-actions-bar');
+    if (!actions) {
+        return;
+    }
+    if (actionsBar) {
+        actionsBar.dataset.activeTab = tab;
+    }
+    hideAllSettingsActions();
+    setPanelActionsLoading(tab, false);
+    enforceSettingsActionOwnership();
+}
+
 function renderPanelActions(tab) {
     const actions = document.getElementById('settings-panel-actions');
     const actionsBar = document.getElementById('settings-actions-bar');
     if (!actions) {
         return;
     }
-    actions.querySelectorAll('.settings-action').forEach(button => {
-        button.style.display = 'none';
-    });
+    if (actionsBar) {
+        actionsBar.dataset.activeTab = tab;
+    }
+    hideAllSettingsActions();
     if (actionsBar) actionsBar.style.display = 'flex';
     if (tab === 'model') {
         document.getElementById('add-profile-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'hooks') {
+    } else if (tab === 'hooks') {
         syncHooksSettingsActions();
-        return;
-    }
-    if (tab === 'agents') {
+    } else if (tab === 'agents') {
         document.getElementById('add-agent-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'roles') {
+    } else if (tab === 'roles') {
         document.getElementById('add-role-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'orchestration') {
+    } else if (tab === 'orchestration') {
         document.getElementById('add-orchestration-preset-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'environment') {
+    } else if (tab === 'environment') {
         document.getElementById('add-env-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'notifications') {
+    } else if (tab === 'notifications') {
         document.getElementById('save-notifications-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'web') {
+    } else if (tab === 'web') {
         document.getElementById('save-web-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'proxy') {
+    } else if (tab === 'proxy') {
         document.getElementById('save-proxy-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'workspace') {
+    } else if (tab === 'workspace') {
         document.getElementById('add-ssh-profile-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'mcp') {
+    } else if (tab === 'mcp') {
         document.getElementById('add-mcp-server-btn').style.display = 'inline-flex';
         document.getElementById('reload-mcp-btn').style.display = 'inline-flex';
-        return;
-    }
-    if (tab === 'commands') {
+    } else if (tab === 'commands') {
         syncCommandsSettingsActions();
-        return;
-    }
-    if (tab === 'appearance') {
+    } else if (tab === 'appearance') {
         document.getElementById('reset-appearance-btn').style.display = 'inline-flex';
+    } else if (actionsBar) {
+        actionsBar.style.display = 'none';
+    }
+    setPanelActionsLoading(tab, false);
+    enforceSettingsActionOwnership();
+}
+
+function warmSettingsHeavyData() {
+    if (settingsWarmupPromise) {
+        return settingsWarmupPromise;
+    }
+    settingsWarmupPromise = Promise.allSettled([
+        fetchRoleConfigs(),
+        fetchRoleConfigOptions(),
+        fetchModelProfiles(),
+        fetchOrchestrationConfig(),
+    ])
+        .then(results => {
+            results.forEach((result, index) => {
+                if (result.status !== 'rejected') {
+                    return;
+                }
+                logError(
+                    'frontend.settings.warmup_failed',
+                    'Failed to warm settings data',
+                    {
+                        dependency: [
+                            'role_configs',
+                            'role_options',
+                            'model_profiles',
+                            'orchestration_config',
+                        ][index],
+                        ...errorToPayload(result.reason),
+                    },
+                );
+            });
+        })
+        .finally(() => {
+            settingsWarmupPromise = null;
+        });
+    return settingsWarmupPromise;
+}
+
+function setPanelActionsLoading(tab, loading) {
+    Object.entries(ACTION_TAB_OWNERS).forEach(([id, ownerTab]) => {
+        if (ownerTab !== tab) {
+            return;
+        }
+        const action = document.getElementById(id);
+        if (!action || !('disabled' in action)) {
+            return;
+        }
+        action.disabled = loading;
+        action.dataset.settingsActionLoading = loading ? 'true' : 'false';
+    });
+}
+
+function hideAllSettingsActions() {
+    Object.keys(ACTION_TAB_OWNERS).forEach(id => {
+        const action = document.getElementById(id);
+        if (action) {
+            action.style.display = 'none';
+        }
+    });
+}
+
+function setupSettingsActionOwnership() {
+    annotateSettingsActions();
+    installSettingsActionOwnershipObserver();
+}
+
+function annotateSettingsActions() {
+    Object.entries(ACTION_TAB_OWNERS).forEach(([id, tab]) => {
+        const action = document.getElementById(id);
+        if (action) {
+            action.dataset.settingsActionTab = tab;
+        }
+    });
+}
+
+function installSettingsActionOwnershipObserver() {
+    if (actionOwnershipObserver || typeof MutationObserver !== 'function') {
         return;
     }
-    if (actionsBar) actionsBar.style.display = 'none';
+    const actions = document.getElementById('settings-panel-actions');
+    if (!actions) {
+        return;
+    }
+    let enforcing = false;
+    actionOwnershipObserver = new MutationObserver(() => {
+        if (enforcing) {
+            return;
+        }
+        enforcing = true;
+        try {
+            enforceSettingsActionOwnership();
+        } finally {
+            enforcing = false;
+        }
+    });
+    actionOwnershipObserver.observe(actions, {
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['style', 'class', 'hidden'],
+    });
+}
+
+function enforceSettingsActionOwnership() {
+    const actionsBar = document.getElementById('settings-actions-bar');
+    const activeTab = String(actionsBar?.dataset.activeTab || currentTab || '').trim();
+    Object.entries(ACTION_TAB_OWNERS).forEach(([id, tab]) => {
+        const action = document.getElementById(id);
+        if (action && tab !== activeTab) {
+            action.style.display = 'none';
+        }
+    });
 }
 
 export function openSettings(tab = null) {
@@ -1051,7 +1218,8 @@ export function openSettings(tab = null) {
     }
     settingsModal.style.display = 'flex';
     settingsModal.classList.add('settings-modal-visible');
-    showPanel(currentTab);
+    void warmSettingsHeavyData();
+    return showPanel(currentTab);
 }
 
 export function closeSettings() {

--- a/frontend/dist/js/components/settings/orchestrationSettings.js
+++ b/frontend/dist/js/components/settings/orchestrationSettings.js
@@ -42,18 +42,21 @@ export function bindOrchestrationSettingsHandlers() {
 
 export async function loadOrchestrationSettingsPanel(preferredOrchestrationId = '') {
     try {
-        const [config, roleSummaries] = await Promise.all([
+        const [config, roleSummaries, roleOptionsResult] = await Promise.all([
             fetchOrchestrationConfig(),
             fetchRoleConfigs(),
+            fetchRoleConfigOptions()
+                .then(value => ({ status: 'fulfilled', value }))
+                .catch(reason => ({ status: 'rejected', reason })),
         ]);
         let roleOptions = null;
-        try {
-            roleOptions = await fetchRoleConfigOptions();
-        } catch (error) {
+        if (roleOptionsResult.status === 'fulfilled') {
+            roleOptions = roleOptionsResult.value;
+        } else {
             logError(
                 'frontend.orchestration_settings.role_options_failed',
                 'Failed to load role options',
-                errorToPayload(error),
+                errorToPayload(roleOptionsResult.reason),
             );
         }
         orchestrationConfig = normalizeOrchestrationConfig(config);

--- a/frontend/dist/js/components/settings/rolesSettings.js
+++ b/frontend/dist/js/components/settings/rolesSettings.js
@@ -83,8 +83,10 @@ export function bindRoleSettingsHandlers() {
 
 export async function loadRoleSettingsPanel(preferredRoleId = '') {
     try {
-        const summaries = await fetchRoleConfigs();
-        await refreshRoleSettingsDependencies();
+        const [summaries] = await Promise.all([
+            fetchRoleConfigs(),
+            refreshRoleSettingsDependencies(),
+        ]);
         roleSummaries = Array.isArray(summaries) ? summaries.map(normalizeRoleSummary) : [];
         renderRolesList();
         if (roleSummaries.length === 0) {

--- a/frontend/dist/js/core/api/roles.js
+++ b/frontend/dist/js/core/api/roles.js
@@ -2,14 +2,26 @@
  * core/api/roles.js
  * Role document settings API wrappers.
  */
-import { requestJson } from './request.js';
+import { invalidateManagedRequests, requestJson, requestJsonManaged } from './request.js';
 
-export async function fetchRoleConfigs() {
-    return requestJson('/api/roles/configs', undefined, 'Failed to fetch role configs');
+export async function fetchRoleConfigs(options = {}) {
+    return requestJsonManaged(
+        'roles:configs',
+        '/api/roles/configs',
+        { signal: options.signal },
+        'Failed to fetch role configs',
+        { ttlMs: 30000 },
+    );
 }
 
 export async function fetchRoleConfigOptions(options = {}) {
-    return requestJson('/api/roles:options', { signal: options.signal }, 'Failed to fetch role options');
+    return requestJsonManaged(
+        'roles:options',
+        '/api/roles:options',
+        { signal: options.signal },
+        'Failed to fetch role options',
+        { ttlMs: 30000 },
+    );
 }
 
 export async function fetchRoleConfig(roleId) {
@@ -17,17 +29,19 @@ export async function fetchRoleConfig(roleId) {
 }
 
 export async function deleteRoleConfig(roleId) {
-    return requestJson(
+    const result = await requestJson(
         `/api/roles/configs/${roleId}`,
         {
             method: 'DELETE',
         },
         'Failed to delete role config',
     );
+    invalidateManagedRequests('roles:');
+    return result;
 }
 
 export async function saveRoleConfig(roleId, payload) {
-    return requestJson(
+    const result = await requestJson(
         `/api/roles/configs/${roleId}`,
         {
             method: 'PUT',
@@ -36,6 +50,8 @@ export async function saveRoleConfig(roleId, payload) {
         },
         'Failed to save role config',
     );
+    invalidateManagedRequests('roles:');
+    return result;
 }
 
 export async function validateRoleConfig(payload) {

--- a/frontend/dist/js/core/api/system.js
+++ b/frontend/dist/js/core/api/system.js
@@ -4,6 +4,10 @@
  */
 import { invalidateManagedRequests, requestJson, requestJsonManaged } from './request.js';
 
+function invalidateRoleOptionDependencies() {
+    invalidateManagedRequests('roles:');
+}
+
 export async function fetchConfigStatus(options = {}) {
     return requestJson('/api/system/configs', { signal: options.signal }, 'Failed to fetch config status');
 }
@@ -222,7 +226,7 @@ export async function fetchExternalAgent(agentId) {
 }
 
 export async function saveExternalAgent(agentId, payload) {
-    return requestJson(
+    const result = await requestJson(
         `/api/system/configs/agents/${encodeURIComponent(agentId)}`,
         {
             method: 'PUT',
@@ -231,14 +235,18 @@ export async function saveExternalAgent(agentId, payload) {
         },
         'Failed to save agent config',
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function deleteExternalAgent(agentId) {
-    return requestJson(
+    const result = await requestJson(
         `/api/system/configs/agents/${encodeURIComponent(agentId)}`,
         { method: 'DELETE' },
         'Failed to delete agent config',
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function testExternalAgent(agentId) {
@@ -302,7 +310,7 @@ export async function fetchClawHubSkill(skillId) {
 }
 
 export async function saveClawHubSkill(skillId, payload) {
-    return requestJson(
+    const result = await requestJson(
         `/api/system/configs/clawhub/skills/${encodeURIComponent(skillId)}`,
         {
             method: 'PUT',
@@ -311,14 +319,18 @@ export async function saveClawHubSkill(skillId, payload) {
         },
         'Failed to save ClawHub skill',
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function deleteClawHubSkill(skillId) {
-    return requestJson(
+    const result = await requestJson(
         `/api/system/configs/clawhub/skills/${encodeURIComponent(skillId)}`,
         { method: 'DELETE' },
         'Failed to delete ClawHub skill',
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function fetchSystemHealth() {
@@ -439,6 +451,7 @@ export async function saveModelProfile(name, profile) {
         'Failed to save model profile',
     );
     invalidateManagedRequests('system:model-profiles');
+    invalidateRoleOptionDependencies();
     return result;
 }
 
@@ -449,6 +462,7 @@ export async function deleteModelProfile(name) {
         'Failed to delete model profile',
     );
     invalidateManagedRequests('system:model-profiles');
+    invalidateRoleOptionDependencies();
     return result;
 }
 
@@ -519,11 +533,13 @@ export async function saveGitHubConfig(config) {
 }
 
 export async function reloadMcpConfig() {
-    return requestJson(
+    const result = await requestJson(
         '/api/system/configs/mcp:reload',
         { method: 'POST' },
         'Failed to reload MCP config',
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function fetchMcpServers() {
@@ -531,7 +547,7 @@ export async function fetchMcpServers() {
 }
 
 export async function addMcpServer(payload) {
-    return requestJson(
+    const result = await requestJson(
         '/api/mcp/servers',
         {
             method: 'POST',
@@ -540,6 +556,8 @@ export async function addMcpServer(payload) {
         },
         'Failed to add MCP server',
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function fetchMcpServer(serverName) {
@@ -551,7 +569,7 @@ export async function fetchMcpServer(serverName) {
 }
 
 export async function updateMcpServer(serverName, payload) {
-    return requestJson(
+    const result = await requestJson(
         `/api/mcp/servers/${encodeURIComponent(serverName)}`,
         {
             method: 'PUT',
@@ -560,6 +578,8 @@ export async function updateMcpServer(serverName, payload) {
         },
         `Failed to update MCP server ${serverName}`,
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function testMcpServerConnection(serverName) {
@@ -571,7 +591,7 @@ export async function testMcpServerConnection(serverName) {
 }
 
 export async function setMcpServerEnabled(serverName, enabled) {
-    return requestJson(
+    const result = await requestJson(
         `/api/mcp/servers/${encodeURIComponent(serverName)}/enabled`,
         {
             method: 'PUT',
@@ -580,6 +600,8 @@ export async function setMcpServerEnabled(serverName, enabled) {
         },
         `Failed to update MCP server ${serverName}`,
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function fetchMcpServerTools(serverName) {
@@ -591,11 +613,13 @@ export async function fetchMcpServerTools(serverName) {
 }
 
 export async function reloadSkillsConfig() {
-    return requestJson(
+    const result = await requestJson(
         '/api/system/configs/skills:reload',
         { method: 'POST' },
         'Failed to reload skills config',
     );
+    invalidateRoleOptionDependencies();
+    return result;
 }
 
 export async function fetchNotificationConfig() {
@@ -603,10 +627,12 @@ export async function fetchNotificationConfig() {
 }
 
 export async function fetchOrchestrationConfig(options = {}) {
-    return requestJson(
+    return requestJsonManaged(
+        'system:orchestration-config',
         '/api/system/configs/orchestration',
         { signal: options.signal },
         'Failed to fetch orchestration config',
+        { ttlMs: 30000 },
     );
 }
 
@@ -623,7 +649,7 @@ export async function saveNotificationConfig(config) {
 }
 
 export async function saveOrchestrationConfig(config) {
-    return requestJson(
+    const result = await requestJson(
         '/api/system/configs/orchestration',
         {
             method: 'PUT',
@@ -632,6 +658,8 @@ export async function saveOrchestrationConfig(config) {
         },
         'Failed to save orchestration config',
     );
+    invalidateManagedRequests('system:orchestration-config');
+    return result;
 }
 
 export async function probeWebConnectivity(payload) {

--- a/tests/unit_tests/frontend/test_api_facade_ui.py
+++ b/tests/unit_tests/frontend/test_api_facade_ui.py
@@ -255,6 +255,324 @@ export function invalidateManagedRequests(prefix) {
     ]
 
 
+def test_role_config_reads_use_managed_requests_and_writes_invalidate_cache(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "core" / "api" / "roles.js"
+    module_under_test_path = tmp_path / "roles.mjs"
+    mock_request_path = tmp_path / "mockRequest.mjs"
+
+    mock_request_path.write_text(
+        """
+export async function requestJson(url, options, errorMessage) {
+    globalThis.__capturedRequests.push({
+        url,
+        options,
+        errorMessage,
+    });
+    return { status: 'ok' };
+}
+
+export async function requestJsonManaged(key, url, options, errorMessage, config) {
+    globalThis.__capturedManagedRequests.push({
+        key,
+        url,
+        options,
+        errorMessage,
+        config,
+    });
+    return { status: 'ok' };
+}
+
+export function invalidateManagedRequests(prefix) {
+    globalThis.__invalidatedPrefixes.push(prefix);
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    source_text = source_path.read_text(encoding="utf-8")
+    module_text = source_text.replace(
+        "from './request.js';",
+        "from './mockRequest.mjs';",
+    )
+    assert module_text != source_text
+    module_under_test_path.write_text(module_text, encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                "globalThis.__capturedManagedRequests = []; "
+                "globalThis.__capturedRequests = []; "
+                "globalThis.__invalidatedPrefixes = []; "
+                f"const mod = await import({module_under_test_path.as_uri()!r}); "
+                "await mod.fetchRoleConfigs(); "
+                "await mod.fetchRoleConfigOptions(); "
+                "await mod.saveRoleConfig('Writer', { role_id: 'Writer' }); "
+                "await mod.deleteRoleConfig('Writer'); "
+                "console.log(JSON.stringify({"
+                "managedRequests: globalThis.__capturedManagedRequests,"
+                "requests: globalThis.__capturedRequests,"
+                "invalidatedPrefixes: globalThis.__invalidatedPrefixes"
+                "}));"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node import failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout.strip())
+    assert payload["managedRequests"] == [
+        {
+            "key": "roles:configs",
+            "url": "/api/roles/configs",
+            "options": {},
+            "errorMessage": "Failed to fetch role configs",
+            "config": {"ttlMs": 30000},
+        },
+        {
+            "key": "roles:options",
+            "url": "/api/roles:options",
+            "options": {},
+            "errorMessage": "Failed to fetch role options",
+            "config": {"ttlMs": 30000},
+        },
+    ]
+    assert payload["requests"][0]["url"] == "/api/roles/configs/Writer"
+    assert payload["requests"][0]["options"]["method"] == "PUT"
+    assert payload["requests"][1]["url"] == "/api/roles/configs/Writer"
+    assert payload["requests"][1]["options"] == {"method": "DELETE"}
+    assert payload["invalidatedPrefixes"] == ["roles:", "roles:"]
+
+
+def test_orchestration_config_uses_managed_request_and_save_invalidates_cache(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "core" / "api" / "system.js"
+    module_under_test_path = tmp_path / "system.mjs"
+    mock_request_path = tmp_path / "mockRequest.mjs"
+
+    mock_request_path.write_text(
+        """
+export async function requestJson(url, options, errorMessage) {
+    globalThis.__capturedRequests.push({
+        url,
+        options,
+        errorMessage,
+    });
+    return { status: 'ok' };
+}
+
+export async function requestJsonManaged(key, url, options, errorMessage, config) {
+    globalThis.__capturedManagedRequests.push({
+        key,
+        url,
+        options,
+        errorMessage,
+        config,
+    });
+    return { status: 'ok' };
+}
+
+export function invalidateManagedRequests(prefix) {
+    globalThis.__invalidatedPrefixes.push(prefix);
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    source_text = source_path.read_text(encoding="utf-8")
+    module_text = source_text.replace(
+        "from './request.js';",
+        "from './mockRequest.mjs';",
+    )
+    assert module_text != source_text
+    module_under_test_path.write_text(module_text, encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                "globalThis.__capturedManagedRequests = []; "
+                "globalThis.__capturedRequests = []; "
+                "globalThis.__invalidatedPrefixes = []; "
+                f"const mod = await import({module_under_test_path.as_uri()!r}); "
+                "await mod.fetchOrchestrationConfig(); "
+                "await mod.saveOrchestrationConfig({ presets: [] }); "
+                "console.log(JSON.stringify({"
+                "managedRequests: globalThis.__capturedManagedRequests,"
+                "requests: globalThis.__capturedRequests,"
+                "invalidatedPrefixes: globalThis.__invalidatedPrefixes"
+                "}));"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node import failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout.strip())
+    assert payload["managedRequests"] == [
+        {
+            "key": "system:orchestration-config",
+            "url": "/api/system/configs/orchestration",
+            "options": {},
+            "errorMessage": "Failed to fetch orchestration config",
+            "config": {"ttlMs": 30000},
+        }
+    ]
+    assert payload["requests"][0]["url"] == "/api/system/configs/orchestration"
+    assert payload["requests"][0]["options"] == {
+        "method": "PUT",
+        "headers": {"Content-Type": "application/json"},
+        "body": '{"config":{"presets":[]}}',
+    }
+    assert payload["invalidatedPrefixes"] == ["system:orchestration-config"]
+
+
+def test_role_option_dependency_writes_invalidate_role_option_cache(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "core" / "api" / "system.js"
+    module_under_test_path = tmp_path / "system.mjs"
+    mock_request_path = tmp_path / "mockRequest.mjs"
+
+    mock_request_path.write_text(
+        """
+export async function requestJson(url, options, errorMessage) {
+    globalThis.__capturedRequests.push({
+        url,
+        options,
+        errorMessage,
+    });
+    return { status: 'ok' };
+}
+
+export async function requestJsonManaged(key, url, options, errorMessage, config) {
+    globalThis.__capturedManagedRequests.push({
+        key,
+        url,
+        options,
+        errorMessage,
+        config,
+    });
+    return { status: 'ok' };
+}
+
+export function invalidateManagedRequests(prefix) {
+    globalThis.__invalidatedPrefixes.push(prefix);
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    source_text = source_path.read_text(encoding="utf-8")
+    module_text = source_text.replace(
+        "from './request.js';",
+        "from './mockRequest.mjs';",
+    )
+    assert module_text != source_text
+    module_under_test_path.write_text(module_text, encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                "globalThis.__capturedManagedRequests = []; "
+                "globalThis.__capturedRequests = []; "
+                "globalThis.__invalidatedPrefixes = []; "
+                f"const mod = await import({module_under_test_path.as_uri()!r}); "
+                "await mod.saveExternalAgent('local-agent', { name: 'Local Agent' }); "
+                "await mod.deleteExternalAgent('local-agent'); "
+                "await mod.saveModelProfile('vision-profile', { model: 'vision-model' }); "
+                "await mod.deleteModelProfile('vision-profile'); "
+                "await mod.saveClawHubSkill('writer', { name: 'Writer' }); "
+                "await mod.deleteClawHubSkill('writer'); "
+                "await mod.reloadMcpConfig(); "
+                "await mod.addMcpServer({ name: 'filesystem' }); "
+                "await mod.updateMcpServer('filesystem', { config: {} }); "
+                "await mod.setMcpServerEnabled('filesystem', true); "
+                "await mod.reloadSkillsConfig(); "
+                "console.log(JSON.stringify({"
+                "requests: globalThis.__capturedRequests,"
+                "invalidatedPrefixes: globalThis.__invalidatedPrefixes"
+                "}));"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node import failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout.strip())
+    assert [request["url"] for request in payload["requests"]] == [
+        "/api/system/configs/agents/local-agent",
+        "/api/system/configs/agents/local-agent",
+        "/api/system/configs/model/profiles/vision-profile",
+        "/api/system/configs/model/profiles/vision-profile",
+        "/api/system/configs/clawhub/skills/writer",
+        "/api/system/configs/clawhub/skills/writer",
+        "/api/system/configs/mcp:reload",
+        "/api/mcp/servers",
+        "/api/mcp/servers/filesystem",
+        "/api/mcp/servers/filesystem/enabled",
+        "/api/system/configs/skills:reload",
+    ]
+    assert payload["invalidatedPrefixes"] == [
+        "roles:",
+        "roles:",
+        "system:model-profiles",
+        "roles:",
+        "system:model-profiles",
+        "roles:",
+        "roles:",
+        "roles:",
+        "roles:",
+        "roles:",
+        "roles:",
+        "roles:",
+        "roles:",
+    ]
+
+
 def test_core_api_facade_exports_legacy_dispatch_human_task_alias() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     api_module_path = repo_root / "frontend" / "dist" / "js" / "core" / "api.js"

--- a/tests/unit_tests/frontend/test_orchestration_settings_ui.py
+++ b/tests/unit_tests/frontend/test_orchestration_settings_ui.py
@@ -99,6 +99,32 @@ console.log(JSON.stringify({
     assert payload["editorDisplay"] == "none"
 
 
+def test_orchestration_initial_load_starts_config_role_and_option_requests_in_parallel(
+    tmp_path: Path,
+) -> None:
+    payload = _run_orchestration_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { loadOrchestrationSettingsPanel } from "./orchestrationSettings.mjs";
+
+installGlobals(createElements());
+await loadOrchestrationSettingsPanel();
+
+console.log(JSON.stringify({
+    requestOrder: globalThis.__requestOrder,
+    listDisplay: document.getElementById("orchestration-preset-list").style.display,
+}));
+""".strip(),
+    )
+
+    assert payload["requestOrder"] == [
+        "fetchOrchestrationConfig:start",
+        "fetchRoleConfigs:start",
+        "fetchRoleConfigOptions:start",
+    ]
+    assert payload["listDisplay"] == "block"
+
+
 def _run_orchestration_settings_script(
     tmp_path: Path, runner_source: str
 ) -> dict[str, object]:
@@ -143,6 +169,7 @@ let orchestrationConfig = {
 };
 
 export async function fetchOrchestrationConfig() {
+    globalThis.__requestOrder.push("fetchOrchestrationConfig:start");
     return JSON.parse(JSON.stringify(orchestrationConfig));
 }
 
@@ -153,6 +180,7 @@ export async function saveOrchestrationConfig(config) {
 }
 
 export async function fetchRoleConfigs() {
+    globalThis.__requestOrder.push("fetchRoleConfigs:start");
     return [
         { role_id: "Writer", name: "Writer" },
         { role_id: "Reviewer", name: "Reviewer" },
@@ -162,6 +190,7 @@ export async function fetchRoleConfigs() {
 }
 
 export async function fetchRoleConfigOptions() {
+    globalThis.__requestOrder.push("fetchRoleConfigOptions:start");
     if (globalThis.__roleConfigOptionsErrorMessage) {
         throw new Error(globalThis.__roleConfigOptionsErrorMessage);
     }
@@ -430,6 +459,7 @@ function installGlobals(elements) {{
     globalThis.__confirmResult = true;
     globalThis.__saveCalls = [];
     globalThis.__roleConfigOptionsErrorMessage = "";
+    globalThis.__requestOrder = [];
     globalThis.__syncEditorFields = html => {{
         const idMatch = html.match(/id="orchestration-id-input" value="([^"]*)"/);
         const nameMatch = html.match(/id="orchestration-name-input" value="([^"]*)"/);

--- a/tests/unit_tests/frontend/test_roles_settings_ui.py
+++ b/tests/unit_tests/frontend/test_roles_settings_ui.py
@@ -79,6 +79,36 @@ console.log(JSON.stringify({
     assert fetch_calls == ["reviewer"]
 
 
+def test_role_settings_initial_load_starts_summary_and_dependency_requests_in_parallel(
+    tmp_path: Path,
+) -> None:
+    payload = _run_roles_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { loadRoleSettingsPanel } from "./rolesSettings.mjs";
+
+installGlobals(createElements());
+await loadRoleSettingsPanel();
+
+console.log(JSON.stringify({
+    requestOrder: globalThis.__requestOrder,
+    roleSummaryCalls: globalThis.__fetchRoleConfigsCount,
+    roleConfigOptionsCalls: globalThis.__fetchRoleConfigOptionsCount,
+    modelProfileCalls: globalThis.__fetchModelProfilesCount,
+}));
+""".strip(),
+    )
+
+    assert payload["requestOrder"] == [
+        "fetchRoleConfigs:start",
+        "fetchRoleConfigOptions:start",
+        "fetchModelProfiles:start",
+    ]
+    assert payload["roleSummaryCalls"] == 1
+    assert payload["roleConfigOptionsCalls"] == 1
+    assert payload["modelProfileCalls"] == 1
+
+
 def test_role_settings_validate_save_and_add_role_use_controlled_options(
     tmp_path: Path,
 ) -> None:
@@ -1891,6 +1921,7 @@ function getRoleRecords() {
 
 export async function fetchRoleConfigs() {
     globalThis.__fetchRoleConfigsCount += 1;
+    globalThis.__requestOrder.push("fetchRoleConfigs:start");
     return Object.values(getRoleRecords()).map(record => ({
         role_id: record.role_id,
         name: record.name,
@@ -1905,6 +1936,7 @@ export async function fetchRoleConfigs() {
 
 export async function fetchRoleConfigOptions() {
     globalThis.__fetchRoleConfigOptionsCount += 1;
+    globalThis.__requestOrder.push("fetchRoleConfigOptions:start");
     if (globalThis.__roleConfigOptionsErrorMessage) {
         throw new Error(globalThis.__roleConfigOptionsErrorMessage);
     }
@@ -1945,6 +1977,7 @@ export async function fetchRoleConfigOptions() {
 
 export async function fetchModelProfiles() {
     globalThis.__fetchModelProfilesCount += 1;
+    globalThis.__requestOrder.push("fetchModelProfiles:start");
     return globalThis.__modelProfilesOverride || {
         default: { model: "gpt-4o-mini" },
         editor: { model: "gpt-4.1" },
@@ -2436,6 +2469,7 @@ function installGlobals(elements) {{
     globalThis.__fetchRoleConfigOptionsCount = 0;
     globalThis.__fetchRoleConfigCalls = [];
     globalThis.__fetchModelProfilesCount = 0;
+    globalThis.__requestOrder = [];
     globalThis.__validateCalls = [];
     globalThis.__validatePayload = null;
     globalThis.__saveCalls = [];

--- a/tests/unit_tests/frontend/test_settings_shell_ui.py
+++ b/tests/unit_tests/frontend/test_settings_shell_ui.py
@@ -20,7 +20,7 @@ def test_settings_modal_uses_flat_content_stacks_and_switches_tabs(
 const { initSettings, openSettings } = await import("./index.mjs");
 
 initSettings();
-openSettings();
+await openSettings();
 
 const tabs = document.querySelectorAll(".settings-tab");
 const notificationsTab = tabs.find(tab => tab.dataset.tab === "notifications");
@@ -92,7 +92,7 @@ def test_settings_panel_actions_use_primary_buttons_for_add_and_reload(
 const { initSettings, openSettings } = await import("./index.mjs");
 
 initSettings();
-openSettings();
+await openSettings();
 
 const tabs = document.querySelectorAll(".settings-tab");
 const rolesTab = tabs.find(tab => tab.dataset.tab === "roles");
@@ -156,7 +156,7 @@ def test_hooks_settings_tab_shows_add_validate_and_save_actions(
 const { initSettings, openSettings } = await import("./index.mjs");
 
 initSettings();
-openSettings("hooks");
+await openSettings("hooks");
 
 console.log(JSON.stringify({
     panelTitle: document.getElementById("settings-panel-title").textContent,
@@ -176,6 +176,109 @@ console.log(JSON.stringify({
     assert payload["validateHooksDisplay"] == "inline-flex"
     assert payload["saveHooksDisplay"] == "inline-flex"
     assert load_calls["hooks"] == 1
+
+
+def test_settings_action_ownership_hides_inactive_tab_actions(
+    tmp_path: Path,
+) -> None:
+    payload = _run_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { initSettings, openSettings } = await import("./index.mjs");
+
+initSettings();
+await openSettings("hooks");
+
+console.log(JSON.stringify({
+    activeTab: document.getElementById("settings-actions-bar").dataset.activeTab,
+    hooksSaveDisplay: document.getElementById("save-hooks-btn").style.display,
+    profileSaveDisplay: document.getElementById("save-profile-btn").style.display,
+    profileActionOwner: document.getElementById("save-profile-btn").dataset.settingsActionTab,
+    hooksActionOwner: document.getElementById("save-hooks-btn").dataset.settingsActionTab,
+}));
+""".strip(),
+    )
+
+    assert payload["activeTab"] == "hooks"
+    assert payload["hooksSaveDisplay"] == "inline-flex"
+    assert payload["profileSaveDisplay"] == "none"
+    assert payload["profileActionOwner"] == "model"
+    assert payload["hooksActionOwner"] == "hooks"
+
+
+def test_settings_actions_are_hidden_until_active_tab_loads(
+    tmp_path: Path,
+) -> None:
+    payload = _run_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { initSettings, openSettings } = await import("./index.mjs");
+
+let releaseRolesLoad;
+globalThis.__rolesLoadBlocker = new Promise(resolve => {
+    releaseRolesLoad = resolve;
+});
+
+initSettings();
+const openPromise = openSettings("roles");
+await Promise.resolve();
+
+const addRoleDuringLoad = document.getElementById("add-role-btn");
+const duringLoadDisplay = addRoleDuringLoad.style.display;
+const duringLoadDisabled = addRoleDuringLoad.disabled;
+
+releaseRolesLoad();
+await openPromise;
+
+const addRoleAfterLoad = document.getElementById("add-role-btn");
+console.log(JSON.stringify({
+    duringLoadDisplay,
+    duringLoadDisabled,
+    afterLoadDisplay: addRoleAfterLoad.style.display,
+    afterLoadDisabled: addRoleAfterLoad.disabled,
+    loadCalls: globalThis.__loadCalls,
+}));
+""".strip(),
+    )
+
+    load_calls = cast(dict[str, JsonValue], payload["loadCalls"])
+    assert payload["duringLoadDisplay"] == "none"
+    assert payload["duringLoadDisabled"] is False
+    assert payload["afterLoadDisplay"] == "inline-flex"
+    assert payload["afterLoadDisabled"] is False
+    assert load_calls["roles"] == 1
+
+
+def test_settings_open_warms_role_and_orchestration_dependencies(
+    tmp_path: Path,
+) -> None:
+    payload = _run_settings_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { initSettings, openSettings } = await import("./index.mjs");
+
+initSettings();
+await openSettings();
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    warmupCalls: globalThis.__warmupCalls,
+    loggedErrors: globalThis.__loggedErrors,
+    activeTab: document.getElementById("settings-actions-bar").dataset.activeTab,
+    appearanceResetDisplay: document.getElementById("reset-appearance-btn").style.display,
+}));
+""".strip(),
+    )
+
+    assert payload["warmupCalls"] == [
+        "role_configs",
+        "role_options",
+        "model_profiles",
+        "orchestration_config",
+    ]
+    assert payload["loggedErrors"] == []
+    assert payload["activeTab"] == "appearance"
+    assert payload["appearanceResetDisplay"] == "inline-flex"
 
 
 def test_settings_tab_order_and_labels_are_simplified() -> None:
@@ -281,6 +384,22 @@ def test_settings_layout_uses_scrolling_body_with_footer_actions() -> None:
     assert ".profiles-list::-webkit-scrollbar {" in components_css
 
 
+def test_settings_action_bar_css_hides_inactive_tab_owned_actions() -> None:
+    components_css = load_components_css()
+
+    assert (
+        '.settings-actions-bar[data-active-tab="model"] '
+        '[data-settings-action-tab]:not([data-settings-action-tab="model"])'
+        in components_css
+    )
+    assert (
+        '.settings-actions-bar[data-active-tab="roles"] '
+        '[data-settings-action-tab]:not([data-settings-action-tab="roles"])'
+        in components_css
+    )
+    assert "display: none !important;" in components_css
+
+
 def test_model_profile_editor_labels_max_output_tokens_and_uses_short_footer_labels(
     tmp_path: Path,
 ) -> None:
@@ -290,7 +409,7 @@ def test_model_profile_editor_labels_max_output_tokens_and_uses_short_footer_lab
 const { initSettings, openSettings } = await import("./index.mjs");
 
 initSettings();
-openSettings();
+await openSettings();
 
 console.log(JSON.stringify({
     modalHtml: document.getElementById("settings-modal").innerHTML,
@@ -502,6 +621,8 @@ def _run_settings_script(tmp_path: Path, runner_source: str) -> dict[str, object
     mock_github_settings_path = tmp_path / "mockGitHubSettings.mjs"
     mock_system_status_path = tmp_path / "mockSystemStatus.mjs"
     mock_appearance_path = tmp_path / "mockAppearanceSettings.mjs"
+    mock_api_path = tmp_path / "mockApi.mjs"
+    mock_logger_path = tmp_path / "mockLogger.mjs"
     mock_i18n_path = tmp_path / "mockI18n.mjs"
     module_under_test_path = tmp_path / "index.mjs"
     runner_path = tmp_path / "runner.mjs"
@@ -571,6 +692,7 @@ export function syncHooksSettingsActions() {
     document.getElementById('add-hook-btn').style.display = 'inline-flex';
     document.getElementById('validate-hooks-btn').style.display = 'inline-flex';
     document.getElementById('save-hooks-btn').style.display = 'inline-flex';
+    document.getElementById('save-profile-btn').style.display = 'inline-flex';
 }
 """.strip(),
         encoding="utf-8",
@@ -619,6 +741,9 @@ export function bindRoleSettingsHandlers() {
 
 export async function loadRoleSettingsPanel() {
     globalThis.__loadCalls.roles += 1;
+    if (globalThis.__rolesLoadBlocker) {
+        await globalThis.__rolesLoadBlocker;
+    }
 }
 """.strip(),
         encoding="utf-8",
@@ -771,6 +896,42 @@ export function translateDocument() {
 """.strip(),
         encoding="utf-8",
     )
+    mock_api_path.write_text(
+        """
+export async function fetchRoleConfigs() {
+    globalThis.__warmupCalls.push('role_configs');
+    return [];
+}
+
+export async function fetchRoleConfigOptions() {
+    globalThis.__warmupCalls.push('role_options');
+    return {};
+}
+
+export async function fetchModelProfiles() {
+    globalThis.__warmupCalls.push('model_profiles');
+    return {};
+}
+
+export async function fetchOrchestrationConfig() {
+    globalThis.__warmupCalls.push('orchestration_config');
+    return {};
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    mock_logger_path.write_text(
+        """
+export function errorToPayload(error) {
+    return { message: String(error?.message || error || '') };
+}
+
+export function logError(eventName, message, payload) {
+    globalThis.__loggedErrors.push({ eventName, message, payload });
+}
+""".strip(),
+        encoding="utf-8",
+    )
 
     source_text = (
         source_path.read_text(encoding="utf-8")
@@ -791,7 +952,9 @@ export function translateDocument() {
         .replace("./rolesSettings.js", "./mockRolesSettings.mjs")
         .replace("./systemStatus.js", "./mockSystemStatus.mjs")
         .replace("./appearanceSettings.js", "./mockAppearanceSettings.mjs")
+        .replace("../../core/api.js", "./mockApi.mjs")
         .replace("../../utils/i18n.js", "./mockI18n.mjs")
+        .replace("../../utils/logger.js", "./mockLogger.mjs")
     )
     module_under_test_path.write_text(source_text, encoding="utf-8")
 
@@ -844,6 +1007,7 @@ function createElement(tagName = "div") {{
         style: {{}},
         dataset: {{}},
         children: [],
+        disabled: false,
         textContent: "",
         onclick: null,
         parentNode: null,
@@ -989,6 +1153,8 @@ globalThis.__loadCalls = {{
     mcp: 0,
     skills: 0,
 }};
+globalThis.__warmupCalls = [];
+globalThis.__loggedErrors = [];
 
 globalThis.document = createDocument();
 globalThis.window = {{}};
@@ -1027,7 +1193,7 @@ def test_environment_settings_tab_uses_add_variable_action(
 const { initSettings, openSettings } = await import("./index.mjs");
 
 initSettings();
-openSettings();
+await openSettings();
 
 const tabs = document.querySelectorAll(".settings-tab");
 const environmentTab = tabs.find(tab => tab.dataset.tab === "environment");
@@ -1058,7 +1224,7 @@ def test_workspace_settings_tab_uses_add_ssh_profile_action(
 const { initSettings, openSettings } = await import("./index.mjs");
 
 initSettings();
-openSettings("workspace");
+await openSettings("workspace");
 
 console.log(JSON.stringify({
     panelTitle: document.getElementById("settings-panel-title").textContent,
@@ -1083,7 +1249,7 @@ def test_settings_modal_only_closes_for_direct_overlay_click(tmp_path: Path) -> 
 const { initSettings, openSettings } = await import("./index.mjs");
 
 initSettings();
-openSettings();
+await openSettings();
 
 const settingsModal = document.getElementById("settings-modal");
 const modalContent = settingsModal.children[0];
@@ -1092,7 +1258,7 @@ settingsModal.onmousedown({ target: modalContent });
 settingsModal.onclick({ target: settingsModal });
 const afterDraggedReleaseDisplay = settingsModal.style.display;
 
-openSettings();
+await openSettings();
 settingsModal.onmousedown({ target: settingsModal });
 settingsModal.onclick({ target: settingsModal });
 const afterDirectOverlayClickDisplay = settingsModal.style.display;


### PR DESCRIPTION
• 这个 PR 主要解决的是：设置页在异步加载和缓存引入后，容易出现旧数据、错位按钮和重复请求的问题。

  核心问题包括：

  - 快速切换 Settings tab 时，旧 tab 的异步加载结果可能晚到，导致当前 tab 的 action 按钮被旧状态覆盖。
  - 不同设置页的顶部操作按钮可能残留或误显示，比如切到另一个 tab 后仍看到不属于当前 tab 的保存/新增按钮。
  - Roles、Orchestration 等设置页会重复请求相同配置数据，打开和切换时等待时间较长。
  - Role options 加缓存后，相关配置变更没有完整清理缓存，可能导致模型能力、角色能力、MCP/skills 等选项短时间显示旧数据。
  - 某些依赖数据加载失败会影响整个设置页体验，PR 改成部分失败可降级并记录日志。
  
## Summary
- isolate settings footer actions by active tab so stale add/save/cancel buttons cannot leak across settings pages
- guard settings panel loading with request ids and render actions only after the active tab finishes loading
- speed up role and orchestration settings by parallelizing dependency loads, prewarming heavy settings data, and caching role/orchestration reads with correct invalidation
- invalidate role option cache when dependent system resources change, including external agents, MCP servers, skills reload, and ClawHub skills

## Tests
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_api_facade_ui.py tests/unit_tests/frontend/test_settings_shell_ui.py tests/unit_tests/frontend/test_roles_settings_ui.py tests/unit_tests/frontend/test_orchestration_settings_ui.py
- pre-commit: ruff-check, ruff-format, basedpyright

Fixes #606