### PR TITLE
修复切换界面语言后的后端状态文案

### DIFF
--- a/frontend/dist/js/utils/backendStatus.js
+++ b/frontend/dist/js/utils/backendStatus.js
@@ -12,17 +12,22 @@ const MAIN_LIVE_TIMEOUT_MS = 1500;
 const CONTROL_PLANE_FALLBACK_PORT_RANGE = 50;
 const CONTROL_PLANE_CACHE_KEY = 'relayTeams.controlPlaneLiveUrl';
 const BACKEND_STATUS_HINT_EVENT = 'agent-teams-backend-status-hint';
+const LANGUAGE_CHANGED_EVENT = 'agent-teams-language-changed';
 
 let healthPollTimer = null;
 let inFlightHealthCheck = null;
 let backendStatus = 'checking';
+let backendStatusCustomLabel = '';
+let backendStatusUsesDefaultLabel = true;
 let controlPlaneLiveUrl = readCachedControlPlaneLiveUrl();
 let controlPlaneDiscoveryAttempted = false;
 let backendStatusHintBound = false;
+let languageChangedBound = false;
 
 export function initBackendStatusMonitor() {
     bindBackendStatusHintListener();
-    applyBackendStatus('checking', t('backend.status.checking'));
+    bindLanguageChangedListener();
+    applyBackendStatus('checking');
     void refreshBackendStatus({ force: true });
     if (healthPollTimer) return;
     healthPollTimer = window.setInterval(() => {
@@ -31,16 +36,17 @@ export function initBackendStatusMonitor() {
 }
 
 bindBackendStatusHintListener();
+bindLanguageChangedListener();
 
-export function markBackendOnline(label = t('backend.status.connected')) {
+export function markBackendOnline(label = null) {
     applyBackendStatus('online', label);
 }
 
-export function markBackendOffline(label = t('backend.status.offline')) {
+export function markBackendOffline(label = null) {
     applyBackendStatus('offline', label);
 }
 
-export function markBackendBusy(label = t('backend.status.busy')) {
+export function markBackendBusy(label = null) {
     applyBackendStatus('busy', label);
 }
 
@@ -70,7 +76,7 @@ async function probeBackendHealth() {
             if (await confirmMainBackendOnline()) {
                 return true;
             }
-            markBackendBusy(t('backend.status.busy'));
+            markBackendBusy();
             return true;
         }
         forgetControlPlaneLiveUrl(controlUrl);
@@ -86,18 +92,18 @@ async function probeBackendHealth() {
         if (await confirmMainBackendOnline()) {
             return true;
         }
-        markBackendBusy(t('backend.status.busy'));
+        markBackendBusy();
         return true;
     }
 
-    markBackendOffline(t('backend.status.offline'));
+    markBackendOffline();
     return false;
 }
 
 async function confirmMainBackendOnline() {
     const mainProbe = await probeJson('/api/system/live', MAIN_LIVE_TIMEOUT_MS);
     if (mainProbe.ok && isLivePayload(mainProbe.payload)) {
-        markBackendOnline(t('backend.status.connected'));
+        markBackendOnline();
         return true;
     }
     return false;
@@ -165,13 +171,22 @@ async function probeFallbackControlPlaneUrls(controlUrl) {
     )) || null;
 }
 
-function applyBackendStatus(nextStatus, label) {
+function applyBackendStatus(nextStatus, label = null) {
     backendStatus = nextStatus;
+    const safeCustomLabel = typeof label === 'string' ? label.trim() : '';
+    backendStatusUsesDefaultLabel = !safeCustomLabel;
+    backendStatusCustomLabel = safeCustomLabel;
+    renderBackendStatus();
+}
+
+function renderBackendStatus() {
     if (!els.backendStatus) return;
     els.backendStatus.classList.remove('online', 'offline', 'checking', 'busy');
-    els.backendStatus.classList.add(nextStatus);
-    els.backendStatus.dataset.status = nextStatus;
-    const safeLabel = String(label || defaultLabelForStatus(nextStatus));
+    els.backendStatus.classList.add(backendStatus);
+    els.backendStatus.dataset.status = backendStatus;
+    const safeLabel = backendStatusUsesDefaultLabel
+        ? defaultLabelForStatus(backendStatus)
+        : backendStatusCustomLabel;
     if (els.backendStatusLabel) {
         els.backendStatusLabel.textContent = safeLabel;
     } else {
@@ -192,15 +207,31 @@ function bindBackendStatusHintListener() {
     backendStatusHintBound = true;
 }
 
+function bindLanguageChangedListener() {
+    if (
+        languageChangedBound
+        || typeof document === 'undefined'
+        || typeof document.addEventListener !== 'function'
+    ) {
+        return;
+    }
+    document.addEventListener(LANGUAGE_CHANGED_EVENT, handleLanguageChanged);
+    languageChangedBound = true;
+}
+
 function handleBackendStatusHint(event) {
     const status = String(event?.detail?.status || '').trim();
     if (status === 'online') {
-        markBackendOnline(t('backend.status.connected'));
+        markBackendOnline();
         return;
     }
     if (status === 'offline') {
-        markBackendOffline(t('backend.status.offline'));
+        markBackendOffline();
     }
+}
+
+function handleLanguageChanged() {
+    renderBackendStatus();
 }
 
 function defaultLabelForStatus(status) {

--- a/tests/unit_tests/frontend/test_backend_status_ui.py
+++ b/tests/unit_tests/frontend/test_backend_status_ui.py
@@ -105,6 +105,133 @@ console.log(JSON.stringify({
     }
 
 
+def test_backend_status_refreshes_default_label_after_language_change(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    backend_status_source = (
+        repo_root / "frontend" / "dist" / "js" / "utils" / "backendStatus.js"
+    ).read_text(encoding="utf-8")
+    module_source = backend_status_source.replace(
+        "import { els } from './dom.js';",
+        "const els = globalThis.__backendStatusEls;",
+    ).replace(
+        "import { t } from './i18n.js';",
+        "const t = key => `${globalThis.__language}:${key}`;",
+    )
+    module_path = tmp_path / "backendStatus.test.mjs"
+    module_path.write_text(module_source, encoding="utf-8")
+    runner_path = tmp_path / "runner-language.mjs"
+    runner_path.write_text(
+        """
+const classNames = new Set();
+const windowListeners = new Map();
+const documentListeners = new Map();
+const backendStatusEl = {
+    classList: {
+        remove: (...names) => names.forEach(name => classNames.delete(name)),
+        add: name => classNames.add(name),
+    },
+    dataset: {},
+    title: '',
+    textContent: '',
+};
+const backendStatusLabel = { textContent: '' };
+const storage = new Map();
+
+globalThis.__language = 'zh-CN';
+globalThis.__backendStatusEls = {
+    backendStatus: backendStatusEl,
+    backendStatusLabel,
+};
+globalThis.window = {
+    location: new URL('http://127.0.0.1:8000/'),
+    localStorage: {
+        getItem: key => storage.get(key) || null,
+        setItem: (key, value) => storage.set(key, value),
+        removeItem: key => storage.delete(key),
+    },
+    addEventListener: (type, listener) => windowListeners.set(type, listener),
+    dispatchEvent: event => windowListeners.get(event.type)?.(event),
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    setInterval: globalThis.setInterval.bind(globalThis),
+};
+globalThis.document = {
+    addEventListener: (type, listener) => documentListeners.set(type, listener),
+    dispatchEvent: event => documentListeners.get(event.type)?.(event),
+};
+
+const backendStatus = await import('./backendStatus.test.mjs');
+window.dispatchEvent({
+    type: 'agent-teams-backend-status-hint',
+    detail: { status: 'online' },
+});
+const beforeLanguageChange = {
+    classNames: Array.from(classNames).sort(),
+    label: backendStatusLabel.textContent,
+    status: backendStatus.getBackendStatus(),
+    title: backendStatusEl.title,
+};
+
+globalThis.__language = 'en-US';
+backendStatusLabel.textContent = 'en-US:backend.status.checking';
+document.dispatchEvent({ type: 'agent-teams-language-changed' });
+const afterLanguageChange = {
+    classNames: Array.from(classNames).sort(),
+    label: backendStatusLabel.textContent,
+    status: backendStatus.getBackendStatus(),
+    title: backendStatusEl.title,
+};
+
+backendStatus.markBackendBusy('Custom busy label');
+globalThis.__language = 'zh-CN';
+document.dispatchEvent({ type: 'agent-teams-language-changed' });
+
+console.log(JSON.stringify({
+    beforeLanguageChange,
+    afterLanguageChange,
+    customLabelSnapshot: {
+        classNames: Array.from(classNames).sort(),
+        label: backendStatusLabel.textContent,
+        status: backendStatus.getBackendStatus(),
+        title: backendStatusEl.title,
+    },
+}));
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload == {
+        "beforeLanguageChange": {
+            "classNames": ["online"],
+            "label": "zh-CN:backend.status.connected",
+            "status": "online",
+            "title": "zh-CN:backend.status.connected",
+        },
+        "afterLanguageChange": {
+            "classNames": ["online"],
+            "label": "en-US:backend.status.connected",
+            "status": "online",
+            "title": "en-US:backend.status.connected",
+        },
+        "customLabelSnapshot": {
+            "classNames": ["busy"],
+            "label": "Custom busy label",
+            "status": "busy",
+            "title": "Custom busy label",
+        },
+    }
+
+
 def test_backend_status_fallback_confirms_main_liveness(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     backend_status_source = (


### PR DESCRIPTION
## Summary
- keep the backend status component stateful across UI language changes
- re-render the current status label from the active language instead of falling back to checking
- add a frontend regression test for the language-change overwrite path

## Tests
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_backend_status_ui.py tests/unit_tests/frontend/test_i18n_ui.py
- uv run --extra dev ruff check tests/unit_tests/frontend/test_backend_status_ui.py
- git diff --check

Fixes #602