### PR TITLE
[codex] Preserve write newlines and fix Windows shell Python output encoding

### DIFF
--- a/src/relay_teams/sessions/runs/background_tasks/command_runtime.py
+++ b/src/relay_teams/sessions/runs/background_tasks/command_runtime.py
@@ -517,6 +517,18 @@ def _sanitize_bash_env(env: dict[str, str]) -> dict[str, str]:
     return sanitized
 
 
+def _set_case_insensitive_env_default(
+    env: dict[str, str],
+    *,
+    key: str,
+    value: str,
+) -> None:
+    normalized_key = key.casefold()
+    if any(existing_key.casefold() == normalized_key for existing_key in env):
+        return
+    env[key] = value
+
+
 def _sanitize_command_env(
     env: dict[str, str],
     *,
@@ -527,7 +539,7 @@ def _sanitize_command_env(
     )
     if _is_windows():
         for key, value in _WINDOWS_PYTHON_UTF8_ENV.items():
-            sanitized.setdefault(key, value)
+            _set_case_insensitive_env_default(sanitized, key=key, value=value)
     return sanitized
 
 

--- a/src/relay_teams/sessions/runs/background_tasks/command_runtime.py
+++ b/src/relay_teams/sessions/runs/background_tasks/command_runtime.py
@@ -50,6 +50,10 @@ _SIGKILL_GRACE_SECONDS = 5
 _SIGKILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
 DEFAULT_TIMEOUT_MS = 120_000
 MAX_TIMEOUT_MS = 1_200_000
+_WINDOWS_PYTHON_UTF8_ENV = {
+    "PYTHONIOENCODING": "utf-8",
+    "PYTHONUTF8": "1",
+}
 _WINDOWS_POWERSHELL_CMDLET_PREFIXES = frozenset(
     {
         "Add",
@@ -518,9 +522,13 @@ def _sanitize_command_env(
     *,
     runtime: ResolvedCommandRuntime,
 ) -> dict[str, str]:
-    if runtime.kind == CommandRuntimeKind.BASH:
-        return _sanitize_bash_env(env)
-    return env
+    sanitized = (
+        _sanitize_bash_env(env) if runtime.kind == CommandRuntimeKind.BASH else env
+    )
+    if _is_windows():
+        for key, value in _WINDOWS_PYTHON_UTF8_ENV.items():
+            sanitized.setdefault(key, value)
+    return sanitized
 
 
 def _prepend_powershell_utf8_prefix(command: str) -> str:

--- a/src/relay_teams/tools/workspace_tools/shell_executor.py
+++ b/src/relay_teams/tools/workspace_tools/shell_executor.py
@@ -51,6 +51,10 @@ _BASH_STARTUP_ENV_KEYS = frozenset(
 )
 _BASH_STARTUP_ENV_PREFIXES = ("BASH_FUNC_",)
 _SIGKILL_GRACE_SECONDS = 5
+_WINDOWS_PYTHON_UTF8_ENV = {
+    "PYTHONIOENCODING": "utf-8",
+    "PYTHONUTF8": "1",
+}
 
 
 class ShellKind(str, Enum):
@@ -359,9 +363,11 @@ def _sanitize_shell_env(
     *,
     shell: ResolvedShell,
 ) -> dict[str, str]:
-    if shell.kind == ShellKind.BASH:
-        return _sanitize_bash_env(env)
-    return env
+    sanitized = _sanitize_bash_env(env) if shell.kind == ShellKind.BASH else env
+    if _is_windows():
+        for key, value in _WINDOWS_PYTHON_UTF8_ENV.items():
+            sanitized.setdefault(key, value)
+    return sanitized
 
 
 def _prepend_powershell_utf8_prefix(command: str) -> str:

--- a/src/relay_teams/tools/workspace_tools/shell_executor.py
+++ b/src/relay_teams/tools/workspace_tools/shell_executor.py
@@ -358,6 +358,18 @@ def _sanitize_bash_env(env: dict[str, str]) -> dict[str, str]:
     return sanitized
 
 
+def _set_case_insensitive_env_default(
+    env: dict[str, str],
+    *,
+    key: str,
+    value: str,
+) -> None:
+    normalized_key = key.casefold()
+    if any(existing_key.casefold() == normalized_key for existing_key in env):
+        return
+    env[key] = value
+
+
 def _sanitize_shell_env(
     env: dict[str, str],
     *,
@@ -366,7 +378,7 @@ def _sanitize_shell_env(
     sanitized = _sanitize_bash_env(env) if shell.kind == ShellKind.BASH else env
     if _is_windows():
         for key, value in _WINDOWS_PYTHON_UTF8_ENV.items():
-            sanitized.setdefault(key, value)
+            _set_case_insensitive_env_default(sanitized, key=key, value=value)
     return sanitized
 
 

--- a/src/relay_teams/tools/workspace_tools/write.py
+++ b/src/relay_teams/tools/workspace_tools/write.py
@@ -68,7 +68,7 @@ def atomic_write(
     file_path: Path,
     content: str,
     encoding: str = "utf-8",
-    newline: str | None = None,
+    newline: str | None = "",
 ) -> None:
     make_dirs(file_path.parent, exist_ok=True)
     with tempfile.NamedTemporaryFile(

--- a/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
@@ -228,6 +228,40 @@ async def test_build_command_env_includes_node_proxy_runtime_defaults(
 
 
 @pytest.mark.asyncio
+async def test_build_command_env_forces_utf8_python_io_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    powershell_runtime = ResolvedCommandRuntime(
+        kind=CommandRuntimeKind.POWERSHELL,
+        executable="powershell.exe",
+        display_name="PowerShell",
+    )
+
+    monkeypatch.setattr(runtime_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(runtime_module, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_gh_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_clawhub_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(runtime_module.os, "environ", {"PATH": r"C:\Windows\System32"})
+
+    env = await build_command_env(
+        runtime=powershell_runtime,
+        command="python -c \"print('hi')\"",
+    )
+
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert env["PYTHONUTF8"] == "1"
+
+
+@pytest.mark.asyncio
 async def test_build_command_env_prepends_existing_gh_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py
@@ -262,6 +262,50 @@ async def test_build_command_env_forces_utf8_python_io_on_windows(
 
 
 @pytest.mark.asyncio
+async def test_build_command_env_respects_case_variant_python_env_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    powershell_runtime = ResolvedCommandRuntime(
+        kind=CommandRuntimeKind.POWERSHELL,
+        executable="powershell.exe",
+        display_name="PowerShell",
+    )
+
+    monkeypatch.setattr(runtime_module, "_is_windows", lambda: True)
+    monkeypatch.setattr(runtime_module, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(runtime_module, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_gh_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_existing_clawhub_path",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        runtime_module.os,
+        "environ",
+        {
+            "PATH": r"C:\Windows\System32",
+            "pythonioencoding": "cp1252",
+            "pythonutf8": "0",
+        },
+    )
+
+    env = await build_command_env(
+        runtime=powershell_runtime,
+        command="python -c \"print('hi')\"",
+    )
+
+    assert env["pythonioencoding"] == "cp1252"
+    assert env["pythonutf8"] == "0"
+    assert "PYTHONIOENCODING" not in env
+    assert "PYTHONUTF8" not in env
+
+
+@pytest.mark.asyncio
 async def test_build_command_env_prepends_existing_gh_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/unit_tests/tools/workspace_tools/test_shell.py
+++ b/tests/unit_tests/tools/workspace_tools/test_shell.py
@@ -773,6 +773,49 @@ async def test_build_shell_env_forces_utf8_python_io_on_windows(monkeypatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_build_shell_env_respects_case_variant_python_env_on_windows(
+    monkeypatch,
+) -> None:
+    from relay_teams.tools.workspace_tools import shell_executor
+
+    shell = shell_executor.ResolvedShell(
+        kind=shell_executor.ShellKind.POWERSHELL,
+        executable="powershell.exe",
+        display_name="PowerShell",
+    )
+
+    monkeypatch.setattr(shell_executor, "_is_windows", lambda: True)
+    monkeypatch.setattr(shell_executor, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(shell_executor, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(
+        shell_executor,
+        "_resolve_gh_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        shell_executor,
+        "_resolve_clawhub_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        shell_executor.os,
+        "environ",
+        {
+            "PATH": r"C:\Windows\System32",
+            "pythonioencoding": "cp1252",
+            "pythonutf8": "0",
+        },
+    )
+
+    env = await shell_executor.build_shell_env(shell=shell)
+
+    assert env["pythonioencoding"] == "cp1252"
+    assert env["pythonutf8"] == "0"
+    assert "PYTHONIOENCODING" not in env
+    assert "PYTHONUTF8" not in env
+
+
+@pytest.mark.asyncio
 async def test_create_shell_subprocess_uses_powershell_wrapper_and_keeps_env(
     monkeypatch,
 ) -> None:

--- a/tests/unit_tests/tools/workspace_tools/test_shell.py
+++ b/tests/unit_tests/tools/workspace_tools/test_shell.py
@@ -736,6 +736,43 @@ async def test_build_shell_env_ignores_gh_lookup_errors(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_build_shell_env_forces_utf8_python_io_on_windows(monkeypatch) -> None:
+    from relay_teams.tools.workspace_tools import shell_executor
+
+    shell = shell_executor.ResolvedShell(
+        kind=shell_executor.ShellKind.POWERSHELL,
+        executable="powershell.exe",
+        display_name="PowerShell",
+    )
+
+    monkeypatch.setattr(shell_executor, "_is_windows", lambda: True)
+    monkeypatch.setattr(shell_executor, "_load_github_cli_env", lambda: {})
+    monkeypatch.setattr(shell_executor, "_load_clawhub_cli_env", lambda: {})
+    monkeypatch.setattr(
+        shell_executor,
+        "_resolve_gh_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        shell_executor,
+        "_resolve_clawhub_path",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        shell_executor.os,
+        "environ",
+        {"PATH": r"C:\Windows\System32"},
+    )
+
+    env = await shell_executor.build_shell_env(
+        shell=shell,
+    )
+
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert env["PYTHONUTF8"] == "1"
+
+
+@pytest.mark.asyncio
 async def test_create_shell_subprocess_uses_powershell_wrapper_and_keeps_env(
     monkeypatch,
 ) -> None:

--- a/tests/unit_tests/tools/workspace_tools/test_write.py
+++ b/tests/unit_tests/tools/workspace_tools/test_write.py
@@ -78,6 +78,16 @@ class TestAtomicWrite:
 
         assert test_file.read_text() == content
 
+    def test_atomic_write_preserves_crlf_sequences(self, tmp_path):
+        from relay_teams.tools.workspace_tools.write import atomic_write
+
+        test_file = tmp_path / "crlf.txt"
+        content = "line1\r\nline2\r\n"
+
+        atomic_write(test_file, content)
+
+        assert test_file.read_bytes() == content.encode("utf-8")
+
 
 class TestGenerateDiff:
     def test_generate_diff_no_change(self):


### PR DESCRIPTION
## What changed - preserved newline bytes in `write`/`write_tmp` by writing content without platform newline translation - forced UTF-8 Python stdout/stderr defaults for Windows shell execution paths used by background tasks and workspace shell tools - added focused unit coverage for CRLF preservation and Windows Python UTF-8 environment injection  ## Why it changed - Windows file writes were expanding existing CRLF content into double-spaced output when shell-generated text was saved back through the write tool - Windows Python commands could emit non-UTF-8 text to piped stdout/stderr, which was then decoded as UTF-8 by the backend and surfaced as mojibake in the frontend  ## Impact - shell output saved through the write tools now preserves original line endings instead of introducing extra blank lines on Windows - Python command output from Windows shell execution now renders correctly in the frontend for Unicode text - Linux and macOS behavior stays stable because newline preservation now follows the provided content rather than platform translation  ## Root cause - `atomic_write()` defaulted to text-mode newline translation, which is unsafe when the input content already contains explicit CRLF sequences - the shell execution layer normalized PowerShell console encodings but did not ensure Python itself emitted UTF-8 when stdout/stderr was redirected to pipes  ## Validation - `uv run --extra dev pytest -q tests/unit_tests/tools/workspace_tools/test_write.py` - `uv run --extra dev pytest -q tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py tests/unit_tests/tools/workspace_tools/test_shell.py` - `uv run --extra dev ruff check src/relay_teams/tools/workspace_tools/write.py tests/unit_tests/tools/workspace_tools/test_write.py` - `uv run --extra dev ruff check src/relay_teams/sessions/runs/background_tasks/command_runtime.py src/relay_teams/tools/workspace_tools/shell_executor.py tests/unit_tests/sessions/runs/background_tasks/test_command_runtime.py tests/unit_tests/tools/workspace_tools/test_shell.py`  

Fixes #620
