### PR TITLE
feat: add xiaoluban notify tool

### DIFF
--- a/docs/xiaoluban-integration.md
+++ b/docs/xiaoluban-integration.md
@@ -16,12 +16,13 @@ Current scope:
 - Xiaoluban IM forwarding for the current token owner
 - inbound WeLink messages forwarded through Xiaoluban's manual forwarding mode
 - Xiaoluban-triggered Relay task execution with a final-result reply
+- Agent-initiated text notifications through the configurable `notify` tool
 - interactive session management via `/new`, `/resume`, `/help` commands
 - instant acknowledgement on every received message
 
 Current non-goals for this phase:
 
-- Xiaoluban tool execution or plugin orchestration
+- Xiaoluban plugin-hosted tool execution or plugin orchestration
 - group, department, or collaborator whitelist editing
 - intermediate progress pushes
 - Xiaoluban plugin script publishing
@@ -183,6 +184,35 @@ Workspace completion behavior:
 - matching enabled accounts with usable credentials receive the run completion body
 - automation-owned terminal notifications are suppressed from the workspace dispatcher to avoid duplicate Xiaoluban messages
 - IM-triggered run terminal notifications are also suppressed from the workspace dispatcher because the IM path sends the final reply itself
+
+### Agent-Initiated Notify Tool
+
+Roles can be explicitly configured with the `notify` tool. Unlike `im_send`,
+`notify` is not implicitly opened for IM sessions; it is a normal configurable
+tool for proactive outbound notifications.
+
+The first provider is `provider="xiaoluban"` and supports text-only messages:
+
+- `target="owner"` is the default and sends only to the selected account's `derived_uid`
+- `target="configured_groups"` sends to every configured `notification_receivers` group
+- `target="owner_and_configured_groups"` sends to the token owner plus configured groups
+- `target="explicit"` accepts `recipients` as candidate group IDs, then filters them through `notification_receivers`
+
+Account selection is automatic when the current session came from Xiaoluban IM
+and its gateway session has `channel_state.account_id`, or when exactly one
+enabled Xiaoluban account has a configured token. If multiple usable accounts
+exist, the tool asks the Agent to retry with `account` set to an account ID or a
+unique display name.
+
+Explicit group recipients are never sent directly. They are intersected with the
+selected account's configured notification group whitelist. Partial matches send
+to the allowed groups and report filtered values in the tool result; no matches
+fail the tool call.
+
+Approval behavior is target-based:
+
+- owner-only notifications do not create an internal tool approval request
+- any resolved group target creates a guarded tool approval request with the account and group count in the target summary
 
 ## Inbound IM Semantics
 

--- a/src/relay_teams/agents/execution/agent_llm_session.py
+++ b/src/relay_teams/agents/execution/agent_llm_session.py
@@ -71,6 +71,10 @@ from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry import ToolRegistry
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from relay_teams.tools.runtime.context import (
+    GatewaySessionLookupLike,
+    XiaolubanNotifyServiceLike,
+)
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.runtime.persisted_state import (
     load_or_recover_tool_call_state,
@@ -137,6 +141,8 @@ class AgentLlmSession(
         | DisabledLlmFallbackMiddleware
         | None = None,
         im_tool_service: ImToolService | None = None,
+        xiaoluban_notify_service: XiaolubanNotifyServiceLike | None = None,
+        gateway_session_lookup: GatewaySessionLookupLike | None = None,
         computer_runtime: ComputerRuntime | None = None,
         shell_approval_repo: ShellApprovalRepository | None = None,
         hook_service: HookService | None = None,
@@ -191,6 +197,8 @@ class AgentLlmSession(
             else DisabledLlmFallbackMiddleware()
         )
         self._im_tool_service = im_tool_service
+        self._xiaoluban_notify_service = xiaoluban_notify_service
+        self._gateway_session_lookup = gateway_session_lookup
         self._computer_runtime = computer_runtime
         self._shell_approval_repo = shell_approval_repo
         self._hook_service = hook_service

--- a/src/relay_teams/agents/execution/session_mixin_base.py
+++ b/src/relay_teams/agents/execution/session_mixin_base.py
@@ -80,7 +80,11 @@ from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry import ToolRegistry
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
-from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.context import (
+    GatewaySessionLookupLike,
+    ToolDeps,
+    XiaolubanNotifyServiceLike,
+)
 from relay_teams.tools.runtime.persisted_state import PersistedToolCallState
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.workspace_tools.shell_approval_repo import (
@@ -131,6 +135,8 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
     _retry_config: LlmRetryConfig
     _fallback_middleware: LlmFallbackMiddleware | DisabledLlmFallbackMiddleware
     _im_tool_service: ImToolService | None
+    _xiaoluban_notify_service: XiaolubanNotifyServiceLike | None
+    _gateway_session_lookup: GatewaySessionLookupLike | None
     _computer_runtime: ComputerRuntime | None
     _shell_approval_repo: ShellApprovalRepository | None
     _hook_service: HookService | None

--- a/src/relay_teams/agents/execution/session_recovery.py
+++ b/src/relay_teams/agents/execution/session_recovery.py
@@ -709,6 +709,16 @@ class SessionRecoveryMixin(AgentLlmSessionMixinBase):
                 DisabledLlmFallbackMiddleware(),
             ),
             im_tool_service=self._im_tool_service,
+            xiaoluban_notify_service=getattr(
+                self,
+                "_xiaoluban_notify_service",
+                None,
+            ),
+            gateway_session_lookup=getattr(
+                self,
+                "_gateway_session_lookup",
+                None,
+            ),
             computer_runtime=self._computer_runtime,
             shell_approval_repo=self._shell_approval_repo,
         )

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -370,6 +370,16 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 metric_recorder=self._metric_recorder,
                 notification_service=self._notification_service,
                 im_tool_service=self._im_tool_service,
+                xiaoluban_notify_service=getattr(
+                    self,
+                    "_xiaoluban_notify_service",
+                    None,
+                ),
+                gateway_session_lookup=getattr(
+                    self,
+                    "_gateway_session_lookup",
+                    None,
+                ),
                 hook_service=hook_service,
                 reminder_service=getattr(self, "_reminder_service", None),
                 model_capabilities=self._config.capabilities,

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -59,7 +59,11 @@ from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
-from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.context import (
+    GatewaySessionLookupLike,
+    ToolDeps,
+    XiaolubanNotifyServiceLike,
+)
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.tools.workspace_tools.shell_approval_repo import (
@@ -188,6 +192,8 @@ class ExternalAcpHostToolBridge:
         media_asset_service: MediaAssetService | None = None,
         metric_recorder: MetricRecorder | None = None,
         im_tool_service: ImToolService | None = None,
+        xiaoluban_notify_service: XiaolubanNotifyServiceLike | None = None,
+        gateway_session_lookup: GatewaySessionLookupLike | None = None,
         computer_runtime: ComputerRuntime | None = None,
         shell_approval_repo: ShellApprovalRepository | None = None,
         reminder_service: SystemReminderService | None = None,
@@ -224,6 +230,8 @@ class ExternalAcpHostToolBridge:
         self._resolve_model_config = resolve_model_config
         self._metric_recorder = metric_recorder
         self._im_tool_service = im_tool_service
+        self._xiaoluban_notify_service = xiaoluban_notify_service
+        self._gateway_session_lookup = gateway_session_lookup
         self._computer_runtime = computer_runtime
         self._shell_approval_repo = shell_approval_repo
         self._reminder_service = reminder_service
@@ -560,6 +568,16 @@ class ExternalAcpHostToolBridge:
             metric_recorder=self._metric_recorder,
             notification_service=self._get_notification_service(),
             im_tool_service=self._im_tool_service,
+            xiaoluban_notify_service=getattr(
+                self,
+                "_xiaoluban_notify_service",
+                None,
+            ),
+            gateway_session_lookup=getattr(
+                self,
+                "_gateway_session_lookup",
+                None,
+            ),
             reminder_service=getattr(self, "_reminder_service", None),
             model_capabilities=self._resolve_request_model_capabilities(
                 request=request

--- a/src/relay_teams/external_agents/provider.py
+++ b/src/relay_teams/external_agents/provider.py
@@ -56,6 +56,10 @@ from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.tools.runtime.context import (
+    GatewaySessionLookupLike,
+    XiaolubanNotifyServiceLike,
+)
 from relay_teams.workspace import WorkspaceManager
 
 if TYPE_CHECKING:
@@ -176,6 +180,12 @@ class ExternalAcpSessionManager:
         media_asset_service: MediaAssetService | None = None,
         metric_recorder: MetricRecorder | None = None,
         im_tool_service: ImToolService | None = None,
+        get_xiaoluban_notify_service: (
+            Callable[[], XiaolubanNotifyServiceLike | None] | None
+        ) = None,
+        get_gateway_session_lookup: (
+            Callable[[], GatewaySessionLookupLike | None] | None
+        ) = None,
         computer_runtime: ComputerRuntime | None = None,
         reminder_service: SystemReminderService | None = None,
     ) -> None:
@@ -215,6 +225,8 @@ class ExternalAcpSessionManager:
         self._resolve_model_config = resolve_model_config
         self._metric_recorder = metric_recorder
         self._im_tool_service = im_tool_service
+        self._get_xiaoluban_notify_service = get_xiaoluban_notify_service
+        self._get_gateway_session_lookup = get_gateway_session_lookup
         self._computer_runtime = computer_runtime
         self._reminder_service = reminder_service
         self._conversations: dict[str, _ConversationHandle] = {}
@@ -988,6 +1000,16 @@ class ExternalAcpSessionManager:
             resolve_model_config=self._resolve_model_config,
             metric_recorder=self._metric_recorder,
             im_tool_service=self._im_tool_service,
+            xiaoluban_notify_service=(
+                self._get_xiaoluban_notify_service()
+                if self._get_xiaoluban_notify_service is not None
+                else None
+            ),
+            gateway_session_lookup=(
+                self._get_gateway_session_lookup()
+                if self._get_gateway_session_lookup is not None
+                else None
+            ),
             computer_runtime=self._computer_runtime,
             reminder_service=self._reminder_service,
         )

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -670,6 +670,16 @@ class ServerContainer:
             resolve_model_config=self.resolve_external_agent_model_config,
             metric_recorder=self.metric_recorder,
             im_tool_service=self.im_tool_service,
+            get_xiaoluban_notify_service=lambda: getattr(
+                self,
+                "xiaoluban_gateway_service",
+                None,
+            ),
+            get_gateway_session_lookup=lambda: getattr(
+                self,
+                "gateway_session_service",
+                None,
+            ),
             computer_runtime=self.computer_runtime,
         )
         self.run_control_manager.bind_runtime(
@@ -1095,6 +1105,16 @@ class ServerContainer:
             token_usage_repo=self.token_usage_repo,
             metric_recorder=self.metric_recorder,
             im_tool_service=self.im_tool_service,
+            get_xiaoluban_notify_service=lambda: getattr(
+                self,
+                "xiaoluban_gateway_service",
+                None,
+            ),
+            get_gateway_session_lookup=lambda: getattr(
+                self,
+                "gateway_session_service",
+                None,
+            ),
             external_agent_session_manager=self.external_acp_session_manager,
             session_model_profile_lookup=self._session_model_profile_lookup,
             hook_service=self.hook_service,

--- a/src/relay_teams/providers/openai_compatible.py
+++ b/src/relay_teams/providers/openai_compatible.py
@@ -77,6 +77,10 @@ from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry import ToolRegistry
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from relay_teams.tools.runtime.context import (
+    GatewaySessionLookupLike,
+    XiaolubanNotifyServiceLike,
+)
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.workspace_tools.shell_approval_repo import (
     ShellApprovalRepository,
@@ -132,6 +136,8 @@ class OpenAICompatibleProvider(LLMProvider):
         | DisabledLlmFallbackMiddleware
         | None = None,
         im_tool_service: ImToolService | None = None,
+        xiaoluban_notify_service: XiaolubanNotifyServiceLike | None = None,
+        gateway_session_lookup: GatewaySessionLookupLike | None = None,
         computer_runtime: ComputerRuntime | None = None,
         hook_service: HookService | None = None,
         reminder_service: SystemReminderService | None = None,
@@ -189,6 +195,8 @@ class OpenAICompatibleProvider(LLMProvider):
             retry_config=retry_config,
             fallback_middleware=fallback_middleware,
             im_tool_service=im_tool_service,
+            xiaoluban_notify_service=xiaoluban_notify_service,
+            gateway_session_lookup=gateway_session_lookup,
             computer_runtime=computer_runtime,
             hook_service=hook_service,
             reminder_service=reminder_service,

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -61,6 +61,10 @@ from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
 from relay_teams.reminders import SystemReminderService
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
+from relay_teams.tools.runtime.context import (
+    GatewaySessionLookupLike,
+    XiaolubanNotifyServiceLike,
+)
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.workspace_tools.shell_approval_repo import (
@@ -111,6 +115,10 @@ def create_provider_factory(
     token_usage_repo: TokenUsageRepository | None = None,
     metric_recorder: MetricRecorder | None = None,
     im_tool_service: ImToolService | None = None,
+    get_xiaoluban_notify_service: Callable[[], XiaolubanNotifyServiceLike | None]
+    | None = None,
+    get_gateway_session_lookup: Callable[[], GatewaySessionLookupLike | None]
+    | None = None,
     external_agent_session_manager: ExternalAcpSessionManager | None = None,
     session_model_profile_lookup: Callable[[str], ModelEndpointConfig | None]
     | None = None,
@@ -243,6 +251,16 @@ def create_provider_factory(
                 retry_config=runtime_to_use.llm_retry,
                 fallback_middleware=profile_fallback_middleware,
                 im_tool_service=im_tool_service,
+                xiaoluban_notify_service=(
+                    get_xiaoluban_notify_service()
+                    if get_xiaoluban_notify_service is not None
+                    else None
+                ),
+                gateway_session_lookup=(
+                    get_gateway_session_lookup()
+                    if get_gateway_session_lookup is not None
+                    else None
+                ),
                 hook_service=hook_service,
                 reminder_service=reminder_service,
             ),

--- a/src/relay_teams/reminders/tool_effects.py
+++ b/src/relay_teams/reminders/tool_effects.py
@@ -33,6 +33,7 @@ MUTATING_TOOLS = frozenset(
         "edit",
         "im_send",
         "notebook_edit",
+        "notify",
         "shell",
         "spawn_subagent",
         "stop_background_task",

--- a/src/relay_teams/tools/notify_tools/__init__.py
+++ b/src/relay_teams/tools/notify_tools/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from relay_teams.tools.notify_tools.notify import register as register_notify
+
+TOOLS = {
+    "notify": register_notify,
+}
+
+__all__ = [
+    "TOOLS",
+    "register_notify",
+]

--- a/src/relay_teams/tools/notify_tools/models.py
+++ b/src/relay_teams/tools/notify_tools/models.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+from relay_teams.gateway.xiaoluban.models import XiaolubanAccountRecord
+
+
+class NotifyProvider(str, Enum):
+    XIAOLUBAN = "xiaoluban"
+
+
+class NotifyTarget(str, Enum):
+    OWNER = "owner"
+    CONFIGURED_GROUPS = "configured_groups"
+    OWNER_AND_CONFIGURED_GROUPS = "owner_and_configured_groups"
+    EXPLICIT = "explicit"
+
+
+class NotifyRecipientKind(str, Enum):
+    OWNER = "owner"
+    GROUP = "group"
+
+
+class NotifyRecipient(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    recipient_id: str = Field(min_length=1)
+    kind: NotifyRecipientKind
+
+
+class NotifyAccountSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    account_id: str = Field(min_length=1)
+    display_name: str = Field(min_length=1)
+    derived_uid: str = Field(min_length=1)
+    configured_group_count: int = Field(ge=0)
+
+
+class NotifyResolution(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    account: XiaolubanAccountRecord
+    recipients: tuple[NotifyRecipient, ...]
+    filtered_recipients: tuple[str, ...] = ()
+
+    @property
+    def includes_group(self) -> bool:
+        return any(
+            recipient.kind == NotifyRecipientKind.GROUP for recipient in self.recipients
+        )
+
+    def target_summary(self) -> str:
+        group_count = sum(
+            1
+            for recipient in self.recipients
+            if recipient.kind == NotifyRecipientKind.GROUP
+        )
+        owner_count = sum(
+            1
+            for recipient in self.recipients
+            if recipient.kind == NotifyRecipientKind.OWNER
+        )
+        fragments = [
+            f"Xiaoluban account {self.account.display_name}"
+            f" ({self.account.account_id})",
+        ]
+        if owner_count:
+            fragments.append(f"{owner_count} owner target")
+        if group_count:
+            fragments.append(f"{group_count} group target(s)")
+        return "; ".join(fragments)
+
+
+class NotifySendAttempt(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    recipient_id: str = Field(min_length=1)
+    kind: NotifyRecipientKind
+    ok: bool
+    message_id: str = ""
+    error: str = ""
+
+
+class NotifySendResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: NotifyProvider
+    account: NotifyAccountSummary
+    target: NotifyTarget
+    sent: tuple[NotifySendAttempt, ...]
+    failed: tuple[NotifySendAttempt, ...] = ()
+    filtered_recipients: tuple[str, ...] = ()
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return self.model_dump(mode="json")
+
+
+def summarize_xiaoluban_account(
+    account: XiaolubanAccountRecord,
+) -> NotifyAccountSummary:
+    return NotifyAccountSummary(
+        account_id=account.account_id,
+        display_name=account.display_name,
+        derived_uid=account.derived_uid,
+        configured_group_count=len(account.notification_receivers),
+    )
+
+
+__all__ = [
+    "NotifyAccountSummary",
+    "NotifyProvider",
+    "NotifyRecipient",
+    "NotifyRecipientKind",
+    "NotifyResolution",
+    "NotifySendAttempt",
+    "NotifySendResult",
+    "NotifyTarget",
+    "summarize_xiaoluban_account",
+]

--- a/src/relay_teams/tools/notify_tools/notify.py
+++ b/src/relay_teams/tools/notify_tools/notify.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pydantic import JsonValue
+from pydantic_ai import Agent
+
+from relay_teams.computer import ComputerActionRisk, ExecutionSurface
+from relay_teams.tools._description_loader import load_tool_description
+from relay_teams.tools.notify_tools.models import NotifyProvider, NotifyTarget
+from relay_teams.tools.notify_tools.models import NotifyResolution
+from relay_teams.tools.notify_tools.xiaoluban import (
+    resolve_xiaoluban_notify_targets,
+    send_xiaoluban_notify,
+)
+from relay_teams.tools.runtime.context import ToolContext, ToolDeps
+from relay_teams.tools.runtime.execution import execute_tool
+from relay_teams.tools.runtime.models import ToolApprovalRequest, ToolExecutionError
+
+DESCRIPTION = load_tool_description(__file__)
+
+
+def register(agent: Agent[ToolDeps, str]) -> None:
+    @agent.tool(description=DESCRIPTION)
+    async def notify(
+        ctx: ToolContext,
+        provider: NotifyProvider,
+        message: str,
+        target: NotifyTarget = NotifyTarget.OWNER,
+        account: str | None = None,
+        recipients: tuple[str, ...] = (),
+    ) -> dict[str, JsonValue]:
+        """Send a proactive notification through a configured provider."""
+
+        async def _action(tool_input: dict[str, JsonValue]) -> dict[str, JsonValue]:
+            return _execute_notify_action(ctx, tool_input)
+
+        return await execute_tool(
+            ctx,
+            tool_name="notify",
+            args_summary={
+                "provider": provider.value,
+                "message": message[:80],
+                "target": target.value,
+                "account": account,
+                "recipients": list(recipients),
+            },
+            tool_input={
+                "provider": provider.value,
+                "message": message,
+                "target": target.value,
+                "account": account,
+                "recipients": list(recipients),
+            },
+            approval_request_factory=lambda tool_input: build_notify_approval_request(
+                ctx,
+                tool_input,
+            ),
+            approval_args_summary_factory=_approval_args_summary,
+            action=_action,
+        )
+
+
+def _execute_notify_action(
+    ctx: ToolContext,
+    tool_input: dict[str, JsonValue],
+) -> dict[str, JsonValue]:
+    _ = NotifyProvider(str(tool_input["provider"]))
+    resolved_target = NotifyTarget(str(tool_input.get("target") or "owner"))
+    resolved_message = str(tool_input["message"])
+    resolution = resolve_xiaoluban_notify_targets(
+        ctx,
+        account=_optional_text(tool_input.get("account")),
+        target=resolved_target,
+        recipients=_recipient_tuple(tool_input.get("recipients")),
+    )
+    result = send_xiaoluban_notify(
+        ctx,
+        message=resolved_message,
+        target=resolved_target,
+        resolution=resolution,
+    )
+    return result.to_payload()
+
+
+def build_notify_approval_request(
+    ctx: ToolContext,
+    tool_input: dict[str, JsonValue],
+) -> ToolApprovalRequest | None:
+    try:
+        resolved = _resolve_input(ctx, tool_input)
+    except ToolExecutionError:
+        return None
+    if not resolved.includes_group:
+        return None
+    return ToolApprovalRequest(
+        risk_level=ComputerActionRisk.GUARDED,
+        target_summary=resolved.target_summary(),
+        source="notify:xiaoluban",
+        execution_surface=ExecutionSurface.API,
+        metadata={
+            "provider": NotifyProvider.XIAOLUBAN.value,
+            "account_id": resolved.account.account_id,
+            "group_target_count": sum(
+                1
+                for recipient in resolved.recipients
+                if recipient.kind.value == "group"
+            ),
+            "filtered_recipients": list(resolved.filtered_recipients),
+        },
+    )
+
+
+def _resolve_input(
+    ctx: ToolContext,
+    tool_input: dict[str, JsonValue],
+) -> NotifyResolution:
+    _ = NotifyProvider(str(tool_input["provider"]))
+    return resolve_xiaoluban_notify_targets(
+        ctx,
+        account=_optional_text(tool_input.get("account")),
+        target=NotifyTarget(str(tool_input.get("target") or "owner")),
+        recipients=_recipient_tuple(tool_input.get("recipients")),
+    )
+
+
+def _approval_args_summary(tool_input: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    return {
+        "provider": str(tool_input.get("provider") or ""),
+        "target": str(tool_input.get("target") or "owner"),
+        "account": _optional_text(tool_input.get("account")),
+        "recipient_count": len(_recipient_tuple(tool_input.get("recipients"))),
+    }
+
+
+def _optional_text(value: JsonValue | None) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _recipient_tuple(value: JsonValue | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, list):
+        return tuple(str(item) for item in value)
+    if isinstance(value, tuple):
+        return tuple(str(item) for item in value)
+    if isinstance(value, str):
+        return (value,)
+    return (str(value),)
+
+
+__all__ = ["build_notify_approval_request", "register"]

--- a/src/relay_teams/tools/notify_tools/notify.txt
+++ b/src/relay_teams/tools/notify_tools/notify.txt
@@ -1,0 +1,10 @@
+Use `notify` to proactively send a short text notification through a configured provider.
+
+Parameters:
+- `provider`: currently only `"xiaoluban"`.
+- `message`: required notification text.
+- `target`: optional. Defaults to `"owner"` and sends only to the Xiaoluban token owner. Use `"configured_groups"` for all configured notification groups, `"owner_and_configured_groups"` for both yourself and configured groups, or `"explicit"` when the user provided exact group IDs.
+- `account`: optional Xiaoluban account selector. Use an account ID or a unique display name only when automatic account selection is ambiguous.
+- `recipients`: optional group ID candidates. For Xiaoluban, explicit group IDs are always filtered through that account's configured notification group whitelist.
+
+Prefer the default `target="owner"` when the user asks you to notify them. Do not ask the user to remember group IDs; use `configured_groups` or `owner_and_configured_groups` for configured group delivery. Group delivery requires approval; owner-only delivery does not.

--- a/src/relay_teams/tools/notify_tools/xiaoluban.py
+++ b/src/relay_teams/tools/notify_tools/xiaoluban.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import cast
+
+from pydantic import JsonValue
+
+from relay_teams.gateway.gateway_models import GatewayChannelType
+from relay_teams.gateway.xiaoluban.models import (
+    XiaolubanAccountRecord,
+    XiaolubanAccountStatus,
+    normalize_xiaoluban_notification_receivers,
+)
+from relay_teams.tools.notify_tools.models import (
+    NotifyProvider,
+    NotifyRecipient,
+    NotifyRecipientKind,
+    NotifyResolution,
+    NotifySendAttempt,
+    NotifySendResult,
+    NotifyTarget,
+    summarize_xiaoluban_account,
+)
+from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.models import ToolExecutionError
+
+
+def resolve_xiaoluban_notify_targets(
+    ctx: ToolContext,
+    *,
+    account: str | None,
+    target: NotifyTarget,
+    recipients: tuple[str, ...],
+) -> NotifyResolution:
+    service = ctx.deps.xiaoluban_notify_service
+    if service is None:
+        raise ToolExecutionError(
+            error_type="provider_unavailable",
+            message="Xiaoluban notify service is not available in this runtime.",
+            retryable=True,
+        )
+    selected_account = _resolve_account(ctx, account=account)
+    normalized_recipients = normalize_xiaoluban_notification_receivers(recipients)
+    resolved_recipients, filtered = _resolve_recipients(
+        account=selected_account,
+        target=target,
+        recipients=normalized_recipients,
+    )
+    if not resolved_recipients:
+        raise ToolExecutionError(
+            error_type="empty_target",
+            message="No Xiaoluban notification targets resolved.",
+            details={
+                "target": target.value,
+                "filtered_recipients": list(filtered),
+                "configured_groups": list(selected_account.notification_receivers),
+            },
+        )
+    return NotifyResolution(
+        account=selected_account,
+        recipients=resolved_recipients,
+        filtered_recipients=filtered,
+    )
+
+
+def send_xiaoluban_notify(
+    ctx: ToolContext,
+    *,
+    message: str,
+    target: NotifyTarget,
+    resolution: NotifyResolution,
+) -> NotifySendResult:
+    service = ctx.deps.xiaoluban_notify_service
+    if service is None:
+        raise ToolExecutionError(
+            error_type="provider_unavailable",
+            message="Xiaoluban notify service is not available in this runtime.",
+            retryable=True,
+        )
+    body = message.strip()
+    if not body:
+        raise ToolExecutionError(
+            error_type="validation_error",
+            message="message must not be empty.",
+        )
+    sent: list[NotifySendAttempt] = []
+    failed: list[NotifySendAttempt] = []
+    for recipient in resolution.recipients:
+        try:
+            message_id = service.send_notification_message(
+                account_id=resolution.account.account_id,
+                workspace_id=ctx.deps.workspace_id,
+                session_id=ctx.deps.session_id,
+                status="notification",
+                body=body,
+                receiver_uid=recipient.recipient_id,
+            )
+            sent.append(
+                NotifySendAttempt(
+                    recipient_id=recipient.recipient_id,
+                    kind=recipient.kind,
+                    ok=True,
+                    message_id=message_id,
+                )
+            )
+        except (RuntimeError, OSError, KeyError, ValueError) as exc:
+            failed.append(
+                NotifySendAttempt(
+                    recipient_id=recipient.recipient_id,
+                    kind=recipient.kind,
+                    ok=False,
+                    error=str(exc),
+                )
+            )
+    if not sent:
+        raise ToolExecutionError(
+            error_type="delivery_failed",
+            message="Xiaoluban notify failed for all resolved targets.",
+            retryable=True,
+            details={
+                "account_id": resolution.account.account_id,
+                "target": target.value,
+                "failed": [_attempt_payload(attempt) for attempt in failed],
+                "filtered_recipients": list(resolution.filtered_recipients),
+            },
+        )
+    return NotifySendResult(
+        provider=NotifyProvider.XIAOLUBAN,
+        account=summarize_xiaoluban_account(resolution.account),
+        target=target,
+        sent=tuple(sent),
+        failed=tuple(failed),
+        filtered_recipients=resolution.filtered_recipients,
+    )
+
+
+def _resolve_account(
+    ctx: ToolContext, *, account: str | None
+) -> XiaolubanAccountRecord:
+    selector = str(account or "").strip()
+    if selector:
+        return _resolve_explicit_account(ctx, selector=selector)
+    session_account_id = _session_xiaoluban_account_id(ctx)
+    if session_account_id:
+        return _resolve_explicit_account(ctx, selector=session_account_id)
+    usable_accounts = _usable_accounts(ctx)
+    if len(usable_accounts) == 1:
+        return usable_accounts[0]
+    if not usable_accounts:
+        raise ToolExecutionError(
+            error_type="account_unavailable",
+            message="No enabled Xiaoluban account with a usable token is available.",
+            retryable=True,
+        )
+    raise ToolExecutionError(
+        error_type="account_ambiguous",
+        message="Multiple Xiaoluban accounts are available; specify account.",
+        details={
+            "candidates": [
+                summarize_xiaoluban_account(item).model_dump(mode="json")
+                for item in usable_accounts
+            ]
+        },
+    )
+
+
+def _resolve_explicit_account(
+    ctx: ToolContext,
+    *,
+    selector: str,
+) -> XiaolubanAccountRecord:
+    service = ctx.deps.xiaoluban_notify_service
+    if service is None:
+        raise ToolExecutionError(
+            error_type="provider_unavailable",
+            message="Xiaoluban notify service is not available in this runtime.",
+            retryable=True,
+        )
+    usable_accounts = _usable_accounts(ctx)
+    for candidate in usable_accounts:
+        if candidate.account_id == selector:
+            return candidate
+    try:
+        existing = cast(XiaolubanAccountRecord, service.get_account(selector))
+    except KeyError:
+        existing = None
+    if existing is not None:
+        raise ToolExecutionError(
+            error_type="account_unavailable",
+            message="The selected Xiaoluban account is disabled or missing a token.",
+            retryable=True,
+            details={"account_id": existing.account_id},
+        )
+    display_matches = [
+        candidate
+        for candidate in usable_accounts
+        if candidate.display_name.strip() == selector
+    ]
+    if len(display_matches) == 1:
+        return display_matches[0]
+    if len(display_matches) > 1:
+        raise ToolExecutionError(
+            error_type="account_ambiguous",
+            message="Multiple usable Xiaoluban accounts have that display_name.",
+            details={
+                "selector": selector,
+                "candidates": [
+                    summarize_xiaoluban_account(item).model_dump(mode="json")
+                    for item in display_matches
+                ],
+            },
+        )
+    all_display_matches = [
+        candidate
+        for candidate in service.list_accounts()
+        if candidate.display_name.strip() == selector
+    ]
+    if len(all_display_matches) == 1:
+        existing = cast(XiaolubanAccountRecord, all_display_matches[0])
+        raise ToolExecutionError(
+            error_type="account_unavailable",
+            message="The selected Xiaoluban account is disabled or missing a token.",
+            retryable=True,
+            details={"account_id": existing.account_id},
+        )
+    if len(all_display_matches) > 1:
+        raise ToolExecutionError(
+            error_type="account_ambiguous",
+            message="Multiple Xiaoluban accounts have that display_name.",
+            details={
+                "selector": selector,
+                "candidates": [
+                    summarize_xiaoluban_account(
+                        cast(XiaolubanAccountRecord, item)
+                    ).model_dump(mode="json")
+                    for item in all_display_matches
+                ],
+            },
+        )
+    raise ToolExecutionError(
+        error_type="account_not_found",
+        message=f"Unknown Xiaoluban account: {selector}",
+        retryable=True,
+    )
+
+
+def _session_xiaoluban_account_id(ctx: ToolContext) -> str:
+    lookup = ctx.deps.gateway_session_lookup
+    if lookup is None:
+        return ""
+    record = lookup.get_by_internal_session_id(ctx.deps.session_id)
+    if record is None or record.channel_type != GatewayChannelType.XIAOLUBAN:
+        return ""
+    account_id = record.channel_state.get("account_id")
+    return str(account_id or "").strip()
+
+
+def _usable_accounts(ctx: ToolContext) -> tuple[XiaolubanAccountRecord, ...]:
+    service = ctx.deps.xiaoluban_notify_service
+    if service is None:
+        return ()
+    return tuple(
+        cast(XiaolubanAccountRecord, account)
+        for account in service.list_accounts()
+        if _is_usable_account(ctx, cast(XiaolubanAccountRecord, account))
+    )
+
+
+def _is_usable_account(ctx: ToolContext, account: XiaolubanAccountRecord) -> bool:
+    service = ctx.deps.xiaoluban_notify_service
+    if service is None:
+        return False
+    if account.status != XiaolubanAccountStatus.ENABLED:
+        return False
+    if not account.secret_status.token_configured:
+        return False
+    return service.has_usable_credentials(account.account_id)
+
+
+def _resolve_recipients(
+    *,
+    account: XiaolubanAccountRecord,
+    target: NotifyTarget,
+    recipients: tuple[str, ...],
+) -> tuple[tuple[NotifyRecipient, ...], tuple[str, ...]]:
+    configured_groups = account.notification_receivers
+    filtered: tuple[str, ...] = ()
+    if target == NotifyTarget.OWNER:
+        return (
+            (
+                NotifyRecipient(
+                    recipient_id=account.derived_uid,
+                    kind=NotifyRecipientKind.OWNER,
+                ),
+            ),
+            (),
+        )
+    if target == NotifyTarget.EXPLICIT:
+        group_targets, filtered = _filter_configured_groups(
+            configured_groups=configured_groups,
+            requested=recipients,
+        )
+    else:
+        group_targets = configured_groups
+
+    resolved: list[NotifyRecipient] = []
+    if target == NotifyTarget.OWNER_AND_CONFIGURED_GROUPS:
+        resolved.append(
+            NotifyRecipient(
+                recipient_id=account.derived_uid,
+                kind=NotifyRecipientKind.OWNER,
+            )
+        )
+    if target in {
+        NotifyTarget.CONFIGURED_GROUPS,
+        NotifyTarget.OWNER_AND_CONFIGURED_GROUPS,
+        NotifyTarget.EXPLICIT,
+    }:
+        for group_id in group_targets:
+            resolved.append(
+                NotifyRecipient(
+                    recipient_id=group_id,
+                    kind=NotifyRecipientKind.GROUP,
+                )
+            )
+    return _deduplicate_recipients(tuple(resolved)), filtered
+
+
+def _filter_configured_groups(
+    *,
+    configured_groups: tuple[str, ...],
+    requested: tuple[str, ...],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    allowed = set(configured_groups)
+    matched: list[str] = []
+    filtered: list[str] = []
+    seen: set[str] = set()
+    for recipient in requested:
+        if recipient in allowed:
+            if recipient not in seen:
+                seen.add(recipient)
+                matched.append(recipient)
+            continue
+        filtered.append(recipient)
+    return tuple(matched), tuple(filtered)
+
+
+def _deduplicate_recipients(
+    recipients: tuple[NotifyRecipient, ...],
+) -> tuple[NotifyRecipient, ...]:
+    seen: set[str] = set()
+    result: list[NotifyRecipient] = []
+    for recipient in recipients:
+        key = recipient.recipient_id
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(recipient)
+    return tuple(result)
+
+
+def _attempt_payload(attempt: NotifySendAttempt) -> dict[str, JsonValue]:
+    return attempt.model_dump(mode="json")
+
+
+__all__ = [
+    "resolve_xiaoluban_notify_targets",
+    "send_xiaoluban_notify",
+]

--- a/src/relay_teams/tools/registry/defaults.py
+++ b/src/relay_teams/tools/registry/defaults.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from relay_teams.tools.computer_tools import TOOLS as COMPUTER_TOOLS
 from relay_teams.tools.im_tools.im_send import register as register_im_send
+from relay_teams.tools.notify_tools import TOOLS as NOTIFY_TOOLS
 from relay_teams.tools.orchestration_tools import TOOLS as ORCHESTRATION_TOOLS
 from relay_teams.tools.registry.registry import ToolRegistry
 from relay_teams.tools.skill_team_tools import TOOLS as SKILL_TEAM_TOOLS
@@ -26,6 +27,7 @@ def build_default_registry() -> ToolRegistry:
         **WEB_TOOLS,
         **WORKSPACE_TOOLS,
         **COMPUTER_TOOLS,
+        **NOTIFY_TOOLS,
         **IM_TOOLS,
     }
     return ToolRegistry(

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation
 from pydantic_ai import RunContext
@@ -15,6 +15,7 @@ from relay_teams.agents.orchestration.task_contracts import (
 )
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.computer import ComputerRuntime
+from relay_teams.gateway.gateway_models import GatewaySessionRecord
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.metrics import MetricRecorder
 from relay_teams.media import MediaAssetService
@@ -61,6 +62,52 @@ class ImToolServiceLike(Protocol):
         file_path: Path,
         run_id: str | None = None,
     ) -> str: ...
+
+
+@runtime_checkable
+class GatewaySessionLookupLike(Protocol):
+    def get_by_internal_session_id(
+        self,
+        internal_session_id: str,
+    ) -> GatewaySessionRecord | None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class XiaolubanSecretStatusLike(Protocol):
+    token_configured: bool
+
+
+class XiaolubanNotifyAccountLike(Protocol):
+    account_id: str
+    display_name: str
+    status: object
+    derived_uid: str
+    notification_receivers: tuple[str, ...]
+    secret_status: XiaolubanSecretStatusLike
+
+
+@runtime_checkable
+class XiaolubanNotifyServiceLike(Protocol):
+    def list_accounts(self) -> tuple[XiaolubanNotifyAccountLike, ...]:
+        raise NotImplementedError  # pragma: no cover
+
+    def get_account(self, account_id: str) -> XiaolubanNotifyAccountLike:
+        raise NotImplementedError  # pragma: no cover
+
+    def has_usable_credentials(self, account_id: str) -> bool:
+        raise NotImplementedError  # pragma: no cover
+
+    def send_notification_message(
+        self,
+        *,
+        account_id: str,
+        workspace_id: str,
+        session_id: str,
+        status: str,
+        body: str,
+        receiver_uid: str | None = None,
+    ) -> str:
+        raise NotImplementedError  # pragma: no cover
 
 
 class SkillRegistryLike(Protocol):
@@ -123,6 +170,8 @@ class ToolDeps(BaseModel):
     metric_recorder: SkipValidation[MetricRecorder | None] = None
     notification_service: SkipValidation[NotificationService | None] = None
     im_tool_service: SkipValidation[ImToolServiceLike | None] = None
+    xiaoluban_notify_service: XiaolubanNotifyServiceLike | None = None
+    gateway_session_lookup: GatewaySessionLookupLike | None = None
     hook_service: SkipValidation[HookService | None] = None
     reminder_service: SkipValidation[SystemReminderService | None] = None
     model_capabilities: SkipValidation[ModelCapabilities] = Field(

--- a/tests/unit_tests/reminders/test_tool_effects.py
+++ b/tests/unit_tests/reminders/test_tool_effects.py
@@ -8,3 +8,7 @@ def test_classify_tool_effect_treats_registered_orchestration_lists_as_read_only
 ):
     assert classify_tool_effect("orch_list_available_roles") == ToolEffect.READ_ONLY
     assert classify_tool_effect("orch_list_delegated_tasks") == ToolEffect.READ_ONLY
+
+
+def test_classify_tool_effect_treats_notify_as_mutating() -> None:
+    assert classify_tool_effect("notify") == ToolEffect.MUTATING

--- a/tests/unit_tests/tools/notify_tools/__init__.py
+++ b/tests/unit_tests/tools/notify_tools/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/tests/unit_tests/tools/notify_tools/test_xiaoluban_notify.py
+++ b/tests/unit_tests/tools/notify_tools/test_xiaoluban_notify.py
@@ -1,0 +1,487 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import cast
+
+import pytest
+from pydantic import JsonValue
+
+from relay_teams.gateway import GatewayChannelType, GatewaySessionRecord
+from relay_teams.gateway.xiaoluban import (
+    DEFAULT_XIAOLUBAN_BASE_URL,
+    XiaolubanAccountRecord,
+    XiaolubanAccountStatus,
+    XiaolubanSecretStatus,
+)
+from relay_teams.tools.notify_tools import notify as notify_module
+from relay_teams.tools.notify_tools.models import NotifyRecipientKind, NotifyTarget
+from relay_teams.tools.notify_tools.notify import build_notify_approval_request
+from relay_teams.tools.notify_tools.xiaoluban import (
+    resolve_xiaoluban_notify_targets,
+    send_xiaoluban_notify,
+)
+from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.models import ToolExecutionError
+
+
+class _FakeXiaolubanService:
+    def __init__(self, accounts: tuple[XiaolubanAccountRecord, ...]) -> None:
+        self._accounts = {account.account_id: account for account in accounts}
+        self.sent: list[tuple[str, str, str]] = []
+        self.fail_targets: set[str] = set()
+
+    def list_accounts(self) -> tuple[XiaolubanAccountRecord, ...]:
+        return tuple(self._accounts.values())
+
+    def get_account(self, account_id: str) -> XiaolubanAccountRecord:
+        if account_id not in self._accounts:
+            raise KeyError(account_id)
+        return self._accounts[account_id]
+
+    def has_usable_credentials(self, account_id: str) -> bool:
+        account = self.get_account(account_id)
+        return (
+            account.status == XiaolubanAccountStatus.ENABLED
+            and account.secret_status.token_configured
+        )
+
+    def send_notification_message(
+        self,
+        *,
+        account_id: str,
+        workspace_id: str,
+        session_id: str,
+        status: str,
+        body: str,
+        receiver_uid: str | None = None,
+    ) -> str:
+        _ = (workspace_id, session_id, status, body)
+        target = receiver_uid or ""
+        if target in self.fail_targets:
+            raise RuntimeError(f"send failed for {target}")
+        self.sent.append((account_id, target, body))
+        return f"msg-{len(self.sent)}"
+
+
+class _FakeGatewaySessionLookup:
+    def __init__(self, record: GatewaySessionRecord | None = None) -> None:
+        self._record = record
+
+    def get_by_internal_session_id(
+        self,
+        internal_session_id: str,
+    ) -> GatewaySessionRecord | None:
+        _ = internal_session_id
+        return self._record
+
+
+class _FakeDeps:
+    def __init__(
+        self,
+        *,
+        xiaoluban_notify_service: _FakeXiaolubanService | None,
+        gateway_session_lookup: _FakeGatewaySessionLookup | None = None,
+    ) -> None:
+        self.xiaoluban_notify_service = xiaoluban_notify_service
+        self.gateway_session_lookup = gateway_session_lookup
+        self.workspace_id = "ws-1"
+        self.session_id = "session-1"
+
+
+class _FakeContext:
+    def __init__(self, deps: _FakeDeps) -> None:
+        self.deps = deps
+
+
+def _account(
+    account_id: str,
+    *,
+    display_name: str = "Xiaoluban",
+    derived_uid: str = "uid_self",
+    groups: tuple[str, ...] = ("group-1", "group-2"),
+    enabled: bool = True,
+    token_configured: bool = True,
+) -> XiaolubanAccountRecord:
+    now = datetime.now(tz=timezone.utc)
+    return XiaolubanAccountRecord(
+        account_id=account_id,
+        display_name=display_name,
+        base_url=DEFAULT_XIAOLUBAN_BASE_URL,
+        status=(
+            XiaolubanAccountStatus.ENABLED
+            if enabled
+            else XiaolubanAccountStatus.DISABLED
+        ),
+        derived_uid=derived_uid,
+        notification_receivers=groups,
+        secret_status=XiaolubanSecretStatus(token_configured=token_configured),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _ctx(
+    service: _FakeXiaolubanService,
+    *,
+    gateway_session: GatewaySessionRecord | None = None,
+) -> ToolContext:
+    return cast(
+        ToolContext,
+        _FakeContext(
+            _FakeDeps(
+                xiaoluban_notify_service=service,
+                gateway_session_lookup=_FakeGatewaySessionLookup(gateway_session),
+            )
+        ),
+    )
+
+
+def _xiaoluban_gateway_session(account_id: str) -> GatewaySessionRecord:
+    return GatewaySessionRecord(
+        gateway_session_id="gws-1",
+        channel_type=GatewayChannelType.XIAOLUBAN,
+        external_session_id="xiaoluban:xlb:ws:remote",
+        internal_session_id="session-1",
+        channel_state={"account_id": account_id},
+    )
+
+
+def test_default_owner_target_uses_single_available_account_owner() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+
+    resolution = resolve_xiaoluban_notify_targets(
+        _ctx(service),
+        account=None,
+        target=NotifyTarget.OWNER,
+        recipients=(),
+    )
+
+    assert resolution.account.account_id == "xlb_1"
+    assert resolution.recipients[0].recipient_id == "uid_self"
+    assert resolution.recipients[0].kind == NotifyRecipientKind.OWNER
+    assert resolution.includes_group is False
+
+
+def test_session_xiaoluban_account_takes_precedence() -> None:
+    service = _FakeXiaolubanService(
+        (
+            _account("xlb_session", display_name="Session"),
+            _account("xlb_other", display_name="Other"),
+        )
+    )
+
+    resolution = resolve_xiaoluban_notify_targets(
+        _ctx(service, gateway_session=_xiaoluban_gateway_session("xlb_session")),
+        account=None,
+        target=NotifyTarget.OWNER,
+        recipients=(),
+    )
+
+    assert resolution.account.account_id == "xlb_session"
+
+
+def test_multiple_accounts_without_selector_fail_with_candidates() -> None:
+    service = _FakeXiaolubanService(
+        (
+            _account("xlb_1", display_name="One"),
+            _account("xlb_2", display_name="Two"),
+        )
+    )
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        _ = resolve_xiaoluban_notify_targets(
+            _ctx(service),
+            account=None,
+            target=NotifyTarget.OWNER,
+            recipients=(),
+        )
+
+    assert exc_info.value.error_type == "account_ambiguous"
+    assert len(cast(list[JsonValue], exc_info.value.details["candidates"])) == 2
+
+
+def test_account_selector_matches_unique_display_name() -> None:
+    service = _FakeXiaolubanService(
+        (
+            _account("xlb_1", display_name="Main"),
+            _account("xlb_2", display_name="Other"),
+        )
+    )
+
+    resolution = resolve_xiaoluban_notify_targets(
+        _ctx(service),
+        account="Main",
+        target=NotifyTarget.OWNER,
+        recipients=(),
+    )
+
+    assert resolution.account.account_id == "xlb_1"
+
+
+def test_account_selector_prioritizes_account_id_over_display_name() -> None:
+    service = _FakeXiaolubanService(
+        (
+            _account("shared", display_name="Disabled", enabled=False),
+            _account("xlb_2", display_name="shared"),
+        )
+    )
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        _ = resolve_xiaoluban_notify_targets(
+            _ctx(service),
+            account="shared",
+            target=NotifyTarget.OWNER,
+            recipients=(),
+        )
+
+    assert exc_info.value.error_type == "account_unavailable"
+    assert exc_info.value.details["account_id"] == "shared"
+
+
+def test_configured_groups_and_owner_plus_groups_resolve_whitelist() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+
+    groups_only = resolve_xiaoluban_notify_targets(
+        _ctx(service),
+        account=None,
+        target=NotifyTarget.CONFIGURED_GROUPS,
+        recipients=(),
+    )
+    owner_and_groups = resolve_xiaoluban_notify_targets(
+        _ctx(service),
+        account=None,
+        target=NotifyTarget.OWNER_AND_CONFIGURED_GROUPS,
+        recipients=(),
+    )
+
+    assert [recipient.recipient_id for recipient in groups_only.recipients] == [
+        "group-1",
+        "group-2",
+    ]
+    assert [recipient.recipient_id for recipient in owner_and_groups.recipients] == [
+        "uid_self",
+        "group-1",
+        "group-2",
+    ]
+
+
+def test_non_explicit_group_targets_ignore_incidental_recipients() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+
+    groups_only = resolve_xiaoluban_notify_targets(
+        _ctx(service),
+        account=None,
+        target=NotifyTarget.CONFIGURED_GROUPS,
+        recipients=("not-allowed", "group-2"),
+    )
+    owner_and_groups = resolve_xiaoluban_notify_targets(
+        _ctx(service),
+        account=None,
+        target=NotifyTarget.OWNER_AND_CONFIGURED_GROUPS,
+        recipients=("not-allowed",),
+    )
+
+    assert [recipient.recipient_id for recipient in groups_only.recipients] == [
+        "group-1",
+        "group-2",
+    ]
+    assert groups_only.filtered_recipients == ()
+    assert [recipient.recipient_id for recipient in owner_and_groups.recipients] == [
+        "uid_self",
+        "group-1",
+        "group-2",
+    ]
+    assert owner_and_groups.filtered_recipients == ()
+
+
+def test_owner_and_group_targets_deduplicate_by_recipient_id() -> None:
+    service = _FakeXiaolubanService(
+        (_account("xlb_1", groups=("uid_self", "group-1")),)
+    )
+    ctx = _ctx(service)
+
+    resolution = resolve_xiaoluban_notify_targets(
+        ctx,
+        account=None,
+        target=NotifyTarget.OWNER_AND_CONFIGURED_GROUPS,
+        recipients=(),
+    )
+    result = send_xiaoluban_notify(
+        ctx,
+        message="hello",
+        target=NotifyTarget.OWNER_AND_CONFIGURED_GROUPS,
+        resolution=resolution,
+    )
+
+    assert [recipient.recipient_id for recipient in resolution.recipients] == [
+        "uid_self",
+        "group-1",
+    ]
+    assert [attempt.recipient_id for attempt in result.sent] == [
+        "uid_self",
+        "group-1",
+    ]
+    assert [sent[1] for sent in service.sent] == ["uid_self", "group-1"]
+
+
+def test_explicit_recipients_are_filtered_to_configured_groups() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+
+    resolution = resolve_xiaoluban_notify_targets(
+        _ctx(service),
+        account=None,
+        target=NotifyTarget.EXPLICIT,
+        recipients=("group-2", "not-allowed"),
+    )
+
+    assert [recipient.recipient_id for recipient in resolution.recipients] == [
+        "group-2"
+    ]
+    assert resolution.filtered_recipients == ("not-allowed",)
+
+
+def test_explicit_recipients_fail_when_all_filtered() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        _ = resolve_xiaoluban_notify_targets(
+            _ctx(service),
+            account=None,
+            target=NotifyTarget.EXPLICIT,
+            recipients=("not-allowed",),
+        )
+
+    assert exc_info.value.error_type == "empty_target"
+    assert exc_info.value.details["filtered_recipients"] == ["not-allowed"]
+
+
+def test_owner_only_notify_does_not_build_approval_request() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+
+    request = build_notify_approval_request(
+        _ctx(service),
+        {
+            "provider": "xiaoluban",
+            "message": "hello",
+            "target": "owner",
+            "recipients": [],
+        },
+    )
+
+    assert request is None
+
+
+def test_group_notify_builds_guarded_approval_request() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+
+    request = build_notify_approval_request(
+        _ctx(service),
+        {
+            "provider": "xiaoluban",
+            "message": "hello",
+            "target": "configured_groups",
+            "recipients": [],
+        },
+    )
+
+    assert request is not None
+    assert request.risk_level is not None
+    assert request.risk_level.value == "guarded"
+    assert request.metadata["group_target_count"] == 2
+    assert "2 group target" in request.target_summary
+
+
+def test_send_reports_partial_failure_and_filtered_recipients() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+    service.fail_targets.add("group-2")
+    ctx = _ctx(service)
+    resolution = resolve_xiaoluban_notify_targets(
+        ctx,
+        account=None,
+        target=NotifyTarget.EXPLICIT,
+        recipients=("group-1", "group-2", "not-allowed"),
+    )
+
+    result = send_xiaoluban_notify(
+        ctx,
+        message="hello",
+        target=NotifyTarget.EXPLICIT,
+        resolution=resolution,
+    )
+
+    assert [attempt.recipient_id for attempt in result.sent] == ["group-1"]
+    assert [attempt.recipient_id for attempt in result.failed] == ["group-2"]
+    assert result.filtered_recipients == ("not-allowed",)
+
+
+def test_send_fails_when_all_targets_fail() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1", groups=("group-1",)),))
+    service.fail_targets.add("group-1")
+    ctx = _ctx(service)
+    resolution = resolve_xiaoluban_notify_targets(
+        ctx,
+        account=None,
+        target=NotifyTarget.CONFIGURED_GROUPS,
+        recipients=(),
+    )
+
+    with pytest.raises(ToolExecutionError) as exc_info:
+        _ = send_xiaoluban_notify(
+            ctx,
+            message="hello",
+            target=NotifyTarget.CONFIGURED_GROUPS,
+            resolution=resolution,
+        )
+
+    assert exc_info.value.error_type == "delivery_failed"
+
+
+def test_notify_action_executes_xiaoluban_send() -> None:
+    service = _FakeXiaolubanService((_account("xlb_1"),))
+
+    payload = notify_module._execute_notify_action(
+        _ctx(service),
+        {
+            "provider": "xiaoluban",
+            "message": " hello ",
+            "target": "owner",
+            "recipients": [],
+        },
+    )
+
+    assert payload["provider"] == "xiaoluban"
+    assert payload["target"] == "owner"
+    sent = cast(list[dict[str, JsonValue]], payload["sent"])
+    assert sent[0]["recipient_id"] == "uid_self"
+    assert service.sent == [("xlb_1", "uid_self", "hello")]
+
+
+def test_notify_input_helpers_normalize_values() -> None:
+    assert notify_module._optional_text(None) is None
+    assert notify_module._optional_text("  ") is None
+    assert notify_module._optional_text(" owner ") == "owner"
+    assert notify_module._optional_text(123) == "123"
+    assert notify_module._recipient_tuple(None) == ()
+    assert notify_module._recipient_tuple(["a", 1]) == ("a", "1")
+    assert notify_module._recipient_tuple(cast(JsonValue, ("b", 2))) == ("b", "2")
+    assert notify_module._recipient_tuple("c") == ("c",)
+    assert notify_module._recipient_tuple(3) == ("3",)
+
+
+def test_notify_approval_args_summary_counts_recipients() -> None:
+    summary = notify_module._approval_args_summary(
+        {
+            "provider": "xiaoluban",
+            "target": "explicit",
+            "account": " xlb_1 ",
+            "recipients": ["group-1", "group-2"],
+        }
+    )
+
+    assert summary == {
+        "provider": "xiaoluban",
+        "target": "explicit",
+        "account": "xlb_1",
+        "recipient_count": 2,
+    }

--- a/tests/unit_tests/tools/registry/test_defaults.py
+++ b/tests/unit_tests/tools/registry/test_defaults.py
@@ -34,6 +34,7 @@ def test_registry_contains_registered_local_tools() -> None:
         "list_skill_roles",
         "list_windows",
         "notebook_edit",
+        "notify",
         "office_read_markdown",
         "orch_create_tasks",
         "orch_create_temporary_role",
@@ -63,6 +64,7 @@ def test_registry_hides_im_send_from_manual_role_configuration() -> None:
     registry = build_default_registry()
 
     assert "im_send" not in registry.list_configurable_names()
+    assert "notify" in registry.list_configurable_names()
 
 
 def test_default_registry_ignores_unknown_tools_for_runtime_resolution() -> None:


### PR DESCRIPTION
- Add a new configurable `notify` tool package with the first provider implementation for Xiaoluban.
- Resolve Xiaoluban accounts from the current IM session, a single usable account, or an explicit account ID/display name selector.
- Support `owner`, `configured_groups`, `owner_and_configured_groups`, and `explicit` targets.
- Filter explicit Xiaoluban group recipients through `notification_receivers` and report filtered recipients in the tool result.
- Reuse `XiaolubanGatewayService.send_notification_message` so proactive notifications keep the existing Relay Teams Xiaoluban message format.
- Add guarded tool approval for notifications that include group recipients while keeping owner-only notifications approval-free.
- Wire Xiaoluban notify dependencies through local provider sessions and external ACP host tool execution.
- Register `notify` in the default tool registry and mark it as a mutating tool.
- Update Xiaoluban integration documentation and focused unit tests.

#614 