### PR TITLE
Fix session switching stream pressure

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -937,6 +937,7 @@ Query parameters:
 - optional `limit`: number of round projections to return for the normal paged view
 - optional `cursor_run_id`: cursor for loading older normal round projections
 - optional `timeline=true`: returns the full lightweight round index for timeline navigation; this mode ignores `limit` and `cursor_run_id`, sets `has_more = false`, and omits heavy message/task mapping fields such as `coordinator_messages`, `tasks`, `instance_role_map`, `role_instance_map`, `task_instance_map`, and `task_status_map`
+- optional `summary=true`: returns the paged lightweight round index for fast session switching; this mode honors `limit` and `cursor_run_id`, keeps pagination fields, and omits the same heavy fields as `timeline=true`
 
 Response shape:
 
@@ -1325,6 +1326,19 @@ Response:
 ```json
 {"run_id": "run-1", "session_id": "session-1", "target_role_id": "Architect"}
 ```
+
+### `GET /runs/events`
+
+Streams multiple main-run event streams over one SSE connection.
+
+Query:
+- `run_id`: repeat once per run, up to 32 values.
+- `after_event_id`: optional repeated replay offset matching each `run_id`; omitted values default to `0`.
+
+The response emits the same `RunEvent` JSON shape as `GET /runs/{run_id}/events`.
+Clients route each event by its `run_id` or `trace_id`. This endpoint is intended
+for browser-side multiplexing of active and recently viewed main sessions so the
+UI does not open one SSE connection per running session.
 
 ### `GET /runs/{run_id}/events`
 

--- a/frontend/dist/js/app/recovery.js
+++ b/frontend/dist/js/app/recovery.js
@@ -139,6 +139,51 @@ export async function hydrateSessionView(
     return snapshot;
 }
 
+export async function hydrateSessionSwitchView(
+    sessionId = state.currentSessionId,
+    {
+        priority = 'high',
+        quiet = true,
+        roundsScrollPolicy = '',
+        signal = null,
+    } = {},
+) {
+    const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+    if (!safeSessionId) {
+        stopSessionContinuity();
+        clearSessionRecovery();
+        return null;
+    }
+    throwIfAborted(signal);
+
+    startSessionContinuity(safeSessionId);
+    await loadSessionRounds(safeSessionId, {
+        priority,
+        render: !shouldPreserveActiveSubagentView(safeSessionId),
+        scrollPolicy: roundsScrollPolicy || undefined,
+        signal,
+        timelineLoadMode: 'background',
+    });
+    throwIfAborted(signal);
+    if (state.currentSessionId !== safeSessionId) {
+        return null;
+    }
+    void hydrateSessionView(safeSessionId, {
+        includeRounds: false,
+        priority: '',
+        quiet,
+        signal,
+    }).catch(error => {
+        if (error?.name === 'AbortError') {
+            return;
+        }
+        if (!quiet) {
+            sysLog(`Failed to complete session hydration: ${error.message || error}`, 'log-error');
+        }
+    });
+    return null;
+}
+
 export function startSessionContinuity(sessionId = state.currentSessionId) {
     const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
     if (!safeSessionId) return;
@@ -545,22 +590,34 @@ export function markRunStreamConnected(runId, { phase = 'running' } = {}) {
 }
 
 export function markRunTerminalState(runId, { status, phase, recoverable } = {}) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return;
+    }
     const activeRun = getActiveRecoveryRun();
-    if (!activeRun || activeRun.run_id !== runId) {
-        if (!recoverable) {
+    const isRecoverable = recoverable !== false;
+    const terminalStatus = status || activeRun?.status || (isRecoverable ? 'stopped' : 'completed');
+    const terminalPhase = phase || activeRun?.phase || (isRecoverable ? 'stopped' : 'terminal');
+    const terminalOverlay = {
+        run_status: terminalStatus,
+        run_phase: terminalPhase,
+        is_recoverable: isRecoverable,
+        pending_tool_approval_count: 0,
+        pending_tool_approvals: [],
+    };
+    if (!activeRun || activeRun.run_id !== safeRunId) {
+        overlayRoundRecoveryState(safeRunId, terminalOverlay);
+        if (recoverable === false) {
             clearSessionRecovery();
         }
+        scheduleSessionsRefresh();
+        renderRecoveryBanner();
+        syncSessionContinuity();
         return;
     }
 
-    if (!recoverable) {
-        overlayRoundRecoveryState(runId, {
-            run_status: status || activeRun.status || 'completed',
-            run_phase: phase || activeRun.phase || 'terminal',
-            is_recoverable: false,
-            pending_tool_approval_count: 0,
-            pending_tool_approvals: [],
-        });
+    if (recoverable === false) {
+        overlayRoundRecoveryState(safeRunId, terminalOverlay);
         clearSessionRecovery();
         return;
     }
@@ -569,8 +626,8 @@ export function markRunTerminalState(runId, { status, phase, recoverable } = {})
         ...state.currentRecoverySnapshot,
         activeRun: {
             ...activeRun,
-            status: status || activeRun.status || 'stopped',
-            phase: phase || 'stopped',
+            status: terminalStatus,
+            phase: terminalPhase,
             is_recoverable: true,
             stream_connected: false,
             should_show_recover: true,
@@ -1011,8 +1068,37 @@ function shouldPollContinuity() {
         || hasUserQuestions
         || hasActiveBackgroundTasks
         || hasPausedSubagent
-        || activeRun?.is_recoverable
+        || isContinuityPollableRun(activeRun)
     );
+}
+
+function isContinuityPollableRun(activeRun) {
+    if (!activeRun || typeof activeRun !== 'object') return false;
+    if (activeRun.is_recoverable === false) return false;
+    if (isTerminalRecoveryRun(activeRun)) return false;
+    const status = String(activeRun.status || '').trim().toLowerCase();
+    const phase = String(activeRun.phase || '').trim().toLowerCase();
+    return [
+        'pending',
+        'queued',
+        'running',
+        'starting',
+        'stopping',
+        'awaiting_input',
+        'awaiting_tool_approval',
+        'awaiting_recovery',
+        'paused',
+    ].includes(status) || [
+        'pending',
+        'queued',
+        'running',
+        'starting',
+        'stopping',
+        'awaiting_input',
+        'awaiting_tool_approval',
+        'awaiting_recovery',
+        'paused',
+    ].includes(phase);
 }
 
 function nextContinuityPollDelay() {

--- a/frontend/dist/js/app/session.js
+++ b/frontend/dist/js/app/session.js
@@ -16,6 +16,7 @@ import {
     clearActiveSubagentSession,
     ensureSessionSubagents,
     getSessionSubagentSessions,
+    isSubagentSessionListExpanded,
     openSubagentSession,
 } from '../components/subagentSessions.js';
 import { fetchSessionHistory, markSessionTerminalRunViewed } from '../core/api.js';
@@ -24,6 +25,7 @@ import {
     hydrateSessionView,
     stopSessionContinuity,
 } from './recovery.js';
+import { hydrateMainSessionForSwitch } from './sessionView.js';
 import { applyCurrentSessionRecord, resetCurrentSessionTopology, state } from '../core/state.js';
 import {
     detachActiveStreamForSessionSwitch,
@@ -157,19 +159,10 @@ export async function selectSession(sessionId) {
     beginSessionSwitchLoading(selectionToken, safeSessionId);
 
     try {
-        const sessionRecordPromise = fetchSessionHistory(safeSessionId, {
+        const sessionRecord = await fetchSessionHistory(safeSessionId, {
             priority: 'high',
             signal: selectionSignal,
         });
-        sessionRecordPromise.catch(() => null);
-        const hydratePromise = hydrateSessionView(safeSessionId, {
-            includeRounds: true,
-            priority: 'high',
-            quiet: true,
-            signal: selectionSignal,
-        });
-        hydratePromise.catch(() => null);
-        const sessionRecord = await sessionRecordPromise;
         if (!isLatestSessionSelection(selectionToken, safeSessionId)) {
             return;
         }
@@ -177,7 +170,20 @@ export async function selectSession(sessionId) {
             || sessionRecordNeedsTerminalView(sessionRecord);
         applyCurrentSessionRecord(sessionRecord);
         refreshSessionTopologyControls();
-        await hydratePromise;
+        if (isSameSession) {
+            await hydrateSessionView(safeSessionId, {
+                includeRounds: true,
+                priority: 'high',
+                quiet: true,
+                signal: selectionSignal,
+            });
+        } else {
+            await hydrateMainSessionForSwitch(safeSessionId, {
+                priority: 'high',
+                quiet: true,
+                signal: selectionSignal,
+            });
+        }
         if (!isLatestSessionSelection(selectionToken, safeSessionId)) {
             return;
         }
@@ -195,10 +201,12 @@ export async function selectSession(sessionId) {
     }
     scheduleCoordinatorContextPreview({ immediate: true });
     scheduleSessionTokenUsageRefresh({ immediate: true });
-    void ensureSessionSubagents(safeSessionId, {
-        force: true,
-        signal: selectionSignal,
-    });
+    if (isSubagentSessionListExpanded(safeSessionId)) {
+        void ensureSessionSubagents(safeSessionId, {
+            force: false,
+            signal: selectionSignal,
+        });
+    }
     document.dispatchEvent(
         new CustomEvent('agent-teams-session-selected', {
             detail: { sessionId: safeSessionId },

--- a/frontend/dist/js/app/sessionView.js
+++ b/frontend/dist/js/app/sessionView.js
@@ -1,0 +1,150 @@
+/**
+ * app/sessionView.js
+ * View-level session hydration boundaries shared by main and subagent navigation.
+ */
+import {
+    hydrateSessionSwitchView,
+    hydrateSessionView,
+} from './recovery.js';
+import { state } from '../core/state.js';
+import { els } from '../utils/dom.js';
+import { t } from '../utils/i18n.js';
+import { sysLog } from '../utils/logger.js';
+
+let mainSessionRestoreController = null;
+let mainSessionRestoreToken = 0;
+
+export async function hydrateMainSessionForSwitch(
+    sessionId,
+    {
+        priority = 'high',
+        quiet = true,
+        roundsScrollPolicy = '',
+        signal = null,
+    } = {},
+) {
+    return hydrateSessionSwitchView(sessionId, {
+        priority,
+        quiet,
+        roundsScrollPolicy,
+        signal,
+    });
+}
+
+export async function restoreMainSessionView(sessionId, { quiet = true } = {}) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId) {
+        abortMainSessionRestore();
+        return null;
+    }
+
+    const restoreRequest = resetMainSessionRestoreController();
+    const restoreController = restoreRequest.controller;
+    const restoreToken = restoreRequest.token;
+    const restoreSignal = restoreController.signal;
+    showMainSessionLoadingPlaceholder(safeSessionId);
+    document.dispatchEvent(new CustomEvent('agent-teams-subagent-session-cleared', {
+        detail: { sessionId: safeSessionId },
+    }));
+    try {
+        const snapshot = await hydrateSessionView(safeSessionId, {
+            includeRounds: true,
+            quiet,
+            signal: restoreSignal,
+        });
+        if (
+            restoreSignal.aborted
+            || !isLatestMainSessionRestore(restoreToken, restoreController, safeSessionId)
+            || String(state.currentSessionId || '').trim() !== safeSessionId
+            || state.activeSubagentSession
+        ) {
+            return null;
+        }
+        document.dispatchEvent(new CustomEvent('agent-teams-session-activated', {
+            detail: { sessionId: safeSessionId },
+        }));
+        document.dispatchEvent(new CustomEvent('agent-teams-session-selected', {
+            detail: { sessionId: safeSessionId },
+        }));
+        return snapshot;
+    } catch (error) {
+        if (error?.name === 'AbortError') {
+            return null;
+        }
+        showMainSessionLoadFailed(safeSessionId);
+        sysLog(`Failed to return to main session: ${error.message || error}`, 'log-error');
+        return null;
+    } finally {
+        clearMainSessionRestoreController(restoreController);
+    }
+}
+
+export function abortMainSessionRestore() {
+    if (!mainSessionRestoreController) {
+        return;
+    }
+    mainSessionRestoreController.abort();
+    mainSessionRestoreController = null;
+    mainSessionRestoreToken += 1;
+}
+
+function resetMainSessionRestoreController() {
+    abortMainSessionRestore();
+    mainSessionRestoreController = new AbortController();
+    mainSessionRestoreToken += 1;
+    return {
+        controller: mainSessionRestoreController,
+        token: mainSessionRestoreToken,
+    };
+}
+
+function clearMainSessionRestoreController(controller) {
+    if (mainSessionRestoreController === controller) {
+        mainSessionRestoreController = null;
+    }
+}
+
+function isLatestMainSessionRestore(token, controller, sessionId) {
+    return !!(
+        mainSessionRestoreController === controller
+        && mainSessionRestoreToken === token
+        && !controller.signal.aborted
+        && String(state.currentSessionId || '').trim() === String(sessionId || '').trim()
+    );
+}
+
+function showMainSessionLoadingPlaceholder(sessionId) {
+    if (!els.chatMessages) {
+        return;
+    }
+    els.chatMessages.innerHTML = `
+        <div class="subagent-main-session-loading" data-session-id="${escapeAttribute(sessionId)}" role="status" aria-live="polite">
+            <span class="subagent-main-session-loading-spinner" aria-hidden="true"></span>
+            <span>${escapeHtml(t('session.loading'))}</span>
+        </div>
+    `;
+}
+
+function showMainSessionLoadFailed(sessionId) {
+    if (!els.chatMessages) {
+        return;
+    }
+    els.chatMessages.innerHTML = `
+        <div class="subagent-main-session-loading is-error" data-session-id="${escapeAttribute(sessionId)}" role="status">
+            <span>${escapeHtml(t('subagent_session.load_failed'))}</span>
+        </div>
+    `;
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
+function escapeAttribute(value) {
+    return escapeHtml(value);
+}

--- a/frontend/dist/js/components/contextIndicators.js
+++ b/frontend/dist/js/components/contextIndicators.js
@@ -133,9 +133,6 @@ async function fetchAndRenderUsage({
 }) {
     const nextRequestId = previewState.requestId + 1;
     previewState.requestId = nextRequestId;
-    if (previewState.controller) {
-        previewState.controller.abort();
-    }
 
     const controller = new AbortController();
     previewState.controller = controller;
@@ -146,9 +143,7 @@ async function fetchAndRenderUsage({
             fetchRunTokenUsage(sessionId, runId, {
                 signal: controller.signal,
             }),
-            fetchModelProfiles({
-                signal: controller.signal,
-            }),
+            fetchModelProfiles(),
         ]);
         if (previewState.requestId !== nextRequestId) return;
         const agentUsage = selectAgentUsage(usage, { roleId, instanceId });

--- a/frontend/dist/js/components/newSessionDraft.js
+++ b/frontend/dist/js/components/newSessionDraft.js
@@ -20,6 +20,10 @@ import { clearSessionTimeline } from './rounds/timeline.js';
 import { clearSessionTokenUsage } from './sessionTokenUsage.js';
 import { clearActiveSubagentSession } from './subagentSessions.js';
 import { renderNewSessionDraftView as renderNewSessionDraftMarkup } from './newSessionDraftView.js';
+import {
+    getSidebarDataSnapshot,
+    hasSidebarDataSnapshot,
+} from './sessionSidebarStore.js';
 import { els } from '../utils/dom.js';
 import { t } from '../utils/i18n.js';
 import { showTextInputDialog } from '../utils/feedback.js';
@@ -51,6 +55,7 @@ export function openNewSessionDraft(workspaceId) {
     bindLanguageRefresh();
     rememberComposerHome();
     draftWorkspaceError = '';
+    adoptSnapshotDraftWorkspaces();
     draftWorkspaceLoadState = draftWorkspaces.length > 0 ? 'ready' : 'loading';
 
     state.pendingNewSessionActive = true;
@@ -259,28 +264,54 @@ function bindLanguageRefresh() {
     });
 }
 
-async function refreshDraftWorkspaces({ preferredWorkspaceId = '' } = {}) {
+async function refreshDraftWorkspaces({ preferredWorkspaceId = '', force = false } = {}) {
+    if (force !== true && adoptSnapshotDraftWorkspaces()) {
+        applyDraftWorkspaceSelection(preferredWorkspaceId);
+        draftWorkspaceLoadState = 'ready';
+        draftWorkspaceError = '';
+        renderWorkspaceSelector();
+        return;
+    }
     draftWorkspaceLoadState = 'loading';
     draftWorkspaceError = '';
     renderWorkspaceSelector();
     try {
         const fetched = await fetchWorkspaces();
         draftWorkspaces = Array.isArray(fetched) ? fetched : [];
-        const preferred = String(preferredWorkspaceId || '').trim();
-        const selected = resolveSelectedWorkspaceId(preferred);
-        state.pendingNewSessionWorkspaceId = selected;
-        if (selected) {
-            state.currentWorkspaceId = selected;
-            document.dispatchEvent(new CustomEvent('agent-teams-draft-workspace-selected', {
-                detail: { workspaceId: selected },
-            }));
-        }
+        applyDraftWorkspaceSelection(preferredWorkspaceId);
         draftWorkspaceLoadState = 'ready';
         renderWorkspaceSelector();
     } catch (error) {
         draftWorkspaceLoadState = 'error';
         draftWorkspaceError = error?.message || String(error);
         renderWorkspaceSelector();
+    }
+}
+
+function adoptSnapshotDraftWorkspaces() {
+    if (!hasSidebarDataSnapshot()) {
+        return false;
+    }
+    const snapshotData = getSidebarDataSnapshot();
+    const workspaces = Array.isArray(snapshotData?.workspaces)
+        ? snapshotData.workspaces
+        : [];
+    if (workspaces.length === 0) {
+        return false;
+    }
+    draftWorkspaces = workspaces;
+    return true;
+}
+
+function applyDraftWorkspaceSelection(preferredWorkspaceId = '') {
+    const preferred = String(preferredWorkspaceId || '').trim();
+    const selected = resolveSelectedWorkspaceId(preferred);
+    state.pendingNewSessionWorkspaceId = selected;
+    if (selected) {
+        state.currentWorkspaceId = selected;
+        document.dispatchEvent(new CustomEvent('agent-teams-draft-workspace-selected', {
+            detail: { workspaceId: selected },
+        }));
     }
 }
 
@@ -373,7 +404,7 @@ async function addDraftWorkspace() {
         document.dispatchEvent(new CustomEvent('agent-teams-draft-workspace-added', {
             detail: { workspaceId, workspace },
         }));
-        await refreshDraftWorkspaces({ preferredWorkspaceId: workspaceId });
+        await refreshDraftWorkspaces({ preferredWorkspaceId: workspaceId, force: true });
     } catch (error) {
         draftWorkspaceError = error?.message || String(error);
         draftWorkspaceMenuOpen = false;

--- a/frontend/dist/js/components/rounds/paging.js
+++ b/frontend/dist/js/components/rounds/paging.js
@@ -10,6 +10,7 @@ export async function fetchInitialRoundsPage(sessionId, options = {}) {
     return fetchSessionRounds(sessionId, {
         limit: roundsState.pageSize,
         priority: options.priority,
+        summary: options.summary === true,
         signal: options.signal,
     });
 }

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -78,8 +78,12 @@ let chatScrollAnimationFrame = 0;
 let chatScrollAnimationToken = 0;
 let scrollToBottomControl = null;
 let historyLoadMoreResizeBound = false;
+let roundTokenUsageController = null;
+const terminalRoundOverlays = new Map();
 
 export function clearSessionTimeline() {
+    abortRoundTokenUsageRequests();
+    terminalRoundOverlays.clear();
     roundsState.currentRounds = [];
     roundsState.timelineRounds = [];
     roundsState.currentRound = null;
@@ -111,11 +115,17 @@ export async function loadSessionRounds(sessionId, options = {}) {
     const signal = options.signal || null;
     throwIfAborted(signal);
     const priority = String(options.priority || '').trim();
-    const timelinePageResult = fetchTimelineRoundsPage(sessionId, { priority, signal })
-        .then(value => ({ status: 'fulfilled', value }))
-        .catch(reason => ({ status: 'rejected', reason }));
+    const timelineLoadMode = options.timelineLoadMode === 'background' ? 'background' : 'await';
+    abortRoundTokenUsageRequests();
     try {
-        const page = await fetchInitialRoundsPage(sessionId, { priority, signal });
+        const timelinePageResult = timelineLoadMode === 'await'
+            ? fetchTimelineRoundPageResult(sessionId, { priority, signal })
+            : null;
+        const page = await fetchInitialRoundsPage(sessionId, {
+            priority,
+            signal,
+            summary: timelineLoadMode === 'background',
+        });
         throwIfAborted(signal);
         if (!isSessionLoadCurrent(sessionId)) {
             return;
@@ -127,14 +137,40 @@ export async function loadSessionRounds(sessionId, options = {}) {
         applyTimelineRoundPage(page);
         reconcileTerminalRoundStreamState(page);
         mergeLiveRoundsForSession(sessionId);
+        applyTerminalRoundOverlays();
         syncExportedState();
-        if (options.render !== false && !shouldPreserveSubagentView(sessionId)) {
-            renderSessionTimeline(roundsState.currentRounds, {
-                scrollPlan: renderPlan,
-                navigatorLayoutReason: renderPlan.navigatorLayoutReason,
+        renderLoadedRoundPage(sessionId, options, renderPlan);
+
+        if (timelineLoadMode === 'background') {
+            void applyFullRoundPageInBackground(sessionId, {
+                options,
+                renderPlan,
+                signal,
+            }).catch(error => {
+                if (error?.name === 'AbortError') {
+                    return;
+                }
+                logError(
+                    'frontend.rounds.full_page_load_failed',
+                    'Failed loading full round page',
+                    errorToPayload(error, { session_id: sessionId }),
+                );
             });
-        } else {
-            renderNavigatorForTimeline({ layoutReason: renderPlan.navigatorLayoutReason });
+            void applyTimelineRoundPageInBackground(sessionId, {
+                priority: '',
+                renderPlan,
+                signal,
+            }).catch(error => {
+                if (error?.name === 'AbortError') {
+                    return;
+                }
+                logError(
+                    'frontend.rounds.timeline_load_failed',
+                    'Failed loading timeline rounds',
+                    errorToPayload(error, { session_id: sessionId }),
+                );
+            });
+            return;
         }
 
         const timelineResult = await timelinePageResult;
@@ -142,19 +178,7 @@ export async function loadSessionRounds(sessionId, options = {}) {
         if (!isSessionLoadCurrent(sessionId)) {
             return;
         }
-        if (timelineResult.status === 'fulfilled') {
-            applyTimelineRoundPage(timelineResult.value);
-            reconcileTerminalRoundStreamState(timelineResult.value);
-            mergeLiveRoundsForSession(sessionId);
-            syncExportedState();
-            renderNavigatorForTimeline({ layoutReason: renderPlan.navigatorLayoutReason });
-        } else {
-            logError(
-                'frontend.rounds.timeline_load_failed',
-                'Failed loading timeline rounds',
-                errorToPayload(timelineResult.reason, { session_id: sessionId }),
-            );
-        }
+        applyTimelineRoundPageResult(sessionId, timelineResult, renderPlan);
     } catch (e) {
         if (e?.name === 'AbortError') {
             throw e;
@@ -165,6 +189,79 @@ export async function loadSessionRounds(sessionId, options = {}) {
             errorToPayload(e, { session_id: sessionId }),
         );
     }
+}
+
+function fetchTimelineRoundPageResult(sessionId, { priority = '', signal = null } = {}) {
+    return fetchTimelineRoundsPage(sessionId, { priority, signal })
+        .then(value => ({ status: 'fulfilled', value }))
+        .catch(reason => ({ status: 'rejected', reason }));
+}
+
+async function applyTimelineRoundPageInBackground(sessionId, { priority, renderPlan, signal }) {
+    const timelineResult = await fetchTimelineRoundPageResult(sessionId, { priority, signal });
+    throwIfAborted(signal);
+    if (!isSessionLoadCurrent(sessionId)) {
+        return;
+    }
+    applyTimelineRoundPageResult(sessionId, timelineResult, renderPlan);
+}
+
+async function applyFullRoundPageInBackground(sessionId, { options, renderPlan, signal }) {
+    const page = await fetchInitialRoundsPage(sessionId, { priority: '', signal });
+    throwIfAborted(signal);
+    if (!isSessionLoadCurrent(sessionId)) {
+        return;
+    }
+    applyRoundPage(page, {
+        prepend: false,
+        mergeExisting: renderPlan.preserveLoadedRounds,
+    });
+    reconcileTerminalRoundStreamState(page);
+    mergeLiveRoundsForSession(sessionId);
+    applyTerminalRoundOverlays();
+    syncExportedState();
+    renderLoadedRoundPage(sessionId, options, renderPlan);
+}
+
+function applyTimelineRoundPageResult(sessionId, timelineResult, renderPlan) {
+    if (timelineResult.status === 'fulfilled') {
+        applyTimelineRoundPage(timelineResult.value);
+        reconcileTerminalRoundStreamState(timelineResult.value);
+        mergeLiveRoundsForSession(sessionId);
+        applyTerminalRoundOverlays();
+        syncExportedState();
+        if (!shouldPreserveSubagentView(sessionId)) {
+            renderNavigatorForTimeline({ layoutReason: renderPlan.navigatorLayoutReason });
+        }
+        return;
+    }
+    logError(
+        'frontend.rounds.timeline_load_failed',
+        'Failed loading timeline rounds',
+        errorToPayload(timelineResult.reason, { session_id: sessionId }),
+    );
+}
+
+function renderLoadedRoundPage(sessionId, options, renderPlan) {
+    if (options.render !== false && !shouldPreserveSubagentView(sessionId)) {
+        renderSessionTimeline(roundsState.currentRounds, {
+            scrollPlan: renderPlan,
+            navigatorLayoutReason: renderPlan.navigatorLayoutReason,
+        });
+        return;
+    }
+    if (!shouldPreserveSubagentView(sessionId)) {
+        renderNavigatorForTimeline({ layoutReason: renderPlan.navigatorLayoutReason });
+    }
+}
+
+function abortRoundTokenUsageRequests() {
+    if (!roundTokenUsageController) {
+        roundTokenUsageController = new AbortController();
+        return;
+    }
+    roundTokenUsageController.abort();
+    roundTokenUsageController = new AbortController();
 }
 
 function reconcileTerminalRoundStreamState(page) {
@@ -309,6 +406,7 @@ function applyTerminalHistoryRound(sessionId, runId, round, options = {}) {
         ...round,
         __liveOnly: false,
     };
+    terminalRoundOverlays.delete(runId);
     roundsState.currentRounds = upsertRound(
         roundsState.currentRounds,
         runId,
@@ -461,7 +559,13 @@ function throwIfAborted(signal) {
 function isSessionLoadCurrent(sessionId) {
     const requestedSessionId = String(sessionId || '').trim();
     const currentSessionId = String(state.currentSessionId || '').trim();
-    return !currentSessionId || currentSessionId === requestedSessionId;
+    if (!requestedSessionId) {
+        return false;
+    }
+    if (state.pendingNewSessionActive === true || state.currentMainView === 'new-session-draft') {
+        return false;
+    }
+    return currentSessionId === requestedSessionId;
 }
 
 export function createLiveRound(runId, intentText, intentParts = null) {
@@ -884,12 +988,18 @@ export function overlayRoundRecoveryState(runId, overlay = {}) {
     const safeRunId = String(runId || '').trim();
     if (!safeRunId) return;
 
+    const overlayPatch = pickDefinedRoundOverlay(overlay);
+    syncTerminalRoundOverlay(safeRunId, overlayPatch);
     const roundIndex = roundsState.currentRounds.findIndex(round => round.run_id === safeRunId);
     const current = roundsState.currentRounds[roundIndex]
         || roundsState.timelineRounds.find(round => round.run_id === safeRunId);
-    if (!current) return;
+    if (!current) {
+        if (isTerminalRoundOverlay(overlayPatch)) {
+            reconcileTerminalRunStreamState(safeRunId);
+        }
+        return;
+    }
 
-    const overlayPatch = pickDefinedRoundOverlay(overlay);
     const nextRound = { ...current, ...overlayPatch };
     roundsState.currentRounds = roundsState.currentRounds.map(round =>
         round.run_id === safeRunId ? { ...round, ...overlayPatch } : round,
@@ -908,6 +1018,9 @@ export function overlayRoundRecoveryState(runId, overlay = {}) {
     if (roundIndex >= 0) {
         patchRoundHeader(nextRound, roundIndex);
     }
+    if (isTerminalRoundOverlay(overlayPatch)) {
+        reconcileTerminalRunStreamState(safeRunId);
+    }
     syncRetryTimelineTimer();
     renderNavigatorForTimeline();
     setActiveRoundNav(roundsState.activeRunId);
@@ -918,6 +1031,68 @@ export function overlayRoundRecoveryState(runId, overlay = {}) {
             : [];
         setRoundPendingApprovals(safeRunId, pendingApprovals);
     }
+}
+
+function syncTerminalRoundOverlay(runId, overlayPatch) {
+    if (typeof overlayPatch !== 'object') {
+        return;
+    }
+    if (isTerminalRoundOverlay(overlayPatch)) {
+        terminalRoundOverlays.set(runId, {
+            ...terminalRoundOverlays.get(runId),
+            ...overlayPatch,
+        });
+        return;
+    }
+    if (String(overlayPatch.run_status || '').trim()) {
+        terminalRoundOverlays.delete(runId);
+    }
+}
+
+function isTerminalRoundOverlay(overlayPatch) {
+    if (!overlayPatch || typeof overlayPatch !== 'object') {
+        return false;
+    }
+    return (
+        isTerminalRoundStatus(overlayPatch.run_status)
+        || overlayPatch.is_recoverable === false
+    );
+}
+
+function applyTerminalRoundOverlays() {
+    if (terminalRoundOverlays.size === 0) {
+        return;
+    }
+    terminalRoundOverlays.forEach((overlayPatch, runId) => {
+        const safeRunId = String(runId || '').trim();
+        if (!safeRunId) {
+            return;
+        }
+        let patched = false;
+        const patchCurrentRound = round => {
+            patched = true;
+            return { ...round, ...overlayPatch };
+        };
+        roundsState.currentRounds = patchRoundCollection(
+            roundsState.currentRounds,
+            safeRunId,
+            patchCurrentRound,
+        );
+        roundsState.timelineRounds = patchRoundCollection(
+            roundsState.timelineRounds,
+            safeRunId,
+            round => ({ ...round, ...overlayPatch }),
+        );
+        if (roundsState.currentRound?.run_id === safeRunId) {
+            roundsState.currentRound = {
+                ...roundsState.currentRound,
+                ...overlayPatch,
+            };
+        }
+        if (patched) {
+            reconcileTerminalRunStreamState(safeRunId);
+        }
+    });
 }
 
 export function updateRoundTodo(runId, todoSnapshot) {
@@ -1557,7 +1732,16 @@ function renderRoundSection(round, index) {
 
     if (state.currentSessionId) {
         const headerEl = header;
-        void fetchRunTokenUsage(state.currentSessionId, round.run_id).then(usage => {
+        const tokenSessionId = String(state.currentSessionId || '').trim();
+        const tokenRunId = String(round.run_id || '').trim();
+        const tokenSignal = roundTokenUsageController?.signal || null;
+        void fetchRunTokenUsage(tokenSessionId, tokenRunId, { signal: tokenSignal }).then(usage => {
+            if (
+                tokenSignal?.aborted
+                || String(state.currentSessionId || '').trim() !== tokenSessionId
+            ) {
+                return;
+            }
             if (!usage || usage.total_tokens === 0) return;
             const fmt = n => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
             const pill = document.createElement('div');
@@ -1575,6 +1759,10 @@ function renderRoundSection(round, index) {
             const tokenHost = headerEl.querySelector('.round-detail-token-host');
             if (tokenHost) {
                 tokenHost.appendChild(pill);
+            }
+        }).catch(error => {
+            if (error?.name === 'AbortError') {
+                return;
             }
         });
     }

--- a/frontend/dist/js/components/sessionTokenUsage.js
+++ b/frontend/dist/js/components/sessionTokenUsage.js
@@ -7,7 +7,7 @@ import { state } from '../core/state.js';
 import { els } from '../utils/dom.js';
 import { formatMessage, getCurrentLanguage, t } from '../utils/i18n.js';
 
-const REFRESH_DEBOUNCE_MS = 160;
+const REFRESH_DEBOUNCE_MS = 400;
 const EMPTY_TEXT = () => t('token_usage.empty');
 
 const refreshState = {

--- a/frontend/dist/js/components/sidebar.js
+++ b/frontend/dist/js/components/sidebar.js
@@ -82,6 +82,7 @@ const FEATURE_IDS = Object.freeze({
 let selectSessionHandler = null;
 let refreshTimer = null;
 let pendingSessionsRefreshForce = false;
+let pendingSessionsRefreshTrailingForce = false;
 const expandedProjectIds = new Set();
 const expandedProjectSessionIds = new Set();
 const initializedProjectIds = new Set();
@@ -98,6 +99,7 @@ let pendingSessionAnimation = null;
 let pendingSessionVisibilityAnimation = null;
 let loadProjectsRequestId = 0;
 let loadProjectsController = null;
+let sessionsRefreshPromise = null;
 let lastProjectsRenderSignature = '';
 let sidebarSelectionToken = 0;
 let sessionAnimationTokenSeed = 0;
@@ -1218,7 +1220,11 @@ async function handlePrimaryNewSessionClick() {
     const draftSelectionToken = sidebarSelectionToken;
     const currentWorkspaceId = String(state.currentWorkspaceId || '').trim();
     try {
-        const fetchedWorkspaces = await fetchWorkspaces();
+        const snapshotData = hasSidebarDataSnapshot() ? getSidebarDataSnapshot() : null;
+        const fetchedWorkspaces = Array.isArray(snapshotData?.workspaces)
+            && snapshotData.workspaces.length > 0
+            ? snapshotData.workspaces
+            : await fetchWorkspaces();
         if (!isLatestSidebarSelection(draftSelectionToken)) {
             return;
         }
@@ -2469,6 +2475,11 @@ export async function loadProjects({ forceRefresh = false } = {}) {
         if (loadProjectsController === controller) {
             loadProjectsController = null;
         }
+        if (pendingSessionsRefreshTrailingForce) {
+            const trailingForce = pendingSessionsRefreshTrailingForce;
+            pendingSessionsRefreshTrailingForce = false;
+            scheduleSessionsRefresh(120, { forceRefresh: trailingForce });
+        }
     }
 }
 
@@ -2484,8 +2495,52 @@ export function scheduleSessionsRefresh(delayMs = 120, { forceRefresh = false } 
             return;
         }
         pendingSessionsRefreshForce = false;
-        void loadProjects({ forceRefresh: forceNow });
+        void refreshSessionsSnapshot({ forceRefresh: forceNow });
     }, safeDelayMs);
+}
+
+async function refreshSessionsSnapshot({ forceRefresh = false } = {}) {
+    if (!els.projectsList) return;
+    if (!hasSidebarDataSnapshot()) {
+        await loadProjects({ forceRefresh });
+        return;
+    }
+    if (loadProjectsController || sessionsRefreshPromise) {
+        pendingSessionsRefreshTrailingForce = (
+            pendingSessionsRefreshTrailingForce
+            || forceRefresh === true
+        );
+        return;
+    }
+    sessionsRefreshPromise = (async () => {
+        try {
+            const sessions = await fetchSessions({ forceRefresh: forceRefresh === true });
+            const snapshotData = getSidebarDataSnapshot();
+            rememberSidebarDataSnapshot({
+                workspaces: snapshotData.workspaces,
+                sessions,
+                automationProjects: snapshotData.automationProjects,
+            });
+            renderProjectSidebarData(
+                snapshotData.workspaces,
+                sessions,
+                snapshotData.automationProjects,
+            );
+        } catch (error) {
+            if (error?.name === 'AbortError') {
+                return;
+            }
+            sysLog(formatMessage('sidebar.error.loading_projects', { error: error.message }), 'log-error');
+        } finally {
+            sessionsRefreshPromise = null;
+            if (pendingSessionsRefreshTrailingForce) {
+                const trailingForce = pendingSessionsRefreshTrailingForce;
+                pendingSessionsRefreshTrailingForce = false;
+                scheduleSessionsRefresh(120, { forceRefresh: trailingForce });
+            }
+        }
+    })();
+    await sessionsRefreshPromise;
 }
 
 export function toggleProjectSortMode() {

--- a/frontend/dist/js/components/subagentSessions.js
+++ b/frontend/dist/js/components/subagentSessions.js
@@ -3,7 +3,10 @@
  * Normal-mode subagent child-session cache, navigation, and read-only view.
  */
 import { fetchSessionSubagents } from '../core/api.js';
-import { hydrateSessionView } from '../app/recovery.js';
+import {
+    abortMainSessionRestore,
+    restoreMainSessionView,
+} from '../app/sessionView.js';
 import { syncNormalModeSubagentStreams } from '../core/stream.js';
 import { clearAllPanels } from './agentPanel.js';
 import { renderInstanceHistoryInto } from './agentPanel/history.js';
@@ -18,12 +21,13 @@ const loadingSessionIds = new Set();
 const loadingPromisesBySessionId = new Map();
 const expandedParentSessionIds = new Set();
 const terminalRefreshTimers = new Map();
+const queuedSubagentSessionLoads = [];
 let activeSubagentRenderSequence = 0;
 let activeSubagentRenderController = null;
-let mainSessionReturnController = null;
-let mainSessionReturnToken = 0;
 let subagentSessionsChangedFrame = 0;
 let pendingSubagentSessionsChangedDetail = null;
+let activeSubagentSessionLoadCount = 0;
+const MAX_PARALLEL_SUBAGENT_SESSION_LOADS = 2;
 const TERMINAL_REFRESH_DELAYS_MS = [120, 250, 500, 900, 1400];
 
 export function getSessionSubagentSessions(sessionId) {
@@ -64,7 +68,7 @@ export function clearActiveSubagentSession({ abortMainReturn = true } = {}) {
         activeSubagentRenderController = null;
     }
     if (abortMainReturn) {
-        abortMainSessionReturn();
+        abortMainSessionRestore();
     }
     cancelTerminalRefreshForInstance(getActiveSubagentSession()?.instanceId || '');
     state.activeSubagentSession = null;
@@ -111,7 +115,10 @@ export async function ensureSessionSubagents(
         });
     }
     const loadPromise = (async () => {
-        const payload = await fetchSessionSubagents(safeSessionId, { signal });
+        const payload = await runQueuedSubagentSessionLoad(
+            () => fetchSessionSubagents(safeSessionId, { signal }),
+            signal,
+        );
         throwIfAborted(signal);
         replaceSessionSubagents(safeSessionId, payload, { emitChange: false });
         return getSessionSubagentSessions(safeSessionId);
@@ -134,6 +141,63 @@ export async function ensureSessionSubagents(
                 sessionId: safeSessionId,
             });
         }
+    }
+}
+
+function runQueuedSubagentSessionLoad(operation, signal) {
+    throwIfAborted(signal);
+    if (activeSubagentSessionLoadCount < MAX_PARALLEL_SUBAGENT_SESSION_LOADS) {
+        return startSubagentSessionLoad(operation, signal);
+    }
+    return new Promise((resolve, reject) => {
+        const entry = {
+            operation,
+            signal,
+            resolve,
+            reject,
+            abortHandler: null,
+        };
+        entry.abortHandler = () => {
+            const index = queuedSubagentSessionLoads.indexOf(entry);
+            if (index >= 0) {
+                queuedSubagentSessionLoads.splice(index, 1);
+            }
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+        };
+        if (signal) {
+            signal.addEventListener('abort', entry.abortHandler, { once: true });
+        }
+        queuedSubagentSessionLoads.push(entry);
+        drainSubagentSessionLoadQueue();
+    });
+}
+
+async function startSubagentSessionLoad(operation, signal) {
+    throwIfAborted(signal);
+    activeSubagentSessionLoadCount += 1;
+    try {
+        return await operation();
+    } finally {
+        activeSubagentSessionLoadCount = Math.max(0, activeSubagentSessionLoadCount - 1);
+        drainSubagentSessionLoadQueue();
+    }
+}
+
+function drainSubagentSessionLoadQueue() {
+    while (
+        activeSubagentSessionLoadCount < MAX_PARALLEL_SUBAGENT_SESSION_LOADS
+        && queuedSubagentSessionLoads.length > 0
+    ) {
+        const entry = queuedSubagentSessionLoads.shift();
+        if (!entry) {
+            continue;
+        }
+        if (entry.signal && entry.abortHandler) {
+            entry.signal.removeEventListener('abort', entry.abortHandler);
+        }
+        startSubagentSessionLoad(entry.operation, entry.signal)
+            .then(entry.resolve)
+            .catch(entry.reject);
     }
 }
 
@@ -282,7 +346,7 @@ export async function openSubagentSession(sessionId, record) {
     if (!safeSessionId || normalized === null) {
         return;
     }
-    abortMainSessionReturn();
+    abortMainSessionRestore();
     state.activeSubagentSession = normalized;
     state.activeView = 'subagent-session';
     state.activeAgentRoleId = normalized.roleId;
@@ -309,44 +373,8 @@ export async function returnToMainSessionView() {
         clearActiveSubagentSession();
         return;
     }
-    const returnRequest = resetMainSessionReturnController();
-    const returnController = returnRequest.controller;
-    const returnToken = returnRequest.token;
-    const returnSignal = returnController.signal;
     clearActiveSubagentSession({ abortMainReturn: false });
-    showMainSessionLoadingPlaceholder(sessionId);
-    document.dispatchEvent(new CustomEvent('agent-teams-subagent-session-cleared', {
-        detail: { sessionId },
-    }));
-    try {
-        await hydrateSessionView(sessionId, {
-            includeRounds: true,
-            quiet: true,
-            signal: returnSignal,
-        });
-        if (
-            returnSignal.aborted
-            || !isLatestMainSessionReturn(returnToken, returnController, sessionId)
-            || String(state.currentSessionId || '').trim() !== sessionId
-            || state.activeSubagentSession
-        ) {
-            return;
-        }
-        document.dispatchEvent(new CustomEvent('agent-teams-session-activated', {
-            detail: { sessionId },
-        }));
-        document.dispatchEvent(new CustomEvent('agent-teams-session-selected', {
-            detail: { sessionId },
-        }));
-    } catch (error) {
-        if (error?.name === 'AbortError') {
-            return;
-        }
-        showMainSessionLoadFailed(sessionId);
-        sysLog(`Failed to return to main session: ${error.message || error}`, 'log-error');
-    } finally {
-        clearMainSessionReturnController(returnController);
-    }
+    await restoreMainSessionView(sessionId, { quiet: true });
 }
 
 export async function renderActiveSubagentSession(options = {}) {
@@ -633,40 +661,6 @@ function cancelTerminalRefreshForInstance(instanceId) {
     terminalRefreshTimers.delete(safeInstanceId);
 }
 
-function resetMainSessionReturnController() {
-    abortMainSessionReturn();
-    mainSessionReturnController = new AbortController();
-    mainSessionReturnToken += 1;
-    return {
-        controller: mainSessionReturnController,
-        token: mainSessionReturnToken,
-    };
-}
-
-function clearMainSessionReturnController(controller) {
-    if (mainSessionReturnController === controller) {
-        mainSessionReturnController = null;
-    }
-}
-
-function abortMainSessionReturn() {
-    if (!mainSessionReturnController) {
-        return;
-    }
-    mainSessionReturnController.abort();
-    mainSessionReturnController = null;
-    mainSessionReturnToken += 1;
-}
-
-function isLatestMainSessionReturn(token, controller, sessionId) {
-    return !!(
-        mainSessionReturnController === controller
-        && mainSessionReturnToken === token
-        && !controller.signal.aborted
-        && String(state.currentSessionId || '').trim() === String(sessionId || '').trim()
-    );
-}
-
 function isStillActiveSubagentRender(active, requestId) {
     return !!(
         requestId === activeSubagentRenderSequence
@@ -742,29 +736,6 @@ function setSubagentSessionLoading(instanceId, loading, wrapper = null) {
     if (loadingEl) {
         loadingEl.hidden = loading !== true;
     }
-}
-
-function showMainSessionLoadingPlaceholder(sessionId) {
-    if (!els.chatMessages) {
-        return;
-    }
-    els.chatMessages.innerHTML = `
-        <div class="subagent-main-session-loading" data-session-id="${escapeAttribute(sessionId)}" role="status" aria-live="polite">
-            <span class="subagent-main-session-loading-spinner" aria-hidden="true"></span>
-            <span>${escapeHtml(t('session.loading'))}</span>
-        </div>
-    `;
-}
-
-function showMainSessionLoadFailed(sessionId) {
-    if (!els.chatMessages) {
-        return;
-    }
-    els.chatMessages.innerHTML = `
-        <div class="subagent-main-session-loading is-error" data-session-id="${escapeAttribute(sessionId)}" role="status">
-            <span>${escapeHtml(t('subagent_session.load_failed'))}</span>
-        </div>
-    `;
 }
 
 function setElementClassFlag(element, className, enabled) {

--- a/frontend/dist/js/core/api/request.js
+++ b/frontend/dist/js/core/api/request.js
@@ -218,6 +218,21 @@ export function invalidateManagedRequests(prefix = '') {
     }
 }
 
+export function invalidateManagedRequestCache(prefix = '') {
+    const safePrefix = String(prefix || '').trim();
+    const shouldInvalidate = key => !safePrefix || String(key).startsWith(safePrefix);
+    for (const key of COALESCED_CACHE.keys()) {
+        if (shouldInvalidate(key)) {
+            deleteManagedCacheEntry(key);
+        }
+    }
+    for (const key of COALESCED_IN_FLIGHT.keys()) {
+        if (shouldInvalidate(key)) {
+            evictManagedInFlightEntry(COALESCED_IN_FLIGHT.get(key));
+        }
+    }
+}
+
 function normalizeRequestLane(lane) {
     const safeLane = String(lane || '').trim();
     if (Object.prototype.hasOwnProperty.call(REQUEST_LIMITS, safeLane)) {

--- a/frontend/dist/js/core/api/sessions.js
+++ b/frontend/dist/js/core/api/sessions.js
@@ -2,7 +2,12 @@
  * core/api/sessions.js
  * Session and history related API wrappers.
  */
-import { invalidateManagedRequests, requestJson, requestJsonManaged } from './request.js';
+import {
+    invalidateManagedRequestCache,
+    invalidateManagedRequests,
+    requestJson,
+    requestJsonManaged,
+} from './request.js';
 
 export async function fetchSessions(options = {}) {
     if (options.forceRefresh === true) {
@@ -27,7 +32,7 @@ export async function startNewSession(workspaceId) {
         },
         'Failed to create session',
     );
-    invalidateManagedRequests('sessions:');
+    invalidateManagedRequestCache('sessions:');
     return result;
 }
 
@@ -55,8 +60,8 @@ export async function markSessionTerminalRunViewed(sessionId, options = {}) {
         },
         'Failed to mark session run viewed',
     );
-    invalidateManagedRequests('sessions:list');
-    invalidateManagedRequests(`sessions:${safeSessionId}:record`);
+    invalidateManagedRequestCache('sessions:list');
+    invalidateManagedRequestCache(`sessions:${safeSessionId}:record`);
     return result;
 }
 
@@ -90,13 +95,23 @@ export async function updateSessionTopology(sessionId, payload) {
 
 export async function fetchSessionRounds(
     sessionId,
-    { limit = 8, cursorRunId = null, priority = '', timeline = false, signal = undefined } = {},
+    {
+        limit = 8,
+        cursorRunId = null,
+        priority = '',
+        timeline = false,
+        summary = false,
+        signal = undefined,
+    } = {},
 ) {
     const params = new URLSearchParams();
     if (timeline) {
         params.set('timeline', 'true');
     } else {
         params.set('limit', String(limit));
+    }
+    if (summary) {
+        params.set('summary', 'true');
     }
     if (cursorRunId) params.set('cursor_run_id', cursorRunId);
     const query = params.toString();

--- a/frontend/dist/js/core/api/system.js
+++ b/frontend/dist/js/core/api/system.js
@@ -349,7 +349,7 @@ export async function fetchModelProfiles(options = {}) {
             signal: options.signal,
         },
         'Failed to fetch model profiles',
-        { ttlMs: 2000 },
+        { ttlMs: 10000 },
     );
 }
 

--- a/frontend/dist/js/core/api/token_usage.js
+++ b/frontend/dist/js/core/api/token_usage.js
@@ -13,7 +13,7 @@ export async function fetchRunTokenUsage(sessionId, runId, options = {}) {
                 signal: options.signal,
             },
             'Failed to fetch run token usage',
-            { ttlMs: 700, lane: 'heavy' },
+            { ttlMs: 1500, lane: 'heavy' },
         );
     } catch (error) {
         if (error?.name === 'AbortError') {
@@ -32,7 +32,7 @@ export async function fetchSessionTokenUsage(sessionId, options = {}) {
                 signal: options.signal,
             },
             'Failed to fetch session token usage',
-            { ttlMs: 700, lane: 'heavy' },
+            { ttlMs: 1500, lane: 'heavy' },
         );
     } catch (error) {
         if (error?.name === 'AbortError') {

--- a/frontend/dist/js/core/eventRouter/index.js
+++ b/frontend/dist/js/core/eventRouter/index.js
@@ -64,7 +64,7 @@ export function routeEvent(evType, payload, eventMeta) {
     const displayableBackgroundTaskEvent = backgroundTaskEvent
         && isDisplayableBackgroundTaskPayload(payload);
     if (isSubagentRun && evType === 'token_usage') {
-        scheduleSessionTokenUsageRefresh({ immediate: true });
+        scheduleSessionTokenUsageRefresh({ immediate: false });
     }
     if (
         isSubagentRun
@@ -200,7 +200,7 @@ export function routeEvent(evType, payload, eventMeta) {
         }
         return;
     } else if (evType === 'token_usage') {
-        scheduleSessionTokenUsageRefresh({ immediate: true });
+        scheduleSessionTokenUsageRefresh({ immediate: false });
     } else if (evType === 'todo_updated') {
         updateRoundTodo(
             payload?.run_id || eventMeta?.run_id || eventMeta?.trace_id || '',
@@ -276,7 +276,7 @@ function scheduleContinuityRefreshForEvent(evType) {
     if (evType === 'run_started' || evType === 'run_resumed') {
         scheduleRecoveryContinuityRefresh({
             sessionId,
-            delayMs: 0,
+            delayMs: 300,
             forceRefresh: true,
             includeRounds: false,
             quiet: true,
@@ -314,9 +314,6 @@ function scheduleContinuityRefreshForEvent(evType) {
         || evType === 'llm_retry_exhausted'
         || evType === 'llm_fallback_activated'
         || evType === 'llm_fallback_exhausted'
-        || evType === 'tool_result'
-        || evType === 'output_delta'
-        || evType === 'generation_progress'
         || evType === 'tool_approval_requested'
         || evType === 'tool_approval_resolved'
         || evType === 'user_question_requested'
@@ -328,7 +325,7 @@ function scheduleContinuityRefreshForEvent(evType) {
     ) {
         scheduleRecoveryContinuityRefresh({
             sessionId,
-            delayMs: 0,
+            delayMs: 350,
             forceRefresh: true,
             includeRounds: false,
             quiet: true,
@@ -356,7 +353,7 @@ function scheduleContinuityRefreshForEvent(evType) {
     if (evType === 'run_completed' || evType === 'run_failed' || evType === 'run_stopped') {
         scheduleRecoveryContinuityRefresh({
             sessionId,
-            delayMs: 0,
+            delayMs: 650,
             forceRefresh: true,
             includeRounds: false,
             quiet: true,

--- a/frontend/dist/js/core/stream.js
+++ b/frontend/dist/js/core/stream.js
@@ -3,7 +3,6 @@
  * Creates a run via HTTP, then subscribes to run events over SSE.
  */
 import {
-    fetchSessionRecovery,
     fetchSessionSubagents,
     fetchSessions,
     sendUserPrompt,
@@ -39,6 +38,15 @@ let activeStreamSessionId = '';
 let activeConnection = null;
 const backgroundStreams = new Map();
 const pendingBackgroundAttachRunIds = new Set();
+let multiplexEventSource = null;
+let multiplexReconnectTimer = null;
+let multiplexConnectionSignature = '';
+let multiplexReconnectDelayMs = 900;
+let multiplexSyncSuspendDepth = 0;
+let multiplexSyncPendingReason = '';
+const runStreamLastEventIds = new Map();
+const runStreamAttention = new Map();
+let runStreamAttentionSequence = 0;
 const normalModeSubagentStreams = new Map();
 let normalModeSubagentConnection = null;
 let backgroundDiscoveryTimer = null;
@@ -53,8 +61,8 @@ const unavailableSessionCooldownUntil = new Map();
 const SESSION_NOT_FOUND_COOLDOWN_MS = 30000;
 const unavailableRunCooldownUntil = new Map();
 const RUN_NOT_FOUND_COOLDOWN_MS = 30000;
-// Keep some room in the browser connection pool for control actions like stop.
-const MAX_BACKGROUND_STREAMS = 2;
+const MAX_MULTIPLEX_RUN_STREAMS = 32;
+const MULTIPLEX_RECONNECT_MAX_DELAY_MS = 5000;
 const FOREGROUND_NAVIGATION_STREAM_PAUSE_MS = 1200;
 const NORMAL_MODE_SUBAGENT_DISCOVERY_DELAY_MS = 2500;
 const NORMAL_MODE_SUBAGENT_RECONNECT_DELAY_MS = 900;
@@ -248,7 +256,7 @@ export function detachActiveStreamForSessionSwitch(options = {}) {
     if (detachPendingRunStartForSessionSwitch(options)) {
         return true;
     }
-    if (!activeConnection?.runId || !activeConnection?.eventSource) {
+    if (!activeConnection?.runId) {
         endStream({
             preserveRunStreamState: true,
             focusPrompt: options.focusPrompt !== false,
@@ -262,6 +270,7 @@ export function detachActiveStreamForSessionSwitch(options = {}) {
     connection.sessionId = String(
         activeStreamSessionId || state.currentSessionId || connection.sessionId || '',
     ).trim();
+    touchRunStreamAttention(connection.runId);
     backgroundStreams.set(connection.runId, connection);
     activeConnection = null;
     state.activeEventSource = null;
@@ -279,18 +288,17 @@ export function prepareStreamsForForegroundNavigation(sessionId = '') {
         Date.now() + FOREGROUND_NAVIGATION_STREAM_PAUSE_MS,
     );
     rescheduleBackgroundDiscoveryAfterPause();
-    let keptTargetBackground = false;
-    Array.from(backgroundStreams.values()).forEach(connection => {
-        if (
-            targetSessionId
-            && connection?.sessionId === targetSessionId
-            && !keptTargetBackground
-        ) {
-            keptTargetBackground = true;
-            return;
-        }
-        finishBackgroundConnection(connection, { rediscover: false, refreshSidebar: false });
-    });
+    const targetBackground = Array.from(backgroundStreams.values()).find(connection => (
+        targetSessionId
+        && connection?.sessionId === targetSessionId
+        && !connection.closed
+        && !connection.terminal
+    ));
+    if (targetBackground) {
+        touchRunStreamAttention(targetBackground.runId);
+    }
+    enforceMultiplexRunBudget(targetBackground?.runId || '');
+    requestMultiplexRunConnection('foreground-navigation');
 
     if (
         normalModeSubagentConnection
@@ -373,7 +381,8 @@ export function attachRunStream(runId, sessionId = state.currentSessionId, onCom
         return;
     }
     const sameRunAlreadyStreaming = !!(
-        state.activeEventSource
+        activeConnection
+        && activeConnection.runId === safeRunId
         && state.activeRunId === safeRunId
         && state.isGenerating
     );
@@ -382,7 +391,7 @@ export function attachRunStream(runId, sessionId = state.currentSessionId, onCom
     }
 
     const backgroundConnection = backgroundStreams.get(safeRunId);
-    if (backgroundConnection && backgroundConnection.eventSource) {
+    if (backgroundConnection && !backgroundConnection.closed) {
         releaseActiveStreamHandle({ close: true });
         promoteBackgroundStream(backgroundConnection, {
             sessionId,
@@ -553,24 +562,20 @@ function releaseActiveStreamHandle(options = {}) {
     const activeRunId = String(state.activeRunId || '').trim();
     if (activeConnection) {
         clearReconnectTimer(activeConnection);
-        if (activeConnection.eventSource && options.close !== false) {
-            activeConnection.eventSource.close();
-        }
         if (options.close !== false) {
             activeConnection.eventSource = null;
             activeConnection.closed = true;
         }
         activeConnection = null;
-    } else if (state.activeEventSource && options.close !== false) {
-        state.activeEventSource.close();
     }
     state.activeEventSource = null;
     activeStreamSessionId = '';
+    requestMultiplexRunConnection('release-active');
     return activeRunId;
 }
 
 function promoteBackgroundStream(connection, options = {}) {
-    if (!connection || !connection.eventSource) {
+    if (!connection || connection.closed || connection.terminal) {
         return;
     }
     backgroundStreams.delete(connection.runId);
@@ -581,117 +586,311 @@ function promoteBackgroundStream(connection, options = {}) {
     connection.primaryLabel = String(getRunPrimaryRoleLabel(connection.runId) || connection.primaryLabel || 'Main Agent');
     activeConnection = connection;
     state.activeRunId = connection.runId;
-    state.activeEventSource = connection.eventSource;
+    connection.eventSource = multiplexEventSource;
+    state.activeEventSource = multiplexEventSource;
     activeStreamSessionId = connection.sessionId;
+    touchRunStreamAttention(connection.runId);
     if (options.makeUiBusy !== false) {
         setStreamUiBusy(true);
     }
+    requestMultiplexRunConnection('promote-background');
     ensureBackgroundDiscoveryLoop();
 }
 
 function openRunStreamConnection(connection, { reason, afterEventId = null } = {}) {
-    const urlParams = afterEventId !== null ? `?after_event_id=${afterEventId}` : '';
-    const url = `/api/runs/${connection.runId}/events${urlParams}`;
-    logInfo('frontend.sse.opened', 'Run event stream opened', {
-        run_id: connection.runId,
-        reason,
-        url,
-        mode: connection.mode,
-    });
-    sysLog(`SSE ${reason} run=${connection.runId}`);
-    const es = new EventSource(url);
-    connection.eventSource = es;
+    const resolvedAfterEventId = afterEventId !== null
+        ? afterEventId
+        : Number(runStreamLastEventIds.get(connection.runId) || connection.lastEventId || 0);
+    connection.lastEventId = Math.max(
+        Number(connection.lastEventId || 0),
+        Number(resolvedAfterEventId || 0),
+    );
+    if (connection.lastEventId > 0) {
+        runStreamLastEventIds.set(connection.runId, connection.lastEventId);
+    }
+    connection.eventSource = multiplexEventSource;
     connection.closed = false;
     connection.terminal = false;
     clearReconnectTimer(connection);
+    touchRunStreamAttention(connection.runId);
 
     if (connection.mode === 'active') {
         activeConnection = connection;
-        state.activeEventSource = es;
         state.activeRunId = connection.runId;
+        state.activeEventSource = multiplexEventSource;
         activeStreamSessionId = connection.sessionId;
     } else {
         backgroundStreams.set(connection.runId, connection);
     }
+    enforceMultiplexRunBudget(connection.runId);
+    requestMultiplexRunConnection(reason || connection.mode || 'run');
     ensureBackgroundDiscoveryLoop();
     if (connection.mode === 'active') {
         ensureNormalModeSubagentDiscoveryLoop();
     }
+}
 
-    es.onmessage = (event) => {
+function requestMultiplexRunConnection(reason = 'sync') {
+    if (multiplexSyncSuspendDepth > 0) {
+        multiplexSyncPendingReason = multiplexSyncPendingReason || reason;
+        return;
+    }
+    ensureMultiplexRunConnection(reason);
+}
+
+function beginMultiplexSyncBatch() {
+    multiplexSyncSuspendDepth += 1;
+}
+
+function endMultiplexSyncBatch(reason = 'sync') {
+    multiplexSyncSuspendDepth = Math.max(0, multiplexSyncSuspendDepth - 1);
+    if (multiplexSyncSuspendDepth > 0) {
+        return;
+    }
+    const pendingReason = multiplexSyncPendingReason || reason;
+    multiplexSyncPendingReason = '';
+    ensureMultiplexRunConnection(pendingReason);
+}
+
+function ensureMultiplexRunConnection(reason = 'sync') {
+    const desiredConnections = desiredMultiplexRunConnections();
+    if (desiredConnections.length === 0) {
+        closeMultiplexRunConnection();
+        return;
+    }
+    const signature = multiplexConnectionSignatureFor(desiredConnections);
+    if (multiplexEventSource && multiplexConnectionSignature === signature) {
+        syncMultiplexEventSourceHandle();
+        return;
+    }
+    closeMultiplexRunConnection({ clearSignature: false });
+    const url = multiplexRunEventsUrl(desiredConnections);
+    multiplexConnectionSignature = signature;
+    logInfo('frontend.sse.multiplex_opened', 'Multiplex run event stream opened', {
+        reason,
+        url,
+        run_count: desiredConnections.length,
+    });
+    sysLog(`SSE multiplex ${reason} runs=${desiredConnections.length}`);
+    const es = new EventSource(url);
+    multiplexEventSource = es;
+    multiplexReconnectDelayMs = 900;
+    syncMultiplexEventSourceHandle();
+
+    es.onmessage = event => {
         try {
             const data = JSON.parse(event.data);
             if (data.error) {
-                if (isRunNotFoundError(data.error)) {
-                    markRunUnavailable(connection.runId);
-                }
-                logError('frontend.sse.payload_error', 'Run stream returned error', {
-                    run_id: connection.runId,
+                logError('frontend.sse.multiplex_payload_error', 'Multiplex run stream returned error', {
                     error: data.error,
-                    mode: connection.mode,
                 });
                 sysLog(`Run stream error: ${data.error}`, 'log-error');
-                if (connection.mode === 'active') {
-                    finishActiveConnection(connection);
-                } else {
-                    finishBackgroundConnection(connection);
-                }
+                scheduleMultiplexReconnect();
                 return;
             }
-
-            const eventId = Number(data.event_id || 0);
-            if (eventId > 0) {
-                connection.lastEventId = Math.max(connection.lastEventId, eventId);
-            }
-
-            const evType = data.event_type;
-            const payload = JSON.parse(data.payload_json || '{}');
-            if (connection.mode === 'background') {
-                applyBackgroundRunEvent(connection, evType, payload, data);
-            } else {
-                routeEvent(evType, payload, data);
-            }
-
-            if (isTerminalRunEvent(evType)) {
-                logInfo('frontend.sse.terminal_event', 'Run stream reached terminal event', {
-                    run_id: connection.runId,
-                    event_type: evType,
-                    mode: connection.mode,
-                });
-                connection.terminal = true;
-                if (connection.mode === 'active') {
-                    finishActiveConnection(connection);
-                } else {
-                    finishBackgroundConnection(connection);
-                }
-            }
+            applyMultiplexRunEvent(data);
         } catch (e) {
             logError(
-                'frontend.sse.parse_error',
-                'SSE parse error',
-                errorToPayload(e, { run_id: connection.runId, raw: event.data, mode: connection.mode }),
+                'frontend.sse.multiplex_parse_error',
+                'Multiplex SSE parse error',
+                errorToPayload(e, { raw: event.data }),
             );
         }
     };
 
     es.onerror = () => {
-        if (connection.closed || connection.terminal) return;
-        logWarn('frontend.sse.closed', 'Run event stream closed', {
-            run_id: connection.runId,
-            mode: connection.mode,
-        });
-        sysLog('SSE closed.', 'log-error');
-        if (connection.mode === 'active') {
-            finishActiveConnection(connection, { preserveRunStreamState: true });
+        if (multiplexEventSource !== es) {
             return;
         }
-        backgroundStreams.set(connection.runId, connection);
-        if (connection.eventSource) {
-            connection.eventSource.close();
-            connection.eventSource = null;
-        }
-        scheduleBackgroundReconnect(connection);
+        logWarn('frontend.sse.multiplex_closed', 'Multiplex run event stream closed', {
+            run_count: desiredMultiplexRunConnections().length,
+        });
+        sysLog('SSE multiplex closed.', 'log-error');
+        multiplexEventSource.close();
+        multiplexEventSource = null;
+        multiplexConnectionSignature = '';
+        syncMultiplexEventSourceHandle();
+        scheduleMultiplexReconnect();
     };
+}
+
+function applyMultiplexRunEvent(data) {
+    const runId = String(data.run_id || data.trace_id || '').trim();
+    if (!runId) {
+        return;
+    }
+    clearRunUnavailableCooldown(runId);
+    const connection = resolveRunConnection(runId);
+    if (!connection || connection.closed) {
+        return;
+    }
+    const eventId = Number(data.event_id || 0);
+    if (eventId > 0) {
+        connection.lastEventId = Math.max(connection.lastEventId || 0, eventId);
+        runStreamLastEventIds.set(runId, connection.lastEventId);
+    }
+    const evType = data.event_type;
+    const payload = JSON.parse(data.payload_json || '{}');
+    if (connection.mode === 'active') {
+        routeEvent(evType, payload, data);
+    } else {
+        applyBackgroundRunEvent(connection, evType, payload, data);
+    }
+
+    if (isTerminalRunEvent(evType)) {
+        logInfo('frontend.sse.terminal_event', 'Run stream reached terminal event', {
+            run_id: runId,
+            event_type: evType,
+            mode: connection.mode,
+        });
+        connection.terminal = true;
+        if (connection.mode === 'active') {
+            finishActiveConnection(connection);
+        } else {
+            finishBackgroundConnection(connection);
+        }
+    }
+}
+
+function scheduleMultiplexReconnect() {
+    if (multiplexReconnectTimer || desiredMultiplexRunConnections().length === 0) {
+        return;
+    }
+    multiplexReconnectTimer = setTimeout(() => {
+        multiplexReconnectTimer = null;
+        const hasDesiredConnections = desiredMultiplexRunConnections().length > 0;
+        if (!hasDesiredConnections) {
+            closeMultiplexRunConnection();
+            return;
+        }
+        multiplexConnectionSignature = '';
+        ensureMultiplexRunConnection('multiplex-reconnect');
+        multiplexReconnectDelayMs = Math.min(
+            MULTIPLEX_RECONNECT_MAX_DELAY_MS,
+            Math.max(900, multiplexReconnectDelayMs * 2),
+        );
+    }, multiplexReconnectDelayMs);
+    multiplexReconnectTimer.unref?.();
+}
+
+function closeMultiplexRunConnection(options = {}) {
+    if (multiplexReconnectTimer) {
+        clearTimeout(multiplexReconnectTimer);
+        multiplexReconnectTimer = null;
+    }
+    if (multiplexEventSource) {
+        multiplexEventSource.close();
+        multiplexEventSource = null;
+    }
+    if (options.clearSignature !== false) {
+        multiplexConnectionSignature = '';
+    }
+    syncMultiplexEventSourceHandle();
+}
+
+function syncMultiplexEventSourceHandle() {
+    const es = multiplexEventSource;
+    if (activeConnection && !activeConnection.closed && !activeConnection.terminal) {
+        activeConnection.eventSource = es;
+        state.activeEventSource = es;
+    } else {
+        state.activeEventSource = null;
+    }
+    backgroundStreams.forEach(connection => {
+        if (!connection.closed && !connection.terminal) {
+            connection.eventSource = es;
+        }
+    });
+}
+
+function desiredMultiplexRunConnections() {
+    const connections = [];
+    if (activeConnection && !activeConnection.closed && !activeConnection.terminal) {
+        connections.push(activeConnection);
+    }
+    Array.from(backgroundStreams.values())
+        .filter(connection => connection && !connection.closed && !connection.terminal)
+        .sort(compareRunStreamAttention)
+        .forEach(connection => {
+            if (!connections.some(item => item.runId === connection.runId)) {
+                connections.push(connection);
+            }
+        });
+    return connections.slice(0, MAX_MULTIPLEX_RUN_STREAMS);
+}
+
+function multiplexConnectionSignatureFor(connections) {
+    return connections
+        .map(connection => connection.runId)
+        .join('|');
+}
+
+function multiplexRunEventsUrl(connections) {
+    const params = new URLSearchParams();
+    connections.forEach(connection => {
+        params.append('run_id', connection.runId);
+        params.append(
+            'after_event_id',
+            String(Number(connection.lastEventId || runStreamLastEventIds.get(connection.runId) || 0)),
+        );
+    });
+    return `/api/runs/events?${params.toString()}`;
+}
+
+function resolveRunConnection(runId) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return null;
+    }
+    if (activeConnection?.runId === safeRunId) {
+        return activeConnection;
+    }
+    return backgroundStreams.get(safeRunId) || null;
+}
+
+function enforceMultiplexRunBudget(preferredRunId = '') {
+    const preferred = String(preferredRunId || '').trim();
+    const hiddenConnections = Array.from(backgroundStreams.values())
+        .filter(connection => connection && !connection.closed && !connection.terminal)
+        .sort(compareRunStreamAttention);
+    const maxHidden = Math.max(
+        0,
+        MAX_MULTIPLEX_RUN_STREAMS - (activeConnection && !activeConnection.closed ? 1 : 0),
+    );
+    hiddenConnections.slice(maxHidden).forEach(connection => {
+        if (preferred && connection.runId === preferred) {
+            const replacement = hiddenConnections
+                .slice(0, maxHidden)
+                .reverse()
+                .find(item => item.runId !== preferred);
+            if (replacement) {
+                finishBackgroundConnection(replacement, { rediscover: false, refreshSidebar: false });
+            }
+            return;
+        }
+        finishBackgroundConnection(connection, { rediscover: false, refreshSidebar: false });
+    });
+}
+
+function compareRunStreamAttention(left, right) {
+    return runStreamAttentionValue(right) - runStreamAttentionValue(left);
+}
+
+function runStreamAttentionValue(connection) {
+    const runId = String(connection?.runId || '').trim();
+    if (!runId) {
+        return 0;
+    }
+    return Number(runStreamAttention.get(runId) || 0);
+}
+
+function touchRunStreamAttention(runId) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return;
+    }
+    runStreamAttentionSequence += 1;
+    runStreamAttention.set(safeRunId, runStreamAttentionSequence);
 }
 
 function finishActiveConnection(connection, finishOptions = {}) {
@@ -699,10 +898,10 @@ function finishActiveConnection(connection, finishOptions = {}) {
     const expectedToolCallIds = collectCoordinatorOverlayToolCallIds(connection.runId);
     connection.closed = true;
     clearReconnectTimer(connection);
-    if (connection.eventSource) {
+    if (connection.eventSource && connection.eventSource !== multiplexEventSource) {
         connection.eventSource.close();
-        connection.eventSource = null;
     }
+    connection.eventSource = null;
     if (activeConnection === connection) {
         activeConnection = null;
     }
@@ -713,6 +912,7 @@ function finishActiveConnection(connection, finishOptions = {}) {
         activeStreamSessionId = '';
     }
     endStream(finishOptions);
+    requestMultiplexRunConnection('finish-active');
     ensureNormalModeSubagentDiscoveryLoop();
     if (typeof connection.onCompleted === 'function') {
         Promise.resolve()
@@ -769,11 +969,12 @@ function finishBackgroundConnection(connection, { rediscover = true, refreshSide
     if (!connection || connection.closed) return;
     connection.closed = true;
     clearReconnectTimer(connection);
-    if (connection.eventSource) {
+    if (connection.eventSource && connection.eventSource !== multiplexEventSource) {
         connection.eventSource.close();
-        connection.eventSource = null;
     }
+    connection.eventSource = null;
     backgroundStreams.delete(connection.runId);
+    requestMultiplexRunConnection('finish-background');
     if (refreshSidebar) {
         scheduleSessionsRefresh();
     }
@@ -839,7 +1040,12 @@ function applyBackgroundRunEvent(connection, evType, payload, eventMeta) {
 }
 
 function isTerminalRunEvent(evType) {
-    return evType === 'run_completed' || evType === 'run_failed' || evType === 'run_stopped';
+    return (
+        evType === 'run_completed'
+        || evType === 'run_failed'
+        || evType === 'run_stopped'
+        || evType === 'run_paused'
+    );
 }
 
 function ensureBackgroundDiscoveryLoop() {
@@ -982,8 +1188,9 @@ function shouldRunBackgroundDiscovery() {
     return !!(
         activeConnection
         || backgroundStreams.size > 0
+        || pendingBackgroundAttachRunIds.size > 0
         || state.isGenerating
-        || String(state.currentSessionId || '').trim()
+        || pendingRunStart
     );
 }
 
@@ -1027,73 +1234,87 @@ async function reconcileBackgroundStreams(sessionRecords = []) {
     if (isBackgroundDiscoveryPaused()) {
         return;
     }
-    const records = Array.isArray(sessionRecords) ? sessionRecords : [];
-    const focusedRunId = String(activeConnection?.runId || '').trim();
-    const backgroundRunIds = new Set();
-    backgroundStreams.forEach(connection => {
-        if (connection?.runId) {
-            backgroundRunIds.add(connection.runId);
+    beginMultiplexSyncBatch();
+    try {
+        const records = Array.isArray(sessionRecords) ? sessionRecords : [];
+        const focusedRunId = String(activeConnection?.runId || '').trim();
+        const backgroundRunIds = new Set();
+        backgroundStreams.forEach(connection => {
+            if (connection?.runId) {
+                backgroundRunIds.add(connection.runId);
+            }
+        });
+        pendingBackgroundAttachRunIds.forEach(runId => {
+            if (runId) {
+                backgroundRunIds.add(runId);
+            }
+        });
+
+        const candidates = [];
+        for (const rawRecord of records) {
+            const record = rawRecord && typeof rawRecord === 'object' ? rawRecord : null;
+            const sessionId = String(record?.session_id || '').trim();
+            const runId = String(record?.active_run_id || '').trim();
+            const status = String(record?.active_run_status || '').trim();
+            if (!sessionId || !runId) {
+                continue;
+            }
+            if (isSessionUnavailable(sessionId)) {
+                continue;
+            }
+            if (isRunUnavailable(runId)) {
+                continue;
+            }
+            if (status !== 'running' && status !== 'queued') {
+                continue;
+            }
+            candidates.push(record);
         }
-    });
-    pendingBackgroundAttachRunIds.forEach(runId => {
-        if (runId) {
+
+        candidates.sort((left, right) => {
+            const leftRunId = String(left?.active_run_id || '').trim();
+            const rightRunId = String(right?.active_run_id || '').trim();
+            const attentionDelta = Number(runStreamAttention.get(rightRunId) || 0)
+                - Number(runStreamAttention.get(leftRunId) || 0);
+            if (attentionDelta !== 0) {
+                return attentionDelta;
+            }
+            return backgroundRecordTimestamp(right) - backgroundRecordTimestamp(left);
+        });
+
+        const desiredRunIds = new Set();
+        for (const record of candidates) {
+            const runId = String(record?.active_run_id || '').trim();
+            if (!runId) {
+                continue;
+            }
+            if (focusedRunId && runId === focusedRunId) {
+                desiredRunIds.add(runId);
+                continue;
+            }
+            if (desiredRunIds.size >= MAX_MULTIPLEX_RUN_STREAMS) {
+                break;
+            }
+            desiredRunIds.add(runId);
+            if (backgroundRunIds.has(runId)) {
+                continue;
+            }
+            attachBackgroundStreamForSession(record);
             backgroundRunIds.add(runId);
         }
-    });
 
-    const candidates = [];
-    for (const rawRecord of records) {
-        const record = rawRecord && typeof rawRecord === 'object' ? rawRecord : null;
-        const sessionId = String(record?.session_id || '').trim();
-        const runId = String(record?.active_run_id || '').trim();
-        const status = String(record?.active_run_status || '').trim();
-        if (!sessionId || !runId) {
-            continue;
-        }
-        if (isSessionUnavailable(sessionId)) {
-            continue;
-        }
-        if (isRunUnavailable(runId)) {
-            continue;
-        }
-        if (status !== 'running' && status !== 'queued') {
-            continue;
-        }
-        candidates.push(record);
+        Array.from(backgroundStreams.values()).forEach(connection => {
+            if (!connection?.runId) {
+                return;
+            }
+            if (desiredRunIds.has(connection.runId)) {
+                return;
+            }
+            finishBackgroundConnection(connection);
+        });
+    } finally {
+        endMultiplexSyncBatch('background-reconcile');
     }
-
-    candidates.sort((left, right) => backgroundRecordTimestamp(right) - backgroundRecordTimestamp(left));
-
-    const desiredRunIds = new Set();
-    for (const record of candidates) {
-        const runId = String(record?.active_run_id || '').trim();
-        if (!runId) {
-            continue;
-        }
-        if (focusedRunId && runId === focusedRunId) {
-            desiredRunIds.add(runId);
-            continue;
-        }
-        if (desiredRunIds.size >= MAX_BACKGROUND_STREAMS) {
-            break;
-        }
-        desiredRunIds.add(runId);
-        if (backgroundRunIds.has(runId)) {
-            continue;
-        }
-        await attachBackgroundStreamForSession(record);
-        backgroundRunIds.add(runId);
-    }
-
-    Array.from(backgroundStreams.values()).forEach(connection => {
-        if (!connection?.runId) {
-            return;
-        }
-        if (desiredRunIds.has(connection.runId)) {
-            return;
-        }
-        finishBackgroundConnection(connection);
-    });
 }
 
 function backgroundRecordTimestamp(record) {
@@ -1105,7 +1326,7 @@ function backgroundRecordTimestamp(record) {
     return Number.isNaN(parsed) ? 0 : parsed;
 }
 
-async function attachBackgroundStreamForSession(record) {
+function attachBackgroundStreamForSession(record) {
     const sessionId = String(record?.session_id || '').trim();
     const runId = String(record?.active_run_id || '').trim();
     if (!sessionId || !runId) {
@@ -1125,35 +1346,18 @@ async function attachBackgroundStreamForSession(record) {
     }
 
     pendingBackgroundAttachRunIds.add(runId);
-    const navigationToken = foregroundNavigationStreamToken;
     try {
-        const snapshot = await fetchSessionRecovery(sessionId);
-        if (navigationToken !== foregroundNavigationStreamToken || isBackgroundDiscoveryPaused()) {
-            return false;
-        }
-        const activeRun = snapshot?.active_run && typeof snapshot.active_run === 'object'
-            ? snapshot.active_run
-            : snapshot?.activeRun && typeof snapshot.activeRun === 'object'
-                ? snapshot.activeRun
-                : null;
         clearSessionUnavailableCooldown(sessionId);
-        const recoveredRunId = String(activeRun?.run_id || '').trim();
-        const recoveredStatus = String(activeRun?.status || '').trim();
-        if (!recoveredRunId || recoveredRunId !== runId) {
-            return false;
-        }
-        if (recoveredStatus !== 'running' && recoveredStatus !== 'queued') {
-            return false;
-        }
-        const recoveredPrimaryRoleId = String(
-            activeRun?.primary_role_id
-            || snapshot?.round_snapshot?.primary_role_id
-            || snapshot?.roundSnapshot?.primary_role_id
+        const sessionMode = String(record?.session_mode || 'normal').trim().toLowerCase();
+        const recordPrimaryRoleId = String(
+            record?.active_run_primary_role_id
+            || record?.activeRunPrimaryRoleId
+            || record?.primary_role_id
             || '',
         ).trim();
-        setRunPrimaryRole(runId, recoveredPrimaryRoleId || null);
-        const sessionMode = String(record?.session_mode || 'normal').trim().toLowerCase();
-        const afterEventId = resolveBackgroundAfterEventId(activeRun);
+        setRunPrimaryRole(runId, recordPrimaryRoleId || null);
+        const knownEventId = Number(runStreamLastEventIds.get(runId) || 0);
+        const afterEventId = knownEventId > 0 ? knownEventId : 0;
         const connection = {
             runId,
             sessionId,
@@ -1162,7 +1366,7 @@ async function attachBackgroundStreamForSession(record) {
             mode: 'background',
             lastEventId: afterEventId,
             primaryRoleId: String(
-                recoveredPrimaryRoleId || getRunPrimaryRoleId(runId, sessionMode) || getPrimaryRoleId(sessionMode) || ''
+                recordPrimaryRoleId || getRunPrimaryRoleId(runId, sessionMode) || getPrimaryRoleId(sessionMode) || ''
             ).trim(),
             primaryLabel: String(getRunPrimaryRoleLabel(runId, sessionMode) || getPrimaryRoleLabel(sessionMode) || 'Main Agent'),
             closed: false,
@@ -1175,9 +1379,6 @@ async function attachBackgroundStreamForSession(record) {
         });
         return true;
     } catch (e) {
-        if (e?.status === 404) {
-            markSessionUnavailable(sessionId);
-        }
         logWarn('frontend.background.attach_failed', 'Failed to attach background stream', {
             session_id: sessionId,
             run_id: runId,
@@ -1492,21 +1693,6 @@ function finishNormalModeSubagentConnection(connection) {
     }
     normalModeSubagentStreams.delete(connection.runId);
     ensureNormalModeSubagentDiscoveryLoop();
-}
-
-function resolveBackgroundAfterEventId(activeRun) {
-    if (!activeRun || typeof activeRun !== 'object') {
-        return 0;
-    }
-    const lastEventId = Number(activeRun.last_event_id || 0);
-    if (lastEventId > 0) {
-        return lastEventId;
-    }
-    const checkpointEventId = Number(activeRun.checkpoint_event_id || 0);
-    if (checkpointEventId > 0) {
-        return checkpointEventId;
-    }
-    return 0;
 }
 
 function isRunNotFoundError(errorMessage) {

--- a/src/relay_teams/interfaces/server/app.py
+++ b/src/relay_teams/interfaces/server/app.py
@@ -5,6 +5,7 @@ import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 import logging
+import os
 import re
 import signal
 import sys
@@ -15,6 +16,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import Response
+from starlette.types import Scope
 
 from relay_teams.builtin import ensure_app_config_bootstrap
 from relay_teams.env.runtime_env import sync_app_env_to_process_env
@@ -82,6 +84,19 @@ _SUPPRESSED_SUCCESS_PATHS = (
 _SUPPRESSED_NOISY_PATHS = (
     re.compile(r"^/\.well-known/appspecific/com\.chrome\.devtools\.json$"),
 )
+
+
+class FrontendStaticFiles(StaticFiles):
+    def file_response(
+        self,
+        full_path: os.PathLike[str] | str,
+        stat_result: os.stat_result,
+        scope: Scope,
+        status_code: int = 200,
+    ) -> Response:
+        response = super().file_response(full_path, stat_result, scope, status_code)
+        response.headers.setdefault("Cache-Control", "no-cache")
+        return response
 
 
 @asynccontextmanager
@@ -394,7 +409,9 @@ def _register_signal_handlers() -> None:
 
 if FRONTEND_DIST_DIR.exists():
     app.mount(
-        "/", StaticFiles(directory=str(FRONTEND_DIST_DIR), html=True), name="frontend"
+        "/",
+        FrontendStaticFiles(directory=str(FRONTEND_DIST_DIR), html=True),
+        name="frontend",
     )
 else:
 

--- a/src/relay_teams/interfaces/server/routers/runs.py
+++ b/src/relay_teams/interfaces/server/routers/runs.py
@@ -6,7 +6,7 @@ import logging
 import time
 from typing import Annotated, ClassVar, Literal, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -40,6 +40,7 @@ from relay_teams.validation import (
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/runs", tags=["Runs"])
+MAX_MULTIPLEX_RUN_STREAMS = 32
 
 
 async def _create_and_start_run(
@@ -114,6 +115,43 @@ def _find_normalized_media_ref(
 
 def _contains_inline_media(parts: tuple[ContentPart, ...]) -> bool:
     return any(isinstance(part, InlineMediaContentPart) for part in parts)
+
+
+def _normalize_multiplex_run_offsets(
+    run_ids: list[str],
+    after_event_ids: list[int],
+) -> tuple[tuple[str, int], ...]:
+    if not run_ids:
+        raise HTTPException(status_code=422, detail="At least one run_id is required")
+    if len(run_ids) > MAX_MULTIPLEX_RUN_STREAMS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"At most {MAX_MULTIPLEX_RUN_STREAMS} run_id values are allowed",
+        )
+    if len(after_event_ids) > len(run_ids):
+        raise HTTPException(
+            status_code=422,
+            detail="after_event_id cannot contain more values than run_id",
+        )
+
+    offsets_by_run_id: dict[str, int] = {}
+    ordered_run_ids: list[str] = []
+    for index, raw_run_id in enumerate(run_ids):
+        run_id = str(raw_run_id).strip()
+        if not run_id or run_id.casefold() in {"none", "null"}:
+            raise HTTPException(status_code=422, detail="run_id cannot be blank")
+        after_event_id = after_event_ids[index] if index < len(after_event_ids) else 0
+        if after_event_id < 0:
+            raise HTTPException(
+                status_code=422,
+                detail="after_event_id must be greater than or equal to 0",
+            )
+        if run_id not in offsets_by_run_id:
+            ordered_run_ids.append(run_id)
+            offsets_by_run_id[run_id] = after_event_id
+            continue
+        offsets_by_run_id[run_id] = max(offsets_by_run_id[run_id], after_event_id)
+    return tuple((run_id, offsets_by_run_id[run_id]) for run_id in ordered_run_ids)
 
 
 class CreateRunRequest(BaseModel):
@@ -325,6 +363,51 @@ async def create_run(
             exc_info=exc,
         )
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.get("/events")
+async def stream_multiplexed_run_events(
+    service: Annotated[SessionRunService, Depends(get_run_service)],
+    run_id: Annotated[list[str], Query(default_factory=list)],
+    after_event_id: Annotated[list[int], Query(default_factory=list)],
+) -> StreamingResponse:
+    run_offsets = _normalize_multiplex_run_offsets(run_id, after_event_id)
+
+    async def event_generator():
+        event_count = 0
+        started = time.perf_counter()
+        log_event(
+            logger,
+            logging.INFO,
+            event="stream.multiplex.opened",
+            message="Multiplex run event stream opened",
+            payload={"run_count": len(run_offsets)},
+        )
+        try:
+            async for event in service.stream_multiplexed_run_events(run_offsets):
+                event_count += 1
+                yield f"data: {event.model_dump_json()}\n\n"
+            elapsed_ms = int((time.perf_counter() - started) * 1000)
+            log_event(
+                logger,
+                logging.INFO,
+                event="stream.multiplex.closed",
+                message="Multiplex run event stream closed",
+                duration_ms=elapsed_ms,
+                payload={"event_count": event_count, "run_count": len(run_offsets)},
+            )
+        except Exception as exc:  # pragma: no cover - defensive path
+            log_event(
+                logger,
+                logging.ERROR,
+                event="stream.multiplex.failed",
+                message="Unexpected multiplex stream failure",
+                payload={"event_count": event_count, "run_count": len(run_offsets)},
+                exc_info=exc,
+            )
+            yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
 @router.get("/{run_id}/events")

--- a/src/relay_teams/interfaces/server/routers/sessions.py
+++ b/src/relay_teams/interfaces/server/routers/sessions.py
@@ -232,6 +232,7 @@ async def get_session_rounds(
     limit: int = 8,
     cursor_run_id: OptionalIdentifierStr = None,
     timeline: bool = False,
+    summary: bool = False,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, object]:
     def _get_session_rounds() -> dict[str, object]:
@@ -240,6 +241,7 @@ async def get_session_rounds(
             limit=limit,
             cursor_run_id=cursor_run_id,
             timeline=timeline,
+            summary=summary,
         )
 
     return await _call_session_read("sessions.rounds", _get_session_rounds)

--- a/src/relay_teams/sessions/runs/event_log.py
+++ b/src/relay_teams/sessions/runs/event_log.py
@@ -45,6 +45,9 @@ class EventLog(SharedSqliteRepository):
                 "CREATE INDEX IF NOT EXISTS idx_events_trace ON events(trace_id)"
             )
             self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_trace_id ON events(trace_id, id)"
+            )
+            self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id)"
             )
             self._conn.execute(
@@ -82,6 +85,10 @@ class EventLog(SharedSqliteRepository):
             await cursor.close()
             cursor = await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_events_trace ON events(trace_id)"
+            )
+            await cursor.close()
+            cursor = await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_events_trace_id ON events(trace_id, id)"
             )
             await cursor.close()
             cursor = await conn.execute(
@@ -251,6 +258,45 @@ class EventLog(SharedSqliteRepository):
             )
         )
         return tuple(self._row_to_dict(row) for row in rows)
+
+    def list_by_traces_after_ids(
+        self,
+        trace_offsets: tuple[tuple[str, int], ...],
+    ) -> tuple[dict[str, JsonValue], ...]:
+        normalized_offsets = _normalize_trace_offsets(trace_offsets)
+        if not normalized_offsets:
+            return ()
+        after_by_trace = dict(normalized_offsets)
+        rows: list[sqlite3.Row] = []
+        chunk_size = _SQLITE_SAFE_VARIABLE_LIMIT - 1
+        with self._lock:
+            for index in range(0, len(normalized_offsets), chunk_size):
+                offset_chunk = normalized_offsets[index : index + chunk_size]
+                trace_ids = tuple(trace_id for trace_id, _offset in offset_chunk)
+                min_after_event_id = min(offset for _trace_id, offset in offset_chunk)
+                placeholders = ", ".join("?" for _trace_id in trace_ids)
+                rows.extend(
+                    self._conn.execute(
+                        "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                        f"FROM events WHERE trace_id IN ({placeholders}) AND id>? ORDER BY id ASC",
+                        (*trace_ids, min_after_event_id),
+                    ).fetchall()
+                )
+        rows.sort(key=_row_event_id)
+        return tuple(
+            self._row_to_dict(row)
+            for row in rows
+            if _row_event_id(row) > after_by_trace.get(str(row["trace_id"]), 0)
+        )
+
+    async def list_by_traces_after_ids_async(
+        self,
+        trace_offsets: tuple[tuple[str, int], ...],
+    ) -> tuple[dict[str, JsonValue], ...]:
+        return await self._call_sync_async(
+            self.list_by_traces_after_ids,
+            trace_offsets,
+        )
 
     def list_by_trace_with_ids(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
         with self._lock:
@@ -628,3 +674,28 @@ class EventLog(SharedSqliteRepository):
         if "id" in row.keys():
             result["id"] = int(row["id"])
         return result
+
+
+def _normalize_trace_offsets(
+    trace_offsets: tuple[tuple[str, int], ...],
+) -> tuple[tuple[str, int], ...]:
+    offsets_by_trace: dict[str, int] = {}
+    ordered_trace_ids: list[str] = []
+    for raw_trace_id, raw_after_event_id in trace_offsets:
+        trace_id = str(raw_trace_id).strip()
+        if not trace_id:
+            continue
+        after_event_id = max(0, int(raw_after_event_id))
+        if trace_id not in offsets_by_trace:
+            ordered_trace_ids.append(trace_id)
+            offsets_by_trace[trace_id] = after_event_id
+            continue
+        offsets_by_trace[trace_id] = max(offsets_by_trace[trace_id], after_event_id)
+    return tuple(
+        (trace_id, offsets_by_trace[trace_id]) for trace_id in ordered_trace_ids
+    )
+
+
+def _row_event_id(row: sqlite3.Row) -> int:
+    row_id = row["id"]
+    return int(row_id) if isinstance(row_id, int) else 0

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -112,6 +112,10 @@ def _clear_current_task_cancellation_requests() -> None:
         current_task.uncancel()
 
 
+def _run_event_replay_sort_key(run_event: RunEvent) -> int:
+    return int(run_event.event_id or 0)
+
+
 class SessionRunService:
     def __init__(
         self,
@@ -1658,6 +1662,128 @@ class SessionRunService:
             self._run_event_hub.unsubscribe(run_id, queue)
             if terminal_reached:
                 self._run_event_hub.unsubscribe_all(run_id)
+
+    async def stream_multiplexed_run_events(
+        self,
+        run_offsets: tuple[tuple[str, int], ...],
+    ):
+        normalized_offsets = tuple(
+            (run_id.strip(), max(0, int(after_event_id)))
+            for run_id, after_event_id in run_offsets
+            if run_id.strip()
+        )
+        if not normalized_offsets:
+            return
+
+        queues = {
+            run_id: self._run_event_hub.subscribe(run_id)
+            for run_id, _after_event_id in normalized_offsets
+        }
+        terminal_run_ids: set[str] = set()
+        replay_high_watermarks: dict[str, int] = {
+            run_id: 0 for run_id, _after_event_id in normalized_offsets
+        }
+        pending_gets: dict[asyncio.Task[RunEvent], str] = {}
+        try:
+            replay_events: list[RunEvent] = []
+            if self._event_log is not None:
+                for row in await self._event_log.list_by_traces_after_ids_async(
+                    normalized_offsets
+                ):
+                    row_id = row.get("id")
+                    if not isinstance(row_id, int):
+                        continue
+                    replay_event = self._run_event_from_log_row(row)
+                    if replay_event is None:
+                        continue
+                    replay_high_watermarks[replay_event.run_id] = max(
+                        replay_high_watermarks.get(replay_event.run_id, 0),
+                        row_id,
+                    )
+                    replay_events.append(replay_event)
+            replay_events.sort(key=_run_event_replay_sort_key)
+            for replayed_event in replay_events:
+                if replayed_event.run_id in terminal_run_ids:
+                    continue
+                yield replayed_event
+                if replayed_event.event_type in (
+                    RunEventType.RUN_PAUSED,
+                    RunEventType.RUN_COMPLETED,
+                    RunEventType.RUN_FAILED,
+                    RunEventType.RUN_STOPPED,
+                ):
+                    terminal_run_ids.add(replayed_event.run_id)
+
+            for run_id in terminal_run_ids:
+                queue = queues.pop(run_id, None)
+                if queue is not None:
+                    self._run_event_hub.unsubscribe(run_id, queue)
+                    self._run_event_hub.unsubscribe_all(run_id)
+
+            pending_gets = {
+                asyncio.create_task(queue.get()): run_id
+                for run_id, queue in queues.items()
+            }
+            while pending_gets:
+                done, _pending = await asyncio.wait(
+                    tuple(pending_gets.keys()),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in done:
+                    run_id = pending_gets.pop(task)
+                    live_event = task.result()
+                    high_watermark = replay_high_watermarks.get(run_id, 0)
+                    if (
+                        high_watermark > 0
+                        and live_event.event_id is not None
+                        and live_event.event_id <= high_watermark
+                    ):
+                        if run_id in queues:
+                            pending_gets[asyncio.create_task(queues[run_id].get())] = (
+                                run_id
+                            )
+                        continue
+                    yield live_event
+                    if live_event.event_type in (
+                        RunEventType.RUN_PAUSED,
+                        RunEventType.RUN_COMPLETED,
+                        RunEventType.RUN_FAILED,
+                        RunEventType.RUN_STOPPED,
+                    ):
+                        queue = queues.pop(run_id, None)
+                        if queue is not None:
+                            self._run_event_hub.unsubscribe(run_id, queue)
+                            self._run_event_hub.unsubscribe_all(run_id)
+                        continue
+                    if run_id in queues:
+                        pending_gets[asyncio.create_task(queues[run_id].get())] = run_id
+        finally:
+            for task in tuple(pending_gets.keys()):
+                task.cancel()
+            for run_id, queue in queues.items():
+                self._run_event_hub.unsubscribe(run_id, queue)
+
+    @staticmethod
+    def _run_event_from_log_row(row: dict[str, JsonValue]) -> RunEvent | None:
+        row_id = row.get("id")
+        if not isinstance(row_id, int):
+            return None
+        try:
+            event_type = RunEventType(str(row["event_type"]))
+        except ValueError:
+            return None
+        return RunEvent(
+            session_id=str(row["session_id"]),
+            run_id=str(row["trace_id"]),
+            trace_id=str(row["trace_id"]),
+            task_id=str(row["task_id"]) if row["task_id"] is not None else None,
+            instance_id=(
+                str(row["instance_id"]) if row["instance_id"] is not None else None
+            ),
+            event_type=event_type,
+            payload_json=str(row["payload_json"]),
+            event_id=row_id,
+        )
 
     async def run_intent_stream(self, intent: IntentInput):
         run_id, _ = await self.create_run_async(intent)

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -124,7 +124,7 @@ _LEGACY_COORDINATOR_IDENTIFIERS = (
 )
 _MAIN_AGENT_IDENTIFIERS = ("mainagent", "main agent", "main_agent")
 _AUTO_SESSION_TITLE_MAX_CHARS = 120
-_LIST_SESSIONS_CACHE_TTL_SECONDS = 0.1
+_LIST_SESSIONS_CACHE_TTL_SECONDS = 0.5
 
 
 def _legacy_coordinator_identifiers() -> tuple[str, ...]:
@@ -1500,6 +1500,7 @@ class SessionService:
         limit: int = 8,
         cursor_run_id: str | None = None,
         timeline: bool = False,
+        summary: bool = False,
     ) -> dict[str, object]:
         if timeline:
             rounds = self.build_session_timeline_rounds(session_id)
@@ -1510,6 +1511,8 @@ class SessionService:
             limit=limit,
             cursor_run_id=cursor_run_id,
         )
+        if summary:
+            return page
         page_items = page.get("items")
         if not isinstance(page_items, list) or not page_items:
             return page
@@ -1552,8 +1555,27 @@ class SessionService:
         return page
 
     def get_round(self, session_id: str, run_id: str) -> dict[str, object]:
-        rounds = self.build_session_rounds(session_id)
-        return find_round_by_run_id(rounds, session_id=session_id, run_id=run_id)
+        safe_run_id = str(run_id or "").strip()
+        timeline_item = next(
+            (
+                item
+                for item in self.build_session_timeline_rounds(session_id)
+                if str(item.get("run_id") or "") == safe_run_id
+            ),
+            None,
+        )
+        rounds = self.build_session_rounds(
+            session_id,
+            included_run_ids={safe_run_id},
+            include_history_markers=False,
+        )
+        round_item = find_round_by_run_id(rounds, session_id=session_id, run_id=run_id)
+        if timeline_item is not None:
+            round_item["clear_marker_before"] = timeline_item.get("clear_marker_before")
+            round_item["compaction_marker_before"] = timeline_item.get(
+                "compaction_marker_before"
+            )
+        return round_item
 
     def get_recovery_snapshot(self, session_id: str) -> dict[str, object]:
         _ = self._session_repo.get(session_id)

--- a/tests/integration_tests/api/test_session_http_pressure.py
+++ b/tests/integration_tests/api/test_session_http_pressure.py
@@ -40,6 +40,7 @@ def test_session_switch_pressure_does_not_starve_backend(
         for index in range(24)
     ]
     subagent_session_ids: list[str] = []
+    completed_run_ids: list[str] = []
     for index, session_id in enumerate(session_ids[1:4], start=1):
         run_id = create_run(
             api_client,
@@ -57,6 +58,7 @@ def test_session_switch_pressure_does_not_starve_backend(
         )
         assert events[-1]["event_type"] == "run_completed"
         subagent_session_ids.append(session_id)
+        completed_run_ids.append(run_id)
 
     create_started = time.perf_counter()
     slow_run_id = create_run(
@@ -68,7 +70,10 @@ def test_session_switch_pressure_does_not_starve_backend(
     create_elapsed_ms = int((time.perf_counter() - create_started) * 1000)
     assert create_elapsed_ms < 3000
 
-    request_plan = _build_pressure_request_plan(session_ids)
+    request_plan = _build_pressure_request_plan(
+        session_ids,
+        multiplex_replay_run_ids=completed_run_ids,
+    )
     results = _run_pressure_requests(
         integration_env.api_base_url,
         request_plan,
@@ -114,12 +119,21 @@ def test_session_switch_pressure_does_not_starve_backend(
 
 def _build_pressure_request_plan(
     session_ids: list[str],
+    *,
+    multiplex_replay_run_ids: list[str] | None = None,
 ) -> list[tuple[HttpMethod, str]]:
     request_plan: list[tuple[HttpMethod, str]] = [("GET", "/api/sessions")]
+    replay_run_ids = multiplex_replay_run_ids or []
+    if replay_run_ids:
+        replay_query = "&".join(
+            f"run_id={run_id}&after_event_id=0" for run_id in replay_run_ids
+        )
+        request_plan.append(("GET", f"/api/runs/events?{replay_query}"))
     for session_id in session_ids:
         request_plan.extend(
             [
                 ("GET", f"/api/sessions/{session_id}"),
+                ("GET", f"/api/sessions/{session_id}/rounds?summary=true&limit=4"),
                 ("GET", f"/api/sessions/{session_id}/rounds?limit=8"),
                 ("GET", f"/api/sessions/{session_id}/recovery"),
                 ("GET", f"/api/sessions/{session_id}/token-usage"),

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -1980,29 +1980,40 @@ def test_browser_sidebar_lazy_loads_subagent_sessions_on_initial_open(
 
     page = browser_page
     subagent_request_urls: list[str] = []
-    page.on(
-        "request",
-        lambda request: (
+    session_index_requests: list[str] = []
+    recovery_requests: list[str] = []
+
+    def track_request(request: Request) -> None:
+        if request.method != "GET":
+            return
+        if request.url.startswith(
+            f"{integration_env.api_base_url}/api/sessions/"
+        ) and request.url.endswith("/subagents"):
             subagent_request_urls.append(request.url)
-            if (
-                request.method == "GET"
-                and request.url.startswith(
-                    f"{integration_env.api_base_url}/api/sessions/"
-                )
-                and request.url.endswith("/subagents")
-            )
-            else None
-        ),
-    )
+            return
+        if request.url == f"{integration_env.api_base_url}/api/sessions":
+            session_index_requests.append(request.url)
+            return
+        if request.url.startswith(
+            f"{integration_env.api_base_url}/api/sessions/"
+        ) and request.url.endswith("/recovery"):
+            recovery_requests.append(request.url)
+
+    page.on("request", track_request)
 
     _open_app(page, integration_env)
     expect(page.locator(".session-item.active")).to_have_count(
         1,
         timeout=_WAIT_TIMEOUT_MS,
     )
-    page.wait_for_timeout(2500)
+    page.wait_for_timeout(800)
+    initial_session_index_request_count = len(session_index_requests)
+    initial_recovery_request_count = len(recovery_requests)
+    page.wait_for_timeout(3200)
 
-    assert len(subagent_request_urls) == 1
+    assert len(subagent_request_urls) == 0
+    assert len(session_index_requests) == initial_session_index_request_count
+    assert len(recovery_requests) == initial_recovery_request_count
 
 
 def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_load(
@@ -2040,10 +2051,16 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
     page = browser_page
     failed_requests: list[str] = []
     subagent_list_requests: list[str] = []
+    session_index_requests: list[str] = []
 
     def track_response(response: Response) -> None:
         if response.status >= 500:
             failed_requests.append(response.url)
+        if (
+            response.request.method == "GET"
+            and response.url == f"{integration_env.api_base_url}/api/sessions"
+        ):
+            session_index_requests.append(response.url)
         if (
             response.request.method == "GET"
             and response.url.startswith(f"{integration_env.api_base_url}/api/sessions/")
@@ -2063,6 +2080,10 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
         "data-session-id",
         switch_targets[-1],
         timeout=2500,
+    )
+    expect(page.locator(".session-item-activating")).to_have_count(0, timeout=2500)
+    expect(page.locator(".home-new-session-btn")).to_be_visible(
+        timeout=_WAIT_TIMEOUT_MS
     )
 
     page.locator(".home-new-session-btn").click()
@@ -2158,7 +2179,120 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
     expect(page.locator(".session-subagent-list.is-animating")).to_have_count(0)
 
     assert failed_requests == []
-    assert len(subagent_list_requests) <= 8
+    assert len(subagent_list_requests) <= 2
+    assert len(session_index_requests) <= 4
+
+
+def test_browser_burst_new_session_starts_stay_within_request_budget(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+    api_client: httpx.Client,
+) -> None:
+    create_session(
+        api_client,
+        session_id=new_session_id("browser-burst-seed"),
+    )
+
+    page = browser_page
+    api_requests: list[tuple[str, str]] = []
+    failed_requests: list[str] = []
+
+    def track_request(request: Request) -> None:
+        if request.url.startswith(f"{integration_env.api_base_url}/api/"):
+            api_requests.append(
+                (request.method, _api_path(integration_env, request.url))
+            )
+
+    def track_response(response: Response) -> None:
+        if (
+            response.url.startswith(f"{integration_env.api_base_url}/api/")
+            and response.status >= 500
+        ):
+            failed_requests.append(response.url)
+
+    page.on("request", track_request)
+    page.on("response", track_response)
+    _open_app(page, integration_env)
+    expect(page.locator(".home-new-session-btn")).to_be_visible(
+        timeout=_WAIT_TIMEOUT_MS
+    )
+    expect(page.locator(".session-item.active")).to_have_count(
+        1,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    expect(
+        page.locator(
+            ".chat-container.is-session-switch-pending, .chat-container.is-session-switching"
+        )
+    ).to_have_count(0, timeout=_WAIT_TIMEOUT_MS)
+    api_requests.clear()
+
+    feedback_times_ms: list[int] = []
+    for index in range(3):
+        page.locator(".home-new-session-btn").click()
+        expect(page.locator(".new-session-draft-page")).to_be_visible(
+            timeout=_WAIT_TIMEOUT_MS,
+        )
+        expect(page.locator("#prompt-input")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+        page.locator("#prompt-input").fill(f"browser burst start {index}")
+        started = time.perf_counter()
+        page.locator("#send-btn").click()
+        expect(
+            page.locator(".session-run-start-placeholder, .session-round-section").first
+        ).to_be_visible(timeout=500)
+        feedback_times_ms.append(int((time.perf_counter() - started) * 1000))
+
+    page.wait_for_timeout(2500)
+
+    get_sessions = [
+        path
+        for method, path in api_requests
+        if method == "GET" and path == "/api/sessions"
+    ]
+    get_workspaces = [
+        path
+        for method, path in api_requests
+        if method == "GET" and path == "/api/workspaces"
+    ]
+    get_recovery = [
+        path
+        for method, path in api_requests
+        if method == "GET"
+        and path.startswith("/api/sessions/")
+        and path.endswith("/recovery")
+    ]
+    get_subagents = [
+        path
+        for method, path in api_requests
+        if method == "GET"
+        and path.startswith("/api/sessions/")
+        and path.endswith("/subagents")
+    ]
+    get_model_profiles = [
+        path
+        for method, path in api_requests
+        if method == "GET" and path == "/api/system/configs/model/profiles"
+    ]
+    post_sessions = [
+        path
+        for method, path in api_requests
+        if method == "POST" and path == "/api/sessions"
+    ]
+    post_runs = [
+        path
+        for method, path in api_requests
+        if method == "POST" and path == "/api/runs"
+    ]
+
+    assert failed_requests == []
+    assert len(post_sessions) == 3
+    assert len(post_runs) == 3
+    assert max(feedback_times_ms) < 500
+    assert len(get_workspaces) == 0
+    assert len(get_sessions) <= 5
+    assert len(get_recovery) <= 5
+    assert len(get_subagents) == 0
+    assert len(get_model_profiles) <= 2
 
 
 def test_browser_terminal_run_viewed_state_survives_reload(
@@ -2239,6 +2373,10 @@ def _open_app(page: Page, integration_env: IntegrationEnvironment) -> None:
         timeout=_WAIT_TIMEOUT_MS,
     )
     expect(page.locator("#projects-list")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+
+def _api_path(integration_env: IntegrationEnvironment, url: str) -> str:
+    return str(url).removeprefix(integration_env.api_base_url)
 
 
 def _open_web_settings_panel(
@@ -2365,6 +2503,11 @@ def _vertical_gap_between(upper: Locator, lower: Locator) -> float:
 
 def _create_session_via_sidebar(page: Page) -> str:
     existing_session_ids = set(_session_ids(page))
+    expect(
+        page.locator(
+            ".chat-container.is-session-switch-pending, .chat-container.is-session-switching"
+        )
+    ).to_have_count(0, timeout=_WAIT_TIMEOUT_MS)
     first_project_row = page.locator(".project-row").first
     first_project_row.hover()
     expect(page.locator(".project-new-session-btn").first).to_be_visible(

--- a/tests/integration_tests/support/session_tool_pressure.py
+++ b/tests/integration_tests/support/session_tool_pressure.py
@@ -169,6 +169,7 @@ def _probe_paths(session_ids: tuple[str, ...]) -> tuple[str, ...]:
         paths.extend(
             [
                 f"/api/sessions/{session_id}",
+                f"/api/sessions/{session_id}/rounds?summary=true&limit=4",
                 f"/api/sessions/{session_id}/rounds?limit=4",
                 f"/api/sessions/{session_id}/recovery",
                 f"/api/sessions/{session_id}/token-usage",

--- a/tests/unit_tests/frontend/test_api_facade_ui.py
+++ b/tests/unit_tests/frontend/test_api_facade_ui.py
@@ -106,6 +106,10 @@ export async function requestJsonManaged(key, url, options, errorMessage) {
 export function invalidateManagedRequests(prefix) {
     globalThis.__invalidatedPrefixes.push(prefix);
 }
+
+export function invalidateManagedRequestCache(prefix) {
+    globalThis.__invalidatedCachePrefixes.push(prefix);
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -126,12 +130,14 @@ export function invalidateManagedRequests(prefix) {
             (
                 "globalThis.__capturedRequests = []; "
                 "globalThis.__invalidatedPrefixes = []; "
+                "globalThis.__invalidatedCachePrefixes = []; "
                 f"const mod = await import({module_under_test_path.as_uri()!r}); "
                 "const result = await mod.markSessionTerminalRunViewed('session-a'); "
                 "console.log(JSON.stringify({"
                 "result,"
                 "requests: globalThis.__capturedRequests,"
-                "invalidatedPrefixes: globalThis.__invalidatedPrefixes"
+                "invalidatedPrefixes: globalThis.__invalidatedPrefixes,"
+                "invalidatedCachePrefixes: globalThis.__invalidatedCachePrefixes"
                 "}));"
             ),
         ],
@@ -158,7 +164,8 @@ export function invalidateManagedRequests(prefix) {
                 "errorMessage": "Failed to mark session run viewed",
             }
         ],
-        "invalidatedPrefixes": ["sessions:list", "sessions:session-a:record"],
+        "invalidatedPrefixes": [],
+        "invalidatedCachePrefixes": ["sessions:list", "sessions:session-a:record"],
     }
 
 
@@ -191,6 +198,10 @@ export async function requestJsonManaged(key, url, options, errorMessage, config
 
 export function invalidateManagedRequests(prefix) {
     globalThis.__invalidatedPrefixes.push(prefix);
+}
+
+export function invalidateManagedRequestCache() {
+    return undefined;
 }
 """.strip(),
         encoding="utf-8",
@@ -570,6 +581,89 @@ export function invalidateManagedRequests(prefix) {
         "roles:",
         "roles:",
         "roles:",
+    ]
+
+
+def test_fetch_session_rounds_supports_summary_query(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "core" / "api" / "sessions.js"
+    )
+    module_under_test_path = tmp_path / "sessions.mjs"
+    mock_request_path = tmp_path / "mockRequest.mjs"
+
+    mock_request_path.write_text(
+        """
+export async function requestJson() {
+    throw new Error('not used');
+}
+
+export async function requestJsonManaged(key, url, options, errorMessage, config) {
+    globalThis.__capturedManagedRequests.push({
+        key,
+        url,
+        options,
+        errorMessage,
+        config,
+    });
+    return { items: [] };
+}
+
+export function invalidateManagedRequests() {
+    return undefined;
+}
+
+export function invalidateManagedRequestCache() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    source_text = source_path.read_text(encoding="utf-8")
+    module_text = source_text.replace(
+        "from './request.js';",
+        "from './mockRequest.mjs';",
+    )
+    assert module_text != source_text
+    module_under_test_path.write_text(module_text, encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                "globalThis.__capturedManagedRequests = []; "
+                f"const mod = await import({module_under_test_path.as_uri()!r}); "
+                "await mod.fetchSessionRounds('session-a', {"
+                "limit: 3, summary: true, priority: 'high'"
+                "}); "
+                "console.log(JSON.stringify(globalThis.__capturedManagedRequests));"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node import failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    assert json.loads(completed.stdout.strip()) == [
+        {
+            "key": "sessions:session-a:rounds:limit=3&summary=true",
+            "url": "/api/sessions/session-a/rounds?limit=3&summary=true",
+            "options": {},
+            "errorMessage": "Failed to fetch session rounds",
+            "config": {"lane": "critical", "priority": "high", "ttlMs": 300},
+        }
     ]
 
 

--- a/tests/unit_tests/frontend/test_api_request_ui.py
+++ b/tests/unit_tests/frontend/test_api_request_ui.py
@@ -359,6 +359,105 @@ console.log(JSON.stringify({
     }
 
 
+def test_request_json_managed_can_invalidate_cache_without_aborting_in_flight_get(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "core" / "api" / "request.js"
+    module_under_test_path = tmp_path / "request.mjs"
+    runner_path = tmp_path / "runner-request-cache-only-invalidate.mjs"
+    logger_path = tmp_path / "mockLogger.mjs"
+
+    source_text = source_path.read_text(encoding="utf-8").replace(
+        "../../utils/logger.js",
+        "./mockLogger.mjs",
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+    logger_path.write_text(
+        """
+export function errorToPayload(error, context = {}) {
+    return { name: error?.name || '', ...context };
+}
+
+export function logError(...args) {
+    globalThis.__logErrorCalls.push(args);
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    runner_path.write_text(
+        """
+globalThis.__logErrorCalls = [];
+let fetchCalls = 0;
+let firstSignalAbortedAfterCacheInvalidation = null;
+const releases = [];
+const startedSignals = [];
+async function waitForFetch(callNumber) {
+    while (!releases[callNumber]) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+}
+globalThis.fetch = async (_url, options = {}) => {
+    fetchCalls += 1;
+    const callNumber = fetchCalls;
+    startedSignals[callNumber] = options.signal || null;
+    await new Promise(resolve => {
+        releases[callNumber] = resolve;
+    });
+    return {
+        ok: true,
+        json: async () => ({ fetchCalls: callNumber }),
+    };
+};
+
+const { invalidateManagedRequestCache, requestJsonManaged } = await import('./request.mjs');
+const firstPromise = requestJsonManaged('sessions:list', '/api/sessions', undefined, 'failed');
+await waitForFetch(1);
+invalidateManagedRequestCache('sessions:');
+firstSignalAbortedAfterCacheInvalidation = startedSignals[1]?.aborted ?? null;
+const secondPromise = requestJsonManaged('sessions:list', '/api/sessions', undefined, 'failed');
+await waitForFetch(2);
+releases[2]();
+const second = await secondPromise;
+releases[1]();
+const first = await firstPromise;
+
+console.log(JSON.stringify({
+    fetchCalls,
+    firstSignalAbortedAfterCacheInvalidation,
+    first,
+    second,
+    logErrorCalls: globalThis.__logErrorCalls.length,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    assert json.loads(completed.stdout) == {
+        "fetchCalls": 2,
+        "firstSignalAbortedAfterCacheInvalidation": False,
+        "first": {"fetchCalls": 1},
+        "second": {"fetchCalls": 2},
+        "logErrorCalls": 0,
+    }
+
+
 def test_request_json_managed_prunes_expired_cached_gets(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = repo_root / "frontend" / "dist" / "js" / "core" / "api" / "request.js"

--- a/tests/unit_tests/frontend/test_context_indicators_ui.py
+++ b/tests/unit_tests/frontend/test_context_indicators_ui.py
@@ -74,9 +74,94 @@ console.log(JSON.stringify({
     assert "128000" in cast(str, payload["title"])
 
 
+def test_context_indicator_burst_refresh_does_not_abort_previous_consumer(
+    tmp_path: Path,
+) -> None:
+    payload = _run_context_indicators_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { refreshVisibleContextIndicators } = await import('./contextIndicators.mjs');
+const { state, setNormalModeRoles } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+state.currentSessionMode = 'normal';
+state.currentNormalRootRoleId = 'writer';
+state.activeRunId = 'run-1';
+setNormalModeRoles([
+    { role_id: 'writer', model_profile: 'writer-profile' },
+]);
+
+refreshVisibleContextIndicators({ immediate: true });
+await Promise.resolve();
+refreshVisibleContextIndicators({ immediate: true });
+await Promise.resolve();
+const abortStatesAfterSecondRefresh = globalThis.__usageSignals.map(signal => signal.aborted);
+
+while (globalThis.__usageResolvers.length > 0) {
+    globalThis.__usageResolvers.shift()();
+    await Promise.resolve();
+}
+for (let index = 0; index < 5; index += 1) {
+    await Promise.resolve();
+}
+
+const indicator = globalThis.document.getElementById('main-context-indicator');
+console.log(JSON.stringify({
+    abortStatesAfterSecondRefresh,
+    usageCalls: globalThis.__usageCalls,
+    profileCalls: globalThis.__profileCalls,
+    textContent: indicator.textContent,
+    state: indicator.dataset.state,
+}));
+""".strip(),
+        mock_api_source="""
+globalThis.__usageCalls = 0;
+globalThis.__profileCalls = 0;
+globalThis.__usageSignals = [];
+globalThis.__usageResolvers = [];
+
+export async function fetchRunTokenUsage(sessionId, runId, options = {}) {
+    globalThis.__usageCalls += 1;
+    globalThis.__usageSignals.push(options.signal);
+    return await new Promise(resolve => {
+        globalThis.__usageResolvers.push(() => resolve({
+            run_id: 'run-1',
+            by_agent: [
+                {
+                    instance_id: 'inst-1',
+                    role_id: 'writer',
+                    input_tokens: 999,
+                    latest_input_tokens: 321,
+                },
+            ],
+        }));
+    });
+}
+
+export async function fetchModelProfiles(options = {}) {
+    globalThis.__profileCalls += 1;
+    if (options.signal) {
+        throw new Error('model profiles should not be tied to indicator abort signals');
+    }
+    return {
+        default: { is_default: true, context_window: 128000 },
+        'writer-profile': { is_default: false, context_window: 64000 },
+    };
+}
+""".strip(),
+    )
+
+    assert payload["abortStatesAfterSecondRefresh"] == [False, False]
+    assert payload["usageCalls"] == 2
+    assert payload["profileCalls"] == 2
+    assert payload["textContent"] == "321 / 64k"
+    assert payload["state"] == "ready"
+
+
 def _run_context_indicators_script(
     tmp_path: Path,
     runner_source: str,
+    mock_api_source: str | None = None,
 ) -> dict[str, object]:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = (
@@ -99,7 +184,8 @@ def _run_context_indicators_script(
     module_under_test_path.write_text(source_text, encoding="utf-8")
 
     (tmp_path / "mockApi.mjs").write_text(
-        """
+        mock_api_source
+        or """
 export async function fetchRunTokenUsage() {
     return {
         run_id: 'run-1',

--- a/tests/unit_tests/frontend/test_projects_sidebar_ui.py
+++ b/tests/unit_tests/frontend/test_projects_sidebar_ui.py
@@ -2927,6 +2927,7 @@ import {
     loadProjects,
     setSelectSessionHandler,
 } from "./sidebar.mjs";
+import { rememberSidebarDataSnapshot } from "./sessionSidebarStore.mjs";
 import { state } from "./mockState.mjs";
 
 installGlobals(createDomEnvironment());
@@ -2936,6 +2937,7 @@ setSelectSessionHandler(async (sessionId) => {
 });
 
 await loadProjects();
+rememberSidebarDataSnapshot({ workspaces: [], sessions: [], automationProjects: [] });
 const projectsList = document.getElementById("projects-list");
 const featureSection = projectsList.children[0];
 const firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
@@ -3515,9 +3517,9 @@ console.log(JSON.stringify({
     }
     assert payload["hoveredCounts"] == payload["initialCounts"]
     assert payload["settledCounts"] == {
-        "workspaces": 2,
+        "workspaces": 1,
         "sessions": 2,
-        "automationProjects": 2,
+        "automationProjects": 1,
     }
 
 
@@ -3651,9 +3653,9 @@ export async function runAutomationProject() {
         "automationProjects": 1,
     }
     assert payload["refreshedCounts"] == {
-        "workspaces": 2,
+        "workspaces": 1,
         "sessions": 2,
-        "automationProjects": 2,
+        "automationProjects": 1,
     }
     assert payload["sessionForceRefreshes"] == [False, True]
 
@@ -3778,11 +3780,169 @@ export async function runAutomationProject() {
     )
 
     assert payload["fetchCounts"] == {
-        "workspaces": 2,
+        "workspaces": 1,
         "sessions": 2,
-        "automationProjects": 2,
+        "automationProjects": 1,
     }
     assert payload["sessionForceRefreshes"] == [False, True]
+
+
+def test_projects_sidebar_coalesces_session_refresh_while_request_is_in_flight(
+    tmp_path: Path,
+) -> None:
+    payload = _run_sidebar_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import {
+    loadProjects,
+    scheduleSessionsRefresh,
+} from "./sidebar.mjs";
+
+await loadProjects();
+globalThis.__deferSessionFetches = true;
+scheduleSessionsRefresh(0);
+await new Promise(resolve => setTimeout(resolve, 20));
+scheduleSessionsRefresh(0, { forceRefresh: true });
+await new Promise(resolve => setTimeout(resolve, 20));
+const countsWhileInFlight = { ...globalThis.__fetchCounts };
+const forceRefreshesWhileInFlight = [...globalThis.__sessionForceRefreshes];
+
+globalThis.__sessionResolvers.shift()();
+await new Promise(resolve => setTimeout(resolve, 180));
+const countsBeforeTrailingResolve = { ...globalThis.__fetchCounts };
+globalThis.__sessionResolvers.shift()();
+await new Promise(resolve => setTimeout(resolve, 20));
+
+console.log(JSON.stringify({
+    countsWhileInFlight,
+    forceRefreshesWhileInFlight,
+    countsBeforeTrailingResolve,
+    finalCounts: globalThis.__fetchCounts,
+    sessionForceRefreshes: globalThis.__sessionForceRefreshes,
+}));
+""".strip(),
+        mock_api_source="""
+const workspaces = [
+    {
+        workspace_id: "alpha-project",
+        root_path: "/work/Alpha Project",
+        updated_at: "2026-03-14T10:00:00Z",
+        profile: {
+            file_scope: {
+                backend: "project",
+            },
+        },
+    },
+];
+
+const sessions = [
+    {
+        session_id: "session-1",
+        workspace_id: "alpha-project",
+        session_mode: "normal",
+        updated_at: "2026-03-14T10:11:00Z",
+        pending_tool_approval_count: 0,
+        metadata: { title: "Root session" },
+    },
+];
+
+globalThis.__fetchCounts = {
+    workspaces: 0,
+    sessions: 0,
+    automationProjects: 0,
+};
+globalThis.__sessionForceRefreshes = [];
+globalThis.__sessionResolvers = [];
+globalThis.__deferSessionFetches = false;
+
+export async function fetchWorkspaces() {
+    globalThis.__fetchCounts.workspaces += 1;
+    return workspaces;
+}
+
+export async function fetchSessions(options = {}) {
+    globalThis.__fetchCounts.sessions += 1;
+    globalThis.__sessionForceRefreshes.push(options.forceRefresh === true);
+    if (globalThis.__deferSessionFetches === true) {
+        return await new Promise(resolve => {
+            globalThis.__sessionResolvers.push(() => resolve(sessions));
+        });
+    }
+    return sessions;
+}
+
+export async function fetchAutomationProjects() {
+    globalThis.__fetchCounts.automationProjects += 1;
+    return [];
+}
+
+export async function fetchAutomationFeishuBindings() {
+    return [];
+}
+
+export async function startNewSession() {
+    throw new Error("not used");
+}
+
+export async function updateSession() {
+    return { status: "ok" };
+}
+
+export async function pickWorkspace() {
+    throw new Error("not used");
+}
+
+export async function forkWorkspace() {
+    throw new Error("not used");
+}
+
+export async function deleteSession() {
+    return undefined;
+}
+
+export async function deleteWorkspace() {
+    return { status: "ok" };
+}
+
+export async function createAutomationProject() {
+    throw new Error("not used");
+}
+
+export async function deleteAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function disableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function enableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function runAutomationProject() {
+    throw new Error("not used");
+}
+""".strip(),
+    )
+
+    assert payload["countsWhileInFlight"] == {
+        "workspaces": 1,
+        "sessions": 2,
+        "automationProjects": 1,
+    }
+    assert payload["forceRefreshesWhileInFlight"] == [False, False]
+    assert payload["countsBeforeTrailingResolve"] == {
+        "workspaces": 1,
+        "sessions": 3,
+        "automationProjects": 1,
+    }
+    assert payload["finalCounts"] == {
+        "workspaces": 1,
+        "sessions": 3,
+        "automationProjects": 1,
+    }
+    assert payload["sessionForceRefreshes"] == [False, False, True]
 
 
 def test_projects_sidebar_defers_subagent_events_without_force_refresh_while_hovering(

--- a/tests/unit_tests/frontend/test_recovery_background_tasks_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_background_tasks_ui.py
@@ -8,6 +8,21 @@ import subprocess
 from .css_helpers import load_components_css
 
 
+def test_recovery_continuity_polling_excludes_terminal_recoverable_runs() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "app" / "recovery.js").read_text(
+        encoding="utf-8"
+    )
+    block = source.split("function shouldPollContinuity()", 1)[1].split(
+        "\n}\n",
+        1,
+    )[0]
+
+    assert "isContinuityPollableRun(activeRun)" in block
+    assert "activeRun?.is_recoverable" not in block
+    assert "if (isTerminalRecoveryRun(activeRun)) return false;" in source
+
+
 def test_recovery_ui_tracks_background_tasks_in_banner_and_events() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     recovery_script = (
@@ -412,3 +427,172 @@ console.log(JSON.stringify({
     assert payload["snapshot"] is None
     assert payload["display"] == "none"
     assert payload["html"] == ""
+
+
+def test_terminal_run_state_patches_round_without_recovery_snapshot(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "app" / "recovery.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "recovery_terminal_state"
+    temp_dir.mkdir()
+    (temp_dir / "recovery.mjs").write_text(
+        source.replace("../components/subagentRail.js", "./mockSubagentRail.mjs")
+        .replace("../components/contextIndicators.js", "./mockContextIndicators.mjs")
+        .replace("../components/messageRenderer.js", "./mockMessageRenderer.mjs")
+        .replace("../components/rounds/timeline.js", "./mockTimeline.mjs")
+        .replace("../components/sidebar.js", "./mockSidebar.mjs")
+        .replace("../core/api.js", "./mockApi.mjs")
+        .replace("../core/state.js", "./mockState.mjs")
+        .replace("../core/stream.js", "./mockStream.mjs")
+        .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/i18n.js", "./mockI18n.mjs")
+        .replace("../utils/logger.js", "./mockLogger.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockSubagentRail.mjs").write_text(
+        "export async function refreshSubagentRail() { return undefined; }",
+        encoding="utf-8",
+    )
+    (temp_dir / "mockContextIndicators.mjs").write_text(
+        "export function refreshVisibleContextIndicators() { return undefined; }",
+        encoding="utf-8",
+    )
+    (temp_dir / "mockMessageRenderer.mjs").write_text(
+        """
+export function clearRunStreamState() { return undefined; }
+export function reconcileTerminalRunStreamState() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockTimeline.mjs").write_text(
+        """
+globalThis.__roundOverlays = [];
+export async function loadSessionRounds() { return undefined; }
+export function overlayRoundRecoveryState(runId, overlay) {
+    globalThis.__roundOverlays.push({ runId, overlay });
+}
+export function syncRoundTodoVisibility() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockSidebar.mjs").write_text(
+        """
+globalThis.__sessionRefreshes = 0;
+export function scheduleSessionsRefresh() {
+    globalThis.__sessionRefreshes += 1;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockApi.mjs").write_text(
+        """
+export async function answerUserQuestion() { return {}; }
+export async function fetchSessionRecovery() { return {}; }
+export async function invalidateSessionRecovery() { return {}; }
+export async function resolveToolApproval() { return {}; }
+export async function resumeRun() { return {}; }
+export async function stopBackgroundTask() { return {}; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: "session-1",
+    currentRecoverySnapshot: null,
+    pausedSubagent: null,
+    isGenerating: true,
+    activeRunId: "run-1",
+};
+export function clearRunPrimaryRole() { return undefined; }
+export function humanizeRoleId(roleId) { return String(roleId || ""); }
+export function isPrimaryRoleId() { return false; }
+export function isReservedSystemRoleId() { return false; }
+export function setRunPrimaryRole() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockStream.mjs").write_text(
+        """
+export function endStream() { return undefined; }
+export function resumeRunStream() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockDom.mjs").write_text(
+        """
+function createElement() {
+    return {
+        style: { display: "none" },
+        innerHTML: "",
+        textContent: "",
+        hidden: false,
+        querySelectorAll() { return []; },
+        querySelector() { return null; },
+    };
+}
+export const els = {
+    backgroundTaskHost: createElement(),
+    recoveryQuestionHost: createElement(),
+    recoveryApprovalHost: createElement(),
+    resumeRunBtn: createElement(),
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function t(key) { return key; }
+export function formatMessage(key) { return key; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockLogger.mjs").write_text(
+        "export function sysLog() { return undefined; }",
+        encoding="utf-8",
+    )
+    runner = """
+import { markRunTerminalState } from "./recovery.mjs";
+import { state } from "./mockState.mjs";
+
+markRunTerminalState("run-1", {
+    status: "completed",
+    phase: "terminal",
+    recoverable: false,
+});
+
+console.log(JSON.stringify({
+    overlays: globalThis.__roundOverlays,
+    refreshes: globalThis.__sessionRefreshes,
+    snapshot: state.currentRecoverySnapshot,
+}));
+""".strip()
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "overlays": [
+            {
+                "runId": "run-1",
+                "overlay": {
+                    "run_status": "completed",
+                    "run_phase": "terminal",
+                    "is_recoverable": False,
+                    "pending_tool_approval_count": 0,
+                    "pending_tool_approvals": [],
+                },
+            }
+        ],
+        "refreshes": 1,
+        "snapshot": None,
+    }

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -143,7 +143,7 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert "clearAllStreamState({ preserveOverlay: true });" in timeline_script
     assert "export function attachRunStream(" in stream_script
     assert "const backgroundStreams = new Map();" in stream_script
-    assert "const MAX_BACKGROUND_STREAMS = 2;" in stream_script
+    assert "const MAX_MULTIPLEX_RUN_STREAMS = 32;" in stream_script
     assert "const unavailableSessionCooldownUntil = new Map();" in stream_script
     assert "const SESSION_NOT_FOUND_COOLDOWN_MS = 30000;" in stream_script
     assert (
@@ -164,24 +164,23 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     )
     assert "const sessions = await fetchSessions();" in stream_script
     assert "reason: 'background-discovery'," in stream_script
-    assert "const snapshot = await fetchSessionRecovery(sessionId);" in stream_script
+    assert "function attachBackgroundStreamForSession(record) {" in stream_script
     assert (
-        "candidates.sort((left, right) => backgroundRecordTimestamp(right) - backgroundRecordTimestamp(left));"
+        "const attentionDelta = Number(runStreamAttention.get(rightRunId) || 0)"
         in stream_script
     )
     assert (
         "const focusedRunId = String(activeConnection?.runId || '').trim();"
         in stream_script
     )
-    assert "|| String(state.currentSessionId || '').trim()" in stream_script
+    assert "|| String(state.currentSessionId || '').trim()" not in stream_script
+    assert "|| pendingBackgroundAttachRunIds.size > 0" in stream_script
+    assert "|| pendingRunStart" in stream_script
     assert "const backgroundRunIds = new Set();" in stream_script
     assert "if (focusedRunId && runId === focusedRunId) {" in stream_script
     assert "if (backgroundRunIds.has(runId)) {" in stream_script
-    assert "if (desiredRunIds.size >= MAX_BACKGROUND_STREAMS) {" in stream_script
-    assert (
-        "finishActiveConnection(connection, { preserveRunStreamState: true });"
-        in stream_script
-    )
+    assert "if (desiredRunIds.size >= MAX_MULTIPLEX_RUN_STREAMS) {" in stream_script
+    assert "requestMultiplexRunConnection('finish-active');" in stream_script
     assert "const unavailableRunCooldownUntil = new Map();" in stream_script
     assert "const RUN_NOT_FOUND_COOLDOWN_MS = 30000;" in stream_script
     assert "status: 'stopped'," in stream_script
@@ -190,8 +189,7 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert "pending_user_question_count: 0," in stream_script
     assert "pending_user_questions: []," in stream_script
     assert "if (isRunNotFoundError(data.error)) {" in stream_script
-    assert "if (e?.status === 404) {" in stream_script
-    assert "markSessionUnavailable(sessionId);" in stream_script
+    assert "markSessionUnavailable(connection.sessionId);" in stream_script
     assert "if (isSessionUnavailable(sessionId)) {" in stream_script
     assert "if (!ignoreUnavailable && isRunUnavailable(safeRunId)) {" in stream_script
     assert "const streamCore = await import('../core/stream.js');" in sidebar_script

--- a/tests/unit_tests/frontend/test_round_retry_timeline_ui.py
+++ b/tests/unit_tests/frontend/test_round_retry_timeline_ui.py
@@ -271,6 +271,224 @@ console.log(JSON.stringify({
     }
 
 
+def test_load_session_rounds_does_not_overwrite_new_session_draft(
+    tmp_path: Path,
+) -> None:
+    payload = _run_round_timeline_script(
+        tmp_path=tmp_path,
+        runner_source="""
+let resolveInitialPage;
+globalThis.__initialRoundsPagePromise = new Promise(resolve => {
+    resolveInitialPage = resolve;
+});
+globalThis.__timelineRoundsPage = {
+    items: [
+        { run_id: 'stale-run', created_at: '2026-04-25T12:00:00', intent: 'Stale' },
+    ],
+    has_more: false,
+    next_cursor: null,
+};
+
+const { state } = await import('./mockState.mjs');
+const { loadSessionRounds } = await import('./timeline.mjs');
+const { roundsState } = await import('./mockRoundsState.mjs');
+
+const loadPromise = loadSessionRounds('session-1', { render: false });
+await Promise.resolve();
+await Promise.resolve();
+
+state.currentSessionId = null;
+state.pendingNewSessionActive = true;
+state.currentMainView = 'new-session-draft';
+resolveInitialPage({
+    items: [
+        { run_id: 'stale-run', created_at: '2026-04-25T12:00:00', intent: 'Stale' },
+    ],
+    has_more: false,
+    next_cursor: null,
+});
+await loadPromise;
+
+console.log(JSON.stringify({
+    currentRunIds: roundsState.currentRounds.map(round => round.run_id),
+    timelineRunIds: roundsState.timelineRounds.map(round => round.run_id),
+    navigatorSnapshots: globalThis.__navigatorRoundSnapshots || [],
+}));
+""".strip(),
+    )
+
+    assert payload == {
+        "currentRunIds": [],
+        "timelineRunIds": [],
+        "navigatorSnapshots": [],
+    }
+
+
+def test_load_session_rounds_background_mode_renders_summary_before_full_page(
+    tmp_path: Path,
+) -> None:
+    payload = _run_round_timeline_script(
+        tmp_path=tmp_path,
+        runner_source="""
+globalThis.__summaryRoundsPage = {
+    items: [
+        {
+            run_id: 'run-1',
+            created_at: '2026-04-25T11:01:00',
+            intent: 'Summary shell',
+            has_user_messages: true,
+        },
+    ],
+    has_more: false,
+    next_cursor: null,
+};
+globalThis.__initialRoundsPagePromise = new Promise(resolve => {
+    globalThis.__resolveFullRoundsPage = resolve;
+});
+globalThis.__timelineRoundsPage = globalThis.__summaryRoundsPage;
+
+const { loadSessionRounds } = await import('./timeline.mjs');
+const { roundsState } = await import('./mockRoundsState.mjs');
+
+await loadSessionRounds('session-1', {
+    render: false,
+    timelineLoadMode: 'background',
+});
+await Promise.resolve();
+
+const afterSummary = {
+    initialFetches: globalThis.__initialRoundFetches,
+    currentRunIds: roundsState.currentRounds.map(round => round.run_id),
+    hasCoordinatorMessages: Object.prototype.hasOwnProperty.call(
+        roundsState.currentRounds[0],
+        'coordinator_messages',
+    ),
+};
+
+globalThis.__resolveFullRoundsPage({
+    items: [
+        {
+            run_id: 'run-1',
+            created_at: '2026-04-25T11:01:00',
+            intent: 'Summary shell',
+            coordinator_messages: [{ role: 'assistant', content: 'full detail' }],
+            has_user_messages: true,
+        },
+    ],
+    has_more: false,
+    next_cursor: null,
+});
+await Promise.resolve();
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    afterSummary,
+    afterFull: {
+        initialFetches: globalThis.__initialRoundFetches,
+        hasCoordinatorMessages: Object.prototype.hasOwnProperty.call(
+            roundsState.currentRounds[0],
+            'coordinator_messages',
+        ),
+    },
+}));
+""".strip(),
+    )
+
+    assert payload == {
+        "afterSummary": {
+            "initialFetches": [{"summary": True}, {"summary": False}],
+            "currentRunIds": ["run-1"],
+            "hasCoordinatorMessages": False,
+        },
+        "afterFull": {
+            "initialFetches": [{"summary": True}, {"summary": False}],
+            "hasCoordinatorMessages": True,
+        },
+    }
+
+
+def test_terminal_overlay_survives_stale_background_full_page(
+    tmp_path: Path,
+) -> None:
+    payload = _run_round_timeline_script(
+        tmp_path=tmp_path,
+        runner_source="""
+globalThis.document = {
+    getElementById: () => null,
+    querySelector: () => null,
+};
+globalThis.__summaryRoundsPage = {
+    items: [
+        {
+            run_id: 'run-1',
+            created_at: '2026-04-25T11:01:00',
+            intent: 'Summary shell',
+            run_status: 'running',
+            run_phase: 'running',
+            has_user_messages: true,
+        },
+    ],
+    has_more: false,
+    next_cursor: null,
+};
+globalThis.__initialRoundsPagePromise = new Promise(resolve => {
+    globalThis.__resolveFullRoundsPage = resolve;
+});
+globalThis.__timelineRoundsPage = globalThis.__summaryRoundsPage;
+
+const {
+    loadSessionRounds,
+    overlayRoundRecoveryState,
+} = await import('./timeline.mjs');
+const { roundsState } = await import('./mockRoundsState.mjs');
+
+await loadSessionRounds('session-1', {
+    render: false,
+    timelineLoadMode: 'background',
+});
+overlayRoundRecoveryState('run-1', {
+    run_status: 'completed',
+    run_phase: 'terminal',
+    is_recoverable: false,
+    pending_tool_approval_count: 0,
+    pending_tool_approvals: [],
+});
+
+globalThis.__resolveFullRoundsPage({
+    items: [
+        {
+            run_id: 'run-1',
+            created_at: '2026-04-25T11:01:00',
+            intent: 'Summary shell',
+            run_status: 'running',
+            run_phase: 'running',
+            coordinator_messages: [{ role: 'assistant', content: 'full detail' }],
+            has_user_messages: true,
+        },
+    ],
+    has_more: false,
+    next_cursor: null,
+});
+await Promise.resolve();
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    currentStatus: roundsState.currentRounds[0].run_status,
+    currentPhase: roundsState.currentRounds[0].run_phase,
+    timelineStatus: roundsState.timelineRounds[0].run_status,
+    reconciledRuns: globalThis.__reconciledTerminalRuns,
+}));
+""".strip(),
+    )
+
+    assert payload == {
+        "currentStatus": "completed",
+        "currentPhase": "terminal",
+        "timelineStatus": "completed",
+        "reconciledRuns": ["run-1", "run-1", "run-1"],
+    }
+
+
 def test_load_session_rounds_evicts_live_round_when_persisted_without_messages(
     tmp_path: Path,
 ) -> None:
@@ -815,7 +1033,17 @@ export function sortRoundsAscending(rounds) {
     );
 }
 
-export async function fetchInitialRoundsPage() {
+export async function fetchInitialRoundsPage(_sessionId, options = {}) {
+    if (!Array.isArray(globalThis.__initialRoundFetches)) {
+        globalThis.__initialRoundFetches = [];
+    }
+    globalThis.__initialRoundFetches.push({ summary: options.summary === true });
+    if (options.summary === true && globalThis.__summaryRoundsPage) {
+        return globalThis.__summaryRoundsPage;
+    }
+    if (globalThis.__initialRoundsPagePromise) {
+        return await globalThis.__initialRoundsPagePromise;
+    }
     return globalThis.__initialRoundsPage || { items: [] };
 }
 

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -286,7 +286,7 @@ console.log(JSON.stringify({
 
     assert payload["activeRunId"] == "run-parent"
     assert payload["recoveryCalls"] == []
-    assert payload["tokenUsageCalls"] == [{"immediate": True}]
+    assert payload["tokenUsageCalls"] == [{"immediate": False}]
     assert payload["runEventCalls"] == [
         {
             "name": "handleTextDelta",
@@ -300,6 +300,34 @@ console.log(JSON.stringify({
                 None,
             ],
         }
+    ]
+
+
+def test_route_event_does_not_refresh_recovery_for_high_frequency_deltas(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+routeEvent('output_delta', {}, { run_id: 'run-1', trace_id: 'run-1' });
+routeEvent('generation_progress', {}, { run_id: 'run-1', trace_id: 'run-1' });
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    recoveryCalls: globalThis.__scheduleRecoveryContinuityRefreshCalls,
+    runEventCalls: globalThis.__runEventCalls,
+}));
+""".strip(),
+    )
+
+    run_event_calls = cast(list[dict[str, object]], payload["runEventCalls"])
+    assert payload["recoveryCalls"] == []
+    assert [call["name"] for call in run_event_calls] == [
+        "handleOutputDelta",
+        "handleGenerationProgress",
     ]
 
 
@@ -384,7 +412,7 @@ console.log(JSON.stringify({
     assert payload["recoveryCalls"] == [
         {
             "sessionId": "session-1",
-            "delayMs": 0,
+            "delayMs": 350,
             "forceRefresh": True,
             "includeRounds": False,
             "quiet": True,
@@ -416,7 +444,7 @@ console.log(JSON.stringify({
     assert payload["recoveryCalls"] == [
         {
             "sessionId": "session-1",
-            "delayMs": 0,
+            "delayMs": 350,
             "forceRefresh": True,
             "includeRounds": False,
             "quiet": True,
@@ -424,7 +452,7 @@ console.log(JSON.stringify({
         },
         {
             "sessionId": "session-1",
-            "delayMs": 0,
+            "delayMs": 350,
             "forceRefresh": True,
             "includeRounds": False,
             "quiet": True,

--- a/tests/unit_tests/frontend/test_session_selection_ui.py
+++ b/tests/unit_tests/frontend/test_session_selection_ui.py
@@ -82,7 +82,7 @@ console.log(JSON.stringify({
     assert payload["selectedAfterB"] == []
     assert payload["selectedEvents"] == ["session-a"]
     assert payload["activatedEvents"] == ["session-a", "session-b", "session-a"]
-    assert payload["ensureSubagentCalls"] == ["session-a"]
+    assert payload["ensureSubagentCalls"] == []
     assert payload["contextPreviewCalls"] == 1
     assert payload["tokenUsageRefreshCalls"] == 1
     assert payload["clearContextIndicatorOptions"] == [
@@ -166,7 +166,7 @@ console.log(JSON.stringify({
     assert payload["viewedBeforeHydration"] == []
     assert payload["viewedAfterHydration"] == ["session-a"]
     assert payload["sidebarViewedTerminalRuns"] == ["session-a"]
-    assert payload["ensureSubagentCalls"] == ["session-a"]
+    assert payload["ensureSubagentCalls"] == []
 
 
 def test_select_session_terminal_view_mark_does_not_survive_cancelled_hydration(
@@ -250,6 +250,38 @@ console.log(JSON.stringify({
     assert payload["viewedAfterHydration"] == ["session-c"]
     assert payload["sidebarViewedTerminalRuns"] == ["session-c"]
     assert payload["appliedRecords"] == ["session-c"]
+
+
+def test_select_session_refreshes_subagents_only_for_expanded_parent(
+    tmp_path: Path,
+) -> None:
+    payload = _run_session_script(
+        tmp_path=tmp_path,
+        runner_source="""
+globalThis.CustomEvent = class CustomEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail || {};
+    }
+};
+globalThis.__expandedSubagentSessionIds.add("session-a");
+
+const { selectSession } = await import("./session.mjs");
+const selection = selectSession("session-a");
+await Promise.resolve();
+globalThis.__hydrateResolvers[0].resolve();
+await selection;
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    ensureSubagentCalls: globalThis.__ensureSubagentCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["ensureSubagentCalls"] == [
+        {"sessionId": "session-a", "force": False}
+    ]
 
 
 def test_select_subagent_cancels_pending_main_session_hydration(
@@ -503,6 +535,7 @@ def _run_session_script(tmp_path: Path, runner_source: str) -> dict[str, object]
     mock_subagent_sessions_path = tmp_path / "mockSubagentSessions.mjs"
     mock_api_path = tmp_path / "mockApi.mjs"
     mock_recovery_path = tmp_path / "mockRecovery.mjs"
+    mock_session_view_path = tmp_path / "mockSessionView.mjs"
     mock_state_path = tmp_path / "mockState.mjs"
     mock_stream_path = tmp_path / "mockStream.mjs"
     mock_submission_path = tmp_path / "mockSubmission.mjs"
@@ -611,8 +644,15 @@ export function getSessionSubagentSessions() {
     return [];
 }
 
-export async function ensureSessionSubagents(sessionId) {
-    globalThis.__ensureSubagentCalls.push(sessionId);
+export function isSubagentSessionListExpanded(sessionId) {
+    return globalThis.__expandedSubagentSessionIds.has(sessionId);
+}
+
+export async function ensureSessionSubagents(sessionId, options = {}) {
+    globalThis.__ensureSubagentCalls.push({
+        sessionId,
+        force: options.force === true,
+    });
     return [];
 }
 
@@ -666,6 +706,23 @@ export async function hydrateSessionView(sessionId, options = {}) {
 
 export function stopSessionContinuity(sessionId) {
     globalThis.__stopSessionContinuityCalls.push(sessionId);
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    mock_session_view_path.write_text(
+        """
+export async function hydrateMainSessionForSwitch(sessionId, options = {}) {
+    const index = globalThis.__hydrateCalls.length;
+    globalThis.__hydrateCalls.push({
+        sessionId,
+        includeRounds: true,
+        priority: options.priority || "",
+        index,
+    });
+    await new Promise(resolve => {
+        globalThis.__hydrateResolvers.push({ sessionId, index, resolve });
+    });
 }
 """.strip(),
         encoding="utf-8",
@@ -903,6 +960,7 @@ export function refreshSessionTopologyControls() {
         .replace("../components/subagentSessions.js", "./mockSubagentSessions.mjs")
         .replace("../core/api.js", "./mockApi.mjs")
         .replace("./recovery.js", "./mockRecovery.mjs")
+        .replace("./sessionView.js", "./mockSessionView.mjs")
         .replace("../core/state.js", "./mockState.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("../core/submission.js", "./mockSubmission.mjs")
@@ -935,6 +993,7 @@ globalThis.__setRoundsModeCalls = 0;
 globalThis.__markSubagentRailLoadingCalls = [];
 globalThis.__clearActiveSubagentSessionCalls = 0;
 globalThis.__ensureSubagentCalls = [];
+globalThis.__expandedSubagentSessionIds = new Set();
 globalThis.__openSubagentSessionCalls = 0;
 globalThis.__fetchCalls = [];
 globalThis.__viewedTerminalRuns = [];

--- a/tests/unit_tests/frontend/test_session_view_ui.py
+++ b/tests/unit_tests/frontend/test_session_view_ui.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+def test_restore_main_session_view_dispatches_events_after_hydration(
+    tmp_path: Path,
+) -> None:
+    payload = _run_session_view_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { els } = await import("./mockDom.mjs");
+const { restoreMainSessionView } = await import("./sessionView.mjs");
+
+const restoring = restoreMainSessionView("session-1", { quiet: true });
+await Promise.resolve();
+
+const immediate = {
+    html: els.chatMessages.innerHTML,
+    eventTypes: globalThis.__events.map(event => event.type),
+    hydrateCalls: globalThis.__hydrateCalls,
+};
+
+globalThis.__hydrateResolvers[0].resolve({ ok: true });
+const snapshot = await restoring;
+
+console.log(JSON.stringify({
+    immediate,
+    snapshot,
+    finalEventTypes: globalThis.__events.map(event => event.type),
+}));
+""".strip(),
+    )
+
+    immediate = payload["immediate"]
+    assert isinstance(immediate, dict)
+    assert "subagent-main-session-loading" in str(immediate["html"])
+    assert immediate["eventTypes"] == [
+        "agent-teams-subagent-session-cleared",
+    ]
+    assert immediate["hydrateCalls"] == [
+        {
+            "sessionId": "session-1",
+            "includeRounds": True,
+            "quiet": True,
+        }
+    ]
+    assert payload["snapshot"] == {"ok": True}
+    assert payload["finalEventTypes"] == [
+        "agent-teams-subagent-session-cleared",
+        "agent-teams-session-activated",
+        "agent-teams-session-selected",
+    ]
+
+
+def test_hydrate_main_session_for_switch_uses_switch_hydration_boundary(
+    tmp_path: Path,
+) -> None:
+    payload = _run_session_view_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { hydrateMainSessionForSwitch } = await import("./sessionView.mjs");
+
+await hydrateMainSessionForSwitch("session-2", {
+    priority: "high",
+    quiet: true,
+    roundsScrollPolicy: "preserve-anchor",
+});
+
+console.log(JSON.stringify({
+    switchCalls: globalThis.__switchHydrateCalls,
+    hydrateCalls: globalThis.__hydrateCalls,
+}));
+""".strip(),
+    )
+
+    assert payload == {
+        "switchCalls": [
+            {
+                "sessionId": "session-2",
+                "priority": "high",
+                "quiet": True,
+                "roundsScrollPolicy": "preserve-anchor",
+            }
+        ],
+        "hydrateCalls": [],
+    }
+
+
+def _run_session_view_script(tmp_path: Path, runner_source: str) -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "app" / "sessionView.js"
+    module_under_test_path = tmp_path / "sessionView.mjs"
+    runner_path = tmp_path / "runner.mjs"
+
+    source_text = (
+        source_path.read_text(encoding="utf-8")
+        .replace("./recovery.js", "./mockRecovery.mjs")
+        .replace("../core/state.js", "./mockState.mjs")
+        .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/i18n.js", "./mockI18n.mjs")
+        .replace("../utils/logger.js", "./mockLogger.mjs")
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+
+    (tmp_path / "mockRecovery.mjs").write_text(
+        """
+export async function hydrateSessionSwitchView(sessionId, options = {}) {
+    globalThis.__switchHydrateCalls.push({
+        sessionId,
+        priority: options.priority || "",
+        quiet: options.quiet === true,
+        roundsScrollPolicy: options.roundsScrollPolicy || "",
+    });
+    return null;
+}
+
+export async function hydrateSessionView(sessionId, options = {}) {
+    globalThis.__hydrateCalls.push({
+        sessionId,
+        includeRounds: options.includeRounds === true,
+        quiet: options.quiet === true,
+    });
+    return await new Promise(resolve => {
+        globalThis.__hydrateResolvers.push({ resolve });
+    });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: "session-1",
+    activeSubagentSession: null,
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockDom.mjs").write_text(
+        """
+export const els = {
+    chatMessages: { innerHTML: "" },
+};
+
+globalThis.CustomEvent = class CustomEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail || {};
+    }
+};
+
+globalThis.document = {
+    dispatchEvent(event) {
+        globalThis.__events.push({ type: event.type, detail: event.detail });
+        return true;
+    },
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockI18n.mjs").write_text(
+        """
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockLogger.mjs").write_text(
+        """
+export function sysLog(message) {
+    globalThis.__logs.push(String(message));
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    runner_path.write_text(
+        f"""
+globalThis.__events = [];
+globalThis.__hydrateCalls = [];
+globalThis.__hydrateResolvers = [];
+globalThis.__switchHydrateCalls = [];
+globalThis.__logs = [];
+
+{runner_source}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=3,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    return json.loads(completed.stdout)

--- a/tests/unit_tests/frontend/test_subagent_sessions_ui.py
+++ b/tests/unit_tests/frontend/test_subagent_sessions_ui.py
@@ -17,7 +17,7 @@ def test_opening_subagent_session_hides_main_input_container(tmp_path: Path) -> 
     source_text = (
         source_path.read_text(encoding="utf-8")
         .replace("../core/api.js", "./mockApi.mjs")
-        .replace("../app/recovery.js", "./mockRecovery.mjs")
+        .replace("../app/sessionView.js", "./mockRecovery.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("./agentPanel.js", "./mockAgentPanel.mjs")
         .replace("./agentPanel/history.js", "./mockAgentPanelHistory.mjs")
@@ -56,7 +56,11 @@ export function syncNormalModeSubagentStreams() {
     )
     (tmp_path / "mockRecovery.mjs").write_text(
         """
-export async function hydrateSessionView() {
+export function abortMainSessionRestore() {
+    globalThis.__abortMainSessionRestoreCalls = (globalThis.__abortMainSessionRestoreCalls || 0) + 1;
+}
+
+export async function restoreMainSessionView() {
     return {};
 }
 """.strip(),
@@ -299,7 +303,7 @@ def test_return_to_main_session_clears_subagent_view_before_hydration(
     source_text = (
         source_path.read_text(encoding="utf-8")
         .replace("../core/api.js", "./mockApi.mjs")
-        .replace("../app/recovery.js", "./mockRecovery.mjs")
+        .replace("../app/sessionView.js", "./mockRecovery.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("./agentPanel.js", "./mockAgentPanel.mjs")
         .replace("./agentPanel/history.js", "./mockAgentPanelHistory.mjs")
@@ -329,20 +333,31 @@ export function syncNormalModeSubagentStreams() {
     )
     (tmp_path / "mockRecovery.mjs").write_text(
         """
-export async function hydrateSessionView(sessionId, options = {}) {
+import { els } from "./mockDom.mjs";
+
+export function abortMainSessionRestore() {
+    globalThis.__abortMainSessionRestoreCalls = (globalThis.__abortMainSessionRestoreCalls || 0) + 1;
+}
+
+export async function restoreMainSessionView(sessionId, options = {}) {
+    els.chatMessages.innerHTML = "<div class='subagent-main-session-loading'></div>";
+    document.dispatchEvent(new CustomEvent("agent-teams-subagent-session-cleared", {
+        detail: { sessionId },
+    }));
     globalThis.__hydrateCalls.push({
         sessionId,
-        includeRounds: options.includeRounds === true,
+        includeRounds: true,
         quiet: options.quiet === true,
     });
-    await new Promise((resolve, reject) => {
-        globalThis.__hydrateResolvers.push({ resolve, reject });
-        options.signal?.addEventListener?.("abort", () => {
-            const error = new Error("aborted");
-            error.name = "AbortError";
-            reject(error);
-        });
+    await new Promise(resolve => {
+        globalThis.__hydrateResolvers.push({ resolve });
     });
+    document.dispatchEvent(new CustomEvent("agent-teams-session-activated", {
+        detail: { sessionId },
+    }));
+    document.dispatchEvent(new CustomEvent("agent-teams-session-selected", {
+        detail: { sessionId },
+    }));
 }
 """.strip(),
         encoding="utf-8",
@@ -534,7 +549,7 @@ def test_return_to_main_session_ignores_stale_hydration_after_subagent_reentry(
     source_text = (
         source_path.read_text(encoding="utf-8")
         .replace("../core/api.js", "./mockApi.mjs")
-        .replace("../app/recovery.js", "./mockRecovery.mjs")
+        .replace("../app/sessionView.js", "./mockRecovery.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("./agentPanel.js", "./mockAgentPanel.mjs")
         .replace("./agentPanel/history.js", "./mockAgentPanelHistory.mjs")
@@ -556,10 +571,24 @@ def test_return_to_main_session_ignores_stale_hydration_after_subagent_reentry(
     )
     (tmp_path / "mockRecovery.mjs").write_text(
         """
-export async function hydrateSessionView() {
+import { state } from "./mockState.mjs";
+
+export function abortMainSessionRestore() {
+    globalThis.__abortMainSessionRestoreCalls = (globalThis.__abortMainSessionRestoreCalls || 0) + 1;
+}
+
+export async function restoreMainSessionView(sessionId) {
+    document.dispatchEvent(new CustomEvent("agent-teams-subagent-session-cleared", {
+        detail: { sessionId },
+    }));
     await new Promise(resolve => {
         globalThis.__hydrateResolvers.push({ resolve });
     });
+    if (!state.activeSubagentSession) {
+        document.dispatchEvent(new CustomEvent("agent-teams-session-selected", {
+            detail: { sessionId },
+        }));
+    }
 }
 """.strip(),
         encoding="utf-8",
@@ -689,7 +718,7 @@ def test_ensure_session_subagents_syncs_running_streams_for_current_session(
     source_text = (
         source_path.read_text(encoding="utf-8")
         .replace("../core/api.js", "./mockApi.mjs")
-        .replace("../app/recovery.js", "./mockRecovery.mjs")
+        .replace("../app/sessionView.js", "./mockRecovery.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("./agentPanel.js", "./mockAgentPanel.mjs")
         .replace("./agentPanel/history.js", "./mockAgentPanelHistory.mjs")
@@ -742,7 +771,11 @@ export function syncNormalModeSubagentStreams(sessionId, records) {
     )
     (tmp_path / "mockRecovery.mjs").write_text(
         """
-export async function hydrateSessionView() {
+export function abortMainSessionRestore() {
+    globalThis.__abortMainSessionRestoreCalls = (globalThis.__abortMainSessionRestoreCalls || 0) + 1;
+}
+
+export async function restoreMainSessionView() {
     return {};
 }
 """.strip(),
@@ -868,6 +901,210 @@ console.log(JSON.stringify({
     ]
 
 
+def test_ensure_session_subagents_limits_parallel_backend_loads(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "subagentSessions.js"
+    )
+    module_under_test_path = tmp_path / "subagentSessions.mjs"
+    runner_path = tmp_path / "runner_concurrency.mjs"
+
+    source_text = (
+        source_path.read_text(encoding="utf-8")
+        .replace("../core/api.js", "./mockApi.mjs")
+        .replace("../app/sessionView.js", "./mockRecovery.mjs")
+        .replace("../core/stream.js", "./mockStream.mjs")
+        .replace("./agentPanel.js", "./mockAgentPanel.mjs")
+        .replace("./agentPanel/history.js", "./mockAgentPanelHistory.mjs")
+        .replace("./rounds/navigator.js", "./mockNavigator.mjs")
+        .replace("../core/state.js", "./mockState.mjs")
+        .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/i18n.js", "./mockI18n.mjs")
+        .replace("../utils/logger.js", "./mockLogger.mjs")
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+
+    (tmp_path / "mockApi.mjs").write_text(
+        """
+export async function fetchAgentMessages() {
+    return [];
+}
+
+export async function fetchSessionSubagents(sessionId) {
+    globalThis.__activeLoads += 1;
+    globalThis.__maxActiveLoads = Math.max(
+        globalThis.__maxActiveLoads,
+        globalThis.__activeLoads,
+    );
+    globalThis.__loadCalls.push(sessionId);
+    return await new Promise(resolve => {
+        globalThis.__loadResolvers.push(() => {
+            globalThis.__activeLoads -= 1;
+            resolve([]);
+        });
+    });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockStream.mjs").write_text(
+        """
+export function syncNormalModeSubagentStreams() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockRecovery.mjs").write_text(
+        """
+export function abortMainSessionRestore() {
+    return undefined;
+}
+
+export async function restoreMainSessionView() {
+    return {};
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockAgentPanel.mjs").write_text(
+        """
+export function clearAllPanels() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockAgentPanelHistory.mjs").write_text(
+        """
+export async function renderInstanceHistoryInto() {
+    return { messages: [], streamOverlayEntry: null };
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockNavigator.mjs").write_text(
+        """
+export function hideRoundNavigator() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: "session-1",
+    activeSubagentSession: null,
+    activeView: "main",
+    isGenerating: false,
+    activeAgentRoleId: null,
+    activeAgentInstanceId: null,
+};
+
+export function getRoleDisplayName(roleId, { fallback } = {}) {
+    return String(roleId || fallback || "Agent");
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockDom.mjs").write_text(
+        """
+export const els = {
+    inputContainer: { style: {} },
+    promptInput: { disabled: false },
+    sendBtn: { disabled: false },
+    promptInputHint: { textContent: "" },
+    chatMessages: null,
+};
+
+globalThis.document = {
+    dispatchEvent() {
+        return undefined;
+    },
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockI18n.mjs").write_text(
+        """
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockLogger.mjs").write_text(
+        """
+export function sysLog() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner_path.write_text(
+        """
+globalThis.__activeLoads = 0;
+globalThis.__maxActiveLoads = 0;
+globalThis.__loadCalls = [];
+globalThis.__loadResolvers = [];
+
+const { ensureSessionSubagents } = await import("./subagentSessions.mjs");
+
+const promises = Array.from({ length: 5 }, (_, index) => (
+    ensureSessionSubagents(`session-${index}`, { force: true })
+));
+await Promise.resolve();
+const callsAfterStart = [...globalThis.__loadCalls];
+const activeAfterStart = globalThis.__activeLoads;
+
+while (globalThis.__loadResolvers.length > 0) {
+    const resolver = globalThis.__loadResolvers.shift();
+    resolver();
+    await Promise.resolve();
+}
+await Promise.all(promises);
+
+console.log(JSON.stringify({
+    activeAfterStart,
+    callsAfterStart,
+    loadCalls: globalThis.__loadCalls,
+    maxActiveLoads: globalThis.__maxActiveLoads,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=3,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+
+    assert payload["activeAfterStart"] == 2
+    assert payload["callsAfterStart"] == ["session-0", "session-1"]
+    assert payload["loadCalls"] == [
+        "session-0",
+        "session-1",
+        "session-2",
+        "session-3",
+        "session-4",
+    ]
+    assert payload["maxActiveLoads"] == 2
+
+
 def test_subagent_status_update_emits_sidebar_refresh_event(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = (
@@ -879,7 +1116,7 @@ def test_subagent_status_update_emits_sidebar_refresh_event(tmp_path: Path) -> N
     source_text = (
         source_path.read_text(encoding="utf-8")
         .replace("../core/api.js", "./mockApi.mjs")
-        .replace("../app/recovery.js", "./mockRecovery.mjs")
+        .replace("../app/sessionView.js", "./mockRecovery.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("./agentPanel.js", "./mockAgentPanel.mjs")
         .replace("./agentPanel/history.js", "./mockAgentPanelHistory.mjs")
@@ -916,7 +1153,11 @@ export function syncNormalModeSubagentStreams(sessionId, records) {
     )
     (tmp_path / "mockRecovery.mjs").write_text(
         """
-export async function hydrateSessionView() {
+export function abortMainSessionRestore() {
+    globalThis.__abortMainSessionRestoreCalls = (globalThis.__abortMainSessionRestoreCalls || 0) + 1;
+}
+
+export async function restoreMainSessionView() {
     return {};
 }
 """.strip(),
@@ -1111,7 +1352,7 @@ def test_background_task_event_records_normal_mode_subagent_immediately(
     source_text = (
         source_path.read_text(encoding="utf-8")
         .replace("../core/api.js", "./mockApi.mjs")
-        .replace("../app/recovery.js", "./mockRecovery.mjs")
+        .replace("../app/sessionView.js", "./mockRecovery.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("./agentPanel.js", "./mockAgentPanel.mjs")
         .replace("./agentPanel/history.js", "./mockAgentPanelHistory.mjs")
@@ -1156,7 +1397,11 @@ export function syncNormalModeSubagentStreams(sessionId, records) {
     )
     (tmp_path / "mockRecovery.mjs").write_text(
         """
-export async function hydrateSessionView() {
+export function abortMainSessionRestore() {
+    globalThis.__abortMainSessionRestoreCalls = (globalThis.__abortMainSessionRestoreCalls || 0) + 1;
+}
+
+export async function restoreMainSessionView() {
     return {};
 }
 """.strip(),
@@ -1356,7 +1601,7 @@ def test_terminal_settle_retries_until_history_is_safe(
     source_text = (
         source_path.read_text(encoding="utf-8")
         .replace("../core/api.js", "./mockApi.mjs")
-        .replace("../app/recovery.js", "./mockRecovery.mjs")
+        .replace("../app/sessionView.js", "./mockRecovery.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("./agentPanel.js", "./mockAgentPanel.mjs")
         .replace("./agentPanel/history.js", "./mockAgentPanelHistory.mjs")
@@ -1390,7 +1635,11 @@ export function syncNormalModeSubagentStreams() {
     )
     (tmp_path / "mockRecovery.mjs").write_text(
         """
-export async function hydrateSessionView() {
+export function abortMainSessionRestore() {
+    globalThis.__abortMainSessionRestoreCalls = (globalThis.__abortMainSessionRestoreCalls || 0) + 1;
+}
+
+export async function restoreMainSessionView() {
     return {};
 }
 """.strip(),

--- a/tests/unit_tests/frontend/test_subagent_streams_ui.py
+++ b/tests/unit_tests/frontend/test_subagent_streams_ui.py
@@ -5,6 +5,21 @@ from pathlib import Path
 import subprocess
 
 
+def test_background_discovery_does_not_poll_for_idle_selected_session() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "frontend" / "dist" / "js" / "core" / "stream.js").read_text(
+        encoding="utf-8"
+    )
+    block = source.split("function shouldRunBackgroundDiscovery()", 1)[1].split(
+        "\n}\n",
+        1,
+    )[0]
+
+    assert "currentSessionId" not in block
+    assert "pendingBackgroundAttachRunIds.size > 0" in block
+    assert "pendingRunStart" in block
+
+
 def test_normal_mode_subagent_streams_attach_route_and_detach(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = repo_root / "frontend" / "dist" / "js" / "core" / "stream.js"
@@ -602,7 +617,9 @@ console.log(JSON.stringify({
 
     payload = json.loads(completed.stdout)
 
-    assert payload["eventSourceUrls"] == ["/api/runs/run-1/events"]
+    assert payload["eventSourceUrls"] == [
+        "/api/runs/events?run_id=run-1&after_event_id=0"
+    ]
     assert 2500 in payload["scheduledDelays"]
     assert payload["fetchSubagentCalls"] == ["session-1"]
 
@@ -906,8 +923,10 @@ console.log(JSON.stringify({
 
     payload = json.loads(completed.stdout)
 
-    assert payload["fetchRecoveryCalls"] == ["session-1"]
-    assert payload["eventSourceUrls"] == ["/api/runs/run-1/events?after_event_id=1"]
+    assert payload["fetchRecoveryCalls"] == []
+    assert payload["eventSourceUrls"] == [
+        "/api/runs/events?run_id=run-1&after_event_id=0"
+    ]
     assert payload["eventSourceClosed"] is True
     assert payload["routeEventCalls"] == [
         {
@@ -1113,8 +1132,8 @@ export function clearRunStreamState() {
     return undefined;
 }
 
-export function applyStreamOverlayEvent() {
-    return undefined;
+export function applyStreamOverlayEvent(evType, payload, options = {}) {
+    globalThis.__overlayCalls.push({ evType, payload, options });
 }
 """.strip(),
         encoding="utf-8",
@@ -1161,6 +1180,7 @@ import { state } from "./mockState.mjs";
 globalThis.__fetchRecoveryCalls = [];
 globalThis.__fetchSessionsCalls = 0;
 globalThis.__routeEventCalls = [];
+globalThis.__overlayCalls = [];
 globalThis.__scheduleSessionsRefreshCalls = 0;
 globalThis.__eventSources = [];
 globalThis.__deferRecovery = false;
@@ -1197,7 +1217,7 @@ const {
 syncBackgroundStreamsForSessions(globalThis.__sessionRecords);
 await new Promise(resolve => setTimeout(resolve, 30));
 const backgroundBeforeNavigation = globalThis.__eventSources.filter(source => (
-    source.url.startsWith("/api/runs/run-session-")
+    source.url.startsWith("/api/runs/events?")
     && source.closed !== true
 )).map(source => source.url);
 
@@ -1218,12 +1238,44 @@ prepareStreamsForForegroundNavigation("session-39");
 const openAfterPrepare = globalThis.__eventSources
     .filter(source => source.closed !== true)
     .map(source => source.url);
+const session39Source = globalThis.__eventSources.find(source => (
+    source.closed !== true && source.url.startsWith("/api/runs/events?")
+));
+session39Source.onmessage({
+    data: JSON.stringify({
+        event_id: 100,
+        event_type: "text_delta",
+        payload_json: JSON.stringify({
+            run_id: "run-session-39",
+            session_id: "session-39",
+            text: "visible",
+        }),
+        run_id: "run-session-39",
+        trace_id: "run-session-39",
+    }),
+});
 
 globalThis.__deferRecovery = true;
 syncBackgroundStreamsForSessions(globalThis.__sessionRecords);
 await Promise.resolve();
 state.currentSessionId = "session-12";
 prepareStreamsForForegroundNavigation("session-12");
+const session12Source = globalThis.__eventSources.find(source => (
+    source.closed !== true && source.url.startsWith("/api/runs/events?")
+));
+session12Source.onmessage({
+    data: JSON.stringify({
+        event_id: 101,
+        event_type: "text_delta",
+        payload_json: JSON.stringify({
+            run_id: "run-session-39",
+            session_id: "session-39",
+            text: "hidden",
+        }),
+        run_id: "run-session-39",
+        trace_id: "run-session-39",
+    }),
+});
 for (const resolveRecovery of globalThis.__recoveryResolvers.splice(0)) {
     resolveRecovery();
 }
@@ -1237,6 +1289,8 @@ console.log(JSON.stringify({
     openUrlsAtEnd: globalThis.__eventSources
         .filter(source => source.closed !== true)
         .map(source => source.url),
+    routeEventCalls: globalThis.__routeEventCalls,
+    overlayCalls: globalThis.__overlayCalls,
     fetchRecoveryCallCount: globalThis.__fetchRecoveryCalls.length,
     fetchRecoveryCalls: globalThis.__fetchRecoveryCalls,
     scheduleSessionsRefreshCalls: globalThis.__scheduleSessionsRefreshCalls,
@@ -1263,15 +1317,22 @@ process.exit(0);
 
     payload = json.loads(completed.stdout)
 
-    assert len(payload["backgroundBeforeNavigation"]) == 2
+    assert len(payload["backgroundBeforeNavigation"]) == 1
+    assert payload["backgroundBeforeNavigation"][0].count("run_id=") == 32
     assert payload["subagentStreamBeforeNavigation"] == [
         "/api/sessions/session-00/subagents/events?after_event_id=18",
     ]
-    assert payload["openAfterPrepare"] == [
-        "/api/runs/run-session-39/events?after_event_id=7",
+    assert len(payload["openAfterPrepare"]) == 1
+    assert payload["openAfterPrepare"][0].startswith("/api/runs/events?")
+    assert "run_id=run-session-39" in payload["openAfterPrepare"][0]
+    assert len(payload["openUrlsAtEnd"]) == 1
+    assert payload["openUrlsAtEnd"][0].startswith("/api/runs/events?")
+    assert "run_id=run-session-12" in payload["openUrlsAtEnd"][0]
+    assert [call["payload"]["text"] for call in payload["routeEventCalls"]] == [
+        "visible"
     ]
-    assert payload["openUrlsAtEnd"] == []
-    assert payload["fetchRecoveryCallCount"] == 2
+    assert [call["payload"]["text"] for call in payload["overlayCalls"]] == ["hidden"]
+    assert payload["fetchRecoveryCallCount"] == 0
     assert payload["scheduleSessionsRefreshCalls"] == 0
 
 
@@ -1582,7 +1643,9 @@ console.log(JSON.stringify({
     assert payload["currentSessionId"] == "session-b"
     assert payload["activeRunId"] is None
     assert payload["activeEventSourceUrl"] is None
-    assert payload["eventSourceUrls"] == ["/api/runs/run-a/events"]
+    assert payload["eventSourceUrls"] == [
+        "/api/runs/events?run_id=run-a&after_event_id=0"
+    ]
     assert payload["runCreated"] == []
     assert payload["completed"] == []
     assert payload["scheduleSessionsRefreshCalls"] == 1
@@ -1590,6 +1653,306 @@ console.log(JSON.stringify({
         {"sessionId": "session-a", "promptText": "hello"},
     ]
     assert payload["stopRunCalls"] == 0
+
+
+def test_active_multiplex_stream_releases_ui_on_run_paused(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "core" / "stream.js"
+    module_under_test_path = tmp_path / "stream.mjs"
+    runner_path = tmp_path / "runner_paused_terminal.mjs"
+
+    source_text = (
+        source_path.read_text(encoding="utf-8")
+        .replace("./api.js", "./mockApi.mjs")
+        .replace("../components/contextIndicators.js", "./mockContextIndicators.mjs")
+        .replace("../app/prompt.js", "./mockPrompt.mjs")
+        .replace("../components/subagentSessions.js", "./mockSubagentSessions.mjs")
+        .replace("../components/sidebar.js", "./mockSidebar.mjs")
+        .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/backendStatus.js", "./mockBackendStatus.mjs")
+        .replace("../utils/logger.js", "./mockLogger.mjs")
+        .replace("./eventRouter.js", "./mockEventRouter.mjs")
+        .replace("../components/messageRenderer.js", "./mockMessageRenderer.mjs")
+        .replace("./state.js", "./mockState.mjs")
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+
+    (tmp_path / "mockApi.mjs").write_text(
+        """
+export async function fetchSessionRecovery() {
+    return {};
+}
+
+export async function fetchSessionSubagents() {
+    return [];
+}
+
+export async function fetchSessions() {
+    return [];
+}
+
+export async function sendUserPrompt() {
+    return { run_id: "run-paused", target_role_id: "MainAgent" };
+}
+
+export async function stopRun() {
+    throw new Error("not used");
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockContextIndicators.mjs").write_text(
+        """
+export function refreshVisibleContextIndicators() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockPrompt.mjs").write_text(
+        """
+export function refreshSessionTopologyControls() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSubagentSessions.mjs").write_text(
+        """
+export function replaceSessionSubagents() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSidebar.mjs").write_text(
+        """
+export function scheduleSessionsRefresh(delay = null, options = {}) {
+    globalThis.__scheduleSessionsRefreshCalls.push({ delay, options });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockDom.mjs").write_text(
+        """
+export const els = {
+    sendBtn: { disabled: false },
+    promptInput: {
+        disabled: false,
+        focus() {
+            globalThis.__focusCalls += 1;
+        },
+    },
+    yoloToggle: { disabled: false },
+    thinkingModeToggle: { disabled: false },
+    thinkingEffortSelect: { disabled: false },
+    stopBtn: { style: {}, disabled: false },
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockBackendStatus.mjs").write_text(
+        """
+export function markBackendOnline() {
+    return undefined;
+}
+
+export async function refreshBackendStatus() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockLogger.mjs").write_text(
+        """
+export function errorToPayload(error, extra = {}) {
+    return { error: String(error?.message || error || ''), ...extra };
+}
+
+export function logError() {
+    return undefined;
+}
+
+export function logInfo() {
+    return undefined;
+}
+
+export function logWarn() {
+    return undefined;
+}
+
+export function sysLog() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockEventRouter.mjs").write_text(
+        """
+export function routeEvent(evType, payload, eventMeta) {
+    globalThis.__routeEventCalls.push({ evType, payload, eventMeta });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockMessageRenderer.mjs").write_text(
+        """
+export function clearRunStreamState(runId) {
+    globalThis.__clearRunStreamStateCalls.push(runId);
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: "session-a",
+    currentSessionMode: "normal",
+    activeSubagentSession: null,
+    activeEventSource: null,
+    activeRunId: null,
+    isGenerating: false,
+    runPrimaryRoleMap: {},
+};
+
+export function getPrimaryRoleId() {
+    return "MainAgent";
+}
+
+export function getPrimaryRoleLabel() {
+    return "Main Agent";
+}
+
+export function getRunPrimaryRoleId() {
+    return "MainAgent";
+}
+
+export function getRunPrimaryRoleLabel() {
+    return "Main Agent";
+}
+
+export function setRunPrimaryRole(runId, roleId) {
+    state.runPrimaryRoleMap[runId] = roleId;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner_path.write_text(
+        """
+import { els } from "./mockDom.mjs";
+import { state } from "./mockState.mjs";
+
+globalThis.__eventSources = [];
+globalThis.__routeEventCalls = [];
+globalThis.__clearRunStreamStateCalls = [];
+globalThis.__scheduleSessionsRefreshCalls = [];
+globalThis.__focusCalls = 0;
+
+class MockEventSource {
+    constructor(url) {
+        this.url = url;
+        this.closed = false;
+        this.onmessage = null;
+        this.onerror = null;
+        globalThis.__eventSources.push(this);
+    }
+
+    close() {
+        this.closed = true;
+    }
+}
+
+globalThis.EventSource = MockEventSource;
+
+const { startIntentStream } = await import("./stream.mjs");
+
+const completed = [];
+await startIntentStream(
+    "hello",
+    "session-a",
+    sessionId => completed.push(sessionId),
+    { targetRoleId: "MainAgent" },
+);
+
+const eventSource = globalThis.__eventSources[0];
+const beforePause = {
+    isGenerating: state.isGenerating,
+    sendDisabled: els.sendBtn.disabled,
+    promptDisabled: els.promptInput.disabled,
+    activeRunId: state.activeRunId,
+    activeEventSourceUrl: state.activeEventSource?.url || null,
+};
+
+eventSource.onmessage({
+    data: JSON.stringify({
+        event_id: 12,
+        event_type: "run_paused",
+        payload_json: JSON.stringify({ reason: "approval" }),
+        run_id: "run-paused",
+        trace_id: "run-paused",
+    }),
+});
+await Promise.resolve();
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    beforePause,
+    afterPause: {
+        isGenerating: state.isGenerating,
+        sendDisabled: els.sendBtn.disabled,
+        promptDisabled: els.promptInput.disabled,
+        activeRunId: state.activeRunId,
+        activeEventSourceUrl: state.activeEventSource?.url || null,
+        eventSourceClosed: eventSource.closed === true,
+    },
+    completed,
+    routeEventCalls: globalThis.__routeEventCalls,
+    clearRunStreamStateCalls: globalThis.__clearRunStreamStateCalls,
+    focusCalls: globalThis.__focusCalls,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=3,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+
+    assert payload["beforePause"] == {
+        "isGenerating": True,
+        "sendDisabled": True,
+        "promptDisabled": True,
+        "activeRunId": "run-paused",
+        "activeEventSourceUrl": "/api/runs/events?run_id=run-paused&after_event_id=0",
+    }
+    assert payload["afterPause"] == {
+        "isGenerating": False,
+        "sendDisabled": False,
+        "promptDisabled": False,
+        "activeRunId": "run-paused",
+        "activeEventSourceUrl": None,
+        "eventSourceClosed": True,
+    }
+    assert payload["completed"] == ["session-a"]
+    assert payload["clearRunStreamStateCalls"] == ["run-paused"]
+    assert payload["focusCalls"] == 1
+    assert [call["evType"] for call in payload["routeEventCalls"]] == ["run_paused"]
 
 
 def test_normal_mode_subagent_discovery_reconciles_sidebar_cache(

--- a/tests/unit_tests/interfaces/server/test_frontend_static_cache.py
+++ b/tests/unit_tests/interfaces/server/test_frontend_static_cache.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from relay_teams.interfaces.server.app import FrontendStaticFiles
+
+
+def test_frontend_static_files_revalidate_browser_modules(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    js_dir = dist_dir / "js"
+    js_dir.mkdir(parents=True)
+    (js_dir / "app.js").write_text("export const ok = true;\n", encoding="utf-8")
+
+    app = FastAPI()
+    app.mount("/", FrontendStaticFiles(directory=str(dist_dir), html=True))
+
+    with TestClient(app) as client:
+        response = client.get("/js/app.js")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-cache"

--- a/tests/unit_tests/interfaces/server/test_runs_router.py
+++ b/tests/unit_tests/interfaces/server/test_runs_router.py
@@ -18,7 +18,9 @@ from relay_teams.media import (
     content_parts_from_text,
 )
 from relay_teams.sessions.runs.run_models import IntentInput
+from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.run_service import SessionRunService
+from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.user_question_models import UserQuestionAnswer
 
 
@@ -33,6 +35,7 @@ class _FakeRunService:
         self.raise_on_inject = False
         self.raise_on_subagent_inject = False
         self.created_run_inputs: list[IntentInput] = []
+        self.multiplex_stream_calls: list[tuple[tuple[str, int], ...]] = []
         self.background_tasks: dict[str, dict[str, object]] = {
             "exec-1": {
                 "background_task_id": "exec-1",
@@ -342,6 +345,21 @@ class _FakeRunService:
     ) -> dict[str, str]:
         return {"instance_id": instance_id, "run_id": run_id}
 
+    async def stream_multiplexed_run_events(self, run_offsets):
+        normalized_offsets = tuple(
+            (str(run_id), int(offset)) for run_id, offset in run_offsets
+        )
+        self.multiplex_stream_calls.append(normalized_offsets)
+        for run_id, offset in normalized_offsets:
+            yield RunEvent(
+                session_id=f"session-{run_id}",
+                run_id=run_id,
+                trace_id=run_id,
+                event_type=RunEventType.RUN_COMPLETED,
+                payload_json='{"status":"completed"}',
+                event_id=offset + 1,
+            )
+
 
 class _CancellationAwareRunService(_FakeRunService):
     def __init__(self) -> None:
@@ -480,6 +498,78 @@ async def test_create_and_start_run_finishes_startup_after_cancellation() -> Non
     await asyncio.wait_for(fake_service.run_started.wait(), timeout=1)
 
     assert fake_service.started_run_ids == ["run-1"]
+
+
+def test_multiplex_run_events_route_streams_multiple_runs() -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+
+    response = client.get(
+        "/api/runs/events?run_id=run-1&after_event_id=4&run_id=run-2&after_event_id=9"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert fake_service.multiplex_stream_calls == [(("run-1", 4), ("run-2", 9))]
+    assert '"run_id":"run-1"' in response.text
+    assert '"event_id":5' in response.text
+    assert '"run_id":"run-2"' in response.text
+    assert '"event_id":10' in response.text
+
+
+def test_multiplex_run_events_route_deduplicates_run_ids_with_max_offset() -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+
+    response = client.get(
+        "/api/runs/events?run_id=run-1&after_event_id=4"
+        "&run_id=run-1&after_event_id=8"
+        "&run_id=run-2"
+    )
+
+    assert response.status_code == 200
+    assert fake_service.multiplex_stream_calls == [(("run-1", 8), ("run-2", 0))]
+
+
+def test_multiplex_run_events_route_rejects_too_many_runs() -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+    query = "&".join(f"run_id=run-{index}" for index in range(33))
+
+    response = client.get(f"/api/runs/events?{query}")
+
+    assert response.status_code == 422
+    assert fake_service.multiplex_stream_calls == []
+
+
+@pytest.mark.parametrize(
+    ("query", "detail"),
+    [
+        ("", "At least one run_id is required"),
+        (
+            "run_id=run-1&after_event_id=1&after_event_id=2",
+            "after_event_id cannot contain more values than run_id",
+        ),
+        ("run_id=%20", "run_id cannot be blank"),
+        (
+            "run_id=run-1&after_event_id=-1",
+            "after_event_id must be greater than or equal to 0",
+        ),
+    ],
+)
+def test_multiplex_run_events_route_rejects_invalid_offsets(
+    query: str,
+    detail: str,
+) -> None:
+    fake_service = _FakeRunService()
+    client = _create_client(fake_service)
+    suffix = f"?{query}" if query else ""
+
+    response = client.get(f"/api/runs/events{suffix}")
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == detail
+    assert fake_service.multiplex_stream_calls == []
 
 
 def test_create_run_route_accepts_yolo() -> None:

--- a/tests/unit_tests/interfaces/server/test_sessions_router.py
+++ b/tests/unit_tests/interfaces/server/test_sessions_router.py
@@ -220,12 +220,14 @@ class _FakeSessionService:
         limit: int,
         cursor_run_id: str | None,
         timeline: bool = False,
+        summary: bool = False,
     ) -> dict[str, object]:
         return {
             "session_id": session_id,
             "limit": limit,
             "cursor_run_id": cursor_run_id,
             "timeline": timeline,
+            "summary": summary,
             "rounds": [],
         }
 

--- a/tests/unit_tests/sessions/runs/test_event_log.py
+++ b/tests/unit_tests/sessions/runs/test_event_log.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -189,3 +190,87 @@ async def test_event_log_lists_session_events_after_id_and_filters_subagent_runs
     assert tuple(row["id"] for row in async_session_rows) == (subagent_id,)
     assert tuple(row["id"] for row in subagent_rows) == (subagent_id,)
     assert tuple(row["id"] for row in async_subagent_rows) == (subagent_id,)
+
+
+@pytest.mark.asyncio
+async def test_event_log_lists_multiple_traces_after_offsets_in_one_batch(
+    tmp_path: Path,
+) -> None:
+    event_log = EventLog(tmp_path / "event_log_multi_trace_after_id.db")
+    run_1_first = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"run": 1, "seq": 1}',
+        )
+    )
+    run_2_first = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-2",
+            run_id="run-2",
+            trace_id="run-2",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"run": 2, "seq": 1}',
+        )
+    )
+    run_1_second = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.MODEL_STEP_STARTED,
+            payload_json='{"run": 1, "seq": 2}',
+        )
+    )
+    run_2_second = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-2",
+            run_id="run-2",
+            trace_id="run-2",
+            event_type=RunEventType.MODEL_STEP_STARTED,
+            payload_json='{"run": 2, "seq": 2}',
+        )
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id="session-3",
+            run_id="run-3",
+            trace_id="run-3",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"run": 3}',
+        )
+    )
+
+    try:
+        rows = await event_log.list_by_traces_after_ids_async(
+            (("run-1", run_1_first), ("run-2", run_2_first), ("run-1", 0))
+        )
+    finally:
+        await event_log.close_async()
+
+    assert run_2_first > run_1_first
+    assert tuple(row["id"] for row in rows) == (run_1_second, run_2_second)
+
+
+def test_event_log_multi_trace_replay_ignores_empty_offsets(tmp_path: Path) -> None:
+    event_log = EventLog(tmp_path / "event_log_multi_trace_empty_offsets.db")
+    try:
+        rows = event_log.list_by_traces_after_ids(((" ", 4),))
+    finally:
+        event_log.close()
+
+    assert rows == ()
+
+
+def test_event_log_has_trace_id_replay_index(tmp_path: Path) -> None:
+    db_path = tmp_path / "event_log_trace_id_index.db"
+    event_log = EventLog(db_path)
+    event_log.close()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("PRAGMA index_list(events)").fetchall()
+
+    assert "idx_events_trace_id" in {str(row["name"]) for row in rows}

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -2524,6 +2524,252 @@ async def test_stream_run_events_stops_after_run_paused(
 
 
 @pytest.mark.asyncio
+async def test_stream_multiplexed_run_events_ignores_empty_offsets(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_multiplex_stream_empty_offsets.db"
+    manager = _build_manager(db_path)
+
+    replayed = [
+        event async for event in manager.stream_multiplexed_run_events(((" ", 3),))
+    ]
+
+    assert replayed == []
+
+
+@pytest.mark.asyncio
+async def test_stream_multiplexed_run_events_replays_runs_and_finishes_live_terminal(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_multiplex_stream_replay_live.db"
+    manager = _build_manager(db_path)
+    run_a_started_id = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-a",
+            run_id="run-a",
+            trace_id="run-a",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"run":"a","step":"started"}',
+        )
+    )
+    run_b_started_id = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-b",
+            run_id="run-b",
+            trace_id="run-b",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"run":"b","step":"started"}',
+        )
+    )
+    run_a_delta_id = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-a",
+            run_id="run-a",
+            trace_id="run-a",
+            event_type=RunEventType.TEXT_DELTA,
+            payload_json='{"text":"after offset"}',
+        )
+    )
+    run_b_completed_id = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-b",
+            run_id="run-b",
+            trace_id="run-b",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed"}',
+        )
+    )
+
+    stream = manager.stream_multiplexed_run_events(
+        (("run-a", run_a_started_id), ("run-b", 0))
+    )
+    replayed = [await anext(stream), await anext(stream), await anext(stream)]
+    live_task = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    live_completed_id = await manager._run_event_hub.publish_async(
+        RunEvent(
+            session_id="session-a",
+            run_id="run-a",
+            trace_id="run-a",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed"}',
+        )
+    )
+    live_completed = await asyncio.wait_for(live_task, timeout=1)
+
+    assert [event.event_id for event in replayed] == [
+        run_b_started_id,
+        run_a_delta_id,
+        run_b_completed_id,
+    ]
+    assert live_completed.event_id == live_completed_id
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(stream), timeout=1)
+    assert manager._run_event_hub.has_subscribers("run-a") is False
+    assert manager._run_event_hub.has_subscribers("run-b") is False
+
+
+@pytest.mark.asyncio
+async def test_stream_multiplexed_run_events_stops_replay_after_terminal_event(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_multiplex_stream_terminal_replay_stop.db"
+    manager = _build_manager(db_path)
+    run_a_started_id = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-a",
+            run_id="run-a",
+            trace_id="run-a",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"run":"a","step":"started"}',
+        )
+    )
+    run_a_paused_id = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-a",
+            run_id="run-a",
+            trace_id="run-a",
+            event_type=RunEventType.RUN_PAUSED,
+            payload_json='{"reason":"approval"}',
+        )
+    )
+    _ = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-a",
+            run_id="run-a",
+            trace_id="run-a",
+            event_type=RunEventType.RUN_RESUMED,
+            payload_json='{"reason":"resume"}',
+        )
+    )
+    _ = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-a",
+            run_id="run-a",
+            trace_id="run-a",
+            event_type=RunEventType.TEXT_DELTA,
+            payload_json='{"text":"after pause"}',
+        )
+    )
+    run_b_started_id = manager._run_event_hub.publish(
+        RunEvent(
+            session_id="session-b",
+            run_id="run-b",
+            trace_id="run-b",
+            event_type=RunEventType.RUN_STARTED,
+            payload_json='{"run":"b","step":"started"}',
+        )
+    )
+
+    stream = manager.stream_multiplexed_run_events((("run-a", 0), ("run-b", 0)))
+    replayed = [await anext(stream), await anext(stream), await anext(stream)]
+    live_task = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    live_completed_id = await manager._run_event_hub.publish_async(
+        RunEvent(
+            session_id="session-b",
+            run_id="run-b",
+            trace_id="run-b",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed"}',
+        )
+    )
+    live_completed = await asyncio.wait_for(live_task, timeout=1)
+
+    assert [event.event_id for event in replayed] == [
+        run_a_started_id,
+        run_a_paused_id,
+        run_b_started_id,
+    ]
+    assert live_completed.event_id == live_completed_id
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(stream), timeout=1)
+    assert manager._run_event_hub.has_subscribers("run-a") is False
+    assert manager._run_event_hub.has_subscribers("run-b") is False
+
+
+@pytest.mark.asyncio
+async def test_stream_multiplexed_run_events_skips_live_events_already_replayed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_multiplex_stream_duplicate_replay.db"
+    manager = _build_manager(db_path)
+    event_log = manager._event_log
+    assert event_log is not None
+    original_list = event_log.list_by_traces_after_ids_async
+
+    async def _list_after_publishing_duplicate(
+        trace_offsets: tuple[tuple[str, int], ...],
+    ) -> tuple[dict[str, JsonValue], ...]:
+        _ = await manager._run_event_hub.publish_async(
+            RunEvent(
+                session_id="session-a",
+                run_id="run-a",
+                trace_id="run-a",
+                event_type=RunEventType.TEXT_DELTA,
+                payload_json='{"text":"duplicate"}',
+            )
+        )
+        return await original_list(trace_offsets)
+
+    monkeypatch.setattr(
+        event_log,
+        "list_by_traces_after_ids_async",
+        _list_after_publishing_duplicate,
+    )
+
+    stream = manager.stream_multiplexed_run_events((("run-a", 0),))
+    replayed = await anext(stream)
+    live_task = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    live_completed_id = await manager._run_event_hub.publish_async(
+        RunEvent(
+            session_id="session-a",
+            run_id="run-a",
+            trace_id="run-a",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed"}',
+        )
+    )
+    live_completed = await asyncio.wait_for(live_task, timeout=1)
+
+    assert replayed.event_type == RunEventType.TEXT_DELTA
+    assert live_completed.event_type == RunEventType.RUN_COMPLETED
+    assert live_completed.event_id == live_completed_id
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(stream), timeout=1)
+    assert manager._run_event_hub.has_subscribers("run-a") is False
+
+
+@pytest.mark.asyncio
+async def test_stream_multiplexed_run_events_streams_live_without_event_log(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_multiplex_stream_no_event_log.db"
+    manager = _build_manager(db_path, attach_manager_event_log=False)
+
+    stream = manager.stream_multiplexed_run_events((("run-live", 0),))
+    live_task = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+    live_completed_id = await manager._run_event_hub.publish_async(
+        RunEvent(
+            session_id="session-live",
+            run_id="run-live",
+            trace_id="run-live",
+            event_type=RunEventType.RUN_COMPLETED,
+            payload_json='{"status":"completed"}',
+        )
+    )
+    live_completed = await asyncio.wait_for(live_task, timeout=1)
+
+    assert live_completed.event_id == live_completed_id
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(stream), timeout=1)
+    assert manager._run_event_hub.has_subscribers("run-live") is False
+
+
+@pytest.mark.asyncio
 async def test_worker_auto_recovers_network_stream_interruption(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py
+++ b/tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py
@@ -243,6 +243,48 @@ def test_session_rounds_timeline_bypasses_full_round_projection(
     assert "coordinator_messages" not in first
 
 
+def test_session_rounds_summary_pages_lightweight_timeline_without_full_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "summary_round_state_overlay.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    task_repo = TaskRepository(db_path)
+    for index in range(3):
+        _ = task_repo.create(
+            TaskEnvelope(
+                task_id=f"task-root-{index}",
+                session_id="session-1",
+                parent_task_id=None,
+                trace_id=f"run-{index}",
+                objective=f"summary only {index}",
+                verification=VerificationPlan(checklist=("non_empty_response",)),
+            )
+        )
+
+    def fail_full_round_projection(**_kwargs: object) -> list[dict[str, object]]:
+        raise AssertionError("summary requests should not build full round payloads")
+
+    monkeypatch.setattr(
+        session_service_module,
+        "build_session_rounds",
+        fail_full_round_projection,
+    )
+
+    page = service.get_session_rounds("session-1", limit=2, summary=True)
+    items = page.get("items")
+
+    assert isinstance(items, list)
+    assert len(items) == 2
+    assert page.get("has_more") is True
+    assert page.get("next_cursor") == items[-1].get("run_id")
+    assert all(
+        "coordinator_messages" not in item for item in items if isinstance(item, dict)
+    )
+
+
 def test_session_rounds_page_targets_only_visible_run_messages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -303,6 +345,65 @@ def test_session_rounds_page_targets_only_visible_run_messages(
     assert len(items) == 1
     assert page.get("has_more") is True
     assert captured_run_ids == [(str(items[0].get("run_id") or ""),)]
+
+
+def test_get_round_targets_single_run_messages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "single_round_targeted_messages.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    task_repo = TaskRepository(db_path)
+    for index in range(3):
+        _ = task_repo.create(
+            TaskEnvelope(
+                task_id=f"task-root-{index}",
+                session_id="session-1",
+                parent_task_id=None,
+                trace_id=f"run-{index}",
+                objective=f"work {index}",
+                verification=VerificationPlan(checklist=("non_empty_response",)),
+            )
+        )
+
+    def fail_full_session_message_load(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("single round reads should not load every session message")
+
+    captured_run_ids: list[tuple[str, ...]] = []
+    original_targeted_load = service._message_repo.get_messages_by_session_run_ids
+
+    def capture_targeted_load(
+        session_id: str,
+        run_ids: tuple[str, ...],
+        *,
+        include_cleared: bool = False,
+        include_hidden_from_context: bool = False,
+    ) -> list[dict[str, JsonValue]]:
+        captured_run_ids.append(run_ids)
+        return original_targeted_load(
+            session_id,
+            run_ids,
+            include_cleared=include_cleared,
+            include_hidden_from_context=include_hidden_from_context,
+        )
+
+    monkeypatch.setattr(
+        service._message_repo,
+        "get_messages_by_session",
+        fail_full_session_message_load,
+    )
+    monkeypatch.setattr(
+        service._message_repo,
+        "get_messages_by_session_run_ids",
+        capture_targeted_load,
+    )
+
+    round_item = service.get_round("session-1", "run-1")
+
+    assert round_item.get("run_id") == "run-1"
+    assert captured_run_ids == [("run-1",)]
 
 
 def test_build_session_timeline_rounds_filters_included_run_ids(


### PR DESCRIPTION
Fixes #594.

## Summary
- Add a single `/api/runs/events` SSE multiplex endpoint for main-run streams with per-run replay offsets.
- Route frontend main-run stream recovery through one multiplex connection while keeping active subagent streams independent.
- Load session rounds through summary/paged APIs so switching sessions does not block on full history or first stream output.
- Preserve subagent expansion/collapse, tool-call cache, and completion state behavior across session switches.

## Tests
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `uv run --extra dev pytest -q tests/integration_tests --basetemp=.pytest-integration-pr-tmp2`