### PR TITLE
Add local plugin runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
   - `notifications/`: notification models, settings, config, and delivery service
   - `paths/`: repository and runtime path helpers
   - `persistence/`: DB access and shared persistence models/repos
+  - `plugins/`: plugin manifests, registry, component source resolution, and plugin-provided MCP source loading
   - `providers/`: provider contracts, model config, HTTP client factory, OpenAI-compatible adapters, token usage
   - `reflection/`: reflection config, models, repository, service, and CLI
   - `roles/`: role models, registry, settings, and CLI
@@ -33,6 +34,7 @@
 - Tests:
   - `tests/unit_tests/`: mirrors `src/relay_teams/` by module
   - `tests/unit_tests/hooks/`: hook loader, executors, and runtime behavior
+  - `tests/unit_tests/plugins/`: plugin manifest loading, namespacing, component source wiring, and runtime integration
   - `tests/integration_tests/api/`: HTTP/SSE integration flows
   - `tests/integration_tests/browser/`: browser scenarios
   - `tests/integration_tests/cli/`: CLI integration coverage

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -364,6 +364,17 @@ The response flattens effective hook handlers across user, project, and project-
 Each entry includes at least the handler name, hook event, matcher, source scope/path, and any scoped filters such as tool names or role IDs.
 When no hook files are active, the endpoint returns an empty `loaded_hooks` list.
 
+### `GET /system/configs/plugins/runtime`
+
+Returns the Phase 1 runtime plugin registry loaded from local plugin roots.
+Local plugin roots are configured through `RELAY_TEAMS_PLUGIN_DIRS`, typically
+from the process environment or the `.env` file in the resolved app config
+directory.
+The response includes enabled plugin records, component source paths for skills,
+roles, commands, hooks, and MCP server configs, plus plugin diagnostics. Invalid
+runtime plugin entries are reported through diagnostics instead of crashing
+startup.
+
 ### `PUT /system/configs/github`
 
 Saves the GitHub CLI configuration.

--- a/docs/plugins-capability-design.md
+++ b/docs/plugins-capability-design.md
@@ -1,0 +1,685 @@
+# Relay Teams Plugins Capability Design
+
+## 1. Goal
+
+Relay Teams should support first-class plugins as installable, versioned capability
+bundles. A plugin packages existing Relay Teams extension surfaces into one
+runtime unit:
+
+- skills
+- roles
+- commands
+- hooks
+- MCP servers
+- monitors
+- default settings
+- supporting scripts and resources
+
+The design is based on the Claude Code plugin reference, but it is intentionally
+adapted to the current Relay Teams architecture. Plugins should be an assembly
+layer over the existing registries and config loaders, not a parallel capability
+system.
+
+Reference material:
+
+- Claude Code plugins reference: `https://code.claude.com/docs/en/plugins-reference`
+- Claude Code create plugins guide: `https://code.claude.com/docs/en/plugins`
+
+## 2. Existing Relay Teams Capabilities
+
+The repository already has most runtime capability primitives:
+
+- skills: `src/relay_teams/skills/`
+- roles: `src/relay_teams/roles/`
+- hooks: `src/relay_teams/hooks/`
+- MCP: `src/relay_teams/mcp/`
+- commands: `src/relay_teams/commands/`
+- monitors: `src/relay_teams/monitors/`
+- config paths: `src/relay_teams/paths/`
+- server wiring: `src/relay_teams/interfaces/server/container.py`
+
+The plugin layer should therefore focus on:
+
+- plugin manifest parsing and validation
+- install, enable, disable, update, and list state
+- scope-aware plugin discovery
+- namespacing plugin-owned capabilities
+- resolving plugin paths and user config variables
+- passing plugin component sources into existing registries
+- surfacing load diagnostics through API and CLI
+
+## 3. Product Model
+
+A Relay Teams plugin is a directory with optional metadata and one or more
+component directories:
+
+```text
+my-plugin/
+  <relay-config-dir-name>/
+    plugin.json
+  .claude-plugin/
+    plugin.json
+  skills/
+  roles/
+  commands/
+  hooks/
+    hooks.json
+  .mcp.json
+  monitors/
+    monitors.json
+  bin/
+  settings.json
+  scripts/
+  README.md
+```
+
+The Relay-native manifest lives under the active Relay Teams config directory
+name inside the plugin root. By default this is `.relay-teams/plugin.json`; when
+`RELAY_TEAMS_CONFIG_DIR` or runtime configuration points at a different config
+directory name, use that directory name instead. Phase 1 also accepts Claude
+Code's `.claude-plugin/plugin.json` as an import-compatible alias. All
+components live at plugin root so that component paths stay simple and
+inspectable.
+
+The manifest is optional for local development plugins that use default
+locations, but installed and marketplace plugins should require it.
+
+## 4. Manifest Schema
+
+Add a new package:
+
+```text
+src/relay_teams/plugins/
+  __init__.py
+  plugin_models.py
+  manifest_loader.py
+  discovery.py
+  install_service.py
+  registry.py
+  config_manager.py
+  path_resolution.py
+  settings_service.py
+  plugin_cli.py
+```
+
+Initial Pydantic models:
+
+```python
+class PluginScope(str, Enum):
+    USER = "user"
+    PROJECT = "project"
+    PROJECT_LOCAL = "project_local"
+    MANAGED = "managed"
+
+
+class PluginComponentKind(str, Enum):
+    SKILLS = "skills"
+    ROLES = "roles"
+    COMMANDS = "commands"
+    HOOKS = "hooks"
+    MCP_SERVERS = "mcp_servers"
+    MONITORS = "monitors"
+    SETTINGS = "settings"
+
+
+class PluginManifest(BaseModel):
+    name: RequiredIdentifierStr
+    version: str | None = None
+    description: str = ""
+    author: PluginAuthor | None = None
+    homepage: str | None = None
+    repository: str | None = None
+    license: str | None = None
+    keywords: tuple[str, ...] = ()
+    skills: PluginPathSpec | None = None
+    roles: PluginPathSpec | None = None  # Claude alias: agents
+    commands: PluginPathSpec | None = None
+    hooks: PluginJsonOrPathSpec | None = None
+    mcp_servers: PluginJsonOrPathSpec | None = None  # Claude alias: mcpServers
+    monitors: PluginJsonOrPathSpec | None = None
+    settings: PluginJsonOrPathSpec | None = None
+    user_config: dict[str, PluginUserConfigField] = Field(default_factory=dict)  # Claude alias: userConfig
+    dependencies: tuple[PluginDependency, ...] = ()
+```
+
+Rules:
+
+- `name` is required and must be identifier-like.
+- component path fields must be relative plugin-root paths beginning with `./`
+  when explicitly configured.
+- absolute paths and `..` traversal are rejected.
+- inline hook and MCP configs are supported only after path-based loading is
+  stable.
+- `user_config` values are parsed in Phase 1 but not yet substituted into
+  hook/MCP runtime config. Prompting, persistence, and sensitive value storage
+  are deferred until install/enable state exists.
+
+Implementation constraints:
+
+- Explicit plugin validation and mutation paths must fail on invalid manifests,
+  paths, and capability references.
+- Runtime loading of configured plugin directories must degrade safely with
+  diagnostics instead of crashing startup.
+- Plugin component paths must stay inside the plugin root. Reject absolute paths
+  and `..` traversal; do not resolve plugin components from sibling directories
+  or global paths.
+- Plugin-provided capabilities must be exposed through stable namespaced runtime
+  identifiers such as `plugin-name:local-name`.
+- Local references inside plugin roles, skills, and hooks should be normalized
+  at plugin load boundaries when they target plugin-owned roles, skills, MCP
+  servers, commands, or hook agent handlers.
+- Preserve the current Claude Code manifest compatibility aliases for local
+  plugins: `.claude-plugin/plugin.json`, `agents`, `mcpServers`, and
+  `userConfig`.
+- Keep Relay Teams runtime names and docs anchored to Relay Teams component
+  names.
+
+## 5. Plugin Scopes and Files
+
+Phase 1 does not read plugin install state files. Runtime plugin roots are
+configured with `RELAY_TEAMS_PLUGIN_DIRS`, usually from the process environment
+or the `.env` file in the resolved app config directory. The resolved config
+directory may default to `.relay-teams`, but callers can change it through the
+runtime config-dir mechanism; plugin scope paths must use that resolved location
+instead of hardcoding the default directory name.
+
+Recommended future state files:
+
+```text
+<resolved-app-config-dir>/plugins/
+  installed/
+  cache/
+  data/
+  plugins.json
+
+<resolved-project-config-dir>/plugins.json
+<resolved-project-config-dir>/plugins.local.json
+```
+
+Scope mapping:
+
+- `user`: available across workspaces, stored under the resolved app config
+  directory.
+- `project`: shared with a repository, stored in the resolved project config
+  directory.
+- `project_local`: local project-only config, stored in
+  `<resolved-project-config-dir>/plugins.local.json`.
+- `managed`: read-only enterprise/admin state. Design now, implement later.
+
+The existing `get_project_root_or_none()` helper should resolve project scope.
+The current `get_project_config_dir()` returns app config, so future plugin
+project config should not reuse it blindly; add explicit plugin path helpers
+that honor the active config-dir settings.
+
+## 6. Runtime Registry
+
+Create `PluginRegistry` as a loaded snapshot:
+
+```python
+class PluginRecord(BaseModel):
+    name: RequiredIdentifierStr
+    version: str
+    scope: PluginScope
+    enabled: bool = True
+    root_dir: Path
+    data_dir: Path
+    source: PluginSource
+    user_config: dict[str, JsonValue] = Field(default_factory=dict)
+    manifest: PluginManifest
+
+
+class PluginRegistry(BaseModel):
+    plugins: tuple[PluginRecord, ...] = ()
+    diagnostics: tuple[PluginDiagnostic, ...] = ()
+```
+
+`PluginConfigManager.load_registry()` should be tolerant: invalid persisted
+plugin records are skipped with warnings. Explicit user mutations through CLI/API
+must stay strict.
+
+This mirrors the repository rule already used by roles, skills, hooks, and MCP:
+runtime loads degrade safely; explicit edits validate strictly.
+
+## 7. Namespacing
+
+Plugins must avoid capability collisions.
+
+Recommended first-cut behavior:
+
+- plugin skills are exposed as `plugin-name:skill-name`
+- plugin roles are exposed as `plugin-name:role-id`
+- plugin commands are exposed as `plugin-name:command-name`
+- plugin MCP servers are exposed as `plugin-name:server-name`
+- plugin hook source paths include plugin scope and plugin name
+
+This is a breaking semantic difference from current unscoped app skills, but it
+keeps plugin capabilities predictable. Standalone app/project skills can keep
+their existing unscoped names.
+
+Implementation detail:
+
+- do not mutate files on disk to add prefixes
+- apply namespace while loading plugin component definitions
+- keep original local names in diagnostics for debugging
+
+## 8. Component Integration
+
+### 8.1 Skills
+
+Current loader:
+
+- `SkillsDirectory.from_config_dirs()`
+- `SkillSource`
+- `SkillRegistry`
+
+Changes:
+
+- add `SkillSource.PLUGIN`
+- add `PluginSkillSourceInfo` or equivalent metadata if source needs plugin name
+- let `SkillsDirectory` accept plugin skill roots from `PluginRegistry`
+- when loading plugin skills, prefix `Skill.metadata.name` and `Skill.ref`
+
+Important compatibility rule:
+
+- role `skills` references must use runtime names, so plugin roles should refer
+  to `plugin-name:skill-name` unless a role owns a local shorthand mapping.
+
+### 8.2 Roles
+
+Current loader:
+
+- `RoleLoader.load_builtin_and_app()`
+- `RoleRegistry`
+- `RoleSettingsService`
+
+Changes:
+
+- add `RoleConfigSource.PLUGIN`
+- add `RoleLoader.load_builtin_app_and_plugins()`
+- prefix non-reserved plugin role IDs with `plugin-name:`
+- reject plugin attempts to define or override reserved system roles
+- plugin roles may reference plugin skills and MCP servers with namespaced refs
+
+Plugin roles should be read-only from the role settings editor. Users can copy a
+plugin role into app scope before editing.
+
+### 8.3 Commands
+
+Current loader:
+
+- `discover_commands(app_config_dir, workspace_root)`
+- `CommandDiscoverySource`
+
+Changes:
+
+- add `CommandDiscoverySource.PLUGIN`
+- add plugin command discovery locations
+- prefix plugin command names unless frontmatter already includes a valid
+  `plugin-name:*` name
+
+Commands are lower risk than roles because they expand into prompts, but they
+still need runtime visibility and source attribution.
+
+### 8.4 Hooks
+
+Current loader:
+
+- user/project/project-local files
+- role frontmatter hooks
+- skill frontmatter hooks
+
+Changes:
+
+- add `HookSourceScope.PLUGIN`
+- load enabled plugin `hooks/hooks.json` or manifest-declared hook configs
+- plugin hook commands receive:
+  - `RELAY_TEAMS_PLUGIN_ROOT`
+  - `RELAY_TEAMS_PLUGIN_DATA`
+  - `RELAY_TEAMS_PLUGIN_NAME`
+- declared `user_config` substitutions are deferred until plugin enable-time
+  configuration exists
+- validate plugin agent hooks against namespaced plugin roles, and normalize
+  local role references to `plugin-name:role-id`
+
+Precedence:
+
+1. managed hooks
+2. project local hooks
+3. project shared hooks
+4. user hooks
+5. plugin hooks
+6. role hooks
+7. skill hooks
+
+This keeps user and project governance higher than convenience hooks shipped by
+plugins.
+
+### 8.5 MCP Servers
+
+Current loader:
+
+- `McpConfigManager.load_registry()` loads app `mcp.json`
+- `McpRegistry`
+
+Changes:
+
+- add `McpConfigScope.PLUGIN`
+- merge MCP specs from enabled plugins after app config
+- prefix plugin server names
+- perform variable substitution for plugin paths
+- declared `user_config` substitution is deferred until plugin enable-time
+  configuration exists
+- apply existing proxy env handling after substitution
+
+Plugin MCP servers should not be written into app `mcp.json`; they are effective
+runtime specs derived from plugin records.
+
+### 8.6 Monitors
+
+Current monitors are persisted runtime subscriptions, not yet plugin background
+process declarations like Claude Code monitors.
+
+First cut:
+
+- define plugin monitor schema but do not auto-start monitor processes.
+- expose parsed plugin monitor definitions in diagnostics.
+
+Second cut:
+
+- integrate plugin monitor declarations with background task runtime.
+- start `always` monitors at session start.
+- start `on-skill-invoke:<skill>` monitors when the namespaced skill is loaded.
+- stop plugin monitors when the owning session ends.
+
+### 8.7 Default Settings
+
+Support a narrow `settings.json` first:
+
+```json
+{
+  "agent": "plugin-name:security-reviewer"
+}
+```
+
+Rules:
+
+- unknown settings are ignored with warning in runtime load.
+- explicit validation rejects unknown keys.
+- plugin settings never override explicit user or project session settings.
+
+## 9. Path and Variable Resolution
+
+Support these substitutions in plugin component configs:
+
+- `${RELAY_TEAMS_PLUGIN_ROOT}`
+- `${RELAY_TEAMS_PLUGIN_DATA}`
+- `${user_config.key}` (deferred until plugin enable-time configuration exists)
+- `${ENV_VAR}` only when explicitly allowed by the component schema
+
+Security rules:
+
+- manifest component paths must resolve inside the plugin root.
+- plugin data paths must resolve inside the plugin data directory.
+- plugin code should not be able to reference sibling plugin cache folders by
+  relative traversal.
+- command hooks and MCP commands are high-trust local execution and must be
+  displayed clearly in plugin diagnostics.
+
+## 10. Installation and Distribution
+
+MVP install sources:
+
+- local directory
+- git repository URL
+- marketplace JSON entry
+
+Commands:
+
+```text
+relay-teams plugin install <source> [--scope user|project|project-local]
+relay-teams plugin uninstall <name> [--scope ...] [--prune]
+relay-teams plugin enable <name> [--scope ...]
+relay-teams plugin disable <name> [--scope ...]
+relay-teams plugin update <name> [--scope ...]
+relay-teams plugin list [--format json] [--available]
+relay-teams plugin validate <path>
+```
+
+CLI output must follow repository rules: table by default, `--format json` for
+query/list commands.
+
+Marketplace support should be separate from plugin loading:
+
+```text
+src/relay_teams/plugins/marketplace_models.py
+src/relay_teams/plugins/marketplace_service.py
+```
+
+The marketplace only resolves available plugin sources and versions. Installed
+plugin state remains local Relay Teams config.
+
+## 11. API Surface
+
+Add endpoints under `/api/system/configs/plugins`:
+
+- `GET /api/system/configs/plugins`
+- `GET /api/system/configs/plugins/runtime`
+- `POST /api/system/configs/plugins:validate`
+- `POST /api/system/configs/plugins:install`
+- `POST /api/system/configs/plugins/{name}:enable`
+- `POST /api/system/configs/plugins/{name}:disable`
+- `POST /api/system/configs/plugins/{name}:update`
+- `DELETE /api/system/configs/plugins/{name}`
+
+The runtime endpoint should return:
+
+- enabled plugin records
+- disabled plugin records
+- component counts
+- diagnostics
+- effective component source paths
+- required user config fields with sensitive values masked
+
+Interface layers must continue using HTTP/SSE only and must not read plugin files
+directly.
+
+## 12. Server Integration
+
+In `ServerContainer`:
+
+1. load `PluginRegistry` after `ensure_app_config_bootstrap()`
+2. build MCP registry from app config plus plugin MCP specs
+3. build skill registry from standard config dirs plus plugin skill dirs
+4. build role registry from builtin, app, and plugin roles
+5. build hook service with plugin-aware hook loader
+6. build command registry with plugin command locations
+7. refresh all runtime dependents on plugin reload
+
+Reload behavior:
+
+- plugin enable/disable/update should refresh plugin registry, MCP, skills,
+  roles, hooks, commands, and runtime dependents.
+- active runs keep their captured hook/runtime snapshots where those snapshots
+  already exist.
+- new runs use the new plugin state.
+
+## 13. Validation Strategy
+
+Strict explicit validation:
+
+- invalid manifest fails
+- path traversal fails
+- unknown component paths fail
+- plugin roles referencing unknown tools, MCP servers, or skills fail
+- plugin hook agent roles must resolve to subagent-capable roles
+- plugin MCP configs must be valid JSON-compatible objects
+
+Tolerant runtime loading:
+
+- invalid installed plugins are skipped
+- invalid component files are skipped when the underlying component loader already
+  supports tolerant behavior
+- missing dependency plugins disable the dependent plugin at runtime and emit a
+  diagnostic
+- unknown persisted references are filtered with warning, matching existing role
+  and hook behavior
+
+## 14. Observability
+
+Add plugin diagnostics to:
+
+- config status service
+- `/api/system/configs/plugins/runtime`
+- CLI `plugin list --format json`
+- debug logs during server startup and reload
+
+Diagnostics should include:
+
+- plugin name and scope
+- manifest path
+- component kind
+- source path
+- severity
+- message
+
+The hooks runtime view should include plugin hook source scope and path so users
+can diagnose hook behavior without reading plugin directories manually.
+
+## 15. Security Model
+
+Plugins are a high-trust local extension mechanism.
+
+Required controls:
+
+- explicit install source and scope
+- no path traversal outside plugin root or data dir
+- sensitive `user_config` stored through existing secret infrastructure
+- command hooks, MCP commands, and monitor commands shown in diagnostics
+- plugin `bin/` PATH injection is deferred in Phase 1; plugin commands should
+  use `${RELAY_TEAMS_PLUGIN_ROOT}` or `${RELAY_TEAMS_PLUGIN_DATA}` explicitly
+- plugin cache should be immutable per installed version where practical
+- plugin updates should not mutate active run snapshots silently
+
+Non-goals for MVP:
+
+- sandboxing plugin scripts
+- remote marketplace trust scoring
+- signed plugin verification
+- managed enterprise policy plugins
+
+## 16. Implementation Phases
+
+### Phase 1: Local Plugin Runtime
+
+Deliver:
+
+- manifest models and loader
+- local runtime loading for development
+- plugin-aware skills, roles, hooks, MCP, and commands
+- diagnostics and unit tests
+- Claude manifest compatibility aliases for `.claude-plugin/plugin.json`,
+  `agents`, `mcpServers`, and `userConfig`
+
+This phase proves runtime composition without install/update complexity.
+
+Initial implementation note: Phase 1 uses the `RELAY_TEAMS_PLUGIN_DIRS`
+environment variable as the local plugin entrypoint. Multiple plugin roots are
+separated by the platform path separator, for example `;` on Windows and `:` on
+Linux/macOS. This keeps server daemon and CLI state untouched while proving the
+runtime composition path.
+
+### Phase 2: Install State and CLI
+
+Deliver:
+
+- user and project plugin state files
+- install, uninstall, enable, disable, list, validate commands
+- plugin data directory
+- strict user mutation validation
+- API runtime listing
+
+This phase makes plugins usable by teams.
+
+### Phase 3: Marketplace and Updates
+
+Deliver:
+
+- marketplace JSON model
+- git/local source installers
+- version resolution
+- update and prune
+- dependency handling
+
+This phase makes plugins distributable.
+
+### Phase 4: Monitors and Managed Policy
+
+Deliver:
+
+- plugin monitor process integration
+- managed scope
+- richer admin diagnostics
+- optional plugin signing or integrity checks
+
+This phase should wait until the core plugin runtime is stable.
+
+## 17. Test Plan
+
+Unit tests:
+
+- `tests/unit_tests/plugins/test_manifest_loader.py`
+- `tests/unit_tests/plugins/test_path_resolution.py`
+- `tests/unit_tests/plugins/test_registry.py`
+- `tests/unit_tests/plugins/test_component_sources.py`
+- `tests/unit_tests/plugins/test_install_service.py`
+
+Integration tests:
+
+- plugin skill is loadable only under namespaced ref
+- plugin role can use plugin skill and plugin MCP server
+- plugin hook appears in hook runtime view
+- disabling plugin removes its roles, skills, commands, and MCP servers from new
+  runtime state
+- invalid persisted plugin does not crash server startup
+
+Regression tests:
+
+- explicit role edits still reject unknown plugin capability refs
+- runtime role sanitization still filters stale plugin refs with warning
+- app/project standalone capabilities keep existing names and behavior
+
+Changes to plugin manifest loading, component source resolution, namespacing, or
+skill/role/hook/MCP/command plugin wiring must include focused coverage under
+`tests/unit_tests/plugins/`. When plugin wiring touches an existing component
+registry or loader, also run the corresponding focused regression tests for that
+component.
+
+## 18. Open Questions
+
+- Should Relay Teams eventually make `.claude-plugin/plugin.json` the primary
+  marketplace import format, or keep it as a local compatibility alias?
+- Should plugin skills be manually invokable by slash command names, or only
+  through `load_skill` and role-bound skill routing?
+- Should plugin roles be editable in place, or copied into app scope before edit?
+- Should plugin dependency version ranges be enforced in MVP or deferred?
+- Should plugin MCP servers be available globally, or only to roles that
+  reference them?
+- Should local development plugins bypass install state only for CLI sessions, or
+  also for the server?
+
+## 19. Recommended First Cut
+
+The best first implementation cut is local runtime loading plus namespaced
+component registration:
+
+1. implement `PluginManifest`, `PluginRecord`, `PluginRegistry`, and path
+   resolution
+2. add `PluginConfigManager.load_registry()` with a development plugin directory
+   input
+3. extend skill, role, hook, MCP, and command loaders to accept plugin component
+   sources
+4. expose `GET /api/system/configs/plugins/runtime`
+5. add tests for namespacing, invalid path rejection, and tolerant runtime skip
+
+This creates a working plugin runtime while leaving marketplace, install, update,
+and monitor process management for later phases.

--- a/frontend/dist/css/components/settings.css
+++ b/frontend/dist/css/components/settings.css
@@ -2503,7 +2503,7 @@
 .workspace-private-key-textarea {
     display: block;
     min-height: 180px;
-    margin: 0;
+    margin: 0.25rem 0 0;
 }
 
 .workspace-auth-state {

--- a/src/relay_teams/commands/command_models.py
+++ b/src/relay_teams/commands/command_models.py
@@ -15,6 +15,7 @@ class CommandScope(str, Enum):
 
 class CommandDiscoverySource(str, Enum):
     APP = "app"
+    PLUGIN = "plugin"
     PROJECT_CODEX = "project_codex"
     PROJECT_CLAUDE = "project_claude"
     PROJECT_OPENCODE = "project_opencode"

--- a/src/relay_teams/commands/discovery.py
+++ b/src/relay_teams/commands/discovery.py
@@ -14,6 +14,8 @@ from relay_teams.commands.command_models import (
     CommandScope,
 )
 from relay_teams.logger import get_logger
+from relay_teams.plugins.path_resolution import namespace_plugin_ref
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.trace import trace_span
 
 LOGGER = get_logger(__name__)
@@ -25,7 +27,7 @@ DEFAULT_COMMAND_MAX_DEPTH = 8
 
 
 class CommandDiscoveryLocation:
-    __slots__ = ("base_dir", "scope", "source")
+    __slots__ = ("base_dir", "plugin_name", "scope", "source")
 
     def __init__(
         self,
@@ -33,21 +35,25 @@ class CommandDiscoveryLocation:
         base_dir: Path,
         scope: CommandScope,
         source: CommandDiscoverySource,
+        plugin_name: str = "",
     ) -> None:
         self.base_dir = base_dir
         self.scope = scope
         self.source = source
+        self.plugin_name = plugin_name
 
 
 def discover_commands(
     *,
     app_config_dir: Path,
     workspace_root: Optional[Path],
+    plugin_sources: tuple[PluginComponentSource, ...] = (),
     max_depth: int = DEFAULT_COMMAND_MAX_DEPTH,
 ) -> tuple[CommandDefinition, ...]:
     locations = _build_locations(
         app_config_dir=app_config_dir,
         workspace_root=workspace_root,
+        plugin_sources=plugin_sources,
     )
     commands: list[CommandDefinition] = []
     with trace_span(
@@ -60,6 +66,7 @@ def discover_commands(
                     "scope": location.scope.value,
                     "source": location.source.value,
                     "base_dir": str(location.base_dir),
+                    "plugin_name": location.plugin_name,
                 }
                 for location in locations
             ],
@@ -75,6 +82,7 @@ def _build_locations(
     *,
     app_config_dir: Path,
     workspace_root: Optional[Path],
+    plugin_sources: tuple[PluginComponentSource, ...],
 ) -> tuple[CommandDiscoveryLocation, ...]:
     locations: list[CommandDiscoveryLocation] = [
         CommandDiscoveryLocation(
@@ -83,6 +91,15 @@ def _build_locations(
             source=CommandDiscoverySource.APP,
         )
     ]
+    for plugin_source in plugin_sources:
+        locations.append(
+            CommandDiscoveryLocation(
+                base_dir=plugin_source.path.resolve(),
+                scope=CommandScope.APP,
+                source=CommandDiscoverySource.PLUGIN,
+                plugin_name=plugin_source.plugin_name,
+            )
+        )
     if workspace_root is None:
         return tuple(locations)
 
@@ -155,11 +172,19 @@ def _load_command(
         LOGGER.warning("Skipping command %s due to parsing error: %s", path, exc)
         return None
 
-    default_name = _default_command_name(rel=rel, source=location.source)
+    default_name = _default_command_name(
+        rel=rel,
+        source=location.source,
+        plugin_name=location.plugin_name,
+    )
     raw_name = data.get("name")
     provided_name = raw_name.strip() if isinstance(raw_name, str) else ""
-    name = provided_name if is_valid_command_name(provided_name) else default_name
-    if provided_name and name != provided_name:
+    name = _provided_command_name(
+        provided_name=provided_name,
+        default_name=default_name,
+        location=location,
+    )
+    if provided_name and not is_valid_command_name(provided_name):
         LOGGER.warning(
             "Ignoring invalid command front matter name %s in %s",
             provided_name,
@@ -172,6 +197,7 @@ def _load_command(
     aliases = _aliases(
         value=data.get("aliases"),
         default_aliases=_default_aliases(name=name, rel=rel, source=location.source),
+        location=location,
     )
     description = _string_field(data, "description")
     argument_hint = _string_field(data, "argument_hint") or _string_field(
@@ -213,13 +239,32 @@ def _default_command_name(
     *,
     rel: Path,
     source: CommandDiscoverySource,
+    plugin_name: str = "",
 ) -> str:
     rel_name = rel.with_suffix("").as_posix()
+    if source == CommandDiscoverySource.PLUGIN and plugin_name:
+        return namespace_plugin_ref(plugin_name=plugin_name, local_name=rel_name)
     if source == CommandDiscoverySource.PROJECT_CLAUDE:
         parts = rel.with_suffix("").parts
         if len(parts) >= 2 and parts[0] == "opsx":
             return f"opsx:{'/'.join(parts[1:])}"
     return rel_name
+
+
+def _provided_command_name(
+    *,
+    provided_name: str,
+    default_name: str,
+    location: CommandDiscoveryLocation,
+) -> str:
+    if not is_valid_command_name(provided_name):
+        return default_name
+    if location.source == CommandDiscoverySource.PLUGIN and location.plugin_name:
+        return namespace_plugin_ref(
+            plugin_name=location.plugin_name,
+            local_name=provided_name,
+        )
+    return provided_name
 
 
 def _default_aliases(
@@ -260,10 +305,20 @@ def _aliases(
     *,
     value: object,
     default_aliases: tuple[str, ...],
+    location: CommandDiscoveryLocation,
 ) -> tuple[str, ...]:
     aliases: list[str] = []
     for item in _string_sequence(value):
         alias = item.removeprefix("/").strip()
+        if (
+            is_valid_command_name(alias)
+            and location.source == CommandDiscoverySource.PLUGIN
+            and location.plugin_name
+        ):
+            alias = namespace_plugin_ref(
+                plugin_name=location.plugin_name,
+                local_name=alias,
+            )
         if is_valid_command_name(alias) and alias not in aliases:
             aliases.append(alias)
     for alias in default_aliases:

--- a/src/relay_teams/commands/registry.py
+++ b/src/relay_teams/commands/registry.py
@@ -15,6 +15,7 @@ from relay_teams.commands.command_models import (
 )
 from relay_teams.commands.discovery import discover_commands
 from relay_teams.logger import get_logger
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.trace import trace_span
 
 LOGGER = get_logger(__name__)
@@ -37,6 +38,7 @@ class CommandRegistry(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     app_config_dir: Path
+    plugin_sources: tuple[PluginComponentSource, ...] = ()
 
     def list_commands(
         self,
@@ -59,6 +61,7 @@ class CommandRegistry(BaseModel):
             discover_commands(
                 app_config_dir=self.app_config_dir,
                 workspace_root=None,
+                plugin_sources=self.plugin_sources,
             )
         )
         return tuple(
@@ -81,6 +84,7 @@ class CommandRegistry(BaseModel):
                 for command in discover_commands(
                     app_config_dir=self.app_config_dir,
                     workspace_root=workspace_root,
+                    plugin_sources=self.plugin_sources,
                 )
                 if command.scope == CommandScope.PROJECT
             )
@@ -102,6 +106,7 @@ class CommandRegistry(BaseModel):
         for command in discover_commands(
             app_config_dir=self.app_config_dir,
             workspace_root=workspace_root,
+            plugin_sources=self.plugin_sources,
         ):
             if command.source_path.resolve() == target_path:
                 return command
@@ -178,6 +183,7 @@ class CommandRegistry(BaseModel):
             discover_commands(
                 app_config_dir=self.app_config_dir,
                 workspace_root=workspace_root,
+                plugin_sources=self.plugin_sources,
             )
         )
         command_map = {command.name: command for command in effective_commands}

--- a/src/relay_teams/hooks/executors/command_executor.py
+++ b/src/relay_teams/hooks/executors/command_executor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -29,18 +30,21 @@ class CommandHookExecutor:
         *,
         handler: HookHandlerConfig,
         event_input: HookEventInput,
+        extra_env: dict[str, str] | None = None,
     ) -> HookDecision:
         command = str(handler.command or "").strip()
         if not command:
             raise ValueError("Command hook requires a command")
         args = _build_command_args(command=command, shell=handler.shell)
         payload = event_input.model_dump_json().encode("utf-8")
+        env = _build_command_env(extra_env)
         try:
             process = await asyncio.create_subprocess_exec(
                 *args,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                env=env,
             )
             stdout, stderr = await asyncio.wait_for(
                 process.communicate(payload),
@@ -56,6 +60,7 @@ class CommandHookExecutor:
                 stderr=subprocess.PIPE,
                 check=False,
                 timeout=handler.timeout_seconds,
+                env=env,
             )
             stdout = completed.stdout
             stderr = completed.stderr
@@ -102,6 +107,14 @@ def _build_command_args(*, command: str, shell: HookShell | None) -> list[str]:
     if sys.platform.startswith("win"):
         return [_strip_wrapping_quotes(arg) for arg in args]
     return args
+
+
+def _build_command_env(extra_env: dict[str, str] | None) -> dict[str, str] | None:
+    if not extra_env:
+        return None
+    env = dict(os.environ)
+    env.update(extra_env)
+    return env
 
 
 def _decode_limited(data: bytes, *, limit_bytes: int, stream_name: str) -> str:

--- a/src/relay_teams/hooks/hook_loader.py
+++ b/src/relay_teams/hooks/hook_loader.py
@@ -21,6 +21,8 @@ from relay_teams.hooks.hook_models import (
 )
 from relay_teams.logger import get_logger
 from relay_teams.paths import get_project_root_or_none
+from relay_teams.plugins.path_resolution import namespace_plugin_ref
+from relay_teams.plugins.plugin_models import PluginComponentSource
 
 LOGGER = get_logger(__name__)
 _CAPABILITY_WILDCARD = "*"
@@ -109,11 +111,13 @@ class HookLoader:
         project_root: Path | None = None,
         get_role_registry: Callable[[], object] | None = None,
         get_skill_registry: Callable[[], object] | None = None,
+        plugin_hook_sources: tuple[PluginComponentSource, ...] = (),
     ) -> None:
         self._app_config_dir = app_config_dir
         self._project_root = project_root or get_project_root_or_none(Path.cwd())
         self._get_role_registry = get_role_registry
         self._get_skill_registry = get_skill_registry
+        self._plugin_hook_sources = plugin_hook_sources
 
     @property
     def user_config_path(self) -> Path:
@@ -182,6 +186,7 @@ class HookLoader:
                             group=group,
                         )
                     )
+        self._append_plugin_hooks(resolved=resolved, sources=sources)
         self._append_role_hooks(resolved=resolved, sources=sources)
         self._append_skill_hooks(resolved=resolved, sources=sources)
         return HookRuntimeSnapshot(
@@ -189,18 +194,34 @@ class HookLoader:
             hooks={key: tuple(value) for key, value in resolved.items()},
         )
 
-    def _load_single_file(self, path: Path, *, tolerant: bool) -> HooksConfig:
+    def _load_single_file(
+        self,
+        path: Path,
+        *,
+        tolerant: bool,
+        plugin_name: str = "",
+    ) -> HooksConfig:
         if not path.exists():
             return HooksConfig()
         try:
             payload = _load_json_object(path)
             if tolerant:
                 normalized_payload = normalize_hooks_payload(payload, tolerant=True)
+                if plugin_name:
+                    normalized_payload = _namespace_plugin_hooks_payload(
+                        normalized_payload,
+                        plugin_name=plugin_name,
+                    )
                 return self._load_tolerant_payload(
                     path=path,
                     payload=normalized_payload,
                 )
             normalized_payload = normalize_hooks_payload(payload)
+            if plugin_name:
+                normalized_payload = _namespace_plugin_hooks_payload(
+                    normalized_payload,
+                    plugin_name=plugin_name,
+                )
             config = HooksConfig.model_validate(normalized_payload)
             validate_hook_event_capabilities(config=config)
             return self._validate_handler_references(config=config, tolerant=False)
@@ -209,6 +230,43 @@ class HookLoader:
                 raise
             LOGGER.warning("Ignoring invalid hook config", extra={"path": str(path)})
             return HooksConfig()
+
+    def _append_plugin_hooks(
+        self,
+        *,
+        resolved: dict[HookEventName, list[ResolvedHookMatcherGroup]],
+        sources: list[HookSourceInfo],
+    ) -> None:
+        for plugin_source in self._plugin_hook_sources:
+            path = plugin_source.path
+            if not path.exists():
+                continue
+            config = self._load_single_file(
+                path,
+                tolerant=True,
+                plugin_name=plugin_source.plugin_name,
+            )
+            if not config.hooks:
+                continue
+            source = HookSourceInfo(
+                scope=HookSourceScope.PLUGIN,
+                path=path,
+                plugin_name=plugin_source.plugin_name,
+                plugin_root=plugin_source.root_dir,
+                plugin_data=plugin_source.data_dir,
+            )
+            sources.append(source)
+            for event_name, groups in config.hooks.items():
+                bucket = resolved.setdefault(event_name, [])
+                for group in groups:
+                    if group.hooks:
+                        bucket.append(
+                            ResolvedHookMatcherGroup(
+                                source=source,
+                                event_name=event_name,
+                                group=group,
+                            )
+                        )
 
     def _load_tolerant_payload(self, *, path: Path, payload: object) -> HooksConfig:
         if not isinstance(payload, dict):
@@ -616,6 +674,72 @@ def normalize_hooks_payload(payload: object, *, tolerant: bool = False) -> objec
         normalized_hooks[event_name] = normalized_groups
     next_payload["hooks"] = normalized_hooks
     return next_payload
+
+
+def _namespace_plugin_hooks_payload(payload: object, *, plugin_name: str) -> object:
+    if not isinstance(payload, dict):
+        return payload
+    raw_hooks = payload.get("hooks")
+    if not isinstance(raw_hooks, dict):
+        return payload
+    next_hooks: dict[object, object] = {}
+    for event_name, raw_groups in raw_hooks.items():
+        if not isinstance(raw_groups, list):
+            next_hooks[event_name] = raw_groups
+            continue
+        next_hooks[event_name] = [
+            _namespace_plugin_hook_group(group, plugin_name=plugin_name)
+            for group in raw_groups
+        ]
+    return dict(payload) | {"hooks": next_hooks}
+
+
+def _namespace_plugin_hook_group(group: object, *, plugin_name: str) -> object:
+    if not isinstance(group, dict):
+        return group
+    next_group = dict(group)
+    raw_role_ids = next_group.get("role_ids")
+    if isinstance(raw_role_ids, list):
+        next_group["role_ids"] = [
+            _namespace_plugin_role_ref(value, plugin_name=plugin_name)
+            for value in raw_role_ids
+        ]
+    elif isinstance(raw_role_ids, tuple):
+        next_group["role_ids"] = tuple(
+            _namespace_plugin_role_ref(value, plugin_name=plugin_name)
+            for value in raw_role_ids
+        )
+    raw_handlers = next_group.get("hooks")
+    if isinstance(raw_handlers, list):
+        next_group["hooks"] = [
+            _namespace_plugin_hook_handler(handler, plugin_name=plugin_name)
+            for handler in raw_handlers
+        ]
+    return next_group
+
+
+def _namespace_plugin_hook_handler(handler: object, *, plugin_name: str) -> object:
+    if not isinstance(handler, dict):
+        return handler
+    next_handler = dict(handler)
+    if str(next_handler.get("type") or "").strip() != HookHandlerType.AGENT.value:
+        return next_handler
+    role_id = next_handler.get("role_id")
+    if isinstance(role_id, str):
+        next_handler["role_id"] = _namespace_plugin_role_ref(
+            role_id,
+            plugin_name=plugin_name,
+        )
+    return next_handler
+
+
+def _namespace_plugin_role_ref(value: object, *, plugin_name: str) -> object:
+    if not isinstance(value, str):
+        return value
+    normalized = value.strip()
+    if not normalized or normalized == _CAPABILITY_WILDCARD or ":" in normalized:
+        return value
+    return namespace_plugin_ref(plugin_name=plugin_name, local_name=normalized)
 
 
 def parse_tolerant_hooks_payload(payload: object) -> HooksConfig:

--- a/src/relay_teams/hooks/hook_models.py
+++ b/src/relay_teams/hooks/hook_models.py
@@ -65,6 +65,7 @@ class HookSourceScope(str, Enum):
     USER = "user"
     PROJECT = "project"
     PROJECT_LOCAL = "project_local"
+    PLUGIN = "plugin"
     ROLE = "role"
     SKILL = "skill"
 
@@ -84,6 +85,9 @@ class HookSourceInfo(BaseModel):
 
     scope: HookSourceScope
     path: Path
+    plugin_name: str = ""
+    plugin_root: Path | None = None
+    plugin_data: Path | None = None
 
 
 class HookDecision(BaseModel):

--- a/src/relay_teams/hooks/hook_service.py
+++ b/src/relay_teams/hooks/hook_service.py
@@ -39,6 +39,7 @@ from relay_teams.hooks.hook_models import (
     HookRuntimeSnapshot,
     HookRuntimeView,
     HookSourceInfo,
+    HookSourceScope,
     HooksConfig,
     LoadedHookRuntimeView,
     ResolvedHookMatcherGroup,
@@ -105,6 +106,9 @@ class HookService:
 
     def get_user_config(self) -> HooksConfig:
         return self._loader.get_user_config()
+
+    def replace_loader(self, loader: HookLoader) -> None:
+        self._loader = loader
 
     def get_effective_config(self) -> HookRuntimeSnapshot:
         return self._loader.load_snapshot()
@@ -226,7 +230,10 @@ class HookService:
                     tool_name=tool_name,
                 ):
                     continue
-                dedup_key = _handler_dedup_key(handler)
+                dedup_key = _handler_dedup_key(
+                    handler=handler,
+                    source=resolved.source,
+                )
                 if handler.run_async:
                     if dedup_key is not None and dedup_key in seen_async_keys:
                         continue
@@ -417,6 +424,7 @@ class HookService:
                 decision = await self._command_executor.execute(
                     handler=handler,
                     event_input=event_input,
+                    extra_env=_plugin_hook_env(source),
                 )
             elif handler.type == HookHandlerType.HTTP:
                 decision = await self._http_executor.execute(
@@ -613,9 +621,13 @@ def _normalize_decision_for_event(
 
 
 def _handler_dedup_key(
+    *,
     handler: HookHandlerConfig,
+    source: HookSourceInfo,
 ) -> Optional[tuple[str, ...]]:
+    source_key = _handler_dedup_source_key(source)
     common = (
+        *source_key,
         handler.type.value,
         handler.name.strip(),
         str(handler.if_rule or "").strip(),
@@ -645,6 +657,31 @@ def _handler_dedup_key(
             ",".join(handler.allowed_env_vars),
         )
     return None
+
+
+def _handler_dedup_source_key(source: HookSourceInfo) -> tuple[str, ...]:
+    if source.scope != HookSourceScope.PLUGIN:
+        return ("",)
+    return (
+        source.scope.value,
+        source.plugin_name,
+        str(source.plugin_root or ""),
+        str(source.plugin_data or ""),
+        str(source.path),
+    )
+
+
+def _plugin_hook_env(source: HookSourceInfo) -> dict[str, str]:
+    if source.scope != HookSourceScope.PLUGIN:
+        return {}
+    env: dict[str, str] = {}
+    if source.plugin_root is not None:
+        env["RELAY_TEAMS_PLUGIN_ROOT"] = str(source.plugin_root)
+    if source.plugin_data is not None:
+        env["RELAY_TEAMS_PLUGIN_DATA"] = str(source.plugin_data)
+    if source.plugin_name:
+        env["RELAY_TEAMS_PLUGIN_NAME"] = source.plugin_name
+    return env
 
 
 def _decision_conflicts(

--- a/src/relay_teams/interfaces/server/config_status_service.py
+++ b/src/relay_teams/interfaces/server/config_status_service.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from pydantic import JsonValue
-from typing import cast
 
 from relay_teams.mcp.mcp_models import McpConfigScope
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.plugins import PluginRegistry
 from relay_teams.sessions.runs.runtime_config import RuntimeConfig
 from relay_teams.skills.skill_registry import SkillRegistry
 
@@ -20,48 +20,72 @@ class ConfigStatusService:
         get_mcp_registry: Callable[[], McpRegistry],
         get_skill_registry: Callable[[], SkillRegistry],
         get_proxy_status: Callable[[], dict[str, JsonValue]],
+        get_plugin_registry: Callable[[], PluginRegistry] | None = None,
     ) -> None:
         self._get_runtime: Callable[[], RuntimeConfig] = get_runtime
         self._get_mcp_registry: Callable[[], McpRegistry] = get_mcp_registry
         self._get_skill_registry: Callable[[], SkillRegistry] = get_skill_registry
         self._get_proxy_status: Callable[[], dict[str, JsonValue]] = get_proxy_status
+        self._get_plugin_registry = get_plugin_registry
 
     def get_config_status(self) -> dict[str, JsonValue]:
         runtime = self._get_runtime()
         mcp_registry = self._get_mcp_registry()
         skill_registry = self._get_skill_registry()
-        app_mcp_server_names = [
+        app_mcp_server_names: list[JsonValue] = [
             spec.name
             for spec in mcp_registry.list_specs()
             if spec.source == McpConfigScope.APP
         ]
-        skill_summaries = [
+        skill_summaries: list[JsonValue] = [
             skill.model_dump(mode="json")
             for skill in skill_registry.list_skill_summaries()
         ]
+        model_profiles: list[JsonValue] = list(runtime.model_status.profiles)
+        model_status: JsonValue = {
+            "loaded": runtime.model_status.loaded,
+            "profiles": model_profiles,
+            "error": runtime.model_status.error,
+        }
+        mcp_status: JsonValue = {
+            "loaded": True,
+            "servers": app_mcp_server_names,
+        }
+        skills_status: JsonValue = {
+            "loaded": True,
+            "skills": skill_summaries,
+        }
         status: dict[str, JsonValue] = {
-            "model": cast(
-                JsonValue,
-                {
-                    "loaded": runtime.model_status.loaded,
-                    "profiles": list(runtime.model_status.profiles),
-                    "error": runtime.model_status.error,
-                },
-            ),
-            "mcp": cast(
-                JsonValue,
-                {
-                    "loaded": True,
-                    "servers": app_mcp_server_names,
-                },
-            ),
-            "skills": cast(
-                JsonValue,
-                {
-                    "loaded": True,
-                    "skills": skill_summaries,
-                },
-            ),
+            "model": model_status,
+            "mcp": mcp_status,
+            "skills": skills_status,
             "proxy": self._get_proxy_status(),
         }
+        if self._get_plugin_registry is not None:
+            plugin_registry = self._get_plugin_registry()
+            plugin_summaries: list[JsonValue] = [
+                {
+                    "name": plugin.name,
+                    "version": plugin.version,
+                    "scope": plugin.scope.value,
+                    "enabled": plugin.enabled,
+                    "root_dir": str(plugin.root_dir),
+                    "skill_count": len(plugin.skill_sources),
+                    "role_count": len(plugin.role_sources),
+                    "command_count": len(plugin.command_sources),
+                    "hook_count": len(plugin.hook_sources),
+                    "mcp_server_config_count": len(plugin.mcp_sources),
+                }
+                for plugin in plugin_registry.plugins
+            ]
+            plugin_diagnostics: list[JsonValue] = [
+                diagnostic.model_dump(mode="json")
+                for diagnostic in plugin_registry.diagnostics
+            ]
+            plugins_status: JsonValue = {
+                "loaded": True,
+                "plugins": plugin_summaries,
+                "diagnostics": plugin_diagnostics,
+            }
+            status["plugins"] = plugins_status
         return status

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -60,6 +60,7 @@ from relay_teams.env.github_config_service import GitHubConfigService
 from relay_teams.env.localhost_run_tunnel_service import LocalhostRunTunnelService
 from relay_teams.env.proxy_config_service import ProxyConfigService
 from relay_teams.env.proxy_env import ProxyEnvConfig, sync_proxy_env_to_process_env
+from relay_teams.env.runtime_env import sync_app_env_to_process_env
 from relay_teams.env.web_config_service import WebConfigService
 from relay_teams.external_agents import (
     ExternalAgentConfigService,
@@ -112,6 +113,8 @@ from relay_teams.notifications import NotificationConfigManager, NotificationSer
 from relay_teams.notifications.notification_settings_service import (
     NotificationSettingsService,
 )
+from relay_teams.plugins import PluginConfigManager, PluginRegistry
+from relay_teams.plugins.mcp_sources import load_plugin_mcp_specs
 from relay_teams.agents.execution.system_prompts import RuntimePromptBuilder
 from relay_teams.retrieval import RetrievalService, SqliteFts5RetrievalStore
 from relay_teams.providers.provider_contracts import LLMProvider, LLMRequest
@@ -270,10 +273,20 @@ class ServerContainer:
         )
         app_config_dir = runtime.paths.config_dir
         ensure_app_config_bootstrap(app_config_dir)
+        sync_app_env_to_process_env(runtime.paths.env_file)
         self.config_dir: Path = app_config_dir
         self.runtime: RuntimeConfig = runtime
         self._project_start_dir = Path.cwd().resolve()
         self._session_model_profile_lookup = session_model_profile_lookup
+        self.plugin_config_manager: PluginConfigManager = (
+            PluginConfigManager.from_environment(app_config_dir=app_config_dir)
+        )
+        self.plugin_registry: PluginRegistry = (
+            self.plugin_config_manager.load_registry()
+        )
+        self._plugin_mcp_specs = load_plugin_mcp_specs(
+            self.plugin_registry.mcp_sources()
+        )
 
         self.model_config_manager: ModelConfigManager = ModelConfigManager(
             config_dir=app_config_dir
@@ -296,12 +309,7 @@ class ServerContainer:
             get_proxy_config=self.proxy_config_service.get_proxy_config,
         )
         self.hook_service = HookService(
-            loader=HookLoader(
-                app_config_dir=app_config_dir,
-                project_root=Path.cwd(),
-                get_role_registry=lambda: self.role_registry,
-                get_skill_registry=lambda: self.skill_registry,
-            ),
+            loader=self._build_hook_loader(),
             runtime_state=HookRuntimeState(),
             command_executor=CommandHookExecutor(),
             http_executor=HttpHookExecutor(
@@ -369,23 +377,29 @@ class ServerContainer:
             retry_config=runtime.llm_retry,
         )
         self.auto_harness_service.register_enabled_tools()
-        self.mcp_registry: McpRegistry = self.mcp_config_manager.load_registry()
+        self.mcp_registry: McpRegistry = self.mcp_config_manager.load_registry(
+            extra_specs=self._plugin_mcp_specs
+        )
         self.mcp_service: McpService = McpService(
             registry=self.mcp_registry,
             config_manager=self.mcp_config_manager,
             on_registry_changed=self.replace_mcp_registry,
+            extra_specs=self._plugin_mcp_specs,
         )
         self.command_registry: CommandRegistry = CommandRegistry(
-            app_config_dir=app_config_dir
+            app_config_dir=app_config_dir,
+            plugin_sources=self.plugin_registry.command_sources(),
         )
         self.skill_registry: SkillRegistry = SkillRegistry.from_config_dirs(
             app_config_dir=app_config_dir,
             project_start_dir=self._project_start_dir,
+            plugin_sources=self.plugin_registry.skill_sources(),
         )
         self.role_registry = self._sanitize_role_registry(
-            RoleLoader().load_builtin_and_app(
+            RoleLoader().load_builtin_app_and_plugins(
                 builtin_roles_dir=get_builtin_roles_dir(),
                 app_roles_dir=runtime.paths.roles_dir,
+                plugin_sources=self.plugin_registry.role_sources(),
                 allow_empty=True,
             )
         )
@@ -991,6 +1005,7 @@ class ServerContainer:
             get_mcp_registry=lambda: self.mcp_registry,
             get_skill_registry=lambda: self.skill_registry,
             get_proxy_status=self.proxy_config_service.get_proxy_status,
+            get_plugin_registry=lambda: self.plugin_registry,
         )
         self.model_config_service: ModelConfigService = ModelConfigService(
             config_dir=app_config_dir,
@@ -1018,16 +1033,19 @@ class ServerContainer:
             reload_skill_registry=lambda: (
                 self.skills_config_reload_service.reload_skills_config()
             ),
+            plugin_sources=self.plugin_registry.role_sources(),
         )
         self.mcp_config_reload_service: McpConfigReloadService = McpConfigReloadService(
             mcp_config_manager=self.mcp_config_manager,
             role_registry=self.role_registry,
             on_mcp_reloaded=self._on_mcp_reloaded,
+            extra_specs=self._plugin_mcp_specs,
         )
         self.skills_config_reload_service: SkillsConfigReloadService = (
             SkillsConfigReloadService(
                 config_dir=app_config_dir,
                 project_start_dir=self._project_start_dir,
+                plugin_sources=self.plugin_registry.skill_sources(),
                 role_registry=self.role_registry,
                 on_skill_reloaded=self._on_skill_reloaded,
             )
@@ -1174,6 +1192,15 @@ class ServerContainer:
             runtime_role_resolver=self.runtime_role_resolver,
             hook_service=self.hook_service,
             run_event_hub=self.run_event_hub,
+        )
+
+    def _build_hook_loader(self) -> HookLoader:
+        return HookLoader(
+            app_config_dir=self.runtime.paths.config_dir,
+            project_root=Path.cwd(),
+            get_role_registry=lambda: self.role_registry,
+            get_skill_registry=lambda: self.skill_registry,
+            plugin_hook_sources=self.plugin_registry.hook_sources(),
         )
 
     def _resolve_reflection_model_config(self) -> Optional[ModelEndpointConfig]:
@@ -1400,10 +1427,12 @@ class ServerContainer:
             mcp_config_manager=self.mcp_config_manager,
             role_registry=self.role_registry,
             on_mcp_reloaded=self._on_mcp_reloaded,
+            extra_specs=self._plugin_mcp_specs,
         )
         self.skills_config_reload_service = SkillsConfigReloadService(
             config_dir=self.runtime.paths.config_dir,
             project_start_dir=self._project_start_dir,
+            plugin_sources=self.plugin_registry.skill_sources(),
             role_registry=self.role_registry,
             on_skill_reloaded=self._on_skill_reloaded,
         )
@@ -1431,13 +1460,19 @@ class ServerContainer:
     def _on_proxy_reloaded(self, proxy_config: ProxyEnvConfig) -> None:
         sync_proxy_env_to_process_env(proxy_config)
         clear_llm_http_client_cache()
-        self._on_mcp_reloaded(self.mcp_config_manager.load_registry())
+        self._on_mcp_reloaded(
+            self.mcp_config_manager.load_registry(extra_specs=self._plugin_mcp_specs)
+        )
         self.feishu_subscription_service.reload()
         self.wechat_gateway_service.reload()
 
     def _reload_mcp_runtime_after_app_env_change(self) -> None:
         try:
-            self._on_mcp_reloaded(self.mcp_config_manager.load_registry())
+            self._on_mcp_reloaded(
+                self.mcp_config_manager.load_registry(
+                    extra_specs=self._plugin_mcp_specs
+                )
+            )
         except Exception as exc:
             LOGGER.warning(
                 "Failed to reload MCP runtime after app environment change: %s",
@@ -1453,6 +1488,62 @@ class ServerContainer:
                 exc,
             )
 
+    def _reload_plugin_runtime_after_app_env_change(self) -> None:
+        sync_app_env_to_process_env(self.runtime.paths.env_file)
+        self.plugin_config_manager = PluginConfigManager.from_environment(
+            app_config_dir=self.runtime.paths.config_dir
+        )
+        self.plugin_registry = self.plugin_config_manager.load_registry()
+        self._plugin_mcp_specs = load_plugin_mcp_specs(
+            self.plugin_registry.mcp_sources()
+        )
+        self.mcp_service.replace_extra_specs(self._plugin_mcp_specs)
+        self.command_registry = CommandRegistry(
+            app_config_dir=self.runtime.paths.config_dir,
+            plugin_sources=self.plugin_registry.command_sources(),
+        )
+        self.hook_service.replace_loader(self._build_hook_loader())
+        self.role_settings_service.replace_plugin_sources(
+            self.plugin_registry.role_sources()
+        )
+        self.skills_config_reload_service.replace_plugin_sources(
+            self.plugin_registry.skill_sources()
+        )
+        self._on_mcp_reloaded(
+            self.mcp_config_manager.load_registry(extra_specs=self._plugin_mcp_specs)
+        )
+        self.skill_registry = SkillRegistry.from_config_dirs(
+            app_config_dir=self.runtime.paths.config_dir,
+            project_start_dir=self._project_start_dir,
+            plugin_sources=self.plugin_registry.skill_sources(),
+        )
+        self.skill_runtime_service = self._build_skill_runtime_service(
+            skill_registry=self.skill_registry
+        )
+        self.role_registry = self._sanitize_role_registry(
+            RoleLoader().load_builtin_app_and_plugins(
+                builtin_roles_dir=get_builtin_roles_dir(),
+                app_roles_dir=self.runtime.paths.roles_dir,
+                plugin_sources=self.plugin_registry.role_sources(),
+                allow_empty=True,
+            )
+        )
+        self.mcp_config_reload_service = McpConfigReloadService(
+            mcp_config_manager=self.mcp_config_manager,
+            role_registry=self.role_registry,
+            on_mcp_reloaded=self._on_mcp_reloaded,
+            extra_specs=self._plugin_mcp_specs,
+        )
+        self.skills_config_reload_service = SkillsConfigReloadService(
+            config_dir=self.runtime.paths.config_dir,
+            project_start_dir=self._project_start_dir,
+            plugin_sources=self.plugin_registry.skill_sources(),
+            role_registry=self.role_registry,
+            on_skill_reloaded=self._on_skill_reloaded,
+        )
+        self._refresh_coordinator_runtime()
+        self._refresh_runtime_dependents()
+
     def _on_app_environment_changed(self, changed_keys: FrozenSet[str]) -> None:
         self.model_config_service.reload_model_config()
         proxy_related_keys = {
@@ -1463,6 +1554,8 @@ class ServerContainer:
             "SSL_VERIFY",
         }
         normalized_keys = {key.upper() for key in changed_keys}
+        if "RELAY_TEAMS_PLUGIN_DIRS" in normalized_keys:
+            self._reload_plugin_runtime_after_app_env_change()
         if normalized_keys.isdisjoint(proxy_related_keys):
             self._reload_mcp_runtime_after_app_env_change()
         else:

--- a/src/relay_teams/interfaces/server/deps.py
+++ b/src/relay_teams/interfaces/server/deps.py
@@ -44,6 +44,7 @@ from relay_teams.net.web_connectivity import WebConnectivityProbeService
 from relay_teams.notifications.notification_settings_service import (
     NotificationSettingsService,
 )
+from relay_teams.plugins import PluginRegistry
 from relay_teams.providers.model_config_service import ModelConfigService
 from relay_teams.roles import RoleMemoryService, RoleRegistry
 from relay_teams.roles.settings_service import RoleSettingsService
@@ -92,6 +93,10 @@ def get_feishu_subscription_service(request: Request) -> FeishuSubscriptionServi
 
 def get_config_status_service(request: Request) -> ConfigStatusService:
     return get_container(request).config_status_service
+
+
+def get_plugin_registry(request: Request) -> PluginRegistry:
+    return get_container(request).plugin_registry
 
 
 def get_model_config_service(request: Request) -> ModelConfigService:

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -85,6 +85,7 @@ from relay_teams.interfaces.server.deps import (
     get_web_config_service,
     get_web_connectivity_probe_service,
     get_hook_service,
+    get_plugin_registry,
 )
 from relay_teams.interfaces.server.control_plane import (
     ControlPlaneDiscoveryPayload,
@@ -148,6 +149,7 @@ from relay_teams.skills.clawhub_models import (
 from relay_teams.skills.clawhub_skill_service import ClawHubSkillService
 from relay_teams.triggers import GitHubTriggerService
 from relay_teams.hooks import HookRuntimeView, HookService, HooksConfig
+from relay_teams.plugins import PluginRegistry
 from relay_teams.validation import RequiredIdentifierStr
 from relay_teams.workspace import (
     SshProfileConfig,
@@ -246,6 +248,13 @@ async def get_config_status(
     service: ConfigStatusService = Depends(get_config_status_service),
 ) -> dict[str, JsonValue]:
     return await call_maybe_async(service.get_config_status)
+
+
+@router.get("/configs/plugins/runtime")
+async def get_plugins_runtime_view(
+    plugin_registry: PluginRegistry = Depends(get_plugin_registry),
+) -> PluginRegistry:
+    return plugin_registry
 
 
 @router.get("/configs/workspace/ssh-profiles")

--- a/src/relay_teams/mcp/config_reload_service.py
+++ b/src/relay_teams/mcp/config_reload_service.py
@@ -25,10 +25,12 @@ class McpConfigReloadService:
         mcp_config_manager: McpConfigManager,
         role_registry: RoleRegistry,
         on_mcp_reloaded: Callable[[McpRegistry], None],
+        extra_specs: tuple[McpServerSpec, ...] = (),
     ) -> None:
         self._mcp_config_manager: McpConfigManager = mcp_config_manager
         self._role_registry: RoleRegistry = role_registry
         self._on_mcp_reloaded: Callable[[McpRegistry], None] = on_mcp_reloaded
+        self._extra_specs = extra_specs
 
     def reload_mcp_config(self) -> None:
         with trace_span(
@@ -36,7 +38,9 @@ class McpConfigReloadService:
             component="mcp.config",
             operation="reload",
         ):
-            mcp_registry = self._mcp_config_manager.load_registry()
+            mcp_registry = self._mcp_config_manager.load_registry(
+                extra_specs=self._extra_specs
+            )
             self._clean_uv_tool_cache(mcp_registry.list_specs())
             for role in self._role_registry.list_roles():
                 mcp_registry.resolve_server_names(

--- a/src/relay_teams/mcp/mcp_config_manager.py
+++ b/src/relay_teams/mcp/mcp_config_manager.py
@@ -45,7 +45,11 @@ class McpConfigManager:
         self._app_config_dir: Path = app_config_dir.expanduser().resolve()
         self._user_home_dir: Path | None = user_home_dir
 
-    def load_registry(self) -> McpRegistry:
+    def load_registry(
+        self,
+        *,
+        extra_specs: tuple[McpServerSpec, ...] = (),
+    ) -> McpRegistry:
         ensure_app_config_bootstrap(self._app_config_dir)
         sync_app_env_to_process_env(self._app_config_dir / _ENV_FILE_NAME)
         with trace_span(
@@ -65,6 +69,11 @@ class McpConfigManager:
                 proxy_env=proxy_env,
             ):
                 merged_specs[spec.name] = spec
+            for spec in extra_specs:
+                merged_specs[spec.name] = _apply_proxy_env_to_mcp_spec(
+                    spec=spec,
+                    proxy_env=proxy_env,
+                )
             return McpRegistry(tuple(merged_specs.values()))
 
     def add_server(
@@ -375,3 +384,23 @@ def _apply_proxy_env_to_mcp_server_config(
         merged_env[key] = value
     merged_config["env"] = merged_env
     return merged_config
+
+
+def _apply_proxy_env_to_mcp_spec(
+    *,
+    spec: McpServerSpec,
+    proxy_env: dict[str, str],
+) -> McpServerSpec:
+    effective_server_config = _apply_proxy_env_to_mcp_server_config(
+        spec.server_config,
+        proxy_env,
+    )
+    wrapped_config: dict[str, JsonValue] = {
+        "mcpServers": {spec.name: effective_server_config},
+    }
+    return spec.model_copy(
+        update={
+            "config": wrapped_config,
+            "server_config": effective_server_config,
+        }
+    )

--- a/src/relay_teams/mcp/mcp_models.py
+++ b/src/relay_teams/mcp/mcp_models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 class McpConfigScope(str, Enum):
     APP = "app"
+    PLUGIN = "plugin"
     SESSION = "session"
 
 

--- a/src/relay_teams/mcp/mcp_service.py
+++ b/src/relay_teams/mcp/mcp_service.py
@@ -8,10 +8,12 @@ from pydantic import JsonValue
 from relay_teams.logger import get_logger
 from relay_teams.mcp.mcp_config_manager import McpConfigManager
 from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
     McpServerAddResult,
     McpServerConfigResult,
     McpServerConnectionTestResult,
     McpServerEnabledUpdateRequest,
+    McpServerSpec,
     McpServerSummary,
     McpServerToolsSummary,
     McpServerUpdateRequest,
@@ -30,15 +32,25 @@ class McpService:
         registry: McpRegistry,
         config_manager: McpConfigManager | None = None,
         on_registry_changed: Callable[[McpRegistry], None] | None = None,
+        extra_specs: tuple[McpServerSpec, ...] = (),
     ) -> None:
         self._registry: McpRegistry = registry
         self._config_manager: McpConfigManager | None = config_manager
         self._on_registry_changed: Callable[[McpRegistry], None] | None = (
             on_registry_changed
         )
+        self._extra_specs: tuple[McpServerSpec, ...] = extra_specs
 
     def replace_registry(self, registry: McpRegistry) -> None:
         self._registry = registry
+
+    def replace_extra_specs(self, extra_specs: tuple[McpServerSpec, ...]) -> None:
+        self._extra_specs = extra_specs
+
+    def _load_registry(self) -> McpRegistry:
+        if self._config_manager is None:
+            raise RuntimeError("MCP config manager is not available")
+        return self._config_manager.load_registry(extra_specs=self._extra_specs)
 
     def _publish_registry(self, registry: McpRegistry) -> None:
         self.replace_registry(registry)
@@ -74,7 +86,11 @@ class McpService:
             attributes={"server_name": name},
         ):
             spec = self._registry.get_spec(name.strip())
-            config = self._config_manager.get_server_config(name)
+            config = (
+                self._config_manager.get_server_config(name)
+                if spec.source == McpConfigScope.APP
+                else spec.server_config
+            )
             return McpServerConfigResult(
                 server=McpServerSummary(
                     name=spec.name,
@@ -117,12 +133,15 @@ class McpService:
             operation="add_server",
             attributes={"server_name": name},
         ):
+            normalized_name = name.strip()
+            if normalized_name:
+                self._require_no_non_app_shadow(normalized_name)
             config_path = self._config_manager.add_server(
                 name=name,
                 server_config=server_config,
                 overwrite=overwrite,
             )
-            self._publish_registry(self._config_manager.load_registry())
+            self._publish_registry(self._load_registry())
             spec = self._registry.get_spec(name.strip())
             return McpServerAddResult(
                 server=McpServerSummary(
@@ -147,11 +166,12 @@ class McpService:
             operation="set_server_enabled",
             attributes={"server_name": name, "enabled": request.enabled},
         ):
+            self._require_app_managed_server(name)
             self._config_manager.set_server_enabled(
                 name=name,
                 enabled=request.enabled,
             )
-            self._publish_registry(self._config_manager.load_registry())
+            self._publish_registry(self._load_registry())
             spec = self._registry.get_spec(name.strip())
             return McpServerSummary(
                 name=spec.name,
@@ -173,11 +193,12 @@ class McpService:
             operation="update_server",
             attributes={"server_name": name},
         ):
+            self._require_app_managed_server(name)
             self._config_manager.update_server(
                 name=name,
                 server_config=request.config,
             )
-            self._publish_registry(self._config_manager.load_registry())
+            self._publish_registry(self._load_registry())
             spec = self._registry.get_spec(name.strip())
             return McpServerConfigResult(
                 server=McpServerSummary(
@@ -217,6 +238,25 @@ class McpService:
                 ok=True,
                 tool_count=len(tools),
                 tools=tools,
+            )
+
+    def _require_app_managed_server(self, name: str) -> None:
+        spec = self._registry.get_spec(name.strip())
+        if spec.source != McpConfigScope.APP:
+            raise ValueError(
+                f"MCP server is managed by {spec.source.value} and cannot be modified: "
+                f"{spec.name}"
+            )
+
+    def _require_no_non_app_shadow(self, name: str) -> None:
+        try:
+            spec = self._registry.get_spec(name)
+        except ValueError:
+            return
+        if spec.source != McpConfigScope.APP:
+            raise ValueError(
+                f"MCP server is managed by {spec.source.value} and cannot be shadowed "
+                f"by app config: {spec.name}"
             )
 
 

--- a/src/relay_teams/plugins/__init__.py
+++ b/src/relay_teams/plugins/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from relay_teams.plugins.plugin_models import (
+    PluginComponentSource,
+    PluginDiagnostic,
+    PluginDiagnosticSeverity,
+    PluginManifest,
+    PluginRecord,
+    PluginRegistry,
+    PluginScope,
+)
+from relay_teams.plugins.config_manager import PluginConfigManager
+
+__all__ = [
+    "PluginComponentSource",
+    "PluginConfigManager",
+    "PluginDiagnostic",
+    "PluginDiagnosticSeverity",
+    "PluginManifest",
+    "PluginRecord",
+    "PluginRegistry",
+    "PluginScope",
+]

--- a/src/relay_teams/plugins/config_manager.py
+++ b/src/relay_teams/plugins/config_manager.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from relay_teams.logger import get_logger
+from relay_teams.plugins.manifest_loader import load_plugin_record
+from relay_teams.plugins.plugin_models import (
+    PluginDiagnostic,
+    PluginDiagnosticSeverity,
+    PluginRecord,
+    PluginRegistry,
+    PluginScope,
+)
+
+LOGGER = get_logger(__name__)
+_PLUGIN_DIRS_ENV_VAR = "RELAY_TEAMS_PLUGIN_DIRS"
+
+
+class PluginConfigManager:
+    def __init__(
+        self,
+        *,
+        app_config_dir: Path,
+        plugin_dirs: tuple[Path, ...] = (),
+    ) -> None:
+        self._app_config_dir = app_config_dir.expanduser().resolve()
+        self._plugin_dirs = tuple(path.expanduser().resolve() for path in plugin_dirs)
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        app_config_dir: Path,
+    ) -> PluginConfigManager:
+        return cls(
+            app_config_dir=app_config_dir,
+            plugin_dirs=_plugin_dirs_from_env(),
+        )
+
+    def load_registry(self) -> PluginRegistry:
+        diagnostics: list[PluginDiagnostic] = []
+        records: list[PluginRecord] = []
+        seen_names: set[str] = set()
+        data_root = self._app_config_dir / "plugins" / "data"
+        for plugin_dir in self._plugin_dirs:
+            if not plugin_dir.exists() or not plugin_dir.is_dir():
+                diagnostics.append(
+                    PluginDiagnostic(
+                        scope=PluginScope.LOCAL,
+                        severity=PluginDiagnosticSeverity.ERROR,
+                        path=plugin_dir,
+                        message="Plugin directory does not exist",
+                    )
+                )
+                continue
+            record, load_diagnostics = load_plugin_record(
+                plugin_root=plugin_dir,
+                data_root=data_root,
+                manifest_config_dir_name=self._app_config_dir.name,
+                scope=PluginScope.LOCAL,
+            )
+            diagnostics.extend(load_diagnostics)
+            if record is not None:
+                if record.name in seen_names:
+                    diagnostics.append(
+                        PluginDiagnostic(
+                            plugin_name=record.name,
+                            scope=record.scope,
+                            severity=PluginDiagnosticSeverity.ERROR,
+                            path=record.manifest_path or record.root_dir,
+                            message=f"Duplicate plugin name skipped: {record.name}",
+                        )
+                    )
+                    continue
+                seen_names.add(record.name)
+                records.append(record)
+        return PluginRegistry(
+            plugins=tuple(records),
+            diagnostics=tuple(diagnostics),
+        )
+
+
+def _plugin_dirs_from_env() -> tuple[Path, ...]:
+    raw_value = os.environ.get(_PLUGIN_DIRS_ENV_VAR, "").strip()
+    if not raw_value:
+        return ()
+    paths: list[Path] = []
+    for item in raw_value.split(os.pathsep):
+        normalized = item.strip()
+        if normalized:
+            paths.append(Path(normalized))
+    return tuple(paths)

--- a/src/relay_teams/plugins/manifest_loader.py
+++ b/src/relay_teams/plugins/manifest_loader.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from json import loads
+from pathlib import Path
+
+from pydantic import JsonValue
+
+from relay_teams.plugins.path_resolution import resolve_plugin_component_path
+from relay_teams.plugins.plugin_models import (
+    PluginComponentKind,
+    PluginComponentSource,
+    PluginDiagnostic,
+    PluginDiagnosticSeverity,
+    PluginManifest,
+    PluginRecord,
+    PluginScope,
+)
+
+_DEFAULT_RELAY_MANIFEST_CONFIG_DIR_NAME = ".relay-teams"
+_CLAUDE_MANIFEST_RELATIVE_PATH = Path(".claude-plugin") / "plugin.json"
+
+
+def load_plugin_record(
+    *,
+    plugin_root: Path,
+    data_root: Path,
+    manifest_config_dir_name: str = _DEFAULT_RELAY_MANIFEST_CONFIG_DIR_NAME,
+    scope: PluginScope = PluginScope.LOCAL,
+) -> tuple[PluginRecord | None, tuple[PluginDiagnostic, ...]]:
+    resolved_root = plugin_root.expanduser().resolve()
+    diagnostics: list[PluginDiagnostic] = []
+    manifest_path = _find_manifest_path(
+        plugin_root=resolved_root,
+        manifest_config_dir_name=manifest_config_dir_name,
+    )
+    try:
+        manifest = _load_manifest_or_default(
+            plugin_root=resolved_root,
+            manifest_path=manifest_path,
+        )
+        data_dir = data_root.expanduser().resolve() / manifest.name
+        record = PluginRecord(
+            name=manifest.name,
+            version=manifest.version or "local",
+            scope=scope,
+            enabled=True,
+            root_dir=resolved_root,
+            data_dir=data_dir,
+            manifest_path=manifest_path if manifest_path.exists() else None,
+            manifest=manifest,
+            skill_sources=_component_sources(
+                manifest_value=manifest.skills,
+                default_relative_path="./skills",
+                component=PluginComponentKind.SKILLS,
+                plugin_name=manifest.name,
+                scope=scope,
+                root_dir=resolved_root,
+                data_dir=data_dir,
+                diagnostics=diagnostics,
+                require_directory=True,
+            ),
+            role_sources=_component_sources(
+                manifest_value=manifest.roles,
+                default_relative_path=("./roles", "./agents"),
+                component=PluginComponentKind.ROLES,
+                plugin_name=manifest.name,
+                scope=scope,
+                root_dir=resolved_root,
+                data_dir=data_dir,
+                diagnostics=diagnostics,
+                require_directory=True,
+            ),
+            command_sources=_component_sources(
+                manifest_value=manifest.commands,
+                default_relative_path="./commands",
+                component=PluginComponentKind.COMMANDS,
+                plugin_name=manifest.name,
+                scope=scope,
+                root_dir=resolved_root,
+                data_dir=data_dir,
+                diagnostics=diagnostics,
+                require_directory=True,
+            ),
+            hook_sources=_component_sources(
+                manifest_value=manifest.hooks,
+                default_relative_path="./hooks/hooks.json",
+                component=PluginComponentKind.HOOKS,
+                plugin_name=manifest.name,
+                scope=scope,
+                root_dir=resolved_root,
+                data_dir=data_dir,
+                diagnostics=diagnostics,
+                require_directory=False,
+            ),
+            mcp_sources=_component_sources(
+                manifest_value=manifest.mcp_servers,
+                default_relative_path=("./.mcp.json", "./mcp.json"),
+                component=PluginComponentKind.MCP_SERVERS,
+                plugin_name=manifest.name,
+                scope=scope,
+                root_dir=resolved_root,
+                data_dir=data_dir,
+                diagnostics=diagnostics,
+                require_directory=False,
+            ),
+        )
+        return record, tuple(diagnostics)
+    except Exception as exc:
+        diagnostics.append(
+            PluginDiagnostic(
+                plugin_name=resolved_root.name,
+                scope=scope,
+                severity=PluginDiagnosticSeverity.ERROR,
+                path=resolved_root,
+                message=str(exc),
+            )
+        )
+        return None, tuple(diagnostics)
+
+
+def _load_manifest_or_default(
+    *,
+    plugin_root: Path,
+    manifest_path: Path,
+) -> PluginManifest:
+    if not manifest_path.exists():
+        return PluginManifest(name=plugin_root.name)
+    raw = loads(manifest_path.read_text(encoding="utf-8-sig"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"Plugin manifest must be a JSON object: {manifest_path}")
+    return PluginManifest.model_validate(_json_object(raw))
+
+
+def _find_manifest_path(*, plugin_root: Path, manifest_config_dir_name: str) -> Path:
+    relay_path = plugin_root / _relay_manifest_relative_path(manifest_config_dir_name)
+    if relay_path.exists():
+        return relay_path
+    claude_path = plugin_root / _CLAUDE_MANIFEST_RELATIVE_PATH
+    if claude_path.exists():
+        return claude_path
+    return relay_path
+
+
+def _relay_manifest_relative_path(manifest_config_dir_name: str) -> Path:
+    normalized = manifest_config_dir_name.strip()
+    if not normalized:
+        normalized = _DEFAULT_RELAY_MANIFEST_CONFIG_DIR_NAME
+    if normalized in {".", ".."} or Path(normalized).name != normalized:
+        raise ValueError("Plugin manifest config directory name must be a safe segment")
+    return Path(normalized) / "plugin.json"
+
+
+def _component_sources(
+    *,
+    manifest_value: str | tuple[str, ...] | dict[str, JsonValue] | None,
+    default_relative_path: str | tuple[str, ...],
+    component: PluginComponentKind,
+    plugin_name: str,
+    scope: PluginScope,
+    root_dir: Path,
+    data_dir: Path,
+    diagnostics: list[PluginDiagnostic],
+    require_directory: bool,
+) -> tuple[PluginComponentSource, ...]:
+    raw_paths = _component_path_values(
+        manifest_value=manifest_value,
+        default_relative_path=default_relative_path,
+        component=component,
+        plugin_name=plugin_name,
+        scope=scope,
+        root_dir=root_dir,
+        diagnostics=diagnostics,
+    )
+    sources: list[PluginComponentSource] = []
+    for raw_path in raw_paths:
+        try:
+            path = resolve_plugin_component_path(
+                plugin_root=root_dir,
+                raw_path=raw_path,
+            )
+        except ValueError as exc:
+            diagnostics.append(
+                PluginDiagnostic(
+                    plugin_name=plugin_name,
+                    scope=scope,
+                    severity=PluginDiagnosticSeverity.ERROR,
+                    component=component,
+                    path=root_dir,
+                    message=str(exc),
+                )
+            )
+            continue
+        if require_directory:
+            exists = path.is_dir()
+        else:
+            exists = path.exists()
+        if not exists:
+            continue
+        if component == PluginComponentKind.MCP_SERVERS:
+            try:
+                _ = _load_component_json_object(path)
+            except Exception as exc:
+                diagnostics.append(
+                    PluginDiagnostic(
+                        plugin_name=plugin_name,
+                        scope=scope,
+                        severity=PluginDiagnosticSeverity.ERROR,
+                        component=component,
+                        path=path,
+                        message=f"Invalid plugin MCP config: {exc}",
+                    )
+                )
+                continue
+        sources.append(
+            PluginComponentSource(
+                plugin_name=plugin_name,
+                scope=scope,
+                root_dir=root_dir,
+                data_dir=data_dir,
+                path=path,
+            )
+        )
+    return tuple(sources)
+
+
+def _component_path_values(
+    *,
+    manifest_value: str | tuple[str, ...] | dict[str, JsonValue] | None,
+    default_relative_path: str | tuple[str, ...],
+    component: PluginComponentKind,
+    plugin_name: str,
+    scope: PluginScope,
+    root_dir: Path,
+    diagnostics: list[PluginDiagnostic],
+) -> tuple[str, ...]:
+    if manifest_value is None:
+        if isinstance(default_relative_path, str):
+            return (default_relative_path,)
+        return default_relative_path
+    if isinstance(manifest_value, str):
+        return (manifest_value,)
+    if isinstance(manifest_value, tuple):
+        return manifest_value
+    diagnostics.append(
+        PluginDiagnostic(
+            plugin_name=plugin_name,
+            scope=scope,
+            severity=PluginDiagnosticSeverity.ERROR,
+            component=component,
+            path=root_dir,
+            message=(
+                "Inline plugin component configs are not supported; "
+                "provide a component path instead"
+            ),
+        )
+    )
+    return ()
+
+
+def _json_object(raw: dict[object, object]) -> dict[str, JsonValue]:
+    return {str(key): _json_value(value) for key, value in raw.items()}
+
+
+def _load_component_json_object(path: Path) -> dict[str, JsonValue]:
+    raw = loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"Plugin component must be a JSON object: {path}")
+    return _json_object(raw)
+
+
+def _json_value(value: object) -> JsonValue:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    return str(value)

--- a/src/relay_teams/plugins/mcp_sources.py
+++ b/src/relay_teams/plugins/mcp_sources.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from json import loads
+from pathlib import Path
+import re
+
+from pydantic import JsonValue
+
+from relay_teams.logger import get_logger
+from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
+from relay_teams.plugins.path_resolution import namespace_plugin_ref
+from relay_teams.plugins.plugin_models import PluginComponentSource
+
+LOGGER = get_logger(__name__)
+_PLUGIN_VAR_PATTERN = re.compile(
+    r"\$\{(?P<name>RELAY_TEAMS_PLUGIN_ROOT|RELAY_TEAMS_PLUGIN_DATA)}"
+)
+
+
+def load_plugin_mcp_specs(
+    sources: tuple[PluginComponentSource, ...],
+) -> tuple[McpServerSpec, ...]:
+    specs: list[McpServerSpec] = []
+    for source in sources:
+        specs.extend(_load_source(source))
+    return tuple(specs)
+
+
+def _load_source(source: PluginComponentSource) -> tuple[McpServerSpec, ...]:
+    try:
+        payload = _load_json_object(source.path)
+    except Exception as exc:
+        LOGGER.warning(
+            "Skipping invalid plugin MCP config",
+            extra={
+                "plugin_name": source.plugin_name,
+                "path": str(source.path),
+                "error": str(exc),
+            },
+        )
+        return ()
+    raw_servers = payload.get("mcpServers", payload)
+    if not isinstance(raw_servers, dict):
+        return ()
+    specs: list[McpServerSpec] = []
+    for raw_name, raw_config in raw_servers.items():
+        local_name = str(raw_name).strip()
+        if not local_name:
+            continue
+        server_name = namespace_plugin_ref(
+            plugin_name=source.plugin_name,
+            local_name=local_name,
+        )
+        normalized_config = _json_object(raw_config)
+        substituted_config = _substitute_plugin_vars(
+            value=normalized_config,
+            plugin_root=source.root_dir,
+            plugin_data=source.data_dir,
+        )
+        server_config = (
+            substituted_config if isinstance(substituted_config, dict) else {}
+        )
+        specs.append(
+            McpServerSpec(
+                name=server_name,
+                config={"mcpServers": {server_name: server_config}},
+                server_config=server_config,
+                source=McpConfigScope.PLUGIN,
+                enabled=_is_enabled(server_config),
+            )
+        )
+    return tuple(specs)
+
+
+def _load_json_object(path: Path) -> dict[str, JsonValue]:
+    raw = loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): _json_value(value) for key, value in raw.items()}
+
+
+def _json_object(value: object) -> dict[str, JsonValue]:
+    normalized = _json_value(value)
+    if isinstance(normalized, dict):
+        return normalized
+    return {}
+
+
+def _json_value(value: object) -> JsonValue:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    return str(value)
+
+
+def _substitute_plugin_vars(
+    *,
+    value: JsonValue,
+    plugin_root: Path,
+    plugin_data: Path,
+) -> JsonValue:
+    if isinstance(value, str):
+        return _PLUGIN_VAR_PATTERN.sub(
+            lambda match: _plugin_var_value(
+                name=match.group("name"),
+                plugin_root=plugin_root,
+                plugin_data=plugin_data,
+            ),
+            value,
+        )
+    if isinstance(value, list):
+        return [
+            _substitute_plugin_vars(
+                value=item,
+                plugin_root=plugin_root,
+                plugin_data=plugin_data,
+            )
+            for item in value
+        ]
+    if isinstance(value, dict):
+        return {
+            key: _substitute_plugin_vars(
+                value=item,
+                plugin_root=plugin_root,
+                plugin_data=plugin_data,
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def _plugin_var_value(*, name: str | None, plugin_root: Path, plugin_data: Path) -> str:
+    if name == "RELAY_TEAMS_PLUGIN_ROOT":
+        return str(plugin_root)
+    if name == "RELAY_TEAMS_PLUGIN_DATA":
+        return str(plugin_data)
+    return ""
+
+
+def _is_enabled(server_config: dict[str, JsonValue]) -> bool:
+    raw_enabled = server_config.get("enabled")
+    if isinstance(raw_enabled, bool):
+        return raw_enabled
+    raw_disabled = server_config.get("disabled")
+    if isinstance(raw_disabled, bool):
+        return not raw_disabled
+    return True

--- a/src/relay_teams/plugins/path_resolution.py
+++ b/src/relay_teams/plugins/path_resolution.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_plugin_component_path(*, plugin_root: Path, raw_path: str) -> Path:
+    normalized = raw_path.strip()
+    if not normalized:
+        raise ValueError("Plugin component path must not be empty")
+    candidate = Path(normalized)
+    if candidate.is_absolute():
+        raise ValueError("Plugin component paths must be relative")
+    if normalized.startswith("../") or normalized == "..":
+        raise ValueError("Plugin component paths must not traverse outside the plugin")
+    if normalized != "." and not normalized.startswith("./"):
+        raise ValueError("Plugin component paths must start with ./")
+    resolved_root = plugin_root.expanduser().resolve()
+    resolved_path = (resolved_root / candidate).resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError("Plugin component path escapes the plugin root") from exc
+    return resolved_path
+
+
+def namespace_plugin_ref(*, plugin_name: str, local_name: str) -> str:
+    normalized_plugin = plugin_name.strip()
+    normalized_local = local_name.strip()
+    if not normalized_plugin:
+        raise ValueError("plugin_name must not be empty")
+    if not normalized_local:
+        raise ValueError("local_name must not be empty")
+    prefix, separator, _ = normalized_local.partition(":")
+    if separator == ":" and prefix == normalized_plugin:
+        return normalized_local
+    return f"{normalized_plugin}:{normalized_local}"

--- a/src/relay_teams/plugins/plugin_models.py
+++ b/src/relay_teams/plugins/plugin_models.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+import re
+
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    field_validator,
+)
+
+from relay_teams.validation import RequiredIdentifierStr
+
+_PLUGIN_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+
+class PluginScope(str, Enum):
+    LOCAL = "local"
+    USER = "user"
+    PROJECT = "project"
+    PROJECT_LOCAL = "project_local"
+    MANAGED = "managed"
+
+
+class PluginDiagnosticSeverity(str, Enum):
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class PluginComponentKind(str, Enum):
+    SKILLS = "skills"
+    ROLES = "roles"
+    COMMANDS = "commands"
+    HOOKS = "hooks"
+    MCP_SERVERS = "mcp_servers"
+    MONITORS = "monitors"
+    SETTINGS = "settings"
+
+
+class PluginAuthor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = ""
+    email: str = ""
+    url: str = ""
+
+
+class PluginDependency(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: RequiredIdentifierStr
+    version: str | None = None
+
+
+class PluginUserConfigField(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = Field(default="string")
+    title: str = ""
+    description: str = ""
+    default: JsonValue | None = None
+    sensitive: bool = False
+    required: bool = False
+
+
+class PluginManifest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: RequiredIdentifierStr
+    version: str | None = None
+    description: str = ""
+    author: PluginAuthor | None = None
+    homepage: str | None = None
+    repository: str | None = None
+    license: str | None = None
+    keywords: tuple[str, ...] = ()
+    skills: str | tuple[str, ...] | None = None
+    roles: str | tuple[str, ...] | None = Field(
+        default=None,
+        validation_alias=AliasChoices("roles", "agents"),
+    )
+    commands: str | tuple[str, ...] | None = None
+    hooks: str | tuple[str, ...] | dict[str, JsonValue] | None = None
+    mcp_servers: str | tuple[str, ...] | dict[str, JsonValue] | None = Field(
+        default=None,
+        validation_alias=AliasChoices("mcp_servers", "mcpServers"),
+    )
+    monitors: str | tuple[str, ...] | dict[str, JsonValue] | None = None
+    settings: str | dict[str, JsonValue] | None = None
+    user_config: dict[str, PluginUserConfigField] = Field(
+        default_factory=dict,
+        validation_alias=AliasChoices("user_config", "userConfig"),
+    )
+    dependencies: tuple[PluginDependency, ...] = ()
+
+    @field_validator("name")
+    @classmethod
+    def _validate_safe_name(cls, value: str) -> str:
+        if not _PLUGIN_NAME_RE.match(value):
+            raise ValueError("Plugin name must be identifier-safe")
+        return value
+
+
+class PluginDiagnostic(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    plugin_name: str = ""
+    scope: PluginScope = PluginScope.LOCAL
+    severity: PluginDiagnosticSeverity
+    component: PluginComponentKind | None = None
+    path: Path | None = None
+    message: str
+
+
+class PluginComponentSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    plugin_name: RequiredIdentifierStr
+    scope: PluginScope = PluginScope.LOCAL
+    root_dir: Path
+    data_dir: Path
+    path: Path
+
+
+class PluginRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: RequiredIdentifierStr
+    version: str
+    scope: PluginScope = PluginScope.LOCAL
+    enabled: bool = True
+    root_dir: Path
+    data_dir: Path
+    manifest_path: Path | None = None
+    manifest: PluginManifest
+    skill_sources: tuple[PluginComponentSource, ...] = ()
+    role_sources: tuple[PluginComponentSource, ...] = ()
+    command_sources: tuple[PluginComponentSource, ...] = ()
+    hook_sources: tuple[PluginComponentSource, ...] = ()
+    mcp_sources: tuple[PluginComponentSource, ...] = ()
+
+
+class PluginRegistry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    plugins: tuple[PluginRecord, ...] = ()
+    diagnostics: tuple[PluginDiagnostic, ...] = ()
+
+    def enabled_plugins(self) -> tuple[PluginRecord, ...]:
+        return tuple(plugin for plugin in self.plugins if plugin.enabled)
+
+    def skill_sources(self) -> tuple[PluginComponentSource, ...]:
+        return tuple(
+            source
+            for plugin in self.enabled_plugins()
+            for source in plugin.skill_sources
+        )
+
+    def role_sources(self) -> tuple[PluginComponentSource, ...]:
+        return tuple(
+            source
+            for plugin in self.enabled_plugins()
+            for source in plugin.role_sources
+        )
+
+    def hook_sources(self) -> tuple[PluginComponentSource, ...]:
+        return tuple(
+            source
+            for plugin in self.enabled_plugins()
+            for source in plugin.hook_sources
+        )
+
+    def command_sources(self) -> tuple[PluginComponentSource, ...]:
+        return tuple(
+            source
+            for plugin in self.enabled_plugins()
+            for source in plugin.command_sources
+        )
+
+    def mcp_sources(self) -> tuple[PluginComponentSource, ...]:
+        return tuple(
+            source for plugin in self.enabled_plugins() for source in plugin.mcp_sources
+        )

--- a/src/relay_teams/roles/role_models.py
+++ b/src/relay_teams/roles/role_models.py
@@ -17,6 +17,7 @@ from pathlib import Path
 class RoleConfigSource(str, Enum):
     BUILTIN = "builtin"
     APP = "app"
+    PLUGIN = "plugin"
 
 
 class RoleMode(str, Enum):

--- a/src/relay_teams/roles/role_registry.py
+++ b/src/relay_teams/roles/role_registry.py
@@ -9,8 +9,10 @@ from relay_teams.computer import ExecutionSurface
 from relay_teams.hooks import (
     parse_tolerant_hooks_payload,
 )
-from relay_teams.hooks.hook_models import HooksConfig
+from relay_teams.hooks.hook_models import HookHandlerType, HooksConfig
 from relay_teams.logger import get_logger
+from relay_teams.plugins.path_resolution import namespace_plugin_ref
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.roles.default_role_tools import (
     COORDINATOR_IDENTIFIERS,
     COORDINATOR_REQUIRED_TOOLS,
@@ -227,6 +229,42 @@ class RoleLoader:
             )
         return registry
 
+    def load_builtin_app_and_plugins(
+        self,
+        *,
+        builtin_roles_dir: Path,
+        app_roles_dir: Path,
+        plugin_sources: tuple[PluginComponentSource, ...] = (),
+        allow_empty: bool = False,
+    ) -> RoleRegistry:
+        registry = self.load_builtin_and_app(
+            builtin_roles_dir=builtin_roles_dir,
+            app_roles_dir=app_roles_dir,
+            allow_empty=True,
+        )
+        for plugin_source in plugin_sources:
+            if not plugin_source.path.exists() or not plugin_source.path.is_dir():
+                continue
+            for md_file in sorted(plugin_source.path.glob("*.md")):
+                try:
+                    role = self.load_one(md_file)
+                    registry.register(
+                        _namespace_plugin_role(
+                            role=role,
+                            plugin_name=plugin_source.plugin_name,
+                        )
+                    )
+                except Exception as exc:
+                    LOGGER.warning(
+                        "Skipping invalid plugin role",
+                        extra={"path": str(md_file), "error": str(exc)},
+                    )
+        if not allow_empty and not registry.list_roles():
+            raise ValueError(
+                f"No role files found in {builtin_roles_dir}, {app_roles_dir}, or plugin sources"
+            )
+        return registry
+
     def build_effective_role_map(
         self,
         *,
@@ -360,6 +398,107 @@ def _role_available_in_normal_mode(role: RoleDefinition) -> bool:
 
 def _role_available_as_subagent(role: RoleDefinition) -> bool:
     return role.mode in {RoleMode.SUBAGENT, RoleMode.ALL}
+
+
+def _namespace_plugin_role(
+    *,
+    role: RoleDefinition,
+    plugin_name: str,
+) -> RoleDefinition:
+    if is_reserved_system_role_definition(role):
+        raise ValueError(
+            f"Plugin role cannot define reserved system role: {role.role_id}"
+        )
+    return role.model_copy(
+        update={
+            "role_id": namespace_plugin_ref(
+                plugin_name=plugin_name,
+                local_name=role.role_id,
+            ),
+            "mcp_servers": _namespace_plugin_refs(
+                plugin_name=plugin_name,
+                refs=role.mcp_servers,
+            ),
+            "skills": _namespace_plugin_refs(
+                plugin_name=plugin_name,
+                refs=role.skills,
+            ),
+            "hooks": _namespace_plugin_hooks(
+                plugin_name=plugin_name,
+                hooks=role.hooks,
+            ),
+        }
+    )
+
+
+def _namespace_plugin_refs(
+    *,
+    plugin_name: str,
+    refs: tuple[str, ...],
+) -> tuple[str, ...]:
+    namespaced: list[str] = []
+    for ref in refs:
+        normalized = ref.strip()
+        if not normalized:
+            continue
+        if normalized == "*":
+            namespaced.append(normalized)
+            continue
+        if ":" in normalized:
+            namespaced.append(normalized)
+            continue
+        namespaced.append(
+            namespace_plugin_ref(plugin_name=plugin_name, local_name=normalized)
+        )
+    return tuple(namespaced)
+
+
+def _namespace_plugin_hooks(
+    *,
+    plugin_name: str,
+    hooks: HooksConfig,
+) -> HooksConfig:
+    if not hooks.hooks:
+        return hooks
+    next_hooks = {}
+    for event_name, groups in hooks.hooks.items():
+        next_groups = []
+        for group in groups:
+            next_handlers = []
+            for handler in group.hooks:
+                if handler.type == HookHandlerType.AGENT and handler.role_id:
+                    next_handlers.append(
+                        handler.model_copy(
+                            update={
+                                "role_id": _namespace_plugin_ref(
+                                    plugin_name=plugin_name,
+                                    ref=handler.role_id,
+                                )
+                            }
+                        )
+                    )
+                    continue
+                next_handlers.append(handler)
+            next_groups.append(
+                group.model_copy(
+                    update={
+                        "role_ids": _namespace_plugin_refs(
+                            plugin_name=plugin_name,
+                            refs=group.role_ids,
+                        ),
+                        "hooks": tuple(next_handlers),
+                    }
+                )
+            )
+        next_hooks[event_name] = tuple(next_groups)
+    return HooksConfig(hooks=next_hooks)
+
+
+def _namespace_plugin_ref(*, plugin_name: str, ref: str) -> str:
+    normalized = ref.strip()
+    if not normalized or normalized == "*" or ":" in normalized:
+        return ref
+    return namespace_plugin_ref(plugin_name=plugin_name, local_name=normalized)
 
 
 def _parse_frontmatter_hooks(

--- a/src/relay_teams/roles/settings_service.py
+++ b/src/relay_teams/roles/settings_service.py
@@ -24,6 +24,7 @@ from relay_teams.roles.role_registry import (
     is_coordinator_role_definition,
     is_reserved_system_role_definition,
 )
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry import ToolRegistry
 from relay_teams.roles.memory_models import default_memory_profile
@@ -44,9 +45,11 @@ class RoleSettingsService:
         get_external_agent_service: Callable[[], ExternalAgentConfigService] | None,
         on_roles_reloaded: Callable[[RoleRegistry], None],
         reload_skill_registry: Callable[[], SkillRegistry] | None = None,
+        plugin_sources: tuple[PluginComponentSource, ...] = (),
     ) -> None:
         self._roles_dir: Path = roles_dir
         self._builtin_roles_dir: Path = builtin_roles_dir
+        self._plugin_sources: tuple[PluginComponentSource, ...] = plugin_sources
         self._loader: RoleLoader = RoleLoader()
         self._get_tool_registry: Callable[[], ToolRegistry] = get_tool_registry
         self._get_mcp_registry: Callable[[], McpRegistry] = get_mcp_registry
@@ -54,6 +57,12 @@ class RoleSettingsService:
         self._reload_skill_registry = reload_skill_registry
         self._get_external_agent_service = get_external_agent_service
         self._on_roles_reloaded: Callable[[RoleRegistry], None] = on_roles_reloaded
+
+    def replace_plugin_sources(
+        self,
+        plugin_sources: tuple[PluginComponentSource, ...],
+    ) -> None:
+        self._plugin_sources = plugin_sources
 
     def list_role_documents(self) -> tuple[RoleDocumentSummary, ...]:
         builtin_role_ids = self._load_builtin_role_ids()
@@ -309,9 +318,10 @@ class RoleSettingsService:
         strict_capability_validation: bool,
         consumer_prefix: str,
     ) -> RoleRegistry:
-        registry = self._loader.load_builtin_and_app(
+        registry = self._loader.load_builtin_app_and_plugins(
             builtin_roles_dir=self._builtin_roles_dir,
             app_roles_dir=self._roles_dir,
+            plugin_sources=self._plugin_sources,
             allow_empty=True,
         )
         sanitized_registry = RoleRegistry()

--- a/src/relay_teams/skills/config_reload_service.py
+++ b/src/relay_teams/skills/config_reload_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pydantic import JsonValue
 
 from relay_teams.logger import get_logger
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.trace import trace_span
@@ -20,13 +21,21 @@ class SkillsConfigReloadService:
         *,
         config_dir: Path,
         project_start_dir: Path | None = None,
+        plugin_sources: tuple[PluginComponentSource, ...] = (),
         role_registry: RoleRegistry,
         on_skill_reloaded: Callable[[SkillRegistry], None],
     ) -> None:
         self._config_dir: Path = config_dir
         self._project_start_dir: Path | None = project_start_dir
+        self._plugin_sources = plugin_sources
         self._role_registry: RoleRegistry = role_registry
         self._on_skill_reloaded: Callable[[SkillRegistry], None] = on_skill_reloaded
+
+    def replace_plugin_sources(
+        self,
+        plugin_sources: tuple[PluginComponentSource, ...],
+    ) -> None:
+        self._plugin_sources = plugin_sources
 
     def reload_skills_config(self) -> SkillRegistry:
         attributes: dict[str, JsonValue] = {"config_dir": str(self._config_dir)}
@@ -40,12 +49,14 @@ class SkillsConfigReloadService:
         ):
             if self._project_start_dir is None:
                 skill_registry = SkillRegistry.from_config_dirs(
-                    app_config_dir=self._config_dir
+                    app_config_dir=self._config_dir,
+                    plugin_sources=self._plugin_sources,
                 )
             else:
                 skill_registry = SkillRegistry.from_config_dirs(
                     app_config_dir=self._config_dir,
                     project_start_dir=self._project_start_dir,
+                    plugin_sources=self._plugin_sources,
                 )
             for role in self._role_registry.list_roles():
                 skill_registry.resolve_known(

--- a/src/relay_teams/skills/discovery.py
+++ b/src/relay_teams/skills/discovery.py
@@ -9,9 +9,11 @@ import yaml
 
 from relay_teams.builtin import get_builtin_skills_dir
 from relay_teams.hooks import parse_tolerant_hooks_payload
-from relay_teams.hooks.hook_models import HooksConfig
+from relay_teams.hooks.hook_models import HookHandlerType, HooksConfig
 from relay_teams.logger import get_logger
 from relay_teams.paths import get_app_config_dir, get_project_root_or_none
+from relay_teams.plugins.path_resolution import namespace_plugin_ref
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.skills.skill_models import (
     Skill,
     SkillMetadata,
@@ -28,7 +30,7 @@ _SCRIPT_DESCRIPTION_PATTERN = re.compile(
 )
 _DISCOVERY_WARNING_SAMPLE_LIMIT = 5
 
-_SkillDiscoverySignature = tuple[tuple[str, str, int, int], ...]
+_SkillDiscoverySignature = tuple[tuple[str, str, str, int, int], ...]
 _SkillLoadWarningEntry = tuple[Path, str]
 _SkillDuplicateWarningEntry = tuple[str, Path, SkillSource, Path, SkillSource]
 
@@ -75,11 +77,16 @@ class SkillsDirectory:
         self,
         *,
         sources: tuple[tuple[SkillSource, Path], ...],
+        plugin_sources: tuple[PluginComponentSource, ...] = (),
         max_depth: int = 3,
     ) -> None:
         self.max_depth = max_depth
         self.sources = tuple(
             (source, _resolve_dir(base_dir)) for source, base_dir in sources
+        )
+        self.plugin_sources = tuple(
+            source.model_copy(update={"path": _resolve_dir(source.path)})
+            for source in plugin_sources
         )
         self._skills: dict[str, Skill] = {}
         self._discovery_signature: _SkillDiscoverySignature | None = None
@@ -91,13 +98,18 @@ class SkillsDirectory:
         *,
         app_skills_dir: Path,
         builtin_skills_dir: Path | None = None,
+        plugin_sources: tuple[PluginComponentSource, ...] = (),
         max_depth: int = 3,
     ) -> SkillsDirectory:
         sources: list[tuple[SkillSource, Path]] = []
         if builtin_skills_dir is not None:
             sources.append((SkillSource.BUILTIN, _resolve_dir(builtin_skills_dir)))
         sources.append((SkillSource.USER_RELAY_TEAMS, _resolve_dir(app_skills_dir)))
-        return cls(sources=tuple(sources), max_depth=max_depth)
+        return cls(
+            sources=tuple(sources),
+            plugin_sources=plugin_sources,
+            max_depth=max_depth,
+        )
 
     @classmethod
     def from_config_dirs(
@@ -106,6 +118,7 @@ class SkillsDirectory:
         app_config_dir: Path,
         max_depth: int = 3,
         project_start_dir: Path | None = None,
+        plugin_sources: tuple[PluginComponentSource, ...] = (),
     ) -> SkillsDirectory:
         resolved_app_config_dir = _resolve_dir(app_config_dir)
         return cls(
@@ -121,6 +134,7 @@ class SkillsDirectory:
                 agents_skills_dir=resolved_app_config_dir.parent / ".agents" / "skills",
                 project_start_dir=project_start_dir,
             ),
+            plugin_sources=plugin_sources,
             max_depth=max_depth,
         )
 
@@ -156,6 +170,13 @@ class SkillsDirectory:
                 "sources": [
                     {"source": source.value, "base_dir": str(path)}
                     for source, path in self.sources
+                ],
+                "plugin_sources": [
+                    {
+                        "plugin_name": source.plugin_name,
+                        "base_dir": str(source.path),
+                    }
+                    for source in self.plugin_sources
                 ],
                 "max_depth": self.max_depth,
             },
@@ -198,6 +219,37 @@ class SkillsDirectory:
                         load_warnings.append((path, str(exc)))
                     except Exception as exc:
                         load_warnings.append((path, str(exc)))
+            for plugin_source in self.plugin_sources:
+                base_dir = plugin_source.path
+                if not base_dir.exists():
+                    continue
+                for path in self._iter_skill_manifest_paths(base_dir):
+                    try:
+                        skill = self._load_skill(
+                            path=path,
+                            source=SkillSource.PLUGIN,
+                            load_warnings=load_warnings,
+                            plugin_name=plugin_source.plugin_name,
+                        )
+                        if skill is None:
+                            continue
+                        existing_skill = discovered_skills.get(skill.metadata.name)
+                        if existing_skill is not None:
+                            duplicate_warnings.append(
+                                (
+                                    skill.metadata.name,
+                                    existing_skill.directory,
+                                    existing_skill.source,
+                                    skill.directory,
+                                    skill.source,
+                                )
+                            )
+                        discovered_skills[skill.metadata.name] = skill
+                    except OSError as exc:
+                        had_transient_load_failure = True
+                        load_warnings.append((path, str(exc)))
+                    except Exception as exc:
+                        load_warnings.append((path, str(exc)))
             with self._lock:
                 self._skills = discovered_skills
                 if had_transient_load_failure:
@@ -210,7 +262,7 @@ class SkillsDirectory:
             )
 
     def _build_discovery_signature(self) -> _SkillDiscoverySignature:
-        signature: list[tuple[str, str, int, int]] = []
+        signature: list[tuple[str, str, str, int, int]] = []
         for source, base_dir in self.sources:
             if not base_dir.exists():
                 continue
@@ -219,7 +271,7 @@ class SkillsDirectory:
                     discovery_paths = _iter_skill_discovery_paths(manifest_path)
                 except (OSError, RuntimeError):
                     signature.append(
-                        (source.value, _safe_signature_path(manifest_path), -1, -1)
+                        (source.value, "", _safe_signature_path(manifest_path), -1, -1)
                     )
                     continue
                 for path in discovery_paths:
@@ -229,13 +281,55 @@ class SkillsDirectory:
                         signature.append(
                             (
                                 source.value,
+                                "",
                                 signature_path,
                                 stat_result.st_mtime_ns,
                                 stat_result.st_size,
                             )
                         )
                     except OSError:
-                        signature.append((source.value, signature_path, -1, -1))
+                        signature.append((source.value, "", signature_path, -1, -1))
+        for plugin_source in self.plugin_sources:
+            base_dir = plugin_source.path
+            if not base_dir.exists():
+                continue
+            for manifest_path in self._iter_skill_manifest_paths(base_dir):
+                try:
+                    discovery_paths = _iter_skill_discovery_paths(manifest_path)
+                except (OSError, RuntimeError):
+                    signature.append(
+                        (
+                            SkillSource.PLUGIN.value,
+                            plugin_source.plugin_name,
+                            _safe_signature_path(manifest_path),
+                            -1,
+                            -1,
+                        )
+                    )
+                    continue
+                for path in discovery_paths:
+                    signature_path = _safe_signature_path(path)
+                    try:
+                        stat_result = path.stat()
+                        signature.append(
+                            (
+                                SkillSource.PLUGIN.value,
+                                plugin_source.plugin_name,
+                                signature_path,
+                                stat_result.st_mtime_ns,
+                                stat_result.st_size,
+                            )
+                        )
+                    except OSError:
+                        signature.append(
+                            (
+                                SkillSource.PLUGIN.value,
+                                plugin_source.plugin_name,
+                                signature_path,
+                                -1,
+                                -1,
+                            )
+                        )
         return tuple(signature)
 
     def _iter_skill_manifest_paths(self, base_dir: Path) -> tuple[Path, ...]:
@@ -322,6 +416,7 @@ class SkillsDirectory:
         path: Path,
         source: SkillSource,
         load_warnings: list[_SkillLoadWarningEntry] | None = None,
+        plugin_name: str | None = None,
     ) -> Skill | None:
         with trace_span(
             logger,
@@ -347,6 +442,11 @@ class SkillsDirectory:
             description = raw_description if isinstance(raw_description, str) else ""
             if not name:
                 return None
+            runtime_name = (
+                namespace_plugin_ref(plugin_name=plugin_name, local_name=name)
+                if plugin_name is not None
+                else name
+            )
 
             resources: dict[str, SkillResource] = {}
             resource_entries = _as_object_mapping(data.get("resources"))
@@ -403,15 +503,18 @@ class SkillsDirectory:
                     )
 
             metadata = SkillMetadata(
-                name=name,
+                name=runtime_name,
                 description=description,
                 instructions=body.strip(),
                 resources=resources,
                 scripts=scripts,
-                hooks=_parse_frontmatter_hooks(data.get("hooks")),
+                hooks=_namespace_plugin_hooks(
+                    plugin_name=plugin_name,
+                    hooks=_parse_frontmatter_hooks(data.get("hooks")),
+                ),
             )
             return Skill(
-                ref=name,
+                ref=runtime_name,
                 metadata=metadata,
                 directory=path.parent,
                 source=source,
@@ -500,6 +603,70 @@ def _resolve_optional_path(base_dir: Path, value: object) -> Path | None:
     if not isinstance(value, str) or not value.strip():
         return None
     return base_dir / value
+
+
+def _namespace_plugin_hooks(
+    *,
+    plugin_name: str | None,
+    hooks: HooksConfig,
+) -> HooksConfig:
+    if plugin_name is None or not hooks.hooks:
+        return hooks
+    next_hooks = {}
+    for event_name, groups in hooks.hooks.items():
+        next_groups = []
+        for group in groups:
+            next_handlers = []
+            for handler in group.hooks:
+                if handler.type == HookHandlerType.AGENT and handler.role_id:
+                    next_handlers.append(
+                        handler.model_copy(
+                            update={
+                                "role_id": _namespace_plugin_ref(
+                                    plugin_name=plugin_name,
+                                    ref=handler.role_id,
+                                )
+                            }
+                        )
+                    )
+                    continue
+                next_handlers.append(handler)
+            next_groups.append(
+                group.model_copy(
+                    update={
+                        "role_ids": _namespace_plugin_refs(
+                            plugin_name=plugin_name,
+                            refs=group.role_ids,
+                        ),
+                        "hooks": tuple(next_handlers),
+                    }
+                )
+            )
+        next_hooks[event_name] = tuple(next_groups)
+    return HooksConfig(hooks=next_hooks)
+
+
+def _namespace_plugin_refs(
+    *,
+    plugin_name: str,
+    refs: tuple[str, ...],
+) -> tuple[str, ...]:
+    namespaced: list[str] = []
+    for ref in refs:
+        normalized = ref.strip()
+        if not normalized:
+            continue
+        namespaced.append(
+            _namespace_plugin_ref(plugin_name=plugin_name, ref=normalized)
+        )
+    return tuple(namespaced)
+
+
+def _namespace_plugin_ref(*, plugin_name: str, ref: str) -> str:
+    normalized = ref.strip()
+    if not normalized or normalized == "*" or ":" in normalized:
+        return ref
+    return namespace_plugin_ref(plugin_name=plugin_name, local_name=normalized)
 
 
 def _safe_signature_path(path: Path) -> str:

--- a/src/relay_teams/skills/skill_models.py
+++ b/src/relay_teams/skills/skill_models.py
@@ -11,6 +11,7 @@ from relay_teams.hooks.hook_models import HooksConfig
 
 class SkillSource(str, Enum):
     BUILTIN = "builtin"
+    PLUGIN = "plugin"
     USER_CODEX = "user_codex"
     USER_CLAUDE = "user_claude"
     USER_OPENCODE = "user_opencode"

--- a/src/relay_teams/skills/skill_registry.py
+++ b/src/relay_teams/skills/skill_registry.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue
 from pydantic_ai import Tool
 
 from relay_teams.logger import get_logger, log_event
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.skills.discovery import SkillsDirectory
 from relay_teams.skills.skill_models import (
     Skill,
@@ -68,12 +69,14 @@ class SkillRegistry(BaseModel):
         *,
         app_skills_dir: Path,
         builtin_skills_dir: Path | None = None,
+        plugin_sources: tuple[PluginComponentSource, ...] = (),
         max_depth: int = 3,
     ) -> SkillRegistry:
         return cls(
             directory=SkillsDirectory.from_skill_dirs(
                 app_skills_dir=app_skills_dir,
                 builtin_skills_dir=builtin_skills_dir,
+                plugin_sources=plugin_sources,
                 max_depth=max_depth,
             )
         )
@@ -85,12 +88,14 @@ class SkillRegistry(BaseModel):
         app_config_dir: Path,
         max_depth: int = 3,
         project_start_dir: Path | None = None,
+        plugin_sources: tuple[PluginComponentSource, ...] = (),
     ) -> SkillRegistry:
         return cls(
             directory=SkillsDirectory.from_config_dirs(
                 app_config_dir=app_config_dir,
                 max_depth=max_depth,
                 project_start_dir=project_start_dir,
+                plugin_sources=plugin_sources,
             )
         )
 

--- a/tests/unit_tests/hooks/test_hook_service.py
+++ b/tests/unit_tests/hooks/test_hook_service.py
@@ -60,6 +60,7 @@ from relay_teams.hooks.hook_service import (
     _handler_dedup_key,
     _merge_decisions,
     _normalize_decision_for_event,
+    _plugin_hook_env,
 )
 from relay_teams.media import UserPromptContent
 from relay_teams.sessions.runs.enums import (
@@ -410,8 +411,9 @@ async def test_supported_events_dispatch_supported_handler_types(
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
-            _ = handler
+            _ = (handler, extra_env)
             self.calls.append(event_input.event_name)
             return HookDecision(decision=HookDecisionType.ALLOW)
 
@@ -539,9 +541,11 @@ async def test_execute_publishes_hook_events_with_async_publisher(
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
             _ = handler
             _ = event_input
+            _ = extra_env
             return HookDecision(decision=HookDecisionType.ALLOW)
 
     source = HookSourceInfo(scope=HookSourceScope.USER, path=tmp_path / "hooks.json")
@@ -757,13 +761,16 @@ def test_decision_conflicts_detects_duplicate_rewrites_and_deferred_actions() ->
 
 
 def test_handler_dedup_key_covers_command_http_and_other_handlers() -> None:
+    source = HookSourceInfo(scope=HookSourceScope.USER, path=Path("hooks.json"))
     command_key = _handler_dedup_key(
-        HookHandlerConfig(
+        handler=HookHandlerConfig(
             type=HookHandlerType.COMMAND,
             command="python hook.py",
-        )
+        ),
+        source=source,
     )
     assert command_key == (
+        "",
         "command",
         "",
         "",
@@ -773,12 +780,14 @@ def test_handler_dedup_key_covers_command_http_and_other_handlers() -> None:
         "python hook.py",
     )
     assert _handler_dedup_key(
-        HookHandlerConfig(
+        handler=HookHandlerConfig(
             type=HookHandlerType.COMMAND,
             command="python hook.py",
             shell=HookShell.POWERSHELL,
-        )
+        ),
+        source=source,
     ) == (
+        "",
         "command",
         "",
         "",
@@ -789,29 +798,82 @@ def test_handler_dedup_key_covers_command_http_and_other_handlers() -> None:
     )
     assert (
         _handler_dedup_key(
-            HookHandlerConfig(
+            handler=HookHandlerConfig(
                 type=HookHandlerType.COMMAND,
                 if_rule="shell(git *)",
                 command="python hook.py",
-            )
+            ),
+            source=source,
         )
         != command_key
     )
     assert _handler_dedup_key(
-        HookHandlerConfig(
+        handler=HookHandlerConfig(
             type=HookHandlerType.HTTP,
             url="https://hook.test/",
-        )
-    ) == ("http", "", "", "5.0", "ignore", "https://hook.test/", "", "")
+        ),
+        source=source,
+    ) == ("", "http", "", "", "5.0", "ignore", "https://hook.test/", "", "")
     assert (
         _handler_dedup_key(
-            HookHandlerConfig(
+            handler=HookHandlerConfig(
                 type=HookHandlerType.PROMPT,
                 prompt="return allow",
-            )
+            ),
+            source=source,
         )
         is None
     )
+
+
+def test_handler_dedup_key_includes_plugin_source_context() -> None:
+    handler = HookHandlerConfig(
+        type=HookHandlerType.COMMAND,
+        command="python hook.py",
+    )
+    first_source = HookSourceInfo(
+        scope=HookSourceScope.PLUGIN,
+        path=Path("first/hooks/hooks.json"),
+        plugin_name="first",
+        plugin_root=Path("first"),
+        plugin_data=Path("data/first"),
+    )
+    second_source = HookSourceInfo(
+        scope=HookSourceScope.PLUGIN,
+        path=Path("second/hooks/hooks.json"),
+        plugin_name="second",
+        plugin_root=Path("second"),
+        plugin_data=Path("data/second"),
+    )
+
+    assert _handler_dedup_key(
+        handler=handler, source=first_source
+    ) != _handler_dedup_key(
+        handler=handler,
+        source=second_source,
+    )
+
+
+def test_plugin_hook_env_includes_plugin_context() -> None:
+    source = HookSourceInfo(
+        scope=HookSourceScope.PLUGIN,
+        path=Path("quality/hooks/hooks.json"),
+        plugin_name="quality",
+        plugin_root=Path("quality"),
+        plugin_data=Path("data/quality"),
+    )
+
+    assert _plugin_hook_env(source) == {
+        "RELAY_TEAMS_PLUGIN_ROOT": "quality",
+        "RELAY_TEAMS_PLUGIN_DATA": str(Path("data/quality")),
+        "RELAY_TEAMS_PLUGIN_NAME": "quality",
+    }
+
+
+def test_non_plugin_hook_env_is_empty() -> None:
+    source = HookSourceInfo(scope=HookSourceScope.USER, path=Path("hooks.json"))
+
+    assert _plugin_hook_env(source) == {}
 
 
 @pytest.mark.asyncio
@@ -824,7 +886,9 @@ async def test_async_hook_does_not_control_current_decision(tmp_path: Path) -> N
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
+            _ = (handler, event_input, extra_env)
             await asyncio.sleep(0)
             completed.set()
             return HookDecision(decision=HookDecisionType.DENY)
@@ -889,8 +953,9 @@ async def test_async_hook_tasks_are_retained_until_done(tmp_path: Path) -> None:
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
-            _ = (handler, event_input)
+            _ = (handler, event_input, extra_env)
             started.set()
             await release.wait()
             return HookDecision(decision=HookDecisionType.ALLOW)
@@ -956,7 +1021,9 @@ async def test_on_error_fail_reraises_hook_failure(tmp_path: Path) -> None:
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
+            _ = (handler, event_input, extra_env)
             raise RuntimeError("boom")
 
     service = HookService(
@@ -995,8 +1062,9 @@ async def test_on_error_fail_stops_later_sync_handlers(tmp_path: Path) -> None:
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
-            _ = event_input
+            _ = (event_input, extra_env)
             command = str(handler.command or "")
             self.commands.append(command)
             if command == "fail":
@@ -1062,7 +1130,9 @@ async def test_execute_publishes_hook_conflict_event(tmp_path: Path) -> None:
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
+            _ = (event_input, extra_env)
             if handler.name == "deny":
                 return HookDecision(decision=HookDecisionType.DENY)
             return HookDecision(
@@ -1138,8 +1208,9 @@ async def test_execute_runs_sync_handlers_concurrently(tmp_path: Path) -> None:
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
-            _ = (handler, event_input)
+            _ = (handler, event_input, extra_env)
             self.started += 1
             if self.started == 2:
                 self.both_started.set()
@@ -1211,8 +1282,9 @@ async def test_execute_filters_handlers_by_tool_if_rule(tmp_path: Path) -> None:
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
-            _ = event_input
+            _ = (event_input, extra_env)
             self.commands.append(str(handler.command or ""))
             return HookDecision(decision=HookDecisionType.ALLOW)
 
@@ -1282,8 +1354,9 @@ async def test_execute_deduplicates_identical_command_handlers(tmp_path: Path) -
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
-            _ = (handler, event_input)
+            _ = (handler, event_input, extra_env)
             self.calls += 1
             return HookDecision(decision=HookDecisionType.ALLOW)
 
@@ -1340,8 +1413,9 @@ async def test_execute_normalizes_observe_only_control_decision(tmp_path: Path) 
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
-            _ = (handler, event_input)
+            _ = (handler, event_input, extra_env)
             return HookDecision(decision=HookDecisionType.DENY, reason="nope")
 
     source = HookSourceInfo(scope=HookSourceScope.USER, path=tmp_path / "hooks.json")
@@ -1411,7 +1485,9 @@ async def test_async_rewake_enqueues_followup_context(tmp_path: Path) -> None:
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
+            _ = (handler, event_input, extra_env)
             completed.set()
             return HookDecision(
                 decision=HookDecisionType.ADDITIONAL_CONTEXT,
@@ -1556,9 +1632,11 @@ async def test_tool_event_variants_use_tool_name_for_matching(
             *,
             handler: HookHandlerConfig,
             event_input: HookEventInput,
+            extra_env: dict[str, str] | None = None,
         ) -> HookDecision:
             _ = handler
             _ = event_input
+            _ = extra_env
             return HookDecision(decision=HookDecisionType.ALLOW)
 
     service = HookService(

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -77,6 +77,40 @@ def _write_app_role(config_dir: Path, *, role_id: str) -> None:
     )
 
 
+def _write_plugin_manifest(
+    plugin_root: Path,
+    *,
+    name: str,
+    config_dir: Path,
+) -> None:
+    manifest_dir = plugin_root / config_dir.name
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        f'{{"name": "{name}", "version": "1.0.0"}}',
+        encoding="utf-8",
+    )
+
+
+def _write_plugin_role(plugin_root: Path, *, role_id: str) -> None:
+    roles_dir = plugin_root / "roles"
+    roles_dir.mkdir(parents=True, exist_ok=True)
+    (roles_dir / f"{role_id}.md").write_text(
+        (
+            "---\n"
+            f"role_id: {role_id}\n"
+            "name: Reviewer\n"
+            "description: Reviews plugin work.\n"
+            "version: 1.0.0\n"
+            "mode: subagent\n"
+            "tools:\n"
+            "  - orch_dispatch_task\n"
+            "---\n\n"
+            "Review carefully.\n"
+        ),
+        encoding="utf-8",
+    )
+
+
 @pytest.fixture(autouse=True)
 def _use_empty_skill_registry(
     monkeypatch: pytest.MonkeyPatch,
@@ -113,6 +147,78 @@ def test_runtime_reload_updates_run_service_provider_factory(
 
     assert container.run_service._provider_factory is container._provider_factory
     assert container.run_service._provider_factory is not previous_provider_factory
+
+
+def test_container_loads_plugin_dirs_from_app_env_before_plugin_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.delenv("RELAY_TEAMS_PLUGIN_DIRS", raising=False)
+    config_dir = tmp_path / ".agent-teams"
+    plugin_root = tmp_path / "plugins" / "quality"
+    _write_model_config(config_dir, api_key="initial-secret")
+    _write_plugin_manifest(plugin_root, name="quality", config_dir=config_dir)
+    (config_dir / ".env").write_text(
+        f"RELAY_TEAMS_PLUGIN_DIRS={plugin_root}\n",
+        encoding="utf-8",
+    )
+
+    container = ServerContainer(config_dir=config_dir)
+
+    assert [plugin.name for plugin in container.plugin_registry.plugins] == ["quality"]
+
+
+def test_app_env_plugin_dirs_change_reloads_plugin_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.delenv("RELAY_TEAMS_PLUGIN_DIRS", raising=False)
+    config_dir = tmp_path / ".agent-teams"
+    plugin_root = tmp_path / "plugins" / "quality"
+    _write_model_config(config_dir, api_key="initial-secret")
+    _write_plugin_manifest(plugin_root, name="quality", config_dir=config_dir)
+    _write_plugin_role(plugin_root, role_id="reviewer")
+    commands_dir = plugin_root / "commands"
+    commands_dir.mkdir(parents=True)
+    (commands_dir / "review.md").write_text(
+        "---\ndescription: Review code\n---\n\nReview $ARGUMENTS\n",
+        encoding="utf-8",
+    )
+    hooks_dir = plugin_root / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "hooks.json").write_text(
+        '{"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "echo ok"}]}]}}',
+        encoding="utf-8",
+    )
+    (plugin_root / "mcp.json").write_text(
+        '{"mcpServers": {"docs": {"command": "docs-server"}}}',
+        encoding="utf-8",
+    )
+    container = ServerContainer(config_dir=config_dir)
+
+    assert container.plugin_registry.plugins == ()
+
+    container.environment_variable_service.save_environment_variable(
+        scope=EnvironmentVariableScope.APP,
+        key="RELAY_TEAMS_PLUGIN_DIRS",
+        request=EnvironmentVariableSaveRequest(value=str(plugin_root)),
+    )
+
+    assert [plugin.name for plugin in container.plugin_registry.plugins] == ["quality"]
+    assert container.role_registry.get("quality:reviewer").name == "Reviewer"
+    assert container.mcp_registry.get_spec("quality:docs").name == "quality:docs"
+    command = container.command_registry.get_command(
+        "quality:review",
+        workspace_root=None,
+    )
+    assert command is not None
+    assert command.name == "quality:review"
+    assert [
+        source.plugin_name
+        for source in container.hook_service.get_effective_config().sources
+    ] == ["quality"]
 
 
 def test_container_injects_fallback_middleware_into_reflection_service(
@@ -269,6 +375,7 @@ def test_container_skill_registry_uses_explicit_project_start_dir_snapshot(
         {
             "app_config_dir": config_dir,
             "project_start_dir": project_dir.resolve(),
+            "plugin_sources": (),
         }
     ]
 
@@ -317,7 +424,7 @@ def test_saving_app_environment_variable_reloads_mcp_and_skills_runtime(
     monkeypatch.setattr(
         container.mcp_config_manager,
         "load_registry",
-        lambda: (mcp_reload_calls.append("mcp"), container.mcp_registry)[1],
+        lambda **_kwargs: (mcp_reload_calls.append("mcp"), container.mcp_registry)[1],
     )
     monkeypatch.setattr(
         container.skills_config_reload_service,
@@ -361,7 +468,7 @@ def test_proxy_environment_variable_change_triggers_proxy_runtime_refresh(
     monkeypatch.setattr(
         container.mcp_config_manager,
         "load_registry",
-        lambda: (mcp_reload_calls.append("mcp"), container.mcp_registry)[1],
+        lambda **_kwargs: (mcp_reload_calls.append("mcp"), container.mcp_registry)[1],
     )
     monkeypatch.setattr(
         container.skills_config_reload_service,

--- a/tests/unit_tests/mcp/test_config_reload_service.py
+++ b/tests/unit_tests/mcp/test_config_reload_service.py
@@ -65,7 +65,7 @@ def test_reload_mcp_config_cleans_uvx_package_cache_before_reload(
         )
     )
     manager = McpConfigManager(app_config_dir=app_config_dir)
-    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
     recorded_commands: list[tuple[str, ...]] = []
 
     def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -114,7 +114,7 @@ def test_reload_mcp_config_cleans_uv_tool_run_package_from_from_flag(
         )
     )
     manager = McpConfigManager(app_config_dir=app_config_dir)
-    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
     recorded_commands: list[tuple[str, ...]] = []
 
     def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -156,7 +156,7 @@ def test_reload_mcp_config_falls_back_to_global_uv_cache_clean_when_package_unkn
         )
     )
     manager = McpConfigManager(app_config_dir=app_config_dir)
-    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
     recorded_commands: list[tuple[str, ...]] = []
 
     def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -198,7 +198,7 @@ def test_reload_mcp_config_skips_uv_cache_clean_for_uv_run_projects(
         )
     )
     manager = McpConfigManager(app_config_dir=app_config_dir)
-    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
     recorded_commands: list[tuple[str, ...]] = []
 
     def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -240,7 +240,7 @@ def test_reload_mcp_config_retries_without_force_for_legacy_uv(
         )
     )
     manager = McpConfigManager(app_config_dir=app_config_dir)
-    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
     recorded_commands: list[tuple[str, ...]] = []
 
     def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -293,7 +293,7 @@ def test_reload_mcp_config_reuses_configured_uv_path_for_uvx_servers(
         )
     )
     manager = McpConfigManager(app_config_dir=app_config_dir)
-    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
     recorded_commands: list[tuple[str, ...]] = []
 
     def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -345,7 +345,7 @@ def test_reload_mcp_config_parses_uv_global_options_before_tool_run(
         )
     )
     manager = McpConfigManager(app_config_dir=app_config_dir)
-    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
     recorded_commands: list[tuple[str, ...]] = []
 
     def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -396,7 +396,7 @@ def test_reload_mcp_config_parses_uv_cache_dir_before_tool_run(
         )
     )
     manager = McpConfigManager(app_config_dir=app_config_dir)
-    monkeypatch.setattr(manager, "load_registry", lambda: registry)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
     recorded_commands: list[tuple[str, ...]] = []
 
     def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:

--- a/tests/unit_tests/mcp/test_mcp_service.py
+++ b/tests/unit_tests/mcp/test_mcp_service.py
@@ -602,6 +602,140 @@ def test_add_server_publishes_registry_updates_to_runtime_callback(
     )
 
 
+def test_add_server_preserves_extra_specs_during_registry_reload(
+    tmp_path: Path,
+) -> None:
+    from relay_teams.mcp.mcp_config_manager import McpConfigManager
+
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir(parents=True)
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    plugin_spec = McpServerSpec(
+        name="quality:docs",
+        config={"mcpServers": {"quality:docs": {"command": "uvx"}}},
+        server_config={"command": "uvx"},
+        source=McpConfigScope.PLUGIN,
+    )
+    service = McpService(
+        registry=manager.load_registry(extra_specs=(plugin_spec,)),
+        config_manager=manager,
+        extra_specs=(plugin_spec,),
+    )
+
+    service.add_server(
+        name="filesystem",
+        server_config={"transport": "stdio", "command": "npx"},
+    )
+
+    assert service.list_servers()[0].name == "filesystem"
+    assert service.list_servers()[1].name == "quality:docs"
+
+
+def test_add_server_rejects_plugin_server_shadow(tmp_path: Path) -> None:
+    from relay_teams.mcp.mcp_config_manager import McpConfigManager
+
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir(parents=True)
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    plugin_spec = McpServerSpec(
+        name="quality:docs",
+        config={"mcpServers": {"quality:docs": {"command": "uvx"}}},
+        server_config={"command": "uvx"},
+        source=McpConfigScope.PLUGIN,
+    )
+    service = McpService(
+        registry=manager.load_registry(extra_specs=(plugin_spec,)),
+        config_manager=manager,
+        extra_specs=(plugin_spec,),
+    )
+
+    with pytest.raises(ValueError, match="cannot be shadowed by app config"):
+        service.add_server(
+            name="quality:docs",
+            server_config={"transport": "stdio", "command": "npx"},
+            overwrite=True,
+        )
+
+    assert not (app_config_dir / "mcp.json").exists()
+    assert (
+        service.get_server_config("quality:docs").server.source == McpConfigScope.PLUGIN
+    )
+
+
+def test_server_mutations_preserve_extra_specs_during_registry_reload(
+    tmp_path: Path,
+) -> None:
+    from relay_teams.mcp.mcp_config_manager import McpConfigManager
+
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir(parents=True)
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    manager.add_server(
+        name="filesystem",
+        server_config={"transport": "stdio", "command": "npx"},
+    )
+    plugin_spec = McpServerSpec(
+        name="quality:docs",
+        config={"mcpServers": {"quality:docs": {"command": "uvx"}}},
+        server_config={"command": "uvx"},
+        source=McpConfigScope.PLUGIN,
+    )
+    service = McpService(
+        registry=manager.load_registry(extra_specs=(plugin_spec,)),
+        config_manager=manager,
+        extra_specs=(plugin_spec,),
+    )
+
+    service.set_server_enabled(
+        "filesystem",
+        McpServerEnabledUpdateRequest(enabled=False),
+    )
+    service.update_server(
+        "filesystem",
+        McpServerUpdateRequest(config={"transport": "stdio", "command": "bunx"}),
+    )
+
+    servers = service.list_servers()
+    assert servers[0].name == "filesystem"
+    assert servers[0].enabled is False
+    assert servers[1].name == "quality:docs"
+
+
+def test_plugin_server_config_is_readonly_from_runtime_registry(tmp_path: Path) -> None:
+    from relay_teams.mcp.mcp_config_manager import McpConfigManager
+
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir(parents=True)
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    plugin_spec = McpServerSpec(
+        name="quality:docs",
+        config={"mcpServers": {"quality:docs": {"command": "uvx"}}},
+        server_config={"command": "uvx"},
+        source=McpConfigScope.PLUGIN,
+    )
+    service = McpService(
+        registry=manager.load_registry(extra_specs=(plugin_spec,)),
+        config_manager=manager,
+        extra_specs=(plugin_spec,),
+    )
+
+    result = service.get_server_config("quality:docs")
+
+    assert result.server.name == "quality:docs"
+    assert result.server.source == McpConfigScope.PLUGIN
+    assert result.config["command"] == "uvx"
+    with pytest.raises(ValueError, match="managed by plugin"):
+        service.set_server_enabled(
+            "quality:docs",
+            McpServerEnabledUpdateRequest(enabled=False),
+        )
+    with pytest.raises(ValueError, match="managed by plugin"):
+        service.update_server(
+            "quality:docs",
+            McpServerUpdateRequest(config={"command": "npx"}),
+        )
+
+
 def test_service_raises_when_config_manager_is_unavailable() -> None:
     service = McpService(registry=McpRegistry(()))
 

--- a/tests/unit_tests/plugins/__init__.py
+++ b/tests/unit_tests/plugins/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/tests/unit_tests/plugins/test_phase1_runtime.py
+++ b/tests/unit_tests/plugins/test_phase1_runtime.py
@@ -1,0 +1,717 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+from relay_teams.hooks import HookLoader
+from relay_teams.hooks.executors.command_executor import CommandHookExecutor
+from relay_teams.hooks.hook_event_models import SessionStartInput
+from relay_teams.hooks.hook_models import HookSourceScope
+from relay_teams.hooks.hook_models import (
+    HookDecisionType,
+    HookEventName,
+    HookHandlerConfig,
+    HookHandlerType,
+)
+from relay_teams.mcp.mcp_config_manager import McpConfigManager
+from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
+from relay_teams.plugins import PluginConfigManager
+from relay_teams.plugins.mcp_sources import load_plugin_mcp_specs
+from relay_teams.plugins.path_resolution import (
+    namespace_plugin_ref,
+    resolve_plugin_component_path,
+)
+from relay_teams.plugins.plugin_models import PluginComponentKind, PluginComponentSource
+from relay_teams.roles import RoleLoader
+from relay_teams.skills import SkillRegistry
+from relay_teams.commands import CommandRegistry
+
+
+def test_resolve_plugin_component_path_rejects_traversal(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+
+    with pytest.raises(ValueError, match="traverse|escapes"):
+        resolve_plugin_component_path(
+            plugin_root=plugin_root,
+            raw_path="../outside",
+        )
+
+
+def test_resolve_plugin_component_path_rejects_empty_absolute_and_unprefixed(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        resolve_plugin_component_path(plugin_root=plugin_root, raw_path=" ")
+    with pytest.raises(ValueError, match="must be relative"):
+        resolve_plugin_component_path(
+            plugin_root=plugin_root,
+            raw_path=str((tmp_path / "outside").resolve()),
+        )
+    with pytest.raises(ValueError, match="must start with ./"):
+        resolve_plugin_component_path(plugin_root=plugin_root, raw_path="roles")
+
+
+def test_resolve_plugin_component_path_rejects_resolved_escape(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+
+    with pytest.raises(ValueError, match="escapes"):
+        resolve_plugin_component_path(
+            plugin_root=plugin_root,
+            raw_path="./nested/../../outside",
+        )
+
+
+def test_namespace_plugin_ref_rejects_blank_parts_and_preserves_existing_namespace() -> (
+    None
+):
+    assert namespace_plugin_ref(plugin_name="quality", local_name="quality:review") == (
+        "quality:review"
+    )
+    with pytest.raises(ValueError, match="plugin_name"):
+        namespace_plugin_ref(plugin_name=" ", local_name="review")
+    with pytest.raises(ValueError, match="local_name"):
+        namespace_plugin_ref(plugin_name="quality", local_name=" ")
+
+
+def test_plugin_registry_loads_default_component_sources(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    (plugin_root / "skills" / "review").mkdir(parents=True)
+    (plugin_root / "roles").mkdir()
+    (plugin_root / "commands").mkdir()
+    (plugin_root / "hooks").mkdir()
+    (plugin_root / "hooks" / "hooks.json").write_text(
+        '{"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "echo ok"}]}]}}',
+        encoding="utf-8",
+    )
+    (plugin_root / "mcp.json").write_text(
+        '{"mcpServers": {"docs": {"command": "${RELAY_TEAMS_PLUGIN_ROOT}/bin/docs"}}}',
+        encoding="utf-8",
+    )
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    assert not registry.diagnostics
+    assert len(registry.plugins) == 1
+    plugin = registry.plugins[0]
+    assert plugin.name == "quality"
+    assert len(plugin.skill_sources) == 1
+    assert len(plugin.role_sources) == 1
+    assert len(plugin.command_sources) == 1
+    assert len(plugin.hook_sources) == 1
+    assert len(plugin.mcp_sources) == 1
+
+
+def test_plugin_registry_uses_app_config_dir_name_for_relay_manifest(
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / "custom-config"
+    plugin_root = tmp_path / "quality"
+    manifest_dir = plugin_root / app_config_dir.name
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        '{"name":"quality","version":"2.0.0"}',
+        encoding="utf-8",
+    )
+
+    registry = PluginConfigManager(
+        app_config_dir=app_config_dir,
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    assert not registry.diagnostics
+    assert len(registry.plugins) == 1
+    assert registry.plugins[0].manifest_path == manifest_dir / "plugin.json"
+    assert registry.plugins[0].version == "2.0.0"
+
+
+def test_plugin_registry_reports_missing_plugin_directory(tmp_path: Path) -> None:
+    missing_plugin_root = tmp_path / "missing"
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(missing_plugin_root,),
+    ).load_registry()
+
+    assert registry.plugins == ()
+    assert len(registry.diagnostics) == 1
+    assert registry.diagnostics[0].path == missing_plugin_root.resolve()
+    assert "does not exist" in registry.diagnostics[0].message
+
+
+def test_plugin_registry_skips_duplicate_plugin_names(tmp_path: Path) -> None:
+    first_plugin_root = tmp_path / "first"
+    second_plugin_root = tmp_path / "second"
+    _write_plugin_manifest(first_plugin_root, name="quality")
+    _write_plugin_manifest(second_plugin_root, name="quality")
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(first_plugin_root, second_plugin_root),
+    ).load_registry()
+
+    assert len(registry.plugins) == 1
+    assert registry.plugins[0].root_dir == first_plugin_root
+    assert len(registry.diagnostics) == 1
+    assert registry.diagnostics[0].plugin_name == "quality"
+    assert "Duplicate plugin name" in registry.diagnostics[0].message
+
+
+def test_plugin_registry_rejects_unsafe_manifest_name(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    _write_plugin_manifest(plugin_root, name="../shared")
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    assert registry.plugins == ()
+    assert len(registry.diagnostics) == 1
+    assert "identifier-safe" in registry.diagnostics[0].message
+
+
+def test_plugin_registry_rejects_manifest_name_with_whitespace(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    _write_plugin_manifest(plugin_root, name="my plugin")
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    assert registry.plugins == ()
+    assert len(registry.diagnostics) == 1
+    assert "identifier-safe" in registry.diagnostics[0].message
+
+
+def test_plugin_registry_uses_default_manifest_and_reports_invalid_component_path(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "quality"
+    plugin_root.mkdir()
+    manifest_dir = plugin_root / "app"
+    manifest_dir.mkdir()
+    (manifest_dir / "plugin.json").write_text(
+        '{"name":"quality","roles":"../outside"}',
+        encoding="utf-8",
+    )
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    assert len(registry.plugins) == 1
+    assert registry.plugins[0].name == "quality"
+    assert registry.plugins[0].role_sources == ()
+    assert len(registry.diagnostics) == 1
+    assert "traverse" in registry.diagnostics[0].message
+
+
+def test_plugin_registry_accepts_claude_manifest_aliases(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    manifest_dir = plugin_root / ".claude-plugin"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        "{"
+        '"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",'
+        '"name": "quality",'
+        '"agents": "./roles",'
+        '"mcpServers": "./.mcp.json",'
+        '"userConfig": {"api_endpoint": {"type": "string"}}'
+        "}",
+        encoding="utf-8",
+    )
+    (plugin_root / "roles").mkdir()
+    (plugin_root / ".mcp.json").write_text(
+        '{"mcpServers": {"docs": {"command": "docs-server"}}}',
+        encoding="utf-8",
+    )
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    assert not registry.diagnostics
+    plugin = registry.plugins[0]
+    assert plugin.manifest_path == manifest_dir / "plugin.json"
+    assert plugin.role_sources[0].path == plugin_root / "roles"
+    assert plugin.mcp_sources[0].path == plugin_root / ".mcp.json"
+    assert "api_endpoint" in plugin.manifest.user_config
+
+
+def test_plugin_registry_reports_inline_component_configs(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    manifest_dir = plugin_root / "app"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        '{"name":"quality","hooks":{"SessionStart":[]},"mcpServers":{"docs":{"command":"uvx"}}}',
+        encoding="utf-8",
+    )
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    assert len(registry.plugins) == 1
+    assert registry.plugins[0].hook_sources == ()
+    assert registry.plugins[0].mcp_sources == ()
+    assert len(registry.diagnostics) == 2
+    assert {diagnostic.component for diagnostic in registry.diagnostics} == {
+        PluginComponentKind.HOOKS,
+        PluginComponentKind.MCP_SERVERS,
+    }
+    assert all(
+        "Inline plugin component configs are not supported" in diagnostic.message
+        for diagnostic in registry.diagnostics
+    )
+
+
+def test_plugin_skill_is_namespaced(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    skill_dir = plugin_root / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: review\ndescription: Review code.\n---\n\nReview carefully.\n",
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    skill_registry = SkillRegistry.from_skill_dirs(
+        app_skills_dir=tmp_path / "app" / "skills",
+        builtin_skills_dir=None,
+        plugin_sources=registry.skill_sources(),
+    )
+
+    assert "quality:review" in skill_registry.list_names()
+
+
+def test_plugin_role_and_mcp_specs_are_namespaced(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    roles_dir = plugin_root / "roles"
+    roles_dir.mkdir(parents=True)
+    (roles_dir / "reviewer.md").write_text(
+        "---\n"
+        "role_id: reviewer\n"
+        "name: Reviewer\n"
+        "description: Reviews code\n"
+        "version: '1'\n"
+        "tools: []\n"
+        "skills: [review]\n"
+        "mcp_servers: [docs]\n"
+        "mode: subagent\n"
+        "---\n\nReview code.\n",
+        encoding="utf-8",
+    )
+    (plugin_root / "mcp.json").write_text(
+        '{"mcpServers": {"docs": {"command": "${RELAY_TEAMS_PLUGIN_ROOT}/bin/docs"}}}',
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    role_registry = RoleLoader().load_builtin_app_and_plugins(
+        builtin_roles_dir=tmp_path / "missing-builtin",
+        app_roles_dir=tmp_path / "missing-app",
+        plugin_sources=registry.role_sources(),
+        allow_empty=True,
+    )
+    role = role_registry.get("quality:reviewer")
+    mcp_specs = load_plugin_mcp_specs(registry.mcp_sources())
+
+    assert role.skills == ("quality:review",)
+    assert role.mcp_servers == ("quality:docs",)
+    assert len(mcp_specs) == 1
+    assert mcp_specs[0].name == "quality:docs"
+    assert mcp_specs[0].source == McpConfigScope.PLUGIN
+    assert str(plugin_root) in str(mcp_specs[0].server_config["command"])
+
+
+def test_plugin_mcp_specs_support_bare_payload_disabled_and_data_vars(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    (plugin_root / "mcp.json").write_text(
+        '{"docs": {"command": "${RELAY_TEAMS_PLUGIN_DATA}/bin/docs", "disabled": true}}',
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    specs = load_plugin_mcp_specs(registry.mcp_sources())
+
+    assert len(specs) == 1
+    assert specs[0].name == "quality:docs"
+    assert specs[0].enabled is False
+    assert str(tmp_path / "app" / "plugins" / "data" / "quality") in str(
+        specs[0].server_config["command"]
+    )
+
+
+def test_plugin_mcp_specs_skip_invalid_runtime_payloads(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    mcp_path = plugin_root / "mcp.json"
+    plugin_root.mkdir()
+    mcp_path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    specs = load_plugin_mcp_specs(
+        (
+            _plugin_component_source(
+                plugin_name="quality",
+                plugin_root=plugin_root,
+                path=mcp_path,
+            ),
+        )
+    )
+
+    assert specs == ()
+
+
+def test_invalid_plugin_mcp_config_is_reported_and_skipped(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    (plugin_root / "mcp.json").write_text("{invalid json", encoding="utf-8")
+
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    assert registry.mcp_sources() == ()
+    assert len(registry.diagnostics) == 1
+    diagnostic = registry.diagnostics[0]
+    assert diagnostic.component is not None
+    assert diagnostic.component.value == "mcp_servers"
+    assert "Invalid plugin MCP config" in diagnostic.message
+
+
+def test_plugin_mcp_specs_receive_app_proxy_env(tmp_path: Path) -> None:
+    app_config_dir = tmp_path / "app"
+    app_config_dir.mkdir()
+    (app_config_dir / ".env").write_text(
+        "HTTPS_PROXY=http://proxy.local:8080\n",
+        encoding="utf-8",
+    )
+    spec = McpServerSpec(
+        name="quality:docs",
+        config={"mcpServers": {"quality:docs": {"command": "docs"}}},
+        server_config={"command": "docs"},
+        source=McpConfigScope.PLUGIN,
+    )
+
+    registry = McpConfigManager(app_config_dir=app_config_dir).load_registry(
+        extra_specs=(spec,)
+    )
+
+    loaded = registry.get_spec("quality:docs")
+    env = loaded.server_config.get("env")
+    assert isinstance(env, dict)
+    assert env["HTTPS_PROXY"] == "http://proxy.local:8080"
+
+
+def test_plugin_role_hooks_use_local_namespace(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    roles_dir = plugin_root / "roles"
+    roles_dir.mkdir(parents=True)
+    (roles_dir / "reviewer.md").write_text(
+        "---\n"
+        "role_id: reviewer\n"
+        "name: Reviewer\n"
+        "description: Reviews code\n"
+        "version: '1'\n"
+        "tools: []\n"
+        "mode: subagent\n"
+        "hooks:\n"
+        "  Stop:\n"
+        "    - role_ids: [reviewer]\n"
+        "      hooks:\n"
+        "        - type: agent\n"
+        "          role_id: reviewer\n"
+        "          prompt: Review\n"
+        "---\n\nReview code.\n",
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    role_registry = RoleLoader().load_builtin_app_and_plugins(
+        builtin_roles_dir=tmp_path / "missing-builtin",
+        app_roles_dir=tmp_path / "missing-app",
+        plugin_sources=registry.role_sources(),
+        allow_empty=True,
+    )
+
+    role = role_registry.get("quality:reviewer")
+    group = role.hooks.hooks[HookEventName.STOP][0]
+    assert group.role_ids == ("quality:reviewer",)
+    assert group.hooks[0].type == HookHandlerType.AGENT
+    assert group.hooks[0].role_id == "quality:reviewer"
+
+
+def test_plugin_role_loader_skips_missing_and_invalid_plugin_sources(
+    tmp_path: Path,
+) -> None:
+    plugin_root = tmp_path / "quality"
+    invalid_roles_dir = plugin_root / "roles"
+    invalid_roles_dir.mkdir(parents=True)
+    (invalid_roles_dir / "bad.md").write_text(
+        "---\nrole_id: bad\n---\n\nMissing fields.\n",
+        encoding="utf-8",
+    )
+
+    registry = RoleLoader().load_builtin_app_and_plugins(
+        builtin_roles_dir=tmp_path / "missing-builtin",
+        app_roles_dir=tmp_path / "missing-app",
+        plugin_sources=(
+            _plugin_component_source(
+                plugin_name="missing",
+                plugin_root=tmp_path / "missing",
+                path=tmp_path / "missing" / "roles",
+            ),
+            _plugin_component_source(
+                plugin_name="quality",
+                plugin_root=plugin_root,
+                path=invalid_roles_dir,
+            ),
+        ),
+        allow_empty=True,
+    )
+
+    assert registry.list_roles() == ()
+
+
+def test_plugin_hook_source_appears_in_runtime_snapshot(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    hooks_dir = plugin_root / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hooks.json").write_text(
+        '{"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "echo ok"}]}]}}',
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    snapshot = HookLoader(
+        app_config_dir=tmp_path / "app",
+        project_root=None,
+        plugin_hook_sources=registry.hook_sources(),
+    ).load_snapshot()
+
+    assert any(source.scope == HookSourceScope.PLUGIN for source in snapshot.sources)
+
+
+def test_plugin_command_is_namespaced(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    commands_dir = plugin_root / "commands"
+    commands_dir.mkdir(parents=True)
+    (commands_dir / "review.md").write_text(
+        "---\ndescription: Review code\n---\n\nReview $ARGUMENTS\n",
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    command_registry = CommandRegistry(
+        app_config_dir=tmp_path / "app",
+        plugin_sources=registry.command_sources(),
+    )
+
+    command = command_registry.get_command("quality:review", workspace_root=None)
+    assert command is not None
+    assert command.name == "quality:review"
+
+
+def test_plugin_command_frontmatter_name_is_namespaced(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    commands_dir = plugin_root / "commands"
+    commands_dir.mkdir(parents=True)
+    (commands_dir / "review.md").write_text(
+        "---\nname: review\ndescription: Review code\n---\n\nReview $ARGUMENTS\n",
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    command_registry = CommandRegistry(
+        app_config_dir=tmp_path / "app",
+        plugin_sources=registry.command_sources(),
+    )
+
+    assert command_registry.get_command("review", workspace_root=None) is None
+    command = command_registry.get_command("quality:review", workspace_root=None)
+    assert command is not None
+    assert command.name == "quality:review"
+
+
+def test_plugin_command_aliases_are_namespaced(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    commands_dir = plugin_root / "commands"
+    commands_dir.mkdir(parents=True)
+    (commands_dir / "review.md").write_text(
+        "---\ndescription: Review code\naliases: [review, /inspect]\n---\n\nReview $ARGUMENTS\n",
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+
+    command_registry = CommandRegistry(
+        app_config_dir=tmp_path / "app",
+        plugin_sources=registry.command_sources(),
+    )
+
+    command = command_registry.get_command("quality:review", workspace_root=None)
+    assert command is not None
+    assert command.aliases == ("quality:review", "quality:inspect")
+    assert command_registry.get_command("inspect", workspace_root=None) is None
+    assert (
+        command_registry.get_command("quality:inspect", workspace_root=None) == command
+    )
+
+
+def test_plugin_hook_agent_role_uses_local_namespace(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "quality"
+    _write_plugin_manifest(plugin_root, name="quality")
+    roles_dir = plugin_root / "roles"
+    roles_dir.mkdir(parents=True)
+    (roles_dir / "reviewer.md").write_text(
+        "---\n"
+        "role_id: reviewer\n"
+        "name: Reviewer\n"
+        "description: Reviews code\n"
+        "version: '1'\n"
+        "tools: []\n"
+        "mode: subagent\n"
+        "---\n\nReview code.\n",
+        encoding="utf-8",
+    )
+    hooks_dir = plugin_root / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "hooks.json").write_text(
+        '{"hooks": {"Stop": [{"role_ids": ["reviewer"], '
+        '"hooks": [{"type": "agent", "role_id": "reviewer", "prompt": "Review"}]}]}}',
+        encoding="utf-8",
+    )
+    registry = PluginConfigManager(
+        app_config_dir=tmp_path / "app",
+        plugin_dirs=(plugin_root,),
+    ).load_registry()
+    role_registry = RoleLoader().load_builtin_app_and_plugins(
+        builtin_roles_dir=tmp_path / "missing-builtin",
+        app_roles_dir=tmp_path / "missing-app",
+        plugin_sources=registry.role_sources(),
+        allow_empty=True,
+    )
+
+    snapshot = HookLoader(
+        app_config_dir=tmp_path / "app",
+        project_root=None,
+        get_role_registry=lambda: role_registry,
+        plugin_hook_sources=registry.hook_sources(),
+    ).load_snapshot()
+
+    group = snapshot.hooks[HookEventName.STOP][0].group
+    assert group.role_ids == ("quality:reviewer",)
+    assert group.hooks[0].type == HookHandlerType.AGENT
+    assert group.hooks[0].role_id == "quality:reviewer"
+
+
+@pytest.mark.asyncio
+async def test_command_hook_executor_receives_plugin_environment(
+    tmp_path: Path,
+) -> None:
+    script_path = tmp_path / "env_hook.py"
+    script_path.write_text(
+        "from __future__ import annotations\n"
+        "import json\n"
+        "import os\n"
+        "print(json.dumps({"
+        "'decision': 'allow', "
+        "'reason': os.environ['RELAY_TEAMS_PLUGIN_ROOT']"
+        "}))\n",
+        encoding="utf-8",
+    )
+    plugin_root = tmp_path / "quality"
+    plugin_root.mkdir()
+
+    decision = await CommandHookExecutor().execute(
+        handler=HookHandlerConfig(
+            type=HookHandlerType.COMMAND,
+            command=f'"{sys.executable}" "{script_path}"',
+        ),
+        event_input=SessionStartInput(
+            event_name=HookEventName.SESSION_START,
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="trace-1",
+        ),
+        extra_env={"RELAY_TEAMS_PLUGIN_ROOT": str(plugin_root)},
+    )
+
+    assert decision.decision == HookDecisionType.ALLOW
+    assert decision.reason == str(plugin_root)
+
+
+def _write_plugin_manifest(plugin_root: Path, *, name: str) -> None:
+    manifest_dir = plugin_root / "app"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        f'{{"name": "{name}", "version": "1.0.0"}}',
+        encoding="utf-8",
+    )
+
+
+def _plugin_component_source(
+    *,
+    plugin_name: str,
+    plugin_root: Path,
+    path: Path,
+) -> PluginComponentSource:
+    return PluginComponentSource(
+        plugin_name=plugin_name,
+        root_dir=plugin_root,
+        data_dir=plugin_root / "data",
+        path=path,
+    )

--- a/tests/unit_tests/roles/test_settings_service.py
+++ b/tests/unit_tests/roles/test_settings_service.py
@@ -16,6 +16,7 @@ from relay_teams.roles import (
     default_memory_profile,
 )
 from relay_teams.roles.settings_service import RoleSettingsService
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry.defaults import build_default_registry
 
@@ -77,6 +78,77 @@ def test_save_role_document_renames_role_file_and_reloads_registry(
     assert "execution_surface: hybrid" in saved.content
     assert "mode: subagent" in saved.content
     assert captured_registry[-1].get("writer_v2").name == "Writer V2"
+
+
+def test_save_role_document_preserves_plugin_roles_on_reload(
+    tmp_path: Path,
+) -> None:
+    roles_dir = tmp_path / "roles"
+    roles_dir.mkdir()
+    _write_role(
+        roles_dir / "writer.md",
+        role_id="writer",
+        name="Writer",
+        description="Drafts user-facing content.",
+        version="1.0.0",
+        tools=("orch_dispatch_task",),
+        system_prompt="Write clearly.",
+    )
+    plugin_root = tmp_path / "plugin"
+    plugin_roles_dir = plugin_root / "roles"
+    plugin_roles_dir.mkdir(parents=True)
+    _write_role(
+        plugin_roles_dir / "reviewer.md",
+        role_id="reviewer",
+        name="Reviewer",
+        description="Reviews plugin work.",
+        version="1.0.0",
+        tools=("orch_dispatch_task",),
+        mode=RoleMode.SUBAGENT,
+        system_prompt="Review carefully.",
+    )
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    captured_registry: list[RoleRegistry] = []
+    service = RoleSettingsService(
+        roles_dir=roles_dir,
+        builtin_roles_dir=_create_builtin_roles_dir(tmp_path),
+        get_tool_registry=build_default_registry,
+        get_mcp_registry=McpRegistry,
+        get_skill_registry=lambda: SkillRegistry.from_skill_dirs(
+            app_skills_dir=skills_dir
+        ),
+        get_external_agent_service=None,
+        on_roles_reloaded=lambda registry: captured_registry.append(registry),
+        plugin_sources=(
+            PluginComponentSource(
+                plugin_name="quality",
+                root_dir=plugin_root,
+                data_dir=plugin_root / "data",
+                path=plugin_roles_dir,
+            ),
+        ),
+    )
+
+    service.save_role_document(
+        "writer",
+        draft=RoleDocumentDraft(
+            role_id="writer",
+            name="Writer",
+            description="Drafts user-facing content.",
+            version="1.0.1",
+            tools=("orch_dispatch_task",),
+            mcp_servers=(),
+            skills=(),
+            model_profile="default",
+            execution_surface=ExecutionSurface.API,
+            mode=RoleMode.PRIMARY,
+            memory_profile=default_memory_profile(),
+            system_prompt="Write clearly.",
+        ),
+    )
+
+    assert captured_registry[-1].get("quality:reviewer").name == "Reviewer"
 
 
 def test_validate_role_document_rejects_unknown_tools(tmp_path: Path) -> None:

--- a/tests/unit_tests/skills/test_config_reload_service.py
+++ b/tests/unit_tests/skills/test_config_reload_service.py
@@ -74,7 +74,7 @@ def test_reload_skills_config_omits_project_start_dir_when_not_configured(
 
     service.reload_skills_config()
 
-    assert captured_kwargs == [{"app_config_dir": app_config_dir}]
+    assert captured_kwargs == [{"app_config_dir": app_config_dir, "plugin_sources": ()}]
 
 
 def test_reload_skills_config_uses_configured_project_start_dir(
@@ -110,5 +110,6 @@ def test_reload_skills_config_uses_configured_project_start_dir(
         {
             "app_config_dir": app_config_dir,
             "project_start_dir": project_dir,
+            "plugin_sources": (),
         }
     ]

--- a/tests/unit_tests/skills/test_discovery.py
+++ b/tests/unit_tests/skills/test_discovery.py
@@ -9,6 +9,7 @@ import pytest
 
 from relay_teams.hooks.hook_models import HookEventName
 from relay_teams.hooks.hook_models import HooksConfig
+from relay_teams.plugins.plugin_models import PluginComponentSource
 from relay_teams.skills import discovery
 from relay_teams.skills.discovery import SkillsDirectory, _parse_frontmatter_hooks
 from relay_teams.skills.skill_models import SkillSource
@@ -107,6 +108,47 @@ def test_skills_directory_from_skill_dirs_uses_builtin_then_user_sources(
         (SkillSource.BUILTIN, builtin_skills_dir.resolve()),
         (SkillSource.USER_RELAY_TEAMS, user_skills_dir.resolve()),
     )
+
+
+def test_plugin_skill_hooks_namespace_role_references(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    skills_dir = plugin_root / "skills"
+    skill_dir = skills_dir / "guardrail"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: guardrail\n"
+        "description: Guardrail skill\n"
+        "hooks:\n"
+        "  Stop:\n"
+        "    - role_ids: [reviewer, other-plugin:shared, '*']\n"
+        "      hooks:\n"
+        "        - type: agent\n"
+        "          role_id: reviewer\n"
+        "          prompt: Review this run\n"
+        "---\n"
+        "Use this skill for guardrails.\n",
+        encoding="utf-8",
+    )
+    directory = SkillsDirectory(
+        sources=(),
+        plugin_sources=(
+            PluginComponentSource(
+                plugin_name="acme",
+                root_dir=plugin_root,
+                data_dir=plugin_root / "data",
+                path=skills_dir,
+            ),
+        ),
+    )
+
+    directory.discover()
+
+    skill = directory.get_skill("acme:guardrail")
+    assert skill is not None
+    groups = skill.metadata.hooks.hooks[HookEventName.STOP]
+    assert groups[0].role_ids == ("acme:reviewer", "other-plugin:shared", "*")
+    assert groups[0].hooks[0].role_id == "acme:reviewer"
 
 
 def test_skills_directory_from_config_dirs_uses_builtin_user_and_agents_sources(

--- a/tests/unit_tests/skills/test_skill_registry.py
+++ b/tests/unit_tests/skills/test_skill_registry.py
@@ -460,6 +460,7 @@ def test_skills_directory_discover_replaces_skill_cache_atomically(
         path: Path,
         source: SkillSource,
         load_warnings: list[tuple[Path, str]] | None = None,
+        plugin_name: str | None = None,
     ):
         if path.parent.name == "alpha":
             load_started.set()
@@ -468,6 +469,7 @@ def test_skills_directory_discover_replaces_skill_cache_atomically(
             path=path,
             source=source,
             load_warnings=load_warnings,
+            plugin_name=plugin_name,
         )
 
     directory._load_skill = blocking_load_skill


### PR DESCRIPTION
核心内容：

- 新增 `src/relay_teams/plugins/` 插件模块，支持读取 Relay-native manifest：`<plugin-root>/<active-config-dir-name>/plugin.json`。
- `<active-config-dir-name>` 来自当前 Relay Teams 配置目录名；默认是 `.relay-teams`，如果 `RELAY_TEAMS_CONFIG_DIR` 或 runtime config 使用其他目录名，插件 manifest 也跟随该目录名。
- Phase 1 的插件范围入口通过 `RELAY_TEAMS_PLUGIN_DIRS` 配置，变量可来自进程环境或 resolved app config dir 下的 `.env`；scope/state file 设计文档使用 `<resolved-app-config-dir>` / `<resolved-project-config-dir>`，不再写死默认 `.relay-teams` 路径。
- 保留 Claude Code 本地插件兼容入口：`<plugin-root>/.claude-plugin/plugin.json`。
- 插件可提供 roles、skills、commands、hooks、MCP servers，并统一用 `plugin-name:local-name` 命名空间隔离。
- Server startup / reload 会加载插件 registry，并把插件来源接入 role、skill、command、hook、MCP 运行时。
- 插件路径解析限制在插件根目录内，拒绝绝对路径和 `..` traversal。
- 插件 runtime loading 采用“降级并记录 diagnostics”的策略，避免坏插件导致启动崩溃。
- MCP 插件 specs 会继承 proxy env，并在 MCP registry reload 后保留。
- 插件 MCP server 可通过 runtime registry 读取配置，但不能通过 app MCP config mutation 修改；app MCP 新增也会拒绝 shadow plugin server。
- 插件名要求 identifier-safe，只允许字母数字、`-`、`_`，避免生成无效 runtime IDs。
- Manifest 中 unsupported inline component object config 不再静默忽略，会产生诊断信息。
- 补充插件相关单元测试，覆盖 manifest loading、namespacing、component paths、hooks、MCP、role/skill/command wiring，以及自定义 Relay Teams 配置目录名。
- 更新插件能力设计文档、API 设计文档和 AGENTS.md repo 指南。

## Summary

- Add the local plugin runtime package, manifest loading, diagnostics, and safe component path resolution.
- Wire plugin-provided skills, roles, commands, hooks, and MCP servers into the existing registries/runtime with `plugin-name:local-name` namespacing.
- Use the active Relay Teams config directory name for Relay-native plugin manifests inside each plugin root instead of hardcoding a plugin-specific manifest directory.
- Keep Phase 1 plugin scope configuration env-driven through `RELAY_TEAMS_PLUGIN_DIRS`, and document future scope files with resolved config-dir placeholders instead of hardcoded default paths.
- Add plugin runtime APIs, design docs, AGENTS.md guidance, and focused plugin tests.

Closes #555

## Validation

- `uv run --extra dev pytest -q tests/unit_tests/mcp/test_mcp_service.py`
- `uv run --extra dev pytest -q tests/unit_tests/mcp/test_mcp_service.py tests/unit_tests/mcp/test_mcp_config_manager.py tests/unit_tests/plugins`
- `uv run --extra dev ruff check --no-cache --force-exclude src/relay_teams/mcp/mcp_service.py tests/unit_tests/mcp/test_mcp_service.py`
- `uv run --extra dev basedpyright src/relay_teams/mcp/mcp_service.py tests/unit_tests/mcp/test_mcp_service.py`
- `uv run --extra dev pytest -q tests/unit_tests/plugins tests/unit_tests/interfaces/server/test_container.py::test_container_loads_plugin_dirs_from_app_env_before_plugin_registry tests/unit_tests/interfaces/server/test_container.py::test_app_env_plugin_dirs_change_reloads_plugin_runtime tests/unit_tests/mcp/test_mcp_service.py tests/unit_tests/mcp/test_mcp_config_manager.py`
- `uv run --extra dev ruff check --no-cache --force-exclude .`
- `uv run --extra dev ruff format --check --no-cache --force-exclude src/relay_teams/plugins/manifest_loader.py src/relay_teams/plugins/config_manager.py tests/unit_tests/plugins/test_phase1_runtime.py tests/unit_tests/interfaces/server/test_container.py`
- `uv run --extra dev basedpyright src/relay_teams/plugins/manifest_loader.py src/relay_teams/plugins/config_manager.py tests/unit_tests/plugins/test_phase1_runtime.py tests/unit_tests/interfaces/server/test_container.py`

## Full-suite notes

- Latest CI rerun had CodeQL and Qodana passing; `agents-self-check` hit the known pressure integration timeout in `test_browser_backend_status_stays_connected_during_tool_pressure` and was rerun before the latest documentation-only amend.
