### PR TITLE
docs: add frontend design guide

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -1,0 +1,41 @@
+# 前端设计文档
+
+本文档组描述 Agent Teams 当前前端实现。前端位于 `frontend/dist/`，由后端 FastAPI 服务在运行时静态托管，是一个基于原生 HTML、CSS 和 ES Modules 的单页应用。当前没有 React、Vue、Vite 或单独源码构建层，`frontend/dist` 下的文件就是需要维护的前端实现。
+
+前端与后端的公共边界是 `/api/*` HTTP JSON 接口和 run 事件 SSE。CLI、SDK、后端仓储等内部实现不应被前端直接访问。
+
+## 阅读顺序
+
+1. `architecture.md`：先了解分层、启动流程和全局状态。
+2. `pages-and-layout.md`：理解用户看到的页面区域和每个视图的表现。
+3. `features.md`：查看项目功能视图和设置弹窗的详细设计。
+4. `runtime-flows.md`：理解会话切换、prompt 提交、SSE、恢复等动态流程。
+5. `api-and-events.md`：查看 API facade、请求策略、浏览器事件和 SSE 分发约定。
+6. `motion-and-loading-states.md`：查看动画、过渡、加载态和流式输出动效。
+7. `styling-and-i18n.md`：查看 CSS、主题和国际化约定。
+8. `testing-and-maintenance.md`：查看测试地图和维护规则。
+
+## 主要代码路径
+
+- `frontend/dist/index.html`：静态页面外壳，声明顶部栏、左侧栏、主工作区、输入区、右侧 rail、设置/观测入口等持久 DOM。
+- `frontend/dist/js/app.js`：入口 facade，启动应用。
+- `frontend/dist/js/app/`：应用编排层，负责 bootstrap、session、prompt、recovery、session view。
+- `frontend/dist/js/core/`：核心运行层，负责 API facade、全局状态、run stream、事件路由、提交状态。
+- `frontend/dist/js/components/`：UI 组件和页面功能区，包括 sidebar、project view、settings、message renderer、rounds、subagent 等。
+- `frontend/dist/js/utils/`：DOM 查询、日志、反馈、i18n、Markdown、后端状态、通知、token 预览等横切工具。
+- `frontend/dist/css/`：主题变量、布局和组件样式。
+
+## 前端职责边界
+
+前端负责：
+
+- 展示 workspace、session、round、message、tool、subagent、automation、gateway、settings 等用户界面。
+- 通过 `core/api` 调用 `/api/*` 接口。
+- 通过 `core/stream.js` 建立 run SSE 连接，并交给 `core/eventRouter` 更新 UI。
+- 在浏览器本地维护当前会话、运行中 run、prompt 控件、布局偏好、语言和主题等 UI 状态。
+
+前端不负责：
+
+- 直接读取后端数据库或仓储。
+- 绕过 `/api/*` 访问后端内部模块。
+- 维护持久业务状态的最终真相。会话、run、workspace、role、hook、trigger、automation 等真相来自后端 API。

--- a/docs/frontend/api-and-events.md
+++ b/docs/frontend/api-and-events.md
@@ -1,0 +1,201 @@
+# API 与事件设计
+
+## API Facade
+
+前端所有后端调用应通过 `frontend/dist/js/core/api/index.js` 统一导出的 facade。它按后端领域聚合具体模块：
+
+- `sessions.js`：session、history、round、tasks、agents、subagents、recovery、topology。
+- `runs.js`：创建 run、stop/resume、gate、tool approval、user question、background task、message injection。
+- `roles.js`：role config、options、validate。
+- `system.js`：配置状态、模型、MCP、commands、hooks、agents、notifications、web、proxy、GitHub、ClawHub、SSH、environment、health。
+- `workspaces.js`：workspace 列表、snapshot、tree、diff、open、fork、search。
+- `triggers.js`：Feishu/GitHub trigger 相关接口。
+- `gateway.js`：WeChat、Xiaoluban gateway。
+- `automation.js`：automation project、delivery binding、sessions、run now。
+- `observability.js`：overview 和 breakdowns。
+- `token_usage.js`：run/session token usage。
+
+组件不应直接绕过这些 facade 在局部重新实现请求封装。新增 API 时应先放入对应领域模块，再从 `core/api/index.js` 导出。
+
+## 请求策略
+
+共享请求 helper 位于 `core/api/request.js`。
+
+### requestJson
+
+`requestJson(url, options, errorMessage)` 是基础 JSON helper：
+
+- GET 和 HEAD 默认使用 `cache: 'no-store'`。
+- 成功后返回 `res.json()`。
+- HTTP 非 2xx 时尝试解析后端 error payload，并构造带 `status`、`detail`、`url`、`method` 的 Error。
+- 请求异常时记录 frontend log，并派发后端 offline hint。
+- AbortError 原样抛出，不当作普通错误记录。
+
+### requestJsonManaged
+
+`requestJsonManaged(key, url, options, errorMessage, options)` 用于 GET 请求合并和限流：
+
+- 只管理 GET 请求，非 GET 回退到 `requestJson`。
+- 使用 request key 做短 TTL 缓存，默认 600ms。
+- 相同 key 的 in-flight 请求会合并，多个消费者共享同一个 promise。
+- 支持 AbortSignal，消费者 abort 不会必然取消所有共享请求。
+- 支持 lane 并发限制：
+  - `critical`：4
+  - `normal`：6
+  - `heavy`：2
+- 支持 high priority，把请求插到队列前端。
+- `invalidateManagedRequests(prefix)` 会清理缓存并 abort in-flight。
+- `invalidateManagedRequestCache(prefix)` 只失效缓存和 in-flight entry，不强调 abort 所有底层请求。
+
+### 后端状态 Hint
+
+请求成功会 emit `agent-teams-backend-status-hint` online，异常会 emit offline。hint 有 30 秒重复抑制，避免频繁刷新 UI。
+
+`utils/backendStatus.js` 监听该 hint，并结合主动探测更新左下角 backend status。
+
+## 主要 API 依赖地图
+
+会话聊天：
+
+- `fetchSessions`
+- `fetchSessionHistory`
+- `fetchSessionRounds`
+- `fetchSessionRound`
+- `fetchSessionRecovery`
+- `sendUserPrompt`
+- `stopRun`
+- `resumeRun`
+
+prompt composer：
+
+- `fetchRoleConfigOptions`
+- `fetchOrchestrationConfig`
+- `fetchCommands`
+- `resolveCommandPrompt`
+- `searchWorkspacePaths`
+- `updateSessionTopology`
+
+workspace/project：
+
+- `fetchWorkspaces`
+- `fetchWorkspaceSnapshot`
+- `fetchWorkspaceTree`
+- `fetchWorkspaceDiffs`
+- `fetchWorkspaceDiffFile`
+- `openWorkspaceRoot`
+- `updateWorkspace`
+
+settings：
+
+- model、MCP、commands、hooks、roles、orchestration、notifications、web、proxy、workspace、environment 等均通过 `system.js` 和 `roles.js` 暴露。
+
+project features：
+
+- Skills 主要使用 system/ClawHub/skills 配置接口。
+- Automation 使用 `automation.js`。
+- Gateway 使用 `gateway.js` 和 `triggers.js`。
+
+## 浏览器事件约定
+
+前端用 DOM `CustomEvent` 做少量跨组件通知。事件名以 `agent-teams-*` 为主。
+
+### session 相关
+
+- `agent-teams-select-session`
+  - 触发方：sidebar、搜索或其他组件。
+  - detail：`{ sessionId }`
+  - 处理方：`app/bootstrap.js` 监听后调用 `selectSession(sessionId)`。
+- `agent-teams-session-activated`
+  - 触发方：`app/session.js`，在设置 `state.currentSessionId` 后立即派发。
+  - detail：`{ sessionId }`
+  - 用途：通知依赖当前 session 的 UI 尽快同步。
+- `agent-teams-session-selected`
+  - 触发方：`app/session.js`，session history 和 view hydration 完成后派发。
+  - detail：`{ sessionId }`
+  - 用途：通知依赖完整 session 内容的 UI 刷新。
+- `agent-teams-session-selection-cancelled`
+  - 处理方：`app/session.js`。
+  - 用途：取消当前 session selection 和 loading 状态。
+
+### subagent 相关
+
+- `agent-teams-select-subagent-session`
+  - detail：`{ sessionId, subagent }`
+  - 处理方：`app/bootstrap.js` 调用 `selectSubagentSession()`。
+- `agent-teams-subagent-session-selected`
+  - detail：`{ sessionId, instanceId }`
+  - 触发方：`app/session.js`，subagent session 打开后派发。
+
+### run/recovery 相关
+
+- `run-approval-resolved`
+  - detail：`{ runId }`
+  - 处理方：`app/bootstrap.js`，调用 `resumeRecoverableRun()`。
+- recovery 内部还会通过 round overlay 和 component render 函数同步 UI，不要求所有状态都走全局事件。
+
+### 状态和偏好
+
+- `agent-teams-backend-status-hint`
+  - detail：`{ status }`
+  - 触发方：`requestJson()`。
+  - 处理方：backend status monitor。
+- layout、theme、language 等偏好主要由对应组件和 localStorage/API 维护。
+
+## SSE Event Router
+
+SSE 事件统一进入 `core/eventRouter/index.js` 的 `routeEvent(evType, payload, eventMeta)`。
+
+核心职责：
+
+- 用 run id 和 event id 去重。
+- 判断是否 subagent run。
+- 更新 task instance map、task status map。
+- 对 token usage、todo、background task 做专项处理。
+- 将事件分发到 run/tool/human/notification handler。
+- terminal event 后清理该 run 的 seen event ids。
+
+### runEvents
+
+`runEvents.js` 处理模型和 run 生命周期：
+
+- run started/resumed/completed/failed/stopped。
+- model step started/finished。
+- LLM retry/fallback 事件。
+- text/output delta。
+- thinking started/delta/finished。
+- generation progress。
+- subagent terminal。
+
+它主要更新 message renderer、round 状态、agent/subagent 状态和 recovery。
+
+### toolEvents
+
+`toolEvents.js` 处理工具调用：
+
+- tool call。
+- tool input validation failed。
+- tool result。
+- tool approval requested/resolved。
+
+它主要更新 tool block、approval controls 和 recovery。
+
+### humanEvents
+
+`humanEvents.js` 处理人工 gate 和 subagent 控制：
+
+- subagent gate。
+- subagent stopped/resumed。
+- gate resolved。
+
+### notificationEvents
+
+`notificationEvents.js` 处理 `notification_requested`，把后端通知请求映射到前端通知服务。
+
+### background task
+
+background task event 在 router 中先判断 payload 是否 displayable。可展示事件会：
+
+- 调用 `rememberNormalModeSubagentFromBackgroundTask()`。
+- 调用 `applyBackgroundTaskEvent()`。
+- 延迟刷新 recovery continuity。
+

--- a/docs/frontend/architecture.md
+++ b/docs/frontend/architecture.md
@@ -1,0 +1,119 @@
+# 前端架构
+
+## 总体分层
+
+前端是一个静态托管的 ES Modules 单页应用，分成六层：
+
+- HTML 外壳：`frontend/dist/index.html` 提供稳定 DOM 容器和入口脚本。
+- 应用编排层：`frontend/dist/js/app/` 负责启动顺序、会话选择、prompt 提交、恢复和主视图同步。
+- 核心运行层：`frontend/dist/js/core/` 负责 API facade、全局状态、SSE stream、事件路由和 foreground submission。
+- 组件层：`frontend/dist/js/components/` 负责具体 UI 区域和功能面板。
+- 工具层：`frontend/dist/js/utils/` 提供 DOM、i18n、日志、反馈、Markdown、通知等横切能力。
+- 样式层：`frontend/dist/css/` 提供主题 token、页面布局和组件样式。
+
+```mermaid
+flowchart TD
+    HTML["index.html 静态外壳"] --> Entry["js/app.js"]
+    Entry --> AppIndex["app/index.js"]
+    AppIndex --> Bootstrap["app/bootstrap.js"]
+    Bootstrap --> AppModules["app/session.js, prompt.js, recovery.js"]
+    AppModules --> Core["core/state.js, api/, stream.js, eventRouter/"]
+    AppModules --> Components["components/*"]
+    Components --> Core
+    Components --> Utils["utils/*"]
+    Core --> Backend["/api/* JSON 与 SSE"]
+    HTML --> CSS["css/base.css, layout.css, components/*"]
+```
+
+## 启动流程
+
+入口文件是 `frontend/dist/js/app.js`，它只导出 `selectSession` 并调用 `startApp()`。`startApp()` 位于 `app/index.js`，负责把 sidebar 的会话选择 handler 绑定到 `app/session.js`，再调用 `initApp()`。
+
+`app/bootstrap.js` 是启动中心，当前初始化顺序是：
+
+1. 安装全局错误日志。
+2. 初始化语言和系统日志。
+3. 初始化 UI feedback、后端状态监测、导航栏绑定。
+4. 初始化 prompt 相关控件：YOLO、thinking、session topology、mention autocomplete。
+5. 初始化上下文、token usage、debug badge、subagent rail、observability、image preview、project view。
+6. 绑定 prompt 输入、提交、停止 run、approval resolved 等事件。
+7. 初始化外观和设置弹窗。
+8. 加载项目/会话列表。
+9. 如果侧边栏已有会话，自动选择第一个会话；否则打开新会话草稿页。
+
+```mermaid
+flowchart TD
+    A["app.js void startApp()"] --> B["setSelectSessionHandler(selectSession)"]
+    B --> C["initApp(selectSession, selectSubagentSession, handleSend)"]
+    C --> D["initializeLanguage 与日志"]
+    D --> E["navbar, backend status, feedback"]
+    E --> F["prompt controls 与 topology options"]
+    F --> G["context, token, subagent, observability, project view"]
+    G --> H["setupEventBindings"]
+    H --> I["initAppearanceOnStartup 与 initSettings"]
+    I --> J["loadProjects"]
+    J --> K{"存在 session-item?"}
+    K -->|是| L["selectSession(firstSessionId)"]
+    K -->|否| M["openNewSessionDraft('')"]
+```
+
+## 应用编排层
+
+`js/app/` 不是页面组件集合，而是运行流程编排层：
+
+- `bootstrap.js`：启动和全局事件绑定。
+- `index.js`：应用启动 facade，连接 sidebar 和 session handler。
+- `prompt.js`：prompt composer、附件、mention、slash command、role/topology 控件、发送流程。
+- `session.js`：会话和 subagent 会话选择，处理切换、取消、加载历史、状态清理。
+- `sessionView.js`：会话视图 hydration 的辅助逻辑。
+- `recovery.js`：run 恢复快照、approval、user question、paused subagent、background task、resume/stop。
+- `retryStatus.js`：重试状态展示辅助。
+
+这一层的特点是会同时调用 `components` 和 `core`。例如 `session.js` 会清理消息面板、隐藏 project view、设置 rounds mode、请求 session history、更新 `state`，再触发 recovery 和 token usage 刷新。
+
+## 核心运行层
+
+`js/core/` 承担跨页面的运行能力：
+
+- `state.js`：全局 UI 状态对象和 role/session helper。
+- `api/`：按后端领域拆分的 API 模块，统一由 `core/api/index.js` 导出。
+- `api/request.js`：共享请求 helper，提供错误处理、GET 合并缓存、并发 lane、AbortSignal 和后端状态 hint。
+- `stream.js`：创建 run、连接前台 SSE、管理后台 run multiplex、subagent stream、停止 run、断线重连和 session switch detach。
+- `eventRouter/`：把 SSE RunEventType 分发到 run、tool、human、notification 等 handler。
+- `submission.js`：前台提交状态，避免 session 切换和 prompt 发送互相踩踏。
+
+## 组件层
+
+`js/components/` 以用户可见区域和功能域组织：
+
+- `sidebar.js`、`sessionSidebarStore.js`、`sessionSearch.js`：左侧项目/会话列表、搜索、排序、会话状态。
+- `newSessionDraft*.js`：新会话草稿页、快捷卡片、workspace 选择、mention 和 aside。
+- `messageRenderer/`、`messageTimeline/`：历史消息和流式消息渲染、timeline store、copy action、scroll controller。
+- `rounds/`：round timeline、navigator、paging、todo、retry、scroll。
+- `projectView.js`：workspace 视图和 feature view 的主要实现，包含 Skills、Automation、Gateway 等入口。
+- `settings/`：设置弹窗 shell 和各 tab panel。
+- `subagentRail.js`、`subagentSessions.js`、`agentPanel/`：右侧 subagent rail、subagent session、agent drawer。
+- `observability.js`：观测视图。
+- `contextIndicators.js`、`sessionTokenUsage.js`、`sessionDebugBadge.js`：composer 附近的状态指示。
+- `imagePreview.js`：图片预览 modal。
+
+## 全局状态模型
+
+`core/state.js` 暴露一个共享 `state` 对象。它不是后端数据模型，而是浏览器 UI 当前态，包括：
+
+- 当前会话：`currentSessionId`、`currentWorkspaceId`、`currentSessionMode`。
+- 当前视图：`currentMainView`、`currentProjectViewWorkspaceId`、`currentFeatureViewId`。
+- run 状态：`isGenerating`、`activeEventSource`、`activeRunId`、`runPrimaryRoleMap`。
+- subagent 状态：`activeSubagentSession`、`activeView`、`activeAgentRoleId`、`activeAgentInstanceId`、`pausedSubagent`。
+- role/topology：coordinator、main agent、normal roles、selected role、orchestration preset。
+- run 事件索引：instance、role、task 映射和 task status。
+- 恢复状态：`currentRecoverySnapshot`。
+- prompt 选项：YOLO 和 thinking。
+- 布局偏好：`rightRailExpanded`。
+
+状态更新规则：
+
+- 后端真相通过 API 拉取后写入 `state`。
+- 跨组件 UI 同步可以通过 `state` helper 或 DOM `CustomEvent`。
+- 组件不应绕过 `core/api` 直接拼散落的请求逻辑。
+

--- a/docs/frontend/features.md
+++ b/docs/frontend/features.md
@@ -1,0 +1,278 @@
+# 功能视图与设置设计
+
+## Project Feature View 总览
+
+项目功能视图由 `components/projectView.js` 管理。左侧 feature navigation 进入对应 feature 后，主工作区仍使用 `#project-view`，但 `currentProjectViewMode` 和 `state.currentFeatureViewId` 会切到功能模式。
+
+当前 feature id：
+
+- `skills`
+- `automation`
+- `gateway`
+
+通用页面表现：
+
+- 顶部保留 project view toolbar，展示标题、摘要、刷新和关闭。
+- 内容区由 feature 专属 markup 替换。
+- 加载时延迟显示 loading，避免快速请求闪烁。
+- 请求失败通过 toast、dialog 或 system log 呈现。
+
+## Skills 视图
+
+负责模块：
+
+- `components/projectView.js`
+- `components/settings/clawhubSettings.js`
+
+主要状态：
+
+- `currentSkillsStatus`
+- 当前 workspace。
+- ClawHub 配置和技能列表相关状态。
+
+用户可见区域：
+
+- 技能状态概览。
+- reload skills 操作。
+- ClawHub 配置入口或状态卡片。
+- 技能列表/资源状态。
+
+空态、加载态、错误态：
+
+- 技能状态未加载时显示 loading。
+- 没有技能或 ClawHub 未配置时显示配置引导。
+- reload 或 probe 失败显示错误消息。
+
+关键交互：
+
+- 刷新技能配置。
+- 打开或保存 ClawHub 设置。
+- 删除 ClawHub skill。
+- 测试 ClawHub 连通性。
+
+依赖 API：
+
+- `fetchConfigStatus`
+- `reloadSkillsConfig`
+- `fetchClawHubConfig`
+- `fetchClawHubSkills`
+- `saveClawHubConfig`
+- `probeClawHubConnectivity`
+- `deleteClawHubSkill`
+
+## Automation 视图
+
+负责模块：
+
+- `components/projectView.js`
+
+主要状态：
+
+- `currentAutomationProjects`
+- `selectedAutomationHomeProjectId`
+- `currentAutomationHomeDetail`
+- `currentAutomationFeatureSection`
+- `currentAutomationEditorState`
+
+用户可见区域：
+
+- automation project 列表。
+- 选中 automation 的详情，包括 workspace、prompt、session mode、role/preset、delivery binding、最近 sessions。
+- schedules 与相关分区。
+- run now、enable/disable、edit、delete 等操作。
+- automation editor modal，用于创建或编辑自动化项目。
+
+编辑弹窗表现：
+
+- 基础字段：名称、workspace、prompt。
+- 调度字段：daily、weekdays、weekly、monthly、one shot、unsupported fallback。
+- session 字段：normal/orchestration，normal role 或 orchestration preset。
+- thinking/YOLO 等运行参数。
+- delivery binding：可选择 IM/网关投递绑定，并选择 started/completed/failed 事件。
+- 保存时按钮进入 submitting，错误显示在弹窗内。
+
+空态、加载态、错误态：
+
+- 没有 automation project 时显示空态和创建入口。
+- 详情加载中显示 loading。
+- schedule 类型无法解析时要求用户重设。
+- delivery binding 不可用或凭据缺失时显示明确错误。
+
+关键交互：
+
+- 新建、编辑、删除自动化项目。
+- 启用或禁用自动化项目。
+- 立即运行自动化项目，并在启动后记录 session/run 信息。
+- 切换选中的 automation project，加载详情和 sessions。
+
+依赖 API：
+
+- `fetchAutomationProjects`
+- `fetchAutomationProject`
+- `fetchAutomationProjectSessions`
+- `createAutomationProject`
+- `updateAutomationProject`
+- `deleteAutomationProject`
+- `enableAutomationProject`
+- `disableAutomationProject`
+- `runAutomationProject`
+- `fetchAutomationDeliveryBindings`
+- `fetchAutomationFeishuBindings`
+- `fetchRoleConfigOptions`
+- `fetchOrchestrationConfig`
+
+## Gateway 视图
+
+负责模块：
+
+- `components/projectView.js`
+
+主要状态：
+
+- `currentGatewayFeatureState`
+- Feishu trigger draft。
+- Xiaoluban accounts。
+- WeChat accounts 和 login session。
+- workspace、normal roles、orchestration presets。
+
+用户可见区域：
+
+- Feishu 触发器列表和编辑器。
+- Xiaoluban gateway accounts。
+- WeChat gateway accounts 和登录流程。
+- workspace/role/preset 选择。
+- trigger rule、session mode、YOLO、thinking 配置。
+- Xiaoluban IM forwarding command 预览。
+
+Feishu 编辑器表现：
+
+- 触发器名称、账号或目标字段。
+- workspace 和 session core 配置。
+- normal/orchestration 模式切换。
+- YOLO 和 thinking 开关。
+- 保存/取消操作。
+
+Xiaoluban 表现：
+
+- 账号 token 配置。
+- enable/disable/delete。
+- IM 配置和回调 URL 相关错误提示。
+- token reveal 或连接测试。
+
+WeChat 表现：
+
+- 登录启动、等待登录结果。
+- 启用/禁用账号。
+- 删除账号。
+- 登录中展示连接状态。
+
+空态、加载态、错误态：
+
+- 没有账号时显示添加或登录入口。
+- workspace 或 role/preset 依赖未加载时禁用相关控件。
+- token 无效、个人 token 类型不对、callback URL 本地不可用、workspace 缺失等错误会映射为用户可读消息。
+
+关键交互：
+
+- 创建、更新、启停、删除 Feishu trigger。
+- 创建、更新、启停、删除 Xiaoluban account。
+- 启动 WeChat 登录并轮询登录结果。
+- 更新 gateway 的目标 workspace、session mode、role/preset。
+
+依赖 API：
+
+- Feishu trigger：`fetchTriggers`、`createTrigger`、`updateTrigger`、`deleteTrigger`、`enableTrigger`、`disableTrigger`。
+- Xiaoluban：`fetchXiaolubanGatewayAccounts`、`prepareXiaolubanGatewayAccount`、`createXiaolubanGatewayAccount`、`updateXiaolubanGatewayAccount`、`enableXiaolubanGatewayAccount`、`disableXiaolubanGatewayAccount`、`deleteXiaolubanGatewayAccount`、`fetchXiaolubanGatewayImForwardingCommand`。
+- WeChat：`fetchWeChatGatewayAccounts`、`startWeChatGatewayLogin`、`waitWeChatGatewayLogin`、`updateWeChatGatewayAccount`、`enableWeChatGatewayAccount`、`disableWeChatGatewayAccount`、`deleteWeChatGatewayAccount`、`reloadWeChatGateway`。
+- 配置依赖：`fetchWorkspaces`、`fetchRoleConfigOptions`、`fetchOrchestrationConfig`。
+
+## 设置弹窗 Shell
+
+入口 DOM：
+
+- 设置弹窗由 `components/settings/index.js` 动态创建并挂载到 document body。
+- topbar 的 `#settings-btn` 调用 `openSettings()`。
+
+负责模块：
+
+- `components/settings/index.js`
+- 各 panel：`appearanceSettings.js`、`modelProfiles.js`、`systemStatus.js`、`commandsSettings.js`、`hooksSettings.js`、`agentsSettings.js`、`rolesSettings.js`、`orchestrationSettings.js`、`notifications.js`、`webSettings.js`、`proxySettings.js`、`workspaceSettings.js`、`environmentVariables.js`。
+
+主要状态：
+
+- `currentTab`
+- `initialized`
+- `panelLoadRequestId`
+- `settingsWarmupPromise`
+- `ACTION_TAB_OWNERS`
+
+页面表现：
+
+- 弹窗左侧是 settings sidebar 和 tab list。
+- 右侧是 panel header、description、body。
+- panel action button 的显示由 action ownership 控制，避免不同 tab 的按钮互相污染。
+- overlay 点击和关闭按钮可关闭弹窗。
+- 打开设置时默认进入 appearance tab，并可预热 model/role/orchestration 等常用配置。
+
+通用交互模式：
+
+- tab click 切换 `currentTab`。
+- 切换 tab 时更新标题、描述、可见 panel 和 action buttons。
+- 每个 panel 自己负责 load 和 bind handlers。
+- 保存、验证、测试等操作走对应 `core/api` facade。
+- 成功或失败通过 inline status、toast、dialog 或 system log 展示。
+
+## 设置 Tab 说明
+
+### Appearance
+
+负责外观偏好，包括主题、字体大小、密度等。启动时 `initAppearanceOnStartup()` 会在应用初始化阶段应用持久化外观。
+
+### Model
+
+负责模型配置和 model profiles。提供 provider/model profile 编辑、测试连接、catalog 发现/刷新、fallback 配置等能力。
+
+### MCP
+
+由 system status panel 管理 MCP server 状态。提供 server 列表、启停、连接测试、reload、工具查看等能力。
+
+### Commands
+
+负责 workspace commands 配置。提供命令 catalog、命令创建/更新/删除、预览 prompt resolve 等能力。
+
+### Hooks
+
+负责 runtime hooks 配置和 runtime view。提供 hook 编辑、验证、保存，并展示有效 source scope/path 和 scoped filters。
+
+### Agents
+
+负责 external agents 配置。提供 agent 列表、添加、保存、删除、测试等能力。
+
+### Roles
+
+负责 role config。提供 role 列表、编辑、验证、保存，并保持未知 tools、mcp servers、skills 的显式 mutation 严格校验语义。
+
+### Orchestration
+
+负责 orchestration presets。提供 preset 列表、编辑、保存、取消等能力，并与 composer 的 orchestration preset select 共享配置来源。
+
+### Notifications
+
+负责通知设置保存和展示。
+
+### Web
+
+负责 web connectivity 相关配置和探测。
+
+### Proxy
+
+负责代理配置、保存、reload 和连通性探测。前端只调用代理相关 API，不自行实现网络代理逻辑。
+
+### Remote Workspace
+
+负责 SSH profile、远程 workspace 相关设置。提供 SSH profile 新增、保存、测试、密码 reveal、删除等能力。
+
+### Environment
+
+负责环境变量配置。提供新增、保存、取消、删除等能力。
+

--- a/docs/frontend/motion-and-loading-states.md
+++ b/docs/frontend/motion-and-loading-states.md
@@ -1,0 +1,362 @@
+# 动效与加载状态设计
+
+本文档描述当前 `frontend/dist` 中已经实现的动画、过渡和加载状态。动效主要由 CSS class、DOM 插入、运行态 class 和 hover/focus/disabled 状态触发；JavaScript 负责切换状态，CSS 负责表达动效。
+
+## 设计目标
+
+前端是高密度工作台界面，动效的作用是给用户状态反馈，而不是制造视觉表演：
+
+- 轻量：多数动效控制在短时淡入、位移、旋转或 opacity 变化。
+- 可感知：会话切换、列表增删、加载中、流式输出、modal 打开等状态需要被看见。
+- 不干扰：聊天、代码、tool result、设置表单是阅读和操作密集区域，动效不能影响文本可读性。
+- 不改变布局：动效应尽量使用 `opacity`、`transform`、`box-shadow`、颜色或边框变化，避免触发布局跳动。
+- 和真实状态绑定：loading spinner、streaming caret、busy 按钮必须对应实际异步或流式状态。
+
+## Keyframes 盘点
+
+### 全局基础动画
+
+来源：`frontend/dist/css/base.css`
+
+- `fadeIn`：通用淡入。
+- `slideUp`：轻微上移动画，用于提示或块级内容进入。
+- `spin`：通用旋转 loading。
+- `typing`：输入/生成中的点状节奏。
+- `streamingCaretPulse`：流式输出光标闪烁。
+
+### 会话与切换动画
+
+来源：`frontend/dist/css/components/interface.css`
+
+- `sessionItemEnter`：session item 插入时淡入并轻微位移。
+- `sessionItemRemove`：session item 删除时收起和淡出。
+- `sessionSwitchSpinner`：会话切换 loading spinner。
+- `sessionSwitchContentReady`：会话内容 ready 后的轻微进入反馈。
+- `sessionItemSwitchTarget`：目标 session item 被切换选中时的状态反馈。
+
+来源：`frontend/dist/css/components/projects.css`
+
+- `sessionItemTargetOverlay`：session item target overlay 的视觉反馈。
+
+来源：`frontend/dist/css/components/session-search.css`
+
+- `sessionSearchResultEnter`：会话搜索结果进入时淡入。
+
+### 新会话草稿动画
+
+来源：`frontend/dist/css/components/new-session-draft.css`
+
+- `newSessionDraftEnter`：新会话草稿页进入时淡入和轻微位移。
+
+### 设置弹窗动画
+
+来源：`frontend/dist/css/components/settings.css`
+
+- `settingsModalEnter`：设置弹窗打开时的 shell 进入。
+- `settingsPanelEnter`：设置 tab panel 切换进入。
+- `settingsCardEnter`：设置卡片或局部块进入。
+
+### Subagent 与项目会话动画
+
+来源：`frontend/dist/css/components/subagent.css`
+
+- `sessionRunIndicatorSpin`：session run indicator 的运行中旋转。
+- `sessionRunTimeFadeIn`：运行时间信息淡入。
+- `projectSessionVisibilityEnter`：项目 session 显示时进入。
+- `projectSessionVisibilityExit`：项目 session 隐藏时退出。
+- `projectMenuEnter`：项目菜单打开时进入。
+- `subagentSessionLoadingSpin`：subagent session 加载 spinner。
+
+### Tool 详情动画
+
+来源：`frontend/dist/css/components/tools.css`
+
+- `tool-detail-in`：tool detail 展开或插入时进入。
+
+## 页面级动效表现
+
+## 新会话草稿页
+
+入口模块：
+
+- `components/newSessionDraft.js`
+- `components/newSessionDraftView.js`
+- `components/newSessionDraftQuickCards.js`
+- `components/newSessionDraftAside.js`
+
+主要动效：
+
+- 草稿页根节点使用 `newSessionDraftEnter`，进入时从轻微下移和透明状态过渡到稳定状态。
+- quick cards、workspace 区域和 composer 控件通过 hover/focus transition 表示可点击、可编辑。
+- mention 菜单打开和选项 hover 依赖组件样式中的 transition，而不是额外 JS 动画。
+
+触发来源：
+
+- 没有可选 session 时 `openNewSessionDraft("")` 插入草稿视图。
+- 切换 workspace、mode、role/preset 时通过 class 和控件 disabled 状态改变视觉。
+
+维护要点：
+
+- 草稿页进入动效不应改变 composer 的实际高度。
+- quick card hover 只做颜色、边框、阴影或轻微 transform，避免卡片重排。
+
+## 会话列表与侧边栏
+
+入口模块：
+
+- `components/sidebar.js`
+- `components/sessionSidebarStore.js`
+- `components/sessionSearch.js`
+
+主要动效：
+
+- 新 session item 插入时使用 `sessionItemEnter`。
+- 删除 session item 时使用 `sessionItemRemove`。
+- 目标 session 切换时使用 `sessionItemSwitchTarget` 或 target overlay。
+- 会话搜索结果使用 `sessionSearchResultEnter`。
+- sidebar 折叠、宽度调整和按钮 hover 依赖 transition。
+
+触发来源：
+
+- `loadProjects()`、`scheduleSessionsRefresh()`、session store 更新会触发列表 DOM 更新。
+- 搜索输入改变会重绘结果列表。
+- session 切换过程会为目标 item 添加状态 class。
+
+维护要点：
+
+- 列表增删动效需要和真实数据变化一致，不能只做视觉删除而不更新 store。
+- session item 的高度变化应短且可预测，避免用户点击目标漂移。
+
+## 会话切换加载态
+
+入口模块：
+
+- `app/session.js`
+- `components/messageRenderer.js`
+- `components/rounds/`
+
+主要动效：
+
+- session switch pending 时 chat container 添加 `is-session-switch-pending`。
+- 超过短延迟后添加 `is-session-switching`，显示 loading node。
+- spinner 使用 `sessionSwitchSpinner`。
+- 内容 ready 后添加 `is-session-switch-ready`，使用 `sessionSwitchContentReady` 反馈完成。
+
+触发来源：
+
+- `beginSessionSwitchLoading()` 设置 pending/switching class。
+- `finishSessionSwitchLoading()` 移除 pending/switching 并短暂添加 ready class。
+- `sessionSelectionToken` 和 AbortController 防止旧请求返回后触发错误动效。
+
+维护要点：
+
+- loading 延迟是为了避免快速切换闪烁；新增加载动效要保留这个思路。
+- ready 动效只表示视图同步完成，不代表 run 完成。
+
+## 聊天与流式输出
+
+入口模块：
+
+- `components/messageRenderer/stream.js`
+- `components/messageTimeline/renderer.js`
+- `components/messageTimeline/scrollController.js`
+- `core/eventRouter/runEvents.js`
+
+主要动效：
+
+- 流式文本持续追加，末尾通过 `streamingCaretPulse` 提示输出仍在继续。
+- thinking、tool call、tool result、status block 插入时使用淡入或局部进入效果。
+- 通用 typing/loading 点使用 `typing`。
+- 消息区滚动由 scroll controller 控制，避免每次 delta 都强制跳动。
+
+触发来源：
+
+- SSE `text_delta`、`output_delta`、`thinking_delta` 进入 event router 后更新 stream block。
+- `run_completed`、`run_failed`、`run_stopped` 会 finalize stream 并清理运行中动效。
+
+维护要点：
+
+- 流式动效必须能被 terminal event 停止。
+- caret 或 typing 这类无限动画只能出现在真实生成中。
+- 长输出时优先保障滚动、复制和文本选择体验。
+
+## Tool Detail
+
+入口模块：
+
+- `components/messageRenderer/helpers/toolBlocks.js`
+- `components/messageRenderer/stream.js`
+- `css/components/tools.css`
+
+主要动效：
+
+- tool detail 插入或展开使用 `tool-detail-in`。
+- tool header、toggle、copy、approval 按钮使用 hover/focus transition。
+- tool result 更新时保持块尺寸稳定，避免结果到达导致页面跳动过大。
+
+触发来源：
+
+- SSE `tool_call` 添加 tool call block。
+- `tool_result` 更新已有块。
+- `tool_approval_requested` 挂载 approval controls。
+- 用户展开/收起 tool detail 时切换对应 class。
+
+维护要点：
+
+- tool detail 动效不能遮挡参数、结果或 approval 按钮。
+- tool result 可能很长，进入动效只作用于外层，不逐行动画。
+
+## Recovery、Approval 与 User Question
+
+入口模块：
+
+- `app/recovery.js`
+- `components/rounds/timeline.js`
+- `css/components/recovery.css`
+
+主要动效：
+
+- recovery banner、approval host、question host 主要通过 transition 和局部淡入表达出现/隐藏。
+- busy 状态通过按钮 disabled、loading 文案或 spinner 表示。
+- round overlay 会同步恢复状态，但不应重排整个 round 列表。
+
+触发来源：
+
+- `applyRecoverySnapshot()` 更新 `state.currentRecoverySnapshot` 后重新渲染。
+- `markToolApprovalPending()`、`markPausedSubagent()` 等运行时函数会触发 recovery banner 更新。
+- approval/question action busy map 控制按钮状态。
+
+维护要点：
+
+- 用户决策类 UI 的动效要克制，不能把 approve/reject 按钮移出用户视线。
+- action 失败后 pending 项需要保留，错误反馈应稳定显示。
+
+## 设置弹窗
+
+入口模块：
+
+- `components/settings/index.js`
+- `css/components/settings.css`
+
+主要动效：
+
+- 打开设置弹窗使用 `settingsModalEnter`。
+- 切换 tab 时 panel 使用 `settingsPanelEnter`。
+- 卡片或局部内容进入使用 `settingsCardEnter`。
+- tab、button、input、toggle、row hover/focus 使用 transition。
+
+触发来源：
+
+- `openSettings()` 显示 modal。
+- tab click 更新 `currentTab`，切换 panel 可见性和 action ownership。
+- panel load 完成后填充内容。
+
+维护要点：
+
+- panel 切换动画不能影响当前表单值。
+- 保存中按钮 disabled 后不能因为 hover transition 看起来仍可点击。
+- 设置弹窗内容多且可滚动，动画应局限在 panel 内，不推动 modal shell。
+
+## Project、Workspace 与 Feature View
+
+入口模块：
+
+- `components/projectView.js`
+- `css/components/projects.css`
+- `css/components/automation.css`
+- `css/components/gateway.css`
+- `css/components/features.css`
+
+主要动效：
+
+- feature navigation、workspace tree、diff list、automation/gateway 控件主要使用 hover/focus transition。
+- session target overlay 使用 `sessionItemTargetOverlay`。
+- feature loading 延迟显示，避免快速请求时 loading 闪烁。
+
+触发来源：
+
+- 打开 project view、切换 feature id、刷新 workspace snapshot。
+- tree 节点展开、diff 文件选择、automation/gateway 编辑状态变化。
+
+维护要点：
+
+- 文件树和 diff 是高信息密度区域，展开/选中反馈要清楚但不能拖慢操作。
+- feature loading 动效要和 request token/AbortController 对齐，旧请求返回不能覆盖新状态。
+
+## Observability
+
+入口模块：
+
+- `components/observability.js`
+- `css/components/observability.css`
+
+主要动效：
+
+- scope button、刷新状态、指标卡 hover 使用 transition。
+- overview、trend、breakdown 加载时使用占位或 loading 状态。
+
+触发来源：
+
+- topbar observability 按钮打开视图。
+- global/session scope 切换。
+- 当前 session 变化后刷新 session scope。
+
+维护要点：
+
+- 指标数字变化可以即时更新，不需要强动画。
+- 错误态和空态必须比 loading 态优先级更高。
+
+## Subagent Rail 与 Inspector
+
+入口模块：
+
+- `components/subagentRail.js`
+- `components/subagentSessions.js`
+- `components/agentPanel/`
+- `css/components/subagent.css`
+
+主要动效：
+
+- run indicator 使用 `sessionRunIndicatorSpin` 表示运行中。
+- run time 使用 `sessionRunTimeFadeIn` 出现。
+- project session visibility 使用 enter/exit keyframes。
+- project menu 使用 `projectMenuEnter`。
+- subagent session loading 使用 `subagentSessionLoadingSpin`。
+- rail 展开、按钮 hover、agent drawer 状态使用 transition。
+
+触发来源：
+
+- 顶部 subagents toggle 展开/收起 rail。
+- subagent session 加载、选择、删除。
+- run event 更新 agent、task、role 状态。
+- reflection refresh 或 stop 操作改变按钮 busy/disabled。
+
+维护要点：
+
+- right rail 是辅助工作区，动效不能抢主聊天区注意力。
+- loading spinner 必须在 subagent list 加载结束后停止。
+
+## 触发机制
+
+当前动效主要由以下机制触发：
+
+- DOM 插入：新节点带着默认 animation 进入，例如 settings panel、session search result、new session draft。
+- CSS class 切换：如 `is-session-switch-pending`、`is-session-switching`、`is-session-switch-ready`、active、busy、loading。
+- 运行态 class：run indicator、streaming block、tool approval、disabled 按钮。
+- 用户交互伪类：hover、focus、focus-within、disabled。
+- JS 定时器：session switch loading 和 ready class 有短延迟，减少闪烁。
+
+## 维护约束
+
+新增或修改动效时遵循这些规则：
+
+- 不要让动画改变文本内容的最终位置，尤其是 chat、tool result、diff、settings form。
+- 无限动画只用于真实等待或生成中，例如 spinner、streaming caret、typing。
+- 动画时长应短，通常使用 120ms 到 300ms；loading spinner 可循环。
+- 优先使用 `transform` 和 `opacity`，谨慎动画化 `height`、`width`、`top`、`left`。
+- loading class 必须由真实异步状态驱动，并在 abort、error、success 三类路径中都能清理。
+- session switch、feature loading、settings panel load 这类并发区域必须配合 token 或 AbortController，避免旧请求触发旧动画。
+- 深浅主题下都要可读，动画不能只依赖单一颜色。
+- 动效不能遮挡 approval、delete、stop、save 等关键按钮。
+- 新增页面或功能视图时，要在 `pages-and-layout.md` 或 `features.md` 描述页面表现，并在本文档补充动效入口。
+

--- a/docs/frontend/pages-and-layout.md
+++ b/docs/frontend/pages-and-layout.md
@@ -1,0 +1,444 @@
+# 页面与布局设计
+
+## 页面骨架
+
+`frontend/dist/index.html` 定义了长期存在的页面骨架：
+
+- `.app-shell`：全屏应用容器，纵向包含 topbar 和 app container。
+- `.topbar`：顶部栏，包含 sidebar toggle、workspace 标题、语言、observability、settings、theme、subagents toggle。
+- `.app-container`：主体横向布局，包含左侧栏、主工作区、右侧 rail。
+- `.sidebar`：左侧项目和会话列表，底部显示后端状态。
+- `.workspace`：主工作区，可显示 observability view、project view 或 chat container。
+- `.chat-container`：消息滚动区和输入区。
+- `.right-rail`：subagent rail 与 inspector。
+- `.input-container`：prompt composer、恢复审批入口、模式/role 控件、usage strip。
+
+CSS 中 `base.css` 定义主题 token，`layout.css` 定义 shell、sidebar、workspace、composer 等主要布局，`components/*` 定义页面局部样式。
+
+动画、过渡和加载态的完整说明见 `motion-and-loading-states.md`。本页只在各页面小节说明动效入口，不重复展开具体 keyframes。
+
+## 顶部栏
+
+入口 DOM：
+
+- `#toggle-sidebar`
+- `#language-toggle-btn`
+- `#observability-btn`
+- `#settings-btn`
+- `#toggle-theme`
+- `#toggle-subagents`
+
+负责模块：
+
+- `components/navbar.js` 绑定 sidebar、theme、right rail 等布局行为。
+- `components/settings.js` 打开设置弹窗。
+- `components/observability.js` 打开观测视图。
+- `utils/i18n.js` 切换语言。
+
+页面表现：
+
+- 左侧是应用标题和 sidebar toggle。
+- 右侧是一排操作按钮，语言按钮显示当前语言，settings/theme/observability 使用图标按钮，subagents 按钮显示汇总状态。
+- topbar 常驻，主工作区切换时不重建。
+- 按钮 hover、focus、disabled 状态使用轻量 transition；subagents toggle 会驱动右侧 rail 的展开/收起表现。
+
+## 左侧栏
+
+入口 DOM：
+
+- `#projects-list`
+- `#rounds-list`
+- `#back-btn`
+- `#backend-status`
+- `#sidebar-resizer`
+
+负责模块：
+
+- `components/sidebar.js`
+- `components/sessionSidebarStore.js`
+- `components/sessionSearch.js`
+- `utils/backendStatus.js`
+
+主要状态：
+
+- 当前 workspace/project 列表。
+- 当前 session 列表、排序模式、活动 session、terminal run 未读/失败/停止指示。
+- rounds mode 和 projects mode 的切换状态。
+
+页面表现：
+
+- 默认显示项目和会话树。
+- 进入 round 导航模式时，`#rounds-list` 显示轮次列表，back 按钮返回项目/会话列表。
+- 底部 status indicator 显示后端 checking、online、offline 等状态。
+- sidebar 可折叠，也可通过 resizer 调整宽度。
+- session item 插入、删除、切换目标和搜索结果进入有独立动画，详见动效文档的“会话列表与侧边栏”。
+
+空态、加载态、错误态：
+
+- 没有项目时显示新建项目相关空态。
+- 会话或 subagent session 加载中会展示 loading 行。
+- 删除、fork、加载失败等错误通过 feedback dialog、toast 或 system log 呈现。
+
+关键交互：
+
+- 选择 session 会触发 `agent-teams-select-session` 或直接调用注册的 `selectSession` handler。
+- 可按最近或名称排序。
+- 可新建 session、删除 subagent session、fork/remove workspace。
+- feature navigation 可进入 Skills、Automation、Gateway 等 project feature view。
+
+依赖 API：
+
+- sessions、workspaces、automation、gateway、trigger 等 API 通过 `core/api` facade 调用。
+
+## 新会话草稿页
+
+入口 DOM：
+
+- 主容器由 `components/newSessionDraft.js` 在 workspace 中渲染。
+- 输入仍复用 `#prompt-input`、`#chat-form`、`#send-btn` 等 composer DOM。
+
+负责模块：
+
+- `components/newSessionDraft.js`
+- `components/newSessionDraftView.js`
+- `components/newSessionDraftQuickCards.js`
+- `components/newSessionDraftAside.js`
+- `components/newSessionDraftIcons.js`
+- `app/prompt.js`
+
+主要状态：
+
+- `state.pendingNewSessionActive`
+- `state.pendingNewSessionWorkspaceId`
+- `state.currentSessionMode`
+- `state.currentNormalRootRoleId`
+- `state.currentOrchestrationPresetId`
+- prompt attachment、mention、slash command 状态由 `app/prompt.js` 维护。
+
+用户可见区域：
+
+- workspace 选择区域。
+- 会话模式 segmented control：Normal / Orchestration。
+- normal role select 或 orchestration preset select。
+- 常用能力快捷卡片。
+- 输入框、mention 菜单、附件预览、token chip。
+- 开始按钮。
+- 页面进入、快捷卡片、workspace 控件和 mention 菜单的动效入口见 `motion-and-loading-states.md`。
+
+空态、加载态、错误态：
+
+- 没有 workspace 时提示先选择或添加 workspace。
+- role/preset 加载失败时使用 system log 提示，控件回退为空。
+- composer 校验失败时通过 input status 或 toast 提示。
+
+关键交互：
+
+- 选择 workspace 后更新 pending session workspace。
+- 切换 normal/orchestration 模式会改变 role/preset 控件可见性。
+- 快捷卡片会把预设 prompt 填入 composer。
+- `@` 触发 repository、files、skills 等 mention。
+- `/` 触发 workspace command autocomplete。
+- 点击 Start 或 Enter 提交。
+
+依赖 API：
+
+- `fetchWorkspaces`
+- `fetchRoleConfigOptions`
+- `fetchOrchestrationConfig`
+- `fetchCommands`
+- `searchWorkspacePaths`
+- `resolveCommandPrompt`
+- `startNewSession`
+- `updateSessionTopology`
+
+## 会话聊天页
+
+入口 DOM：
+
+- `#chat-container`
+- `#chat-messages`
+- `#input-container`
+- `#recovery-approval-host`
+- `#prompt-input`
+- `#prompt-attachments`
+- `#prompt-mention-menu`
+- `#resume-run-btn`
+- `#send-btn`
+- `#stop-btn`
+
+负责模块：
+
+- `app/session.js`
+- `app/sessionView.js`
+- `app/prompt.js`
+- `app/recovery.js`
+- `components/messageRenderer/`
+- `components/messageTimeline/`
+- `components/rounds/`
+
+主要状态：
+
+- `state.currentSessionId`
+- `state.isGenerating`
+- `state.activeRunId`
+- `state.currentRecoverySnapshot`
+- message timeline store 中的历史和流式状态。
+
+用户可见区域：
+
+- 历史消息列表。
+- 流式输出块，包括 text/output delta、thinking、tool call、tool result、approval controls。
+- Markdown、代码高亮、图片或富内容渲染。
+- 最后一条回答复制按钮。
+- composer 附近的上下文窗口、session token usage、debug badge。
+- stop 按钮在运行中显示。
+- 流式 caret、typing/loading、thinking/tool block 插入和 session switch loading 详见动效文档。
+
+空态、加载态、错误态：
+
+- 会话切换时 chat container 进入 pending/switching/ready 状态，并显示 loading node。
+- 历史加载失败会通过 system log 或错误反馈呈现。
+- stream 创建失败会释放 busy 状态并在 system log 记录。
+
+关键交互：
+
+- Enter 发送，Shift+Enter 换行。
+- 粘贴图片或文件时生成 attachment。
+- 运行中禁用 prompt、send、YOLO、thinking 控件。
+- stop 按钮调用 run stop。
+- approval resolved 后触发恢复尝试。
+
+依赖 API：
+
+- `fetchSessionHistory`
+- `sendUserPrompt`
+- `stopRun`
+- `fetchSessionRecovery`
+- `resolveToolApproval`
+- `answerUserQuestion`
+- `resumeRun`
+
+## 轮次视图
+
+入口 DOM：
+
+- `#rounds-list`
+- `#chat-messages`
+- timeline 节点由 `components/rounds/timeline.js` 和 message timeline 渲染。
+
+负责模块：
+
+- `components/rounds/index.js`
+- `components/rounds/timeline.js`
+- `components/rounds/navigator.js`
+- `components/rounds/paging.js`
+- `components/rounds/scrollController.js`
+- `components/rounds/todo.js`
+- `components/messageTimeline/*`
+
+主要状态：
+
+- 当前 session 的 round 列表。
+- 当前选中 round。
+- round run 状态、todo 状态、retry 状态。
+- 分页和滚动锚点。
+
+用户可见区域：
+
+- 左侧 round list 或浮动/docked navigator。
+- 主区 round card、prompt、answer、tool/thinking/message block。
+- todo card 和 retry 操作。
+- 历史分页加载出的旧 round。
+- round 内容和恢复 overlay 的动效保持克制，重点是状态可感知和滚动稳定。
+
+空态、加载态、错误态：
+
+- 没有 round 时显示空历史。
+- 分页加载中保持滚动位置。
+- retry 或 round 加载失败通过状态块或 system log 呈现。
+
+关键交互：
+
+- 点击 round item 切换当前轮次。
+- 滚动时 navigator 同步当前可见 round。
+- 长历史通过分页和虚拟可见窗口控制渲染量。
+- run 事件会 overlay 到当前 round recovery state。
+
+依赖 API：
+
+- `fetchSessionRounds`
+- `fetchSessionRound`
+- `fetchSessionTasks`
+- run/recovery 相关 API。
+
+## 项目与 Workspace 视图
+
+入口 DOM：
+
+- `#project-view`
+- `#project-view-title`
+- `#project-view-summary`
+- `#project-view-content`
+- `#project-view-reload`
+- `#project-view-close`
+
+负责模块：
+
+- `components/projectView.js`
+- feature 局部复用 `settings/clawhubSettings.js` 和 `settings/githubSettings.js` 的渲染/handler。
+
+主要状态：
+
+- `state.currentMainView`
+- `state.currentProjectViewWorkspaceId`
+- `state.currentFeatureViewId`
+- `currentProjectViewMode`
+- `currentWorkspace`
+- `currentSnapshot`
+- `currentMountName`
+- tree、diff、feature view 的局部状态。
+
+用户可见区域：
+
+- toolbar：标题、摘要、刷新、关闭。
+- workspace snapshot：文件树、挂载点、workspace 信息。
+- diff 视图：文件变更列表、diff 内容。
+- open workspace/root 操作。
+- feature navigation：Skills、Automation、Gateway。
+- workspace tree、diff、feature navigation 和 feature loading 的动效入口见动效文档。
+
+空态、加载态、错误态：
+
+- workspace 不存在或未选择时显示空态。
+- snapshot、tree、diff 加载中显示加载 UI。
+- tree 节点加载失败记录错误并可重试刷新。
+
+关键交互：
+
+- 打开项目进入 workspace mode。
+- 切换 feature 进入 skills、automation、gateway。
+- 选择文件树路径加载子树或预览。
+- 刷新重新拉取 snapshot。
+- 关闭返回 session/chat 视图。
+
+依赖 API：
+
+- `fetchWorkspaceSnapshot`
+- `fetchWorkspaceTree`
+- `fetchWorkspaceDiffs`
+- `fetchWorkspaceDiffFile`
+- `openWorkspaceRoot`
+- `updateWorkspace`
+- feature 相关 API。
+
+## Observability 视图
+
+入口 DOM：
+
+- `#observability-view`
+- `#observability-global-btn`
+- `#observability-session-btn`
+- `#observability-scope-indicator`
+- `#observability-overview`
+- `#observability-trends`
+- `#observability-breakdowns`
+- `#observability-back-btn`
+
+负责模块：
+
+- `components/observability.js`
+
+主要状态：
+
+- 当前 scope：global 或 session。
+- 当前 session label。
+- overview、trend、breakdown 请求结果。
+
+用户可见区域：
+
+- 顶部 toolbar，展示标题、scope 切换、当前 session。
+- overview 指标区。
+- trends 区。
+- breakdowns 区。
+- scope 切换和指标区域以 hover/focus transition、loading/empty/error 状态为主，不做强数字动画。
+
+空态、加载态、错误态：
+
+- session scope 没有当前 session 时显示不可用或空态。
+- 请求加载中显示占位。
+- 请求失败显示错误提示并记录日志。
+
+关键交互：
+
+- 顶部按钮切换 global/session scope。
+- back 返回主会话或项目视图。
+- session 切换事件会刷新 session scope 的 label 和数据。
+
+依赖 API：
+
+- `fetchObservabilityOverview`
+- `fetchObservabilityBreakdowns`
+
+## 右侧 Rail 与 Inspector
+
+入口 DOM：
+
+- `#right-rail`
+- `#right-rail-resizer`
+- `#subagent-role-select`
+- `#subagent-status-summary`
+- `#subagent-role-meta`
+- `#agent-drawer`
+- `#rail-inspector`
+- `#system-logs`
+
+负责模块：
+
+- `components/subagentRail.js`
+- `components/subagentSessions.js`
+- `components/agentPanel/*`
+- `utils/logger.js`
+- `components/navbar.js`
+
+主要状态：
+
+- `state.rightRailExpanded`
+- `state.activeSubagentSession`
+- `state.activeView`
+- `state.activeAgentRoleId`
+- `state.activeAgentInstanceId`
+- `state.sessionAgents`
+- `state.sessionTasks`
+
+用户可见区域：
+
+- subagent 当前 agent 名称、id、role select、token badge。
+- reflection 刷新按钮和 stop 按钮。
+- 状态摘要和 role meta。
+- agent drawer 中的 agent history、reflection、task prompt 等面板。
+- inspector 中的 system logs。
+- run indicator、subagent session loading、project menu、rail 展开收起等动效详见 `motion-and-loading-states.md`。
+
+空态、加载态、错误态：
+
+- 没有 subagent 时显示空提示。
+- 加载 subagent 列表时显示 loading。
+- reflection 或 stop 失败通过 log/feedback 呈现。
+
+关键交互：
+
+- 顶部 subagents toggle 展开/收起 rail。
+- role select 切换观察的 agent。
+- reflection 按钮刷新 agent reflection。
+- stop 按钮停止 subagent 或相关 run。
+- system log 持续追加前端运行日志。
+
+依赖 API：
+
+- `fetchSessionAgents`
+- `fetchSessionSubagents`
+- `fetchAgentMessages`
+- `fetchAgentReflection`
+- `refreshAgentReflection`
+- `updateAgentReflection`
+- `stopBackgroundTask`

--- a/docs/frontend/runtime-flows.md
+++ b/docs/frontend/runtime-flows.md
@@ -1,0 +1,267 @@
+# 运行流程设计
+
+## 会话选择流程
+
+负责模块：
+
+- `app/session.js`
+- `app/sessionView.js`
+- `app/recovery.js`
+- `core/stream.js`
+- `components/sidebar.js`
+- `components/messageRenderer.js`
+- `components/subagentSessions.js`
+- `components/subagentRail.js`
+
+流程说明：
+
+1. 用户点击 sidebar session 或触发 `agent-teams-select-session`。
+2. `selectSession(sessionId)` 标准化 id，并创建新的 selection token 和 AbortController。
+3. 如果正在选择旧 session，旧 controller 被 abort，旧 loading 状态被清理。
+4. 如果切换到不同 session，前台 submission 和 active stream 会 detach，可能转入后台 stream。
+5. 更新 `state.currentSessionId`，清理 active subagent、agent panels、context indicators、token usage、stream overlay、recovery snapshot。
+6. UI 进入 session switch pending/loading 状态。
+7. 调用 `fetchSessionHistory(sessionId)`。
+8. 应用 session record 中的 mode、normal root role、orchestration preset、can switch mode。
+9. 调用 `hydrateMainSessionForSwitch()` 或 `hydrateSessionView()` 渲染历史和 round。
+10. 根据 terminal run 状态调用 `markSessionTerminalRunViewed()`。
+11. 刷新 coordinator context、session token usage、subagent session list。
+12. 派发 `agent-teams-session-selected`。
+
+```mermaid
+flowchart TD
+    A["用户选择 session"] --> B["selectSession(sessionId)"]
+    B --> C["abort 旧 selection controller"]
+    C --> D{"是否不同 session?"}
+    D -->|是| E["detach foreground submission 与 active stream"]
+    D -->|否| F["同步 live session"]
+    E --> G["写入 state.currentSessionId"]
+    G --> H["清理 panels, stream state, recovery, subagent"]
+    H --> I["fetchSessionHistory"]
+    I --> J["applyCurrentSessionRecord"]
+    J --> K["hydrateMainSessionForSwitch 或 hydrateSessionView"]
+    K --> L["mark terminal viewed, refresh token/context/subagent"]
+    L --> M["dispatch agent-teams-session-selected"]
+    F --> N["hydrateSessionView quiet"]
+    N --> L
+```
+
+并发与取消：
+
+- `sessionSelectionToken` 保证旧请求返回后不会覆盖新选择。
+- `AbortController` 传入 API 请求，切换时主动取消。
+- session switch loading 有短延迟，快速切换不会闪烁。
+
+## Subagent 会话选择流程
+
+负责模块：
+
+- `app/session.js`
+- `components/subagentSessions.js`
+- `components/subagentRail.js`
+
+流程说明：
+
+1. 用户选择 subagent session 或触发 `agent-teams-select-subagent-session`。
+2. 如果 parent session 正在加载，取消 parent selection，但保留目标 session id。
+3. 如果当前不是 parent session，先 `selectSession(parentSessionId)`。
+4. 从缓存 subagent records 中解析目标 instance，找不到时使用 fallback。
+5. 隐藏 project view，切回 rounds mode。
+6. 调用 `openSubagentSession()`。
+7. 后台刷新 subagent session list。
+8. 派发 `agent-teams-subagent-session-selected`。
+
+## Prompt 提交流程
+
+负责模块：
+
+- `app/prompt.js`
+- `components/newSessionDraft.js`
+- `components/rounds/timeline.js`
+- `core/submission.js`
+- `core/stream.js`
+
+流程说明：
+
+1. 用户在 composer 输入文本、附件、mention 或 slash command。
+2. `handlePromptComposerInput()` 同步输入状态、mention 菜单和 token chip。
+3. Enter 或表单 submit 调用 `handleSend()`。
+4. 如果当前是新会话草稿，先 `ensureSessionForNewSessionDraft()` 创建 session 并应用 topology。
+5. 根据 composer 解析 prompt text、input parts、display input parts、skills、target role、YOLO、thinking。
+6. 创建 live round 或 pending run placeholder。
+7. `beginForegroundSubmission()` 标记前台提交。
+8. `startIntentStream()` 调用 `sendUserPrompt()`，即 POST `/api/runs`。
+9. 后端返回 run 后，更新 `state.activeRunId` 和 run primary role。
+10. 连接前台 SSE，stream event 进入 `routeEvent()`。
+11. run terminal 后结束 stream，释放 composer busy 状态并刷新 session/recovery。
+
+```mermaid
+flowchart TD
+    A["composer 输入"] --> B["mention, slash command, attachment 解析"]
+    B --> C["handleSend"]
+    C --> D{"新会话草稿?"}
+    D -->|是| E["ensureSessionForNewSessionDraft"]
+    D -->|否| F["使用当前 session"]
+    E --> G["解析 prompt payload"]
+    F --> G
+    G --> H["createLiveRound 或 pending placeholder"]
+    H --> I["beginForegroundSubmission"]
+    I --> J["sendUserPrompt POST /api/runs"]
+    J --> K["设置 activeRunId 与 primary role"]
+    K --> L["attachRunStream"]
+    L --> M["SSE event -> routeEvent"]
+    M --> N["message timeline / tool / recovery UI 更新"]
+    N --> O["terminal event -> endStream"]
+```
+
+关键状态：
+
+- `state.isGenerating` 控制 composer 是否 busy。
+- `pendingRunStart` 用于处理 run 创建过程中 session 切换。
+- `pendingStopRequest` 支持 run 创建尚未完成时立即 stop。
+- `state.thinking` 和 `state.yolo` 来自 composer 控件和 localStorage。
+
+## SSE 流程
+
+负责模块：
+
+- `core/stream.js`
+- `core/eventRouter/index.js`
+- `core/eventRouter/runEvents.js`
+- `core/eventRouter/toolEvents.js`
+- `core/eventRouter/humanEvents.js`
+- `core/eventRouter/notificationEvents.js`
+- `components/messageRenderer/stream.js`
+- `app/recovery.js`
+
+连接类型：
+
+- 前台 run stream：当前会话正在运行的主要 EventSource。
+- 后台 run multiplex：用户切走 session 后仍需要跟踪的 run。
+- normal mode subagent stream：normal mode 下 subagent/background task 的流。
+
+流程说明：
+
+1. run 创建成功后 `attachRunStream()` 打开 EventSource。
+2. 收到 SSE 后解析 event type、payload、event meta。
+3. `routeEvent(evType, payload, eventMeta)` 去重 event id。
+4. 根据 run id 判断是否 subagent run。
+5. 更新 task instance/status、role instance 映射。
+6. 分发到 run/tool/human/notification/background task handler。
+7. handler 更新 message stream、thinking block、tool block、approval controls、round todo、token usage、recovery snapshot。
+8. terminal event 清理 seen event ids、stream state、busy 状态。
+
+```mermaid
+flowchart TD
+    A["EventSource message"] --> B["parse event type, payload, meta"]
+    B --> C["routeEvent"]
+    C --> D{"duplicate event_id?"}
+    D -->|是| E["ignore"]
+    D -->|否| F{"subagent run?"}
+    F -->|是| G["subagent run/tool/thinking handlers"]
+    F -->|否| H["main run/tool/human/notification handlers"]
+    G --> I["messageRenderer, subagentRail, recovery"]
+    H --> I
+    I --> J{"terminal event?"}
+    J -->|是| K["clear stream state and seen ids"]
+    J -->|否| L["keep stream active"]
+```
+
+断线与后台策略：
+
+- 前台切换 session 时，active stream 会 detach 为 background stream，避免 run 失联。
+- multiplex 连接维护多个后台 run，并有最大 stream 数预算。
+- reconnect delay 有上限，避免频繁重连。
+- 对 session/run not found 有 cooldown，避免重复请求打爆后端。
+
+## Event Router 分发
+
+主 run event：
+
+- `run_started`、`run_resumed`：标记 run 开始，同步 round todo。
+- `model_step_started` / `model_step_finished`：同步 agent/role/task 状态。
+- `text_delta` / `output_delta`：追加流式内容。
+- `thinking_started` / `thinking_delta` / `thinking_finished`：渲染 thinking block。
+- `generation_progress`：渲染生成进度。
+- `run_completed` / `run_failed` / `run_stopped`：终止 run，刷新 round 和 recovery。
+- `token_usage`：刷新 session token usage。
+- `todo_updated`：更新 round todo。
+
+tool event：
+
+- `tool_call`：追加 tool call block。
+- `tool_input_validation_failed`：标记输入校验失败。
+- `tool_result`：更新 tool result。
+- `tool_approval_requested`：挂载 approval controls。
+- `tool_approval_resolved`：标记 approval 结果，并触发恢复。
+
+human event：
+
+- `subagent_gate`
+- `subagent_stopped`
+- `subagent_resumed`
+- `gate_resolved`
+- user question requested/answered 主要通过 recovery snapshot 呈现。
+
+background task event：
+
+- `background_task_started`
+- `background_task_updated`
+- `background_task_completed`
+- `background_task_stopped`
+
+这些事件会刷新 recovery continuity，并在 payload 可展示时更新后台任务 UI 和 subagent session 记忆。
+
+## Recovery 流程
+
+负责模块：
+
+- `app/recovery.js`
+- `components/rounds/timeline.js`
+- `components/subagentRail.js`
+- `core/api/runs.js`
+- `core/api/sessions.js`
+
+恢复快照内容：
+
+- active run。
+- pending tool approvals。
+- pending user questions。
+- active background tasks。
+- paused subagent。
+- terminal run 状态。
+
+流程说明：
+
+1. session hydration 或 run event 后调用 `scheduleRecoveryContinuityRefresh()`。
+2. `refreshSessionRecovery()` 请求 `fetchSessionRecovery()`。
+3. `applyRecoverySnapshot()` 标准化快照，写入 `state.currentRecoverySnapshot`。
+4. 渲染 recovery banner、approval host、question host，并 overlay 到 round。
+5. 如果需要自动恢复，调用 `resumeRecoverableRun()`。
+6. 用户处理 approval 或 question 后，调用对应 API，再派发或监听恢复事件。
+7. terminal 状态或没有待处理项时清理 recovery snapshot。
+
+approval 表现：
+
+- pending approval 在 composer 上方或 message/tool block 中显示。
+- 用户可 approve/reject，并可提供 feedback。
+- action busy 时禁用对应按钮。
+- 失败时保留 pending 项并显示错误。
+
+user question 表现：
+
+- 展示一个或多个问题。
+- 支持选项或自由补充。
+- 支持 none-of-the-above 风格选项。
+- 提交后刷新 recovery。
+
+paused subagent 表现：
+
+- 显示暂停的 subagent、role、run 信息。
+- 用户可进入 subagent session 或恢复主 run。
+
+background task 表现：
+
+- 后台任务出现在 recovery/banner 或 session 相关状态中。
+- task 更新会延迟刷新 recovery，避免事件密集时过度请求。
+

--- a/docs/frontend/styling-and-i18n.md
+++ b/docs/frontend/styling-and-i18n.md
@@ -1,0 +1,190 @@
+# 样式与国际化设计
+
+## CSS 组织
+
+前端样式位于 `frontend/dist/css/`。
+
+### 基础样式
+
+- `base.css`
+  - 主题变量、字体、颜色、阴影、圆角。
+  - `body.light-theme` 下的浅色主题变量。
+  - 全局 reset、选区、基础动画 keyframes。动画详情见 `motion-and-loading-states.md`。
+- `layout.css`
+  - `.app-shell`、`.app-container`、`.topbar`、`.sidebar`、`.workspace`。
+  - chat container、chat scroll、input container、prompt attachment、prompt token 等主布局。
+
+### 组件样式
+
+`css/components/` 按功能拆分：
+
+- `base.css`：通用按钮、状态、小组件基础样式。
+- `features.css`：feature navigation 和功能入口。
+- `session-search.css`：会话搜索。
+- `projects.css`：项目、workspace、文件树、diff 等。
+- `automation.css`：自动化页面和编辑器。
+- `gateway.css`：网关页面、Feishu/Xiaoluban/WeChat 配置。
+- `messages.css`：消息样式 facade，继续引入 messages 子模块。
+- `orchestration.css`：编排相关表现。
+- `feedback.css`：toast、confirm、form dialog 等。
+- `rounds.css`：rounds 样式 facade，继续引入 rounds 子模块。
+- `recovery.css`：恢复 banner、approval、question 等。
+- `settings.css`：设置弹窗主样式。
+- `tokens.css`：token usage。
+- `tools.css`：tool call/result block。
+- `triggers.css`：trigger 相关 UI。
+- `subagent.css`：右侧 rail、subagent、agent drawer。
+- `observability.css`：观测视图。
+- `interface.css`：界面级控件补充。
+- `new-session-draft*.css`：新会话草稿页拆分样式。
+- `highlight.css`：代码高亮。
+
+### 子目录拆分
+
+- `components/messages/`
+  - `base.css`
+  - `actions.css`
+  - `blocks.css`
+  - `markdown.css`
+  - `prompt.css`
+  - `status.css`
+  - `streaming.css`
+  - `thinking.css`
+- `components/rounds/`
+  - `cards.css`
+  - `detail.css`
+  - `history.css`
+  - `navigator.css`
+  - `retry.css`
+  - `todo.css`
+- `components/settings/`
+  - `model-profiles.css`
+
+新增样式时应优先放入对应功能文件，避免继续把大量不相关样式塞入同一个大文件。
+
+动画、过渡和加载状态不在本文展开；维护这些表现时同时参考 `motion-and-loading-states.md`。
+
+## 主题 Token
+
+`base.css` 使用 CSS custom properties 管理主题。常用变量包括：
+
+- 背景：`--bg-base`、`--bg-surface`、`--bg-surface-glass`、`--bg-surface-muted`。
+- 文本：`--text-primary`、`--text-secondary`、`--text-on-primary`、`--text-msg-content`。
+- 边框：`--border-color`。
+- 操作色：`--primary`、`--primary-hover`、`--success`、`--danger`、`--warning`。
+- 按钮：`--button-primary-*`、`--button-secondary-*`。
+- 工具块：`--bg-tool-header`、`--bg-tool-body`、`--bg-tool-block`。
+- 设置弹窗：`--settings-*`。
+- 字体：`--font-ui`、`--font-mono`。
+- 圆角和阴影：`--radius-*`、`--shadow-*`。
+
+深色主题是默认主题，浅色主题通过 `body.light-theme` 覆盖变量实现。组件样式应引用变量，不应硬编码成只能适配单一主题的颜色。
+
+## 页面视觉约定
+
+整体视觉是紧凑、工具型、控制台式应用，而不是营销页：
+
+- 主布局保持 topbar、sidebar、workspace、right rail 的工作台结构。
+- 信息密度偏高，但通过分区、边框、弱背景和状态色保持可扫描。
+- 按钮、select、toggle、segmented control 等控件使用稳定尺寸，避免状态变化导致布局跳动。
+- 卡片只用于可重复项目、modal 或明确 framed tool，不把页面大段 section 套成多层 card。
+- 状态色语义固定：
+  - success 表示成功、在线、已完成。
+  - danger 表示失败、删除、危险操作。
+  - warning 表示警告、等待、需要用户处理。
+  - primary 表示当前选择、焦点或主要操作。
+- 右侧 rail 和 sidebar 通过 resizer 调整宽度，主工作区应在窄宽下保持 `min-width: 0` 防止溢出。
+
+## 响应与滚动
+
+当前前端是桌面工作台优先：
+
+- `body` 高度为 `100vh`，整体禁止页面级滚动。
+- sidebar、chat scroll、project content、settings body 等内部区域自己滚动。
+- chat 输入区固定在底部，消息区使用 `flex: 1`。
+- 长消息和长历史通过 message timeline、round paging、scroll controller 处理。
+- 文件树、diff、设置列表等区域应避免撑破父容器，必要时使用内部滚动。
+
+## Composer 样式约定
+
+composer 包含：
+
+- textarea 输入。
+- attachment 预览。
+- mention menu。
+- resume、send、stop 操作。
+- topology 控件：mode segmented、normal role、orchestration preset。
+- YOLO 和 thinking toggle。
+- context/token usage strip。
+
+运行中：
+
+- send、prompt、YOLO、thinking 控件禁用。
+- stop 按钮显示。
+- input wrapper 继续保持可读 busy 状态。
+
+错误或校验失败：
+
+- 使用 `prompt-input-status` 或 toast 显示用户可理解信息。
+- 附件错误可通过 `.prompt-attachments.is-error` 增强视觉。
+
+## Modal 与反馈
+
+反馈工具位于 `utils/feedback.js`，样式在 `components/feedback.css` 和各功能 CSS 中。
+
+常见 UI：
+
+- toast：短反馈。
+- confirm dialog：删除、启停、危险操作确认。
+- form dialog：需要输入或选择的操作。
+- settings modal：大型配置弹窗。
+- automation editor modal、gateway modal：feature 内专用编辑弹窗。
+
+Modal 约定：
+
+- overlay 点击可关闭的弹窗应明确处理 pointer down/up，避免拖拽误关。
+- 保存中禁用提交按钮。
+- 错误优先显示在弹窗内部，必要时同步 toast 或 system log。
+
+## 国际化设计
+
+国际化工具位于 `frontend/dist/js/utils/i18n.js`。
+
+当前支持语言：
+
+- `zh-CN`
+- `en-US`
+
+默认语言：
+
+- `zh-CN`
+
+语言来源：
+
+- 后端 UI language settings。
+- localStorage：`agent_teams_ui_language`。
+- 运行时切换按钮：`#language-toggle-btn`。
+
+## DOM 翻译约定
+
+静态 DOM 使用 data attribute：
+
+- `data-i18n`：设置文本内容。
+- `data-i18n-title`：设置 title。
+- `data-i18n-aria-label`：设置 aria-label。
+
+JS 动态 HTML 应使用：
+
+- `t(key)` 获取翻译。
+- `formatMessage(key, values)` 插值。
+- 渲染用户或 API 内容时先 escape，再和翻译拼接。
+- 动态插入大量 DOM 后调用 `translateDocument()` 或对应局部同步函数。
+
+## 文案维护规则
+
+新增用户可见文案时：
+
+1. 同时添加 `zh-CN` 和 `en-US` key。
+2. key 按功能域命名，例如 `settings.proxy.*`、`automation.schedule.*`、`sidebar.*`。
+3. 不在组件中写只支持一种语言的固定文本。
+4. title、aria-label、empty state、error message 都属于用户可见文案，应进入 i18n。

--- a/docs/frontend/testing-and-maintenance.md
+++ b/docs/frontend/testing-and-maintenance.md
@@ -1,0 +1,141 @@
+# 测试与维护
+
+## 测试地图
+
+前端测试分布在两个主要目录。
+
+### 单元测试
+
+`tests/unit_tests/frontend/` 覆盖静态前端模块的行为和结构。当前测试主题包括：
+
+- API facade 和 request helper。
+- backend status。
+- i18n。
+- logger。
+- Markdown 和 rich content。
+- message renderer、message timeline、scroll controller、streaming cursor、tool block。
+- run events、stream session overlay、recovery stream/background tasks。
+- rounds paging、retry、todo、history。
+- session selection、session view、session sidebar store。
+- project view、projects sidebar。
+- settings shell、accessibility、各 settings panel。
+- model profiles、roles、agents、commands、hooks、proxy、workspace、environment、system status。
+- subagent rail、subagent sessions、subagent streams。
+- prompt tokens、YOLO、workspace prompt。
+- CSS module split 和样式辅助校验。
+
+### 浏览器集成测试
+
+`tests/integration_tests/browser/` 覆盖真实浏览器或浏览器式场景：
+
+- backend status pressure。
+- browser smoke。
+- frontend module loading。
+- streaming message timeline。
+- message copy actions。
+- ClawHub browser flow。
+- GitHub browser flow。
+
+## 推荐验证命令
+
+文档变更通常不需要跑前端测试。前端代码或页面表现变更建议至少运行：
+
+```powershell
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_core_api_facade_exports.py
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_message_renderer_facade_exports.py
+uv run --extra dev pytest -q tests/integration_tests/browser/test_frontend_module_loading.py
+```
+
+涉及消息流、SSE、round、recovery 的变更建议补充：
+
+```powershell
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_run_events_ui.py
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_recovery_stream_ui.py
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_message_timeline_ui.py
+uv run --extra dev pytest -q tests/integration_tests/browser/test_streaming_message_timeline.py
+```
+
+涉及 settings 的变更建议运行对应 panel 测试，例如：
+
+```powershell
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_settings_shell_ui.py
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_model_profiles_ui.py
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_hooks_settings_ui.py
+```
+
+完整仓库自检仍以根目录 `AGENTS.md` 的 pre-commit self-check 为准。
+
+## 维护规则
+
+### 保持接口边界
+
+- 前端只能通过 `/api/*` HTTP/SSE 与后端交互。
+- 新增后端接口时，在 `frontend/dist/js/core/api/` 对应领域模块中封装，并从 `core/api/index.js` 导出。
+- 组件中不要散落裸 `fetch()`，除非是底层请求 helper 或非常明确的浏览器能力。
+
+### 保持模块边界
+
+- `app/` 负责流程编排，不承载大量局部 UI markup。
+- `core/` 负责共享运行能力，不包含页面专属布局。
+- `components/` 负责 UI 和功能区。
+- `utils/` 放横切工具，不放业务状态机。
+- 大文件继续拆分。特别是 project view、settings、message renderer、rounds 相关变更，应优先抽出 cohesive 子模块。
+
+### 状态同步
+
+- 当前会话、run、role、subagent 等共享状态使用 `core/state.js`。
+- 跨组件通知优先使用已有 DOM `CustomEvent` 约定。
+- 对异步请求要使用 token 或 AbortController 防止旧请求覆盖新 UI。
+- session switch、run creation、SSE attach/detach 是高并发区域，修改时要明确处理用户快速切换会话的情况。
+
+### 请求和缓存
+
+- GET 请求优先使用 `requestJsonManaged()`，尤其是列表、状态、配置、观测类接口。
+- mutation 后要调用对应 invalidate helper，确保列表和详情刷新。
+- 重请求或重 UI 刷新应设置合理 delay，避免 SSE 密集事件导致请求风暴。
+- AbortError 不应显示为普通错误。
+
+### SSE 和消息渲染
+
+- 新增 run event type 时，要更新 `core/eventRouter` 的分发、对应 handler、message/round/recovery 表现和测试。
+- stream block 更新要走 message renderer/timeline 的公共 API。
+- tool approval、user question、paused subagent 等会同时影响 message block、recovery banner 和 round overlay，需要一起验证。
+- terminal event 后要清理 run stream state，避免旧 overlay 残留。
+
+### 页面表现
+
+页面或组件新增状态时，至少考虑：
+
+- 正常数据态。
+- 空态。
+- 加载态。
+- 错误态。
+- 禁用态。
+- 长文本和窄宽显示。
+- 深色和浅色主题。
+- 中英文文案长度差异。
+
+### 国际化
+
+- 新增文案必须同时添加 `zh-CN` 和 `en-US`。
+- 静态 DOM 使用 `data-i18n`、`data-i18n-title`、`data-i18n-aria-label`。
+- 动态 HTML 使用 `t()` 或 `formatMessage()`。
+- 用户输入和 API 返回内容必须 escape 后再写入 HTML。
+
+### CSS
+
+- 优先使用 `base.css` 的主题变量。
+- 新样式放到对应组件 CSS，不要继续扩大不相关文件。
+- 避免只在深色或浅色主题下可读的硬编码颜色。
+- 固定格式 UI 需要稳定尺寸，防止 hover、loading、label 或动态内容改变布局。
+
+## 文档维护
+
+当以下内容变化时，应同步更新 `docs/frontend/`：
+
+- 新增或移除顶层页面/feature view。
+- 调整 `app/`、`core/`、`components/` 的职责边界。
+- 新增 SSE event type 或浏览器 CustomEvent。
+- 修改 settings tab、project feature、gateway、automation 的页面结构。
+- 改变 API facade 或请求策略。
+- 改变主题、i18n 或测试组织。


### PR DESCRIPTION
## Summary
- add a frontend documentation set under `docs/frontend/`
- cover architecture, page behavior, features, runtime flows, API/events, styling/i18n, motion/loading states, and maintenance guidance
- document current `frontend/dist` implementation without changing runtime frontend code

## Validation
- verified referenced documentation and CSS paths exist
- verified documented motion keyframes exist in current CSS

Fixes #594