### PR TITLE
FE-5: add evidence bundle and semantic verification

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory is organized by documentation purpose and runtime module.
 
 - [Agents](modules/agents/)
 - [Orchestration policy](modules/agents/orchestration-policy-design.md)
+- [Verification evidence and semantic checks](modules/agents/verification-evidence-semantic-spec.md)
 - [Automation](modules/automation/ao4-async-path-unification.md)
 - [CLI commands](modules/cli/commands.md)
 - [Frontend](modules/frontend/README.md)

--- a/docs/modules/agents/verification-evidence-semantic-spec.md
+++ b/docs/modules/agents/verification-evidence-semantic-spec.md
@@ -72,7 +72,7 @@ Supported kinds:
 - `formal_proof`: command output with formal verification markers
 - `tool_call`: scoped tool invocation event
 - `tool_result`: scoped tool result event
-- `gate_finding`: scoped gate, finding, or timeout event
+- `gate_finding`: scoped gate, finding, or timeout event; gate and finding events are successful evidence unless they explicitly carry `passed=false`, while timeout events are failed evidence
 
 `VerificationEvidenceLink` connects one acceptance criterion or evidence expectation to matching evidence item ids. A link is satisfied only when at least one eligible evidence item matches the target text.
 

--- a/docs/modules/agents/verification-evidence-semantic-spec.md
+++ b/docs/modules/agents/verification-evidence-semantic-spec.md
@@ -1,0 +1,153 @@
+# Verification Evidence and Semantic Checks Spec
+
+## 1. Goal
+
+FE-5 upgrades task verification from result-text matching to evidence-backed verification.
+
+The runtime should produce a `VerificationReport` that explains:
+
+- which structure, behavior, evidence, and semantic checks ran
+- which concrete evidence items were collected
+- which evidence items support each acceptance criterion or expected evidence statement
+- which semantic verdict was reached for each acceptance criterion
+
+This makes task verification auditable while keeping the public task contract explicit and serializable.
+
+## 2. Scope
+
+This phase covers the in-process verification engine used by `verify_task(...)`.
+
+Included behavior:
+
+- normalize task result text, required-file checks, command checks, scoped tool events, and gate findings into a `VerificationEvidenceBundle`
+- classify command output as test, lint, diff, formal-proof, or generic command evidence
+- parse lightweight metrics from command output, such as passed tests, lint errors, changed files, and formal proof completion
+- link acceptance criteria and evidence expectations to concrete evidence items
+- add evidence and semantic check layers to the report
+- support an optional semantic evaluator callback with rule fallback
+
+Out of scope for this phase:
+
+- wiring an LLM semantic evaluator into provider runtime configuration
+- changing database schema or HTTP API contracts
+- making task-result self-reports sufficient evidence
+- accepting unscoped run events as task evidence
+
+## 3. Runtime Contract
+
+### 3.1 Inputs
+
+`VerificationPlan` remains the input contract. Existing fields continue to drive verification:
+
+- `checklist` performs structural result checks such as `non_empty_response`
+- `required_files` checks workspace artifacts
+- `command_checks` runs approved shell commands with bounded output capture
+- `acceptance_criteria` defines the semantic target statements
+- `evidence_expectations` defines expected proof artifacts or command output
+
+`verify_task(...)` also accepts an optional `semantic_evaluator` callback. The callback receives a `SemanticEvaluationRequest` with task id, criterion, result excerpt, and linked evidence items.
+
+### 3.2 Outputs
+
+`VerificationReport` now carries:
+
+- `checks`: structure, behavior, evidence, and semantic check results
+- `evidence_bundle`: normalized evidence items plus acceptance and expectation links
+- `semantic_results`: per-criterion semantic verdicts with confidence, reason, evaluator name, and evidence ids
+
+The report still determines pass/fail from failed checks. A task only passes when all required checks, evidence links, and semantic acceptance checks pass.
+
+## 4. Evidence Model
+
+`VerificationEvidenceItem` is the normalized evidence unit.
+
+Supported kinds:
+
+- `task_result`: task result text, retained for context but not linkable evidence
+- `required_file`: required artifact exists and is a regular file
+- `command`: generic command output
+- `test_result`: command output with test markers
+- `lint_result`: command output with lint/type-check markers
+- `diff_summary`: command output with diff summary markers
+- `formal_proof`: command output with formal verification markers
+- `tool_call`: scoped tool invocation event
+- `tool_result`: scoped tool result event
+- `gate_finding`: scoped gate, finding, or timeout event
+
+`VerificationEvidenceLink` connects one acceptance criterion or evidence expectation to matching evidence item ids. A link is satisfied only when at least one eligible evidence item matches the target text.
+
+Eligibility rules:
+
+- failed evidence cannot support a link
+- skipped verification checks cannot support a link
+- `task_result` cannot support acceptance or evidence links
+- `tool_call` cannot support acceptance criteria because a call alone does not prove completion
+- run-event evidence must have `task_id` equal to the verified task id
+
+## 5. Semantic Checks
+
+Semantic checks run after evidence linking.
+
+The rule evaluator accepts an acceptance criterion only when linked evidence includes at least one strong evidence item:
+
+- required file
+- command result
+- test result
+- lint result
+- diff summary
+- formal proof
+- tool result
+- gate finding
+
+Self-reported result text and tool-call-only evidence are treated as weak evidence and fail semantic acceptance. This prevents a task from passing by repeating the criterion in its final answer without independent proof.
+
+If an external semantic evaluator is provided, its result is used after normalizing the evaluator name. If it raises, `verify_task(...)` logs `verification.semantic_evaluator_failed` and uses the rule verdict instead.
+
+## 6. Implementation
+
+Primary source files:
+
+- `src/relay_teams/agents/tasks/enums.py`
+- `src/relay_teams/agents/tasks/models.py`
+- `src/relay_teams/agents/tasks/__init__.py`
+- `src/relay_teams/agents/orchestration/verification.py`
+
+The orchestration flow is:
+
+1. Build baseline checklist, required-file, and command checks.
+2. Convert checks into normalized evidence items.
+3. Collect task-scoped run events from `EventLog`.
+4. Link evidence items to acceptance criteria and evidence expectations.
+5. Add evidence coverage checks.
+6. Run rule or external semantic evaluation.
+7. Add semantic checks and emit the final `VerificationReport`.
+
+The implementation keeps imports at module scope and uses explicit Pydantic models instead of loose dictionaries for public task contracts.
+
+## 7. Validation
+
+Unit coverage lives in:
+
+- `tests/unit_tests/agents/orchestration/test_verification.py`
+- `tests/unit_tests/agents/tasks/test_task_models.py`
+
+The tests cover:
+
+- structured report generation
+- command output evidence linking
+- missing evidence failures
+- task-scoped tool result evidence
+- rejection of unscoped run events
+- semantic evaluator fallback
+- required-file edge cases
+- bounded command output behavior
+- evidence helper edge cases
+- lint classification before generic test/pass terms
+- singular/plural token normalization for evidence matching
+
+Recommended validation for this feature:
+
+```bash
+uv run --extra dev pytest -q tests/unit_tests/agents/orchestration/test_verification.py tests/unit_tests/agents/tasks/test_task_models.py
+uv run --extra dev ruff check src/relay_teams/agents/orchestration/verification.py src/relay_teams/agents/tasks tests/unit_tests/agents/orchestration/test_verification.py tests/unit_tests/agents/tasks/test_task_models.py
+```

--- a/docs/research/lessons-learned-2026.md
+++ b/docs/research/lessons-learned-2026.md
@@ -969,7 +969,9 @@ MCP 集成已存在（`mcp/` 模块），但 A2A 协议尚未实现。`external_
 
 部分已升级（2026-04-28）。`verify_task()` 不再只是非空/字符串 checklist：`VerificationPlan` 支持 `required_files`、`command_checks`、`acceptance_criteria`、`evidence_expectations`，命令验证会受 `ToolApprovalPolicy` 和 role allowed tools 约束，并对 stdout/stderr 做 bounded capture；结果汇总为结构化 `VerificationReport`。
 
-仍然薄弱的是语义层：acceptance criteria 和 evidence expectations 目前仍以"结果文本是否引用该条目"为主，无法判断实现是否真的满足规格；也没有将文件 diff、测试日志、工具调用、Gater findings 归一化为 Evidence Bundle。
+2026-05-01 已继续补齐 Evidence Bundle 与语义判定基础：`VerificationReport` 现在携带 normalized `VerificationEvidenceBundle`，会把任务结果、required file、命令输出、工具调用/结果事件和 Gater/timeout 类 findings 归一化为 evidence item；测试、lint、diff、形式化验证命令输出会解析为结构化 metrics。acceptance criteria 与 evidence expectations 不再只看结果文本引用，而是生成 evidence link，并新增 Evidence 与 Semantic 两层检查。语义层先落地规则 evaluator，并预留外部/LLM evaluator 注入点；外部 evaluator 失败时会记录日志并回退到规则判定。
+
+仍需后续增强的是：将真实 LLM evaluator 接入运行时 provider，并对高严格度任务增加更强的重复性控制、多模型互评和形式化验证 profile。
 
 #### 对比价值
 
@@ -985,7 +987,7 @@ MCP 集成已存在（`mcp/` 模块），但 A2A 协议尚未实现。`external_
 
 #### 实施建议
 
-在现有 `VerificationReport` 上继续升级为四层验证：(1) **结构验证**——沿用 required files、格式/schema、关键字段检查；(2) **行为验证**——沿用 command checks，并增加测试、lint、diff 统计的标准化解析；(3) **证据验证**——检查每条 acceptance criterion 是否有对应 evidence item，而不仅是文本引用；(4) **语义合规验证**——由 LLM 或规则+LLM 混合 evaluator 判断实现是否满足 spec，并输出可复核理由。
+在现有 `VerificationReport` 上继续升级为四层验证：(1) **结构验证**——沿用 required files、格式/schema、关键字段检查；(2) **行为验证**——沿用 command checks，并增加测试、lint、diff 统计的标准化解析；(3) **证据验证**——检查每条 acceptance criterion 是否有对应 evidence item，而不仅是文本引用；(4) **语义合规验证**——由 LLM 或规则+LLM 混合 evaluator 判断实现是否满足 spec，并输出可复核理由。第一阶段已落地 Evidence Bundle、证据链接、规则语义 evaluator 和外部 evaluator 回退机制，后续应把 LLM evaluator 接到受控运行时配置。
 
 #### 可行性确认
 

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -1113,7 +1113,7 @@ def _rule_semantic_evaluation(
 
 
 def _is_strong_evidence(item: VerificationEvidenceItem) -> bool:
-    if item.passed is not True:
+    if not item.passed:
         return False
     return item.kind in {
         VerificationEvidenceKind.REQUIRED_FILE,

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -788,7 +788,7 @@ def _event_evidence_items(
     items: list[VerificationEvidenceItem] = []
     for index, event in enumerate(event_bus.list_by_trace(trace_id), start=1):
         event_task_id = str(event.get("task_id") or "")
-        if event_task_id and event_task_id != task_id:
+        if event_task_id != task_id:
             continue
         item = _event_evidence_item(index=index, event=event)
         if item is not None:

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -894,9 +894,18 @@ def _gate_finding_evidence_item(
         kind=VerificationEvidenceKind.GATE_FINDING,
         summary=f"Gate event {event_type} was recorded.",
         source="event_log",
-        passed=None,
+        passed=_gate_finding_passed(event_type=event_type, payload=payload),
         output_excerpt=_json_excerpt(feedback),
     )
+
+
+def _gate_finding_passed(*, event_type: str, payload: dict[str, object]) -> bool:
+    if event_type == EventType.TASK_TIMEOUT.value:
+        return False
+    passed = payload.get("passed")
+    if isinstance(passed, bool):
+        return passed
+    return True
 
 
 def _link_evidence_to_plan(

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -969,6 +969,8 @@ def _evidence_can_support_text(
         return False
     if item.source == "verification_check_skipped":
         return False
+    if item.kind == VerificationEvidenceKind.TASK_RESULT:
+        return False
     if (
         target == VerificationEvidenceTarget.ACCEPTANCE_CRITERION
         and item.kind == VerificationEvidenceKind.TOOL_CALL
@@ -1095,11 +1097,11 @@ def _rule_semantic_evaluation(
     if self_report_ids:
         return SemanticEvaluationResult(
             criterion=criterion,
-            passed=True,
-            confidence=0.45,
+            passed=False,
+            confidence=0.25,
             reason=(
-                "The task result self-reports this criterion, but no independent "
-                "verification evidence was linked."
+                "The task result self-reports this criterion, but independent "
+                "verification evidence is required."
             ),
             evidence_ids=self_report_ids,
         )

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -1,23 +1,39 @@
 from __future__ import annotations
 
 import io
+import json
+import logging
+import re
 import subprocess
 import threading
 import time
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import IO, Literal, NamedTuple
 
 from relay_teams.agents.tasks.enums import TaskStatus
 from relay_teams.agents.tasks.events import EventEnvelope, EventType
 from relay_teams.agents.tasks.models import (
+    SemanticEvaluationRequest,
+    SemanticEvaluationResult,
     VerificationCheckResult,
     VerificationCommand,
+    VerificationEvidenceBundle,
+    VerificationEvidenceItem,
+    VerificationEvidenceLink,
+    VerificationEvidenceMetric,
     VerificationPlan,
     VerificationReport,
     VerificationResult,
 )
-from relay_teams.agents.tasks.enums import VerificationLayer
+from relay_teams.agents.tasks.enums import (
+    VerificationEvidenceKind,
+    VerificationEvidenceTarget,
+    VerificationLayer,
+)
+from relay_teams.logger import get_logger, log_event
 from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.tools.runtime.models import ToolRuntimeDecision
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
@@ -27,6 +43,14 @@ _OUTPUT_READ_CHUNK_BYTES = 8192
 _OUTPUT_EXCERPT_CHARS = 2000
 _PROCESS_POLL_INTERVAL_SECONDS = 0.05
 _OUTPUT_READER_JOIN_TIMEOUT_SECONDS = 0.05
+_EVIDENCE_TEXT_MATCH_MIN_TOKEN_COUNT = 2
+_EVIDENCE_TEXT_MATCH_MIN_OVERLAP = 0.6
+
+LOGGER = get_logger(__name__)
+
+SemanticVerificationEvaluator = Callable[
+    [SemanticEvaluationRequest], SemanticEvaluationResult
+]
 
 
 class _BoundedCommandResult(NamedTuple):
@@ -34,6 +58,12 @@ class _BoundedCommandResult(NamedTuple):
     stdout: bytes
     stderr: bytes
     output_truncated: bool
+
+
+class _VerificationPlanRun(NamedTuple):
+    checks: tuple[VerificationCheckResult, ...]
+    evidence_bundle: VerificationEvidenceBundle
+    semantic_results: tuple[SemanticEvaluationResult, ...]
 
 
 class _BoundedOutputCapture:
@@ -80,8 +110,11 @@ def verify_task(
     allowed_tools: tuple[str, ...] = (),
     tool_approval_policy: ToolApprovalPolicy | None = None,
     workspace_root: Path | None = None,
+    semantic_evaluator: SemanticVerificationEvaluator | None = None,
 ) -> VerificationResult:
     task = task_repo.get(task_id)
+    evidence_bundle: VerificationEvidenceBundle | None = None
+    semantic_results: tuple[SemanticEvaluationResult, ...] = ()
     if task.status != TaskStatus.COMPLETED or task.result is None:
         passed = False
         details = ("Task not completed yet",)
@@ -95,13 +128,21 @@ def verify_task(
         )
         event_type = EventType.VERIFICATION_FAILED
     else:
-        checks = _run_verification_plan(
+        plan_run = _run_verification_plan(
+            task_id=task.envelope.task_id,
             plan=task.envelope.verification,
             result=task.result,
+            event_bus=event_bus,
+            trace_id=task.envelope.trace_id,
+            task_id_filter=task.envelope.task_id,
             allowed_tools=allowed_tools,
             tool_approval_policy=tool_approval_policy or ToolApprovalPolicy(),
             workspace_root=workspace_root,
+            semantic_evaluator=semantic_evaluator,
         )
+        checks = plan_run.checks
+        evidence_bundle = plan_run.evidence_bundle
+        semantic_results = plan_run.semantic_results
         missing = tuple(
             check.name for check in checks if not check.passed and check.name
         )
@@ -116,6 +157,8 @@ def verify_task(
         passed=passed,
         checks=checks,
         unmet_items=() if passed else details,
+        evidence_bundle=evidence_bundle,
+        semantic_results=semantic_results,
     )
     verification = VerificationResult(
         task_id=task.envelope.task_id,
@@ -137,25 +180,73 @@ def verify_task(
 
 def _run_verification_plan(
     *,
+    task_id: str,
     plan: VerificationPlan,
     result: str,
+    event_bus: EventLog,
+    trace_id: str,
+    task_id_filter: str,
     allowed_tools: tuple[str, ...],
     tool_approval_policy: ToolApprovalPolicy,
     workspace_root: Path | None,
-) -> tuple[VerificationCheckResult, ...]:
+    semantic_evaluator: SemanticVerificationEvaluator | None,
+) -> _VerificationPlanRun:
     checks: list[VerificationCheckResult] = []
+    evidence_items: list[VerificationEvidenceItem] = [
+        _task_result_evidence_item(result)
+    ]
     checks.extend(_run_checklist_checks(plan=plan, result=result))
-    checks.extend(_run_required_file_checks(plan=plan, workspace_root=workspace_root))
-    checks.extend(
-        _run_command_checks(
-            plan=plan,
-            allowed_tools=allowed_tools,
-            tool_approval_policy=tool_approval_policy,
-            workspace_root=workspace_root,
+    required_file_checks = _run_required_file_checks(
+        plan=plan, workspace_root=workspace_root
+    )
+    checks.extend(required_file_checks)
+    evidence_items.extend(_evidence_items_from_checks(required_file_checks))
+    command_checks = _run_command_checks(
+        plan=plan,
+        allowed_tools=allowed_tools,
+        tool_approval_policy=tool_approval_policy,
+        workspace_root=workspace_root,
+    )
+    checks.extend(command_checks)
+    evidence_items.extend(_evidence_items_from_checks(command_checks))
+    evidence_items.extend(
+        _event_evidence_items(
+            event_bus=event_bus,
+            trace_id=trace_id,
+            task_id=task_id_filter,
         )
     )
-    checks.extend(_run_spec_evidence_checks(plan=plan, result=result))
-    return tuple(checks)
+    (
+        evidence_items_with_supports,
+        acceptance_links,
+        expectation_links,
+    ) = _link_evidence_to_plan(plan=plan, evidence_items=tuple(evidence_items))
+    checks.extend(
+        _run_evidence_coverage_checks(
+            acceptance_links=acceptance_links,
+            expectation_links=expectation_links,
+        )
+    )
+    semantic_results = _run_semantic_evaluations(
+        task_id=task_id,
+        criteria=plan.acceptance_criteria,
+        result=result,
+        evidence_items=evidence_items_with_supports,
+        acceptance_links=acceptance_links,
+        semantic_evaluator=semantic_evaluator,
+    )
+    checks.extend(_semantic_evaluation_checks(semantic_results))
+    evidence_bundle = VerificationEvidenceBundle(
+        task_id=task_id,
+        items=evidence_items_with_supports,
+        acceptance_links=acceptance_links,
+        expectation_links=expectation_links,
+    )
+    return _VerificationPlanRun(
+        checks=tuple(checks),
+        evidence_bundle=evidence_bundle,
+        semantic_results=semantic_results,
+    )
 
 
 def _run_checklist_checks(
@@ -525,42 +616,717 @@ def _kill_process_and_wait(process: subprocess.Popen[bytes]) -> int:
     return process.wait()
 
 
-def _run_spec_evidence_checks(
+def _task_result_evidence_item(result: str) -> VerificationEvidenceItem:
+    return VerificationEvidenceItem(
+        evidence_id="task_result",
+        kind=VerificationEvidenceKind.TASK_RESULT,
+        summary="Task result text",
+        source="task_result",
+        passed=bool(result.strip()),
+        output_excerpt=_text_excerpt(result),
+    )
+
+
+def _evidence_items_from_checks(
+    checks: list[VerificationCheckResult],
+) -> tuple[VerificationEvidenceItem, ...]:
+    items: list[VerificationEvidenceItem] = []
+    for index, check in enumerate(checks, start=1):
+        items.append(
+            VerificationEvidenceItem(
+                evidence_id=_evidence_id("check", index, check.name),
+                kind=_evidence_kind_from_check(check),
+                summary=_check_evidence_summary(check),
+                source=_check_evidence_source(check),
+                passed=_check_evidence_passed(check),
+                path=check.evidence_path,
+                command=check.command,
+                exit_code=check.exit_code,
+                output_excerpt=check.output_excerpt,
+                metrics=_evidence_metrics_for_check(check),
+            )
+        )
+    return tuple(items)
+
+
+def _evidence_kind_from_check(
+    check: VerificationCheckResult,
+) -> VerificationEvidenceKind:
+    if check.layer == VerificationLayer.STRUCTURE and check.name.startswith(
+        "required_file:"
+    ):
+        return VerificationEvidenceKind.REQUIRED_FILE
+    if check.layer == VerificationLayer.BEHAVIOR:
+        return _command_evidence_kind(check)
+    return VerificationEvidenceKind.COMMAND
+
+
+def _command_evidence_kind(
+    check: VerificationCheckResult,
+) -> VerificationEvidenceKind:
+    command_text = " ".join(check.command).casefold()
+    output_text = check.output_excerpt.casefold()
+    combined_text = f"{command_text}\n{output_text}"
+    if _text_mentions_any(
+        combined_text,
+        ("pytest", "unittest", "test", "passed", "failed", "coverage"),
+    ):
+        return VerificationEvidenceKind.TEST_RESULT
+    if _text_mentions_any(
+        combined_text,
+        ("ruff", "lint", "basedpyright", "pyright", "mypy", "flake8"),
+    ):
+        return VerificationEvidenceKind.LINT_RESULT
+    if _text_mentions_any(
+        combined_text,
+        ("git diff", "files changed", "insertion", "deletion"),
+    ):
+        return VerificationEvidenceKind.DIFF_SUMMARY
+    if _text_mentions_any(
+        combined_text,
+        ("tla", "alloy", "lean", "coq", "isabelle", "model check", "proof"),
+    ):
+        return VerificationEvidenceKind.FORMAL_PROOF
+    return VerificationEvidenceKind.COMMAND
+
+
+def _check_evidence_summary(check: VerificationCheckResult) -> str:
+    if check.command:
+        command_text = " ".join(check.command)
+        status = "passed" if check.passed else "failed"
+        return f"Command {command_text} {status}."
+    if check.evidence_path is not None:
+        status = "exists" if check.passed else "missing"
+        return f"Required file {check.evidence_path} {status}."
+    return check.details or check.name
+
+
+def _check_evidence_source(check: VerificationCheckResult) -> str:
+    if "skipped until shell approval" in check.details:
+        return "verification_check_skipped"
+    return "verification_check"
+
+
+def _check_evidence_passed(check: VerificationCheckResult) -> bool | None:
+    if "skipped until shell approval" in check.details:
+        return None
+    return check.passed
+
+
+def _evidence_metrics_for_check(
+    check: VerificationCheckResult,
+) -> tuple[VerificationEvidenceMetric, ...]:
+    output = check.output_excerpt
+    values: dict[str, int] = {}
+    _collect_test_metrics(output, values)
+    _collect_lint_metrics(output, values)
+    _collect_diff_metrics(output, values)
+    _collect_formal_metrics(check, output, values)
+    return tuple(
+        VerificationEvidenceMetric(name=name, value=value)
+        for name, value in sorted(values.items())
+    )
+
+
+def _collect_test_metrics(output: str, values: dict[str, int]) -> None:
+    metric_patterns = {
+        "tests_passed": r"(\d+)\s+passed",
+        "tests_failed": r"(\d+)\s+failed",
+        "test_errors": r"(\d+)\s+errors?",
+        "tests_skipped": r"(\d+)\s+skipped",
+    }
+    for metric_name, pattern in metric_patterns.items():
+        match = re.search(pattern, output, flags=re.IGNORECASE)
+        if match is not None:
+            values[metric_name] = int(match.group(1))
+    ran_match = re.search(r"Ran\s+(\d+)\s+tests?", output, flags=re.IGNORECASE)
+    if ran_match is not None:
+        values["tests_total"] = int(ran_match.group(1))
+
+
+def _collect_lint_metrics(output: str, values: dict[str, int]) -> None:
+    found_match = re.search(r"Found\s+(\d+)\s+errors?", output, flags=re.IGNORECASE)
+    if found_match is not None:
+        values["lint_errors"] = int(found_match.group(1))
+        return
+    if re.search(r"All checks passed", output, flags=re.IGNORECASE) is not None:
+        values["lint_errors"] = 0
+
+
+def _collect_diff_metrics(output: str, values: dict[str, int]) -> None:
+    pattern_by_name = {
+        "files_changed": r"(\d+)\s+files?\s+changed",
+        "insertions": r"(\d+)\s+insertions?\(\+\)",
+        "deletions": r"(\d+)\s+deletions?\(-\)",
+    }
+    for metric_name, pattern in pattern_by_name.items():
+        match = re.search(pattern, output, flags=re.IGNORECASE)
+        if match is not None:
+            values[metric_name] = int(match.group(1))
+
+
+def _collect_formal_metrics(
+    check: VerificationCheckResult,
+    output: str,
+    values: dict[str, int],
+) -> None:
+    if _command_evidence_kind(check) != VerificationEvidenceKind.FORMAL_PROOF:
+        return
+    if check.passed or _text_mentions_any(
+        output.casefold(),
+        ("no error has been found", "proof completed", "qed", "no counterexample"),
+    ):
+        values["formal_checks_passed"] = 1
+
+
+def _event_evidence_items(
+    *,
+    event_bus: EventLog,
+    trace_id: str,
+    task_id: str,
+) -> tuple[VerificationEvidenceItem, ...]:
+    items: list[VerificationEvidenceItem] = []
+    for index, event in enumerate(event_bus.list_by_trace(trace_id), start=1):
+        event_task_id = str(event.get("task_id") or "")
+        if event_task_id and event_task_id != task_id:
+            continue
+        item = _event_evidence_item(index=index, event=event)
+        if item is not None:
+            items.append(item)
+    return tuple(items)
+
+
+def _event_evidence_item(
+    *,
+    index: int,
+    event: Mapping[str, object],
+) -> VerificationEvidenceItem | None:
+    event_type = str(event.get("event_type") or "")
+    payload = _parse_event_payload(event.get("payload_json"))
+    if event_type == RunEventType.TOOL_CALL.value:
+        return _tool_call_evidence_item(index=index, payload=payload)
+    if event_type == RunEventType.TOOL_RESULT.value:
+        return _tool_result_evidence_item(index=index, payload=payload)
+    if _is_gate_finding_event(event_type=event_type, payload=payload):
+        return _gate_finding_evidence_item(
+            index=index, event_type=event_type, payload=payload
+        )
+    return None
+
+
+def _tool_call_evidence_item(
+    *,
+    index: int,
+    payload: dict[str, object],
+) -> VerificationEvidenceItem | None:
+    tool_name = str(payload.get("tool_name") or "").strip()
+    tool_call_id = str(payload.get("tool_call_id") or "").strip()
+    if not tool_name or not tool_call_id:
+        return None
+    return VerificationEvidenceItem(
+        evidence_id=_evidence_id("tool_call", index, tool_call_id),
+        kind=VerificationEvidenceKind.TOOL_CALL,
+        summary=f"Tool {tool_name} was called.",
+        source="event_log",
+        passed=None,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        output_excerpt=_json_excerpt(payload.get("args")),
+    )
+
+
+def _tool_result_evidence_item(
+    *,
+    index: int,
+    payload: dict[str, object],
+) -> VerificationEvidenceItem | None:
+    tool_name = str(payload.get("tool_name") or "").strip()
+    tool_call_id = str(payload.get("tool_call_id") or "").strip()
+    if not tool_name or not tool_call_id:
+        return None
+    is_error = payload.get("error") is True
+    return VerificationEvidenceItem(
+        evidence_id=_evidence_id("tool_result", index, tool_call_id),
+        kind=VerificationEvidenceKind.TOOL_RESULT,
+        summary=f"Tool {tool_name} returned {'an error' if is_error else 'a result'}.",
+        source="event_log",
+        passed=not is_error,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        output_excerpt=_json_excerpt(payload.get("result")),
+    )
+
+
+def _is_gate_finding_event(
+    *,
+    event_type: str,
+    payload: dict[str, object],
+) -> bool:
+    role_id = str(payload.get("role_id") or "").casefold()
+    return (
+        "gater" in role_id
+        or "gate" in role_id
+        or "finding" in payload
+        or "findings" in payload
+        or event_type == EventType.TASK_TIMEOUT.value
+    )
+
+
+def _gate_finding_evidence_item(
+    *,
+    index: int,
+    event_type: str,
+    payload: dict[str, object],
+) -> VerificationEvidenceItem:
+    feedback = (
+        payload.get("findings")
+        or payload.get("finding")
+        or payload.get("feedback")
+        or payload
+    )
+    return VerificationEvidenceItem(
+        evidence_id=_evidence_id("gate", index, event_type),
+        kind=VerificationEvidenceKind.GATE_FINDING,
+        summary=f"Gate event {event_type} was recorded.",
+        source="event_log",
+        passed=None,
+        output_excerpt=_json_excerpt(feedback),
+    )
+
+
+def _link_evidence_to_plan(
     *,
     plan: VerificationPlan,
-    result: str,
-) -> list[VerificationCheckResult]:
-    normalized_result = result.lower()
+    evidence_items: tuple[VerificationEvidenceItem, ...],
+) -> tuple[
+    tuple[VerificationEvidenceItem, ...],
+    tuple[VerificationEvidenceLink, ...],
+    tuple[VerificationEvidenceLink, ...],
+]:
+    supports_by_id: dict[str, set[str]] = {
+        item.evidence_id: set(item.supports) for item in evidence_items
+    }
+    acceptance_links = tuple(
+        _link_text_to_evidence(
+            text=criterion,
+            target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,
+            evidence_items=evidence_items,
+            supports_by_id=supports_by_id,
+        )
+        for criterion in plan.acceptance_criteria
+    )
+    expectation_links = tuple(
+        _link_text_to_evidence(
+            text=expectation,
+            target=VerificationEvidenceTarget.EVIDENCE_EXPECTATION,
+            evidence_items=evidence_items,
+            supports_by_id=supports_by_id,
+        )
+        for expectation in plan.evidence_expectations
+    )
+    supported_items = tuple(
+        item.model_copy(
+            update={"supports": tuple(sorted(supports_by_id[item.evidence_id]))}
+        )
+        for item in evidence_items
+    )
+    return supported_items, acceptance_links, expectation_links
+
+
+def _link_text_to_evidence(
+    *,
+    text: str,
+    target: VerificationEvidenceTarget,
+    evidence_items: tuple[VerificationEvidenceItem, ...],
+    supports_by_id: dict[str, set[str]],
+) -> VerificationEvidenceLink:
+    evidence_ids: list[str] = []
+    for item in evidence_items:
+        if not _evidence_can_support_text(text=text, target=target, item=item):
+            continue
+        evidence_ids.append(item.evidence_id)
+        supports_by_id[item.evidence_id].add(text)
+    satisfied = bool(evidence_ids)
+    return VerificationEvidenceLink(
+        target=target,
+        text=text,
+        evidence_ids=tuple(evidence_ids),
+        satisfied=satisfied,
+        reason=_evidence_link_reason(
+            target=target,
+            evidence_ids=tuple(evidence_ids),
+        ),
+    )
+
+
+def _evidence_can_support_text(
+    *,
+    text: str,
+    target: VerificationEvidenceTarget,
+    item: VerificationEvidenceItem,
+) -> bool:
+    if item.passed is False:
+        return False
+    if item.source == "verification_check_skipped":
+        return False
+    if (
+        target == VerificationEvidenceTarget.ACCEPTANCE_CRITERION
+        and item.kind == VerificationEvidenceKind.TOOL_CALL
+    ):
+        return False
+    return _text_matches_evidence(text=text, item=item)
+
+
+def _evidence_link_reason(
+    *,
+    target: VerificationEvidenceTarget,
+    evidence_ids: tuple[str, ...],
+) -> str:
+    if evidence_ids:
+        return (
+            f"Matched {len(evidence_ids)} evidence item(s): {', '.join(evidence_ids)}."
+        )
+    if target == VerificationEvidenceTarget.ACCEPTANCE_CRITERION:
+        return "No concrete evidence item matched this acceptance criterion."
+    return "No concrete evidence item matched this expected evidence."
+
+
+def _run_evidence_coverage_checks(
+    *,
+    acceptance_links: tuple[VerificationEvidenceLink, ...],
+    expectation_links: tuple[VerificationEvidenceLink, ...],
+) -> tuple[VerificationCheckResult, ...]:
     checks: list[VerificationCheckResult] = []
-    for criterion in plan.acceptance_criteria:
-        passed = criterion.lower() in normalized_result
+    for link in acceptance_links:
         checks.append(
             VerificationCheckResult(
-                layer=VerificationLayer.SPEC,
-                name=f"acceptance:{criterion}",
-                passed=passed,
-                details=(
-                    "Acceptance criterion was cited in the result."
-                    if passed
-                    else "Acceptance criterion was not cited in the result."
-                ),
+                layer=VerificationLayer.EVIDENCE,
+                name=f"acceptance_evidence:{link.text}",
+                passed=link.satisfied,
+                details=link.reason,
             )
         )
-    for expectation in plan.evidence_expectations:
-        passed = expectation.lower() in normalized_result
+    for link in expectation_links:
         checks.append(
             VerificationCheckResult(
-                layer=VerificationLayer.SPEC,
-                name=f"evidence:{expectation}",
-                passed=passed,
-                details=(
-                    "Expected evidence was cited in the result."
-                    if passed
-                    else "Expected evidence was not cited in the result."
-                ),
+                layer=VerificationLayer.EVIDENCE,
+                name=f"expected_evidence:{link.text}",
+                passed=link.satisfied,
+                details=link.reason,
             )
         )
-    return checks
+    return tuple(checks)
+
+
+def _run_semantic_evaluations(
+    *,
+    task_id: str,
+    criteria: tuple[str, ...],
+    result: str,
+    evidence_items: tuple[VerificationEvidenceItem, ...],
+    acceptance_links: tuple[VerificationEvidenceLink, ...],
+    semantic_evaluator: SemanticVerificationEvaluator | None,
+) -> tuple[SemanticEvaluationResult, ...]:
+    links_by_text = {link.text: link for link in acceptance_links}
+    results: list[SemanticEvaluationResult] = []
+    for criterion in criteria:
+        link = links_by_text.get(criterion)
+        linked_evidence = _linked_evidence_items(
+            link=link, evidence_items=evidence_items
+        )
+        baseline = _rule_semantic_evaluation(
+            criterion=criterion,
+            link=link,
+            linked_evidence=linked_evidence,
+        )
+        results.append(
+            _run_optional_semantic_evaluator(
+                task_id=task_id,
+                criterion=criterion,
+                result=result,
+                linked_evidence=linked_evidence,
+                baseline=baseline,
+                semantic_evaluator=semantic_evaluator,
+            )
+        )
+    return tuple(results)
+
+
+def _linked_evidence_items(
+    *,
+    link: VerificationEvidenceLink | None,
+    evidence_items: tuple[VerificationEvidenceItem, ...],
+) -> tuple[VerificationEvidenceItem, ...]:
+    if link is None:
+        return ()
+    evidence_ids = set(link.evidence_ids)
+    return tuple(item for item in evidence_items if item.evidence_id in evidence_ids)
+
+
+def _rule_semantic_evaluation(
+    *,
+    criterion: str,
+    link: VerificationEvidenceLink | None,
+    linked_evidence: tuple[VerificationEvidenceItem, ...],
+) -> SemanticEvaluationResult:
+    if link is None or not link.evidence_ids:
+        return SemanticEvaluationResult(
+            criterion=criterion,
+            passed=False,
+            confidence=0.0,
+            reason="No evidence was linked to this acceptance criterion.",
+        )
+    strong_evidence_ids = tuple(
+        item.evidence_id for item in linked_evidence if _is_strong_evidence(item)
+    )
+    if strong_evidence_ids:
+        return SemanticEvaluationResult(
+            criterion=criterion,
+            passed=True,
+            confidence=0.85,
+            reason="Concrete verification evidence supports this acceptance criterion.",
+            evidence_ids=strong_evidence_ids,
+        )
+    self_report_ids = tuple(
+        item.evidence_id
+        for item in linked_evidence
+        if item.kind == VerificationEvidenceKind.TASK_RESULT
+    )
+    if self_report_ids:
+        return SemanticEvaluationResult(
+            criterion=criterion,
+            passed=True,
+            confidence=0.45,
+            reason=(
+                "The task result self-reports this criterion, but no independent "
+                "verification evidence was linked."
+            ),
+            evidence_ids=self_report_ids,
+        )
+    return SemanticEvaluationResult(
+        criterion=criterion,
+        passed=False,
+        confidence=0.2,
+        reason="Only weak or inconclusive evidence was linked to this criterion.",
+        evidence_ids=tuple(item.evidence_id for item in linked_evidence),
+    )
+
+
+def _is_strong_evidence(item: VerificationEvidenceItem) -> bool:
+    if item.passed is not True:
+        return False
+    return item.kind in {
+        VerificationEvidenceKind.REQUIRED_FILE,
+        VerificationEvidenceKind.COMMAND,
+        VerificationEvidenceKind.TEST_RESULT,
+        VerificationEvidenceKind.LINT_RESULT,
+        VerificationEvidenceKind.DIFF_SUMMARY,
+        VerificationEvidenceKind.FORMAL_PROOF,
+        VerificationEvidenceKind.TOOL_RESULT,
+        VerificationEvidenceKind.GATE_FINDING,
+    }
+
+
+def _run_optional_semantic_evaluator(
+    *,
+    task_id: str,
+    criterion: str,
+    result: str,
+    linked_evidence: tuple[VerificationEvidenceItem, ...],
+    baseline: SemanticEvaluationResult,
+    semantic_evaluator: SemanticVerificationEvaluator | None,
+) -> SemanticEvaluationResult:
+    if semantic_evaluator is None:
+        return baseline
+    request = SemanticEvaluationRequest(
+        task_id=task_id,
+        criterion=criterion,
+        result_excerpt=_text_excerpt(result),
+        evidence=linked_evidence,
+    )
+    try:
+        evaluated = semantic_evaluator(request)
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="verification.semantic_evaluator_failed",
+            message="Semantic verification evaluator failed; using rule fallback",
+            payload={"task_id": task_id, "criterion": criterion, "error": str(exc)},
+        )
+        return baseline.model_copy(
+            update={
+                "reason": (
+                    f"{baseline.reason} External evaluator failed; rule fallback used."
+                )
+            }
+        )
+    evaluator_name = evaluated.evaluator
+    if evaluator_name == "rule":
+        evaluator_name = "external"
+    return evaluated.model_copy(
+        update={
+            "criterion": criterion,
+            "evaluator": evaluator_name,
+        }
+    )
+
+
+def _semantic_evaluation_checks(
+    semantic_results: tuple[SemanticEvaluationResult, ...],
+) -> tuple[VerificationCheckResult, ...]:
+    return tuple(
+        VerificationCheckResult(
+            layer=VerificationLayer.SEMANTIC,
+            name=f"semantic_acceptance:{result.criterion}",
+            passed=result.passed,
+            details=(
+                f"{result.reason} confidence={result.confidence:.2f}; "
+                f"evidence={', '.join(result.evidence_ids) or 'none'}"
+            ),
+        )
+        for result in semantic_results
+    )
+
+
+def _text_matches_evidence(
+    *,
+    text: str,
+    item: VerificationEvidenceItem,
+) -> bool:
+    normalized_text = text.casefold().strip()
+    searchable_text = _evidence_search_text(item).casefold()
+    if normalized_text and normalized_text in searchable_text:
+        return True
+    expected_tokens = _significant_tokens(normalized_text)
+    evidence_tokens = _significant_tokens(searchable_text)
+    if not expected_tokens:
+        return False
+    if len(expected_tokens) < _EVIDENCE_TEXT_MATCH_MIN_TOKEN_COUNT:
+        return expected_tokens.issubset(evidence_tokens)
+    overlap = len(expected_tokens & evidence_tokens) / len(expected_tokens)
+    return overlap >= _EVIDENCE_TEXT_MATCH_MIN_OVERLAP
+
+
+def _evidence_search_text(item: VerificationEvidenceItem) -> str:
+    path = "" if item.path is None else str(item.path)
+    metrics = " ".join(f"{metric.name} {metric.value}" for metric in item.metrics)
+    return "\n".join(
+        part
+        for part in (
+            item.kind.value.replace("_", " "),
+            item.summary,
+            item.source,
+            path,
+            " ".join(item.command),
+            item.tool_name,
+            item.output_excerpt,
+            metrics,
+        )
+        if part
+    )
+
+
+def _significant_tokens(text: str) -> set[str]:
+    tokens: set[str] = set()
+    for token in re.findall(r"[a-zA-Z0-9_]+", text.casefold()):
+        normalized = _normalize_match_token(token)
+        if token in _MATCH_STOPWORDS or normalized in _MATCH_STOPWORDS:
+            continue
+        if normalized:
+            tokens.add(normalized)
+    return tokens
+
+
+_MATCH_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "is",
+        "it",
+        "of",
+        "or",
+        "output",
+        "should",
+        "that",
+        "the",
+        "this",
+        "to",
+        "with",
+    }
+)
+
+
+def _normalize_match_token(token: str) -> str:
+    normalized = token.strip("_")
+    if normalized == "pass":
+        return normalized
+    if normalized in {"pytest", "unittest"}:
+        return "test"
+    if normalized in {"passes", "passed", "passing"}:
+        return "pass"
+    if normalized in {"fails", "failed", "failing"}:
+        return "fail"
+    if len(normalized) > 4 and normalized.endswith("ies"):
+        return normalized[:-3] + "y"
+    if len(normalized) > 4 and normalized.endswith("es"):
+        return normalized[:-2]
+    if len(normalized) > 3 and normalized.endswith("s"):
+        return normalized[:-1]
+    return normalized
+
+
+def _parse_event_payload(value: object) -> dict[str, object]:
+    if not isinstance(value, str) or not value.strip():
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(key): item for key, item in parsed.items()}
+
+
+def _json_excerpt(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return _text_excerpt(value)
+    try:
+        return _text_excerpt(json.dumps(value, sort_keys=True))
+    except TypeError:
+        return _text_excerpt(str(value))
+
+
+def _text_excerpt(value: str) -> str:
+    return _command_output_excerpt(stdout=value, stderr="")
+
+
+def _evidence_id(prefix: str, index: int, text: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.:-]+", "-", text.strip()).strip("-").lower()
+    if not normalized:
+        return f"{prefix}:{index}"
+    return f"{prefix}:{index}:{normalized[:80]}"
+
+
+def _text_mentions_any(text: str, needles: tuple[str, ...]) -> bool:
+    for needle in needles:
+        if " " in needle:
+            if needle in text:
+                return True
+            continue
+        if re.search(rf"(?<![A-Za-z0-9_]){re.escape(needle)}(?![A-Za-z0-9_])", text):
+            return True
+    return False
 
 
 def _command_output_excerpt(

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -1284,8 +1284,12 @@ def _normalize_match_token(token: str) -> str:
         return "fail"
     if len(normalized) > 4 and normalized.endswith("ies"):
         return normalized[:-3] + "y"
-    if len(normalized) > 4 and normalized.endswith("es"):
+    if len(normalized) > 4 and normalized.endswith(
+        ("ches", "shes", "sses", "xes", "zes")
+    ):
         return normalized[:-2]
+    if len(normalized) > 4 and normalized.endswith("es"):
+        return normalized[:-1]
     if len(normalized) > 3 and normalized.endswith("s"):
         return normalized[:-1]
     return normalized

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -669,11 +669,6 @@ def _command_evidence_kind(
     combined_text = f"{command_text}\n{output_text}"
     if _text_mentions_any(
         combined_text,
-        ("pytest", "unittest", "test", "passed", "failed", "coverage"),
-    ):
-        return VerificationEvidenceKind.TEST_RESULT
-    if _text_mentions_any(
-        combined_text,
         ("ruff", "lint", "basedpyright", "pyright", "mypy", "flake8"),
     ):
         return VerificationEvidenceKind.LINT_RESULT
@@ -687,6 +682,11 @@ def _command_evidence_kind(
         ("tla", "alloy", "lean", "coq", "isabelle", "model check", "proof"),
     ):
         return VerificationEvidenceKind.FORMAL_PROOF
+    if _text_mentions_any(
+        combined_text,
+        ("pytest", "unittest", "test", "passed", "failed", "coverage"),
+    ):
+        return VerificationEvidenceKind.TEST_RESULT
     return VerificationEvidenceKind.COMMAND
 
 
@@ -718,10 +718,15 @@ def _evidence_metrics_for_check(
 ) -> tuple[VerificationEvidenceMetric, ...]:
     output = check.output_excerpt
     values: dict[str, int] = {}
-    _collect_test_metrics(output, values)
-    _collect_lint_metrics(output, values)
-    _collect_diff_metrics(output, values)
-    _collect_formal_metrics(check, output, values)
+    kind = _command_evidence_kind(check)
+    if kind == VerificationEvidenceKind.TEST_RESULT:
+        _collect_test_metrics(output, values)
+    elif kind == VerificationEvidenceKind.LINT_RESULT:
+        _collect_lint_metrics(output, values)
+    elif kind == VerificationEvidenceKind.DIFF_SUMMARY:
+        _collect_diff_metrics(output, values)
+    elif kind == VerificationEvidenceKind.FORMAL_PROOF:
+        _collect_formal_metrics(check, output, values)
     return tuple(
         VerificationEvidenceMetric(name=name, value=value)
         for name, value in sorted(values.items())

--- a/src/relay_teams/agents/tasks/__init__.py
+++ b/src/relay_teams/agents/tasks/__init__.py
@@ -5,6 +5,8 @@ from relay_teams.agents.tasks.enums import TaskStatus
 from relay_teams.agents.tasks.events import EventEnvelope, EventType
 from relay_teams.agents.tasks.ids import TaskId, new_task_id
 from relay_teams.agents.tasks.models import (
+    SemanticEvaluationRequest,
+    SemanticEvaluationResult,
     TaskEnvelope,
     TaskHandoff,
     TaskLifecyclePolicy,
@@ -12,6 +14,10 @@ from relay_teams.agents.tasks.models import (
     TaskSpec,
     VerificationCommand,
     VerificationCheckResult,
+    VerificationEvidenceBundle,
+    VerificationEvidenceItem,
+    VerificationEvidenceLink,
+    VerificationEvidenceMetric,
     VerificationPlan,
     VerificationReport,
     VerificationResult,
@@ -21,6 +27,8 @@ from relay_teams.agents.tasks.task_repository import TaskRepository
 __all__ = [
     "EventEnvelope",
     "EventType",
+    "SemanticEvaluationRequest",
+    "SemanticEvaluationResult",
     "TaskEnvelope",
     "TaskHandoff",
     "TaskId",
@@ -31,6 +39,10 @@ __all__ = [
     "TaskStatus",
     "VerificationCommand",
     "VerificationCheckResult",
+    "VerificationEvidenceBundle",
+    "VerificationEvidenceItem",
+    "VerificationEvidenceLink",
+    "VerificationEvidenceMetric",
     "VerificationPlan",
     "VerificationReport",
     "VerificationResult",

--- a/src/relay_teams/agents/tasks/enums.py
+++ b/src/relay_teams/agents/tasks/enums.py
@@ -28,4 +28,24 @@ class TaskTimeoutAction(str, Enum):
 class VerificationLayer(str, Enum):
     STRUCTURE = "structure"
     BEHAVIOR = "behavior"
+    EVIDENCE = "evidence"
+    SEMANTIC = "semantic"
     SPEC = "spec"
+
+
+class VerificationEvidenceKind(str, Enum):
+    TASK_RESULT = "task_result"
+    REQUIRED_FILE = "required_file"
+    COMMAND = "command"
+    TEST_RESULT = "test_result"
+    LINT_RESULT = "lint_result"
+    DIFF_SUMMARY = "diff_summary"
+    FORMAL_PROOF = "formal_proof"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    GATE_FINDING = "gate_finding"
+
+
+class VerificationEvidenceTarget(str, Enum):
+    ACCEPTANCE_CRITERION = "acceptance_criterion"
+    EVIDENCE_EXPECTATION = "evidence_expectation"

--- a/src/relay_teams/agents/tasks/models.py
+++ b/src/relay_teams/agents/tasks/models.py
@@ -12,6 +12,8 @@ from relay_teams.agents.tasks.enums import (
     TaskSpecStrictness,
     TaskStatus,
     TaskTimeoutAction,
+    VerificationEvidenceKind,
+    VerificationEvidenceTarget,
     VerificationLayer,
 )
 from relay_teams.validation import (
@@ -219,6 +221,85 @@ class VerificationCheckResult(BaseModel):
     output_excerpt: str = ""
 
 
+class VerificationEvidenceMetric(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    value: int
+
+
+class VerificationEvidenceItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_id: RequiredIdentifierStr
+    kind: VerificationEvidenceKind
+    summary: str = Field(min_length=1)
+    source: str = ""
+    passed: bool | None = None
+    path: Path | None = None
+    command: tuple[str, ...] = ()
+    exit_code: int | None = None
+    tool_name: str = ""
+    tool_call_id: str = ""
+    output_excerpt: str = ""
+    metrics: tuple[VerificationEvidenceMetric, ...] = ()
+    supports: tuple[str, ...] = ()
+
+    @field_validator("command", "supports", mode="before")
+    @classmethod
+    def _normalize_text_items(cls, value: object) -> tuple[str, ...]:
+        return _normalize_text_tuple(value, field_name="verification evidence text")
+
+
+class VerificationEvidenceLink(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target: VerificationEvidenceTarget
+    text: str = Field(min_length=1)
+    evidence_ids: tuple[str, ...] = ()
+    satisfied: bool
+    reason: str = ""
+
+    @field_validator("evidence_ids", mode="before")
+    @classmethod
+    def _normalize_evidence_ids(cls, value: object) -> tuple[str, ...]:
+        return _normalize_text_tuple(value, field_name="verification evidence id")
+
+
+class VerificationEvidenceBundle(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: RequiredIdentifierStr
+    items: tuple[VerificationEvidenceItem, ...] = ()
+    acceptance_links: tuple[VerificationEvidenceLink, ...] = ()
+    expectation_links: tuple[VerificationEvidenceLink, ...] = ()
+
+
+class SemanticEvaluationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: RequiredIdentifierStr
+    criterion: str = Field(min_length=1)
+    result_excerpt: str = ""
+    evidence: tuple[VerificationEvidenceItem, ...] = ()
+
+
+class SemanticEvaluationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    criterion: str = Field(min_length=1)
+    passed: bool
+    confidence: float = Field(ge=0.0, le=1.0)
+    reason: str = ""
+    evidence_ids: tuple[str, ...] = ()
+    evaluator: str = "rule"
+
+    @field_validator("evidence_ids", mode="before")
+    @classmethod
+    def _normalize_semantic_evidence_ids(cls, value: object) -> tuple[str, ...]:
+        return _normalize_text_tuple(value, field_name="semantic evidence id")
+
+
 class VerificationReport(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -226,6 +307,8 @@ class VerificationReport(BaseModel):
     passed: bool
     checks: tuple[VerificationCheckResult, ...]
     unmet_items: tuple[str, ...] = ()
+    evidence_bundle: VerificationEvidenceBundle | None = None
+    semantic_results: tuple[SemanticEvaluationResult, ...] = ()
     generated_at: datetime = Field(
         default_factory=lambda: datetime.now(tz=timezone.utc)
     )

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -1030,10 +1030,14 @@ def test_evidence_helpers_classify_metrics_and_generic_checks() -> None:
     assert {
         metric.name: metric.value
         for metric in verification_module._evidence_metrics_for_check(lint_failure)
-    } == {"lint_errors": 2, "test_errors": 2}
+    } == {"lint_errors": 2}
 
     lint_success = lint_failure.model_copy(
         update={"passed": True, "output_excerpt": "All checks passed!"}
+    )
+    assert (
+        verification_module._command_evidence_kind(lint_success)
+        == VerificationEvidenceKind.LINT_RESULT
     )
     assert {
         metric.name: metric.value

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from json import dumps
 import subprocess
 import sys
 import threading
@@ -13,12 +14,16 @@ from relay_teams.agents.orchestration import verification as verification_module
 from relay_teams.agents.orchestration.verification import verify_task
 from relay_teams.agents.tasks.enums import TaskStatus, VerificationLayer
 from relay_teams.agents.tasks.models import (
+    SemanticEvaluationRequest,
+    SemanticEvaluationResult,
     TaskEnvelope,
     VerificationCommand,
     VerificationPlan,
 )
 from relay_teams.agents.tasks.task_repository import TaskRepository
+from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 
 YOLO_TOOL_APPROVAL_POLICY = ToolApprovalPolicy(yolo=True)
@@ -111,9 +116,207 @@ def test_verify_task_builds_structured_report(tmp_path: Path) -> None:
     assert {check.layer for check in result.report.checks} == {
         VerificationLayer.STRUCTURE,
         VerificationLayer.BEHAVIOR,
-        VerificationLayer.SPEC,
+        VerificationLayer.EVIDENCE,
+        VerificationLayer.SEMANTIC,
     }
+    assert result.report.evidence_bundle is not None
+    assert result.report.evidence_bundle.acceptance_links[0].satisfied is True
+    assert result.report.evidence_bundle.expectation_links[0].satisfied is True
+    assert result.report.semantic_results[0].passed is True
     assert result.report.unmet_items == ()
+
+
+def test_verify_task_links_command_output_to_spec_evidence(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_command_evidence.db"
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Run tests",
+        verification=VerificationPlan(
+            command_checks=(
+                VerificationCommand(
+                    command=(
+                        sys.executable,
+                        "-c",
+                        "print('1 passed in 0.01s')",
+                    ),
+                    timeout_seconds=5,
+                ),
+            ),
+            acceptance_criteria=("unit tests pass",),
+            evidence_expectations=("pytest output",),
+        ),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        allowed_tools=("shell",),
+        tool_approval_policy=YOLO_TOOL_APPROVAL_POLICY,
+        workspace_root=tmp_path,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    command_evidence = next(
+        item
+        for item in result.report.evidence_bundle.items
+        if item.output_excerpt == "1 passed in 0.01s"
+    )
+    assert command_evidence.kind.value == "test_result"
+    assert command_evidence.metrics[0].name == "tests_passed"
+    assert command_evidence.metrics[0].value == 1
+    assert result.report.evidence_bundle.acceptance_links[0].evidence_ids == (
+        command_evidence.evidence_id,
+    )
+    assert result.report.evidence_bundle.expectation_links[0].evidence_ids == (
+        command_evidence.evidence_id,
+    )
+    assert result.report.semantic_results[0].passed is True
+    assert result.report.semantic_results[0].confidence == 0.85
+
+
+def test_verify_task_fails_acceptance_without_matching_evidence(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_missing_evidence.db"
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Run migration",
+        verification=VerificationPlan(
+            acceptance_criteria=("database migration runs",),
+        ),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(task_repo, event_log, task.task_id)
+
+    assert result.passed is False
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    assert result.report.evidence_bundle.acceptance_links[0].satisfied is False
+    failed_checks = [check for check in result.report.checks if not check.passed]
+    assert "acceptance_evidence:database migration runs" in {
+        check.name for check in failed_checks
+    }
+    assert "semantic_acceptance:database migration runs" in {
+        check.name for check in failed_checks
+    }
+
+
+def test_verify_task_uses_tool_result_events_as_evidence(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_tool_event_evidence.db"
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Read artifact",
+        verification=VerificationPlan(
+            acceptance_criteria=("read evidence file",),
+        ),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+    event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json=dumps(
+                {
+                    "tool_name": "read",
+                    "tool_call_id": "call-1",
+                    "result": "read evidence file contents",
+                    "error": False,
+                }
+            ),
+        )
+    )
+
+    result = verify_task(task_repo, event_log, task.task_id)
+
+    assert result.passed is True
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    linked_id = result.report.evidence_bundle.acceptance_links[0].evidence_ids[0]
+    linked_item = next(
+        item
+        for item in result.report.evidence_bundle.items
+        if item.evidence_id == linked_id
+    )
+    assert linked_item.kind.value == "tool_result"
+    assert result.report.semantic_results[0].evidence_ids == (linked_id,)
+
+
+def test_verify_task_uses_rule_fallback_when_semantic_evaluator_fails(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_semantic_fallback.db"
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Run tests",
+        verification=VerificationPlan(
+            command_checks=(
+                VerificationCommand(
+                    command=(
+                        sys.executable,
+                        "-c",
+                        "print('1 passed in 0.01s')",
+                    ),
+                    timeout_seconds=5,
+                ),
+            ),
+            acceptance_criteria=("unit tests pass",),
+        ),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    def failing_evaluator(
+        _request: SemanticEvaluationRequest,
+    ) -> SemanticEvaluationResult:
+        raise RuntimeError("model unavailable")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        allowed_tools=("shell",),
+        tool_approval_policy=YOLO_TOOL_APPROVAL_POLICY,
+        workspace_root=tmp_path,
+        semantic_evaluator=failing_evaluator,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    semantic_result = result.report.semantic_results[0]
+    assert semantic_result.passed is True
+    assert semantic_result.evaluator == "rule"
+    assert "rule fallback used" in semantic_result.reason
 
 
 def test_verify_task_required_file_rejects_directory(tmp_path: Path) -> None:

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -268,6 +268,50 @@ def test_verify_task_uses_tool_result_events_as_evidence(
     assert result.report.semantic_results[0].evidence_ids == (linked_id,)
 
 
+def test_verify_task_ignores_unscoped_tool_result_events(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_unscoped_tool_event_evidence.db"
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Read artifact",
+        verification=VerificationPlan(
+            acceptance_criteria=("read evidence file",),
+        ),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+    event_log.emit_run_event(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json=dumps(
+                {
+                    "tool_name": "read",
+                    "tool_call_id": "call-1",
+                    "result": "read evidence file contents",
+                    "error": False,
+                }
+            ),
+        )
+    )
+
+    result = verify_task(task_repo, event_log, task.task_id)
+
+    assert result.passed is False
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    assert result.report.evidence_bundle.acceptance_links[0].satisfied is False
+    evidence_kinds = {item.kind.value for item in result.report.evidence_bundle.items}
+    assert "tool_result" not in evidence_kinds
+
+
 def test_verify_task_uses_rule_fallback_when_semantic_evaluator_fails(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -95,7 +95,11 @@ def test_verify_task_builds_structured_report(tmp_path: Path) -> None:
             required_files=(Path("evidence.txt"),),
             command_checks=(
                 VerificationCommand(
-                    command=(sys.executable, "-c", "raise SystemExit(0)"),
+                    command=(
+                        sys.executable,
+                        "-c",
+                        "print('evidence complete coverage output')",
+                    ),
                     timeout_seconds=5,
                 ),
             ),
@@ -209,7 +213,11 @@ def test_verify_task_fails_acceptance_without_matching_evidence(
         ),
     )
     _ = task_repo.create(task)
-    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+    task_repo.update_status(
+        task.task_id,
+        TaskStatus.COMPLETED,
+        result="database migration runs",
+    )
 
     result = verify_task(task_repo, event_log, task.task_id)
 
@@ -1160,6 +1168,22 @@ def test_evidence_linking_and_semantic_helper_edges() -> None:
         is False
     )
 
+    task_result_item = failed_item.model_copy(
+        update={
+            "evidence_id": "task-result",
+            "kind": VerificationEvidenceKind.TASK_RESULT,
+            "passed": True,
+        }
+    )
+    assert (
+        verification_module._evidence_can_support_text(
+            text="target criterion",
+            target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,
+            item=task_result_item,
+        )
+        is False
+    )
+
     tool_call_item = VerificationEvidenceItem(
         evidence_id="tool-call",
         kind=VerificationEvidenceKind.TOOL_CALL,
@@ -1199,6 +1223,20 @@ def test_evidence_linking_and_semantic_helper_edges() -> None:
     )
     assert weak_result.passed is False
     assert weak_result.evidence_ids == ("tool-call",)
+
+    self_report_link = VerificationEvidenceLink(
+        target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,
+        text="target criterion",
+        evidence_ids=("task-result",),
+        satisfied=True,
+    )
+    self_report_result = verification_module._rule_semantic_evaluation(
+        criterion="target criterion",
+        link=self_report_link,
+        linked_evidence=(task_result_item,),
+    )
+    assert self_report_result.passed is False
+    assert self_report_result.confidence == 0.25
 
     def evaluator(
         _request: SemanticEvaluationRequest,

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -12,12 +12,20 @@ import pytest
 
 from relay_teams.agents.orchestration import verification as verification_module
 from relay_teams.agents.orchestration.verification import verify_task
-from relay_teams.agents.tasks.enums import TaskStatus, VerificationLayer
+from relay_teams.agents.tasks.enums import (
+    TaskStatus,
+    VerificationEvidenceKind,
+    VerificationEvidenceTarget,
+    VerificationLayer,
+)
 from relay_teams.agents.tasks.models import (
     SemanticEvaluationRequest,
     SemanticEvaluationResult,
     TaskEnvelope,
     VerificationCommand,
+    VerificationCheckResult,
+    VerificationEvidenceItem,
+    VerificationEvidenceLink,
     VerificationPlan,
 )
 from relay_teams.agents.tasks.task_repository import TaskRepository
@@ -983,3 +991,245 @@ def test_verify_task_fails_when_command_output_exceeds_capture_limit(
     command_check = result.report.checks[-1]
     assert "output exceeded 32 byte" in command_check.details
     assert command_check.output_excerpt.endswith("...(truncated)")
+
+
+def test_evidence_helpers_classify_metrics_and_generic_checks() -> None:
+    generic_check = VerificationCheckResult(
+        layer=VerificationLayer.EVIDENCE,
+        name="manual",
+        passed=True,
+        details="manual evidence",
+    )
+    assert (
+        verification_module._evidence_kind_from_check(generic_check)
+        == VerificationEvidenceKind.COMMAND
+    )
+    assert (
+        verification_module._check_evidence_summary(generic_check) == "manual evidence"
+    )
+
+    lint_failure = VerificationCheckResult(
+        layer=VerificationLayer.BEHAVIOR,
+        name="command:ruff",
+        passed=False,
+        command=("ruff", "check"),
+        output_excerpt="Found 2 errors",
+    )
+    assert (
+        verification_module._command_evidence_kind(lint_failure)
+        == VerificationEvidenceKind.LINT_RESULT
+    )
+    assert {
+        metric.name: metric.value
+        for metric in verification_module._evidence_metrics_for_check(lint_failure)
+    } == {"lint_errors": 2, "test_errors": 2}
+
+    lint_success = lint_failure.model_copy(
+        update={"passed": True, "output_excerpt": "All checks passed!"}
+    )
+    assert {
+        metric.name: metric.value
+        for metric in verification_module._evidence_metrics_for_check(lint_success)
+    } == {"lint_errors": 0}
+
+    diff_check = VerificationCheckResult(
+        layer=VerificationLayer.BEHAVIOR,
+        name="command:diff",
+        passed=True,
+        command=("git", "diff", "--stat"),
+        output_excerpt="3 files changed, 4 insertions(+), 5 deletions(-)",
+    )
+    assert (
+        verification_module._command_evidence_kind(diff_check)
+        == VerificationEvidenceKind.DIFF_SUMMARY
+    )
+    assert {
+        metric.name: metric.value
+        for metric in verification_module._evidence_metrics_for_check(diff_check)
+    } == {"deletions": 5, "files_changed": 3, "insertions": 4}
+
+    formal_check = VerificationCheckResult(
+        layer=VerificationLayer.BEHAVIOR,
+        name="command:tla",
+        passed=False,
+        command=("tla", "check"),
+        output_excerpt="proof completed",
+    )
+    assert (
+        verification_module._command_evidence_kind(formal_check)
+        == VerificationEvidenceKind.FORMAL_PROOF
+    )
+    assert {
+        metric.name: metric.value
+        for metric in verification_module._evidence_metrics_for_check(formal_check)
+    } == {"formal_checks_passed": 1}
+
+    unittest_check = VerificationCheckResult(
+        layer=VerificationLayer.BEHAVIOR,
+        name="command:unittest",
+        passed=True,
+        command=("python", "-m", "unittest"),
+        output_excerpt="Ran 7 tests in 0.01s",
+    )
+    assert {
+        metric.name: metric.value
+        for metric in verification_module._evidence_metrics_for_check(unittest_check)
+    } == {"tests_total": 7}
+
+
+def test_event_evidence_helpers_parse_scoped_events() -> None:
+    invalid_tool_call = verification_module._event_evidence_item(
+        index=1,
+        event={
+            "event_type": RunEventType.TOOL_CALL.value,
+            "payload_json": dumps({"tool_name": "", "tool_call_id": ""}),
+        },
+    )
+    assert invalid_tool_call is None
+
+    tool_call = verification_module._event_evidence_item(
+        index=2,
+        event={
+            "event_type": RunEventType.TOOL_CALL.value,
+            "payload_json": dumps(
+                {"tool_name": "read", "tool_call_id": "call-1", "args": {"path": "a"}}
+            ),
+        },
+    )
+    assert tool_call is not None
+    assert tool_call.kind == VerificationEvidenceKind.TOOL_CALL
+    assert tool_call.output_excerpt == '{"path": "a"}'
+
+    invalid_tool_result = verification_module._event_evidence_item(
+        index=3,
+        event={
+            "event_type": RunEventType.TOOL_RESULT.value,
+            "payload_json": dumps({"tool_name": "read"}),
+        },
+    )
+    assert invalid_tool_result is None
+
+    gate_item = verification_module._event_evidence_item(
+        index=4,
+        event={
+            "event_type": "gate_finished",
+            "payload_json": dumps({"role_id": "Gater", "findings": ["looks good"]}),
+        },
+    )
+    assert gate_item is not None
+    assert gate_item.kind == VerificationEvidenceKind.GATE_FINDING
+    assert "looks good" in gate_item.output_excerpt
+
+    assert verification_module._parse_event_payload(None) == {}
+    assert verification_module._parse_event_payload("not-json") == {}
+    assert verification_module._parse_event_payload("[]") == {}
+    assert verification_module._json_excerpt(None) == ""
+    assert verification_module._json_excerpt({"bad": {1, 2}})
+
+
+def test_evidence_linking_and_semantic_helper_edges() -> None:
+    failed_item = VerificationEvidenceItem(
+        evidence_id="failed",
+        kind=VerificationEvidenceKind.COMMAND,
+        summary="failed",
+        passed=False,
+        output_excerpt="target criterion",
+    )
+    assert (
+        verification_module._evidence_can_support_text(
+            text="target criterion",
+            target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,
+            item=failed_item,
+        )
+        is False
+    )
+
+    skipped_item = failed_item.model_copy(
+        update={
+            "evidence_id": "skipped",
+            "source": "verification_check_skipped",
+            "passed": None,
+        }
+    )
+    assert (
+        verification_module._evidence_can_support_text(
+            text="target criterion",
+            target=VerificationEvidenceTarget.EVIDENCE_EXPECTATION,
+            item=skipped_item,
+        )
+        is False
+    )
+
+    tool_call_item = VerificationEvidenceItem(
+        evidence_id="tool-call",
+        kind=VerificationEvidenceKind.TOOL_CALL,
+        summary="Tool read was called.",
+        passed=None,
+        output_excerpt="target criterion",
+    )
+    assert (
+        verification_module._evidence_can_support_text(
+            text="target criterion",
+            target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,
+            item=tool_call_item,
+        )
+        is False
+    )
+    assert (
+        verification_module._evidence_link_reason(
+            target=VerificationEvidenceTarget.EVIDENCE_EXPECTATION,
+            evidence_ids=(),
+        )
+        == "No concrete evidence item matched this expected evidence."
+    )
+    assert (
+        verification_module._linked_evidence_items(link=None, evidence_items=()) == ()
+    )
+
+    weak_link = VerificationEvidenceLink(
+        target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,
+        text="target criterion",
+        evidence_ids=("tool-call",),
+        satisfied=True,
+    )
+    weak_result = verification_module._rule_semantic_evaluation(
+        criterion="target criterion",
+        link=weak_link,
+        linked_evidence=(tool_call_item,),
+    )
+    assert weak_result.passed is False
+    assert weak_result.evidence_ids == ("tool-call",)
+
+    def evaluator(
+        _request: SemanticEvaluationRequest,
+    ) -> SemanticEvaluationResult:
+        return SemanticEvaluationResult(
+            criterion="external criterion",
+            passed=True,
+            confidence=0.9,
+            evaluator="rule",
+        )
+
+    evaluated = verification_module._run_optional_semantic_evaluator(
+        task_id="task-1",
+        criterion="target criterion",
+        result="result text",
+        linked_evidence=(),
+        baseline=weak_result,
+        semantic_evaluator=evaluator,
+    )
+    assert evaluated.criterion == "target criterion"
+    assert evaluated.evaluator == "external"
+
+    assert (
+        verification_module._text_matches_evidence(text="", item=tool_call_item)
+        is False
+    )
+    assert verification_module._normalize_match_token("fails") == "fail"
+    assert verification_module._normalize_match_token("stories") == "story"
+    assert verification_module._normalize_match_token("boxes") == "box"
+    assert verification_module._evidence_id("empty", 3, "   ") == "empty:3"
+    assert verification_module._text_mentions_any(
+        "the model check completed",
+        ("model check",),
+    )

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -18,6 +18,7 @@ from relay_teams.agents.tasks.enums import (
     VerificationEvidenceTarget,
     VerificationLayer,
 )
+from relay_teams.agents.tasks.events import EventType
 from relay_teams.agents.tasks.models import (
     SemanticEvaluationRequest,
     SemanticEvaluationResult,
@@ -1130,7 +1131,18 @@ def test_event_evidence_helpers_parse_scoped_events() -> None:
     )
     assert gate_item is not None
     assert gate_item.kind == VerificationEvidenceKind.GATE_FINDING
+    assert gate_item.passed is True
     assert "looks good" in gate_item.output_excerpt
+    timeout_item = verification_module._event_evidence_item(
+        index=5,
+        event={
+            "event_type": EventType.TASK_TIMEOUT.value,
+            "payload_json": dumps({"reason": "deadline exceeded"}),
+        },
+    )
+    assert timeout_item is not None
+    assert timeout_item.kind == VerificationEvidenceKind.GATE_FINDING
+    assert timeout_item.passed is False
 
     assert verification_module._parse_event_payload(None) == {}
     assert verification_module._parse_event_payload("not-json") == {}
@@ -1227,6 +1239,27 @@ def test_evidence_linking_and_semantic_helper_edges() -> None:
     )
     assert weak_result.passed is False
     assert weak_result.evidence_ids == ("tool-call",)
+
+    gate_item = VerificationEvidenceItem(
+        evidence_id="gate-finding",
+        kind=VerificationEvidenceKind.GATE_FINDING,
+        summary="Gate finding matched.",
+        passed=True,
+        output_excerpt="target criterion",
+    )
+    gate_link = VerificationEvidenceLink(
+        target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,
+        text="target criterion",
+        evidence_ids=("gate-finding",),
+        satisfied=True,
+    )
+    gate_result = verification_module._rule_semantic_evaluation(
+        criterion="target criterion",
+        link=gate_link,
+        linked_evidence=(gate_item,),
+    )
+    assert gate_result.passed is True
+    assert gate_result.evidence_ids == ("gate-finding",)
 
     self_report_link = VerificationEvidenceLink(
         target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -1270,6 +1270,9 @@ def test_evidence_linking_and_semantic_helper_edges() -> None:
     assert verification_module._normalize_match_token("fails") == "fail"
     assert verification_module._normalize_match_token("stories") == "story"
     assert verification_module._normalize_match_token("boxes") == "box"
+    assert verification_module._normalize_match_token("classes") == "class"
+    assert verification_module._normalize_match_token("cases") == "case"
+    assert verification_module._normalize_match_token("files") == "file"
     assert verification_module._evidence_id("empty", 3, "   ") == "empty:3"
     assert verification_module._text_mentions_any(
         "the model check completed",

--- a/tests/unit_tests/agents/tasks/test_task_models.py
+++ b/tests/unit_tests/agents/tasks/test_task_models.py
@@ -4,14 +4,27 @@ import pytest
 
 from pydantic import ValidationError
 
-from relay_teams.agents.tasks.enums import TaskSpecStrictness, TaskTimeoutAction
+from relay_teams.agents.tasks.enums import (
+    TaskSpecStrictness,
+    TaskTimeoutAction,
+    VerificationEvidenceKind,
+    VerificationEvidenceTarget,
+    VerificationLayer,
+)
 from relay_teams.agents.tasks.models import (
+    SemanticEvaluationResult,
     TaskEnvelope,
     TaskHandoff,
     TaskLifecyclePolicy,
     TaskSpec,
     VerificationCommand,
+    VerificationCheckResult,
+    VerificationEvidenceBundle,
+    VerificationEvidenceItem,
+    VerificationEvidenceLink,
+    VerificationEvidenceMetric,
     VerificationPlan,
+    VerificationReport,
     _split_command_string,
 )
 
@@ -77,6 +90,54 @@ def test_task_contract_models_normalize_optional_text_inputs() -> None:
     assert spec.requirements == ("persist state",)
     assert handoff.reason == ""
     assert handoff.completed == ("implemented",)
+
+
+def test_verification_report_accepts_evidence_bundle() -> None:
+    evidence_item = VerificationEvidenceItem(
+        evidence_id="command-1",
+        kind=VerificationEvidenceKind.TEST_RESULT,
+        summary="pytest passed",
+        source="verification_check",
+        passed=True,
+        output_excerpt="1 passed",
+        metrics=(VerificationEvidenceMetric(name="tests_passed", value=1),),
+        supports=("unit tests pass",),
+    )
+    report = VerificationReport(
+        task_id="task-1",
+        passed=True,
+        checks=(
+            VerificationCheckResult(
+                layer=VerificationLayer.SEMANTIC,
+                name="semantic_acceptance:unit tests pass",
+                passed=True,
+            ),
+        ),
+        evidence_bundle=VerificationEvidenceBundle(
+            task_id="task-1",
+            items=(evidence_item,),
+            acceptance_links=(
+                VerificationEvidenceLink(
+                    target=VerificationEvidenceTarget.ACCEPTANCE_CRITERION,
+                    text="unit tests pass",
+                    evidence_ids=("command-1",),
+                    satisfied=True,
+                ),
+            ),
+        ),
+        semantic_results=(
+            SemanticEvaluationResult(
+                criterion="unit tests pass",
+                passed=True,
+                confidence=0.85,
+                evidence_ids=("command-1",),
+            ),
+        ),
+    )
+
+    assert report.evidence_bundle is not None
+    assert report.evidence_bundle.items[0].metrics[0].value == 1
+    assert report.semantic_results[0].evidence_ids == ("command-1",)
 
 
 def test_verification_command_uses_windows_aware_string_splitting() -> None:


### PR DESCRIPTION
## Summary
- Add normalized verification evidence bundles for task results, required files, command checks, tool events, and gate/timeout findings.
- Link acceptance criteria and evidence expectations to concrete evidence items, with new evidence and semantic verification layers.
- Add a deterministic semantic baseline plus external evaluator injection/fallback behavior.
- Update FE-5 research status and focused unit coverage.

Closes #640

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests` -> 4841 passed, 5 skipped
- `uv run --extra dev pytest -q tests/unit_tests/agents/tasks/test_task_models.py tests/unit_tests/agents/orchestration/test_verification.py` -> 28 passed
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests` -> 106 passed, 3 skipped, 1 local browser smoke perf-threshold failure (`max(feedback_times_ms) < 500`, observed 540ms; retry observed 636ms)
- Chrome MCP E2E against `http://127.0.0.1:8765`: health ok, UI loaded, backend connected, API/XHR/EventSource requests 200, no console errors/warnings
