### PR TITLE
Implement SP-3 spec checkpoint refresh

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This directory is organized by documentation purpose and runtime module.
 - [Providers](modules/providers/)
 - [Reminders](modules/reminders/system-reminders-design.md)
 - [Sessions](modules/sessions/)
+- [SP-3 spec checkpoint refresh](modules/sessions/spec-checkpoint-refresh-design.md)
 - [Skills](modules/skills/)
 - [Workspace runtime](modules/workspace/)
 

--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -1388,6 +1388,9 @@ Thinking events:
 - `thinking_delta`: payload includes `part_index`, `text`, `role_id`, `instance_id`.
 - `thinking_finished`: payload includes `part_index`, `role_id`, `instance_id`.
 
+Spec checkpoint events:
+- `spec_checkpoint_applied`: emitted at a safe model boundary when a non-coordinator task with a `TaskSpec` crosses its `lifecycle.spec_checkpoint` refresh threshold. The backend persists an internal system prompt containing the current task spec before rebuilding the next model request. Payload includes `task_id`, `role_id`, `instance_id`, `sequence`, `reason`, `tool_calls_since_last_checkpoint`, `messages_since_last_checkpoint`, and `history_tokens_since_last_checkpoint`.
+
 Retry events:
 - `llm_retry_scheduled`: payload includes `instance_id`, `role_id`, `attempt_number`, `total_attempts`, `retry_in_ms`, `error_code`, and `error_message`.
 - `llm_retry_exhausted`: payload includes `instance_id`, `role_id`, `attempt_number`, `total_attempts`, `error_code`, and `error_message`.
@@ -1901,6 +1904,7 @@ Behavior:
 - Creates delegated task contracts only.
 - Role binding happens later during dispatch.
 - If a task contract sets `lifecycle.timeout_seconds`, the timeout is progress-sensitive rather than a strict wall clock cap. The dispatch starts with one timeout window, and each persisted model/tool message for the same task and assigned instance extends the deadline by another full window. If no new task message is persisted before the current deadline, the worker is cancelled and `lifecycle.on_timeout` is applied. Task status heartbeats only keep the running row fresh; they do not extend the lifecycle timeout by themselves.
+- `lifecycle.spec_checkpoint` controls automatic spec refresh for long non-coordinator runs. Defaults are enabled with refresh thresholds of 12 completed tool calls, 48 active history messages, or 8000 estimated history tokens since the previous checkpoint. The object accepts `enabled`, `refresh_interval_tool_calls`, `refresh_interval_messages`, `refresh_interval_history_tokens`, and `max_summary_chars`.
 
 Response:
 

--- a/docs/core/database-schema.md
+++ b/docs/core/database-schema.md
@@ -212,6 +212,7 @@ Required fields:
 Notes:
 - `role_id` is the execution target for the task.
 - `title` is a persisted task summary used by session projections and task APIs.
+- `lifecycle.spec_checkpoint` is stored inside `envelope_json` and controls automatic Spec Checkpoint refresh thresholds for long non-coordinator executions.
 - The system no longer stores workflow graphs. `tasks` is the only orchestration source of truth.
 - Role behavioral contracts are not copied into `tasks.envelope_json`. The task
   stores only the selected `role_id`; dispatch and verification resolve the
@@ -270,6 +271,7 @@ CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
 
 Purpose: append-only business/run event log.
 Tool call and tool result events are the durable source used to rebuild missing `tool_call_state:*` and `tool_call_batch:*` shared-state entries after a forced backend stop.
+`spec_checkpoint_applied` events are durable observability markers emitted after an internal spec-refresh system prompt is persisted for the next model request.
 
 ---
 
@@ -309,6 +311,7 @@ Notes:
 - Session-level `clear` operations no longer delete rows from `messages`.
 - The active conversation context is derived by looking up the latest `session_history_markers.marker_type = 'clear'` entry for the same `session_id` and filtering rows with `created_at` after that marker.
 - Historical session round rendering may still read the full `messages` history for the same session.
+- Runtime-internal guidance, including automatic Spec Checkpoint refreshes, may be stored as `ModelRequest` rows whose message part is `system-prompt`; the `role` column remains `user` because it describes the persisted Pydantic message envelope, not the semantic prompt authority.
 
 ---
 
@@ -330,7 +333,7 @@ CREATE INDEX IF NOT EXISTS idx_session_history_markers_session
 Purpose: append-only logical history boundaries for a session.
 
 Notes:
-- `marker_type` currently starts with `clear`.
+- `marker_type` currently includes `clear` and `compaction`.
 - A `clear` marker divides active context from earlier persisted history without deleting earlier `messages`, `events`, or `token_usage`.
 - Multiple markers may exist for the same session. Runtime context uses the latest matching marker.
 

--- a/docs/modules/sessions/spec-checkpoint-refresh-design.md
+++ b/docs/modules/sessions/spec-checkpoint-refresh-design.md
@@ -1,0 +1,168 @@
+# SP-3 Spec Checkpoint Refresh Spec
+
+## Status
+
+Implemented for the 2026-05-01 PR scope. This document records the feature
+design and implementation contract for SP-3, the Spec-Checkpoint
+anti-degradation mechanism.
+
+## Context
+
+Long non-coordinator task runs can drift away from the original task contract
+after many tool calls, active history messages, or a large prompt history. Full
+conversation compaction preserves useful progress, but it can still make the
+current task specification compete with older conversational context. SP-3 adds a
+deterministic refresh layer: when a task has a persisted `TaskSpec`, the runtime
+can persist a bounded internal system prompt that restates the current spec
+before the next model request.
+
+The refresh is not a user-visible answer, not a new public API command, and not a
+replacement for compaction. It is a durable runtime marker that keeps requirements,
+constraints, acceptance criteria, verification commands, and expected evidence in
+the prompt after long-running work.
+
+## Goals
+
+- Keep non-coordinator agents aligned to persisted task specs during long runs.
+- Trigger refreshes from explicit lifecycle thresholds for completed tool calls,
+  active history messages, and estimated history tokens.
+- Persist refresh prompts as internal system messages so retries and recovery see
+  the same context boundary.
+- Emit a durable `spec_checkpoint_applied` run event for timeline and recovery
+  observability.
+- Preserve model fallback eligibility when the only new persisted state is the
+  internal checkpoint prompt.
+- Avoid restarts once a final answer is already present at the safe boundary.
+
+## Non-Goals
+
+- Changing coordinator orchestration prompts.
+- Replacing full conversation compaction or hidden-history markers.
+- Introducing new `/api/*` routes, CLI commands, or database tables.
+- Accepting unknown lifecycle fields beyond the explicit task model contract.
+- Injecting checkpoints for tasks without a persisted `TaskSpec`.
+
+## Feature Design
+
+`TaskLifecyclePolicy` owns the feature configuration through
+`SpecCheckpointPolicy`. The default policy is enabled and refreshes after any of
+these thresholds is crossed since the previous spec checkpoint:
+
+- `refresh_interval_tool_calls`: 12 completed tool calls or retry prompts with a
+  tool name.
+- `refresh_interval_messages`: 48 active history messages.
+- `refresh_interval_history_tokens`: 8000 estimated history tokens.
+
+The rendered checkpoint is intentionally bounded by `max_summary_chars`. It
+includes a marker comment, task and role identity, checkpoint sequence, trigger
+reason, refresh counters, and the populated sections of the persisted
+`TaskSpec`. The marker lets later decisions count from the latest checkpoint
+instead of repeatedly triggering from the beginning of the conversation.
+
+Coordinator roles are exempt because their prompt and task responsibilities are
+orchestration-level contracts. SP-3 is scoped to worker/subagent execution where
+the persisted task spec is the strongest local contract.
+
+## Runtime Contract
+
+The runtime may apply a spec checkpoint only at a safe model boundary:
+
+1. Resolve the current task record from `request.task_id`.
+2. Skip when the role registry marks the role as coordinator.
+3. Skip when the task has no meaningful spec content or the policy is disabled.
+4. Count completed tool calls, messages, and estimated tokens since the latest
+   checkpoint marker for the same task.
+5. Persist the rendered checkpoint with
+   `append_system_prompt_if_missing_async(...)`.
+6. Emit `RunEventType.SPEC_CHECKPOINT_APPLIED` with sequence, reason, and
+   counter payload.
+7. Rebuild the agent iteration context so the next model request sees the
+   checkpoint prompt.
+
+The checkpoint prompt is internal state. It must not mark the current attempt as
+user-visible message committed by itself, because that would incorrectly block
+provider fallback after retry exhaustion. Actual assistant/tool messages still
+set the normal commit flags.
+
+When a boundary batch already contains a final text response, checkpoint
+refreshes are skipped for that boundary. User-visible completion has priority
+over optional spec refresh so the runtime does not add an extra model turn,
+duplicate output, or change an already-finished answer.
+
+## Implementation Spec
+
+### Task Models
+
+`src/relay_teams/agents/tasks/models.py` defines:
+
+- `SpecCheckpointPolicy`
+- `TaskLifecyclePolicy.spec_checkpoint`
+
+The policy uses strict Pydantic v2 models and normalizes `None` to the default
+policy for persisted lifecycle payload tolerance.
+
+### Checkpoint Decision And Rendering
+
+`src/relay_teams/agents/execution/spec_checkpoint.py` owns deterministic decision
+logic:
+
+- `build_spec_checkpoint_decision(...)`
+- `spec_checkpoint_reason(...)`
+- `render_spec_checkpoint(...)`
+- `latest_spec_checkpoint_position(...)`
+- `is_spec_checkpoint_content(...)`
+- `count_completed_tool_calls(...)`
+
+The module does not access repositories. It receives a `TaskEnvelope`, role id,
+and history, then returns a frozen `SpecCheckpointDecision`.
+
+### Session Runtime Integration
+
+`src/relay_teams/agents/execution/session_runtime.py` adds
+`apply_spec_checkpoint_if_due()` inside the LLM generation loop. It runs before a
+new model request and after safe-boundary processing when no interrupt or queued
+injection has already restarted the turn.
+
+The integration preserves these ordering rules:
+
+- Interrupt injections are checked first.
+- Queued user/runtime injections take precedence at model boundaries.
+- Spec checkpoint injection happens only when no final answer is ready.
+- Tool input validation restarts still rebuild context through the existing
+  shared path.
+- AutoHarness dirty-tool rebuilds remain separate from checkpoint refresh.
+
+### Compaction Integration
+
+`src/relay_teams/agents/execution/conversation_compaction.py` renders preserved
+system prompts in compaction summaries, including Task Spec and Spec Checkpoint
+messages. This keeps the spec contract visible even after older transcript
+sections are summarized.
+
+### Observability And API Docs
+
+`RunEventType.SPEC_CHECKPOINT_APPLIED` records checkpoint application in the run
+stream. `docs/core/api-design.md` documents the event payload, and
+`docs/core/database-schema.md` documents the persisted lifecycle policy and event
+storage semantics.
+
+## Validation Matrix
+
+| Area | Coverage |
+| --- | --- |
+| Decision thresholds | `tests/unit_tests/agents/execution/test_spec_checkpoint.py` covers tool-call, message, token, marker, clipping, and task-spec filtering behavior. |
+| Runtime repository lookup | `tests/unit_tests/agents/execution/test_session_runtime.py` covers task lookup, coordinator exemption, missing task records, event payloads, and safe-boundary behavior. |
+| Fallback eligibility | `tests/unit_tests/agents/execution/test_session_runtime.py` verifies checkpoint persistence alone does not block provider fallback exhaustion handling. |
+| Final answer priority | `tests/unit_tests/agents/execution/test_session_runtime.py` verifies a final answer in the current boundary batch does not trigger a spec-checkpoint restart. |
+| Compaction preservation | `tests/unit_tests/agents/execution/test_conversation_compaction.py` covers preservation of spec checkpoint system messages in rendered transcript summaries. |
+| Task model contract | `tests/unit_tests/agents/tasks/test_task_models.py` covers lifecycle defaults and explicit checkpoint policy parsing. |
+
+## Operational Invariants
+
+- Checkpoints are only persisted for tasks with meaningful `TaskSpec` content.
+- Checkpoints are bounded, deterministic, and marked with task id plus sequence.
+- Runtime checkpoint application is idempotent through the message repository's
+  missing-prompt append operation.
+- Checkpoint event payloads include enough context to diagnose trigger source.
+- No public API or database schema migration is required beyond existing JSON
+  lifecycle/event payload fields.

--- a/src/relay_teams/agents/execution/__init__.py
+++ b/src/relay_teams/agents/execution/__init__.py
@@ -2,7 +2,13 @@
 from __future__ import annotations
 
 from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.agents.execution.spec_checkpoint import (
+    SpecCheckpointDecision,
+    build_spec_checkpoint_decision,
+)
 
 __all__ = [
     "MessageRepository",
+    "SpecCheckpointDecision",
+    "build_spec_checkpoint_decision",
 ]

--- a/src/relay_teams/agents/execution/conversation_compaction.py
+++ b/src/relay_teams/agents/execution/conversation_compaction.py
@@ -15,6 +15,7 @@ from pydantic_ai.messages import (
     PartEndEvent,
     PartStartEvent,
     RetryPromptPart,
+    SystemPromptPart,
     TextPart,
     TextPartDelta,
     ThinkingPart,
@@ -605,6 +606,8 @@ class ConversationCompactionService:
                 "Rewrite the summary as concise markdown that preserves the information needed to continue the conversation after older turns are hidden. "
                 "Keep objectives, decisions, constraints, tool outcomes, artifacts, unresolved threads, important paths, filenames, commands, identifiers, and concrete next-step instructions whenever they matter. "
                 "Preserve exact technical details when they are needed for future execution, especially filesystem paths, branch names, API names, config keys, error messages, and artifact locations. "
+                "If the transcript contains a Task Spec or Spec Checkpoint, preserve its requirements, constraints, acceptance criteria, out-of-scope items, verification commands, and evidence expectations in a dedicated spec section. "
+                "Spec constraints are higher priority than ordinary conversation details and must not be weakened or generalized. "
                 "Drop chatter, repetition, timestamps, and redundant narration. "
                 "Output only the final markdown."
             ),
@@ -931,6 +934,8 @@ def _render_message(message: ModelRequest | ModelResponse) -> str:
     for part in message.parts:
         if isinstance(part, UserPromptPart):
             fragments.append(f"User: {user_prompt_content_to_text(part.content)}")
+        elif isinstance(part, SystemPromptPart):
+            fragments.append(f"System: {str(part.content or '').strip()}")
         elif isinstance(part, TextPart):
             fragments.append(f"Assistant: {str(part.content or '').strip()}")
         elif isinstance(part, ThinkingPart):
@@ -977,6 +982,8 @@ def message_has_replay_anchor(message: ModelRequest | ModelResponse) -> bool:
     if not isinstance(message, ModelRequest):
         return False
     for part in message.parts:
+        if isinstance(part, SystemPromptPart):
+            return True
         if isinstance(part, UserPromptPart):
             return True
         if isinstance(part, RetryPromptPart) and not str(part.tool_name or "").strip():

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -728,7 +728,6 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 nonlocal coordination_agent
                 nonlocal seen_count
                 nonlocal buffered_messages
-                nonlocal attempt_messages_committed
 
                 decision = await _build_spec_checkpoint_decision_async(
                     task_repo=self._task_repo,
@@ -802,7 +801,6 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 coordination_agent = cast(CoordinationAgent, rebuilt_agent)
                 seen_count = 0
                 buffered_messages = []
-                attempt_messages_committed = True
                 return True
 
             async def process_safe_boundary(

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -32,6 +32,11 @@ from relay_teams.agents.execution.message_commit import (
 )
 from relay_teams.agents.execution.prompt_history import PreparedPromptContext
 from relay_teams.agents.execution.session_mixin_base import AgentLlmSessionMixinBase
+from relay_teams.agents.execution.spec_checkpoint import (
+    SpecCheckpointDecision,
+    build_spec_checkpoint_decision,
+)
+from relay_teams.agents.tasks.models import TaskEnvelope
 from relay_teams.logger import (
     close_model_stream,
     get_logger,
@@ -716,6 +721,88 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                     final_answer_ready=final_answer_ready,
                 )
 
+            async def apply_spec_checkpoint_if_due() -> bool:
+                nonlocal history
+                nonlocal prepared_prompt
+                nonlocal agent_system_prompt
+                nonlocal coordination_agent
+                nonlocal seen_count
+                nonlocal buffered_messages
+                nonlocal attempt_messages_committed
+
+                decision = await _build_spec_checkpoint_decision_async(
+                    session=self,
+                    request=request,
+                    history=history,
+                )
+                if not decision.should_inject:
+                    return False
+                appended = (
+                    await self._message_repo.append_system_prompt_if_missing_async(
+                        session_id=request.session_id,
+                        workspace_id=resolved_workspace_id,
+                        conversation_id=resolved_conversation_id,
+                        agent_role_id=request.role_id,
+                        instance_id=request.instance_id,
+                        task_id=request.task_id,
+                        trace_id=request.trace_id,
+                        content=decision.content,
+                    )
+                )
+                if appended is False:
+                    return False
+                await publish_run_event_async(
+                    self._run_event_hub,
+                    RunEvent(
+                        session_id=request.session_id,
+                        run_id=request.run_id,
+                        trace_id=request.trace_id,
+                        task_id=request.task_id,
+                        instance_id=request.instance_id,
+                        role_id=request.role_id,
+                        event_type=RunEventType.SPEC_CHECKPOINT_APPLIED,
+                        payload_json=dumps(
+                            _spec_checkpoint_event_payload(
+                                decision=decision,
+                                request=request,
+                            )
+                        ),
+                    ),
+                )
+                log_event(
+                    LOGGER,
+                    logging.INFO,
+                    event="llm.spec_checkpoint.applied",
+                    message="Applied automatic spec checkpoint refresh",
+                    payload={
+                        "run_id": request.run_id,
+                        "task_id": request.task_id,
+                        "role_id": request.role_id,
+                        "instance_id": request.instance_id,
+                        "sequence": decision.sequence,
+                        "reason": decision.reason,
+                    },
+                )
+                (
+                    prepared_prompt,
+                    history,
+                    agent_system_prompt,
+                    rebuilt_agent,
+                ) = await self._build_agent_iteration_context(
+                    request=request,
+                    conversation_id=resolved_conversation_id,
+                    system_prompt=request.system_prompt,
+                    reserve_user_prompt_tokens=False,
+                    allowed_tools=allowed_tools,
+                    allowed_mcp_servers=self._allowed_mcp_servers,
+                    allowed_skills=self._allowed_skills,
+                )
+                coordination_agent = cast(CoordinationAgent, rebuilt_agent)
+                seen_count = 0
+                buffered_messages = []
+                attempt_messages_committed = True
+                return True
+
             async def process_safe_boundary(
                 boundary_agent_run: AgentRun,
                 *,
@@ -824,10 +911,12 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 if not boundary_has_activity and not final_answer_ready:
                     return False
                 boundary_checked_after_latest_batch = True
-                return await apply_queued_injections_at_boundary(
+                if await apply_queued_injections_at_boundary(
                     final_answer_ready=final_answer_ready
                     or _messages_include_final_answer(new_to_process),
-                )
+                ):
+                    return True
+                return not final_answer_ready and await apply_spec_checkpoint_if_due()
         except BaseException:
             await self._close_run_scoped_llm_http_client(request=request)
             raise
@@ -839,6 +928,8 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                     if await apply_interrupt_injections():
                         continue
                     if await apply_queued_injections_at_boundary():
+                        continue
+                    if await apply_spec_checkpoint_if_due():
                         continue
                     restarted = False
                     provider_history = self._provider_history_for_model_turn(
@@ -1538,3 +1629,61 @@ def _messages_include_final_answer(
         if any(isinstance(part, TextPart) for part in message.parts):
             return True
     return False
+
+
+async def _build_spec_checkpoint_decision_async(
+    *,
+    session: AgentLlmSessionMixinBase,
+    request: LLMRequest,
+    history: Sequence[ModelRequest | ModelResponse],
+) -> SpecCheckpointDecision:
+    if _role_uses_coordinator_checkpoint_exemption(
+        session=session,
+        role_id=request.role_id,
+    ):
+        return SpecCheckpointDecision()
+    try:
+        task_record = await session._task_repo.get_async(request.task_id)
+    except (AttributeError, KeyError):
+        return SpecCheckpointDecision()
+    task = getattr(task_record, "envelope", None)
+    if not isinstance(task, TaskEnvelope):
+        return SpecCheckpointDecision()
+    return build_spec_checkpoint_decision(
+        task=task,
+        role_id=request.role_id,
+        history=history,
+    )
+
+
+def _role_uses_coordinator_checkpoint_exemption(
+    *,
+    session: AgentLlmSessionMixinBase,
+    role_id: str,
+) -> bool:
+    role_registry = getattr(session, "_role_registry", None)
+    if role_registry is None:
+        return False
+    try:
+        return bool(role_registry.is_coordinator_role(role_id))
+    except (AttributeError, KeyError):
+        return False
+
+
+def _spec_checkpoint_event_payload(
+    *,
+    decision: SpecCheckpointDecision,
+    request: LLMRequest,
+) -> dict[str, JsonValue]:
+    return {
+        "role_id": request.role_id,
+        "instance_id": request.instance_id,
+        "task_id": request.task_id,
+        "sequence": decision.sequence,
+        "reason": decision.reason,
+        "tool_calls_since_last_checkpoint": (decision.tool_calls_since_last_checkpoint),
+        "messages_since_last_checkpoint": decision.messages_since_last_checkpoint,
+        "history_tokens_since_last_checkpoint": (
+            decision.history_tokens_since_last_checkpoint
+        ),
+    }

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -911,12 +911,17 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 if not boundary_has_activity and not final_answer_ready:
                     return False
                 boundary_checked_after_latest_batch = True
+                boundary_final_answer_ready = (
+                    final_answer_ready or _messages_include_final_answer(new_to_process)
+                )
                 if await apply_queued_injections_at_boundary(
-                    final_answer_ready=final_answer_ready
-                    or _messages_include_final_answer(new_to_process),
+                    final_answer_ready=boundary_final_answer_ready,
                 ):
                     return True
-                return not final_answer_ready and await apply_spec_checkpoint_if_due()
+                return (
+                    not boundary_final_answer_ready
+                    and await apply_spec_checkpoint_if_due()
+                )
         except BaseException:
             await self._close_run_scoped_llm_http_client(request=request)
             raise

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -36,7 +36,7 @@ from relay_teams.agents.execution.spec_checkpoint import (
     SpecCheckpointDecision,
     build_spec_checkpoint_decision,
 )
-from relay_teams.agents.tasks.models import TaskEnvelope
+from relay_teams.agents.tasks.models import TaskRecord
 from relay_teams.logger import (
     close_model_stream,
     get_logger,
@@ -731,25 +731,27 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 nonlocal attempt_messages_committed
 
                 decision = await _build_spec_checkpoint_decision_async(
-                    session=self,
+                    task_repo=self._task_repo,
+                    role_registry=self._role_registry,
                     request=request,
                     history=history,
                 )
                 if not decision.should_inject:
                     return False
-                appended = (
-                    await self._message_repo.append_system_prompt_if_missing_async(
-                        session_id=request.session_id,
-                        workspace_id=resolved_workspace_id,
-                        conversation_id=resolved_conversation_id,
-                        agent_role_id=request.role_id,
-                        instance_id=request.instance_id,
-                        task_id=request.task_id,
-                        trace_id=request.trace_id,
-                        content=decision.content,
-                    )
+                append_system_prompt = (
+                    self._message_repo.append_system_prompt_if_missing_async
                 )
-                if appended is False:
+                checkpoint_appended = await append_system_prompt(
+                    session_id=request.session_id,
+                    workspace_id=resolved_workspace_id,
+                    conversation_id=resolved_conversation_id,
+                    agent_role_id=request.role_id,
+                    instance_id=request.instance_id,
+                    task_id=request.task_id,
+                    trace_id=request.trace_id,
+                    content=decision.content,
+                )
+                if not checkpoint_appended:
                     return False
                 await publish_run_event_async(
                     self._run_event_hub,
@@ -1631,26 +1633,36 @@ def _messages_include_final_answer(
     return False
 
 
+class _SpecCheckpointTaskRepository(Protocol):
+    async def get_async(self, task_id: str) -> TaskRecord:
+        raise NotImplementedError  # pragma: no cover
+
+
+class _SpecCheckpointRoleRegistry(Protocol):
+    def is_coordinator_role(self, role_id: str) -> bool:
+        raise NotImplementedError  # pragma: no cover
+
+
 async def _build_spec_checkpoint_decision_async(
     *,
-    session: AgentLlmSessionMixinBase,
+    task_repo: _SpecCheckpointTaskRepository | None,
+    role_registry: _SpecCheckpointRoleRegistry | None,
     request: LLMRequest,
     history: Sequence[ModelRequest | ModelResponse],
 ) -> SpecCheckpointDecision:
     if _role_uses_coordinator_checkpoint_exemption(
-        session=session,
+        role_registry=role_registry,
         role_id=request.role_id,
     ):
         return SpecCheckpointDecision()
-    try:
-        task_record = await session._task_repo.get_async(request.task_id)
-    except (AttributeError, KeyError):
+    if task_repo is None:
         return SpecCheckpointDecision()
-    task = getattr(task_record, "envelope", None)
-    if not isinstance(task, TaskEnvelope):
+    try:
+        task_record = await task_repo.get_async(request.task_id)
+    except KeyError:
         return SpecCheckpointDecision()
     return build_spec_checkpoint_decision(
-        task=task,
+        task=task_record.envelope,
         role_id=request.role_id,
         history=history,
     )
@@ -1658,15 +1670,14 @@ async def _build_spec_checkpoint_decision_async(
 
 def _role_uses_coordinator_checkpoint_exemption(
     *,
-    session: AgentLlmSessionMixinBase,
+    role_registry: _SpecCheckpointRoleRegistry | None,
     role_id: str,
 ) -> bool:
-    role_registry = getattr(session, "_role_registry", None)
     if role_registry is None:
         return False
     try:
         return bool(role_registry.is_coordinator_role(role_id))
-    except (AttributeError, KeyError):
+    except KeyError:
         return False
 
 
@@ -1675,15 +1686,14 @@ def _spec_checkpoint_event_payload(
     decision: SpecCheckpointDecision,
     request: LLMRequest,
 ) -> dict[str, JsonValue]:
+    history_tokens_since_last_checkpoint = decision.history_tokens_since_last_checkpoint
     return {
         "role_id": request.role_id,
         "instance_id": request.instance_id,
         "task_id": request.task_id,
         "sequence": decision.sequence,
         "reason": decision.reason,
-        "tool_calls_since_last_checkpoint": (decision.tool_calls_since_last_checkpoint),
+        "tool_calls_since_last_checkpoint": decision.tool_calls_since_last_checkpoint,
         "messages_since_last_checkpoint": decision.messages_since_last_checkpoint,
-        "history_tokens_since_last_checkpoint": (
-            decision.history_tokens_since_last_checkpoint
-        ),
+        "history_tokens_since_last_checkpoint": history_tokens_since_last_checkpoint,
     }

--- a/src/relay_teams/agents/execution/spec_checkpoint.py
+++ b/src/relay_teams/agents/execution/spec_checkpoint.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    RetryPromptPart,
+    SystemPromptPart,
+    ToolReturnPart,
+)
+
+from relay_teams.agents.execution.conversation_compaction import (
+    ConversationTokenEstimator,
+)
+from relay_teams.agents.tasks.models import (
+    SpecCheckpointPolicy,
+    TaskEnvelope,
+    TaskSpec,
+)
+
+SPEC_CHECKPOINT_MARKER = "<!-- relay-spec-checkpoint"
+_SEQUENCE_ATTRIBUTE = 'sequence="'
+_TASK_ID_ATTRIBUTE = 'task_id="'
+_ITEM_MAX_CHARS = 700
+
+
+class SpecCheckpointDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    should_inject: bool = False
+    content: str = ""
+    sequence: int = Field(default=0, ge=0)
+    reason: str = ""
+    tool_calls_since_last_checkpoint: int = Field(default=0, ge=0)
+    messages_since_last_checkpoint: int = Field(default=0, ge=0)
+    history_tokens_since_last_checkpoint: int = Field(default=0, ge=0)
+
+
+def build_spec_checkpoint_decision(
+    *,
+    task: TaskEnvelope,
+    role_id: str,
+    history: Sequence[ModelRequest | ModelResponse],
+) -> SpecCheckpointDecision:
+    policy = task.lifecycle.spec_checkpoint
+    spec = task.spec
+    if not policy.enabled or spec is None or not task_spec_has_content(spec):
+        return SpecCheckpointDecision()
+
+    last_checkpoint_index, last_sequence = latest_spec_checkpoint_position(
+        history=history,
+        task_id=task.task_id,
+    )
+    history_since_checkpoint = tuple(history[last_checkpoint_index + 1 :])
+    tool_calls_since_checkpoint = count_completed_tool_calls(history_since_checkpoint)
+    messages_since_checkpoint = len(history_since_checkpoint)
+    tokens_since_checkpoint = ConversationTokenEstimator().estimate_history_tokens(
+        history_since_checkpoint
+    )
+    reason = spec_checkpoint_reason(
+        policy=policy,
+        tool_calls_since_checkpoint=tool_calls_since_checkpoint,
+        messages_since_checkpoint=messages_since_checkpoint,
+        tokens_since_checkpoint=tokens_since_checkpoint,
+    )
+    if not reason:
+        return SpecCheckpointDecision(
+            tool_calls_since_last_checkpoint=tool_calls_since_checkpoint,
+            messages_since_last_checkpoint=messages_since_checkpoint,
+            history_tokens_since_last_checkpoint=tokens_since_checkpoint,
+        )
+
+    sequence = last_sequence + 1
+    return SpecCheckpointDecision(
+        should_inject=True,
+        content=render_spec_checkpoint(
+            task=task,
+            role_id=role_id,
+            sequence=sequence,
+            reason=reason,
+            policy=policy,
+            tool_calls_since_checkpoint=tool_calls_since_checkpoint,
+            messages_since_checkpoint=messages_since_checkpoint,
+            tokens_since_checkpoint=tokens_since_checkpoint,
+        ),
+        sequence=sequence,
+        reason=reason,
+        tool_calls_since_last_checkpoint=tool_calls_since_checkpoint,
+        messages_since_last_checkpoint=messages_since_checkpoint,
+        history_tokens_since_last_checkpoint=tokens_since_checkpoint,
+    )
+
+
+def task_spec_has_content(spec: TaskSpec) -> bool:
+    return bool(
+        spec.summary
+        or spec.requirements
+        or spec.constraints
+        or spec.acceptance_criteria
+        or spec.out_of_scope
+        or spec.verification_commands
+        or spec.evidence_expectations
+    )
+
+
+def spec_checkpoint_reason(
+    *,
+    policy: SpecCheckpointPolicy,
+    tool_calls_since_checkpoint: int,
+    messages_since_checkpoint: int,
+    tokens_since_checkpoint: int,
+) -> str:
+    reasons: list[str] = []
+    if tool_calls_since_checkpoint >= policy.refresh_interval_tool_calls:
+        reasons.append(f"tool_calls>={policy.refresh_interval_tool_calls}")
+    if messages_since_checkpoint >= policy.refresh_interval_messages:
+        reasons.append(f"messages>={policy.refresh_interval_messages}")
+    if tokens_since_checkpoint >= policy.refresh_interval_history_tokens:
+        reasons.append(f"history_tokens>={policy.refresh_interval_history_tokens}")
+    return ", ".join(reasons)
+
+
+def render_spec_checkpoint(
+    *,
+    task: TaskEnvelope,
+    role_id: str,
+    sequence: int,
+    reason: str,
+    policy: SpecCheckpointPolicy,
+    tool_calls_since_checkpoint: int,
+    messages_since_checkpoint: int,
+    tokens_since_checkpoint: int,
+) -> str:
+    spec = task.spec
+    if spec is None:
+        return ""
+    lines = [
+        spec_checkpoint_marker(task_id=task.task_id, sequence=sequence),
+        "## Spec Checkpoint",
+        (
+            "Automatic specification refresh. Treat this task spec as "
+            "authoritative over older compressed or conversational context."
+        ),
+        "",
+        f"- Task ID: {task.task_id}",
+        f"- Role ID: {role_id}",
+        f"- Sequence: {sequence}",
+        f"- Trigger: {reason}",
+        (
+            "- Since Previous Checkpoint: "
+            f"{tool_calls_since_checkpoint} tool calls, "
+            f"{messages_since_checkpoint} messages, "
+            f"{tokens_since_checkpoint} estimated history tokens"
+        ),
+        "",
+        "### Task Spec",
+    ]
+    if spec.summary:
+        lines.append(f"- Summary: {_clip_item(spec.summary)}")
+    lines.extend(_format_items("Requirements", spec.requirements))
+    lines.extend(_format_items("Constraints", spec.constraints))
+    lines.extend(_format_items("Acceptance Criteria", spec.acceptance_criteria))
+    lines.extend(_format_items("Out of Scope", spec.out_of_scope))
+    lines.extend(_format_items("Verification Commands", spec.verification_commands))
+    lines.extend(_format_items("Evidence Expectations", spec.evidence_expectations))
+    lines.append(f"- Strictness: {spec.strictness.value}")
+    return _clip_checkpoint_text(
+        "\n".join(lines).strip(),
+        max_chars=policy.max_summary_chars,
+    )
+
+
+def spec_checkpoint_marker(*, task_id: str, sequence: int) -> str:
+    return (
+        f'{SPEC_CHECKPOINT_MARKER} task_id="{task_id}" '
+        f'sequence="{max(0, sequence)}" -->'
+    )
+
+
+def latest_spec_checkpoint_position(
+    *,
+    history: Sequence[ModelRequest | ModelResponse],
+    task_id: str,
+) -> tuple[int, int]:
+    last_index = -1
+    last_sequence = 0
+    for index, message in enumerate(history):
+        if not isinstance(message, ModelRequest):
+            continue
+        for part in message.parts:
+            if not isinstance(part, SystemPromptPart):
+                continue
+            content = str(part.content or "")
+            if not is_spec_checkpoint_content(content, task_id=task_id):
+                continue
+            last_index = index
+            last_sequence = max(last_sequence, _extract_sequence(content))
+    return last_index, last_sequence
+
+
+def is_spec_checkpoint_content(content: str, *, task_id: str | None = None) -> bool:
+    if SPEC_CHECKPOINT_MARKER not in content:
+        return False
+    if task_id is None:
+        return True
+    task_id_marker = f'{_TASK_ID_ATTRIBUTE}{task_id}"'
+    return task_id_marker in content
+
+
+def count_completed_tool_calls(
+    history: Sequence[ModelRequest | ModelResponse],
+) -> int:
+    count = 0
+    for message in history:
+        if not isinstance(message, ModelRequest):
+            continue
+        for part in message.parts:
+            if isinstance(part, ToolReturnPart):
+                count += 1
+                continue
+            if isinstance(part, RetryPromptPart) and str(part.tool_name or "").strip():
+                count += 1
+    return count
+
+
+def _format_items(label: str, items: tuple[str, ...]) -> list[str]:
+    if not items:
+        return []
+    return [f"- {label}:"] + [f"  - {_clip_item(item)}" for item in items]
+
+
+def _clip_item(item: str) -> str:
+    text = str(item or "").strip()
+    if len(text) <= _ITEM_MAX_CHARS:
+        return text
+    clipped = text[: _ITEM_MAX_CHARS - 15].rstrip()
+    return f"{clipped} [truncated]"
+
+
+def _clip_checkpoint_text(text: str, *, max_chars: int) -> str:
+    stripped = text.strip()
+    if len(stripped) <= max_chars:
+        return stripped
+    prefix = stripped[: max(0, max_chars - 48)].rstrip()
+    last_newline = prefix.rfind("\n")
+    if last_newline > 0:
+        prefix = prefix[:last_newline].rstrip()
+    return f"{prefix}\n[spec checkpoint truncated]"
+
+
+def _extract_sequence(content: str) -> int:
+    start = content.find(_SEQUENCE_ATTRIBUTE)
+    if start < 0:
+        return 0
+    start += len(_SEQUENCE_ATTRIBUTE)
+    end = content.find('"', start)
+    if end < 0:
+        return 0
+    raw_sequence = content[start:end].strip()
+    if not raw_sequence.isdigit():
+        return 0
+    return int(raw_sequence)

--- a/src/relay_teams/agents/tasks/__init__.py
+++ b/src/relay_teams/agents/tasks/__init__.py
@@ -7,6 +7,7 @@ from relay_teams.agents.tasks.ids import TaskId, new_task_id
 from relay_teams.agents.tasks.models import (
     SemanticEvaluationRequest,
     SemanticEvaluationResult,
+    SpecCheckpointPolicy,
     TaskEnvelope,
     TaskHandoff,
     TaskLifecyclePolicy,
@@ -29,6 +30,7 @@ __all__ = [
     "EventType",
     "SemanticEvaluationRequest",
     "SemanticEvaluationResult",
+    "SpecCheckpointPolicy",
     "TaskEnvelope",
     "TaskHandoff",
     "TaskId",

--- a/src/relay_teams/agents/tasks/models.py
+++ b/src/relay_teams/agents/tasks/models.py
@@ -170,12 +170,33 @@ class TaskSpec(BaseModel):
         return _normalize_text_tuple(value, field_name="task spec text")
 
 
+class SpecCheckpointPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    refresh_interval_tool_calls: int = Field(default=12, ge=1, le=1000)
+    refresh_interval_messages: int = Field(default=48, ge=1, le=5000)
+    refresh_interval_history_tokens: int = Field(default=8000, ge=1, le=1_000_000)
+    max_summary_chars: int = Field(default=6000, ge=500, le=50_000)
+
+
 class TaskLifecyclePolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     timeout_seconds: float | None = Field(default=None, gt=0.0, le=86_400.0)
     heartbeat_interval_seconds: float | None = Field(default=None, gt=0.0, le=3600.0)
     on_timeout: TaskTimeoutAction = TaskTimeoutAction.FAIL
+    spec_checkpoint: SpecCheckpointPolicy = Field(default_factory=SpecCheckpointPolicy)
+
+    @field_validator("spec_checkpoint", mode="before")
+    @classmethod
+    def _normalize_spec_checkpoint(
+        cls,
+        value: object,
+    ) -> SpecCheckpointPolicy | object:
+        if value is None:
+            return SpecCheckpointPolicy()
+        return value
 
 
 class TaskHandoff(BaseModel):

--- a/src/relay_teams/sessions/runs/enums.py
+++ b/src/relay_teams/sessions/runs/enums.py
@@ -47,6 +47,7 @@ class RunEventType(str, Enum):
     TOOL_CALL_BATCH_SEALED = "tool_call_batch_sealed"
     TOOL_INPUT_VALIDATION_FAILED = "tool_input_validation_failed"
     TOOL_RESULT = "tool_result"
+    SPEC_CHECKPOINT_APPLIED = "spec_checkpoint_applied"
     INJECTION_ENQUEUED = "injection_enqueued"
     INJECTION_APPLIED = "injection_applied"
     TOOL_APPROVAL_REQUESTED = "tool_approval_requested"

--- a/src/relay_teams/sessions/runs/run_state_models.py
+++ b/src/relay_teams/sessions/runs/run_state_models.py
@@ -104,6 +104,7 @@ _CHECKPOINT_EVENT_TYPES = {
     RunEventType.USER_QUESTION_REQUESTED,
     RunEventType.USER_QUESTION_ANSWERED,
     RunEventType.TOOL_RESULT,
+    RunEventType.SPEC_CHECKPOINT_APPLIED,
     RunEventType.SUBAGENT_STOPPED,
     RunEventType.SUBAGENT_RESUMED,
     RunEventType.RUN_STOPPED,
@@ -197,6 +198,7 @@ def apply_run_event_to_state(
         RunEventType.THINKING_DELTA,
         RunEventType.THINKING_FINISHED,
         RunEventType.MODEL_STEP_FINISHED,
+        RunEventType.SPEC_CHECKPOINT_APPLIED,
     }:
         if status not in _TERMINAL_STATES and status != _STOPPED_STATE:
             status = RunStateStatus.RUNNING

--- a/tests/unit_tests/agents/execution/test_conversation_compaction.py
+++ b/tests/unit_tests/agents/execution/test_conversation_compaction.py
@@ -33,6 +33,7 @@ from pydantic_ai.messages import (
     PartStartEvent,
     TextPart,
     TextPartDelta,
+    SystemPromptPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
@@ -258,6 +259,27 @@ def test_render_transcript_does_not_clip_mid_line_fact() -> None:
     assert "lunar-min" not in transcript
     assert "phase-4 anchor" not in transcript
     assert transcript.splitlines()[-1] == "Tool result [shell]: line-a"
+
+
+def test_render_transcript_preserves_spec_checkpoint_system_messages() -> None:
+    history = [
+        ModelRequest(
+            parts=[
+                SystemPromptPart(
+                    content=(
+                        "## Spec Checkpoint\n- Requirements:\n  - preserve public API"
+                    )
+                )
+            ]
+        )
+    ]
+
+    transcript = compaction_module._render_transcript(history, max_chars=4000)
+
+    assert "System: ## Spec Checkpoint" in transcript
+    assert "preserve public API" in transcript
+    assert compaction_module.message_has_replay_anchor(history[0]) is True
+    assert compaction_module.is_replayable_history(history) is True
 
 
 def test_render_transcript_keeps_single_line_message_body_when_truncated() -> None:

--- a/tests/unit_tests/agents/execution/test_session_runtime.py
+++ b/tests/unit_tests/agents/execution/test_session_runtime.py
@@ -14,6 +14,7 @@ from relay_teams.agents.tasks.models import (
     SpecCheckpointPolicy,
     TaskEnvelope,
     TaskLifecyclePolicy,
+    TaskRecord,
     TaskSpec,
     VerificationPlan,
 )
@@ -42,7 +43,6 @@ from .agent_llm_session_test_support import (
 
 @pytest.mark.asyncio
 async def test_spec_checkpoint_decision_reads_task_spec_from_runtime_repo() -> None:
-    session = object.__new__(AgentLlmSession)
     task = TaskEnvelope(
         task_id="task-1",
         session_id="session-1",
@@ -60,22 +60,20 @@ async def test_spec_checkpoint_decision_reads_task_spec_from_runtime_repo() -> N
     )
 
     class _TaskRepo:
-        async def get_async(self, task_id: str) -> object:
+        async def get_async(self, task_id: str) -> TaskRecord:
             assert task_id == "task-1"
-            return SimpleNamespace(envelope=task)
+            return TaskRecord(envelope=task)
 
     class _RoleRegistry:
         def is_coordinator_role(self, role_id: str) -> bool:
             assert role_id == "Crafter"
             return False
 
-    session.__dict__["_task_repo"] = _TaskRepo()
-    session.__dict__["_role_registry"] = _RoleRegistry()
-
     decision = await session_runtime_module._build_spec_checkpoint_decision_async(
-        session=session,
+        task_repo=_TaskRepo(),
+        role_registry=_RoleRegistry(),
         request=_build_request(user_prompt=None).model_copy(
-            update={"role_id": "Crafter"}
+            update={"role_id": "Crafter", "task_id": "task-1"}
         ),
         history=[
             ModelRequest(
@@ -92,6 +90,86 @@ async def test_spec_checkpoint_decision_reads_task_spec_from_runtime_repo() -> N
 
     assert decision.should_inject is True
     assert "keep the route stable" in decision.content
+
+
+@pytest.mark.asyncio
+async def test_spec_checkpoint_decision_skips_coordinator_roles() -> None:
+    class _TaskRepo:
+        async def get_async(self, task_id: str) -> TaskRecord:
+            raise AssertionError(task_id)
+
+    class _RoleRegistry:
+        def is_coordinator_role(self, role_id: str) -> bool:
+            assert role_id == "Coordinator"
+            return True
+
+    decision = await session_runtime_module._build_spec_checkpoint_decision_async(
+        task_repo=_TaskRepo(),
+        role_registry=_RoleRegistry(),
+        request=_build_request(user_prompt=None).model_copy(
+            update={"role_id": "Coordinator", "task_id": "task-1"}
+        ),
+        history=[],
+    )
+
+    assert decision.should_inject is False
+
+
+@pytest.mark.asyncio
+async def test_spec_checkpoint_decision_ignores_missing_task_record() -> None:
+    class _TaskRepo:
+        async def get_async(self, task_id: str) -> TaskRecord:
+            assert task_id == "missing-task"
+            raise KeyError(task_id)
+
+    class _RoleRegistry:
+        def is_coordinator_role(self, role_id: str) -> bool:
+            assert role_id == "Crafter"
+            raise KeyError(role_id)
+
+    decision = await session_runtime_module._build_spec_checkpoint_decision_async(
+        task_repo=_TaskRepo(),
+        role_registry=_RoleRegistry(),
+        request=_build_request(user_prompt=None).model_copy(
+            update={"role_id": "Crafter", "task_id": "missing-task"}
+        ),
+        history=[],
+    )
+
+    assert decision.should_inject is False
+
+
+def test_spec_checkpoint_event_payload_contains_refresh_counters() -> None:
+    request = _build_request(user_prompt=None).model_copy(
+        update={
+            "role_id": "Crafter",
+            "instance_id": "inst-1",
+            "task_id": "task-1",
+        }
+    )
+    decision = session_runtime_module.SpecCheckpointDecision(
+        sequence=2,
+        reason="messages>=2",
+        tool_calls_since_last_checkpoint=1,
+        messages_since_last_checkpoint=2,
+        history_tokens_since_last_checkpoint=3,
+    )
+
+    payload = session_runtime_module._spec_checkpoint_event_payload(
+        decision=decision,
+        request=request,
+    )
+
+    assert payload == {
+        "role_id": "Crafter",
+        "instance_id": "inst-1",
+        "task_id": "task-1",
+        "sequence": 2,
+        "reason": "messages>=2",
+        "tool_calls_since_last_checkpoint": 1,
+        "messages_since_last_checkpoint": 2,
+        "history_tokens_since_last_checkpoint": 3,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/test_session_runtime.py
+++ b/tests/unit_tests/agents/execution/test_session_runtime.py
@@ -7,7 +7,12 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
-from pydantic_ai.messages import FunctionToolResultEvent, ToolCallPart, ToolReturnPart
+from pydantic_ai.messages import (
+    FunctionToolResultEvent,
+    SystemPromptPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
 
 from relay_teams.agents.execution import session_runtime as session_runtime_module
 from relay_teams.agents.tasks.models import (
@@ -816,6 +821,53 @@ async def test_generate_async_does_not_emit_retry_exhausted_after_fallback_exhau
     None
 ):
     session = object.__new__(AgentLlmSession)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Implement API",
+        verification=VerificationPlan(),
+        spec=TaskSpec(requirements=("keep retry fallback available",)),
+        lifecycle=TaskLifecyclePolicy(
+            spec_checkpoint=SpecCheckpointPolicy(
+                refresh_interval_tool_calls=99,
+                refresh_interval_messages=1,
+                refresh_interval_history_tokens=999_999,
+            )
+        ),
+    )
+
+    class _TaskRepo:
+        async def get_async(self, task_id: str) -> TaskRecord:
+            assert task_id == "task-1"
+            return TaskRecord(envelope=task)
+
+    class _SpecCheckpointMessageRepo(_FakeMessageRepo):
+        async def append_system_prompt_if_missing_async(
+            self,
+            *,
+            session_id: str,
+            workspace_id: str,
+            conversation_id: str,
+            agent_role_id: str,
+            instance_id: str,
+            task_id: str,
+            trace_id: str,
+            content: str,
+        ) -> bool:
+            _ = (
+                session_id,
+                workspace_id,
+                conversation_id,
+                agent_role_id,
+                instance_id,
+                task_id,
+                trace_id,
+            )
+            self.appended_system_prompts.append(content)
+            return True
+
+    message_repo = _SpecCheckpointMessageRepo(history=[])
     session.__dict__["_config"] = ModelEndpointConfig(
         model="primary-model",
         base_url="https://example.test/v1",
@@ -829,12 +881,10 @@ async def test_generate_async_does_not_emit_retry_exhausted_after_fallback_exhau
     session.__dict__["_allowed_tools"] = ()
     session.__dict__["_allowed_mcp_servers"] = ()
     session.__dict__["_allowed_skills"] = ()
-    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_task_repo"] = _TaskRepo()
     session.__dict__["_shared_store"] = cast(object, None)
     session.__dict__["_event_bus"] = cast(object, None)
-    session.__dict__["_message_repo"] = cast(
-        MessageRepository, _FakeMessageRepo(history=[])
-    )
+    session.__dict__["_message_repo"] = cast(MessageRepository, message_repo)
     session.__dict__["_approval_ticket_repo"] = cast(object, None)
     session.__dict__["_run_runtime_repo"] = cast(object, None)
     session.__dict__["_injection_manager"] = type(
@@ -943,9 +993,20 @@ async def test_generate_async_does_not_emit_retry_exhausted_after_fallback_exhau
 
     async def _build_agent_iteration_context(
         **kwargs: object,
-    ) -> tuple[str, list[object], str, object]:
+    ) -> tuple[str, list[ModelRequest], str, object]:
         _ = kwargs
-        return "", [], "System prompt", _FailingAgent()
+        history = [ModelRequest(parts=[UserPromptPart(content="existing progress")])]
+        if message_repo.appended_system_prompts:
+            history.append(
+                ModelRequest(
+                    parts=[
+                        SystemPromptPart(
+                            content=message_repo.appended_system_prompts[-1]
+                        )
+                    ]
+                )
+            )
+        return "", history, "System prompt", _FailingAgent()
 
     session.__dict__["_build_agent_iteration_context"] = _build_agent_iteration_context
 
@@ -956,6 +1017,7 @@ async def test_generate_async_does_not_emit_retry_exhausted_after_fallback_exhau
         )
 
     assert len(fallback_exhausted_calls) == 1
+    assert len(message_repo.appended_system_prompts) == 1
     assert retry_scheduled_calls == []
     assert retry_exhausted_calls == []
 

--- a/tests/unit_tests/agents/execution/test_session_runtime.py
+++ b/tests/unit_tests/agents/execution/test_session_runtime.py
@@ -10,6 +10,13 @@ import pytest
 from pydantic_ai.messages import FunctionToolResultEvent, ToolCallPart, ToolReturnPart
 
 from relay_teams.agents.execution import session_runtime as session_runtime_module
+from relay_teams.agents.tasks.models import (
+    SpecCheckpointPolicy,
+    TaskEnvelope,
+    TaskLifecyclePolicy,
+    TaskSpec,
+    VerificationPlan,
+)
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.tools.registry import ToolRegistry
@@ -31,6 +38,60 @@ from .agent_llm_session_test_support import (
     _build_request,
     httpx,
 )
+
+
+@pytest.mark.asyncio
+async def test_spec_checkpoint_decision_reads_task_spec_from_runtime_repo() -> None:
+    session = object.__new__(AgentLlmSession)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Implement API",
+        verification=VerificationPlan(),
+        spec=TaskSpec(requirements=("keep the route stable",)),
+        lifecycle=TaskLifecyclePolicy(
+            spec_checkpoint=SpecCheckpointPolicy(
+                refresh_interval_tool_calls=1,
+                refresh_interval_messages=99,
+                refresh_interval_history_tokens=999_999,
+            )
+        ),
+    )
+
+    class _TaskRepo:
+        async def get_async(self, task_id: str) -> object:
+            assert task_id == "task-1"
+            return SimpleNamespace(envelope=task)
+
+    class _RoleRegistry:
+        def is_coordinator_role(self, role_id: str) -> bool:
+            assert role_id == "Crafter"
+            return False
+
+    session.__dict__["_task_repo"] = _TaskRepo()
+    session.__dict__["_role_registry"] = _RoleRegistry()
+
+    decision = await session_runtime_module._build_spec_checkpoint_decision_async(
+        session=session,
+        request=_build_request(user_prompt=None).model_copy(
+            update={"role_id": "Crafter"}
+        ),
+        history=[
+            ModelRequest(
+                parts=[
+                    ToolReturnPart(
+                        tool_name="shell",
+                        tool_call_id="call-1",
+                        content="ok",
+                    )
+                ]
+            )
+        ],
+    )
+
+    assert decision.should_inject is True
+    assert "keep the route stable" in decision.content
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/test_session_runtime.py
+++ b/tests/unit_tests/agents/execution/test_session_runtime.py
@@ -219,8 +219,59 @@ async def test_generate_async_persists_only_provider_canonical_tool_messages(
         parts=[TextPart(content="done")],
         model_name="fake-model",
     )
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Implement API",
+        verification=VerificationPlan(),
+        spec=TaskSpec(requirements=("return the completed answer without restart",)),
+        lifecycle=TaskLifecyclePolicy(
+            spec_checkpoint=SpecCheckpointPolicy(
+                refresh_interval_tool_calls=99,
+                refresh_interval_messages=1,
+                refresh_interval_history_tokens=999_999,
+            )
+        ),
+    )
     provider_history = [echoed_request]
-    message_repo = _FakeMessageRepo(history=[])
+
+    class _TaskRepo:
+        async def get_async(self, task_id: str) -> TaskRecord:
+            assert task_id == "task-1"
+            return TaskRecord(envelope=task)
+
+    class _RoleRegistry:
+        def is_coordinator_role(self, role_id: str) -> bool:
+            assert role_id == "writer"
+            return False
+
+    class _SpecCheckpointMessageRepo(_FakeMessageRepo):
+        async def append_system_prompt_if_missing_async(
+            self,
+            *,
+            session_id: str,
+            workspace_id: str,
+            conversation_id: str,
+            agent_role_id: str,
+            instance_id: str,
+            task_id: str,
+            trace_id: str,
+            content: str,
+        ) -> bool:
+            _ = (
+                session_id,
+                workspace_id,
+                conversation_id,
+                agent_role_id,
+                instance_id,
+                task_id,
+                trace_id,
+            )
+            self.appended_system_prompts.append(content)
+            return True
+
+    message_repo = _SpecCheckpointMessageRepo(history=[])
     streamed_tool_result = ToolReturnPart(
         tool_name="test_tool",
         content={"ok": True},
@@ -352,7 +403,7 @@ async def test_generate_async_persists_only_provider_canonical_tool_messages(
     session.__dict__["_allowed_tools"] = ()
     session.__dict__["_allowed_mcp_servers"] = ()
     session.__dict__["_allowed_skills"] = ()
-    session.__dict__["_task_repo"] = cast(object, None)
+    session.__dict__["_task_repo"] = _TaskRepo()
     session.__dict__["_shared_store"] = cast(object, None)
     session.__dict__["_event_bus"] = cast(object, None)
     session.__dict__["_message_repo"] = cast(MessageRepository, message_repo)
@@ -375,7 +426,7 @@ async def test_generate_async_persists_only_provider_canonical_tool_messages(
     session.__dict__["_conversation_microcompact_service"] = None
     session.__dict__["_mcp_registry"] = McpRegistry()
     session.__dict__["_skill_registry"] = cast(object, None)
-    session.__dict__["_role_registry"] = cast(object, None)
+    session.__dict__["_role_registry"] = _RoleRegistry()
     session.__dict__["_task_execution_service"] = cast(object, object())
     session.__dict__["_task_service"] = cast(object, None)
     session.__dict__["_run_control_manager"] = _FakeRunControlManager()
@@ -437,10 +488,16 @@ async def test_generate_async_persists_only_provider_canonical_tool_messages(
         _publish_committed_tool_outcome_events_from_messages_async
     )
 
+    build_context_calls = 0
+
     async def _build_agent_iteration_context(
         **kwargs: object,
     ) -> tuple[object, Sequence[ModelRequest | ModelResponse], str, object]:
+        nonlocal build_context_calls
         _ = kwargs
+        build_context_calls += 1
+        if build_context_calls > 1:
+            raise AssertionError("final answer boundary should not restart")
         prepared_prompt = SimpleNamespace(
             history=(),
             system_prompt="System prompt",
@@ -490,6 +547,8 @@ async def test_generate_async_persists_only_provider_canonical_tool_messages(
     assert result == "done"
     assert observed_histories
     assert all(list(history) == provider_history for history in observed_histories)
+    assert build_context_calls == 1
+    assert message_repo.appended_system_prompts == []
     assert len(message_repo.append_calls) == 1
     assert message_repo.append_calls[0] == [
         canonical_tool_call,

--- a/tests/unit_tests/agents/execution/test_spec_checkpoint.py
+++ b/tests/unit_tests/agents/execution/test_spec_checkpoint.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    SystemPromptPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from relay_teams.agents.execution.spec_checkpoint import (
+    build_spec_checkpoint_decision,
+    count_completed_tool_calls,
+    is_spec_checkpoint_content,
+    latest_spec_checkpoint_position,
+    spec_checkpoint_marker,
+)
+from relay_teams.agents.tasks.enums import TaskSpecStrictness
+from relay_teams.agents.tasks.models import (
+    SpecCheckpointPolicy,
+    TaskEnvelope,
+    TaskLifecyclePolicy,
+    TaskSpec,
+    VerificationPlan,
+)
+
+
+def test_spec_checkpoint_triggers_after_tool_call_interval() -> None:
+    task = _task(
+        policy=SpecCheckpointPolicy(
+            refresh_interval_tool_calls=2,
+            refresh_interval_messages=99,
+            refresh_interval_history_tokens=999_999,
+        )
+    )
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="initial task")]),
+        _tool_result("call-1"),
+        _tool_result("call-2"),
+    ]
+
+    decision = build_spec_checkpoint_decision(
+        task=task,
+        role_id="Crafter",
+        history=history,
+    )
+
+    assert decision.should_inject is True
+    assert decision.sequence == 1
+    assert decision.reason == "tool_calls>=2"
+    assert "## Spec Checkpoint" in decision.content
+    assert "- Summary: Build the endpoint" in decision.content
+    assert "  - return HTTP 201" in decision.content
+    assert "  - do not change the public route" in decision.content
+    assert "  - pytest tests/unit_tests/api" in decision.content
+
+
+def test_spec_checkpoint_counts_from_latest_checkpoint() -> None:
+    task = _task(
+        policy=SpecCheckpointPolicy(
+            refresh_interval_tool_calls=2,
+            refresh_interval_messages=99,
+            refresh_interval_history_tokens=999_999,
+        )
+    )
+    checkpoint = ModelRequest(
+        parts=[
+            SystemPromptPart(
+                content=spec_checkpoint_marker(task_id=task.task_id, sequence=3)
+            )
+        ]
+    )
+    history = [
+        _tool_result("call-1"),
+        checkpoint,
+        _tool_result("call-2"),
+    ]
+
+    decision = build_spec_checkpoint_decision(
+        task=task,
+        role_id="Crafter",
+        history=history,
+    )
+
+    assert decision.should_inject is False
+    assert decision.tool_calls_since_last_checkpoint == 1
+    assert latest_spec_checkpoint_position(history=history, task_id=task.task_id) == (
+        1,
+        3,
+    )
+    assert is_spec_checkpoint_content(
+        spec_checkpoint_marker(task_id=task.task_id, sequence=3),
+        task_id=task.task_id,
+    )
+
+
+def test_spec_checkpoint_can_trigger_on_message_interval_without_tools() -> None:
+    task = _task(
+        policy=SpecCheckpointPolicy(
+            refresh_interval_tool_calls=99,
+            refresh_interval_messages=2,
+            refresh_interval_history_tokens=999_999,
+        )
+    )
+
+    decision = build_spec_checkpoint_decision(
+        task=task,
+        role_id="Crafter",
+        history=[
+            ModelRequest(parts=[UserPromptPart(content="first")]),
+            ModelRequest(parts=[UserPromptPart(content="second")]),
+        ],
+    )
+
+    assert decision.should_inject is True
+    assert decision.reason == "messages>=2"
+
+
+def test_spec_checkpoint_skips_tasks_without_spec_content() -> None:
+    task = _task(spec=TaskSpec())
+
+    decision = build_spec_checkpoint_decision(
+        task=task,
+        role_id="Crafter",
+        history=[_tool_result("call-1"), _tool_result("call-2")],
+    )
+
+    assert decision.should_inject is False
+    assert count_completed_tool_calls([_tool_result("call-1")]) == 1
+
+
+def _task(
+    *,
+    policy: SpecCheckpointPolicy | None = None,
+    spec: TaskSpec | None = None,
+) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        role_id="Crafter",
+        objective="Build endpoint",
+        verification=VerificationPlan(),
+        spec=spec
+        or TaskSpec(
+            summary="Build the endpoint",
+            requirements=("return HTTP 201",),
+            constraints=("do not change the public route",),
+            acceptance_criteria=("new API test passes",),
+            verification_commands=("pytest tests/unit_tests/api",),
+            evidence_expectations=("pytest output",),
+            strictness=TaskSpecStrictness.HIGH,
+        ),
+        lifecycle=TaskLifecyclePolicy(spec_checkpoint=policy or SpecCheckpointPolicy()),
+    )
+
+
+def _tool_result(tool_call_id: str) -> ModelRequest:
+    return ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="shell",
+                tool_call_id=tool_call_id,
+                content="ok",
+            )
+        ]
+    )

--- a/tests/unit_tests/agents/execution/test_spec_checkpoint.py
+++ b/tests/unit_tests/agents/execution/test_spec_checkpoint.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from pydantic_ai.messages import (
+    ModelResponse,
     ModelRequest,
+    RetryPromptPart,
     SystemPromptPart,
+    TextPart,
     ToolReturnPart,
     UserPromptPart,
 )
@@ -12,6 +15,8 @@ from relay_teams.agents.execution.spec_checkpoint import (
     count_completed_tool_calls,
     is_spec_checkpoint_content,
     latest_spec_checkpoint_position,
+    render_spec_checkpoint,
+    spec_checkpoint_reason,
     spec_checkpoint_marker,
 )
 from relay_teams.agents.tasks.enums import TaskSpecStrictness
@@ -115,6 +120,40 @@ def test_spec_checkpoint_can_trigger_on_message_interval_without_tools() -> None
     assert decision.reason == "messages>=2"
 
 
+def test_spec_checkpoint_can_trigger_on_history_token_interval() -> None:
+    task = _task(
+        policy=SpecCheckpointPolicy(
+            refresh_interval_tool_calls=99,
+            refresh_interval_messages=99,
+            refresh_interval_history_tokens=1,
+        )
+    )
+
+    decision = build_spec_checkpoint_decision(
+        task=task,
+        role_id="Crafter",
+        history=[ModelRequest(parts=[UserPromptPart(content="large context")])],
+    )
+
+    assert decision.should_inject is True
+    assert decision.reason == "history_tokens>=1"
+
+
+def test_spec_checkpoint_reason_combines_thresholds() -> None:
+    reason = spec_checkpoint_reason(
+        policy=SpecCheckpointPolicy(
+            refresh_interval_tool_calls=2,
+            refresh_interval_messages=3,
+            refresh_interval_history_tokens=4,
+        ),
+        tool_calls_since_checkpoint=2,
+        messages_since_checkpoint=3,
+        tokens_since_checkpoint=4,
+    )
+
+    assert reason == "tool_calls>=2, messages>=3, history_tokens>=4"
+
+
 def test_spec_checkpoint_skips_tasks_without_spec_content() -> None:
     task = _task(spec=TaskSpec())
 
@@ -126,6 +165,158 @@ def test_spec_checkpoint_skips_tasks_without_spec_content() -> None:
 
     assert decision.should_inject is False
     assert count_completed_tool_calls([_tool_result("call-1")]) == 1
+
+
+def test_render_spec_checkpoint_returns_empty_without_spec() -> None:
+    task = _task().model_copy(update={"spec": None})
+
+    content = render_spec_checkpoint(
+        task=task,
+        role_id="Crafter",
+        sequence=1,
+        reason="messages>=1",
+        policy=SpecCheckpointPolicy(),
+        tool_calls_since_checkpoint=0,
+        messages_since_checkpoint=1,
+        tokens_since_checkpoint=12,
+    )
+
+    assert content == ""
+
+
+def test_spec_checkpoint_marker_clamps_negative_sequence() -> None:
+    marker = spec_checkpoint_marker(task_id="task-1", sequence=-5)
+
+    assert 'sequence="0"' in marker
+
+
+def test_latest_spec_checkpoint_position_ignores_unrelated_content() -> None:
+    history = [
+        ModelResponse(
+            parts=[
+                TextPart(content=spec_checkpoint_marker(task_id="task-1", sequence=9))
+            ],
+            model_name="fake-model",
+        ),
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    content=spec_checkpoint_marker(task_id="task-1", sequence=8)
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                SystemPromptPart(
+                    content=spec_checkpoint_marker(task_id="other-task", sequence=7)
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                SystemPromptPart(
+                    content='<!-- relay-spec-checkpoint task_id="task-1" -->'
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                SystemPromptPart(
+                    content=(
+                        '<!-- relay-spec-checkpoint task_id="task-1" '
+                        'sequence="not-a-number" -->'
+                    )
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                SystemPromptPart(
+                    content=('<!-- relay-spec-checkpoint task_id="task-1" sequence="')
+                )
+            ]
+        ),
+    ]
+
+    assert latest_spec_checkpoint_position(history=history, task_id="task-1") == (
+        5,
+        0,
+    )
+
+
+def test_spec_checkpoint_content_detection_filters_plain_and_task_mismatch() -> None:
+    marker = spec_checkpoint_marker(task_id="task-1", sequence=1)
+
+    assert is_spec_checkpoint_content("plain text") is False
+    assert is_spec_checkpoint_content(marker) is True
+    assert is_spec_checkpoint_content(marker, task_id="other-task") is False
+
+
+def test_count_completed_tool_calls_includes_retry_prompts_with_tool_names() -> None:
+    history = [
+        ModelResponse(
+            parts=[TextPart(content="provider text")], model_name="fake-model"
+        ),
+        ModelRequest(
+            parts=[
+                RetryPromptPart(
+                    content="retry",
+                    tool_name="shell",
+                    tool_call_id="call-1",
+                ),
+                RetryPromptPart(content="retry", tool_call_id="call-2"),
+                UserPromptPart(content="manual follow-up"),
+            ]
+        ),
+    ]
+
+    assert count_completed_tool_calls(history) == 1
+
+
+def test_render_spec_checkpoint_clips_long_spec_items() -> None:
+    content = render_spec_checkpoint(
+        task=_task(
+            policy=SpecCheckpointPolicy(max_summary_chars=2000),
+            spec=TaskSpec(
+                summary="Long requirement task",
+                requirements=("x" * 800,),
+                strictness=TaskSpecStrictness.HIGH,
+            ),
+        ),
+        role_id="Crafter",
+        sequence=1,
+        reason="messages>=1",
+        policy=SpecCheckpointPolicy(max_summary_chars=2000),
+        tool_calls_since_checkpoint=0,
+        messages_since_checkpoint=1,
+        tokens_since_checkpoint=12,
+    )
+
+    assert "[truncated]" in content
+
+
+def test_render_spec_checkpoint_clips_full_checkpoint_text() -> None:
+    policy = SpecCheckpointPolicy(max_summary_chars=500)
+    content = render_spec_checkpoint(
+        task=_task(
+            policy=policy,
+            spec=TaskSpec(
+                summary="Large task",
+                requirements=tuple(f"requirement {index}" for index in range(80)),
+                strictness=TaskSpecStrictness.HIGH,
+            ),
+        ),
+        role_id="Crafter",
+        sequence=1,
+        reason="messages>=1",
+        policy=policy,
+        tool_calls_since_checkpoint=0,
+        messages_since_checkpoint=1,
+        tokens_since_checkpoint=12,
+    )
+
+    assert content.endswith("[spec checkpoint truncated]")
+    assert len(content) <= policy.max_summary_chars
 
 
 def _task(

--- a/tests/unit_tests/agents/tasks/test_task_models.py
+++ b/tests/unit_tests/agents/tasks/test_task_models.py
@@ -13,6 +13,7 @@ from relay_teams.agents.tasks.enums import (
 )
 from relay_teams.agents.tasks.models import (
     SemanticEvaluationResult,
+    SpecCheckpointPolicy,
     TaskEnvelope,
     TaskHandoff,
     TaskLifecyclePolicy,
@@ -66,6 +67,7 @@ def test_task_envelope_accepts_spec_lifecycle_and_handoff() -> None:
     assert envelope.spec is not None
     assert envelope.spec.requirements == ("persist state",)
     assert envelope.lifecycle.on_timeout == TaskTimeoutAction.HUMAN_GATE
+    assert envelope.lifecycle.spec_checkpoint.enabled is True
     assert envelope.handoff is not None
     assert envelope.handoff.next_steps == ("rerun tests",)
 
@@ -138,6 +140,28 @@ def test_verification_report_accepts_evidence_bundle() -> None:
     assert report.evidence_bundle is not None
     assert report.evidence_bundle.items[0].metrics[0].value == 1
     assert report.semantic_results[0].evidence_ids == ("command-1",)
+
+
+def test_task_lifecycle_accepts_spec_checkpoint_policy() -> None:
+    lifecycle = TaskLifecyclePolicy.model_validate(
+        {
+            "spec_checkpoint": {
+                "refresh_interval_tool_calls": 3,
+                "refresh_interval_messages": 12,
+                "refresh_interval_history_tokens": 2000,
+                "max_summary_chars": 1200,
+            }
+        }
+    )
+    defaulted = TaskLifecyclePolicy.model_validate({"spec_checkpoint": None})
+
+    assert lifecycle.spec_checkpoint == SpecCheckpointPolicy(
+        refresh_interval_tool_calls=3,
+        refresh_interval_messages=12,
+        refresh_interval_history_tokens=2000,
+        max_summary_chars=1200,
+    )
+    assert defaulted.spec_checkpoint.enabled is True
 
 
 def test_verification_command_uses_windows_aware_string_splitting() -> None:


### PR DESCRIPTION
## Summary
Closes #642.

Implements the SP-3 Spec-Checkpoint anti-degradation mechanism from `docs/research/lessons-learned-2026.md`.

## Changes
- Added `SpecCheckpointPolicy` to task lifecycle contracts with default thresholds for tool calls, message count, and estimated history tokens.
- Added spec checkpoint decision/rendering logic that rebuilds a bounded task-spec refresh from persisted `TaskEnvelope.spec`.
- Integrated checkpoint injection into non-coordinator LLM runtime safe boundaries and top-of-turn checks, persisting the refresh as an internal system prompt.
- Preserved provider fallback eligibility when only an internal checkpoint prompt is persisted.
- Skipped optional spec checkpoint restarts when the current safe-boundary batch already contains a final answer.
- Added `spec_checkpoint_applied` run events and state checkpoint support for durable observability.
- Updated compaction to render system prompts and preserve Task Spec / Spec Checkpoint constraints, acceptance criteria, verification commands, and evidence expectations as high-priority summary content.
- Added the feature design and implementation spec at `docs/modules/sessions/spec-checkpoint-refresh-design.md`.
- Updated API, database, and documentation index docs.

## Research Notes
Referenced `/opt/workspace/hello` materials while designing the implementation:
- `docs/paper-analysis/paper-2603.22862v2.md`: long-horizon orchestration, context drift, memory compression, and process-level verification.
- `The_Playbook_For_Building_An_AI_Native_Company.md`: specs, tests, and artifacts as closed-loop execution inputs.

## Latest Local Verification
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_session_runtime.py tests/unit_tests/agents/execution/test_spec_checkpoint.py tests/unit_tests/agents/execution/test_conversation_compaction.py tests/unit_tests/agents/tasks/test_task_models.py` -> 57 passed
- `uv run --extra dev pytest -q tests/unit_tests` -> 4965 passed, 5 skipped, 1 pytest-timeout teardown error in `tests/unit_tests/agents/orchestration/test_coordinator_terminal_status.py::test_pending_delegated_task_cancellation_exits_lane_when_stop_requested`
- `uv run --extra dev pytest -q tests/unit_tests/agents/orchestration/test_coordinator_terminal_status.py::test_pending_delegated_task_cancellation_exits_lane_when_stop_requested` -> 1 passed
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/relay-teams-playwright uv run --extra dev pytest -q tests/integration_tests` -> 107 passed, 3 skipped

## Previous Chrome MCP Acceptance
- Chrome MCP acceptance on `http://127.0.0.1:8765/` against this worktree:
  - UI loads with title `Agent Teams`
  - no browser console errors
  - `/api/system/health` returns `status=ok` and `package_root=/opt/workspace/relay-teams-spec/src/relay_teams`
  - `/api/tasks` returns HTTP 200
  - page shows backend connected and composer present
  - screenshot saved at `/tmp/relay-teams-spec-chrome-acceptance.png`