### PR TITLE
SG-2: enforce role behavior boundaries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This directory is organized by documentation purpose and runtime module.
 - [Orchestration policy](modules/agents/orchestration-policy-design.md)
 - [Verification evidence and semantic checks](modules/agents/verification-evidence-semantic-spec.md)
 - [SP-2 role contracts](modules/agents/sp2-role-contracts-spec.md)
+- [SG-2 role behavior boundaries](modules/agents/sg2-role-behavior-boundaries-spec.md)
 - [Automation](modules/automation/ao4-async-path-unification.md)
 - [CLI commands](modules/cli/commands.md)
 - [Frontend](modules/frontend/README.md)

--- a/docs/modules/agents/sg2-role-behavior-boundaries-spec.md
+++ b/docs/modules/agents/sg2-role-behavior-boundaries-spec.md
@@ -1,0 +1,99 @@
+# SG-2 Role Behavior Boundaries Spec
+
+## 1. Purpose
+
+SG-2 makes role behavior boundaries deterministic at runtime. A role contract is
+not only prompt guidance: every `must_not_have_tools` invariant removes matching
+local tools from the runtime tool surface and blocks matching tool calls in the
+shared tool execution policy.
+
+This closes the shell/write_tmp escape path called out in
+`docs/research/lessons-learned-2026.md`.
+
+## 2. Goals
+
+- Enforce role tool deny lists before tools are registered with a model.
+- Enforce the same deny lists again inside `execute_tool(...)` so stale runtime
+  state, old snapshots, or direct tool invocation cannot bypass the boundary.
+- Keep dirty persisted role state tolerant: runtime reloads do not fail only
+  because a saved role still contains a forbidden tool, but that tool is filtered
+  and logged before use.
+- Keep explicit role edits strict: save and validation paths still reject roles
+  whose selected tools violate their own contract invariants.
+- Remove the built-in Gater role's shell and write_tmp escape channels.
+
+## 3. Non-Goals
+
+- SG-2 does not add a new database table or public API field.
+- SG-2 does not add parameter-level shell command classification. Roles that
+  must not execute commands must deny the `shell` tool.
+- SG-2 does not remove temporary report writing from Explorer or Designer,
+  because their contracts allow temporary artifacts while denying production
+  edit and shell tools.
+
+## 4. Domain Contract
+
+`RoleContractInvariantType.MUST_NOT_HAVE_TOOLS` is the source of truth for
+runtime-denied local tool names.
+
+`roles.runtime_tools.runtime_denied_tools_for_role(role)` returns the ordered,
+deduplicated deny list declared by the role contract.
+
+`roles.runtime_tools.strip_contract_denied_tools(...)` removes those denied
+tools from a candidate runtime tool list and emits a warning event with the role
+id, consumer, and removed tools.
+
+`runtime_tools_for_role(...)` applies both existing coordinator-only filtering
+and SG-2 contract-denied filtering. All prompt assembly, runtime snapshots, and
+session tool registration paths that already use `runtime_tools_for_role(...)`
+therefore receive the hardened tool list.
+
+## 5. Execution Policy
+
+The shared tool runtime policy now resolves the effective role allowlist through
+`runtime_tools_for_role(...)` instead of raw `role.tools`.
+
+The policy also removes contract-denied tools after loading persisted runtime
+tool snapshots. This prevents stale snapshots from re-authorizing a tool that
+the current role contract forbids.
+
+When a denied tool is attempted, the existing tool result envelope is reused:
+
+- `ok: false`
+- `error.type: tool_policy_denied`
+- `meta.runtime_policy_decision: deny`
+- `meta.approval_status: denied_by_policy`
+
+The action body is not invoked and approval/yolo mode cannot override the deny.
+
+## 6. Built-In Role Boundary
+
+Gater is now a read-only auditor:
+
+- allowed: grep, glob, read, office_read_markdown, background task observation,
+  and monitor controls
+- denied by contract: edit, write, notebook_edit, write_tmp, shell
+
+This matches the role's behavioral boundary: Gater audits existing evidence and
+returns a conclusion; it does not create report files or execute commands.
+
+## 7. Validation And Compatibility
+
+Strict role mutation paths continue to call
+`role_contract_invariant_failures(...)`, so explicitly saving a role with a
+forbidden selected tool still fails validation.
+
+Non-strict runtime reload paths may load stale role files. SG-2 filters the
+forbidden tool at runtime instead of failing startup, which keeps existing dirty
+configuration tolerant while preserving the security boundary.
+
+## 8. Tests
+
+Required coverage:
+
+- Runtime tool helper filters `must_not_have_tools`.
+- Dirty persisted role state cannot execute a contract-forbidden tool, even in
+  yolo mode.
+- Stale runtime tool snapshots cannot regrant a contract-forbidden tool.
+- Built-in Gater does not expose shell or write_tmp and denies them in contract.
+

--- a/docs/research/lessons-learned-2026.md
+++ b/docs/research/lessons-learned-2026.md
@@ -635,6 +635,10 @@ Crafter 在执行复杂任务时依赖单一 LLM 会话上下文。虽然存在 
 
 将角色的"禁区"约束从 prompt 层提升到工具注册层——为每个角色定义"工具调用的运行时权限策略"（existing `runtime/policy` 模块的增强版）。例如，Gater 角色的策略在运行时拦截所有 write 类工具调用，Designer 角色拦截所有 `shell` 工具调用。这实际上是现有 `tools/runtime/` 中策略机制的深化——从审批模式扩展到强制拒绝模式。
 
+#### 落地状态
+
+2026-05-01 已落地 SG-2 基础强制执行：`must_not_have_tools` 不变量会在运行时工具注册和共享工具执行策略中同时生效，脏的既有角色配置不会阻断启动，但被合约禁止的工具会被过滤并记录警告；旧的 runtime tool snapshot 也不能重新授予被合约禁止的工具。内置 Gater 已关闭 `shell` 与 `write_tmp`，只保留读取、后台任务观察和监控控制能力。设计与实现规格见 [`docs/modules/agents/sg2-role-behavior-boundaries-spec.md`](../modules/agents/sg2-role-behavior-boundaries-spec.md)。
+
 ---
 
 ### SG-3：审计追踪增强

--- a/src/relay_teams/builtin/roles/gater.md
+++ b/src/relay_teams/builtin/roles/gater.md
@@ -10,8 +10,6 @@ tools:
   - glob
   - read
   - office_read_markdown
-  - write_tmp
-  - shell
   - list_background_tasks
   - wait_background_task
   - stop_background_task
@@ -31,6 +29,8 @@ contract:
         - edit
         - write
         - notebook_edit
+        - write_tmp
+        - shell
 ---
 
 ## 角色：Gater (质量审计员) 
@@ -44,8 +44,6 @@ contract:
 * 意图驱动验收 (Intent-Driven)：审计的终极标准是“用户意图是否达成”而非“代码逻辑是否正确”。即便代码在技术层面无误、测试通过，若偏离了原始意图或未解决核心痛点，必须判定为不通过。 
 
 * 审计证据：只有文件实际变化(git diff)、运行日志、变化的文件的单元测试用例实际运行日志被视为有效审计依据。 
-
-* 临时文件存储：如需使用 `write_tmp` 工具，只允许写入 `tmp/` 目录下的临时文件。 
 
 ## 验收职责 
 
@@ -67,4 +65,6 @@ contract:
 
 * 禁区 4：严禁全目录静态分析，仅对本次变更的文件进行静态检查。
 
-* 禁区 5：禁止反复更新结果报告，输出结果报告即意味着返回。当且仅当总结内容过长时才书写报告文件，如书写报告文件，禁止重复输出报告，仅提供关键总结和报告文件路径。
+* 禁区 5：禁止写入临时报告文件；验收结论必须直接返回，不能通过 `write_tmp` 或 shell 生成文件。
+
+* 禁区 6：禁止反复更新结果报告，输出结果报告即意味着返回。

--- a/src/relay_teams/roles/__init__.py
+++ b/src/relay_teams/roles/__init__.py
@@ -34,8 +34,10 @@ from relay_teams.roles.role_contracts import (
 from relay_teams.roles.role_registry import RoleLoader, RoleRegistry
 from relay_teams.roles.runtime_tools import (
     role_with_runtime_tools,
+    runtime_denied_tools_for_role,
     runtime_tools_for_role,
     strip_coordinator_only_tools,
+    strip_contract_denied_tools,
 )
 from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.roles.role_registry import (
@@ -80,8 +82,10 @@ __all__ = [
     "RoleValidationResult",
     "RuntimeRoleResolver",
     "role_with_runtime_tools",
+    "runtime_denied_tools_for_role",
     "runtime_tools_for_role",
     "strip_coordinator_only_tools",
+    "strip_contract_denied_tools",
     "ensure_required_system_roles",
     "TemporaryRoleRecord",
     "TemporaryRoleRepository",

--- a/src/relay_teams/roles/runtime_tools.py
+++ b/src/relay_teams/roles/runtime_tools.py
@@ -5,6 +5,7 @@ import logging
 
 from relay_teams.logger import get_logger, log_event
 from relay_teams.roles.default_role_tools import COORDINATOR_ONLY_TOOLS
+from relay_teams.roles.role_contracts import RoleContractInvariantType
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 
@@ -18,21 +19,30 @@ def runtime_tools_for_role(
     consumer: str,
 ) -> tuple[str, ...]:
     if role_registry.is_coordinator_role(role.role_id):
-        return role.tools
-    filtered = strip_coordinator_only_tools(role.tools)
+        return strip_contract_denied_tools(
+            role=role,
+            tools=role.tools,
+            consumer=consumer,
+        )
+    filtered = strip_contract_denied_tools(
+        role=role,
+        tools=strip_coordinator_only_tools(role.tools),
+        consumer=consumer,
+    )
     if filtered != role.tools:
         removed = tuple(tool for tool in role.tools if tool in COORDINATOR_ONLY_TOOLS)
-        log_event(
-            LOGGER,
-            logging.WARNING,
-            event="roles.runtime_tools.filtered_coordinator_only_tools",
-            message="Filtered coordinator-only tools from non-coordinator role",
-            payload={
-                "role_id": role.role_id,
-                "consumer": consumer,
-                "removed_tools": list(removed),
-            },
-        )
+        if removed:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="roles.runtime_tools.filtered_coordinator_only_tools",
+                message="Filtered coordinator-only tools from non-coordinator role",
+                payload={
+                    "role_id": role.role_id,
+                    "consumer": consumer,
+                    "removed_tools": list(removed),
+                },
+            )
     return filtered
 
 
@@ -54,3 +64,43 @@ def role_with_runtime_tools(
 
 def strip_coordinator_only_tools(tools: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(tool for tool in tools if tool not in COORDINATOR_ONLY_TOOLS)
+
+
+def strip_contract_denied_tools(
+    *,
+    role: RoleDefinition,
+    tools: tuple[str, ...],
+    consumer: str,
+) -> tuple[str, ...]:
+    denied_tools = runtime_denied_tools_for_role(role)
+    if not denied_tools:
+        return tools
+    denied_set = set(denied_tools)
+    filtered = tuple(tool for tool in tools if tool not in denied_set)
+    if filtered != tools:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="roles.runtime_tools.filtered_contract_denied_tools",
+            message="Filtered role-contract denied tools from runtime role tools",
+            payload={
+                "role_id": role.role_id,
+                "consumer": consumer,
+                "removed_tools": [tool for tool in tools if tool in denied_set],
+            },
+        )
+    return filtered
+
+
+def runtime_denied_tools_for_role(role: RoleDefinition) -> tuple[str, ...]:
+    denied_tools: list[str] = []
+    seen: set[str] = set()
+    for invariant in role.contract.invariants:
+        if invariant.invariant != RoleContractInvariantType.MUST_NOT_HAVE_TOOLS:
+            continue
+        for tool in invariant.tools:
+            if tool in seen:
+                continue
+            seen.add(tool)
+            denied_tools.append(tool)
+    return tuple(denied_tools)

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -47,6 +47,10 @@ from relay_teams.agents.tasks.task_status_sanitizer import (
     sanitize_task_status_payload,
 )
 from relay_teams.reminders import ToolResultObservation
+from relay_teams.roles.runtime_tools import (
+    runtime_denied_tools_for_role,
+    runtime_tools_for_role,
+)
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.event_stream import publish_run_event_async
 from relay_teams.sessions.runs.run_models import RunEvent
@@ -2544,8 +2548,16 @@ async def _allowed_tools_for_runtime_policy(
             },
         )
         return ()
-    tools = set(role.tools)
+    tools = set(
+        runtime_tools_for_role(
+            role_registry=ctx.deps.role_registry,
+            role=role,
+            consumer="tools.runtime.execution.allowed_tools",
+        )
+    )
     tools.update(await _runtime_snapshot_tool_names_for_policy(ctx=ctx))
+    denied_tools = set(runtime_denied_tools_for_role(role))
+    tools.difference_update(denied_tools)
     return tuple(sorted(tools))
 
 

--- a/tests/unit_tests/roles/test_builtin_role_tools.py
+++ b/tests/unit_tests/roles/test_builtin_role_tools.py
@@ -45,7 +45,8 @@ def test_builtin_roles_mount_expected_write_tools() -> None:
     assert "auto_harness_synthesize_tool" in crafter.tools
     assert "auto_harness_enable_tool" in crafter.tools
     assert background_task_tools.issubset(set(crafter.tools))
-    assert background_task_tools.issubset(set(gater.tools))
+    assert background_task_tools.difference({"shell"}).issubset(set(gater.tools))
+    assert "shell" not in gater.tools
     assert background_task_tools.issubset(set(main_agent.tools))
     assert "spawn_subagent" in main_agent.tools
     assert "list_skill_roles" in main_agent.tools
@@ -84,6 +85,15 @@ def test_builtin_roles_mount_expected_write_tools() -> None:
     assert "office_read_markdown" in gater.tools
     assert "todo_write" not in gater.tools
     assert "todo_read" not in gater.tools
-    assert "write_tmp" in gater.tools
+    assert "write_tmp" not in gater.tools
     assert "write" not in gater.tools
     assert "edit" not in gater.tools
+    gater_denied_tools = {
+        tool
+        for invariant in gater.contract.invariants
+        for tool in invariant.tools
+        if invariant.invariant == "must_not_have_tools"
+    }
+    assert {"edit", "write", "notebook_edit", "write_tmp", "shell"}.issubset(
+        gater_denied_tools
+    )

--- a/tests/unit_tests/roles/test_runtime_tools.py
+++ b/tests/unit_tests/roles/test_runtime_tools.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
+from relay_teams.roles.role_contracts import (
+    RoleContract,
+    RoleContractInvariant,
+    RoleContractInvariantType,
+)
 from relay_teams.roles.runtime_tools import (
     role_with_runtime_tools,
+    runtime_denied_tools_for_role,
     runtime_tools_for_role,
     strip_coordinator_only_tools,
+    strip_contract_denied_tools,
 )
 
 
@@ -114,3 +121,45 @@ def test_strip_coordinator_only_tools_removes_orchestration_tools() -> None:
         "read",
         "shell",
     )
+
+
+def test_runtime_tools_filter_contract_denied_tools() -> None:
+    registry = RoleRegistry()
+    registry.register(
+        RoleDefinition(
+            role_id="Coordinator",
+            name="Coordinator",
+            description="Coordinates work.",
+            version="1",
+            tools=("orch_dispatch_task",),
+            system_prompt="Coordinate.",
+        )
+    )
+    reviewer = RoleDefinition(
+        role_id="Reviewer",
+        name="Reviewer",
+        description="Reviews work.",
+        version="1",
+        tools=("read", "write_tmp", "shell"),
+        contract=RoleContract(
+            invariants=(
+                RoleContractInvariant(
+                    invariant=RoleContractInvariantType.MUST_NOT_HAVE_TOOLS,
+                    tools=("write_tmp", "shell"),
+                ),
+            ),
+        ),
+        system_prompt="Review.",
+    )
+
+    assert runtime_denied_tools_for_role(reviewer) == ("write_tmp", "shell")
+    assert strip_contract_denied_tools(
+        role=reviewer,
+        tools=reviewer.tools,
+        consumer="test",
+    ) == ("read",)
+    assert runtime_tools_for_role(
+        role_registry=registry,
+        role=reviewer,
+        consumer="test",
+    ) == ("read",)

--- a/tests/unit_tests/tools/runtime/test_runtime_policy_boundaries.py
+++ b/tests/unit_tests/tools/runtime/test_runtime_policy_boundaries.py
@@ -13,6 +13,11 @@ from relay_teams.agents.instances.models import (
     RuntimeToolsSnapshot,
 )
 from relay_teams.computer import ComputerActionRisk
+from relay_teams.roles.role_contracts import (
+    RoleContract,
+    RoleContractInvariant,
+    RoleContractInvariantType,
+)
 from relay_teams.tools.runtime.context import ToolContext
 from relay_teams.tools.runtime.execution import execute_tool
 from relay_teams.tools.runtime.models import ToolApprovalRequest, ToolRuntimeDecision
@@ -138,6 +143,102 @@ def test_execute_tool_denies_tool_outside_runtime_role_boundary() -> None:
     assert tool_result_payloads[0]["tool_call_id"] == "call-policy-deny"
     assert tool_result_payloads[0]["error"] is True
     assert tool_result_payloads[0]["result"] == result
+
+
+def test_execute_tool_denies_contract_forbidden_tool_from_dirty_role_state() -> None:
+    deps = _PolicyDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(yolo=True),
+    )
+    deps.role_registry.register(
+        deps.role_registry.get("spec_coder").model_copy(
+            update={
+                "tools": ("read", "shell"),
+                "contract": RoleContract(
+                    invariants=(
+                        RoleContractInvariant(
+                            invariant=RoleContractInvariantType.MUST_NOT_HAVE_TOOLS,
+                            tools=("shell",),
+                        ),
+                    ),
+                ),
+            }
+        )
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-policy-contract-deny"
+    called = False
+
+    def action() -> str:
+        nonlocal called
+        called = True
+        return "should not run"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="shell",
+            args_summary={"command": "touch a.txt"},
+            action=action,
+        )
+    )
+
+    error = cast(dict[str, JsonValue], result["error"])
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert called is False
+    assert result["ok"] is False
+    assert error["type"] == "tool_policy_denied"
+    assert meta["runtime_policy_decision"] == "deny"
+    assert meta["approval_status"] == "denied_by_policy"
+
+
+def test_execute_tool_contract_denial_overrides_runtime_snapshot() -> None:
+    snapshot = RuntimeToolsSnapshot(
+        local_tools=(RuntimeToolSnapshotEntry(source="local", name="shell"),),
+    )
+    deps = _PolicyDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(yolo=True),
+    )
+    deps.role_registry.register(
+        deps.role_registry.get("spec_coder").model_copy(
+            update={
+                "tools": ("read",),
+                "contract": RoleContract(
+                    invariants=(
+                        RoleContractInvariant(
+                            invariant=RoleContractInvariantType.MUST_NOT_HAVE_TOOLS,
+                            tools=("shell",),
+                        ),
+                    ),
+                ),
+            }
+        )
+    )
+    deps.agent_repo = _RuntimeToolsAgentRepo(snapshot.model_dump_json())
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-policy-contract-snapshot-deny"
+    called = False
+
+    def action() -> str:
+        nonlocal called
+        called = True
+        return "should not run"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="shell",
+            args_summary={"command": "touch a.txt"},
+            action=action,
+        )
+    )
+
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert called is False
+    assert result["ok"] is False
+    assert meta["runtime_policy_decision"] == "deny"
+    assert meta["approval_status"] == "denied_by_policy"
 
 
 def test_execute_tool_allows_skill_and_mcp_tools_from_runtime_snapshot() -> None:


### PR DESCRIPTION
Closes #650

## Summary
- enforce role contract `must_not_have_tools` during runtime tool registration
- deny contract-forbidden tool calls in the shared tool runtime policy, including yolo mode and stale runtime tool snapshots
- close Gater shell/write_tmp escape channels and document the SG-2 design/implementation spec

## Validation
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests`
- Chrome MCP: loaded `http://127.0.0.1:8765`, verified `/api/roles` exposes Gater without `shell`/`write_tmp`, and verified `/api/roles:validate-config` rejects adding `shell` back to Gater with `Role contract invariants failed`.

## Notes
- The first plain integration run failed only because Playwright could not find Chromium under the temporary HOME used by integration tests. Re-running with `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright` passed: 107 passed, 3 skipped.