### PR TITLE
Implement SG-3 audit trail enhancement

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -30,7 +30,7 @@ Query fields:
 - `event_type`: optional `file_write`, `shell_command`, or `coordinator_decision`.
 - `trace_id`, `run_id`, `session_id`, `task_id`, `role_id`: optional exact-match filters.
 - `after_id`: optional cursor, default `0`.
-- `since`, `until`: optional ISO 8601 timestamps matched against `occurred_at`.
+- `since`, `until`: optional ISO 8601 timestamps matched against `occurred_at`; offsets are normalized to UTC before comparison.
 - `limit`: optional page size from `1` to `500`, default `100`.
 
 Response fields:
@@ -63,6 +63,7 @@ Notes:
 - File write audit events store a final content digest and size, not raw content.
 - Shell command audit events store the command text and execution context.
 - Coordinator decision audit events store the selected delegated task/role channel and the dispatch reason captured from `orch_dispatch_task`.
+- `occurred_at` and `created_at` are persisted and filtered as UTC ISO 8601 timestamps.
 - The API is read-only. Audit rows are written by backend runtime paths and cannot be mutated by Agent tools.
 
 ## Core Concepts

--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -20,6 +20,51 @@ Common validation rules:
 - Identifier and reference fields reject blank strings, whitespace-only strings, and the explicit string values `"None"` and `"null"` with `422`.
 - Optional identifier fields still accept real JSON `null`.
 
+## Audit APIs
+
+### `GET /audit`
+
+Lists immutable security audit events for external compliance systems.
+
+Query fields:
+- `event_type`: optional `file_write`, `shell_command`, or `coordinator_decision`.
+- `trace_id`, `run_id`, `session_id`, `task_id`, `role_id`: optional exact-match filters.
+- `after_id`: optional cursor, default `0`.
+- `since`, `until`: optional ISO 8601 timestamps matched against `occurred_at`.
+- `limit`: optional page size from `1` to `500`, default `100`.
+
+Response fields:
+- `items[]`
+  - `id`
+  - `audit_event_id`
+  - `event_type`
+  - `trace_id`
+  - `run_id`
+  - `session_id`
+  - `task_id`
+  - `instance_id`
+  - `role_id`
+  - `tool_call_id`
+  - `span_id`
+  - `parent_span_id`
+  - `action`
+  - `target`
+  - `content_digest`
+  - `content_size_bytes`
+  - `command`
+  - `decision_reason`
+  - `outcome`
+  - `metadata`
+  - `occurred_at`
+  - `created_at`
+- `next_after_id`: cursor for the next page when more rows are available.
+
+Notes:
+- File write audit events store a final content digest and size, not raw content.
+- Shell command audit events store the command text and execution context.
+- Coordinator decision audit events store the selected delegated task/role channel and the dispatch reason captured from `orch_dispatch_task`.
+- The API is read-only. Audit rows are written by backend runtime paths and cannot be mutated by Agent tools.
+
 ## Core Concepts
 
 - A run starts from one root task.

--- a/docs/core/database-schema.md
+++ b/docs/core/database-schema.md
@@ -327,6 +327,7 @@ Notes:
 - Shell command events record the command string plus execution context and result metadata such as `exit_code` when available.
 - Coordinator decision events record `orch_dispatch_task` selections as the task-to-role channel decision plus the dispatch prompt/reason, capped by the application layer.
 - `span_id` and `parent_span_id` bind each row to a `security.audit` trace span.
+- `occurred_at` and `created_at` are stored as UTC ISO 8601 text so SQLite range filters are stable across client-provided offsets.
 - Repositories expose append and list operations only; there is no source path for Agent tools to update or delete audit rows.
 
 ---

--- a/docs/core/database-schema.md
+++ b/docs/core/database-schema.md
@@ -275,6 +275,62 @@ Tool call and tool result events are the durable source used to rebuild missing 
 
 ---
 
+### 2.5.1 `security_audit_events`
+
+```sql
+CREATE TABLE IF NOT EXISTS security_audit_events (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    audit_event_id     TEXT NOT NULL UNIQUE,
+    event_type         TEXT NOT NULL,
+    trace_id           TEXT NOT NULL,
+    run_id             TEXT NOT NULL,
+    session_id         TEXT NOT NULL,
+    task_id            TEXT,
+    instance_id        TEXT,
+    role_id            TEXT,
+    tool_call_id       TEXT,
+    span_id            TEXT,
+    parent_span_id     TEXT,
+    action             TEXT NOT NULL,
+    target             TEXT NOT NULL,
+    content_digest     TEXT,
+    content_size_bytes INTEGER,
+    command            TEXT,
+    decision_reason    TEXT,
+    outcome            TEXT NOT NULL,
+    metadata_json      TEXT NOT NULL,
+    occurred_at        TEXT NOT NULL,
+    created_at         TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_security_audit_events_type_id
+    ON security_audit_events(event_type, id);
+CREATE INDEX IF NOT EXISTS idx_security_audit_events_trace_id
+    ON security_audit_events(trace_id, id);
+CREATE INDEX IF NOT EXISTS idx_security_audit_events_run_id
+    ON security_audit_events(run_id, id);
+CREATE INDEX IF NOT EXISTS idx_security_audit_events_session_id
+    ON security_audit_events(session_id, id);
+CREATE INDEX IF NOT EXISTS idx_security_audit_events_task_id
+    ON security_audit_events(task_id, id);
+CREATE INDEX IF NOT EXISTS idx_security_audit_events_role_id
+    ON security_audit_events(role_id, id);
+CREATE INDEX IF NOT EXISTS idx_security_audit_events_time_id
+    ON security_audit_events(occurred_at, id);
+```
+
+Purpose: immutable security/compliance audit log separate from the business run event stream.
+
+Notes:
+- `event_type` is `file_write`, `shell_command`, or `coordinator_decision`.
+- File write events record the logical path, final content SHA-256 digest, byte size, role, task, run, and tool call context. Raw file content is not stored.
+- Shell command events record the command string plus execution context and result metadata such as `exit_code` when available.
+- Coordinator decision events record `orch_dispatch_task` selections as the task-to-role channel decision plus the dispatch prompt/reason, capped by the application layer.
+- `span_id` and `parent_span_id` bind each row to a `security.audit` trace span.
+- Repositories expose append and list operations only; there is no source path for Agent tools to update or delete audit rows.
+
+---
+
 ### 2.6 `messages`
 
 ```sql
@@ -662,12 +718,12 @@ Notes:
 ## 3. Relationship Keys
 
 Primary query keys used by repositories:
-- `session_id`: session-level retrieval across `sessions`, `external_agent_sessions`, `tasks`, `agent_instances`, `events`, `messages`, `session_history_markers`, `token_usage`, `background_tasks`, `run_todos`.
-- `trace_id` (`run_id`): run-level retrieval across `tasks`, `events`, `messages`, `token_usage`, `background_tasks`, `run_todos`.
+- `session_id`: session-level retrieval across `sessions`, `external_agent_sessions`, `tasks`, `agent_instances`, `events`, `security_audit_events`, `messages`, `session_history_markers`, `token_usage`, `background_tasks`, `run_todos`.
+- `trace_id` (`run_id`): run-level retrieval across `tasks`, `events`, `security_audit_events`, `messages`, `token_usage`, `background_tasks`, `run_todos`.
 - `task_id`: task-level retrieval and task assignment tracking.
 - `instance_id`: agent-level retrieval and message history.
 - `trigger_id`: Feishu-account scoped retrieval across `external_session_bindings`, `feishu_message_pool`.
-- `event_id`: message/event level retrieval for audit and replay preparation.
+- `event_id`: message/event/audit level retrieval for audit and replay preparation.
 - `platform + trigger_id + tenant_key + external_chat_id`: external-chat lookup for inbound IM accounts.
 - `gateway_session_id`: external channel session retrieval across `gateway_sessions`.
 - `external_session_id`: channel-scoped lookup key for reconnect and session resume flows.
@@ -685,6 +741,7 @@ Primary query keys used by repositories:
 - `relay_teams.external_agents`: `external_agent_sessions`.
 - `relay_teams.workspace`: `workspaces`.
 - `relay_teams.sessions.runs`: `events`, `run_intents`, `run_runtime`, `run_states`, `run_snapshots`, `background_tasks`, `run_todos`.
+- `relay_teams.audit`: `security_audit_events`.
 - `relay_teams.monitors`: `monitor_subscriptions`, `monitor_triggers`.
 - `relay_teams.agents`: `agent_instances`.
 - `relay_teams.agents.tasks`: `tasks`.

--- a/docs/modules/security/audit-trail-enhancement-spec.md
+++ b/docs/modules/security/audit-trail-enhancement-spec.md
@@ -35,13 +35,13 @@ Raw file content is never stored in audit rows. Dispatch reasons are capped at 4
 
 ## Runtime Integration
 
-Audit recording is centralized in `relay_teams.tools.runtime.execution` after hook rewriting has produced the effective tool input. The runtime records audit events before persisting the tool result envelope, and audit persistence failures are logged without failing the user-visible tool result.
+Audit recording is centralized in `relay_teams.tools.runtime.execution` after hook rewriting has produced the effective tool input. The runtime records successful audit events after the tool result envelope is persisted so persistence failures do not create contradictory completed and failed audit rows. Audit persistence failures are logged without failing the user-visible tool result.
 
 The audit service is carried on `ToolDeps` as an optional backend dependency. Agent tools do not expose any audit mutation function, and the repository has no update/delete API.
 
 ## API
 
-`GET /api/audit` accepts exact filters for event type and trace/session/run/task/role identifiers, cursor pagination with `after_id`, time filtering with `since`/`until`, and `limit` up to 500.
+`GET /api/audit` accepts exact filters for event type and trace/session/run/task/role identifiers, cursor pagination with `after_id`, time filtering with `since`/`until`, and `limit` up to 500. Persisted timestamps and query timestamp offsets are normalized to UTC before range comparison.
 
 The response is:
 

--- a/docs/modules/security/audit-trail-enhancement-spec.md
+++ b/docs/modules/security/audit-trail-enhancement-spec.md
@@ -35,7 +35,7 @@ Raw file content is never stored in audit rows. Dispatch reasons are capped at 4
 
 ## Runtime Integration
 
-Audit recording is centralized in `relay_teams.tools.runtime.execution` after hook rewriting has produced the effective tool input. The runtime records successful audit events after the tool result envelope is persisted so persistence failures do not create contradictory completed and failed audit rows. Audit persistence failures are logged without failing the user-visible tool result.
+Audit recording is centralized in `relay_teams.tools.runtime.execution` after hook rewriting has produced the effective tool input. The runtime records successful audit events after the tool result envelope is persisted and post-run cleanup completes so persistence or cleanup failures do not create contradictory completed and failed audit rows. Audit persistence failures are logged without failing the user-visible tool result.
 
 The audit service is carried on `ToolDeps` as an optional backend dependency. Agent tools do not expose any audit mutation function, and the repository has no update/delete API.
 
@@ -48,7 +48,7 @@ The tool runtime builds audit events from the effective tool input and the persi
 - shell command events capture the command and selected execution metadata without storing stdout/stderr bodies;
 - Coordinator dispatch events capture the selected task/role target and a bounded dispatch reason.
 
-Successful audit rows are written only after tool result persistence succeeds. If result persistence fails, the failure path records one failed audit row for the same action. If audit persistence itself fails, the runtime logs `security.audit.record_failed` and preserves the user-visible tool outcome.
+Successful audit rows are written only after tool result persistence and approval-ticket cleanup succeed. If result persistence or cleanup fails, the failure path records one failed audit row for the same action. If audit persistence itself fails, the runtime logs `security.audit.record_failed` and preserves the user-visible tool outcome.
 
 ## API
 
@@ -69,6 +69,6 @@ Unit coverage includes:
 - repository append/filter/pagination
 - API route filtering and validation
 - UTC time filtering, dirty persisted value conversion, and missing-row behavior
-- tool runtime audit creation for file write variants, worker-thread digest calculation, shell command, Coordinator dispatch decision, persistence-failure ordering, and audit-write failure isolation
+- tool runtime audit creation for file write variants, worker-thread digest calculation, shell command, Coordinator dispatch decision, persistence/cleanup-failure ordering, and audit-write failure isolation
 
 End-to-end acceptance should start the FastAPI app, call `/api/audit` through a browser context, and confirm the endpoint returns the immutable audit page shape.

--- a/docs/modules/security/audit-trail-enhancement-spec.md
+++ b/docs/modules/security/audit-trail-enhancement-spec.md
@@ -44,7 +44,7 @@ The audit service is carried on `ToolDeps` as an optional backend dependency. Ag
 `relay_teams.audit` owns the event models, SQLite repository, and service wrapper. The repository stores audit rows as immutable append-only records and normalizes all persisted timestamps to UTC ISO-8601 text before SQL comparison. Dirty persisted JSON and integer values are converted through typed helpers so the read path remains explicit without exposing loose dictionaries.
 
 The tool runtime builds audit events from the effective tool input and the persisted result envelope:
-- file write events derive logical paths from the file-oriented tool input or result metadata, then calculate a final `sha256:<hex>` digest and byte size when the target exists;
+- file write events derive logical paths from the file-oriented tool input or result metadata, then calculate a final `sha256:<hex>` digest and byte size in a worker thread when the target exists;
 - shell command events capture the command and selected execution metadata without storing stdout/stderr bodies;
 - Coordinator dispatch events capture the selected task/role target and a bounded dispatch reason.
 
@@ -69,6 +69,6 @@ Unit coverage includes:
 - repository append/filter/pagination
 - API route filtering and validation
 - UTC time filtering, dirty persisted value conversion, and missing-row behavior
-- tool runtime audit creation for file write variants, shell command, Coordinator dispatch decision, persistence-failure ordering, and audit-write failure isolation
+- tool runtime audit creation for file write variants, worker-thread digest calculation, shell command, Coordinator dispatch decision, persistence-failure ordering, and audit-write failure isolation
 
 End-to-end acceptance should start the FastAPI app, call `/api/audit` through a browser context, and confirm the endpoint returns the immutable audit page shape.

--- a/docs/modules/security/audit-trail-enhancement-spec.md
+++ b/docs/modules/security/audit-trail-enhancement-spec.md
@@ -1,0 +1,62 @@
+# SG-3 Audit Trail Enhancement Spec
+
+## Goal
+
+Implement SG-3 from `docs/research/lessons-learned-2026.md`: security-focused audit tracking for file writes, shell commands, and Coordinator channel-selection decisions, with an external read-only `/api/audit` query endpoint.
+
+## Scope
+
+- Add a dedicated `relay_teams.audit` module.
+- Persist audit events in `security_audit_events`, separate from the run `events` stream.
+- Record a `security.audit` trace span for each audit row.
+- Capture these runtime actions:
+  - workspace file writes from `write`, `write_tmp`, `edit`, and `notebook_edit`
+  - shell tool command executions and denied/failed shell attempts that reach tool runtime handling
+  - Coordinator `orch_dispatch_task` task-to-role decisions
+- Expose read-only filtering through `GET /api/audit`.
+
+## Event Contract
+
+Common fields:
+- `audit_event_id`
+- `event_type`
+- `trace_id`, `run_id`, `session_id`, `task_id`, `instance_id`, `role_id`, `tool_call_id`
+- `span_id`, `parent_span_id`
+- `action`, `target`, `outcome`
+- `metadata`
+- `occurred_at`, `created_at`
+
+Event-specific fields:
+- `file_write`: `target` is the logical path, `content_digest` is `sha256:<hex>`, and `content_size_bytes` is the final file byte size.
+- `shell_command`: `command` contains the command text, and metadata may include `workdir`, `background`, `tty`, `timeout_ms`, `status`, and `exit_code`.
+- `coordinator_decision`: `target` is `task:<task_id>->role:<role_id>`, and `decision_reason` is the dispatch prompt or the default dispatch reason.
+
+Raw file content is never stored in audit rows. Dispatch reasons are capped at 4,000 characters and accompanied by a digest/length in metadata.
+
+## Runtime Integration
+
+Audit recording is centralized in `relay_teams.tools.runtime.execution` after hook rewriting has produced the effective tool input. The runtime records audit events before persisting the tool result envelope, and audit persistence failures are logged without failing the user-visible tool result.
+
+The audit service is carried on `ToolDeps` as an optional backend dependency. Agent tools do not expose any audit mutation function, and the repository has no update/delete API.
+
+## API
+
+`GET /api/audit` accepts exact filters for event type and trace/session/run/task/role identifiers, cursor pagination with `after_id`, time filtering with `since`/`until`, and `limit` up to 500.
+
+The response is:
+
+```json
+{
+  "items": [],
+  "next_after_id": null
+}
+```
+
+## Verification
+
+Unit coverage includes:
+- repository append/filter/pagination
+- API route filtering and validation
+- tool runtime audit creation for file write, shell command, and Coordinator dispatch decision
+
+End-to-end acceptance should start the FastAPI app, call `/api/audit` through a browser context, and confirm the endpoint returns the immutable audit page shape.

--- a/docs/modules/security/audit-trail-enhancement-spec.md
+++ b/docs/modules/security/audit-trail-enhancement-spec.md
@@ -39,6 +39,17 @@ Audit recording is centralized in `relay_teams.tools.runtime.execution` after ho
 
 The audit service is carried on `ToolDeps` as an optional backend dependency. Agent tools do not expose any audit mutation function, and the repository has no update/delete API.
 
+## Implementation Design
+
+`relay_teams.audit` owns the event models, SQLite repository, and service wrapper. The repository stores audit rows as immutable append-only records and normalizes all persisted timestamps to UTC ISO-8601 text before SQL comparison. Dirty persisted JSON and integer values are converted through typed helpers so the read path remains explicit without exposing loose dictionaries.
+
+The tool runtime builds audit events from the effective tool input and the persisted result envelope:
+- file write events derive logical paths from the file-oriented tool input or result metadata, then calculate a final `sha256:<hex>` digest and byte size when the target exists;
+- shell command events capture the command and selected execution metadata without storing stdout/stderr bodies;
+- Coordinator dispatch events capture the selected task/role target and a bounded dispatch reason.
+
+Successful audit rows are written only after tool result persistence succeeds. If result persistence fails, the failure path records one failed audit row for the same action. If audit persistence itself fails, the runtime logs `security.audit.record_failed` and preserves the user-visible tool outcome.
+
 ## API
 
 `GET /api/audit` accepts exact filters for event type and trace/session/run/task/role identifiers, cursor pagination with `after_id`, time filtering with `since`/`until`, and `limit` up to 500. Persisted timestamps and query timestamp offsets are normalized to UTC before range comparison.
@@ -57,6 +68,7 @@ The response is:
 Unit coverage includes:
 - repository append/filter/pagination
 - API route filtering and validation
-- tool runtime audit creation for file write, shell command, and Coordinator dispatch decision
+- UTC time filtering, dirty persisted value conversion, and missing-row behavior
+- tool runtime audit creation for file write variants, shell command, Coordinator dispatch decision, persistence-failure ordering, and audit-write failure isolation
 
 End-to-end acceptance should start the FastAPI app, call `/api/audit` through a browser context, and confirm the endpoint returns the immutable audit page shape.

--- a/src/relay_teams/agents/execution/agent_llm_session.py
+++ b/src/relay_teams/agents/execution/agent_llm_session.py
@@ -84,6 +84,7 @@ from relay_teams.tools.workspace_tools.shell_approval_repo import (
     ShellApprovalRepository,
 )
 from relay_teams.workspace import WorkspaceManager
+from relay_teams.audit import AuditService
 
 
 class AgentLlmSession(
@@ -148,6 +149,7 @@ class AgentLlmSession(
         hook_service: HookService | None = None,
         reminder_service: SystemReminderService | None = None,
         auto_harness_service: object | None = None,
+        audit_service: AuditService | None = None,
     ) -> None:
         self._config = config
         self._profile_name = (
@@ -205,6 +207,7 @@ class AgentLlmSession(
         self._hook_service = hook_service
         self._reminder_service = reminder_service
         self._auto_harness_service = auto_harness_service
+        self._audit_service = audit_service
         self._mcp_tool_context_token_cache: dict[str, int] = {}
 
 

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -440,6 +440,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 hook_service=hook_service,
                 reminder_service=getattr(self, "_reminder_service", None),
                 auto_harness_service=getattr(self, "_auto_harness_service", None),
+                audit_service=getattr(self, "_audit_service", None),
                 model_capabilities=self._config.capabilities,
                 hook_runtime_env=hook_runtime_env,
             )

--- a/src/relay_teams/audit/__init__.py
+++ b/src/relay_teams/audit/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from relay_teams.audit.models import (
+    AuditEventCreate,
+    AuditEventFilter,
+    AuditEventPage,
+    AuditEventRecord,
+    AuditEventType,
+)
+from relay_teams.audit.repository import AuditEventRepository
+from relay_teams.audit.service import AuditService
+
+__all__ = [
+    "AuditEventCreate",
+    "AuditEventFilter",
+    "AuditEventPage",
+    "AuditEventRecord",
+    "AuditEventRepository",
+    "AuditEventType",
+    "AuditService",
+]

--- a/src/relay_teams/audit/models.py
+++ b/src/relay_teams/audit/models.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import Enum
+from typing import ClassVar
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+
+
+class AuditEventType(str, Enum):
+    FILE_WRITE = "file_write"
+    SHELL_COMMAND = "shell_command"
+    COORDINATOR_DECISION = "coordinator_decision"
+
+
+def new_audit_event_id() -> str:
+    return f"audit_{uuid4().hex[:16]}"
+
+
+class AuditEventCreate(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
+
+    audit_event_id: str = Field(default_factory=new_audit_event_id)
+    event_type: AuditEventType
+    trace_id: str
+    run_id: str
+    session_id: str
+    task_id: str | None = None
+    instance_id: str | None = None
+    role_id: str | None = None
+    tool_call_id: str | None = None
+    span_id: str | None = None
+    parent_span_id: str | None = None
+    action: str
+    target: str
+    content_digest: str | None = None
+    content_size_bytes: int | None = None
+    command: str | None = None
+    decision_reason: str | None = None
+    outcome: str
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
+    occurred_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @model_validator(mode="after")
+    def _validate_event_specific_fields(self) -> AuditEventCreate:
+        if self.event_type == AuditEventType.FILE_WRITE and not self.target.strip():
+            raise ValueError("file write audit events require target")
+        if self.event_type == AuditEventType.SHELL_COMMAND and not self.command:
+            raise ValueError("shell command audit events require command")
+        if (
+            self.event_type == AuditEventType.COORDINATOR_DECISION
+            and not self.decision_reason
+        ):
+            raise ValueError("coordinator decision audit events require reason")
+        return self
+
+
+class AuditEventRecord(AuditEventCreate):
+    id: int
+    created_at: datetime
+
+
+class AuditEventFilter(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
+
+    event_type: AuditEventType | None = None
+    trace_id: str | None = None
+    run_id: str | None = None
+    session_id: str | None = None
+    task_id: str | None = None
+    role_id: str | None = None
+    after_id: int = Field(default=0, ge=0)
+    since: datetime | None = None
+    until: datetime | None = None
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+class AuditEventPage(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
+
+    items: tuple[AuditEventRecord, ...]
+    next_after_id: int | None = None

--- a/src/relay_teams/audit/repository.py
+++ b/src/relay_teams/audit/repository.py
@@ -1,0 +1,389 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from json import dumps, loads
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+from pydantic import JsonValue
+
+from relay_teams.audit.models import (
+    AuditEventCreate,
+    AuditEventFilter,
+    AuditEventPage,
+    AuditEventRecord,
+    AuditEventType,
+)
+from relay_teams.persistence import async_fetchall
+from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
+
+
+class AuditEventRepository(SharedSqliteRepository):
+    def __init__(self, db_path: Path) -> None:
+        super().__init__(db_path)
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        def operation() -> None:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS security_audit_events (
+                    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                    audit_event_id     TEXT NOT NULL UNIQUE,
+                    event_type         TEXT NOT NULL,
+                    trace_id           TEXT NOT NULL,
+                    run_id             TEXT NOT NULL,
+                    session_id         TEXT NOT NULL,
+                    task_id            TEXT,
+                    instance_id        TEXT,
+                    role_id            TEXT,
+                    tool_call_id       TEXT,
+                    span_id            TEXT,
+                    parent_span_id     TEXT,
+                    action             TEXT NOT NULL,
+                    target             TEXT NOT NULL,
+                    content_digest     TEXT,
+                    content_size_bytes INTEGER,
+                    command            TEXT,
+                    decision_reason    TEXT,
+                    outcome            TEXT NOT NULL,
+                    metadata_json      TEXT NOT NULL,
+                    occurred_at        TEXT NOT NULL,
+                    created_at         TEXT NOT NULL
+                )
+                """
+            )
+            self._create_indexes()
+
+        self._run_write(operation_name="init_tables", operation=operation)
+
+    async def _init_tables_async(self) -> None:
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS security_audit_events (
+                    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                    audit_event_id     TEXT NOT NULL UNIQUE,
+                    event_type         TEXT NOT NULL,
+                    trace_id           TEXT NOT NULL,
+                    run_id             TEXT NOT NULL,
+                    session_id         TEXT NOT NULL,
+                    task_id            TEXT,
+                    instance_id        TEXT,
+                    role_id            TEXT,
+                    tool_call_id       TEXT,
+                    span_id            TEXT,
+                    parent_span_id     TEXT,
+                    action             TEXT NOT NULL,
+                    target             TEXT NOT NULL,
+                    content_digest     TEXT,
+                    content_size_bytes INTEGER,
+                    command            TEXT,
+                    decision_reason    TEXT,
+                    outcome            TEXT NOT NULL,
+                    metadata_json      TEXT NOT NULL,
+                    occurred_at        TEXT NOT NULL,
+                    created_at         TEXT NOT NULL
+                )
+                """
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_security_audit_events_type_id "
+                "ON security_audit_events(event_type, id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_security_audit_events_trace_id "
+                "ON security_audit_events(trace_id, id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_security_audit_events_run_id "
+                "ON security_audit_events(run_id, id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_security_audit_events_session_id "
+                "ON security_audit_events(session_id, id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_security_audit_events_task_id "
+                "ON security_audit_events(task_id, id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_security_audit_events_role_id "
+                "ON security_audit_events(role_id, id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_security_audit_events_time_id "
+                "ON security_audit_events(occurred_at, id)"
+            )
+
+        await self._run_async_write(
+            operation_name="init_tables_async",
+            operation=lambda _conn: operation(),
+        )
+
+    def _create_indexes(self) -> None:
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_security_audit_events_type_id "
+            "ON security_audit_events(event_type, id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_security_audit_events_trace_id "
+            "ON security_audit_events(trace_id, id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_security_audit_events_run_id "
+            "ON security_audit_events(run_id, id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_security_audit_events_session_id "
+            "ON security_audit_events(session_id, id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_security_audit_events_task_id "
+            "ON security_audit_events(task_id, id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_security_audit_events_role_id "
+            "ON security_audit_events(role_id, id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_security_audit_events_time_id "
+            "ON security_audit_events(occurred_at, id)"
+        )
+
+    def append(self, event: AuditEventCreate) -> AuditEventRecord:
+        created_at = datetime.now(UTC)
+        self._run_write(
+            operation_name="append",
+            operation=lambda: self._conn.execute(
+                """
+                INSERT INTO security_audit_events(
+                    audit_event_id, event_type, trace_id, run_id, session_id,
+                    task_id, instance_id, role_id, tool_call_id, span_id,
+                    parent_span_id, action, target, content_digest,
+                    content_size_bytes, command, decision_reason, outcome,
+                    metadata_json, occurred_at, created_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                _event_insert_values(event=event, created_at=created_at),
+            ),
+        )
+        return self.get_by_audit_event_id(event.audit_event_id)
+
+    async def append_async(self, event: AuditEventCreate) -> AuditEventRecord:
+        created_at = datetime.now(UTC)
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO security_audit_events(
+                    audit_event_id, event_type, trace_id, run_id, session_id,
+                    task_id, instance_id, role_id, tool_call_id, span_id,
+                    parent_span_id, action, target, content_digest,
+                    content_size_bytes, command, decision_reason, outcome,
+                    metadata_json, occurred_at, created_at
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                _event_insert_values(event=event, created_at=created_at),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="append_async",
+            operation=lambda _conn: operation(),
+        )
+        return await self.get_by_audit_event_id_async(event.audit_event_id)
+
+    def get_by_audit_event_id(self, audit_event_id: str) -> AuditEventRecord:
+        with self._lock:
+            row = self._conn.execute(
+                _SELECT_COLUMNS + " FROM security_audit_events WHERE audit_event_id=?",
+                (audit_event_id,),
+            ).fetchone()
+        if row is None:
+            raise KeyError(f"Unknown audit_event_id: {audit_event_id}")
+        return _row_to_record(row)
+
+    async def get_by_audit_event_id_async(
+        self, audit_event_id: str
+    ) -> AuditEventRecord:
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                _SELECT_COLUMNS + " FROM security_audit_events WHERE audit_event_id=?",
+                (audit_event_id,),
+            )
+        )
+        if not rows:
+            raise KeyError(f"Unknown audit_event_id: {audit_event_id}")
+        return _row_to_record(rows[0])
+
+    def list_events(self, query: AuditEventFilter) -> AuditEventPage:
+        sql, parameters = _list_query_parts(query)
+        with self._lock:
+            rows = self._conn.execute(sql, parameters).fetchall()
+        return _page_from_rows(rows, limit=query.limit)
+
+    async def list_events_async(self, query: AuditEventFilter) -> AuditEventPage:
+        sql, parameters = _list_query_parts(query)
+        rows = await self._run_async_read(
+            lambda conn: async_fetchall(conn, sql, parameters)
+        )
+        return _page_from_rows(rows, limit=query.limit)
+
+
+_SELECT_COLUMNS = (
+    "SELECT id, audit_event_id, event_type, trace_id, run_id, session_id, "
+    "task_id, instance_id, role_id, tool_call_id, span_id, parent_span_id, "
+    "action, target, content_digest, content_size_bytes, command, "
+    "decision_reason, outcome, metadata_json, occurred_at, created_at"
+)
+
+
+def _event_insert_values(
+    *,
+    event: AuditEventCreate,
+    created_at: datetime,
+) -> tuple[object, ...]:
+    return (
+        event.audit_event_id,
+        event.event_type.value,
+        event.trace_id,
+        event.run_id,
+        event.session_id,
+        event.task_id,
+        event.instance_id,
+        event.role_id,
+        event.tool_call_id,
+        event.span_id,
+        event.parent_span_id,
+        event.action,
+        event.target,
+        event.content_digest,
+        event.content_size_bytes,
+        event.command,
+        event.decision_reason,
+        event.outcome,
+        dumps(event.metadata, ensure_ascii=False, sort_keys=True),
+        event.occurred_at.isoformat(),
+        created_at.isoformat(),
+    )
+
+
+def _list_query_parts(query: AuditEventFilter) -> tuple[str, tuple[object, ...]]:
+    clauses = ["id > ?"]
+    parameters: list[object] = [query.after_id]
+    if query.event_type is not None:
+        clauses.append("event_type = ?")
+        parameters.append(query.event_type.value)
+    if query.trace_id is not None:
+        clauses.append("trace_id = ?")
+        parameters.append(query.trace_id)
+    if query.run_id is not None:
+        clauses.append("run_id = ?")
+        parameters.append(query.run_id)
+    if query.session_id is not None:
+        clauses.append("session_id = ?")
+        parameters.append(query.session_id)
+    if query.task_id is not None:
+        clauses.append("task_id = ?")
+        parameters.append(query.task_id)
+    if query.role_id is not None:
+        clauses.append("role_id = ?")
+        parameters.append(query.role_id)
+    if query.since is not None:
+        clauses.append("occurred_at >= ?")
+        parameters.append(query.since.isoformat())
+    if query.until is not None:
+        clauses.append("occurred_at <= ?")
+        parameters.append(query.until.isoformat())
+    sql = (
+        _SELECT_COLUMNS
+        + " FROM security_audit_events WHERE "
+        + " AND ".join(clauses)
+        + " ORDER BY id ASC LIMIT ?"
+    )
+    parameters.append(query.limit + 1)
+    return sql, tuple(parameters)
+
+
+def _page_from_rows(
+    rows: list[sqlite3.Row],
+    *,
+    limit: int,
+) -> AuditEventPage:
+    has_more = len(rows) > limit
+    visible_rows = rows[:limit]
+    items = tuple(_row_to_record(row) for row in visible_rows)
+    next_after_id = items[-1].id if has_more and items else None
+    return AuditEventPage(items=items, next_after_id=next_after_id)
+
+
+def _row_to_record(row: sqlite3.Row) -> AuditEventRecord:
+    return AuditEventRecord(
+        id=int(row["id"]),
+        audit_event_id=str(row["audit_event_id"]),
+        event_type=AuditEventType(str(row["event_type"])),
+        trace_id=str(row["trace_id"]),
+        run_id=str(row["run_id"]),
+        session_id=str(row["session_id"]),
+        task_id=_optional_text(row["task_id"]),
+        instance_id=_optional_text(row["instance_id"]),
+        role_id=_optional_text(row["role_id"]),
+        tool_call_id=_optional_text(row["tool_call_id"]),
+        span_id=_optional_text(row["span_id"]),
+        parent_span_id=_optional_text(row["parent_span_id"]),
+        action=str(row["action"]),
+        target=str(row["target"]),
+        content_digest=_optional_text(row["content_digest"]),
+        content_size_bytes=_optional_int(row["content_size_bytes"]),
+        command=_optional_text(row["command"]),
+        decision_reason=_optional_text(row["decision_reason"]),
+        outcome=str(row["outcome"]),
+        metadata=_json_object(str(row["metadata_json"])),
+        occurred_at=datetime.fromisoformat(str(row["occurred_at"])),
+        created_at=datetime.fromisoformat(str(row["created_at"])),
+    )
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value)
+    raise ValueError(f"Invalid persisted integer value: {value}")
+
+
+def _json_object(value: str) -> dict[str, JsonValue]:
+    loaded: object = loads(value)
+    if not isinstance(loaded, dict):
+        return {}
+    result: dict[str, JsonValue] = {}
+    for key, item in loaded.items():
+        result[str(key)] = _json_value(item)
+    return result
+
+
+def _json_value(value: object) -> JsonValue:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    return cast(JsonValue, str(value))

--- a/src/relay_teams/audit/repository.py
+++ b/src/relay_teams/audit/repository.py
@@ -5,7 +5,6 @@ from datetime import UTC, datetime
 from json import dumps, loads
 import sqlite3
 from pathlib import Path
-from typing import cast
 
 from pydantic import JsonValue
 
@@ -386,4 +385,4 @@ def _json_value(value: object) -> JsonValue:
         return [_json_value(item) for item in value]
     if isinstance(value, dict):
         return {str(key): _json_value(item) for key, item in value.items()}
-    return cast(JsonValue, str(value))
+    return str(value)

--- a/src/relay_teams/audit/repository.py
+++ b/src/relay_teams/audit/repository.py
@@ -270,8 +270,8 @@ def _event_insert_values(
         event.decision_reason,
         event.outcome,
         dumps(event.metadata, ensure_ascii=False, sort_keys=True),
-        event.occurred_at.isoformat(),
-        created_at.isoformat(),
+        _utc_timestamp(event.occurred_at),
+        _utc_timestamp(created_at),
     )
 
 
@@ -298,10 +298,10 @@ def _list_query_parts(query: AuditEventFilter) -> tuple[str, tuple[object, ...]]
         parameters.append(query.role_id)
     if query.since is not None:
         clauses.append("occurred_at >= ?")
-        parameters.append(query.since.isoformat())
+        parameters.append(_utc_timestamp(query.since))
     if query.until is not None:
         clauses.append("occurred_at <= ?")
-        parameters.append(query.until.isoformat())
+        parameters.append(_utc_timestamp(query.until))
     sql = (
         _SELECT_COLUMNS
         + " FROM security_audit_events WHERE "
@@ -346,8 +346,8 @@ def _row_to_record(row: sqlite3.Row) -> AuditEventRecord:
         decision_reason=_optional_text(row["decision_reason"]),
         outcome=str(row["outcome"]),
         metadata=_json_object(str(row["metadata_json"])),
-        occurred_at=datetime.fromisoformat(str(row["occurred_at"])),
-        created_at=datetime.fromisoformat(str(row["created_at"])),
+        occurred_at=_parse_persisted_datetime(str(row["occurred_at"])),
+        created_at=_parse_persisted_datetime(str(row["created_at"])),
     )
 
 
@@ -386,3 +386,18 @@ def _json_value(value: object) -> JsonValue:
     if isinstance(value, dict):
         return {str(key): _json_value(item) for key, item in value.items()}
     return str(value)
+
+
+def _utc_datetime(value: datetime) -> datetime:
+    if value.utcoffset() is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _utc_timestamp(value: datetime) -> str:
+    return _utc_datetime(value).isoformat(timespec="microseconds")
+
+
+def _parse_persisted_datetime(value: str) -> datetime:
+    text = value[:-1] + "+00:00" if value.endswith("Z") else value
+    return _utc_datetime(datetime.fromisoformat(text))

--- a/src/relay_teams/audit/service.py
+++ b/src/relay_teams/audit/service.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import logging
+
+from relay_teams.audit.models import (
+    AuditEventCreate,
+    AuditEventFilter,
+    AuditEventPage,
+    AuditEventRecord,
+)
+from relay_teams.audit.repository import AuditEventRepository
+from relay_teams.logger import get_logger, log_event
+from relay_teams.trace import get_trace_context, trace_span
+
+LOGGER = get_logger(__name__)
+
+
+class AuditService:
+    def __init__(self, repository: AuditEventRepository) -> None:
+        self._repository = repository
+
+    def record_event(self, event: AuditEventCreate) -> AuditEventRecord:
+        with trace_span(
+            LOGGER,
+            component="security.audit",
+            operation=event.event_type.value,
+            attributes={
+                "audit_event_id": event.audit_event_id,
+                "audit_event_type": event.event_type.value,
+                "target": event.target,
+            },
+            trace_id=event.trace_id,
+            run_id=event.run_id,
+            session_id=event.session_id,
+            task_id=event.task_id,
+            instance_id=event.instance_id,
+            role_id=event.role_id,
+            tool_call_id=event.tool_call_id,
+        ):
+            enriched = _event_with_current_span(event)
+            record = self._repository.append(enriched)
+        _log_recorded_event(record)
+        return record
+
+    async def record_event_async(self, event: AuditEventCreate) -> AuditEventRecord:
+        with trace_span(
+            LOGGER,
+            component="security.audit",
+            operation=event.event_type.value,
+            attributes={
+                "audit_event_id": event.audit_event_id,
+                "audit_event_type": event.event_type.value,
+                "target": event.target,
+            },
+            trace_id=event.trace_id,
+            run_id=event.run_id,
+            session_id=event.session_id,
+            task_id=event.task_id,
+            instance_id=event.instance_id,
+            role_id=event.role_id,
+            tool_call_id=event.tool_call_id,
+        ):
+            enriched = _event_with_current_span(event)
+            record = await self._repository.append_async(enriched)
+        _log_recorded_event(record)
+        return record
+
+    def list_events(self, query: AuditEventFilter) -> AuditEventPage:
+        return self._repository.list_events(query)
+
+    async def list_events_async(self, query: AuditEventFilter) -> AuditEventPage:
+        return await self._repository.list_events_async(query)
+
+
+def _event_with_current_span(event: AuditEventCreate) -> AuditEventCreate:
+    context = get_trace_context()
+    return event.model_copy(
+        update={
+            "span_id": event.span_id or context.span_id,
+            "parent_span_id": event.parent_span_id or context.parent_span_id,
+        }
+    )
+
+
+def _log_recorded_event(record: AuditEventRecord) -> None:
+    log_event(
+        LOGGER,
+        logging.INFO,
+        event="security.audit.recorded",
+        message="Security audit event recorded",
+        payload={
+            "audit_event_id": record.audit_event_id,
+            "audit_event_type": record.event_type.value,
+            "trace_id": record.trace_id,
+            "run_id": record.run_id,
+            "session_id": record.session_id,
+            "task_id": record.task_id,
+            "role_id": record.role_id,
+            "target": record.target,
+            "outcome": record.outcome,
+        },
+    )

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -35,6 +35,7 @@ from pydantic_ai.usage import RunUsage
 from relay_teams.agents.execution.coordination_agent_builder import (
     build_coordination_agent,
 )
+from relay_teams.audit import AuditService
 from relay_teams.computer import ComputerRuntime
 from relay_teams.media import MediaAssetService
 from relay_teams.monitors import MonitorService
@@ -197,6 +198,7 @@ class ExternalAcpHostToolBridge:
         computer_runtime: ComputerRuntime | None = None,
         shell_approval_repo: ShellApprovalRepository | None = None,
         reminder_service: SystemReminderService | None = None,
+        audit_service: AuditService | None = None,
     ) -> None:
         self._task_repo = task_repo
         self._shared_store = shared_store
@@ -235,6 +237,7 @@ class ExternalAcpHostToolBridge:
         self._computer_runtime = computer_runtime
         self._shell_approval_repo = shell_approval_repo
         self._reminder_service = reminder_service
+        self._audit_service = audit_service
 
         self._catalog_by_name: dict[str, HostedToolDefinition] = {}
         self._catalog_signature = ""
@@ -579,6 +582,7 @@ class ExternalAcpHostToolBridge:
                 None,
             ),
             reminder_service=getattr(self, "_reminder_service", None),
+            audit_service=getattr(self, "_audit_service", None),
             model_capabilities=self._resolve_request_model_capabilities(
                 request=request
             ),

--- a/src/relay_teams/external_agents/provider.py
+++ b/src/relay_teams/external_agents/provider.py
@@ -17,6 +17,7 @@ from pydantic import JsonValue
 from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart
 from pydantic_ai.messages import UserPromptPart
 
+from relay_teams.audit import AuditService
 from relay_teams.computer import (
     ComputerRuntime,
     build_computer_tool_payload,
@@ -191,6 +192,7 @@ class ExternalAcpSessionManager:
         ) = None,
         computer_runtime: ComputerRuntime | None = None,
         reminder_service: SystemReminderService | None = None,
+        audit_service: AuditService | None = None,
     ) -> None:
         self._config_dir = config_dir
         self._config_service = config_service
@@ -232,6 +234,7 @@ class ExternalAcpSessionManager:
         self._get_gateway_session_lookup = get_gateway_session_lookup
         self._computer_runtime = computer_runtime
         self._reminder_service = reminder_service
+        self._audit_service = audit_service
         self._conversations: dict[str, _ConversationHandle] = {}
         self._locks: dict[str, asyncio.Lock] = {}
 
@@ -1078,6 +1081,7 @@ class ExternalAcpSessionManager:
             ),
             computer_runtime=self._computer_runtime,
             reminder_service=self._reminder_service,
+            audit_service=self._audit_service,
         )
 
     def _resolve_transport_agent_config(

--- a/src/relay_teams/interfaces/server/app.py
+++ b/src/relay_teams/interfaces/server/app.py
@@ -39,6 +39,7 @@ from relay_teams.interfaces.server.runtime_identity import (
     build_server_health_payload,
 )
 from relay_teams.interfaces.server.routers import (
+    audit,
     automation,
     commands,
     feishu_gateway,
@@ -199,6 +200,7 @@ app = FastAPI(
 )
 
 app.include_router(system.router, prefix="/api")
+app.include_router(audit.router, prefix="/api")
 app.include_router(commands.router, prefix="/api")
 app.include_router(automation.router, prefix="/api")
 app.include_router(feishu_gateway.router, prefix="/api")

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import FrozenSet, List, Optional, Protocol, Tuple
 
 from relay_teams.agents.execution.prompt_instructions import PromptInstructionResolver
+from relay_teams.audit import AuditEventRepository, AuditService
 from relay_teams.automation.automation_bound_session_queue_repository import (
     AutomationBoundSessionQueueRepository,
 )
@@ -413,6 +414,10 @@ class ServerContainer:
         )
 
         self.task_repo: TaskRepository = TaskRepository(runtime.paths.db_path)
+        self.audit_repository: AuditEventRepository = AuditEventRepository(
+            runtime.paths.db_path
+        )
+        self.audit_service: AuditService = AuditService(self.audit_repository)
         self.shared_store: SharedStateRepository = SharedStateRepository(
             runtime.paths.db_path
         )
@@ -718,6 +723,7 @@ class ServerContainer:
                 None,
             ),
             computer_runtime=self.computer_runtime,
+            audit_service=self.audit_service,
         )
         self.run_control_manager.bind_runtime(
             run_event_hub=self.run_event_hub,
@@ -1064,6 +1070,7 @@ class ServerContainer:
         )
         self._async_closeables: tuple[AsyncCloseableRepository, ...] = (
             self.task_repo,
+            self.audit_repository,
             self.shared_store,
             self.workspace_repo,
             self.ssh_profile_repo,
@@ -1161,6 +1168,7 @@ class ServerContainer:
             hook_service=self.hook_service,
             reminder_service=self.reminder_service,
             auto_harness_service=self.auto_harness_service,
+            audit_service=self.audit_service,
         )
         self.task_execution_service = create_task_execution_service(
             role_registry=self.role_registry,

--- a/src/relay_teams/interfaces/server/deps.py
+++ b/src/relay_teams/interfaces/server/deps.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from fastapi import Request, WebSocket
 
+from relay_teams.audit import AuditService
 from relay_teams.commands import CommandRegistry
 from relay_teams.agents.orchestration.settings_service import (
     OrchestrationSettingsService,
@@ -78,6 +79,10 @@ def get_session_service(request: Request) -> SessionService:
 
 def get_task_service(request: Request) -> TaskOrchestrationService:
     return get_container(request).task_service
+
+
+def get_audit_service(request: Request) -> AuditService:
+    return get_container(request).audit_service
 
 
 def get_automation_service(request: Request) -> AutomationService:

--- a/src/relay_teams/interfaces/server/routers/__init__.py
+++ b/src/relay_teams/interfaces/server/routers/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from relay_teams.interfaces.server.routers import (
+    audit,
     automation,
     commands,
     feishu_gateway,
@@ -22,6 +23,7 @@ from relay_teams.interfaces.server.routers import (
 )
 
 __all__ = [
+    "audit",
     "automation",
     "commands",
     "feishu_gateway",

--- a/src/relay_teams/interfaces/server/routers/audit.py
+++ b/src/relay_teams/interfaces/server/routers/audit.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+
+from relay_teams.audit import AuditEventFilter, AuditEventType, AuditService
+from relay_teams.interfaces.server.deps import get_audit_service
+from relay_teams.validation import OptionalIdentifierStr
+
+router = APIRouter(prefix="/audit", tags=["Audit"])
+
+
+@router.get("")
+async def list_audit_events(
+    event_type: AuditEventType | None = None,
+    trace_id: OptionalIdentifierStr = None,
+    run_id: OptionalIdentifierStr = None,
+    session_id: OptionalIdentifierStr = None,
+    task_id: OptionalIdentifierStr = None,
+    role_id: OptionalIdentifierStr = None,
+    after_id: int = Query(default=0, ge=0),
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = Query(default=100, ge=1, le=500),
+    service: AuditService = Depends(get_audit_service),
+) -> dict[str, object]:
+    page = await service.list_events_async(
+        AuditEventFilter(
+            event_type=event_type,
+            trace_id=trace_id,
+            run_id=run_id,
+            session_id=session_id,
+            task_id=task_id,
+            role_id=role_id,
+            after_id=after_id,
+            since=since,
+            until=until,
+            limit=limit,
+        )
+    )
+    return page.model_dump(mode="json")

--- a/src/relay_teams/providers/openai_compatible.py
+++ b/src/relay_teams/providers/openai_compatible.py
@@ -11,6 +11,7 @@ import httpx
 from pydantic_ai.exceptions import ModelAPIError
 from pydantic_ai.messages import ModelRequest, ModelResponse
 
+from relay_teams.audit import AuditService
 from relay_teams.agents.execution.conversation_compaction import (
     ConversationCompactionService,
 )
@@ -142,6 +143,7 @@ class OpenAICompatibleProvider(LLMProvider):
         hook_service: HookService | None = None,
         reminder_service: SystemReminderService | None = None,
         auto_harness_service: object | None = None,
+        audit_service: AuditService | None = None,
     ) -> None:
         self._config_ref = config
         self._media_asset_service = media_asset_service
@@ -202,6 +204,7 @@ class OpenAICompatibleProvider(LLMProvider):
             hook_service=hook_service,
             reminder_service=reminder_service,
             auto_harness_service=auto_harness_service,
+            audit_service=audit_service,
         )
 
     @override

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -7,6 +7,7 @@ import json
 from threading import Lock
 from typing import TYPE_CHECKING
 
+from relay_teams.audit import AuditService
 from relay_teams.external_agents.provider import (
     ExternalAcpProvider,
     ExternalAcpSessionManager,
@@ -126,6 +127,7 @@ def create_provider_factory(
     hook_service: HookService | None = None,
     reminder_service: SystemReminderService | None = None,
     auto_harness_service: object | None = None,
+    audit_service: AuditService | None = None,
 ) -> Callable[[RoleDefinition, str | None], LLMProvider]:
     fallback_cooldown_registries: dict[tuple[str, ...], ProfileCooldownRegistry] = {}
     fallback_cooldown_registry_lock = Lock()
@@ -271,6 +273,7 @@ def create_provider_factory(
                 hook_service=hook_service,
                 reminder_service=reminder_service,
                 auto_harness_service=auto_harness_service,
+                audit_service=audit_service,
             ),
         )
         return provider_registry.create(config_to_use)

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -130,23 +130,25 @@ class ToolDeps(BaseModel):
         arbitrary_types_allowed=True,
     )
 
-    task_repo: SkipValidation[TaskRepository]
-    shared_store: SkipValidation[SharedStateRepository]
-    event_bus: SkipValidation[EventLog]
-    message_repo: SkipValidation[MessageRepository]
-    approval_ticket_repo: SkipValidation[ApprovalTicketRepository]
-    user_question_repo: SkipValidation[UserQuestionRepository | None] = None
-    run_runtime_repo: SkipValidation[RunRuntimeRepository]
-    injection_manager: SkipValidation[RunInjectionManager]
+    task_repo: Annotated[TaskRepository, SkipValidation]
+    shared_store: Annotated[SharedStateRepository, SkipValidation]
+    event_bus: Annotated[EventLog, SkipValidation]
+    message_repo: Annotated[MessageRepository, SkipValidation]
+    approval_ticket_repo: Annotated[ApprovalTicketRepository, SkipValidation]
+    user_question_repo: Annotated[UserQuestionRepository | None, SkipValidation] = None
+    run_runtime_repo: Annotated[RunRuntimeRepository, SkipValidation]
+    injection_manager: Annotated[RunInjectionManager, SkipValidation]
     run_event_hub: Annotated[RunEventHub, SkipValidation]
-    agent_repo: SkipValidation[AgentInstanceRepository]
-    workspace: SkipValidation[WorkspaceHandle]
-    role_memory: SkipValidation[RoleMemoryService | None] = None
-    media_asset_service: SkipValidation[MediaAssetService | None] = None
-    computer_runtime: SkipValidation[ComputerRuntime | None] = None
-    background_task_service: SkipValidation[BackgroundTaskService | None] = None
-    monitor_service: SkipValidation[MonitorService | None] = None
-    todo_service: SkipValidation[TodoService | None] = None
+    agent_repo: Annotated[AgentInstanceRepository, SkipValidation]
+    workspace: Annotated[WorkspaceHandle, SkipValidation]
+    role_memory: Annotated[RoleMemoryService | None, SkipValidation] = None
+    media_asset_service: Annotated[MediaAssetService | None, SkipValidation] = None
+    computer_runtime: Annotated[ComputerRuntime | None, SkipValidation] = None
+    background_task_service: Annotated[BackgroundTaskService | None, SkipValidation] = (
+        None
+    )
+    monitor_service: Annotated[MonitorService | None, SkipValidation] = None
+    todo_service: Annotated[TodoService | None, SkipValidation] = None
     run_id: str
     trace_id: str
     task_id: str
@@ -157,27 +159,29 @@ class ToolDeps(BaseModel):
     conversation_id: str
     instance_id: str
     role_id: str
-    role_registry: SkipValidation[RoleRegistry]
-    runtime_role_resolver: SkipValidation[RuntimeRoleResolver | None] = None
-    skill_registry: SkipValidation[SkillRegistryLike | None] = None
-    mcp_registry: SkipValidation[McpRegistry]
-    task_service: SkipValidation[TaskOrchestrationServiceLike]
-    task_execution_service: SkipValidation[TaskExecutionServiceLike]
-    run_control_manager: SkipValidation[RunControlManager]
-    tool_approval_manager: SkipValidation[ToolApprovalManager]
-    user_question_manager: SkipValidation[UserQuestionManager | None] = None
-    tool_approval_policy: SkipValidation[ToolApprovalPolicy]
-    shell_approval_repo: SkipValidation[ShellApprovalRepository | None] = None
-    metric_recorder: SkipValidation[MetricRecorder | None] = None
-    notification_service: SkipValidation[NotificationService | None] = None
-    im_tool_service: SkipValidation[ImToolServiceLike | None] = None
+    role_registry: Annotated[RoleRegistry, SkipValidation]
+    runtime_role_resolver: Annotated[RuntimeRoleResolver | None, SkipValidation] = None
+    skill_registry: Annotated[SkillRegistryLike | None, SkipValidation] = None
+    mcp_registry: Annotated[McpRegistry, SkipValidation]
+    task_service: Annotated[TaskOrchestrationServiceLike, SkipValidation]
+    task_execution_service: Annotated[TaskExecutionServiceLike, SkipValidation]
+    run_control_manager: Annotated[RunControlManager, SkipValidation]
+    tool_approval_manager: Annotated[ToolApprovalManager, SkipValidation]
+    user_question_manager: Annotated[UserQuestionManager | None, SkipValidation] = None
+    tool_approval_policy: Annotated[ToolApprovalPolicy, SkipValidation]
+    shell_approval_repo: Annotated[ShellApprovalRepository | None, SkipValidation] = (
+        None
+    )
+    metric_recorder: Annotated[MetricRecorder | None, SkipValidation] = None
+    notification_service: Annotated[NotificationService | None, SkipValidation] = None
+    im_tool_service: Annotated[ImToolServiceLike | None, SkipValidation] = None
     xiaoluban_notify_service: XiaolubanNotifyServiceLike | None = None
     gateway_session_lookup: GatewaySessionLookupLike | None = None
-    hook_service: SkipValidation[HookService | None] = None
-    reminder_service: SkipValidation[SystemReminderService | None] = None
-    auto_harness_service: SkipValidation[object | None] = None
-    audit_service: SkipValidation[AuditService | None] = None
-    model_capabilities: SkipValidation[ModelCapabilities] = Field(
+    hook_service: Annotated[HookService | None, SkipValidation] = None
+    reminder_service: Annotated[SystemReminderService | None, SkipValidation] = None
+    auto_harness_service: Annotated[object | None, SkipValidation] = None
+    audit_service: Annotated[AuditService | None, SkipValidation] = None
+    model_capabilities: Annotated[ModelCapabilities, SkipValidation] = Field(
         default_factory=ModelCapabilities
     )
     hook_runtime_env: dict[str, str] = Field(default_factory=dict)

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Annotated, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation
 from pydantic_ai import RunContext
@@ -138,7 +138,7 @@ class ToolDeps(BaseModel):
     user_question_repo: SkipValidation[UserQuestionRepository | None] = None
     run_runtime_repo: SkipValidation[RunRuntimeRepository]
     injection_manager: SkipValidation[RunInjectionManager]
-    run_event_hub: SkipValidation[RunEventHub]
+    run_event_hub: Annotated[RunEventHub, SkipValidation]
     agent_repo: SkipValidation[AgentInstanceRepository]
     workspace: SkipValidation[WorkspaceHandle]
     role_memory: SkipValidation[RoleMemoryService | None] = None

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -123,6 +123,9 @@ class SkillRegistryLike(Protocol):
     ) -> str | None: ...
 
 
+_SKIP_VALIDATION: object = SkipValidation
+
+
 class ToolDeps(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -130,25 +133,27 @@ class ToolDeps(BaseModel):
         arbitrary_types_allowed=True,
     )
 
-    task_repo: Annotated[TaskRepository, SkipValidation]
-    shared_store: Annotated[SharedStateRepository, SkipValidation]
-    event_bus: Annotated[EventLog, SkipValidation]
-    message_repo: Annotated[MessageRepository, SkipValidation]
-    approval_ticket_repo: Annotated[ApprovalTicketRepository, SkipValidation]
-    user_question_repo: Annotated[UserQuestionRepository | None, SkipValidation] = None
-    run_runtime_repo: Annotated[RunRuntimeRepository, SkipValidation]
-    injection_manager: Annotated[RunInjectionManager, SkipValidation]
-    run_event_hub: Annotated[RunEventHub, SkipValidation]
-    agent_repo: Annotated[AgentInstanceRepository, SkipValidation]
-    workspace: Annotated[WorkspaceHandle, SkipValidation]
-    role_memory: Annotated[RoleMemoryService | None, SkipValidation] = None
-    media_asset_service: Annotated[MediaAssetService | None, SkipValidation] = None
-    computer_runtime: Annotated[ComputerRuntime | None, SkipValidation] = None
-    background_task_service: Annotated[BackgroundTaskService | None, SkipValidation] = (
+    task_repo: Annotated[TaskRepository, _SKIP_VALIDATION]
+    shared_store: Annotated[SharedStateRepository, _SKIP_VALIDATION]
+    event_bus: Annotated[EventLog, _SKIP_VALIDATION]
+    message_repo: Annotated[MessageRepository, _SKIP_VALIDATION]
+    approval_ticket_repo: Annotated[ApprovalTicketRepository, _SKIP_VALIDATION]
+    user_question_repo: Annotated[UserQuestionRepository | None, _SKIP_VALIDATION] = (
         None
     )
-    monitor_service: Annotated[MonitorService | None, SkipValidation] = None
-    todo_service: Annotated[TodoService | None, SkipValidation] = None
+    run_runtime_repo: Annotated[RunRuntimeRepository, _SKIP_VALIDATION]
+    injection_manager: Annotated[RunInjectionManager, _SKIP_VALIDATION]
+    run_event_hub: Annotated[RunEventHub, _SKIP_VALIDATION]
+    agent_repo: Annotated[AgentInstanceRepository, _SKIP_VALIDATION]
+    workspace: Annotated[WorkspaceHandle, _SKIP_VALIDATION]
+    role_memory: Annotated[RoleMemoryService | None, _SKIP_VALIDATION] = None
+    media_asset_service: Annotated[MediaAssetService | None, _SKIP_VALIDATION] = None
+    computer_runtime: Annotated[ComputerRuntime | None, _SKIP_VALIDATION] = None
+    background_task_service: Annotated[
+        BackgroundTaskService | None, _SKIP_VALIDATION
+    ] = None
+    monitor_service: Annotated[MonitorService | None, _SKIP_VALIDATION] = None
+    todo_service: Annotated[TodoService | None, _SKIP_VALIDATION] = None
     run_id: str
     trace_id: str
     task_id: str
@@ -159,29 +164,33 @@ class ToolDeps(BaseModel):
     conversation_id: str
     instance_id: str
     role_id: str
-    role_registry: Annotated[RoleRegistry, SkipValidation]
-    runtime_role_resolver: Annotated[RuntimeRoleResolver | None, SkipValidation] = None
-    skill_registry: Annotated[SkillRegistryLike | None, SkipValidation] = None
-    mcp_registry: Annotated[McpRegistry, SkipValidation]
-    task_service: Annotated[TaskOrchestrationServiceLike, SkipValidation]
-    task_execution_service: Annotated[TaskExecutionServiceLike, SkipValidation]
-    run_control_manager: Annotated[RunControlManager, SkipValidation]
-    tool_approval_manager: Annotated[ToolApprovalManager, SkipValidation]
-    user_question_manager: Annotated[UserQuestionManager | None, SkipValidation] = None
-    tool_approval_policy: Annotated[ToolApprovalPolicy, SkipValidation]
-    shell_approval_repo: Annotated[ShellApprovalRepository | None, SkipValidation] = (
+    role_registry: Annotated[RoleRegistry, _SKIP_VALIDATION]
+    runtime_role_resolver: Annotated[RuntimeRoleResolver | None, _SKIP_VALIDATION] = (
         None
     )
-    metric_recorder: Annotated[MetricRecorder | None, SkipValidation] = None
-    notification_service: Annotated[NotificationService | None, SkipValidation] = None
-    im_tool_service: Annotated[ImToolServiceLike | None, SkipValidation] = None
+    skill_registry: Annotated[SkillRegistryLike | None, _SKIP_VALIDATION] = None
+    mcp_registry: Annotated[McpRegistry, _SKIP_VALIDATION]
+    task_service: Annotated[TaskOrchestrationServiceLike, _SKIP_VALIDATION]
+    task_execution_service: Annotated[TaskExecutionServiceLike, _SKIP_VALIDATION]
+    run_control_manager: Annotated[RunControlManager, _SKIP_VALIDATION]
+    tool_approval_manager: Annotated[ToolApprovalManager, _SKIP_VALIDATION]
+    user_question_manager: Annotated[UserQuestionManager | None, _SKIP_VALIDATION] = (
+        None
+    )
+    tool_approval_policy: Annotated[ToolApprovalPolicy, _SKIP_VALIDATION]
+    shell_approval_repo: Annotated[ShellApprovalRepository | None, _SKIP_VALIDATION] = (
+        None
+    )
+    metric_recorder: Annotated[MetricRecorder | None, _SKIP_VALIDATION] = None
+    notification_service: Annotated[NotificationService | None, _SKIP_VALIDATION] = None
+    im_tool_service: Annotated[ImToolServiceLike | None, _SKIP_VALIDATION] = None
     xiaoluban_notify_service: XiaolubanNotifyServiceLike | None = None
     gateway_session_lookup: GatewaySessionLookupLike | None = None
-    hook_service: Annotated[HookService | None, SkipValidation] = None
-    reminder_service: Annotated[SystemReminderService | None, SkipValidation] = None
-    auto_harness_service: Annotated[object | None, SkipValidation] = None
-    audit_service: Annotated[AuditService | None, SkipValidation] = None
-    model_capabilities: Annotated[ModelCapabilities, SkipValidation] = Field(
+    hook_service: Annotated[HookService | None, _SKIP_VALIDATION] = None
+    reminder_service: Annotated[SystemReminderService | None, _SKIP_VALIDATION] = None
+    auto_harness_service: Annotated[object | None, _SKIP_VALIDATION] = None
+    audit_service: Annotated[AuditService | None, _SKIP_VALIDATION] = None
+    model_capabilities: Annotated[ModelCapabilities, _SKIP_VALIDATION] = Field(
         default_factory=ModelCapabilities
     )
     hook_runtime_env: dict[str, str] = Field(default_factory=dict)

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -7,6 +7,7 @@ from typing import Protocol, runtime_checkable
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation
 from pydantic_ai import RunContext
 
+from relay_teams.audit import AuditService
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.agents.orchestration.task_contracts import (
@@ -175,6 +176,7 @@ class ToolDeps(BaseModel):
     hook_service: SkipValidation[HookService | None] = None
     reminder_service: SkipValidation[SystemReminderService | None] = None
     auto_harness_service: SkipValidation[object | None] = None
+    audit_service: SkipValidation[AuditService | None] = None
     model_capabilities: SkipValidation[ModelCapabilities] = Field(
         default_factory=ModelCapabilities
     )

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -884,10 +884,7 @@ async def _record_security_audit_event_async(
 
 
 def _audit_service(ctx: ToolContext) -> AuditService | None:
-    service = getattr(ctx.deps, "audit_service", None)
-    if service is None:
-        return None
-    return cast(AuditService, service)
+    return ctx.deps.audit_service
 
 
 def _build_security_audit_event(

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -503,15 +503,6 @@ async def execute_tool(
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            await _record_security_audit_event_async(
-                ctx=ctx,
-                tool_name=tool_name,
-                tool_call_id=tool_call_id,
-                tool_input=effective_tool_input,
-                visible_envelope=envelope,
-                internal_data=internal_data,
-                execution_status=ToolExecutionStatus.COMPLETED,
-            )
             await _persist_and_publish_tool_result_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
@@ -522,6 +513,15 @@ async def execute_tool(
                 runtime_meta=meta,
                 execution_status=ToolExecutionStatus.COMPLETED,
                 tool_content_parts=tool_content_parts,
+            )
+            await _record_security_audit_event_async(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=effective_tool_input,
+                visible_envelope=envelope,
+                internal_data=internal_data,
+                execution_status=ToolExecutionStatus.COMPLETED,
             )
             await _record_tool_metrics_async(
                 ctx=ctx,

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -852,7 +852,7 @@ async def _record_security_audit_event_async(
     service = _audit_service(ctx)
     if service is None:
         return
-    event = _build_security_audit_event(
+    event = await _build_security_audit_event_async(
         ctx=ctx,
         tool_name=tool_name,
         tool_call_id=tool_call_id,
@@ -887,7 +887,7 @@ def _audit_service(ctx: ToolContext) -> AuditService | None:
     return ctx.deps.audit_service
 
 
-def _build_security_audit_event(
+async def _build_security_audit_event_async(
     *,
     ctx: ToolContext,
     tool_name: str,
@@ -898,7 +898,7 @@ def _build_security_audit_event(
     execution_status: ToolExecutionStatus,
 ) -> AuditEventCreate | None:
     if tool_name in _AUDITED_FILE_WRITE_TOOLS:
-        return _build_file_write_audit_event(
+        return await _build_file_write_audit_event_async(
             ctx=ctx,
             tool_name=tool_name,
             tool_call_id=tool_call_id,
@@ -926,7 +926,7 @@ def _build_security_audit_event(
     return None
 
 
-def _build_file_write_audit_event(
+async def _build_file_write_audit_event_async(
     *,
     ctx: ToolContext,
     tool_name: str,
@@ -939,7 +939,8 @@ def _build_file_write_audit_event(
     target = _file_write_target(tool_name, tool_input, internal_data)
     if target is None:
         return None
-    content_digest, content_size_bytes, digest_error = _workspace_file_digest(
+    content_digest, content_size_bytes, digest_error = await asyncio.to_thread(
+        _workspace_file_digest,
         ctx=ctx,
         logical_path=target,
     )

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -14,6 +14,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
+from hashlib import sha256
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime, timezone
 from enum import Enum
@@ -33,6 +34,7 @@ from typing import (
 )
 from uuid import uuid4
 
+from relay_teams.audit import AuditEventCreate, AuditEventType, AuditService
 from relay_teams.logger import get_logger, log_event, log_tool_error
 from relay_teams.agents.instances.models import (
     AgentRuntimeRecord,
@@ -42,6 +44,7 @@ from relay_teams.agents.instances.models import (
 from relay_teams.media import ContentPart, TextContentPart, UserPromptContent
 from relay_teams.metrics.adapters import record_tool_execution_async
 from relay_teams.notifications import NotificationContext, NotificationType
+from relay_teams.paths import path_is_file, read_bytes_file
 from relay_teams.persistence import is_retryable_sqlite_error
 from relay_teams.agents.tasks.task_status_sanitizer import (
     sanitize_task_status_payload,
@@ -120,6 +123,11 @@ _TOOL_APPROVAL_EXECUTOR = ThreadPoolExecutor(
 _GLOBAL_TOOL_ACTION_SEMAPHORE = asyncio.Semaphore(GLOBAL_TOOL_ACTION_CONCURRENCY)
 _RUN_TOOL_ACTION_GATES_LOCK = threading.Lock()
 _RUN_TOOL_ACTION_GATES: dict[str, _RunToolActionGate] = {}
+_AUDITED_FILE_WRITE_TOOLS = frozenset({"write", "write_tmp", "edit", "notebook_edit"})
+_AUDITED_TOOL_NAMES = _AUDITED_FILE_WRITE_TOOLS | frozenset(
+    {"shell", "orch_dispatch_task"}
+)
+_AUDIT_REASON_LIMIT = 4_000
 
 
 class _RunToolActionGate:
@@ -366,6 +374,15 @@ async def execute_tool(
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
+            await _record_security_audit_event_async(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=effective_tool_input,
+                visible_envelope=envelope,
+                internal_data=None,
+                execution_status=ToolExecutionStatus.FAILED,
+            )
             await _persist_and_publish_tool_result_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
@@ -486,6 +503,15 @@ async def execute_tool(
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
+            await _record_security_audit_event_async(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=effective_tool_input,
+                visible_envelope=envelope,
+                internal_data=internal_data,
+                execution_status=ToolExecutionStatus.COMPLETED,
+            )
             await _persist_and_publish_tool_result_async(
                 ctx=ctx,
                 tool_call_id=tool_call_id,
@@ -560,6 +586,15 @@ async def execute_tool(
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
                 envelope=envelope,
+            )
+            await _record_security_audit_event_async(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=effective_tool_input,
+                visible_envelope=envelope,
+                internal_data=None,
+                execution_status=ToolExecutionStatus.FAILED,
             )
             await _persist_and_publish_tool_result_async(
                 ctx=ctx,
@@ -800,6 +835,403 @@ async def _record_tool_metrics_async(
         duration_ms=duration_ms,
         success=success,
     )
+
+
+async def _record_security_audit_event_async(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> None:
+    if tool_name not in _AUDITED_TOOL_NAMES:
+        return
+    service = _audit_service(ctx)
+    if service is None:
+        return
+    event = _build_security_audit_event(
+        ctx=ctx,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        tool_input=tool_input,
+        visible_envelope=visible_envelope,
+        internal_data=internal_data,
+        execution_status=execution_status,
+    )
+    if event is None:
+        return
+    try:
+        await service.record_event_async(event)
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="security.audit.record_failed",
+            message="Security audit event could not be recorded",
+            payload={
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "audit_event_type": event.event_type.value,
+                "run_id": ctx.deps.run_id,
+                "task_id": ctx.deps.task_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+
+def _audit_service(ctx: ToolContext) -> AuditService | None:
+    service = getattr(ctx.deps, "audit_service", None)
+    if service is None:
+        return None
+    return cast(AuditService, service)
+
+
+def _build_security_audit_event(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> AuditEventCreate | None:
+    if tool_name in _AUDITED_FILE_WRITE_TOOLS:
+        return _build_file_write_audit_event(
+            ctx=ctx,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            tool_input=tool_input,
+            visible_envelope=visible_envelope,
+            internal_data=internal_data,
+            execution_status=execution_status,
+        )
+    if tool_name == "shell":
+        return _build_shell_command_audit_event(
+            ctx=ctx,
+            tool_call_id=tool_call_id,
+            tool_input=tool_input,
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        )
+    if tool_name == "orch_dispatch_task":
+        return _build_coordinator_decision_audit_event(
+            ctx=ctx,
+            tool_call_id=tool_call_id,
+            tool_input=tool_input,
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        )
+    return None
+
+
+def _build_file_write_audit_event(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> AuditEventCreate | None:
+    target = _file_write_target(tool_name, tool_input, internal_data)
+    if target is None:
+        return None
+    content_digest, content_size_bytes, digest_error = _workspace_file_digest(
+        ctx=ctx,
+        logical_path=target,
+    )
+    metadata = _base_audit_metadata(
+        tool_name=tool_name,
+        visible_envelope=visible_envelope,
+        execution_status=execution_status,
+    )
+    if digest_error is not None:
+        metadata["content_digest_error"] = digest_error
+    _add_file_write_metadata(
+        metadata=metadata,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        internal_data=internal_data,
+    )
+    return AuditEventCreate(
+        event_type=AuditEventType.FILE_WRITE,
+        trace_id=ctx.deps.trace_id,
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        tool_call_id=tool_call_id,
+        action=_file_write_action(tool_name),
+        target=target,
+        content_digest=content_digest,
+        content_size_bytes=content_size_bytes,
+        outcome=_audit_outcome(
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        ),
+        metadata=metadata,
+    )
+
+
+def _build_shell_command_audit_event(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+) -> AuditEventCreate | None:
+    command = _string_value(tool_input.get("command"))
+    if command is None:
+        return None
+    metadata = _base_audit_metadata(
+        tool_name="shell",
+        visible_envelope=visible_envelope,
+        execution_status=execution_status,
+    )
+    _copy_json_metadata(metadata, tool_input, "workdir")
+    _copy_json_metadata(metadata, tool_input, "background")
+    _copy_json_metadata(metadata, tool_input, "tty")
+    _copy_json_metadata(metadata, tool_input, "yield_time_ms")
+    _copy_json_metadata(metadata, tool_input, "timeout_ms")
+    _copy_result_metadata(metadata, visible_envelope, "status")
+    _copy_result_metadata(metadata, visible_envelope, "exit_code")
+    return AuditEventCreate(
+        event_type=AuditEventType.SHELL_COMMAND,
+        trace_id=ctx.deps.trace_id,
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        tool_call_id=tool_call_id,
+        action="execute_shell_command",
+        target=_truncate_text(command, 200)[0],
+        command=command,
+        outcome=_audit_outcome(
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        ),
+        metadata=metadata,
+    )
+
+
+def _build_coordinator_decision_audit_event(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+) -> AuditEventCreate | None:
+    task_id = _string_value(tool_input.get("task_id"))
+    selected_role_id = _string_value(tool_input.get("role_id"))
+    if task_id is None or selected_role_id is None:
+        return None
+    prompt = _string_value(tool_input.get("prompt")) or ""
+    reason_source = (
+        prompt.strip()
+        or "Coordinator dispatched task with the default execution prompt."
+    )
+    decision_reason, reason_truncated = _truncate_text(
+        reason_source,
+        _AUDIT_REASON_LIMIT,
+    )
+    metadata = _base_audit_metadata(
+        tool_name="orch_dispatch_task",
+        visible_envelope=visible_envelope,
+        execution_status=execution_status,
+    )
+    metadata["dispatched_task_id"] = task_id
+    metadata["selected_role_id"] = selected_role_id
+    metadata["decision_reason_digest"] = _text_digest(reason_source)
+    metadata["decision_reason_length"] = len(reason_source)
+    metadata["decision_reason_truncated"] = reason_truncated
+    return AuditEventCreate(
+        event_type=AuditEventType.COORDINATOR_DECISION,
+        trace_id=ctx.deps.trace_id,
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        tool_call_id=tool_call_id,
+        action="dispatch_task",
+        target=f"task:{task_id}->role:{selected_role_id}",
+        decision_reason=decision_reason,
+        outcome=_audit_outcome(
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        ),
+        metadata=metadata,
+    )
+
+
+def _base_audit_metadata(
+    *,
+    tool_name: str,
+    visible_envelope: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+) -> dict[str, JsonValue]:
+    metadata: dict[str, JsonValue] = {
+        "tool_name": tool_name,
+        "execution_status": execution_status.value,
+        "tool_ok": visible_envelope.get("ok") is True,
+    }
+    error_type = _visible_error_type(visible_envelope)
+    if error_type is not None:
+        metadata["error_type"] = error_type
+    return metadata
+
+
+def _audit_outcome(
+    *,
+    visible_envelope: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+) -> str:
+    if visible_envelope.get("ok") is True and execution_status == (
+        ToolExecutionStatus.COMPLETED
+    ):
+        return "completed"
+    return "failed"
+
+
+def _visible_error_type(visible_envelope: dict[str, JsonValue]) -> str | None:
+    error = visible_envelope.get("error")
+    if not isinstance(error, dict):
+        return None
+    value = error.get("type")
+    return value if isinstance(value, str) and value else None
+
+
+def _copy_json_metadata(
+    metadata: dict[str, JsonValue],
+    source: dict[str, JsonValue],
+    key: str,
+) -> None:
+    if key in source:
+        metadata[key] = source[key]
+
+
+def _copy_result_metadata(
+    metadata: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    key: str,
+) -> None:
+    data = visible_envelope.get("data")
+    if not isinstance(data, dict):
+        return
+    value = data.get(key)
+    if value is not None:
+        metadata[key] = _normalize_json_value(value)
+
+
+def _add_file_write_metadata(
+    *,
+    metadata: dict[str, JsonValue],
+    tool_name: str,
+    tool_input: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+) -> None:
+    content_field = _file_content_input_field(tool_name)
+    if content_field is not None:
+        content = _string_value(tool_input.get(content_field))
+        if content is not None:
+            metadata["input_content_digest"] = _text_digest(content)
+            metadata["input_content_length"] = len(content)
+    if isinstance(internal_data, dict):
+        created = internal_data.get("created")
+        if isinstance(created, bool):
+            metadata["created"] = created
+        diff_summary = internal_data.get("diff_summary")
+        if isinstance(diff_summary, str) and diff_summary:
+            metadata["diff_summary"] = diff_summary
+
+
+def _file_content_input_field(tool_name: str) -> str | None:
+    if tool_name in {"write", "write_tmp"}:
+        return "content"
+    if tool_name == "edit":
+        return "new_string"
+    if tool_name == "notebook_edit":
+        return "new_source"
+    return None
+
+
+def _file_write_target(
+    tool_name: str,
+    tool_input: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+) -> str | None:
+    if tool_name == "write_tmp":
+        internal_path = _internal_data_text(internal_data, "path")
+        if internal_path is not None:
+            return internal_path
+        raw_tmp_path = _string_value(tool_input.get("path"))
+        if raw_tmp_path is None:
+            return None
+        if raw_tmp_path == "tmp" or raw_tmp_path.startswith(("tmp/", "tmp\\")):
+            return raw_tmp_path
+        return f"tmp/{raw_tmp_path}"
+    return _string_value(tool_input.get("path")) or _internal_data_text(
+        internal_data,
+        "path",
+    )
+
+
+def _file_write_action(tool_name: str) -> str:
+    if tool_name == "edit":
+        return "edit_file"
+    if tool_name == "notebook_edit":
+        return "edit_notebook"
+    if tool_name == "write_tmp":
+        return "write_tmp_file"
+    return "write_file"
+
+
+def _workspace_file_digest(
+    *,
+    ctx: ToolContext,
+    logical_path: str,
+) -> tuple[str | None, int | None, str | None]:
+    try:
+        file_path = ctx.deps.workspace.resolve_path(logical_path, write=False)
+        if not path_is_file(file_path):
+            return None, None, "target is not a file"
+        content = read_bytes_file(file_path)
+    except Exception as exc:
+        return None, None, f"{type(exc).__name__}: {exc}"
+    return f"sha256:{sha256(content).hexdigest()}", len(content), None
+
+
+def _internal_data_text(internal_data: JsonValue | None, key: str) -> str | None:
+    if not isinstance(internal_data, dict):
+        return None
+    return _string_value(internal_data.get(key))
+
+
+def _string_value(value: JsonValue | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+def _text_digest(value: str) -> str:
+    return f"sha256:{sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def _truncate_text(value: str, limit: int) -> tuple[str, bool]:
+    if len(value) <= limit:
+        return value, False
+    return value[:limit], True
 
 
 async def _ensure_run_runtime_async(

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -514,15 +514,6 @@ async def execute_tool(
                 execution_status=ToolExecutionStatus.COMPLETED,
                 tool_content_parts=tool_content_parts,
             )
-            await _record_security_audit_event_async(
-                ctx=ctx,
-                tool_name=tool_name,
-                tool_call_id=tool_call_id,
-                tool_input=effective_tool_input,
-                visible_envelope=envelope,
-                internal_data=internal_data,
-                execution_status=ToolExecutionStatus.COMPLETED,
-            )
             await _record_tool_metrics_async(
                 ctx=ctx,
                 tool_name=tool_name,
@@ -533,6 +524,15 @@ async def execute_tool(
                 await ctx.deps.approval_ticket_repo.mark_completed_async(
                     approval_ticket_id
                 )
+            await _record_security_audit_event_async(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=effective_tool_input,
+                visible_envelope=envelope,
+                internal_data=internal_data,
+                execution_status=ToolExecutionStatus.COMPLETED,
+            )
             if tool_return_content is not None:
                 return ToolReturn(
                     return_value=envelope,

--- a/tests/unit_tests/audit/__init__.py
+++ b/tests/unit_tests/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for audit support."""

--- a/tests/unit_tests/audit/test_audit_repository.py
+++ b/tests/unit_tests/audit/test_audit_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
 from pydantic import JsonValue
@@ -78,6 +78,41 @@ def test_audit_repository_paginates_async(tmp_path: Path) -> None:
         assert [item.target for item in next_page.items] == ["src/file_2.py"]
 
     asyncio.run(scenario())
+
+
+def test_audit_repository_normalizes_timestamp_filters_to_utc(tmp_path: Path) -> None:
+    repository = AuditEventRepository(tmp_path / "audit-time.db")
+    event = repository.append(
+        _event(
+            event_type=AuditEventType.FILE_WRITE,
+            target="src/offset.py",
+            occurred_at=datetime(
+                2026,
+                5,
+                1,
+                0,
+                0,
+                tzinfo=timezone(timedelta(hours=-5)),
+            ),
+        )
+    )
+
+    page = repository.list_events(
+        AuditEventFilter(
+            since=datetime(2026, 5, 1, 3, 0, tzinfo=UTC),
+            until=datetime(
+                2026,
+                5,
+                1,
+                1,
+                0,
+                tzinfo=timezone(timedelta(hours=-4)),
+            ),
+        )
+    )
+
+    assert [item.audit_event_id for item in page.items] == [event.audit_event_id]
+    assert page.items[0].occurred_at == datetime(2026, 5, 1, 5, 0, tzinfo=UTC)
 
 
 def _event(

--- a/tests/unit_tests/audit/test_audit_repository.py
+++ b/tests/unit_tests/audit/test_audit_repository.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pydantic import JsonValue
+
+from relay_teams.audit import (
+    AuditEventCreate,
+    AuditEventFilter,
+    AuditEventRepository,
+    AuditEventType,
+)
+
+
+def test_audit_repository_appends_and_filters_events(tmp_path: Path) -> None:
+    repository = AuditEventRepository(tmp_path / "audit.db")
+    file_event = repository.append(
+        _event(
+            event_type=AuditEventType.FILE_WRITE,
+            target="src/app.py",
+            metadata={"created": True},
+        )
+    )
+    shell_event = repository.append(
+        _event(
+            event_type=AuditEventType.SHELL_COMMAND,
+            target="uv run pytest",
+            command="uv run pytest",
+        )
+    )
+
+    page = repository.list_events(
+        AuditEventFilter(
+            event_type=AuditEventType.SHELL_COMMAND,
+            run_id="run-1",
+            after_id=file_event.id,
+        )
+    )
+
+    assert tuple(item.audit_event_id for item in page.items) == (
+        shell_event.audit_event_id,
+    )
+    assert page.items[0].command == "uv run pytest"
+    assert page.next_after_id is None
+
+
+def test_audit_repository_paginates_async(tmp_path: Path) -> None:
+    repository = AuditEventRepository(tmp_path / "audit-async.db")
+    started = datetime.now(UTC)
+    for index in range(3):
+        repository.append(
+            _event(
+                event_type=AuditEventType.FILE_WRITE,
+                target=f"src/file_{index}.py",
+                occurred_at=started + timedelta(seconds=index),
+            )
+        )
+
+    async def scenario() -> None:
+        page = await repository.list_events_async(
+            AuditEventFilter(
+                event_type=AuditEventType.FILE_WRITE,
+                since=started,
+                limit=2,
+            )
+        )
+        assert [item.target for item in page.items] == [
+            "src/file_0.py",
+            "src/file_1.py",
+        ]
+        assert page.next_after_id == page.items[-1].id
+
+        next_page = await repository.list_events_async(
+            AuditEventFilter(after_id=page.next_after_id or 0)
+        )
+        assert [item.target for item in next_page.items] == ["src/file_2.py"]
+
+    asyncio.run(scenario())
+
+
+def _event(
+    *,
+    event_type: AuditEventType,
+    target: str,
+    command: str | None = None,
+    occurred_at: datetime | None = None,
+    metadata: dict[str, JsonValue] | None = None,
+) -> AuditEventCreate:
+    return AuditEventCreate(
+        event_type=event_type,
+        trace_id="trace-1",
+        run_id="run-1",
+        session_id="session-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        role_id="coder",
+        tool_call_id="toolcall-1",
+        action="execute_shell_command"
+        if event_type == AuditEventType.SHELL_COMMAND
+        else "write_file",
+        target=target,
+        command=command,
+        decision_reason="selected role for task"
+        if event_type == AuditEventType.COORDINATOR_DECISION
+        else None,
+        outcome="completed",
+        metadata=metadata or {},
+        occurred_at=occurred_at or datetime.now(UTC),
+    )

--- a/tests/unit_tests/audit/test_audit_repository.py
+++ b/tests/unit_tests/audit/test_audit_repository.py
@@ -4,7 +4,8 @@ import asyncio
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
-from pydantic import JsonValue
+import pytest
+from pydantic import JsonValue, ValidationError
 
 from relay_teams.audit import (
     AuditEventCreate,
@@ -12,6 +13,8 @@ from relay_teams.audit import (
     AuditEventRepository,
     AuditEventType,
 )
+from relay_teams.audit.repository import _json_object, _json_value, _optional_int
+from relay_teams.audit.service import AuditService
 
 
 def test_audit_repository_appends_and_filters_events(tmp_path: Path) -> None:
@@ -46,6 +49,23 @@ def test_audit_repository_appends_and_filters_events(tmp_path: Path) -> None:
     assert page.next_after_id is None
 
 
+def test_audit_event_model_validates_event_specific_fields() -> None:
+    with pytest.raises(ValidationError):
+        _event(event_type=AuditEventType.FILE_WRITE, target="")
+    with pytest.raises(ValidationError):
+        _event(event_type=AuditEventType.SHELL_COMMAND, target="shell")
+    with pytest.raises(ValidationError):
+        AuditEventCreate(
+            event_type=AuditEventType.COORDINATOR_DECISION,
+            trace_id="trace-1",
+            run_id="run-1",
+            session_id="session-1",
+            action="dispatch_task",
+            target="task:task-1->role:Reviewer",
+            outcome="completed",
+        )
+
+
 def test_audit_repository_paginates_async(tmp_path: Path) -> None:
     repository = AuditEventRepository(tmp_path / "audit-async.db")
     started = datetime.now(UTC)
@@ -76,6 +96,65 @@ def test_audit_repository_paginates_async(tmp_path: Path) -> None:
             AuditEventFilter(after_id=page.next_after_id or 0)
         )
         assert [item.target for item in next_page.items] == ["src/file_2.py"]
+
+    asyncio.run(scenario())
+
+
+def test_audit_repository_filters_identifiers_and_reports_missing_rows(
+    tmp_path: Path,
+) -> None:
+    repository = AuditEventRepository(tmp_path / "audit-filter.db")
+    expected = repository.append(
+        _event(
+            event_type=AuditEventType.FILE_WRITE,
+            target="src/filter.py",
+            trace_id="trace-filter",
+            run_id="run-filter",
+            session_id="session-filter",
+            task_id="task-filter",
+            role_id="role-filter",
+        )
+    )
+    repository.append(
+        _event(
+            event_type=AuditEventType.FILE_WRITE,
+            target="src/other.py",
+            trace_id="trace-other",
+            run_id="run-other",
+            session_id="session-other",
+            task_id="task-other",
+            role_id="role-other",
+        )
+    )
+
+    page = repository.list_events(
+        AuditEventFilter(
+            trace_id="trace-filter",
+            run_id="run-filter",
+            session_id="session-filter",
+            task_id="task-filter",
+            role_id="role-filter",
+        )
+    )
+    assert [item.audit_event_id for item in page.items] == [expected.audit_event_id]
+    with pytest.raises(KeyError):
+        repository.get_by_audit_event_id("missing")
+
+    async def scenario() -> None:
+        await repository._init_tables_async()
+        async_page = await repository.list_events_async(
+            AuditEventFilter(
+                trace_id="trace-filter",
+                session_id="session-filter",
+                task_id="task-filter",
+                role_id="role-filter",
+            )
+        )
+        assert [item.audit_event_id for item in async_page.items] == [
+            expected.audit_event_id
+        ]
+        with pytest.raises(KeyError):
+            await repository.get_by_audit_event_id_async("missing")
 
     asyncio.run(scenario())
 
@@ -115,6 +194,38 @@ def test_audit_repository_normalizes_timestamp_filters_to_utc(tmp_path: Path) ->
     assert page.items[0].occurred_at == datetime(2026, 5, 1, 5, 0, tzinfo=UTC)
 
 
+def test_audit_repository_json_and_integer_helpers_cover_dirty_values() -> None:
+    assert _optional_int("42") == 42
+    with pytest.raises(ValueError):
+        _optional_int(object())
+    assert _json_object("[]") == {}
+    converted = _json_value(["x", {"nested": object()}])
+    assert isinstance(converted, list)
+    nested = converted[1]
+    assert isinstance(nested, dict)
+    assert isinstance(nested["nested"], str)
+
+
+def test_audit_service_records_and_lists_sync_and_async(tmp_path: Path) -> None:
+    repository = AuditEventRepository(tmp_path / "audit-service.db")
+    service = AuditService(repository)
+    sync_record = service.record_event(
+        _event(event_type=AuditEventType.FILE_WRITE, target="src/sync.py")
+    )
+    assert service.list_events(AuditEventFilter()).items[0].id == sync_record.id
+
+    async def scenario() -> None:
+        async_record = await service.record_event_async(
+            _event(event_type=AuditEventType.FILE_WRITE, target="src/async.py")
+        )
+        page = await service.list_events_async(
+            AuditEventFilter(after_id=sync_record.id)
+        )
+        assert [item.id for item in page.items] == [async_record.id]
+
+    asyncio.run(scenario())
+
+
 def _event(
     *,
     event_type: AuditEventType,
@@ -122,15 +233,20 @@ def _event(
     command: str | None = None,
     occurred_at: datetime | None = None,
     metadata: dict[str, JsonValue] | None = None,
+    trace_id: str = "trace-1",
+    run_id: str = "run-1",
+    session_id: str = "session-1",
+    task_id: str = "task-1",
+    role_id: str = "coder",
 ) -> AuditEventCreate:
     return AuditEventCreate(
         event_type=event_type,
-        trace_id="trace-1",
-        run_id="run-1",
-        session_id="session-1",
-        task_id="task-1",
+        trace_id=trace_id,
+        run_id=run_id,
+        session_id=session_id,
+        task_id=task_id,
         instance_id="instance-1",
-        role_id="coder",
+        role_id=role_id,
         tool_call_id="toolcall-1",
         action="execute_shell_command"
         if event_type == AuditEventType.SHELL_COMMAND

--- a/tests/unit_tests/interfaces/server/test_audit_router.py
+++ b/tests/unit_tests/interfaces/server/test_audit_router.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from relay_teams.audit import (
+    AuditEventCreate,
+    AuditEventFilter,
+    AuditEventPage,
+    AuditEventRecord,
+    AuditEventType,
+)
+from relay_teams.interfaces.server.deps import get_audit_service
+from relay_teams.interfaces.server.routers import audit
+
+
+class _FakeAuditService:
+    def __init__(self) -> None:
+        self.queries: list[AuditEventFilter] = []
+
+    async def list_events_async(self, query: AuditEventFilter) -> AuditEventPage:
+        self.queries.append(query)
+        event = AuditEventRecord(
+            id=7,
+            created_at=datetime(2026, 5, 1, tzinfo=UTC),
+            **AuditEventCreate(
+                event_type=AuditEventType.SHELL_COMMAND,
+                trace_id="trace-1",
+                run_id="run-1",
+                session_id="session-1",
+                task_id="task-1",
+                instance_id="instance-1",
+                role_id="coder",
+                tool_call_id="toolcall-1",
+                action="execute_shell_command",
+                target="uv run pytest",
+                command="uv run pytest",
+                outcome="completed",
+                metadata={"exit_code": 0},
+                occurred_at=datetime(2026, 5, 1, tzinfo=UTC),
+            ).model_dump(),
+        )
+        return AuditEventPage(items=(event,), next_after_id=None)
+
+
+def test_audit_route_returns_filtered_events() -> None:
+    service = _FakeAuditService()
+    app = FastAPI()
+    app.include_router(audit.router, prefix="/api")
+    app.dependency_overrides[get_audit_service] = lambda: service
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/audit?event_type=shell_command&run_id=run-1&after_id=2&limit=50"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"][0]["event_type"] == "shell_command"
+    assert payload["items"][0]["command"] == "uv run pytest"
+    assert payload["next_after_id"] is None
+    assert service.queries == [
+        AuditEventFilter(
+            event_type=AuditEventType.SHELL_COMMAND,
+            run_id="run-1",
+            after_id=2,
+            limit=50,
+        )
+    ]
+
+
+def test_audit_route_validates_limit() -> None:
+    service = _FakeAuditService()
+    app = FastAPI()
+    app.include_router(audit.router, prefix="/api")
+    app.dependency_overrides[get_audit_service] = lambda: service
+    client = TestClient(app)
+
+    response = client.get("/api/audit?limit=501")
+
+    assert response.status_code == 422

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -361,9 +361,11 @@ class _FakeDeps:
         self.notification_service = _build_notification_service(self.run_event_hub)
         self.hook_service: object | None = None
         self.reminder_service: object | None = None
+        self.audit_service: object | None = None
         self.hook_runtime_env: dict[str, str] = {}
         self.injection_manager = _FakeInjectionManager()
         self.media_asset_service: object | None = None
+        self.workspace: object | None = None
         self.message_repo = MessageRepository(db_path)
         self.approval_ticket_repo = ApprovalTicketRepository(db_path)
         self.run_runtime_repo = RunRuntimeRepository(db_path)

--- a/tests/unit_tests/tools/runtime/test_security_audit.py
+++ b/tests/unit_tests/tools/runtime/test_security_audit.py
@@ -73,6 +73,99 @@ def test_execute_tool_records_file_write_audit_event(tmp_path: Path) -> None:
     assert event.metadata["created"] is True
 
 
+def test_execute_tool_records_file_write_variant_audit_events(tmp_path: Path) -> None:
+    audit_repository = AuditEventRepository(tmp_path / "audit.db")
+    deps = _deps_with_audit(tmp_path, audit_repository)
+    ctx = cast(ToolContext, cast(object, _FakeCtx(deps)))
+
+    def write_file(relative_path: str, content: str) -> None:
+        target_path = tmp_path / relative_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(content, encoding="utf-8")
+
+    asyncio.run(
+        execute_tool(
+            ctx,
+            tool_name="write_tmp",
+            args_summary={"path": "scratch.txt"},
+            tool_input={"path": "scratch.txt", "content": "tmp body"},
+            action=lambda: (
+                write_file("tmp/scratch.txt", "tmp body")
+                or ToolResultProjection(
+                    visible_data={"output": "Wrote tmp file."},
+                    internal_data={},
+                )
+            ),
+        )
+    )
+    asyncio.run(
+        execute_tool(
+            ctx,
+            tool_name="edit",
+            args_summary={"path": "src/edit.txt"},
+            tool_input={"path": "src/edit.txt", "new_string": "edit body"},
+            action=lambda: (
+                write_file("src/edit.txt", "edit body")
+                or ToolResultProjection(
+                    visible_data={"output": "Edited file."},
+                    internal_data={"created": False},
+                )
+            ),
+        )
+    )
+    asyncio.run(
+        execute_tool(
+            ctx,
+            tool_name="notebook_edit",
+            args_summary={"path": "notebook.ipynb"},
+            tool_input={"path": "notebook.ipynb", "new_source": "print(1)"},
+            action=lambda: (
+                write_file("notebook.ipynb", "print(1)")
+                or ToolResultProjection(
+                    visible_data={"output": "Edited notebook."},
+                    internal_data={},
+                )
+            ),
+        )
+    )
+
+    page = audit_repository.list_events(
+        AuditEventFilter(event_type=AuditEventType.FILE_WRITE)
+    )
+    events = {event.target: event for event in page.items}
+    assert events["tmp/scratch.txt"].action == "write_tmp_file"
+    assert events["src/edit.txt"].action == "edit_file"
+    assert events["notebook.ipynb"].action == "edit_notebook"
+    assert events["tmp/scratch.txt"].metadata["input_content_length"] == 8
+    assert events["src/edit.txt"].metadata["created"] is False
+
+
+def test_execute_tool_records_file_digest_error_when_target_missing(
+    tmp_path: Path,
+) -> None:
+    audit_repository = AuditEventRepository(tmp_path / "audit.db")
+    deps = _deps_with_audit(tmp_path, audit_repository)
+
+    asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, _FakeCtx(deps))),
+            tool_name="write",
+            args_summary={"path": "missing.txt"},
+            tool_input={"path": "missing.txt", "content": "not written"},
+            action=lambda: ToolResultProjection(
+                visible_data={"output": "Skipped write."},
+                internal_data={},
+            ),
+        )
+    )
+
+    page = audit_repository.list_events(
+        AuditEventFilter(event_type=AuditEventType.FILE_WRITE)
+    )
+    assert page.items[0].content_digest is None
+    assert page.items[0].metadata["content_digest_error"] == "target is not a file"
+
+
 def test_execute_tool_records_shell_and_coordinator_audit_events(
     tmp_path: Path,
 ) -> None:
@@ -120,6 +213,38 @@ def test_execute_tool_records_shell_and_coordinator_audit_events(
     assert decision_page.items[0].target == "task:task-child->role:Reviewer"
     assert decision_page.items[0].decision_reason is not None
     assert "audit coverage" in decision_page.items[0].decision_reason
+
+
+def test_execute_tool_logs_audit_recording_failure_without_failing_tool(
+    tmp_path: Path,
+) -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+
+    class FailingAuditService:
+        async def record_event_async(self, event: object) -> object:
+            _ = event
+            raise RuntimeError("audit store unavailable")
+
+    deps.audit_service = FailingAuditService()
+    deps.workspace = _FakeWorkspace(tmp_path)
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, _FakeCtx(deps))),
+            tool_name="shell",
+            args_summary={"command": "uv run pytest"},
+            tool_input={"command": "uv run pytest"},
+            action=lambda: ToolResultProjection(
+                visible_data={"status": "completed", "exit_code": 0},
+                internal_data={"status": "completed", "exit_code": 0},
+            ),
+        )
+    )
+
+    assert cast(dict[str, JsonValue], result)["ok"] is True
 
 
 def test_execute_tool_records_failed_audit_when_success_persistence_fails(

--- a/tests/unit_tests/tools/runtime/test_security_audit.py
+++ b/tests/unit_tests/tools/runtime/test_security_audit.py
@@ -5,11 +5,13 @@ from hashlib import sha256
 from pathlib import Path
 from typing import cast
 
+import pytest
 from pydantic import JsonValue
 
 from relay_teams.audit import AuditEventFilter, AuditEventRepository, AuditEventType
 from relay_teams.audit.service import AuditService
 from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime import execution as execution_module
 from relay_teams.tools.runtime.execution import execute_tool
 from relay_teams.tools.runtime.models import ToolResultProjection
 from tests.unit_tests.tools.runtime.test_execution import (
@@ -118,6 +120,45 @@ def test_execute_tool_records_shell_and_coordinator_audit_events(
     assert decision_page.items[0].target == "task:task-child->role:Reviewer"
     assert decision_page.items[0].decision_reason is not None
     assert "audit coverage" in decision_page.items[0].decision_reason
+
+
+def test_execute_tool_records_failed_audit_when_success_persistence_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_repository = AuditEventRepository(tmp_path / "audit.db")
+    deps = _deps_with_audit(tmp_path, audit_repository)
+
+    async def fail_persistence(**kwargs: object) -> None:
+        _ = kwargs
+        raise RuntimeError("tool result persistence unavailable")
+
+    monkeypatch.setattr(
+        execution_module,
+        "_persist_and_publish_tool_result_async",
+        fail_persistence,
+    )
+
+    with pytest.raises(RuntimeError, match="tool result persistence unavailable"):
+        asyncio.run(
+            execute_tool(
+                cast(ToolContext, cast(object, _FakeCtx(deps))),
+                tool_name="shell",
+                args_summary={"command": "uv run pytest"},
+                tool_input={"command": "uv run pytest"},
+                action=lambda: ToolResultProjection(
+                    visible_data={"status": "completed", "exit_code": 0},
+                    internal_data={"status": "completed", "exit_code": 0},
+                ),
+            )
+        )
+
+    page = audit_repository.list_events(
+        AuditEventFilter(event_type=AuditEventType.SHELL_COMMAND)
+    )
+    assert len(page.items) == 1
+    assert page.items[0].command == "uv run pytest"
+    assert page.items[0].outcome == "failed"
 
 
 def _deps_with_audit(

--- a/tests/unit_tests/tools/runtime/test_security_audit.py
+++ b/tests/unit_tests/tools/runtime/test_security_audit.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+from hashlib import sha256
+from pathlib import Path
+from typing import cast
+
+from pydantic import JsonValue
+
+from relay_teams.audit import AuditEventFilter, AuditEventRepository, AuditEventType
+from relay_teams.audit.service import AuditService
+from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.execution import execute_tool
+from relay_teams.tools.runtime.models import ToolResultProjection
+from tests.unit_tests.tools.runtime.test_execution import (
+    _FakeApprovalManager,
+    _FakeCtx,
+    _FakeDeps,
+    _FakePolicy,
+)
+
+
+class _FakeWorkspace:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def resolve_path(self, relative_path: str, *, write: bool = False) -> Path:
+        _ = write
+        return (self.root / relative_path).resolve()
+
+
+def test_execute_tool_records_file_write_audit_event(tmp_path: Path) -> None:
+    audit_repository = AuditEventRepository(tmp_path / "audit.db")
+    deps = _deps_with_audit(tmp_path, audit_repository)
+    target_path = tmp_path / "src" / "audit.txt"
+
+    def action() -> ToolResultProjection:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text("audit body", encoding="utf-8")
+        return ToolResultProjection(
+            visible_data={"output": "Wrote file successfully."},
+            internal_data={
+                "path": "src/audit.txt",
+                "created": True,
+                "diff_summary": "+ 1: 1 line(s) added",
+            },
+        )
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, _FakeCtx(deps))),
+            tool_name="write",
+            args_summary={"path": "src/audit.txt", "content_len": 10},
+            tool_input={"path": "src/audit.txt", "content": "audit body"},
+            action=action,
+        )
+    )
+
+    page = audit_repository.list_events(
+        AuditEventFilter(event_type=AuditEventType.FILE_WRITE)
+    )
+    assert cast(dict[str, JsonValue], result)["ok"] is True
+    assert len(page.items) == 1
+    event = page.items[0]
+    assert event.target == "src/audit.txt"
+    assert event.role_id == "spec_coder"
+    assert event.task_id == "task-1"
+    assert event.content_digest == (
+        "sha256:" + sha256("audit body".encode("utf-8")).hexdigest()
+    )
+    assert event.metadata["created"] is True
+
+
+def test_execute_tool_records_shell_and_coordinator_audit_events(
+    tmp_path: Path,
+) -> None:
+    audit_repository = AuditEventRepository(tmp_path / "audit.db")
+    deps = _deps_with_audit(tmp_path, audit_repository)
+    ctx = cast(ToolContext, cast(object, _FakeCtx(deps)))
+
+    asyncio.run(
+        execute_tool(
+            ctx,
+            tool_name="shell",
+            args_summary={"command": "uv run pytest"},
+            tool_input={"command": "uv run pytest", "workdir": "."},
+            action=lambda: ToolResultProjection(
+                visible_data={"status": "completed", "exit_code": 0},
+                internal_data={"status": "completed", "exit_code": 0},
+            ),
+        )
+    )
+    asyncio.run(
+        execute_tool(
+            ctx,
+            tool_name="orch_dispatch_task",
+            args_summary={"task_id": "task-child", "role_id": "Reviewer"},
+            tool_input={
+                "task_id": "task-child",
+                "role_id": "Reviewer",
+                "prompt": "Review the implementation because the task needs audit coverage.",
+            },
+            action=lambda: ToolResultProjection(
+                visible_data={"task": {"task_id": "task-child"}},
+                internal_data={"task": {"task_id": "task-child"}},
+            ),
+        )
+    )
+
+    shell_page = audit_repository.list_events(
+        AuditEventFilter(event_type=AuditEventType.SHELL_COMMAND)
+    )
+    decision_page = audit_repository.list_events(
+        AuditEventFilter(event_type=AuditEventType.COORDINATOR_DECISION)
+    )
+    assert shell_page.items[0].command == "uv run pytest"
+    assert shell_page.items[0].metadata["exit_code"] == 0
+    assert decision_page.items[0].target == "task:task-child->role:Reviewer"
+    assert decision_page.items[0].decision_reason is not None
+    assert "audit coverage" in decision_page.items[0].decision_reason
+
+
+def _deps_with_audit(
+    tmp_path: Path,
+    audit_repository: AuditEventRepository,
+) -> _FakeDeps:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    deps.audit_service = AuditService(audit_repository)
+    deps.workspace = _FakeWorkspace(tmp_path)
+    return deps

--- a/tests/unit_tests/tools/runtime/test_security_audit.py
+++ b/tests/unit_tests/tools/runtime/test_security_audit.py
@@ -334,6 +334,48 @@ def test_execute_tool_records_failed_audit_when_success_persistence_fails(
     assert page.items[0].outcome == "failed"
 
 
+def test_execute_tool_records_failed_audit_when_approval_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_repository = AuditEventRepository(tmp_path / "audit.db")
+    deps = _deps_with_audit(tmp_path, audit_repository)
+    deps.tool_approval_policy = _FakePolicy(needs_approval=True)
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-shell-cleanup"
+
+    async def fail_mark_completed(tool_call_id: str) -> object:
+        assert tool_call_id == "call-shell-cleanup"
+        raise RuntimeError("approval cleanup unavailable")
+
+    monkeypatch.setattr(
+        deps.approval_ticket_repo,
+        "mark_completed_async",
+        fail_mark_completed,
+    )
+
+    with pytest.raises(RuntimeError, match="approval cleanup unavailable"):
+        asyncio.run(
+            execute_tool(
+                cast(ToolContext, cast(object, ctx)),
+                tool_name="shell",
+                args_summary={"command": "uv run pytest"},
+                tool_input={"command": "uv run pytest"},
+                action=lambda: ToolResultProjection(
+                    visible_data={"status": "completed", "exit_code": 0},
+                    internal_data={"status": "completed", "exit_code": 0},
+                ),
+            )
+        )
+
+    page = audit_repository.list_events(
+        AuditEventFilter(event_type=AuditEventType.SHELL_COMMAND)
+    )
+    assert len(page.items) == 1
+    assert page.items[0].command == "uv run pytest"
+    assert page.items[0].outcome == "failed"
+
+
 def _deps_with_audit(
     tmp_path: Path,
     audit_repository: AuditEventRepository,

--- a/tests/unit_tests/tools/runtime/test_security_audit.py
+++ b/tests/unit_tests/tools/runtime/test_security_audit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from hashlib import sha256
 from pathlib import Path
+from threading import get_ident
 from typing import cast
 
 import pytest
@@ -138,6 +139,53 @@ def test_execute_tool_records_file_write_variant_audit_events(tmp_path: Path) ->
     assert events["notebook.ipynb"].action == "edit_notebook"
     assert events["tmp/scratch.txt"].metadata["input_content_length"] == 8
     assert events["src/edit.txt"].metadata["created"] is False
+
+
+def test_execute_tool_hashes_file_write_digest_off_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_repository = AuditEventRepository(tmp_path / "audit.db")
+    deps = _deps_with_audit(tmp_path, audit_repository)
+    target_path = tmp_path / "src" / "audit.txt"
+    event_loop_thread_id = get_ident()
+    digest_thread_ids: list[int] = []
+    original_digest = execution_module._workspace_file_digest
+
+    def recording_digest(
+        *,
+        ctx: ToolContext,
+        logical_path: str,
+    ) -> tuple[str | None, int | None, str | None]:
+        digest_thread_ids.append(get_ident())
+        return original_digest(ctx=ctx, logical_path=logical_path)
+
+    monkeypatch.setattr(
+        execution_module,
+        "_workspace_file_digest",
+        recording_digest,
+    )
+
+    def action() -> ToolResultProjection:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text("audit body", encoding="utf-8")
+        return ToolResultProjection(
+            visible_data={"output": "Wrote file successfully."},
+            internal_data={"path": "src/audit.txt"},
+        )
+
+    asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, _FakeCtx(deps))),
+            tool_name="write",
+            args_summary={"path": "src/audit.txt"},
+            tool_input={"path": "src/audit.txt", "content": "audit body"},
+            action=action,
+        )
+    )
+
+    assert digest_thread_ids
+    assert all(thread_id != event_loop_thread_id for thread_id in digest_thread_ids)
 
 
 def test_execute_tool_records_file_digest_error_when_target_missing(


### PR DESCRIPTION
Closes #652.\n\n## Summary\n\n- Add immutable security audit models, SQLite repository, service, and read-only /api/audit endpoint.\n- Record audit events for file writes, shell commands, and Coordinator orch_dispatch_task decisions through the tool runtime.\n- Wire audit service through normal and external-agent tool dependency paths.\n- Document the API, database table, and SG-3 design/implementation spec.\n\n## Verification\n\n- uv run --extra dev ruff check --fix\n- uv run --extra dev ruff format --no-cache --force-exclude\n- uv run --extra dev basedpyright\n- uv run --extra dev pytest -q tests/unit_tests\n- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests\n- Chrome MCP E2E: opened /api/audit?event_type=shell_command&run_id=run-e2e&limit=10 and confirmed status 200 with the seeded shell_command audit row.