### PR TITLE
Implement SG-1 runtime guardrails

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This directory is organized by documentation purpose and runtime module.
 - [Prompt behavior](modules/prompt/system-prompt-layering.md)
 - [Providers](modules/providers/)
 - [Reminders](modules/reminders/system-reminders-design.md)
+- [SG-1 runtime guardrails](modules/security/runtime-guardrails-sg1.md)
 - [Sessions](modules/sessions/)
 - [SP-3 spec checkpoint refresh](modules/sessions/spec-checkpoint-refresh-design.md)
 - [Skills](modules/skills/)

--- a/docs/modules/security/runtime-guardrails-sg1.md
+++ b/docs/modules/security/runtime-guardrails-sg1.md
@@ -1,0 +1,86 @@
+# SG-1 Runtime Guardrails
+
+## 1. Purpose
+
+SG-1 adds a deterministic runtime safety layer around tool execution and task acceptance. The implementation turns runtime safety from prompt-only guidance into auditable controls that run before tool execution, during tool result handling, and after task completion.
+
+## 2. Goals
+
+- Deny tool calls outside the effective role tool boundary before the action body runs.
+- Deny tools explicitly blocked by runtime policy, even when approval mode would otherwise allow them.
+- Block common destructive shell command patterns before shell execution.
+- Warn on unusually large tool inputs, unusually large tool outputs, and frequent write-capable calls.
+- Persist task-scoped guardrail state and publish guardrail alert/report events for auditability.
+- Make Gater verification require a parseable runtime guardrail report for coordinator-driven acceptance.
+
+## 3. Non-Goals
+
+- SG-1 does not replace role contract enforcement. SG-2 remains the source of truth for role-level tool boundary filtering.
+- SG-1 does not add a new public API surface or database table.
+- SG-1 does not attempt full shell semantic analysis; it applies deterministic pattern checks for high-risk commands.
+- SG-1 does not make persistence failures block unrelated tool results. Failures are logged and the original tool flow continues unless a guardrail rule itself denies the call.
+
+## 4. Feature Design
+
+The guardrail layer has three stages:
+
+1. Pre-execution guardrails run after hook input rewriting and before reusable tool results, approval prompts, or tool actions. They enforce the effective role tool boundary, explicit denied tools, destructive shell command patterns, tool input size limits, and per-task call-frequency thresholds.
+2. In-execution guardrails run after tool output normalization and post-tool hooks. They inspect the final tool result envelope and can warn or block the visible result before it is persisted and returned to the model.
+3. Post-validation guardrails generate a `RuntimeGuardrailReport` when task execution completes. The report is persisted in shared task state and published as a `runtime_guardrail_report` run event so Gater verification can use it as required acceptance evidence.
+
+## 5. Configuration Contract
+
+`ToolApprovalPolicy` now owns `guardrails: RuntimeGuardrailPolicy`. A policy contains ordered `RuntimeGuardrailRule` entries with:
+
+- `layer`: `pre_execution`, `in_execution`, or `post_validation`
+- `rule_type`: allowlist, denylist, size, frequency, or destructive shell pattern
+- `action`: `allow`, `warn`, or `deny`
+- optional selectors for tool names, role ids, session modes, and run kinds
+- rule-specific thresholds such as `max_bytes`, `max_calls_per_task`, and `blocked_patterns`
+
+The default rules deny tools outside the effective role tool set, deny explicitly disabled tools, block common destructive shell patterns, warn on large inputs, warn on frequent write-capable calls, and warn on large outputs. Callers can replace the rules through `ToolApprovalPolicy(guardrails=...)`.
+
+## 6. Implementation Spec
+
+Runtime execution integrates SG-1 through `execute_tool_call(...)` and `execute_tool(...)`:
+
+- Pre-tool hooks may rewrite arguments first; guardrails evaluate the rewritten tool input.
+- The guardrail context records run, session, task, instance, role, tool name, tool call id, session mode, and run kind.
+- Tool call counts and findings are persisted through a single shared-state update operation so parallel tool calls cannot overwrite each other.
+- A pre-execution denial returns a deterministic `ToolError` without opening approval or invoking the action body.
+- In-execution warnings annotate the result envelope; in-execution denials replace the visible result with a deterministic guardrail error.
+- Guardrail alerts are published as run events containing the tool name, tool call id, and serialized non-allow findings.
+
+## 7. Persistence and Events
+
+Guardrail state is stored in `SharedStateRepository` under the task scope:
+
+- `runtime_guardrails`: tool call counters and recorded findings
+- `runtime_guardrail_report`: generated task-level report
+
+`runtime_guardrails` keeps cumulative warning and blocked counts separately from retained observations. Only the newest observations are retained to bound state size, but the report status and aggregate counts remain stable after older WARN/DENY observations are truncated.
+
+Run events:
+
+- `runtime_guardrail_alert`: emitted when a rule produces a warning or denial
+- `runtime_guardrail_report`: emitted when the task-level report is generated
+
+Tool result metadata includes `runtime_guardrail_status`, warning/block counts, and serialized findings when guardrails trigger.
+
+## 8. Verification Contract
+
+`verify_task(..., require_guardrail_report=True)` fails if no parseable report event exists for the task. Coordinator-driven verification sets this flag so Gater acceptance requires the Proof-of-Guardrail report. If an existing report event is stale or malformed, coordinator verification regenerates and republishes the report before calling Gater verification.
+
+The report also becomes structured verification evidence with `runtime_guardrail_report` evidence kind and `security` verification layer checks.
+
+## 9. Failure Handling
+
+Guardrail state persistence and alert publishing failures are logged through the project logger and do not hide the original tool result. A guardrail denial itself returns a deterministic tool error before action execution for pre-execution rules, or replaces the visible result for in-execution deny rules.
+
+## 10. Required Tests
+
+- Default policy construction uses the rule factory directly.
+- Concurrent guardrail state updates preserve all per-task tool calls and findings.
+- Truncated observations do not downgrade cumulative WARN/DENY report counts or status.
+- Malformed runtime guardrail report events do not satisfy coordinator verification prechecks.
+- Pre-execution and in-execution guardrail denials produce deterministic tool errors and metadata.

--- a/src/relay_teams/agents/orchestration/coordinator.py
+++ b/src/relay_teams/agents/orchestration/coordinator.py
@@ -76,6 +76,10 @@ from relay_teams.hooks import (
     HookService,
     TaskCreatedInput,
 )
+from relay_teams.tools.runtime.guardrails import (
+    generate_runtime_guardrail_report_async,
+    runtime_guardrail_report_from_event_payload,
+)
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 
 LOGGER = get_logger(__name__)
@@ -1768,6 +1772,8 @@ class CoordinatorGraph(BaseModel):
                     "error": str(exc),
                 },
             )
+        if root_record is not None:
+            await self._ensure_runtime_guardrail_report_async(root_record=root_record)
         verification = await asyncio.to_thread(
             verify_task,
             self.task_repo,
@@ -1777,6 +1783,7 @@ class CoordinatorGraph(BaseModel):
             tool_approval_policy=tool_approval_policy,
             workspace_root=workspace_root,
             role=role,
+            require_guardrail_report=True,
         )
         if root_record is None:
             return verification
@@ -1789,6 +1796,73 @@ class CoordinatorGraph(BaseModel):
             verification=verification,
             checks=delegated_contract_checks,
         )
+
+    async def _ensure_runtime_guardrail_report_async(
+        self,
+        *,
+        root_record: TaskRecord,
+    ) -> None:
+        task = root_record.envelope
+        report_events = [
+            event
+            for event in await self.event_bus.list_by_trace_async(task.trace_id)
+            if str(event.get("task_id") or "") == task.task_id
+            and str(event.get("event_type") or "")
+            == RunEventType.RUNTIME_GUARDRAIL_REPORT.value
+        ]
+        for event in report_events:
+            if (
+                runtime_guardrail_report_from_event_payload(event.get("payload_json"))
+                is not None
+            ):
+                return
+        if report_events:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="coord.verification.guardrail_report_corrupted",
+                message="Existing runtime guardrail report event has unparseable payload; regenerating",
+                payload={
+                    "task_id": task.task_id,
+                    "trace_id": task.trace_id,
+                },
+            )
+        role_id = task.role_id or ""
+        try:
+            report = await generate_runtime_guardrail_report_async(
+                shared_store=self.shared_store,
+                task_id=task.task_id,
+                run_id=task.trace_id,
+                session_id=task.session_id,
+                role_id=role_id,
+            )
+            event = RunEvent(
+                session_id=task.session_id,
+                run_id=task.trace_id,
+                trace_id=task.trace_id,
+                task_id=task.task_id,
+                instance_id=root_record.assigned_instance_id,
+                role_id=task.role_id,
+                event_type=RunEventType.RUNTIME_GUARDRAIL_REPORT,
+                payload_json=report.model_dump_json(),
+            )
+            if self.run_event_hub is not None:
+                _ = await self.run_event_hub.publish_async(event)
+            else:
+                _ = await self.event_bus.emit_run_event_async(event)
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="coord.verification.guardrail_report_failed",
+                message="Runtime guardrail report could not be generated before verification",
+                payload={
+                    "task_id": task.task_id,
+                    "trace_id": task.trace_id,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
 
     async def _delegated_role_contract_verification_checks_async(
         self,

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -57,6 +57,7 @@ from relay_teams.sessions.runs.assistant_errors import (
     build_assistant_error_message,
 )
 from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.recoverable_pause import (
@@ -67,6 +68,7 @@ from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_models import (
     RunKind,
+    RunEvent,
     RuntimePromptConversationContext,
     RunThinkingConfig,
     RunTopologySnapshot,
@@ -79,6 +81,7 @@ from relay_teams.sessions.runs.run_runtime_repo import (
 from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.skills.skill_models import SkillInstructionEntry
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
+from relay_teams.tools.runtime.guardrails import generate_runtime_guardrail_report_async
 from relay_teams.workspace import WorkspaceHandle, WorkspaceManager
 
 LOGGER = get_logger(__name__)
@@ -459,6 +462,11 @@ class TaskExecutionService(BaseModel):
                     payload_json="{}",
                 )
             )
+            await self._publish_runtime_guardrail_report_async(
+                task=task,
+                instance_id=instance_id,
+                role_id=role_id,
+            )
             await persistence_harness.record_memory_if_needed_async(
                 role_id=role_id,
                 workspace_id=workspace.ref.workspace_id,
@@ -628,6 +636,50 @@ class TaskExecutionService(BaseModel):
                 ),
                 error_code="internal_execution_error",
                 error_message=str(exc),
+            )
+
+    async def _publish_runtime_guardrail_report_async(
+        self,
+        *,
+        task: TaskEnvelope,
+        instance_id: str,
+        role_id: str,
+    ) -> None:
+        try:
+            report = await generate_runtime_guardrail_report_async(
+                shared_store=self.shared_store,
+                task_id=task.task_id,
+                run_id=task.trace_id,
+                session_id=task.session_id,
+                role_id=role_id,
+            )
+            event = RunEvent(
+                session_id=task.session_id,
+                run_id=task.trace_id,
+                trace_id=task.trace_id,
+                task_id=task.task_id,
+                instance_id=instance_id,
+                role_id=role_id,
+                event_type=RunEventType.RUNTIME_GUARDRAIL_REPORT,
+                payload_json=report.model_dump_json(),
+            )
+            if self.run_event_hub is not None:
+                _ = await self.run_event_hub.publish_async(event)
+            else:
+                _ = await self.event_bus.emit_run_event_async(event)
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="task.execution.guardrail_report_failed",
+                message="Runtime guardrail report could not be generated",
+                payload={
+                    "task_id": task.task_id,
+                    "instance_id": instance_id,
+                    "role_id": role_id,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
             )
 
     def _start_task_heartbeat(

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -39,6 +39,11 @@ from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.roles.role_models import RoleDefinition
+from relay_teams.tools.runtime.guardrails import (
+    RuntimeGuardrailReport,
+    RuntimeGuardrailStatus,
+    runtime_guardrail_report_from_payload,
+)
 from relay_teams.tools.runtime.models import ToolRuntimeDecision
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 
@@ -116,6 +121,7 @@ def verify_task(
     workspace_root: Path | None = None,
     semantic_evaluator: SemanticVerificationEvaluator | None = None,
     role: RoleDefinition | None = None,
+    require_guardrail_report: bool = False,
 ) -> VerificationResult:
     task = task_repo.get(task_id)
     evidence_bundle: VerificationEvidenceBundle | None = None
@@ -144,6 +150,12 @@ def verify_task(
             tool_approval_policy=tool_approval_policy or ToolApprovalPolicy(),
             workspace_root=workspace_root,
             semantic_evaluator=semantic_evaluator,
+            guardrail_report=_latest_guardrail_report(
+                event_bus=event_bus,
+                trace_id=task.envelope.trace_id,
+                task_id=task.envelope.task_id,
+            ),
+            require_guardrail_report=require_guardrail_report,
         )
         checks = list(plan_run.checks)
         evidence_bundle = plan_run.evidence_bundle
@@ -203,6 +215,8 @@ def _run_verification_plan(
     tool_approval_policy: ToolApprovalPolicy,
     workspace_root: Path | None,
     semantic_evaluator: SemanticVerificationEvaluator | None,
+    guardrail_report: RuntimeGuardrailReport | None,
+    require_guardrail_report: bool,
 ) -> _VerificationPlanRun:
     checks: list[VerificationCheckResult] = []
     evidence_items: list[VerificationEvidenceItem] = [
@@ -229,6 +243,11 @@ def _run_verification_plan(
             task_id=task_id_filter,
         )
     )
+    guardrail_checks = _runtime_guardrail_checks(
+        report=guardrail_report,
+        required=require_guardrail_report,
+    )
+    checks.extend(guardrail_checks)
     (
         evidence_items_with_supports,
         acceptance_links,
@@ -825,6 +844,10 @@ def _event_evidence_item(
         return _tool_call_evidence_item(index=index, payload=payload)
     if event_type == RunEventType.TOOL_RESULT.value:
         return _tool_result_evidence_item(index=index, payload=payload)
+    if event_type == RunEventType.RUNTIME_GUARDRAIL_REPORT.value:
+        report = runtime_guardrail_report_from_payload(payload)
+        if report is not None:
+            return _runtime_guardrail_evidence_item(index=index, report=report)
     if _is_gate_finding_event(event_type=event_type, payload=payload):
         return _gate_finding_evidence_item(
             index=index, event_type=event_type, payload=payload
@@ -872,6 +895,111 @@ def _tool_result_evidence_item(
         tool_name=tool_name,
         tool_call_id=tool_call_id,
         output_excerpt=_json_excerpt(payload.get("result")),
+    )
+
+
+def _latest_guardrail_report(
+    *,
+    event_bus: EventLog,
+    trace_id: str,
+    task_id: str,
+) -> RuntimeGuardrailReport | None:
+    report: RuntimeGuardrailReport | None = None
+    for event in event_bus.list_by_trace(trace_id):
+        if str(event.get("task_id") or "") != task_id:
+            continue
+        if (
+            str(event.get("event_type") or "")
+            != RunEventType.RUNTIME_GUARDRAIL_REPORT.value
+        ):
+            continue
+        candidate = runtime_guardrail_report_from_payload(
+            _parse_event_payload(event.get("payload_json"))
+        )
+        if candidate is not None:
+            report = candidate
+    return report
+
+
+def _runtime_guardrail_checks(
+    *,
+    report: RuntimeGuardrailReport | None,
+    required: bool,
+) -> tuple[VerificationCheckResult, ...]:
+    if report is None:
+        if not required:
+            return ()
+        return (
+            VerificationCheckResult(
+                layer=VerificationLayer.SECURITY,
+                name="runtime_guardrail_report",
+                passed=False,
+                details="Runtime guardrail report is required but was not generated.",
+            ),
+        )
+    checks = [
+        VerificationCheckResult(
+            layer=VerificationLayer.SECURITY,
+            name=f"runtime_guardrail:{check.name}",
+            passed=check.passed,
+            details=check.details,
+        )
+        for check in report.checks
+    ]
+    checks.append(
+        VerificationCheckResult(
+            layer=VerificationLayer.SECURITY,
+            name="runtime_guardrail_status",
+            passed=report.status != RuntimeGuardrailStatus.BLOCKED,
+            details=(
+                "Runtime guardrail report is clear."
+                if report.status == RuntimeGuardrailStatus.PASSED
+                else (
+                    "Runtime guardrail report contains warnings."
+                    if report.status == RuntimeGuardrailStatus.WARNING
+                    else "Runtime guardrail report contains blocked actions."
+                )
+            ),
+        )
+    )
+    return tuple(checks)
+
+
+def _runtime_guardrail_evidence_items(
+    report: RuntimeGuardrailReport | None,
+) -> tuple[VerificationEvidenceItem, ...]:
+    if report is None:
+        return ()
+    return (_runtime_guardrail_evidence_item(index=0, report=report),)
+
+
+def _runtime_guardrail_evidence_item(
+    *,
+    index: int,
+    report: RuntimeGuardrailReport,
+) -> VerificationEvidenceItem:
+    status = report.status.value
+    return VerificationEvidenceItem(
+        evidence_id=_evidence_id("guardrail", index, report.task_id),
+        kind=VerificationEvidenceKind.RUNTIME_GUARDRAIL_REPORT,
+        summary=f"Runtime guardrail report status is {status}.",
+        source="runtime_guardrail_report",
+        passed=report.status != RuntimeGuardrailStatus.BLOCKED,
+        output_excerpt=_json_excerpt(report.model_dump(mode="json")),
+        metrics=(
+            VerificationEvidenceMetric(
+                name="guardrail_tool_calls",
+                value=report.total_tool_calls,
+            ),
+            VerificationEvidenceMetric(
+                name="guardrail_warnings",
+                value=report.warning_count,
+            ),
+            VerificationEvidenceMetric(
+                name="guardrail_blocks",
+                value=report.blocked_count,
+            ),
+        ),
     )
 
 

--- a/src/relay_teams/agents/tasks/enums.py
+++ b/src/relay_teams/agents/tasks/enums.py
@@ -32,6 +32,7 @@ class VerificationLayer(str, Enum):
     SEMANTIC = "semantic"
     SPEC = "spec"
     CONTRACT = "contract"
+    SECURITY = "security"
 
 
 class VerificationEvidenceKind(str, Enum):
@@ -45,6 +46,7 @@ class VerificationEvidenceKind(str, Enum):
     TOOL_CALL = "tool_call"
     TOOL_RESULT = "tool_result"
     GATE_FINDING = "gate_finding"
+    RUNTIME_GUARDRAIL_REPORT = "runtime_guardrail_report"
 
 
 class VerificationEvidenceTarget(str, Enum):

--- a/src/relay_teams/persistence/shared_state_repo.py
+++ b/src/relay_teams/persistence/shared_state_repo.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -80,6 +81,56 @@ class SharedStateRepository(SharedSqliteRepository):
 
         await self._run_async_write(
             operation_name="manage_state",
+            operation=lambda _conn: operation(),
+        )
+
+    async def update_state_async(
+        self,
+        *,
+        scope: ScopeRef,
+        key: str,
+        update: Callable[[str | None], str],
+        ttl_seconds: int | None = None,
+    ) -> str:
+        expires_at: str | None = None
+        if ttl_seconds is not None:
+            expires_at = (
+                datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
+            ).isoformat()
+
+        async def operation() -> str:
+            conn = await self._get_async_conn()
+            row = await async_fetchone(
+                conn,
+                """
+                SELECT value_json FROM shared_state
+                WHERE scope_type=? AND scope_id=? AND state_key=?
+                  AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                """,
+                (scope.scope_type.value, scope.scope_id, key),
+            )
+            current_value = None if row is None else str(row["value_json"])
+            next_value = update(current_value)
+            await conn.execute(
+                """
+                INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
+                VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
+                ON CONFLICT(scope_type, scope_id, state_key)
+                DO UPDATE SET value_json=excluded.value_json, updated_at=CURRENT_TIMESTAMP,
+                              expires_at=COALESCE(excluded.expires_at, expires_at)
+                """,
+                (
+                    scope.scope_type.value,
+                    scope.scope_id,
+                    key,
+                    next_value,
+                    expires_at,
+                ),
+            )
+            return next_value
+
+        return await self._run_async_write(
+            operation_name="update_state",
             operation=lambda _conn: operation(),
         )
 

--- a/src/relay_teams/sessions/runs/enums.py
+++ b/src/relay_teams/sessions/runs/enums.py
@@ -52,6 +52,8 @@ class RunEventType(str, Enum):
     INJECTION_APPLIED = "injection_applied"
     TOOL_APPROVAL_REQUESTED = "tool_approval_requested"
     TOOL_APPROVAL_RESOLVED = "tool_approval_resolved"
+    RUNTIME_GUARDRAIL_ALERT = "runtime_guardrail_alert"
+    RUNTIME_GUARDRAIL_REPORT = "runtime_guardrail_report"
     USER_QUESTION_REQUESTED = "user_question_requested"
     USER_QUESTION_ANSWERED = "user_question_answered"
     NOTIFICATION_REQUESTED = "notification_requested"

--- a/src/relay_teams/tools/runtime/__init__.py
+++ b/src/relay_teams/tools/runtime/__init__.py
@@ -1,4 +1,36 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-__all__: list[str] = []
+from relay_teams.tools.runtime.guardrails import (
+    RuntimeGuardrailAction,
+    RuntimeGuardrailContext,
+    RuntimeGuardrailEvaluation,
+    RuntimeGuardrailFinding,
+    RuntimeGuardrailLayer,
+    RuntimeGuardrailObservation,
+    RuntimeGuardrailPolicy,
+    RuntimeGuardrailReport,
+    RuntimeGuardrailReportCheck,
+    RuntimeGuardrailRule,
+    RuntimeGuardrailRuleType,
+    RuntimeGuardrailState,
+    RuntimeGuardrailStatus,
+    runtime_guardrail_report_from_event_payload,
+)
+
+__all__ = [
+    "RuntimeGuardrailAction",
+    "RuntimeGuardrailContext",
+    "RuntimeGuardrailEvaluation",
+    "RuntimeGuardrailFinding",
+    "RuntimeGuardrailLayer",
+    "RuntimeGuardrailObservation",
+    "RuntimeGuardrailPolicy",
+    "RuntimeGuardrailReport",
+    "RuntimeGuardrailReportCheck",
+    "RuntimeGuardrailRule",
+    "RuntimeGuardrailRuleType",
+    "RuntimeGuardrailState",
+    "RuntimeGuardrailStatus",
+    "runtime_guardrail_report_from_event_payload",
+]

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -67,6 +67,21 @@ from relay_teams.tools.runtime.approval_ticket_repo import (
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimePhase, RunRuntimeStatus
 from relay_teams.trace import trace_span
 from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.guardrails import (
+    RuntimeGuardrailAction,
+    RuntimeGuardrailContext,
+    RuntimeGuardrailEvaluation,
+    RuntimeGuardrailFinding,
+    RuntimeGuardrailPolicy,
+    RuntimeGuardrailRuleType,
+    RuntimeGuardrailStatus,
+    evaluate_in_execution_guardrails,
+    evaluate_pre_execution_guardrails,
+    guardrail_findings_payload,
+    guardrail_meta_status,
+    record_runtime_guardrail_findings_async,
+    record_runtime_guardrail_tool_call_async,
+)
 from relay_teams.tools.runtime.models import (
     ToolApprovalDecision,
     ToolApprovalRequest,
@@ -315,6 +330,15 @@ async def execute_tool(
             tool_input=effective_tool_input,
         )
         args_summary = dict(effective_tool_input)
+        pre_guardrail_error = await _apply_pre_execution_guardrails(
+            ctx=ctx,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            tool_input=effective_tool_input,
+            meta=meta,
+        )
+        if pre_tool_error is None and pre_guardrail_error is not None:
+            pre_tool_error = pre_guardrail_error
         reusable_result = await _reusable_tool_result_async(
             ctx=ctx,
             args_preview=_safe_json(args_summary),
@@ -497,6 +521,19 @@ async def execute_tool(
                 args_summary=args_summary,
                 envelope=envelope,
             )
+            envelope = await _apply_in_execution_guardrails(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=effective_tool_input,
+                envelope=envelope,
+            )
+            final_success = not _visible_tool_result_is_error(envelope)
+            execution_status = (
+                ToolExecutionStatus.COMPLETED
+                if final_success
+                else ToolExecutionStatus.FAILED
+            )
             await _observe_tool_result_reminders_async(
                 ctx=ctx,
                 tool_name=tool_name,
@@ -509,16 +546,16 @@ async def execute_tool(
                 tool_name=tool_name,
                 args_summary=args_summary,
                 visible_envelope=envelope,
-                internal_data=internal_data,
+                internal_data=internal_data if final_success else None,
                 runtime_meta=meta,
-                execution_status=ToolExecutionStatus.COMPLETED,
-                tool_content_parts=tool_content_parts,
+                execution_status=execution_status,
+                tool_content_parts=tool_content_parts if final_success else (),
             )
             await _record_tool_metrics_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 duration_ms=elapsed_ms,
-                success=True,
+                success=final_success,
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
                 await ctx.deps.approval_ticket_repo.mark_completed_async(
@@ -531,9 +568,9 @@ async def execute_tool(
                 tool_input=effective_tool_input,
                 visible_envelope=envelope,
                 internal_data=internal_data,
-                execution_status=ToolExecutionStatus.COMPLETED,
+                execution_status=execution_status,
             )
-            if tool_return_content is not None:
+            if final_success and tool_return_content is not None:
                 return ToolReturn(
                     return_value=envelope,
                     content=tool_return_content,
@@ -579,6 +616,13 @@ async def execute_tool(
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
                 args_summary=args_summary,
+                envelope=envelope,
+            )
+            envelope = await _apply_in_execution_guardrails(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=effective_tool_input,
                 envelope=envelope,
             )
             await _observe_tool_result_reminders_async(
@@ -1991,6 +2035,313 @@ async def _apply_pre_tool_hooks(
     if isinstance(bundle.updated_input, dict):
         next_args = _normalize_json_object(bundle.updated_input)
     return next_args, None, bundle.decision == HookDecisionType.ASK
+
+
+async def _apply_pre_execution_guardrails(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    meta: dict[str, JsonValue],
+) -> ToolError | None:
+    policy = ctx.deps.tool_approval_policy
+    guardrail_policy = _guardrail_policy_from_runtime_policy(policy)
+    if not guardrail_policy.enabled:
+        return None
+    context = _runtime_guardrail_context(
+        ctx=ctx,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+    )
+    call_count = await _record_guardrail_tool_call_count(
+        ctx=ctx,
+        context=context,
+    )
+    allowed_tools: tuple[str, ...] | None = None
+    denied_tools: tuple[str, ...] = ()
+    if isinstance(policy, ToolApprovalPolicy):
+        allowed_tools = await _allowed_tools_for_runtime_policy(ctx=ctx)
+        denied_tools = tuple(sorted(policy.denied_tools))
+    evaluation = evaluate_pre_execution_guardrails(
+        policy=guardrail_policy,
+        context=context,
+        tool_input=tool_input,
+        allowed_tools=allowed_tools,
+        denied_tools=denied_tools,
+        call_count=call_count,
+    )
+    if not evaluation.findings:
+        return None
+    _apply_guardrail_findings_to_meta(meta=meta, evaluation=evaluation)
+    await _record_and_publish_guardrail_findings_async(
+        ctx=ctx,
+        context=context,
+        findings=evaluation.findings,
+    )
+    if not evaluation.blocked:
+        return None
+    denial = _first_guardrail_block(evaluation.findings)
+    meta["approval_required"] = False
+    meta["approval_mode"] = ToolApprovalMode.POLICY_EXEMPT.value
+    meta["approval_status"] = (
+        "denied_by_policy"
+        if _guardrail_block_is_policy_boundary(denial)
+        else "denied_by_guardrail"
+    )
+    meta["runtime_policy_decision"] = ToolRuntimeDecision.DENY.value
+    meta["runtime_policy_reason"] = denial.message
+    return ToolError(
+        type=_guardrail_denial_error_type(denial),
+        message=denial.message,
+        retryable=False,
+        details=denial.details,
+    )
+
+
+async def _apply_in_execution_guardrails(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    envelope: dict[str, JsonValue],
+) -> dict[str, JsonValue]:
+    policy = ctx.deps.tool_approval_policy
+    guardrail_policy = _guardrail_policy_from_runtime_policy(policy)
+    if not guardrail_policy.enabled:
+        return envelope
+    context = _runtime_guardrail_context(
+        ctx=ctx,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+    )
+    evaluation = evaluate_in_execution_guardrails(
+        policy=guardrail_policy,
+        context=context,
+        tool_input=tool_input,
+        result_envelope=envelope,
+    )
+    if not evaluation.findings:
+        return envelope
+    meta = _envelope_meta(envelope)
+    _apply_guardrail_findings_to_meta(meta=meta, evaluation=evaluation)
+    envelope["meta"] = meta
+    await _record_and_publish_guardrail_findings_async(
+        ctx=ctx,
+        context=context,
+        findings=evaluation.findings,
+    )
+    if not evaluation.blocked:
+        return envelope
+    denial = _first_guardrail_block(evaluation.findings)
+    return _visible_envelope(
+        ok=False,
+        error=ToolError(
+            type=_guardrail_denial_error_type(denial),
+            message=denial.message,
+            retryable=False,
+            details=denial.details,
+        ),
+        meta=meta,
+    )
+
+
+async def _record_guardrail_tool_call_count(
+    *,
+    ctx: ToolContext,
+    context: RuntimeGuardrailContext,
+) -> int:
+    try:
+        return await record_runtime_guardrail_tool_call_async(
+            shared_store=ctx.deps.shared_store,
+            context=context,
+        )
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="runtime_guardrail.state_update_failed",
+            message="Runtime guardrail could not record tool call count",
+            payload={
+                "run_id": ctx.deps.run_id,
+                "task_id": ctx.deps.task_id,
+                "tool_name": context.tool_name,
+                "tool_call_id": context.tool_call_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+        return 1
+
+
+async def _record_and_publish_guardrail_findings_async(
+    *,
+    ctx: ToolContext,
+    context: RuntimeGuardrailContext,
+    findings: tuple[RuntimeGuardrailFinding, ...],
+) -> None:
+    try:
+        _ = await record_runtime_guardrail_findings_async(
+            shared_store=ctx.deps.shared_store,
+            context=context,
+            findings=findings,
+        )
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="runtime_guardrail.finding_persist_failed",
+            message="Runtime guardrail finding could not be persisted",
+            payload={
+                "run_id": ctx.deps.run_id,
+                "task_id": ctx.deps.task_id,
+                "tool_name": context.tool_name,
+                "tool_call_id": context.tool_call_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+    try:
+        await publish_run_event_async(
+            ctx.deps.run_event_hub,
+            RunEvent(
+                session_id=ctx.deps.session_id,
+                run_id=ctx.deps.run_id,
+                trace_id=ctx.deps.trace_id,
+                task_id=ctx.deps.task_id,
+                instance_id=ctx.deps.instance_id,
+                role_id=ctx.deps.role_id,
+                event_type=RunEventType.RUNTIME_GUARDRAIL_ALERT,
+                payload_json=dumps(
+                    {
+                        "tool_name": context.tool_name,
+                        "tool_call_id": context.tool_call_id,
+                        "findings": guardrail_findings_payload(findings),
+                    },
+                    ensure_ascii=False,
+                ),
+            ),
+        )
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="runtime_guardrail.alert_publish_failed",
+            message="Runtime guardrail alert event could not be published",
+            payload={
+                "run_id": ctx.deps.run_id,
+                "task_id": ctx.deps.task_id,
+                "tool_name": context.tool_name,
+                "tool_call_id": context.tool_call_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+
+def _runtime_guardrail_context(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+) -> RuntimeGuardrailContext:
+    return RuntimeGuardrailContext(
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        session_mode=ctx.deps.session_mode,
+        run_kind=ctx.deps.run_kind,
+    )
+
+
+def _guardrail_policy_from_runtime_policy(
+    policy: object,
+) -> RuntimeGuardrailPolicy:
+    if isinstance(policy, ToolApprovalPolicy):
+        return policy.guardrails
+    return RuntimeGuardrailPolicy(enabled=False)
+
+
+def _apply_guardrail_findings_to_meta(
+    *,
+    meta: dict[str, JsonValue],
+    evaluation: RuntimeGuardrailEvaluation,
+) -> None:
+    findings = tuple(
+        finding
+        for finding in evaluation.findings
+        if finding.action != RuntimeGuardrailAction.ALLOW
+    )
+    if not findings:
+        return
+    new_blocked = evaluation.blocked_count
+    new_warnings = evaluation.warning_count
+    new_status = guardrail_meta_status(findings).value
+    new_payload = guardrail_findings_payload(findings)
+    existing_blocked = meta.get("runtime_guardrail_blocked_count")
+    existing_warnings = meta.get("runtime_guardrail_warning_count")
+    existing_findings = meta.get("runtime_guardrail_findings")
+    existing_status = meta.get("runtime_guardrail_status")
+    if isinstance(existing_blocked, int):
+        meta["runtime_guardrail_blocked_count"] = existing_blocked + new_blocked
+    else:
+        meta["runtime_guardrail_blocked_count"] = new_blocked
+    if isinstance(existing_warnings, int):
+        meta["runtime_guardrail_warning_count"] = existing_warnings + new_warnings
+    else:
+        meta["runtime_guardrail_warning_count"] = new_warnings
+    if isinstance(existing_findings, list):
+        existing_list: list[JsonValue] = existing_findings
+        meta["runtime_guardrail_findings"] = existing_list + new_payload
+    else:
+        meta["runtime_guardrail_findings"] = new_payload
+    if isinstance(existing_status, str) and existing_status != new_status:
+        _status_severity: dict[str, int] = {
+            RuntimeGuardrailStatus.BLOCKED.value: 3,
+            RuntimeGuardrailStatus.WARNING.value: 2,
+            RuntimeGuardrailStatus.PASSED.value: 1,
+        }
+        existing_rank = _status_severity.get(existing_status, 0)
+        new_rank = _status_severity.get(new_status, 0)
+        meta["runtime_guardrail_status"] = (
+            new_status if new_rank > existing_rank else existing_status
+        )
+    else:
+        meta["runtime_guardrail_status"] = new_status
+
+
+def _first_guardrail_block(
+    findings: tuple[RuntimeGuardrailFinding, ...],
+) -> RuntimeGuardrailFinding:
+    for finding in findings:
+        if finding.action == RuntimeGuardrailAction.DENY:
+            return finding
+    raise RuntimeError("Expected a runtime guardrail denial finding")
+
+
+def _guardrail_block_is_policy_boundary(finding: RuntimeGuardrailFinding) -> bool:
+    return finding.rule_type in {
+        RuntimeGuardrailRuleType.TOOL_ALLOWLIST,
+        RuntimeGuardrailRuleType.TOOL_DENYLIST,
+    }
+
+
+def _guardrail_denial_error_type(finding: RuntimeGuardrailFinding) -> str:
+    if _guardrail_block_is_policy_boundary(finding):
+        return "tool_policy_denied"
+    return "runtime_guardrail_denied"
+
+
+def _envelope_meta(envelope: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    raw_meta = envelope.get("meta")
+    if not isinstance(raw_meta, dict):
+        return {}
+    return _normalize_json_object(raw_meta)
 
 
 async def _apply_permission_request_hooks(

--- a/src/relay_teams/tools/runtime/guardrails.py
+++ b/src/relay_teams/tools/runtime/guardrails.py
@@ -1,0 +1,873 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+import asyncio
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
+
+from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+
+GUARDRAIL_STATE_KEY = "runtime_guardrails"
+GUARDRAIL_REPORT_KEY = "runtime_guardrail_report"
+MAX_RECORDED_GUARDRAIL_OBSERVATIONS = 200
+DEFAULT_GUARDRAIL_PAYLOAD_LIMIT_BYTES = 1024 * 1024
+
+_per_task_locks: dict[str, asyncio.Lock] = {}
+
+
+def _get_task_lock(task_id: str) -> asyncio.Lock:
+    lock = _per_task_locks.get(task_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _per_task_locks[task_id] = lock
+    return lock
+
+
+class RuntimeGuardrailLayer(str, Enum):
+    PRE_EXECUTION = "pre_execution"
+    IN_EXECUTION = "in_execution"
+    POST_VALIDATION = "post_validation"
+
+
+class RuntimeGuardrailAction(str, Enum):
+    ALLOW = "allow"
+    WARN = "warn"
+    DENY = "deny"
+
+
+class RuntimeGuardrailRuleType(str, Enum):
+    TOOL_ALLOWLIST = "tool_allowlist"
+    TOOL_DENYLIST = "tool_denylist"
+    INPUT_SIZE = "input_size"
+    OUTPUT_SIZE = "output_size"
+    CALL_FREQUENCY = "call_frequency"
+    SHELL_DESTRUCTIVE_PATTERN = "shell_destructive_pattern"
+
+
+class RuntimeGuardrailStatus(str, Enum):
+    PASSED = "passed"
+    WARNING = "warning"
+    BLOCKED = "blocked"
+
+
+class RuntimeGuardrailRule(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    rule_id: str = Field(min_length=1)
+    layer: RuntimeGuardrailLayer
+    rule_type: RuntimeGuardrailRuleType
+    action: RuntimeGuardrailAction = RuntimeGuardrailAction.WARN
+    description: str = ""
+    enabled: bool = True
+    tool_names: tuple[str, ...] = ()
+    role_ids: tuple[str, ...] = ()
+    session_modes: tuple[str, ...] = ()
+    run_kinds: tuple[str, ...] = ()
+    max_bytes: int | None = Field(default=None, ge=1)
+    max_calls_per_task: int | None = Field(default=None, ge=1)
+    blocked_patterns: tuple[str, ...] = ()
+
+
+def default_runtime_guardrail_rules() -> tuple[RuntimeGuardrailRule, ...]:
+    return (
+        RuntimeGuardrailRule(
+            rule_id="role_tool_allowlist",
+            layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+            rule_type=RuntimeGuardrailRuleType.TOOL_ALLOWLIST,
+            action=RuntimeGuardrailAction.DENY,
+            description="Deny tool calls outside the effective role tool boundary.",
+        ),
+        RuntimeGuardrailRule(
+            rule_id="runtime_denied_tools",
+            layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+            rule_type=RuntimeGuardrailRuleType.TOOL_DENYLIST,
+            action=RuntimeGuardrailAction.DENY,
+            description="Deny tools explicitly disabled by runtime policy.",
+        ),
+        RuntimeGuardrailRule(
+            rule_id="destructive_shell_pattern",
+            layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+            rule_type=RuntimeGuardrailRuleType.SHELL_DESTRUCTIVE_PATTERN,
+            action=RuntimeGuardrailAction.DENY,
+            tool_names=("shell",),
+            blocked_patterns=(
+                r"(^|[;&|]\s*)rm\s+(-[A-Za-z]*[rf][A-Za-z]*|--recursive|--force)\b",
+                r"(^|[;&|]\s*)git\s+reset\s+--hard\b",
+                r"(^|[;&|]\s*)git\s+clean\s+-[A-Za-z]*[xdf][A-Za-z]*\b",
+                r"(^|[;&|]\s*)del\s+(/s|/q)\b",
+                r"\bRemove-Item\b.*\s-Recurse\b",
+            ),
+            description="Block common destructive filesystem shell patterns.",
+        ),
+        RuntimeGuardrailRule(
+            rule_id="large_tool_input",
+            layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+            rule_type=RuntimeGuardrailRuleType.INPUT_SIZE,
+            action=RuntimeGuardrailAction.WARN,
+            max_bytes=DEFAULT_GUARDRAIL_PAYLOAD_LIMIT_BYTES,
+            description="Flag unusually large tool inputs before execution.",
+        ),
+        RuntimeGuardrailRule(
+            rule_id="write_surface_frequency",
+            layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+            rule_type=RuntimeGuardrailRuleType.CALL_FREQUENCY,
+            action=RuntimeGuardrailAction.WARN,
+            tool_names=("edit", "shell", "write", "write_tmp"),
+            max_calls_per_task=20,
+            description="Flag unusually frequent write-capable tool calls.",
+        ),
+        RuntimeGuardrailRule(
+            rule_id="large_tool_output",
+            layer=RuntimeGuardrailLayer.IN_EXECUTION,
+            rule_type=RuntimeGuardrailRuleType.OUTPUT_SIZE,
+            action=RuntimeGuardrailAction.WARN,
+            max_bytes=DEFAULT_GUARDRAIL_PAYLOAD_LIMIT_BYTES,
+            description="Flag unusually large tool outputs after execution.",
+        ),
+    )
+
+
+class RuntimeGuardrailPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    enabled: bool = True
+    rules: tuple[RuntimeGuardrailRule, ...] = Field(
+        default_factory=default_runtime_guardrail_rules
+    )
+
+    def matching_rules(
+        self,
+        *,
+        layer: RuntimeGuardrailLayer,
+        context: RuntimeGuardrailContext,
+    ) -> tuple[RuntimeGuardrailRule, ...]:
+        if not self.enabled:
+            return ()
+        return tuple(
+            rule
+            for rule in self.rules
+            if rule.enabled
+            and rule.layer == layer
+            and _rule_matches_context(rule=rule, context=context)
+        )
+
+
+class RuntimeGuardrailContext(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    run_id: str = Field(min_length=1)
+    session_id: str = Field(min_length=1)
+    task_id: str = Field(min_length=1)
+    instance_id: str = Field(min_length=1)
+    role_id: str = Field(min_length=1)
+    tool_name: str = Field(min_length=1)
+    tool_call_id: str = Field(min_length=1)
+    session_mode: str = ""
+    run_kind: str = ""
+
+
+class RuntimeGuardrailFinding(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    layer: RuntimeGuardrailLayer
+    rule_id: str = Field(min_length=1)
+    rule_type: RuntimeGuardrailRuleType
+    action: RuntimeGuardrailAction
+    message: str = Field(min_length=1)
+    details: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+class RuntimeGuardrailEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    findings: tuple[RuntimeGuardrailFinding, ...] = ()
+
+    @property
+    def blocked(self) -> bool:
+        return any(
+            finding.action == RuntimeGuardrailAction.DENY for finding in self.findings
+        )
+
+    @property
+    def warning_count(self) -> int:
+        return sum(
+            1
+            for finding in self.findings
+            if finding.action == RuntimeGuardrailAction.WARN
+        )
+
+    @property
+    def blocked_count(self) -> int:
+        return sum(
+            1
+            for finding in self.findings
+            if finding.action == RuntimeGuardrailAction.DENY
+        )
+
+
+class RuntimeGuardrailObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(min_length=1)
+    session_id: str = Field(min_length=1)
+    task_id: str = Field(min_length=1)
+    instance_id: str = Field(min_length=1)
+    role_id: str = Field(min_length=1)
+    tool_name: str = Field(min_length=1)
+    tool_call_id: str = Field(min_length=1)
+    layer: RuntimeGuardrailLayer
+    rule_id: str = Field(min_length=1)
+    rule_type: RuntimeGuardrailRuleType
+    action: RuntimeGuardrailAction
+    message: str = Field(min_length=1)
+    details: dict[str, JsonValue] = Field(default_factory=dict)
+    observed_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+
+class RuntimeGuardrailState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str = Field(min_length=1)
+    run_id: str = ""
+    session_id: str = ""
+    role_id: str = ""
+    tool_call_counts: dict[str, int] = Field(default_factory=dict)
+    warning_count: int = Field(default=0, ge=0)
+    blocked_count: int = Field(default=0, ge=0)
+    observations: tuple[RuntimeGuardrailObservation, ...] = ()
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+
+class RuntimeGuardrailReportCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    layer: RuntimeGuardrailLayer
+    name: str = Field(min_length=1)
+    passed: bool
+    details: str = ""
+
+
+class RuntimeGuardrailReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str = Field(min_length=1)
+    run_id: str = ""
+    session_id: str = ""
+    role_id: str = ""
+    status: RuntimeGuardrailStatus = RuntimeGuardrailStatus.PASSED
+    required_for_gate: bool = True
+    total_tool_calls: int = Field(default=0, ge=0)
+    warning_count: int = Field(default=0, ge=0)
+    blocked_count: int = Field(default=0, ge=0)
+    tool_call_counts: dict[str, int] = Field(default_factory=dict)
+    observations: tuple[RuntimeGuardrailObservation, ...] = ()
+    checks: tuple[RuntimeGuardrailReportCheck, ...] = ()
+    generated_at: datetime = Field(
+        default_factory=lambda: datetime.now(tz=timezone.utc)
+    )
+
+
+def evaluate_pre_execution_guardrails(
+    *,
+    policy: RuntimeGuardrailPolicy,
+    context: RuntimeGuardrailContext,
+    tool_input: dict[str, JsonValue],
+    allowed_tools: tuple[str, ...] | None,
+    denied_tools: tuple[str, ...],
+    call_count: int,
+) -> RuntimeGuardrailEvaluation:
+    findings: list[RuntimeGuardrailFinding] = []
+    allowed_tool_names = set(allowed_tools) if allowed_tools is not None else None
+    denied_tool_names = set(denied_tools)
+    for rule in policy.matching_rules(
+        layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+        context=context,
+    ):
+        finding = _evaluate_pre_execution_rule(
+            rule=rule,
+            context=context,
+            tool_input=tool_input,
+            allowed_tools=allowed_tool_names,
+            denied_tools=denied_tool_names,
+            call_count=call_count,
+        )
+        if finding is not None:
+            findings.append(finding)
+    return RuntimeGuardrailEvaluation(findings=tuple(findings))
+
+
+def evaluate_in_execution_guardrails(
+    *,
+    policy: RuntimeGuardrailPolicy,
+    context: RuntimeGuardrailContext,
+    tool_input: dict[str, JsonValue],
+    result_envelope: dict[str, JsonValue],
+) -> RuntimeGuardrailEvaluation:
+    findings: list[RuntimeGuardrailFinding] = []
+    _ = tool_input
+    for rule in policy.matching_rules(
+        layer=RuntimeGuardrailLayer.IN_EXECUTION,
+        context=context,
+    ):
+        finding = _evaluate_in_execution_rule(
+            rule=rule,
+            context=context,
+            result_envelope=result_envelope,
+        )
+        if finding is not None:
+            findings.append(finding)
+    return RuntimeGuardrailEvaluation(findings=tuple(findings))
+
+
+async def record_runtime_guardrail_tool_call_async(
+    *,
+    shared_store: SharedStateRepository,
+    context: RuntimeGuardrailContext,
+) -> int:
+    lock = _get_task_lock(context.task_id)
+    async with lock:
+        saved_json = await shared_store.update_state_async(
+            scope=_task_scope(context.task_id),
+            key=GUARDRAIL_STATE_KEY,
+            update=lambda raw: _record_tool_call_state_json(
+                raw=raw,
+                context=context,
+            ),
+        )
+    saved_state = RuntimeGuardrailState.model_validate_json(saved_json)
+    return saved_state.tool_call_counts.get(context.tool_name, 0)
+
+
+async def record_runtime_guardrail_findings_async(
+    *,
+    shared_store: SharedStateRepository,
+    context: RuntimeGuardrailContext,
+    findings: tuple[RuntimeGuardrailFinding, ...],
+) -> RuntimeGuardrailState:
+    lock = _get_task_lock(context.task_id)
+    async with lock:
+        saved_json = await shared_store.update_state_async(
+            scope=_task_scope(context.task_id),
+            key=GUARDRAIL_STATE_KEY,
+            update=lambda raw: _record_findings_state_json(
+                raw=raw,
+                context=context,
+                findings=findings,
+            ),
+        )
+    return RuntimeGuardrailState.model_validate_json(saved_json)
+
+
+async def load_runtime_guardrail_state_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+) -> RuntimeGuardrailState | None:
+    raw = await shared_store.get_state_async(_task_scope(task_id), GUARDRAIL_STATE_KEY)
+    if raw is None:
+        return None
+    try:
+        return RuntimeGuardrailState.model_validate_json(raw)
+    except ValueError:
+        return None
+
+
+def load_runtime_guardrail_report(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+) -> RuntimeGuardrailReport | None:
+    raw = shared_store.get_state(_task_scope(task_id), GUARDRAIL_REPORT_KEY)
+    if raw is None:
+        return None
+    try:
+        return RuntimeGuardrailReport.model_validate_json(raw)
+    except ValueError:
+        return None
+
+
+async def generate_runtime_guardrail_report_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    run_id: str,
+    session_id: str,
+    role_id: str,
+) -> RuntimeGuardrailReport:
+    state = await load_runtime_guardrail_state_async(
+        shared_store=shared_store,
+        task_id=task_id,
+    )
+    report = build_runtime_guardrail_report(
+        state=state,
+        task_id=task_id,
+        run_id=run_id,
+        session_id=session_id,
+        role_id=role_id,
+    )
+    await shared_store.manage_state_async(
+        StateMutation(
+            scope=_task_scope(task_id),
+            key=GUARDRAIL_REPORT_KEY,
+            value_json=report.model_dump_json(),
+        )
+    )
+    return report
+
+
+def build_runtime_guardrail_report(
+    *,
+    state: RuntimeGuardrailState | None,
+    task_id: str,
+    run_id: str,
+    session_id: str,
+    role_id: str,
+) -> RuntimeGuardrailReport:
+    observations = () if state is None else state.observations
+    counts = {} if state is None else dict(state.tool_call_counts)
+    retained_blocked_count = _count_observations_by_action(
+        observations=observations,
+        action=RuntimeGuardrailAction.DENY,
+    )
+    retained_warning_count = _count_observations_by_action(
+        observations=observations,
+        action=RuntimeGuardrailAction.WARN,
+    )
+    blocked_count = (
+        retained_blocked_count
+        if state is None
+        else max(state.blocked_count, retained_blocked_count)
+    )
+    warning_count = (
+        retained_warning_count
+        if state is None
+        else max(state.warning_count, retained_warning_count)
+    )
+    status = _report_status(blocked_count=blocked_count, warning_count=warning_count)
+    return RuntimeGuardrailReport(
+        task_id=task_id,
+        run_id=run_id or (state.run_id if state is not None else ""),
+        session_id=session_id or (state.session_id if state is not None else ""),
+        role_id=role_id or (state.role_id if state is not None else ""),
+        status=status,
+        total_tool_calls=sum(counts.values()),
+        warning_count=warning_count,
+        blocked_count=blocked_count,
+        tool_call_counts=counts,
+        observations=observations,
+        checks=_report_checks(
+            blocked_count=blocked_count,
+            warning_count=warning_count,
+            observations=observations,
+        ),
+    )
+
+
+def runtime_guardrail_report_from_payload(
+    payload: dict[str, object],
+) -> RuntimeGuardrailReport | None:
+    candidate = payload.get("report")
+    if isinstance(candidate, dict):
+        try:
+            return RuntimeGuardrailReport.model_validate(candidate)
+        except ValueError:
+            return None
+    try:
+        return RuntimeGuardrailReport.model_validate(payload)
+    except ValueError:
+        return None
+
+
+def runtime_guardrail_report_from_event_payload(
+    value: object,
+) -> RuntimeGuardrailReport | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return runtime_guardrail_report_from_payload(
+        {str(key): item for key, item in parsed.items()}
+    )
+
+
+def guardrail_findings_payload(
+    findings: tuple[RuntimeGuardrailFinding, ...],
+) -> list[JsonValue]:
+    return [
+        finding.model_dump(mode="json")
+        for finding in findings
+        if finding.action != RuntimeGuardrailAction.ALLOW
+    ]
+
+
+def guardrail_meta_status(
+    findings: tuple[RuntimeGuardrailFinding, ...],
+) -> RuntimeGuardrailStatus:
+    blocked_count = sum(
+        1 for finding in findings if finding.action == RuntimeGuardrailAction.DENY
+    )
+    warning_count = sum(
+        1 for finding in findings if finding.action == RuntimeGuardrailAction.WARN
+    )
+    return _report_status(blocked_count=blocked_count, warning_count=warning_count)
+
+
+def _evaluate_pre_execution_rule(
+    *,
+    rule: RuntimeGuardrailRule,
+    context: RuntimeGuardrailContext,
+    tool_input: dict[str, JsonValue],
+    allowed_tools: set[str] | None,
+    denied_tools: set[str],
+    call_count: int,
+) -> RuntimeGuardrailFinding | None:
+    if (
+        rule.rule_type == RuntimeGuardrailRuleType.TOOL_ALLOWLIST
+        and allowed_tools is not None
+        and context.tool_name not in allowed_tools
+    ):
+        return _finding(
+            rule=rule,
+            context=context,
+            message=f"Tool {context.tool_name} is not authorized for {context.role_id}.",
+            details={"allowed_tools": _json_string_list(allowed_tools)},
+        )
+    if (
+        rule.rule_type == RuntimeGuardrailRuleType.TOOL_DENYLIST
+        and context.tool_name in denied_tools
+    ):
+        return _finding(
+            rule=rule,
+            context=context,
+            message=f"Tool {context.tool_name} is denied by runtime policy.",
+            details={"denied_tools": _json_string_list(denied_tools)},
+        )
+    if rule.rule_type == RuntimeGuardrailRuleType.INPUT_SIZE:
+        limit = rule.max_bytes or DEFAULT_GUARDRAIL_PAYLOAD_LIMIT_BYTES
+        size = _json_size_bytes(tool_input)
+        if size > limit:
+            return _finding(
+                rule=rule,
+                context=context,
+                message=(
+                    f"Tool {context.tool_name} input is {size} bytes, above "
+                    f"{limit} byte guardrail limit."
+                ),
+                details={"input_bytes": size, "max_bytes": limit},
+            )
+    if rule.rule_type == RuntimeGuardrailRuleType.CALL_FREQUENCY:
+        limit = rule.max_calls_per_task
+        if limit is not None and call_count > limit:
+            return _finding(
+                rule=rule,
+                context=context,
+                message=(
+                    f"Tool {context.tool_name} has been called {call_count} times "
+                    f"for this task, above guardrail limit {limit}."
+                ),
+                details={"call_count": call_count, "max_calls_per_task": limit},
+            )
+    if rule.rule_type == RuntimeGuardrailRuleType.SHELL_DESTRUCTIVE_PATTERN:
+        command = _tool_command(tool_input)
+        if not command:
+            return None
+        pattern = _matching_pattern(command=command, patterns=rule.blocked_patterns)
+        if pattern:
+            return _finding(
+                rule=rule,
+                context=context,
+                message="Shell command matched a destructive runtime guardrail pattern.",
+                details={"pattern": pattern, "command": command[:500]},
+            )
+    return None
+
+
+def _evaluate_in_execution_rule(
+    *,
+    rule: RuntimeGuardrailRule,
+    context: RuntimeGuardrailContext,
+    result_envelope: dict[str, JsonValue],
+) -> RuntimeGuardrailFinding | None:
+    if rule.rule_type != RuntimeGuardrailRuleType.OUTPUT_SIZE:
+        return None
+    limit = rule.max_bytes or DEFAULT_GUARDRAIL_PAYLOAD_LIMIT_BYTES
+    size = _json_size_bytes(result_envelope)
+    if size <= limit:
+        return None
+    return _finding(
+        rule=rule,
+        context=context,
+        message=(
+            f"Tool {context.tool_name} output is {size} bytes, above "
+            f"{limit} byte guardrail limit."
+        ),
+        details={"output_bytes": size, "max_bytes": limit},
+    )
+
+
+def _record_tool_call_state_json(
+    *,
+    raw: str | None,
+    context: RuntimeGuardrailContext,
+) -> str:
+    state = _runtime_guardrail_state_from_raw(raw=raw, context=context)
+    counts = dict(state.tool_call_counts)
+    counts[context.tool_name] = counts.get(context.tool_name, 0) + 1
+    return state.model_copy(
+        update={
+            "run_id": context.run_id,
+            "session_id": context.session_id,
+            "role_id": context.role_id,
+            "tool_call_counts": counts,
+            "updated_at": datetime.now(tz=timezone.utc),
+        }
+    ).model_dump_json()
+
+
+def _record_findings_state_json(
+    *,
+    raw: str | None,
+    context: RuntimeGuardrailContext,
+    findings: tuple[RuntimeGuardrailFinding, ...],
+) -> str:
+    state = _runtime_guardrail_state_from_raw(raw=raw, context=context)
+    retained_warning_count = _count_observations_by_action(
+        observations=state.observations,
+        action=RuntimeGuardrailAction.WARN,
+    )
+    retained_blocked_count = _count_observations_by_action(
+        observations=state.observations,
+        action=RuntimeGuardrailAction.DENY,
+    )
+    warning_count = max(state.warning_count, retained_warning_count) + sum(
+        1 for finding in findings if finding.action == RuntimeGuardrailAction.WARN
+    )
+    blocked_count = max(state.blocked_count, retained_blocked_count) + sum(
+        1 for finding in findings if finding.action == RuntimeGuardrailAction.DENY
+    )
+    observations = list(state.observations)
+    observations.extend(
+        RuntimeGuardrailObservation(
+            run_id=context.run_id,
+            session_id=context.session_id,
+            task_id=context.task_id,
+            instance_id=context.instance_id,
+            role_id=context.role_id,
+            tool_name=context.tool_name,
+            tool_call_id=context.tool_call_id,
+            layer=finding.layer,
+            rule_id=finding.rule_id,
+            rule_type=finding.rule_type,
+            action=finding.action,
+            message=finding.message,
+            details=finding.details,
+        )
+        for finding in findings
+    )
+    retained = _retain_observations(
+        observations=observations,
+        limit=MAX_RECORDED_GUARDRAIL_OBSERVATIONS,
+    )
+    return state.model_copy(
+        update={
+            "run_id": context.run_id,
+            "session_id": context.session_id,
+            "role_id": context.role_id,
+            "warning_count": warning_count,
+            "blocked_count": blocked_count,
+            "observations": retained,
+            "updated_at": datetime.now(tz=timezone.utc),
+        }
+    ).model_dump_json()
+
+
+def _runtime_guardrail_state_from_raw(
+    *,
+    raw: str | None,
+    context: RuntimeGuardrailContext,
+) -> RuntimeGuardrailState:
+    if raw is not None:
+        try:
+            return RuntimeGuardrailState.model_validate_json(raw)
+        except ValueError:
+            pass
+    return RuntimeGuardrailState(
+        task_id=context.task_id,
+        run_id=context.run_id,
+        session_id=context.session_id,
+        role_id=context.role_id,
+    )
+
+
+def _report_checks(
+    *,
+    blocked_count: int,
+    warning_count: int,
+    observations: tuple[RuntimeGuardrailObservation, ...],
+) -> tuple[RuntimeGuardrailReportCheck, ...]:
+    pre_blocked = _count_observations(
+        observations=observations,
+        layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+        action=RuntimeGuardrailAction.DENY,
+    )
+    in_execution_blocked = _count_observations(
+        observations=observations,
+        layer=RuntimeGuardrailLayer.IN_EXECUTION,
+        action=RuntimeGuardrailAction.DENY,
+    )
+    return (
+        RuntimeGuardrailReportCheck(
+            layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+            name="pre_execution_boundary",
+            passed=pre_blocked == 0,
+            details=(
+                "No pre-execution guardrail blocked tool calls."
+                if pre_blocked == 0
+                else f"{pre_blocked} pre-execution guardrail block(s) recorded."
+            ),
+        ),
+        RuntimeGuardrailReportCheck(
+            layer=RuntimeGuardrailLayer.IN_EXECUTION,
+            name="execution_monitoring",
+            passed=in_execution_blocked == 0,
+            details=(
+                "Execution monitoring did not block tool outputs."
+                if in_execution_blocked == 0
+                else f"{in_execution_blocked} execution monitoring block(s) recorded."
+            ),
+        ),
+        RuntimeGuardrailReportCheck(
+            layer=RuntimeGuardrailLayer.POST_VALIDATION,
+            name="guardrail_report_available",
+            passed=True,
+            details=(
+                f"Runtime guardrail report generated with {blocked_count} block(s) "
+                f"and {warning_count} warning(s)."
+            ),
+        ),
+    )
+
+
+def _report_status(
+    *,
+    blocked_count: int,
+    warning_count: int,
+) -> RuntimeGuardrailStatus:
+    if blocked_count > 0:
+        return RuntimeGuardrailStatus.BLOCKED
+    if warning_count > 0:
+        return RuntimeGuardrailStatus.WARNING
+    return RuntimeGuardrailStatus.PASSED
+
+
+def _count_observations(
+    *,
+    observations: tuple[RuntimeGuardrailObservation, ...],
+    layer: RuntimeGuardrailLayer,
+    action: RuntimeGuardrailAction,
+) -> int:
+    return sum(
+        1
+        for observation in observations
+        if observation.layer == layer and observation.action == action
+    )
+
+
+def _count_observations_by_action(
+    *,
+    observations: tuple[RuntimeGuardrailObservation, ...],
+    action: RuntimeGuardrailAction,
+) -> int:
+    return sum(1 for observation in observations if observation.action == action)
+
+
+def _retain_observations(
+    *,
+    observations: list[RuntimeGuardrailObservation],
+    limit: int,
+) -> tuple[RuntimeGuardrailObservation, ...]:
+    if len(observations) <= limit:
+        return tuple(observations)
+    deny_obs = [o for o in observations if o.action == RuntimeGuardrailAction.DENY]
+    other_obs = [o for o in observations if o.action != RuntimeGuardrailAction.DENY]
+    if len(deny_obs) >= limit:
+        return tuple(deny_obs[-limit:])
+    remaining = limit - len(deny_obs)
+    return tuple(deny_obs + other_obs[-remaining:])
+
+
+def _finding(
+    *,
+    rule: RuntimeGuardrailRule,
+    context: RuntimeGuardrailContext,
+    message: str,
+    details: dict[str, JsonValue],
+) -> RuntimeGuardrailFinding:
+    scoped_details = dict(details)
+    scoped_details["role_id"] = context.role_id
+    scoped_details["task_id"] = context.task_id
+    return RuntimeGuardrailFinding(
+        layer=rule.layer,
+        rule_id=rule.rule_id,
+        rule_type=rule.rule_type,
+        action=rule.action,
+        message=message,
+        details=scoped_details,
+    )
+
+
+def _rule_matches_context(
+    *,
+    rule: RuntimeGuardrailRule,
+    context: RuntimeGuardrailContext,
+) -> bool:
+    if rule.tool_names and context.tool_name not in rule.tool_names:
+        return False
+    if rule.role_ids and context.role_id not in rule.role_ids:
+        return False
+    if rule.session_modes and context.session_mode not in rule.session_modes:
+        return False
+    return not rule.run_kinds or context.run_kind in rule.run_kinds
+
+
+def _tool_command(tool_input: dict[str, JsonValue]) -> str:
+    value = tool_input.get("command")
+    return value if isinstance(value, str) else ""
+
+
+def _matching_pattern(*, command: str, patterns: tuple[str, ...]) -> str:
+    for pattern in patterns:
+        if _pattern_matches(command=command, pattern=pattern):
+            return pattern
+    return ""
+
+
+def _pattern_matches(*, command: str, pattern: str) -> bool:
+    try:
+        return re.search(pattern, command, flags=re.IGNORECASE) is not None
+    except re.error:
+        return pattern.casefold() in command.casefold()
+
+
+def _json_size_bytes(value: JsonValue | dict[str, JsonValue]) -> int:
+    return len(json.dumps(value, ensure_ascii=False, sort_keys=True).encode("utf-8"))
+
+
+def _json_string_list(items: set[str]) -> list[JsonValue]:
+    result: list[JsonValue] = []
+    for item in sorted(items):
+        result.append(item)
+    return result
+
+
+def _task_scope(task_id: str) -> ScopeRef:
+    return ScopeRef(scope_type=ScopeType.TASK, scope_id=task_id)

--- a/src/relay_teams/tools/runtime/policy.py
+++ b/src/relay_teams/tools/runtime/policy.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from relay_teams.computer import ComputerActionRisk
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
+from relay_teams.tools.runtime.guardrails import RuntimeGuardrailPolicy
 from relay_teams.tools.runtime.models import (
     ToolApprovalDecision,
     ToolApprovalRequest,
@@ -32,6 +33,7 @@ class ToolRuntimePolicy(BaseModel):
     yolo: bool = False
     approval_required_tools: frozenset[str] = DEFAULT_APPROVAL_REQUIRED_TOOLS
     denied_tools: frozenset[str] = frozenset()
+    guardrails: RuntimeGuardrailPolicy = Field(default_factory=RuntimeGuardrailPolicy)
     timeout_seconds: float = 300.0
 
     def requires_approval(self, tool_name: str) -> bool:
@@ -104,6 +106,7 @@ class ToolApprovalPolicy(ToolRuntimePolicy):
             yolo=yolo,
             approval_required_tools=self.approval_required_tools,
             denied_tools=self.denied_tools,
+            guardrails=self.guardrails,
             timeout_seconds=self.timeout_seconds,
         )
 

--- a/tests/unit_tests/agents/orchestration/test_runtime_guardrail_reports.py
+++ b/tests/unit_tests/agents/orchestration/test_runtime_guardrail_reports.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from relay_teams.agents.orchestration.coordinator import CoordinatorGraph
+from relay_teams.agents.orchestration.task_execution_service import TaskExecutionService
+from relay_teams.agents.tasks.models import TaskEnvelope, TaskRecord, VerificationPlan
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.tools.runtime.guardrails import (
+    runtime_guardrail_report_from_event_payload,
+)
+
+
+class _AsyncRunEventHub:
+    def __init__(self) -> None:
+        self.events: list[RunEvent] = []
+
+    async def publish_async(self, event: RunEvent) -> int:
+        self.events.append(event)
+        return len(self.events)
+
+
+def _task() -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        role_id="gater",
+        objective="Verify guarded runtime execution",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+
+
+def _malformed_guardrail_report_event(task: TaskEnvelope) -> RunEvent:
+    return RunEvent(
+        session_id=task.session_id,
+        run_id=task.trace_id,
+        trace_id=task.trace_id,
+        task_id=task.task_id,
+        instance_id="inst-1",
+        role_id=task.role_id,
+        event_type=RunEventType.RUNTIME_GUARDRAIL_REPORT,
+        payload_json='{"report": "not-a-report"}',
+    )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_regenerates_unparseable_runtime_guardrail_report(
+    tmp_path: Path,
+) -> None:
+    task = _task()
+    event_log = EventLog(tmp_path / "events.db")
+    _ = event_log.emit_run_event(_malformed_guardrail_report_event(task))
+    coordinator = CoordinatorGraph.model_construct(
+        shared_store=SharedStateRepository(tmp_path / "state.db"),
+        event_bus=event_log,
+        run_event_hub=None,
+    )
+
+    await coordinator._ensure_runtime_guardrail_report_async(
+        root_record=TaskRecord(envelope=task, assigned_instance_id="inst-1")
+    )
+
+    report_events = tuple(
+        event
+        for event in event_log.list_by_trace(task.trace_id)
+        if event.get("event_type") == RunEventType.RUNTIME_GUARDRAIL_REPORT.value
+    )
+    parsed = runtime_guardrail_report_from_event_payload(
+        report_events[-1].get("payload_json")
+    )
+    assert len(report_events) == 2
+    assert parsed is not None
+    assert parsed.task_id == task.task_id
+
+
+@pytest.mark.asyncio
+async def test_coordinator_keeps_parseable_runtime_guardrail_report(
+    tmp_path: Path,
+) -> None:
+    task = _task()
+    event_log = EventLog(tmp_path / "events.db")
+    coordinator = CoordinatorGraph.model_construct(
+        shared_store=SharedStateRepository(tmp_path / "state.db"),
+        event_bus=event_log,
+        run_event_hub=None,
+    )
+
+    await coordinator._ensure_runtime_guardrail_report_async(
+        root_record=TaskRecord(envelope=task, assigned_instance_id="inst-1")
+    )
+    await coordinator._ensure_runtime_guardrail_report_async(
+        root_record=TaskRecord(envelope=task, assigned_instance_id="inst-1")
+    )
+
+    report_events = tuple(
+        event
+        for event in event_log.list_by_trace(task.trace_id)
+        if event.get("event_type") == RunEventType.RUNTIME_GUARDRAIL_REPORT.value
+    )
+    assert len(report_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_coordinator_publishes_runtime_guardrail_report_to_hub(
+    tmp_path: Path,
+) -> None:
+    task = _task()
+    hub = _AsyncRunEventHub()
+    coordinator = CoordinatorGraph.model_construct(
+        shared_store=SharedStateRepository(tmp_path / "state.db"),
+        event_bus=EventLog(tmp_path / "events.db"),
+        run_event_hub=hub,
+    )
+
+    await coordinator._ensure_runtime_guardrail_report_async(
+        root_record=TaskRecord(envelope=task, assigned_instance_id="inst-1")
+    )
+
+    assert len(hub.events) == 1
+    assert hub.events[0].event_type == RunEventType.RUNTIME_GUARDRAIL_REPORT
+
+
+@pytest.mark.asyncio
+async def test_task_execution_service_publishes_runtime_guardrail_report_to_event_log(
+    tmp_path: Path,
+) -> None:
+    task = _task()
+    event_log = EventLog(tmp_path / "events.db")
+    service = TaskExecutionService.model_construct(
+        shared_store=SharedStateRepository(tmp_path / "state.db"),
+        event_bus=event_log,
+        run_event_hub=None,
+    )
+
+    await service._publish_runtime_guardrail_report_async(
+        task=task,
+        instance_id="inst-1",
+        role_id="gater",
+    )
+
+    events = event_log.list_by_trace(task.trace_id)
+    assert len(events) == 1
+    assert events[0].get("event_type") == RunEventType.RUNTIME_GUARDRAIL_REPORT.value
+
+
+@pytest.mark.asyncio
+async def test_task_execution_service_publishes_runtime_guardrail_report_to_hub(
+    tmp_path: Path,
+) -> None:
+    task = _task()
+    hub = _AsyncRunEventHub()
+    service = TaskExecutionService.model_construct(
+        shared_store=SharedStateRepository(tmp_path / "state.db"),
+        event_bus=EventLog(tmp_path / "events.db"),
+        run_event_hub=hub,
+    )
+
+    await service._publish_runtime_guardrail_report_async(
+        task=task,
+        instance_id="inst-1",
+        role_id="gater",
+    )
+
+    assert len(hub.events) == 1
+    assert hub.events[0].event_type == RunEventType.RUNTIME_GUARDRAIL_REPORT

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -39,6 +39,10 @@ from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.tools.runtime.guardrails import (
+    RuntimeGuardrailReport,
+    RuntimeGuardrailStatus,
+)
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 
 YOLO_TOOL_APPROVAL_POLICY = ToolApprovalPolicy(yolo=True)
@@ -143,6 +147,99 @@ def test_verify_task_builds_structured_report(tmp_path: Path) -> None:
     assert result.report.evidence_bundle.expectation_links[0].satisfied is True
     assert result.report.semantic_results[0].passed is True
     assert result.report.unmet_items == ()
+
+
+def test_verify_task_requires_runtime_guardrail_report_when_requested(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_guardrail_missing.db"
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Return evidence",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(
+        task.task_id,
+        TaskStatus.COMPLETED,
+        result="done",
+    )
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        require_guardrail_report=True,
+    )
+
+    assert result.passed is False
+    assert result.report is not None
+    assert "runtime_guardrail_report" in result.report.unmet_items
+
+
+def test_verify_task_accepts_runtime_guardrail_report_as_security_evidence(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_guardrail_present.db"
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-1",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Return evidence",
+        verification=VerificationPlan(checklist=("non_empty_response",)),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(
+        task.task_id,
+        TaskStatus.COMPLETED,
+        result="done",
+    )
+    report = RuntimeGuardrailReport(
+        task_id=task.task_id,
+        run_id=task.trace_id,
+        session_id=task.session_id,
+        role_id="gater",
+        status=RuntimeGuardrailStatus.PASSED,
+    )
+    _ = event_log.emit_run_event(
+        RunEvent(
+            session_id=task.session_id,
+            run_id=task.trace_id,
+            trace_id=task.trace_id,
+            task_id=task.task_id,
+            instance_id="inst-1",
+            role_id="gater",
+            event_type=RunEventType.RUNTIME_GUARDRAIL_REPORT,
+            payload_json=report.model_dump_json(),
+        )
+    )
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        require_guardrail_report=True,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    assert any(
+        check.layer == VerificationLayer.SECURITY
+        and check.name == "runtime_guardrail_status"
+        and check.passed
+        for check in result.report.checks
+    )
+    assert result.report.evidence_bundle is not None
+    assert any(
+        item.kind == VerificationEvidenceKind.RUNTIME_GUARDRAIL_REPORT
+        for item in result.report.evidence_bundle.items
+    )
 
 
 def test_verify_task_enforces_role_contract_postconditions(tmp_path: Path) -> None:

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -64,6 +64,14 @@ from relay_teams.tools.runtime.models import (
     ToolExecutionError,
     ToolResultProjection,
 )
+from relay_teams.tools.runtime.guardrails import (
+    RuntimeGuardrailAction,
+    RuntimeGuardrailLayer,
+    RuntimeGuardrailPolicy,
+    RuntimeGuardrailRule,
+    RuntimeGuardrailRuleType,
+    RuntimeGuardrailStatus,
+)
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.runtime.persisted_state import (
     ToolApprovalMode,
@@ -1889,6 +1897,144 @@ def test_execute_tool_marks_sqlite_lock_error_as_retryable() -> None:
     assert result["ok"] is False
     assert error["type"] == "internal_error"
     assert error["retryable"] is True
+
+
+def test_execute_tool_blocks_destructive_shell_with_runtime_guardrail() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(yolo=True),
+    )
+    deps.role_registry.register(
+        RoleDefinition(
+            role_id="spec_coder",
+            name="Spec Coder",
+            description="Implements requested changes.",
+            version="1",
+            tools=("shell",),
+            system_prompt="Implement tasks.",
+        )
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-shell-destructive-1"
+    action_calls = 0
+
+    def action() -> str:
+        nonlocal action_calls
+        action_calls += 1
+        return "should not run"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="shell",
+            args_summary={"command": "rm -rf build"},
+            action=action,
+        )
+    )
+
+    error = cast(dict[str, JsonValue], result["error"])
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert action_calls == 0
+    assert result["ok"] is False
+    assert error["type"] == "runtime_guardrail_denied"
+    assert meta["runtime_guardrail_status"] == RuntimeGuardrailStatus.BLOCKED.value
+    assert meta["approval_status"] == "denied_by_guardrail"
+    assert meta["runtime_policy_decision"] == "deny"
+
+
+def test_execute_tool_keeps_result_when_in_execution_guardrail_warns() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(
+            yolo=True,
+            guardrails=RuntimeGuardrailPolicy(
+                rules=(
+                    RuntimeGuardrailRule(
+                        rule_id="tiny-output-warning",
+                        layer=RuntimeGuardrailLayer.IN_EXECUTION,
+                        rule_type=RuntimeGuardrailRuleType.OUTPUT_SIZE,
+                        action=RuntimeGuardrailAction.WARN,
+                        max_bytes=1,
+                    ),
+                )
+            ),
+        ),
+    )
+    deps.role_registry.register(
+        RoleDefinition(
+            role_id="spec_coder",
+            name="Spec Coder",
+            description="Implements requested changes.",
+            version="1",
+            tools=("read",),
+            system_prompt="Implement tasks.",
+        )
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-read-output-warning-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=lambda: {"content": "x" * 32},
+        )
+    )
+
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert result["ok"] is True
+    assert result["data"] == {"content": "x" * 32}
+    assert meta["runtime_guardrail_status"] == RuntimeGuardrailStatus.WARNING.value
+    assert meta["runtime_guardrail_warning_count"] == 1
+
+
+def test_execute_tool_replaces_result_when_in_execution_guardrail_denies() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(
+            yolo=True,
+            guardrails=RuntimeGuardrailPolicy(
+                rules=(
+                    RuntimeGuardrailRule(
+                        rule_id="tiny-output-deny",
+                        layer=RuntimeGuardrailLayer.IN_EXECUTION,
+                        rule_type=RuntimeGuardrailRuleType.OUTPUT_SIZE,
+                        action=RuntimeGuardrailAction.DENY,
+                        max_bytes=1,
+                    ),
+                )
+            ),
+        ),
+    )
+    deps.role_registry.register(
+        RoleDefinition(
+            role_id="spec_coder",
+            name="Spec Coder",
+            description="Implements requested changes.",
+            version="1",
+            tools=("read",),
+            system_prompt="Implement tasks.",
+        )
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-read-output-deny-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=lambda: {"content": "x" * 32},
+        )
+    )
+
+    error = cast(dict[str, JsonValue], result["error"])
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert result["ok"] is False
+    assert error["type"] == "runtime_guardrail_denied"
+    assert meta["runtime_guardrail_status"] == RuntimeGuardrailStatus.BLOCKED.value
+    assert meta["runtime_guardrail_blocked_count"] == 1
 
 
 class _FakeHookService:

--- a/tests/unit_tests/tools/runtime/test_guardrails.py
+++ b/tests/unit_tests/tools/runtime/test_guardrails.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from relay_teams.persistence.shared_state_repo import SharedStateRepository
+from relay_teams.tools.runtime.guardrails import (
+    MAX_RECORDED_GUARDRAIL_OBSERVATIONS,
+    RuntimeGuardrailAction,
+    RuntimeGuardrailContext,
+    RuntimeGuardrailFinding,
+    RuntimeGuardrailPolicy,
+    RuntimeGuardrailLayer,
+    RuntimeGuardrailReport,
+    RuntimeGuardrailRule,
+    RuntimeGuardrailRuleType,
+    RuntimeGuardrailStatus,
+    build_runtime_guardrail_report,
+    evaluate_in_execution_guardrails,
+    evaluate_pre_execution_guardrails,
+    generate_runtime_guardrail_report_async,
+    load_runtime_guardrail_state_async,
+    record_runtime_guardrail_findings_async,
+    record_runtime_guardrail_tool_call_async,
+    runtime_guardrail_report_from_event_payload,
+)
+
+
+def _context() -> RuntimeGuardrailContext:
+    return RuntimeGuardrailContext(
+        run_id="run-1",
+        session_id="session-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="gater",
+        tool_name="shell",
+        tool_call_id="call-1",
+        session_mode="orchestration",
+        run_kind="conversation",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_execution_guardrails_deny_unauthorized_tool() -> None:
+    context = _context()
+
+    evaluation = evaluate_pre_execution_guardrails(
+        policy=RuntimeGuardrailPolicy(),
+        context=context,
+        tool_input={"command": "pytest -q"},
+        allowed_tools=("read",),
+        denied_tools=(),
+        call_count=1,
+    )
+
+    assert evaluation.blocked is True
+    assert evaluation.findings[0].rule_type == RuntimeGuardrailRuleType.TOOL_ALLOWLIST
+    assert evaluation.findings[0].action == RuntimeGuardrailAction.DENY
+
+
+@pytest.mark.asyncio
+async def test_pre_execution_guardrails_deny_destructive_shell_pattern() -> None:
+    context = _context()
+
+    evaluation = evaluate_pre_execution_guardrails(
+        policy=RuntimeGuardrailPolicy(),
+        context=context,
+        tool_input={"command": "rm -rf build"},
+        allowed_tools=("shell",),
+        denied_tools=(),
+        call_count=1,
+    )
+
+    assert evaluation.blocked is True
+    assert evaluation.findings[0].rule_id == "destructive_shell_pattern"
+
+
+@pytest.mark.asyncio
+async def test_in_execution_guardrails_can_block_large_output() -> None:
+    context = _context()
+    policy = RuntimeGuardrailPolicy(
+        rules=(
+            RuntimeGuardrailRule(
+                rule_id="tiny-output",
+                layer=RuntimeGuardrailLayer.IN_EXECUTION,
+                rule_type=RuntimeGuardrailRuleType.OUTPUT_SIZE,
+                action=RuntimeGuardrailAction.DENY,
+                max_bytes=10,
+            ),
+        )
+    )
+
+    evaluation = evaluate_in_execution_guardrails(
+        policy=policy,
+        context=context,
+        tool_input={"command": "printf large"},
+        result_envelope={"ok": True, "data": {"content": "x" * 64}, "meta": {}},
+    )
+
+    assert evaluation.blocked is True
+    assert evaluation.findings[0].rule_id == "tiny-output"
+
+
+@pytest.mark.asyncio
+async def test_guardrail_report_summarizes_recorded_findings(tmp_path: Path) -> None:
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    context = _context()
+    call_count = await record_runtime_guardrail_tool_call_async(
+        shared_store=shared_store,
+        context=context,
+    )
+    evaluation = evaluate_pre_execution_guardrails(
+        policy=RuntimeGuardrailPolicy(),
+        context=context,
+        tool_input={"command": "rm -rf build"},
+        allowed_tools=("shell",),
+        denied_tools=(),
+        call_count=call_count,
+    )
+    _ = await record_runtime_guardrail_findings_async(
+        shared_store=shared_store,
+        context=context,
+        findings=evaluation.findings,
+    )
+
+    report = await generate_runtime_guardrail_report_async(
+        shared_store=shared_store,
+        task_id=context.task_id,
+        run_id=context.run_id,
+        session_id=context.session_id,
+        role_id=context.role_id,
+    )
+
+    assert isinstance(report, RuntimeGuardrailReport)
+    assert report.status == RuntimeGuardrailStatus.BLOCKED
+    assert report.total_tool_calls == 1
+    assert report.blocked_count == 1
+    assert report.checks[0].passed is False
+
+
+@pytest.mark.asyncio
+async def test_guardrail_state_preserves_concurrent_updates(tmp_path: Path) -> None:
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    contexts = tuple(
+        _context().model_copy(update={"tool_call_id": f"call-{index}"})
+        for index in range(1, 25)
+    )
+
+    counts = await asyncio.gather(
+        *(
+            record_runtime_guardrail_tool_call_async(
+                shared_store=shared_store,
+                context=context,
+            )
+            for context in contexts
+        )
+    )
+    evaluations = tuple(
+        evaluate_pre_execution_guardrails(
+            policy=RuntimeGuardrailPolicy(),
+            context=context,
+            tool_input={"command": f"rm -rf build-{index}"},
+            allowed_tools=("shell",),
+            denied_tools=(),
+            call_count=1,
+        )
+        for index, context in enumerate(contexts, start=1)
+    )
+    _ = await asyncio.gather(
+        *(
+            record_runtime_guardrail_findings_async(
+                shared_store=shared_store,
+                context=context,
+                findings=evaluation.findings,
+            )
+            for context, evaluation in zip(contexts, evaluations, strict=True)
+        )
+    )
+
+    state = await load_runtime_guardrail_state_async(
+        shared_store=shared_store,
+        task_id="task-1",
+    )
+
+    assert sorted(counts) == list(range(1, 25))
+    assert state is not None
+    assert state.tool_call_counts == {"shell": 24}
+    assert len(state.observations) == 24
+    assert {observation.tool_call_id for observation in state.observations} == {
+        context.tool_call_id for context in contexts
+    }
+
+
+@pytest.mark.asyncio
+async def test_guardrail_report_preserves_counts_after_observation_truncation(
+    tmp_path: Path,
+) -> None:
+    shared_store = SharedStateRepository(tmp_path / "state.db")
+    context = _context()
+    blocked_finding = RuntimeGuardrailFinding(
+        layer=RuntimeGuardrailLayer.PRE_EXECUTION,
+        rule_id="blocked-shell",
+        rule_type=RuntimeGuardrailRuleType.SHELL_DESTRUCTIVE_PATTERN,
+        action=RuntimeGuardrailAction.DENY,
+        message="blocked",
+    )
+    warning_finding = RuntimeGuardrailFinding(
+        layer=RuntimeGuardrailLayer.IN_EXECUTION,
+        rule_id="large-output",
+        rule_type=RuntimeGuardrailRuleType.OUTPUT_SIZE,
+        action=RuntimeGuardrailAction.WARN,
+        message="large output",
+    )
+
+    _ = await record_runtime_guardrail_findings_async(
+        shared_store=shared_store,
+        context=context,
+        findings=(blocked_finding,),
+    )
+    for index in range(MAX_RECORDED_GUARDRAIL_OBSERVATIONS + 5):
+        _ = await record_runtime_guardrail_findings_async(
+            shared_store=shared_store,
+            context=context.model_copy(update={"tool_call_id": f"warn-{index}"}),
+            findings=(warning_finding,),
+        )
+
+    report = await generate_runtime_guardrail_report_async(
+        shared_store=shared_store,
+        task_id=context.task_id,
+        run_id=context.run_id,
+        session_id=context.session_id,
+        role_id=context.role_id,
+    )
+
+    assert len(report.observations) == MAX_RECORDED_GUARDRAIL_OBSERVATIONS
+    deny_obs = [
+        o for o in report.observations if o.action == RuntimeGuardrailAction.DENY
+    ]
+    warn_obs = [
+        o for o in report.observations if o.action == RuntimeGuardrailAction.WARN
+    ]
+    assert len(deny_obs) == 1
+    assert len(warn_obs) == MAX_RECORDED_GUARDRAIL_OBSERVATIONS - 1
+    assert report.blocked_count == 1
+    assert report.warning_count == MAX_RECORDED_GUARDRAIL_OBSERVATIONS + 5
+    assert report.status == RuntimeGuardrailStatus.BLOCKED
+
+
+def test_guardrail_report_without_state_is_passed() -> None:
+    report = build_runtime_guardrail_report(
+        state=None,
+        task_id="task-1",
+        run_id="run-1",
+        session_id="session-1",
+        role_id="gater",
+    )
+
+    assert report.status == RuntimeGuardrailStatus.PASSED
+    assert report.total_tool_calls == 0
+
+
+def test_runtime_guardrail_report_from_event_payload_parses_valid_reports() -> None:
+    report = RuntimeGuardrailReport(
+        task_id="task-1",
+        run_id="run-1",
+        session_id="session-1",
+        role_id="gater",
+        status=RuntimeGuardrailStatus.WARNING,
+        warning_count=1,
+    )
+
+    parsed = runtime_guardrail_report_from_event_payload(report.model_dump_json())
+
+    assert parsed is not None
+    assert parsed.status == RuntimeGuardrailStatus.WARNING
+    assert runtime_guardrail_report_from_event_payload("{") is None
+    assert runtime_guardrail_report_from_event_payload("[]") is None

--- a/tests/unit_tests/tools/runtime/test_runtime_policy_boundaries.py
+++ b/tests/unit_tests/tools/runtime/test_runtime_policy_boundaries.py
@@ -18,10 +18,22 @@ from relay_teams.roles.role_contracts import (
     RoleContractInvariant,
     RoleContractInvariantType,
 )
+from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.tools.runtime.context import ToolContext
 from relay_teams.tools.runtime.execution import execute_tool
+from relay_teams.tools.runtime.guardrails import (
+    RuntimeGuardrailAction,
+    RuntimeGuardrailLayer,
+    RuntimeGuardrailPolicy,
+    RuntimeGuardrailRule,
+    RuntimeGuardrailRuleType,
+)
 from relay_teams.tools.runtime.models import ToolApprovalRequest, ToolRuntimeDecision
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
+from relay_teams.tools.runtime.persisted_state import (
+    ToolExecutionStatus,
+    load_tool_call_state,
+)
 from tests.unit_tests.tools.runtime.test_execution import (
     _FakeApprovalManager,
     _FakeCtx,
@@ -349,3 +361,88 @@ def test_execute_tool_denies_when_role_capabilities_cannot_be_resolved() -> None
     assert error["type"] == "tool_policy_denied"
     assert meta["runtime_policy_decision"] == "deny"
     assert meta["approval_status"] == "denied_by_policy"
+
+
+def test_execute_tool_blocks_destructive_shell_in_pre_execution_guardrail() -> None:
+    deps = _PolicyDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(yolo=True),
+    )
+    deps.role_registry.register(
+        deps.role_registry.get("spec_coder").model_copy(update={"tools": ("shell",)})
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-guardrail-rm"
+    called = False
+
+    def action() -> str:
+        nonlocal called
+        called = True
+        return "should not run"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="shell",
+            args_summary={"command": "rm -rf build"},
+            tool_input={"command": "rm -rf build"},
+            action=action,
+        )
+    )
+
+    error = cast(dict[str, JsonValue], result["error"])
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert called is False
+    assert result["ok"] is False
+    assert error["type"] == "runtime_guardrail_denied"
+    assert meta["runtime_guardrail_status"] == "blocked"
+    assert meta["approval_status"] == "denied_by_guardrail"
+    assert any(
+        event.event_type == RunEventType.RUNTIME_GUARDRAIL_ALERT
+        for event in deps.run_event_hub.events
+    )
+
+
+def test_execute_tool_can_block_large_output_in_execution_guardrail() -> None:
+    policy = ToolApprovalPolicy(
+        yolo=True,
+        guardrails=RuntimeGuardrailPolicy(
+            rules=(
+                RuntimeGuardrailRule(
+                    rule_id="tiny-output",
+                    layer=RuntimeGuardrailLayer.IN_EXECUTION,
+                    rule_type=RuntimeGuardrailRuleType.OUTPUT_SIZE,
+                    action=RuntimeGuardrailAction.DENY,
+                    max_bytes=10,
+                ),
+            )
+        ),
+    )
+    deps = _PolicyDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=policy,
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-guardrail-output"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="webfetch",
+            args_summary={"url": "https://example.com"},
+            action=lambda: {"content": "x" * 128},
+        )
+    )
+
+    error = cast(dict[str, JsonValue], result["error"])
+    meta = cast(dict[str, JsonValue], result["meta"])
+    state = load_tool_call_state(
+        shared_store=deps.shared_store,
+        task_id=deps.task_id,
+        tool_call_id="call-guardrail-output",
+    )
+    assert result["ok"] is False
+    assert error["type"] == "runtime_guardrail_denied"
+    assert meta["runtime_guardrail_status"] == "blocked"
+    assert state is not None
+    assert state.execution_status == ToolExecutionStatus.FAILED


### PR DESCRIPTION
## Summary
- add deterministic pre-execution and in-execution runtime guardrail evaluation around tool calls
- persist guardrail observations and publish runtime_guardrail_alert/runtime_guardrail_report events
- require Proof-of-Guardrail evidence in coordinator-driven Gater verification
- document the SG-1 design and implementation contract

Closes #654

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests
- Browser E2E acceptance against a local backend with a fake OpenAI-compatible model requesting shell rm -rf: observed runtime_guardrail_alert, runtime_guardrail_denied tool_result, runtime_guardrail_report, and verified target directory remained present.