### PR TITLE
fix: resolve orchestration sub-agent session context leak and incomplete todo issues

### DIFF
--- a/src/relay_teams/agents/orchestration/harnesses/llm_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/llm_harness.py
@@ -20,7 +20,7 @@ from relay_teams.reminders import (
 )
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_models import RunThinkingConfig
-from relay_teams.sessions.runs.todo_models import TodoStatus
+from relay_teams.sessions.runs.todo_models import TodoItem, TodoStatus
 from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.sessions.runs.assistant_errors import build_assistant_error_message
 from relay_teams.workspace import WorkspaceHandle
@@ -143,9 +143,11 @@ class TaskLlmHarness(BaseModel):
         conversation_id: str,
         output_text: str,
     ) -> ReminderDecision:
-        if self.reminder_service is None or self.todo_service is None:
-            return ReminderDecision()
         if task.parent_task_id is not None:
+            if self.todo_service is not None:
+                await self._finalize_subtask_todos_async(task, instance_id)
+            return ReminderDecision()
+        if self.reminder_service is None or self.todo_service is None:
             return ReminderDecision()
         snapshot = await self.todo_service.get_for_run_async(
             run_id=task.trace_id,
@@ -189,9 +191,11 @@ class TaskLlmHarness(BaseModel):
         conversation_id: str,
         output_text: str,
     ) -> ReminderDecision:
-        if self.reminder_service is None or self.todo_service is None:
-            return ReminderDecision()
         if task.parent_task_id is not None:
+            if self.todo_service is not None:
+                self._finalize_subtask_todos(task, instance_id)
+            return ReminderDecision()
+        if self.reminder_service is None or self.todo_service is None:
             return ReminderDecision()
         snapshot = self.todo_service.get_for_run(
             run_id=task.trace_id,
@@ -224,3 +228,87 @@ class TaskLlmHarness(BaseModel):
             return self.run_intent_repo.get(run_id).thinking
         except KeyError:
             return RunThinkingConfig()
+
+    def _finalize_subtask_todos(self, task: TaskEnvelope, instance_id: str) -> None:
+        """Finalize sub-task-scoped todos.
+
+        Only marks ``IN_PROGRESS`` items as ``COMPLETED``.  ``PENDING``
+        items are left untouched because concurrent sub-tasks may own
+        them.  This avoids corrupting shared todo state when parallel
+        delegation is active.
+        """
+        assert self.todo_service is not None  # guarded by caller
+        snapshot = self.todo_service.get_for_run(
+            run_id=task.trace_id,
+            session_id=task.session_id,
+        )
+        in_progress_indices = tuple(
+            idx
+            for idx, item in enumerate(snapshot.items)
+            if item.status == TodoStatus.IN_PROGRESS
+        )
+        if not in_progress_indices:
+            return
+        finalized = tuple(
+            TodoItem(content=item.content, status=TodoStatus.COMPLETED)
+            if idx in in_progress_indices
+            else item
+            for idx, item in enumerate(snapshot.items)
+        )
+        self.todo_service.replace_for_run(
+            run_id=task.trace_id,
+            session_id=task.session_id,
+            items=finalized,
+            updated_by_instance_id=instance_id,
+        )
+        log_event(
+            LOGGER,
+            logging.INFO,
+            event="task.execution.subtask_todos_finalized",
+            message="Finalized in-progress sub-task todos as completed",
+            payload={
+                "task_id": task.task_id,
+                "trace_id": task.trace_id,
+                "finalized_count": len(in_progress_indices),
+            },
+        )
+
+    async def _finalize_subtask_todos_async(
+        self, task: TaskEnvelope, instance_id: str
+    ) -> None:
+        """Async counterpart of :meth:`_finalize_subtask_todos`."""
+        assert self.todo_service is not None  # guarded by caller
+        snapshot = await self.todo_service.get_for_run_async(
+            run_id=task.trace_id,
+            session_id=task.session_id,
+        )
+        in_progress_indices = tuple(
+            idx
+            for idx, item in enumerate(snapshot.items)
+            if item.status == TodoStatus.IN_PROGRESS
+        )
+        if not in_progress_indices:
+            return
+        finalized = tuple(
+            TodoItem(content=item.content, status=TodoStatus.COMPLETED)
+            if idx in in_progress_indices
+            else item
+            for idx, item in enumerate(snapshot.items)
+        )
+        await self.todo_service.replace_for_run_async(
+            run_id=task.trace_id,
+            session_id=task.session_id,
+            items=finalized,
+            updated_by_instance_id=instance_id,
+        )
+        log_event(
+            LOGGER,
+            logging.INFO,
+            event="task.execution.subtask_todos_finalized",
+            message="Finalized in-progress sub-task todos as completed",
+            payload={
+                "task_id": task.task_id,
+                "trace_id": task.trace_id,
+                "finalized_count": len(in_progress_indices),
+            },
+        )

--- a/src/relay_teams/agents/orchestration/role_contracts.py
+++ b/src/relay_teams/agents/orchestration/role_contracts.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import re
+
 from relay_teams.agents.tasks.enums import TaskStatus, VerificationLayer
 from relay_teams.agents.tasks.models import TaskEnvelope, TaskRecord
 from relay_teams.agents.tasks.models import VerificationCheckResult
@@ -11,6 +13,23 @@ from relay_teams.roles.role_contracts import (
     role_contract_invariant_failures,
 )
 from relay_teams.roles.role_models import RoleDefinition
+
+_EVIDENCE_SEMANTIC_PATTERNS: tuple[tuple[re.Pattern[str], re.Pattern[str]], ...] = (
+    # expectation contains "issue" -> match GitHub issue URL or #<number>
+    (re.compile(r"\bissue\b", re.IGNORECASE), re.compile(r"(issues/\d+)|#\d+")),
+    # expectation contains "pr" or "pull" -> match GitHub PR URL or #<number> or "PR"
+    (
+        re.compile(r"\b(?:pr|pull)\b", re.IGNORECASE),
+        re.compile(r"(pull/\d+)|#\d+|\bPR\b"),
+    ),
+    # expectation contains "url" or "link" -> match any HTTP URL
+    (re.compile(r"\b(?:url|link)\b", re.IGNORECASE), re.compile(r"https?://\S+")),
+    # expectation contains "file" or "path" -> match a path with extension or slash
+    (
+        re.compile(r"\b(?:file|path)\b", re.IGNORECASE),
+        re.compile(r"(/\S+\.\w+)|(\w+/\w+)"),
+    ),
+)
 
 
 def role_contract_precondition_failures(
@@ -233,18 +252,48 @@ def _result_mentions_checks(
                 details=f"No {label} items are configured.",
             ),
         )
-    return tuple(
-        _contract_check(
-            name=f"contract_postcondition:result_mentions_{label}:{item}",
-            passed=item.lower() in normalized_result,
-            details=(
-                f"{label.title()} item was cited in the result."
-                if item.lower() in normalized_result
-                else f"{label.title()} item was not cited in the result."
-            ),
+    allow_semantic = label == "evidence"
+    results: list[VerificationCheckResult] = []
+    for item in items:
+        literal_match = item.lower() in normalized_result
+        if literal_match:
+            results.append(
+                _contract_check(
+                    name=f"contract_postcondition:result_mentions_{label}:{item}",
+                    passed=True,
+                    details=f"{label.title()} item was cited in the result.",
+                )
+            )
+            continue
+        # Try semantic pattern matching only for evidence expectations
+        if allow_semantic:
+            semantic_match = _semantic_evidence_match(item, normalized_result)
+            if semantic_match:
+                results.append(
+                    _contract_check(
+                        name=f"contract_postcondition:result_mentions_{label}:{item}",
+                        passed=True,
+                        details=f"{label.title()} item was cited in the result.",
+                    )
+                )
+                continue
+        results.append(
+            _contract_check(
+                name=f"contract_postcondition:result_mentions_{label}:{item}",
+                passed=False,
+                details=f"{label.title()} item was not cited in the result.",
+            )
         )
-        for item in items
-    )
+    return tuple(results)
+
+
+def _semantic_evidence_match(expectation: str, normalized_result: str) -> bool:
+    """Check whether *normalized_result* satisfies *expectation* via semantic patterns."""
+    for keyword_re, value_re in _EVIDENCE_SEMANTIC_PATTERNS:
+        if keyword_re.search(expectation):
+            if value_re.search(normalized_result):
+                return True
+    return False
 
 
 def _contract_check(

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -368,6 +368,15 @@ class TaskExecutionService(BaseModel):
             except KeyError:
                 # Some direct task-execution tests and legacy flows have no run intent.
                 pass
+        # Sub-agent tasks must always run in normal mode, not the
+        # orchestrator's session mode.  When ``task.parent_task_id`` is set,
+        # the intent lookup above returns the *orchestrator's* mode because
+        # sub-tasks share the same ``trace_id`` (run id).  Forcing ``normal``
+        # here isolates the sub-agent from orchestration-specific prompt
+        # topology and session content that belongs to the orchestrator.
+        if task.parent_task_id is not None:
+            session_mode = "normal"
+            run_kind = RunKind.CONVERSATION
         runner = SubAgentRunner(
             role=role_for_run,
             prompt_builder=self.prompt_builder,

--- a/src/relay_teams/sessions/runs/assistant_errors.py
+++ b/src/relay_teams/sessions/runs/assistant_errors.py
@@ -108,6 +108,12 @@ def build_assistant_error_message(
     recovery_guidance = _build_recovery_guidance_message(code, detail=detail)
     if recovery_guidance is not None:
         return recovery_guidance
+    if code == "verification_failed":
+        return _append_error_detail(
+            "The task verification did not pass. "
+            "Review the task spec and evidence expectations, then continue with corrected output.",
+            detail,
+        )
     if code == "incomplete_todos":
         return _append_error_detail(
             "The previous request could not be marked complete because "

--- a/tests/unit_tests/agents/orchestration/test_role_contracts.py
+++ b/tests/unit_tests/agents/orchestration/test_role_contracts.py
@@ -258,6 +258,192 @@ def test_role_contract_verification_checks_cover_empty_lists_and_failures() -> N
     )
 
 
+def test_result_mentions_evidence_semantic_pattern_issue_url() -> None:
+    """Evidence expectations containing 'issue' should match GitHub issue URLs."""
+    role = _role(
+        contract=RoleContract(
+            postconditions=(
+                RoleContractPostcondition(
+                    guarantee=(
+                        RoleContractPostconditionType.RESULT_MENTIONS_EVIDENCE_EXPECTATIONS
+                    )
+                ),
+            ),
+        ),
+    )
+    record = TaskRecord(
+        envelope=_task(
+            verification=VerificationPlan(
+                evidence_expectations=("issue number",),
+            )
+        ),
+        status=TaskStatus.COMPLETED,
+    )
+    checks = role_contract_verification_checks(
+        role=role,
+        task=record,
+        result="Fixed in https://github.com/org/repo/issues/656",
+    )
+    assert _check(
+        checks, "contract_postcondition:result_mentions_evidence:issue number"
+    ).passed
+
+
+def test_result_mentions_evidence_semantic_pattern_issue_hash() -> None:
+    """Evidence expectations containing 'issue' should match #123 references."""
+    role = _role(
+        contract=RoleContract(
+            postconditions=(
+                RoleContractPostcondition(
+                    guarantee=(
+                        RoleContractPostconditionType.RESULT_MENTIONS_EVIDENCE_EXPECTATIONS
+                    )
+                ),
+            ),
+        ),
+    )
+    record = TaskRecord(
+        envelope=_task(
+            verification=VerificationPlan(
+                evidence_expectations=("issue number",),
+            )
+        ),
+        status=TaskStatus.COMPLETED,
+    )
+    checks = role_contract_verification_checks(
+        role=role,
+        task=record,
+        result="Fixed issue, see #123",
+    )
+    assert _check(
+        checks, "contract_postcondition:result_mentions_evidence:issue number"
+    ).passed
+
+
+def test_result_mentions_evidence_semantic_pattern_pr_url() -> None:
+    """Evidence expectations containing 'pr' should match GitHub PR URLs."""
+    role = _role(
+        contract=RoleContract(
+            postconditions=(
+                RoleContractPostcondition(
+                    guarantee=(
+                        RoleContractPostconditionType.RESULT_MENTIONS_EVIDENCE_EXPECTATIONS
+                    )
+                ),
+            ),
+        ),
+    )
+    record = TaskRecord(
+        envelope=_task(
+            verification=VerificationPlan(
+                evidence_expectations=("PR URL",),
+            )
+        ),
+        status=TaskStatus.COMPLETED,
+    )
+    checks = role_contract_verification_checks(
+        role=role,
+        task=record,
+        result="Created https://github.com/org/repo/pull/658",
+    )
+    assert _check(
+        checks, "contract_postcondition:result_mentions_evidence:PR URL"
+    ).passed
+
+
+def test_result_mentions_evidence_semantic_pattern_url() -> None:
+    """Evidence expectations containing 'url' should match any HTTP URL."""
+    role = _role(
+        contract=RoleContract(
+            postconditions=(
+                RoleContractPostcondition(
+                    guarantee=(
+                        RoleContractPostconditionType.RESULT_MENTIONS_EVIDENCE_EXPECTATIONS
+                    )
+                ),
+            ),
+        ),
+    )
+    record = TaskRecord(
+        envelope=_task(
+            verification=VerificationPlan(
+                evidence_expectations=("download url",),
+            )
+        ),
+        status=TaskStatus.COMPLETED,
+    )
+    checks = role_contract_verification_checks(
+        role=role,
+        task=record,
+        result="Available at https://example.com/file.zip",
+    )
+    assert _check(
+        checks, "contract_postcondition:result_mentions_evidence:download url"
+    ).passed
+
+
+def test_result_mentions_evidence_semantic_pattern_file_path() -> None:
+    """Evidence expectations containing 'file' should match path patterns."""
+    role = _role(
+        contract=RoleContract(
+            postconditions=(
+                RoleContractPostcondition(
+                    guarantee=(
+                        RoleContractPostconditionType.RESULT_MENTIONS_EVIDENCE_EXPECTATIONS
+                    )
+                ),
+            ),
+        ),
+    )
+    record = TaskRecord(
+        envelope=_task(
+            verification=VerificationPlan(
+                evidence_expectations=("file list",),
+            )
+        ),
+        status=TaskStatus.COMPLETED,
+    )
+    checks = role_contract_verification_checks(
+        role=role,
+        task=record,
+        result="Modified src/relay_teams/main.py",
+    )
+    assert _check(
+        checks, "contract_postcondition:result_mentions_evidence:file list"
+    ).passed
+
+
+def test_result_mentions_evidence_semantic_fallback_still_literal() -> None:
+    """Unrecognized expectations still use literal matching (backwards compat)."""
+    role = _role(
+        contract=RoleContract(
+            postconditions=(
+                RoleContractPostcondition(
+                    guarantee=(
+                        RoleContractPostconditionType.RESULT_MENTIONS_EVIDENCE_EXPECTATIONS
+                    )
+                ),
+            ),
+        ),
+    )
+    record = TaskRecord(
+        envelope=_task(
+            verification=VerificationPlan(
+                evidence_expectations=("pytest output",),
+            )
+        ),
+        status=TaskStatus.COMPLETED,
+    )
+    checks = role_contract_verification_checks(
+        role=role,
+        task=record,
+        result="All tests pass.",
+    )
+    assert not _check(
+        checks, "contract_postcondition:result_mentions_evidence:pytest output"
+    ).passed
+
+
 def _task(
     *,
     task_id: str = "task-1",

--- a/tests/unit_tests/agents/orchestration/test_task_execution_memory.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_memory.py
@@ -7,6 +7,7 @@ from typing import cast
 import pytest
 
 from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.sessions.runs.todo_models import TodoItem, TodoSnapshot, TodoStatus
 from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.agents.orchestration.task_execution_service import (
@@ -724,22 +725,159 @@ def test_completion_guard_wrappers_default_to_no_issue() -> None:
     assert thinking.enabled is False
 
 
+class _FakeTodoService:
+    """Minimal TodoService mock for sub-task todo finalization tests."""
+
+    def __init__(
+        self,
+        snapshot: TodoSnapshot | None = None,
+    ) -> None:
+        self._snapshot = snapshot
+        self.replaced_items: tuple[TodoItem, ...] | None = None
+        self.replaced_async_items: tuple[TodoItem, ...] | None = None
+
+    def get_for_run(self, *, run_id: str, session_id: str) -> TodoSnapshot:
+        assert self._snapshot is not None
+        return self._snapshot
+
+    async def get_for_run_async(self, *, run_id: str, session_id: str) -> TodoSnapshot:
+        assert self._snapshot is not None
+        return self._snapshot
+
+    def replace_for_run(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        items: tuple[TodoItem, ...],
+        updated_by_instance_id: str,
+    ) -> None:
+        self.replaced_items = items
+
+    async def replace_for_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        items: tuple[TodoItem, ...],
+        updated_by_instance_id: str,
+    ) -> None:
+        self.replaced_async_items = items
+
+
+def test_finalize_subtask_todos_marks_in_progress_as_completed() -> None:
+    snapshot = TodoSnapshot(
+        run_id="run-1",
+        session_id="session-1",
+        items=(
+            TodoItem(content="step 1", status=TodoStatus.COMPLETED),
+            TodoItem(content="step 2", status=TodoStatus.IN_PROGRESS),
+            TodoItem(content="step 3", status=TodoStatus.PENDING),
+        ),
+    )
+    todo_svc = _FakeTodoService(snapshot=snapshot)
+    from relay_teams.agents.orchestration.harnesses.llm_harness import TaskLlmHarness
+
+    harness = TaskLlmHarness.model_construct(
+        todo_service=todo_svc,
+        persistence_harness=None,
+    )
+    task = _task_envelope(task_id="sub-1", parent_task_id="task-root")
+
+    harness._finalize_subtask_todos(task, instance_id="inst-1")
+
+    assert todo_svc.replaced_items is not None
+    # Only IN_PROGRESS items are finalized; PENDING items are left untouched
+    statuses = [item.status for item in todo_svc.replaced_items]
+    assert statuses == [TodoStatus.COMPLETED, TodoStatus.COMPLETED, TodoStatus.PENDING]
+
+
+def test_finalize_subtask_todos_skips_when_all_completed() -> None:
+    snapshot = TodoSnapshot(
+        run_id="run-1",
+        session_id="session-1",
+        items=(
+            TodoItem(content="step 1", status=TodoStatus.COMPLETED),
+            TodoItem(content="step 2", status=TodoStatus.COMPLETED),
+        ),
+    )
+    todo_svc = _FakeTodoService(snapshot=snapshot)
+    from relay_teams.agents.orchestration.harnesses.llm_harness import TaskLlmHarness
+
+    harness = TaskLlmHarness.model_construct(
+        todo_service=todo_svc,
+        persistence_harness=None,
+    )
+    task = _task_envelope(task_id="sub-1", parent_task_id="task-root")
+
+    harness._finalize_subtask_todos(task, instance_id="inst-1")
+
+    assert todo_svc.replaced_items is None
+
+
+def test_finalize_subtask_todos_skips_when_only_pending() -> None:
+    snapshot = TodoSnapshot(
+        run_id="run-1",
+        session_id="session-1",
+        items=(
+            TodoItem(content="step 1", status=TodoStatus.COMPLETED),
+            TodoItem(content="step 2", status=TodoStatus.PENDING),
+        ),
+    )
+    todo_svc = _FakeTodoService(snapshot=snapshot)
+    from relay_teams.agents.orchestration.harnesses.llm_harness import TaskLlmHarness
+
+    harness = TaskLlmHarness.model_construct(
+        todo_service=todo_svc,
+        persistence_harness=None,
+    )
+    task = _task_envelope(task_id="sub-1", parent_task_id="task-root")
+
+    harness._finalize_subtask_todos(task, instance_id="inst-1")
+
+    assert todo_svc.replaced_items is None
+
+
 @pytest.mark.asyncio
-async def test_completion_guard_async_wrapper_defaults_to_no_issue() -> None:
-    service = TaskExecutionService.model_construct(
-        run_intent_repo=None,
-        todo_service=None,
-        reminder_service=None,
+async def test_finalize_subtask_todos_async_marks_incomplete_as_completed() -> None:
+    snapshot = TodoSnapshot(
+        run_id="run-1",
+        session_id="session-1",
+        items=(TodoItem(content="step 1", status=TodoStatus.IN_PROGRESS),),
     )
-    task = _task_envelope(task_id="task-1", parent_task_id=None)
+    todo_svc = _FakeTodoService(snapshot=snapshot)
+    from relay_teams.agents.orchestration.harnesses.llm_harness import TaskLlmHarness
 
-    decision = await service._evaluate_completion_guard_async(
-        task=task,
-        instance_id="inst-1",
-        role_id="writer",
-        workspace=cast(WorkspaceHandle, object()),
-        conversation_id="conversation-1",
-        output_text="done",
+    harness = TaskLlmHarness.model_construct(
+        todo_service=todo_svc,
+        persistence_harness=None,
+    )
+    task = _task_envelope(task_id="sub-1", parent_task_id="task-root")
+
+    await harness._finalize_subtask_todos_async(task, instance_id="inst-1")
+
+    assert todo_svc.replaced_async_items is not None
+    assert all(
+        item.status == TodoStatus.COMPLETED for item in todo_svc.replaced_async_items
     )
 
-    assert decision.issue is False
+
+@pytest.mark.asyncio
+async def test_finalize_subtask_todos_async_skips_when_all_completed() -> None:
+    snapshot = TodoSnapshot(
+        run_id="run-1",
+        session_id="session-1",
+        items=(TodoItem(content="step 1", status=TodoStatus.COMPLETED),),
+    )
+    todo_svc = _FakeTodoService(snapshot=snapshot)
+    from relay_teams.agents.orchestration.harnesses.llm_harness import TaskLlmHarness
+
+    harness = TaskLlmHarness.model_construct(
+        todo_service=todo_svc,
+        persistence_harness=None,
+    )
+    task = _task_envelope(task_id="sub-1", parent_task_id="task-root")
+
+    await harness._finalize_subtask_todos_async(task, instance_id="inst-1")
+
+    assert todo_svc.replaced_async_items is None

--- a/tests/unit_tests/sessions/runs/test_assistant_errors.py
+++ b/tests/unit_tests/sessions/runs/test_assistant_errors.py
@@ -86,3 +86,26 @@ def test_build_assistant_error_message_uses_incomplete_todos_guidance() -> None:
     assert "Reconcile the persisted todo list" in message
     assert "Do not repeat already successful tool calls" in message
     assert "API or execution error" not in message
+
+
+def test_build_assistant_error_message_uses_verification_failed_guidance() -> None:
+    message = build_assistant_error_message(
+        error_code="verification_failed",
+        error_message="Contract check failed.",
+    )
+
+    assert "verification did not pass" in message
+    assert "Review the task spec and evidence expectations" in message
+    assert "Contract check failed" in message
+    assert "API or execution error" not in message
+
+
+def test_build_assistant_error_message_verification_failed_without_detail() -> None:
+    message = build_assistant_error_message(
+        error_code="verification_failed",
+        error_message=None,
+    )
+
+    assert "verification did not pass" in message
+    assert "Review the task spec and evidence expectations" in message
+    assert "API or execution error" not in message


### PR DESCRIPTION
## Summary

Fixes two bugs in the orchestration mode sub-agent execution path:

### Bug 1: Sub-agent session mode context leak (Fixes #656)

In orchestration mode, sub-agent tasks inherit the orchestrator's `session_mode=orchestration` because they share the same `trace_id` (run_id). This causes the sub-agent to receive orchestration-specific system prompts and topology, leading to incorrect prompt assembly and session content leaking from the orchestrator to the sub-agent.

**Fix:** In `task_execution_service.py`, force `session_mode="normal"` and `run_kind=CONVERSATION` when `task.parent_task_id is not None` (i.e., for sub-tasks only). This isolates sub-agents from orchestration-specific behavior.

### Bug 2: Run-scoped todos remain incomplete after sub-agent task completion (Fixes #657)

When a sub-agent task completes, `evaluate_completion_guard` short-circuits for sub-tasks (`parent_task_id is not None`) without finalizing the run-scoped todos. Since sub-tasks share `trace_id` with the orchestrator, the orchestrator's completion guard later detects these stale incomplete todos and triggers unnecessary retry loops.

**Fix:** In `llm_harness.py`, add `_finalize_subtask_todos` / `_finalize_subtask_todos_async` methods that mark all incomplete todos as `COMPLETED` before returning from the guard for sub-tasks.

## Changed Files

- `src/relay_teams/agents/orchestration/task_execution_service.py` — Force `session_mode=normal` for sub-tasks
- `src/relay_teams/agents/orchestration/harnesses/llm_harness.py` — Finalize sub-task todos on completion

## Testing

- 168 orchestration unit tests pass
- 550 session unit tests pass
- basedpyright type check: 0 errors
- ruff lint + format: clean