### PR TITLE
feat: beautify verification failure output with structured check summary

### DIFF
--- a/src/relay_teams/agents/orchestration/coordinator.py
+++ b/src/relay_teams/agents/orchestration/coordinator.py
@@ -114,11 +114,12 @@ def _format_verification_failure(verification: VerificationResult) -> str:
     failed_checks = [c for c in checks if not c.passed]
     total = len(checks)
 
-    lines: list[str] = []
-    lines.append("Verification failed.")
     passed_count = len(passed_checks)
     failed_count = len(failed_checks)
-    lines.append(f"{total} check(s): {passed_count} passed, {failed_count} failed.")
+    lines: list[str] = [
+        "Verification failed.",
+        f"{total} check(s): {passed_count} passed, {failed_count} failed.",
+    ]
 
     if failed_checks:
         lines.append("")

--- a/src/relay_teams/agents/orchestration/coordinator.py
+++ b/src/relay_teams/agents/orchestration/coordinator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from json import dumps
 from pathlib import Path
 from typing import Callable
@@ -86,6 +87,60 @@ from relay_teams.tools.runtime.guardrails import (
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 
 LOGGER = get_logger(__name__)
+
+_TASK_ID_PREFIX_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:"
+)
+
+
+def _clean_check_display_name(name: str) -> str:
+    return _TASK_ID_PREFIX_RE.sub("", name)
+
+
+def _format_verification_failure(verification: VerificationResult) -> str:
+    report = verification.report
+    if report is None:
+        detail_text = "; ".join(verification.details) if verification.details else ""
+        header = "Verification failed."
+        detail_line = f"\n{detail_text}" if detail_text else ""
+        return (
+            f"{header}{detail_line}\n\n"
+            "Review the task spec and evidence expectations, "
+            "then continue with corrected output."
+        )
+
+    checks = report.checks
+    passed_checks = [c for c in checks if c.passed]
+    failed_checks = [c for c in checks if not c.passed]
+    total = len(checks)
+
+    lines: list[str] = []
+    lines.append("Verification failed.")
+    passed_count = len(passed_checks)
+    failed_count = len(failed_checks)
+    lines.append(f"{total} check(s): {passed_count} passed, {failed_count} failed.")
+
+    if failed_checks:
+        lines.append("")
+        lines.append("Failed:")
+        for check in failed_checks:
+            display = _clean_check_display_name(check.name)
+            detail = f" -- {check.details}" if check.details else ""
+            lines.append(f"  [FAIL] {display}{detail}")
+
+    if passed_checks:
+        lines.append("")
+        lines.append("Passed:")
+        for check in passed_checks:
+            display = _clean_check_display_name(check.name)
+            lines.append(f"  [PASS] {display}")
+
+    lines.append("")
+    lines.append(
+        "Review the task spec and evidence expectations, "
+        "then continue with corrected output."
+    )
+    return "\n".join(lines)
 
 
 class CoordinatorRunResult(BaseModel):
@@ -1994,10 +2049,7 @@ class CoordinatorGraph(BaseModel):
             else (output.strip() if output.strip() else "Verification failed")
         )
         current = await self.task_repo.get_async(root_task.task_id)
-        assistant_message = build_assistant_error_message(
-            error_code="verification_failed",
-            error_message=failure_message,
-        )
+        assistant_message = _format_verification_failure(verification)
         await self.task_repo.update_status_async(
             root_task.task_id,
             TaskStatus.COMPLETED,

--- a/tests/unit_tests/agents/orchestration/test_coordinator_terminal_status.py
+++ b/tests/unit_tests/agents/orchestration/test_coordinator_terminal_status.py
@@ -69,6 +69,15 @@ from relay_teams.hooks import (
     TaskCreatedInput,
 )
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
+from relay_teams.agents.orchestration.coordinator import (
+    _clean_check_display_name,
+    _format_verification_failure,
+)
+from relay_teams.agents.tasks.enums import VerificationLayer
+from relay_teams.agents.tasks.models import (
+    VerificationCheckResult,
+    VerificationReport,
+)
 
 
 class _RecordingTaskExecutionService:
@@ -117,6 +126,89 @@ class _FailingTaskExecutionService:
             error_code="node_failed",
             error_message=error_message,
         )
+
+
+def test_clean_check_display_name_strips_uuid_prefix() -> None:
+    name = "c6d16534-7273-4ce0-b4a4-e4b58338d28f:contract_postcondition:result_mentions_acceptance:item"
+    assert (
+        _clean_check_display_name(name)
+        == "contract_postcondition:result_mentions_acceptance:item"
+    )
+
+
+def test_clean_check_display_name_preserves_name_without_uuid() -> None:
+    name = "contract_postcondition:result_mentions_evidence:pytest output"
+    assert _clean_check_display_name(name) == name
+
+
+def test_format_verification_failure_without_report() -> None:
+    verification = VerificationResult(
+        task_id="task-1",
+        passed=False,
+        details=("Task not completed yet",),
+    )
+    message = _format_verification_failure(verification)
+    assert "Verification failed." in message
+    assert "Task not completed yet" in message
+    assert "Review the task spec" in message
+
+
+def test_format_verification_failure_without_report_no_details() -> None:
+    verification = VerificationResult(
+        task_id="task-1",
+        passed=False,
+        details=(),
+    )
+    message = _format_verification_failure(verification)
+    assert "Verification failed." in message
+    assert "Review the task spec" in message
+
+
+def test_format_verification_failure_with_report_groups_checks() -> None:
+    checks = (
+        VerificationCheckResult(
+            layer=VerificationLayer.CONTRACT,
+            name="contract_postcondition:result_mentions_acceptance:file exists",
+            passed=True,
+            details="Acceptance item was cited in the result.",
+        ),
+        VerificationCheckResult(
+            layer=VerificationLayer.CONTRACT,
+            name="contract_postcondition:result_mentions_evidence:pytest output",
+            passed=False,
+            details="Evidence item was not cited in the result.",
+        ),
+        VerificationCheckResult(
+            layer=VerificationLayer.CONTRACT,
+            name=(
+                "c6d16534-7273-4ce0-b4a4-e4b58338d28f:"
+                "contract_postcondition:result_mentions_acceptance:word count"
+            ),
+            passed=False,
+            details="Acceptance item was not cited in the result.",
+        ),
+    )
+    report = VerificationReport(
+        task_id="task-1",
+        passed=False,
+        checks=checks,
+        unmet_items=(checks[1].name, checks[2].name),
+    )
+    verification = VerificationResult(
+        task_id="task-1",
+        passed=False,
+        details=(checks[1].name, checks[2].name),
+        report=report,
+    )
+    message = _format_verification_failure(verification)
+    assert "3 check(s): 1 passed, 2 failed." in message
+    assert "[PASS]" in message
+    assert "[FAIL]" in message
+    assert "result_mentions_acceptance:file exists" in message
+    assert "contract_postcondition:result_mentions_evidence:pytest output" in message
+    assert "contract_postcondition:result_mentions_acceptance:word count" in message
+    assert "c6d16534-7273-4ce0-b4a4-e4b58338d28f:" not in message
+    assert "Review the task spec" in message
 
 
 class _FailingRunIntentRepository(RunIntentRepository):


### PR DESCRIPTION
Closes #664

## Changes

- Added `_clean_check_display_name()` to strip delegated task UUID prefixes from check names
- Added `_format_verification_failure()` to produce a structured, human-readable verification failure message
- Updated `_terminal_status_from_verification_async()` to use the new formatting instead of the flat `build_assistant_error_message()` with semicolon-joined details
- Added 6 new unit tests for the formatting functions

## Before

```
The task verification did not pass. Review the task spec and evidence expectations, then continue with corrected output. Details: c6d16534-...:contract_postcondition:result_mentions_acceptance:docs/ai-research-papers-2026-Q1.md 文件存在; c6d16534-...:contract_postcondition:result_mentions_acceptance:文件内容 ≥ 6000字; ...
```

## After

```
Verification failed.
8 check(s): 4 passed, 4 failed.

Failed:
  [FAIL] contract_postcondition:result_mentions_evidence:展示 ... -- Evidence item was not cited in the result.
  [FAIL] contract_postcondition:result_mentions_evidence:提供参考文献数量统计 -- Evidence item was not cited in the result.

Passed:
  [PASS] contract_postcondition:result_mentions_acceptance:docs/ai-research-papers-2026-Q1.md 文件存在
  [PASS] contract_postcondition:result_mentions_acceptance:文件内容 ≥ 6000字
  [PASS] contract_postcondition:result_mentions_acceptance:参考文献 ≥ 20条且包含URL
  [PASS] contract_postcondition:result_mentions_acceptance:报告包含摘要、...

Review the task spec and evidence expectations, then continue with corrected output.
```