### PR TITLE
fix: close aiosqlite connections before event loop teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,5 +61,18 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
 
     funcargs = pyfuncitem.funcargs
     test_args = {name: funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
-    asyncio.run(test_function(**test_args))
+
+    async def _run_test_with_sqlite_cleanup() -> None:
+        try:
+            await test_function(**test_args)
+        finally:
+            await _close_live_sqlite_repos_in_current_loop()
+
+    asyncio.run(_run_test_with_sqlite_cleanup())
     return True
+
+
+async def _close_live_sqlite_repos_in_current_loop() -> None:
+    from relay_teams.persistence import close_live_sqlite_repositories_async
+
+    await close_live_sqlite_repositories_async()

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import Generator
 from os import environ
 from pathlib import Path
 
 import pytest
-import pytest_asyncio
 
 from relay_teams.persistence import close_live_sqlite_repositories_async
+from relay_teams.persistence.db import run_async_blocking
 from relay_teams.secrets import AppSecretStore
 
 _UNIT_TESTS_ROOT = Path(__file__).resolve().parent
@@ -27,10 +27,10 @@ def _disable_system_keyring_for_unit_tests(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(secret_store, "_SECRET_STORE", _UnitTestSecretStore())
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def _close_sqlite_repositories_after_unit_test() -> AsyncIterator[None]:
+@pytest.fixture(autouse=True)
+def _close_sqlite_repositories_after_unit_test() -> Generator[None, None, None]:
     yield
-    await close_live_sqlite_repositories_async()
+    run_async_blocking(close_live_sqlite_repositories_async())
 
 
 def pytest_collection_modifyitems(


### PR DESCRIPTION
## Summary

Closes #552

Fixes `ResourceWarning: \<aiosqlite.core.Connection\> was deleted before being closed` warnings emitted during unit test runs.

### Root cause
`pytest_pyfunc_call` in `tests/conftest.py` runs async tests via `asyncio.run()`, which creates and immediately destroys an event loop. aiosqlite connections opened during the test were not closed before the loop was torn down, so their `__del__` emitted ResourceWarning.

### Changes

1. **`tests/conftest.py`**: wrap the async test body in a cleanup coroutine that calls `close_live_sqlite_repositories_async()` inside a `finally` block *before* `asyncio.run()` closes the loop.

2. **`tests/unit_tests/conftest.py`**: replace the `@pytest_asyncio.fixture` autouse fixture with a regular `@pytest.fixture` that uses `run_async_blocking()` for teardown. This removes the dependency on the pytest-asyncio loop lifecycle and ensures cleanup runs in a dedicated thread loop that persists across all fixtures.

### Test results
- ResourceWarning count reduced from **109** to **0** (aiosqlite-specific warnings fully eliminated).
- Pre-commit hooks (ruff, ruff-format, basedpyright) all pass.
- 1 pre-existing test failure (`test_start_runs_uvicorn_and_tracks_managed_process`) is unrelated.