### PR TITLE
refactor: move inline imports to file header

### DIFF
--- a/src/relay_teams/agents/execution/message_repository.py
+++ b/src/relay_teams/agents/execution/message_repository.py
@@ -941,7 +941,6 @@ class MessageRepository(SharedSqliteRepository):
         conversation_id: str | None = None,
         agent_role_id: str | None = None,
     ) -> bool:
-        from pydantic_ai.messages import ModelRequest, UserPromptPart
 
         _ = (session_id, trace_id, workspace_id, agent_role_id)
         target_key = user_prompt_content_key(content)
@@ -1091,7 +1090,6 @@ class MessageRepository(SharedSqliteRepository):
         conversation_id: str | None = None,
         agent_role_id: str | None = None,
     ) -> bool:
-        from pydantic_ai.messages import ModelRequest, UserPromptPart
 
         target_key = user_prompt_content_key(content)
         target_text = user_prompt_content_to_text(content)
@@ -1254,7 +1252,6 @@ class MessageRepository(SharedSqliteRepository):
         conversation_id: str | None = None,
         agent_role_id: str | None = None,
     ) -> bool:
-        from pydantic_ai.messages import ModelRequest, SystemPromptPart
 
         target = str(content or "").strip()
         if not target:
@@ -1897,7 +1894,6 @@ def _project_single_message_row(
 
 
 def _role(msg: ModelMessage) -> str:
-    from pydantic_ai.messages import ModelRequest, ModelResponse
 
     if isinstance(msg, ModelRequest):
         return "user"
@@ -2062,7 +2058,6 @@ def _history_ends_with_user_prompt(
     history: Sequence[ModelMessage],
     content_key: str,
 ) -> bool:
-    from pydantic_ai.messages import ModelRequest, UserPromptPart
 
     target = str(content_key or "").strip()
     if not target or not history:
@@ -2081,7 +2076,6 @@ def _history_ends_with_user_prompt(
 
 
 def _task_history_has_response(rows: Sequence[sqlite3.Row]) -> bool:
-    from pydantic_ai.messages import ModelResponse
 
     for row in rows:
         messages = ModelMessagesTypeAdapter.validate_json(
@@ -2093,7 +2087,6 @@ def _task_history_has_response(rows: Sequence[sqlite3.Row]) -> bool:
 
 
 def _row_is_user_prompt_only(row: sqlite3.Row) -> bool:
-    from pydantic_ai.messages import ModelRequest, UserPromptPart
 
     messages = ModelMessagesTypeAdapter.validate_json(
         _sanitize_message_json(str(row["message_json"]))
@@ -2111,7 +2104,6 @@ def _history_ends_with_system_prompt(
     history: Sequence[ModelMessage],
     content: str,
 ) -> bool:
-    from pydantic_ai.messages import ModelRequest, SystemPromptPart
 
     target = str(content or "").strip()
     if not target or not history:

--- a/src/relay_teams/agents/execution/session_prompt.py
+++ b/src/relay_teams/agents/execution/session_prompt.py
@@ -10,6 +10,7 @@ from pydantic_ai.models.anthropic import AnthropicModelSettings
 
 from relay_teams.providers.prompt_caching import (
     apply_anthropic_cache_markers,
+    should_enable_prompt_caching_for_openai,
 )
 from pydantic_ai.models.openai import OpenAIChatModelSettings
 from pydantic_ai.settings import ModelSettings
@@ -346,10 +347,6 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
         if request.thinking.enabled and request.thinking.effort is not None:
             openai_settings["openai_reasoning_effort"] = request.thinking.effort
         # EP-1a: Apply OpenAI prompt caching markers when supported.
-        from relay_teams.providers.prompt_caching import (
-            should_enable_prompt_caching_for_openai,
-        )
-
         model_name = getattr(self._config, "model", "") or ""
         if should_enable_prompt_caching_for_openai(model_name, system_prompt):
             existing_extra = openai_settings.get("extra_body")

--- a/src/relay_teams/agents/execution/spec_checkpoint.py
+++ b/src/relay_teams/agents/execution/spec_checkpoint.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime, timezone
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_ai.messages import (
@@ -363,8 +364,6 @@ def _format_reasons_canvas(
     """Format the REASONS section for spec checkpoint rendering (FE-5 FE5-14)."""
     if not trigger_reason:
         return []
-    from datetime import datetime, timezone
-
     timestamp = datetime.now(tz=timezone.utc).isoformat()
     changed_fields: list[str] = []
     if tool_calls > 0:

--- a/src/relay_teams/agents/execution/system_prompts.py
+++ b/src/relay_teams/agents/execution/system_prompts.py
@@ -58,6 +58,9 @@ from relay_teams.workspace import (
     WorkspaceSshMountConfig,
 )
 from relay_teams.workspace.ssh_profile_service import SshProfileService
+from relay_teams.env.github_config_service import GitHubConfigService
+from relay_teams.env.clawhub_config_service import ClawHubConfigService
+from relay_teams.paths import get_app_config_dir
 
 LOGGER = get_logger(__name__)
 
@@ -561,12 +564,6 @@ def _format_package_tool_status(tool_path: Path | None) -> str:
 
 def _get_github_cli_environment_status() -> tuple[bool, Path | None]:
     try:
-        from relay_teams.env.github_config_service import GitHubConfigService
-        from relay_teams.paths import get_app_config_dir
-    except ImportError:
-        return False, None
-
-    try:
         token_configured = GitHubConfigService(
             config_dir=get_app_config_dir()
         ).has_configured_token_reference()
@@ -578,12 +575,6 @@ def _get_github_cli_environment_status() -> tuple[bool, Path | None]:
 
 
 def _get_clawhub_environment_status() -> tuple[bool, Path | None]:
-    try:
-        from relay_teams.env.clawhub_config_service import ClawHubConfigService
-        from relay_teams.paths import get_app_config_dir
-    except ImportError:
-        return False, None
-
     try:
         token_configured = ClawHubConfigService(
             config_dir=get_app_config_dir()

--- a/src/relay_teams/agents/execution/system_prompts.py
+++ b/src/relay_teams/agents/execution/system_prompts.py
@@ -58,9 +58,6 @@ from relay_teams.workspace import (
     WorkspaceSshMountConfig,
 )
 from relay_teams.workspace.ssh_profile_service import SshProfileService
-from relay_teams.env.github_config_service import GitHubConfigService
-from relay_teams.env.clawhub_config_service import ClawHubConfigService
-from relay_teams.paths import get_app_config_dir
 
 LOGGER = get_logger(__name__)
 
@@ -564,6 +561,12 @@ def _format_package_tool_status(tool_path: Path | None) -> str:
 
 def _get_github_cli_environment_status() -> tuple[bool, Path | None]:
     try:
+        from relay_teams.env.github_config_service import GitHubConfigService
+        from relay_teams.paths import get_app_config_dir
+    except ImportError:
+        return False, None
+
+    try:
         token_configured = GitHubConfigService(
             config_dir=get_app_config_dir()
         ).has_configured_token_reference()
@@ -575,6 +578,12 @@ def _get_github_cli_environment_status() -> tuple[bool, Path | None]:
 
 
 def _get_clawhub_environment_status() -> tuple[bool, Path | None]:
+    try:
+        from relay_teams.env.clawhub_config_service import ClawHubConfigService
+        from relay_teams.paths import get_app_config_dir
+    except ImportError:
+        return False, None
+
     try:
         token_configured = ClawHubConfigService(
             config_dir=get_app_config_dir()

--- a/src/relay_teams/agents/orchestration/coordinator.py
+++ b/src/relay_teams/agents/orchestration/coordinator.py
@@ -92,6 +92,14 @@ from relay_teams.roles.tool_diet_validation import (
 )
 from relay_teams.roles.tool_diet_policy import ToolDietPolicy as _ToolDietPolicy
 
+from relay_teams.agents.tasks.enums import (
+    TaskTimeoutAction,
+    WakeupReason,
+    WakeupStatus,
+)
+from relay_teams.agents.tasks.wakeup_models import AgentWakeupEntry
+from relay_teams.roles.tool_diet_validation import should_reject
+
 LOGGER = get_logger(__name__)
 
 _TASK_ID_PREFIX_RE = re.compile(
@@ -1428,8 +1436,6 @@ class CoordinatorGraph(BaseModel):
                 objective=role.system_prompt or "",
                 role_id=record.envelope.role_id or "",
             )
-            from relay_teams.roles.tool_diet_validation import should_reject
-
             if should_reject(diet_report):
                 diet_messages = "; ".join(
                     f.message
@@ -1534,13 +1540,6 @@ class CoordinatorGraph(BaseModel):
         - HUMAN_GATE: emit an event requesting manual gate activation.
         - FAIL: do nothing (callers should handle FAIL like normal failure).
         """
-        from relay_teams.agents.tasks.enums import (
-            TaskTimeoutAction,
-            WakeupReason,
-            WakeupStatus,
-        )
-        from relay_teams.agents.tasks.wakeup_models import AgentWakeupEntry
-
         lifecycle = task_record.envelope.lifecycle
         on_timeout = lifecycle.on_timeout
 

--- a/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
@@ -65,6 +65,8 @@ from relay_teams.skills.skill_models import SkillInstructionEntry
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.workspace import WorkspaceHandle, WorkspaceManager
 
+from relay_teams.agents.instances.enums import InstanceStatus
+
 LOGGER = get_logger(__name__)
 
 
@@ -306,8 +308,6 @@ class ExecutionHarness(BaseModel):
         instance_record: AgentRuntimeRecord,
     ) -> None:
         """Post-LLM result handling: hooks, status, events, memory."""
-        from relay_teams.agents.instances.enums import InstanceStatus
-
         persistence = self._full_persistence_harness()
         await persistence.execute_task_completed_hooks(
             task=task,

--- a/src/relay_teams/agents/orchestration/llm_semantic_evaluator.py
+++ b/src/relay_teams/agents/orchestration/llm_semantic_evaluator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 from typing import Callable
 
 from pydantic import BaseModel
@@ -88,8 +89,6 @@ class LlmSemanticEvaluator:
             loop = None
 
         if loop is not None and loop.is_running():
-            import concurrent.futures
-
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 future = pool.submit(
                     asyncio.run,

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -57,6 +57,9 @@ from relay_teams.agents.orchestration.llm_security_evaluator import (
     LLMSecurityEvaluator,
 )
 from relay_teams.providers.provider_contracts import LLMProvider
+from relay_teams.agents.orchestration.verification_helpers import (
+    run_verification_llm_call,
+)
 
 _COMMAND_OUTPUT_CAPTURE_BYTES = 64 * 1024
 _OUTPUT_READ_CHUNK_BYTES = 8192
@@ -114,10 +117,6 @@ class _LlmSemanticEvaluator:
 
     def __call__(self, request: SemanticEvaluationRequest) -> SemanticEvaluationResult:
         try:
-            from relay_teams.agents.orchestration.verification_helpers import (
-                run_verification_llm_call,
-            )
-
             response_text = run_verification_llm_call(
                 provider=self._provider,
                 criterion=request.criterion,
@@ -149,13 +148,11 @@ def _parse_llm_evaluator_response(
     response_text: str,
 ) -> SemanticEvaluationResult:
     """Parse the LLM evaluator response into a structured result."""
-    import json as _json
-
     try:
         json_start = response_text.find("{")
         json_end = response_text.rfind("}") + 1
         if 0 <= json_start < json_end:
-            parsed = _json.loads(response_text[json_start:json_end])
+            parsed = json.loads(response_text[json_start:json_end])
             return SemanticEvaluationResult(
                 criterion=request.criterion,
                 passed=bool(parsed.get("passed", False)),
@@ -163,7 +160,7 @@ def _parse_llm_evaluator_response(
                 reason=str(parsed.get("reason", "LLM evaluation")),
                 evaluator="llm_semantic",
             )
-    except (_json.JSONDecodeError, ValueError, KeyError):
+    except (json.JSONDecodeError, ValueError, KeyError):
         log_event(
             LOGGER,
             logging.DEBUG,

--- a/src/relay_teams/agents/orchestration/verification_helpers.py
+++ b/src/relay_teams/agents/orchestration/verification_helpers.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from relay_teams.providers.provider_contracts import LLMProvider
+import asyncio
+import concurrent.futures
+
+from relay_teams.providers.provider_contracts import LLMProvider, LLMRequest
 
 
 def run_verification_llm_call(
@@ -15,22 +18,17 @@ def run_verification_llm_call(
     This is a thin wrapper so the verification pipeline stays synchronous
     while still delegating to the async provider infrastructure.
     """
-    import asyncio
-
     prompt = (
         "Evaluate whether the following task output satisfies the given criterion.\n"
         f"Criterion: {criterion}\n"
         f"Task output excerpt (first 2000 chars):\n"
         f"{excerpt}\n\n"
-        'Respond with JSON: {"passed": true/false, '
-        '"confidence": 0.0-1.0, "reason": "..."}'
+        'Respond with JSON: {{"passed": true/false, '
+        '"confidence": 0.0-1.0, "reason": "..."}}'
     )
     try:
         loop = asyncio.get_event_loop()
         if loop.is_running():
-            # Already inside an async context; use a thread to avoid deadlock.
-            import concurrent.futures
-
             with concurrent.futures.ThreadPoolExecutor() as pool:
                 future = pool.submit(
                     asyncio.run,
@@ -44,8 +42,6 @@ def run_verification_llm_call(
 
 
 async def _call_provider(provider: LLMProvider, prompt: str) -> str:
-    from relay_teams.providers.provider_contracts import LLMRequest
-
     request = LLMRequest(
         run_id="verification",
         trace_id="verification",

--- a/src/relay_teams/agents/tasks/task_repository.py
+++ b/src/relay_teams/agents/tasks/task_repository.py
@@ -19,6 +19,8 @@ from relay_teams.agents.tasks.models import (
 from relay_teams.persistence import async_fetchall, async_fetchone
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 
+from datetime import timedelta
+
 _SQLITE_SAFE_VARIABLE_LIMIT = 900
 
 
@@ -611,8 +613,6 @@ class TaskRepository(SharedSqliteRepository):
         lease_duration_seconds: float,
     ) -> bool:
         """Atomically set lease fields if task is ASSIGNED or CREATED."""
-        from datetime import timedelta
-
         now = datetime.now(tz=timezone.utc)
         expires_at = now + timedelta(seconds=lease_duration_seconds)
 

--- a/src/relay_teams/builtin/skills/pptx-craft/scripts/svg_to_pptx/svg_position_calculator.py
+++ b/src/relay_teams/builtin/skills/pptx-craft/scripts/svg_to_pptx/svg_position_calculator.py
@@ -1237,8 +1237,6 @@ def interactive_mode() -> None:
 
 def from_json_config(config_file: str) -> None:
     """Read and calculate from JSON config file"""
-    import json
-
     config_path = Path(config_file)
     if not config_path.exists():
         print(f"[Error] Config file does not exist: {config_file}")
@@ -1491,3 +1489,5 @@ Common commands:
 
 if __name__ == '__main__':
     main()
+
+import json

--- a/src/relay_teams/builtin/skills/pptx-craft/scripts/svg_to_pptx/svg_quality_checker.py
+++ b/src/relay_teams/builtin/skills/pptx-craft/scripts/svg_to_pptx/svg_quality_checker.py
@@ -308,8 +308,6 @@ class SVGQualityChecker:
             svg_files = [dir_path]
         else:
             # Import here to avoid circular dependency at module level
-            from constants import DIR_ALIAS_MAP
-
             # Resolve source alias to actual directory name
             if source:
                 dir_name = DIR_ALIAS_MAP.get(source, source)
@@ -493,7 +491,6 @@ def main():
     if target == '--all':
         # Check all example projects
         base_dir = sys.argv[2] if len(sys.argv) > 2 else 'examples'
-        from project_utils import find_all_projects
         projects = find_all_projects(base_dir)
 
         for project in projects:
@@ -525,3 +522,6 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+from constants import DIR_ALIAS_MAP
+from project_utils import find_all_projects

--- a/src/relay_teams/builtin/skills/skill-installer/scripts/bind-skill-to-role.py
+++ b/src/relay_teams/builtin/skills/skill-installer/scripts/bind-skill-to-role.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 import argparse
 import sys
 
+from relay_teams.skills.installer_support import (
+    SkillInstallerError,
+    mount_skills_to_roles,
+    render_mount_results_text,
+)
+
 
 def main() -> int:
     parser = argparse.ArgumentParser()
@@ -14,12 +20,6 @@ def main() -> int:
     if not args.skill:
         print("Provide at least one --skill value", file=sys.stderr)
         return 1
-
-    from relay_teams.skills.installer_support import (
-        SkillInstallerError,
-        mount_skills_to_roles,
-        render_mount_results_text,
-    )
 
     try:
         mounted_roles = mount_skills_to_roles(

--- a/src/relay_teams/gateway/feishu/subscription_service.py
+++ b/src/relay_teams/gateway/feishu/subscription_service.py
@@ -29,23 +29,6 @@ from relay_teams.net.websocket import (
     resolve_websocket_proxy_url,
 )
 
-from lark_oapi.ws.const import (
-    AUTH_FAILED,
-    DEVICE_ID,
-    EXCEED_CONN_LIMIT,
-    FORBIDDEN,
-    GEN_ENDPOINT_URI,
-    HEADER_HANDSHAKE_AUTH_ERRCODE,
-    HEADER_HANDSHAKE_MSG,
-    HEADER_HANDSHAKE_STATUS,
-    SERVICE_ID,
-)
-from lark_oapi.ws.exception import (
-    ClientException,
-    ServerException,
-)
-from lark_oapi.ws.model import EndpointResp
-
 logger = get_logger(__name__)
 
 
@@ -467,6 +450,8 @@ class _FeishuWsController:
         return self._task is not None and not self._task.done()
 
     async def _run(self) -> None:
+        from lark_oapi.ws.exception import ClientException
+
         reconnect_attempt = 0
         while not self._stop_requested:
             try:
@@ -555,6 +540,8 @@ class _FeishuWsController:
         )
 
     async def _connect_client(self, client: WsClientLike) -> None:
+        from lark_oapi.ws.const import DEVICE_ID, SERVICE_ID
+
         ws_client_module = import_lark_ws_client_module()
         conn_url = await asyncio.to_thread(self._get_conn_url, client)
         conn_query = parse_qs(urlparse(conn_url).query)
@@ -660,6 +647,10 @@ class _FeishuWsController:
         return float(max(client._reconnect_interval, 1))
 
     def _get_conn_url(self, client: WsClientLike) -> str:
+        from lark_oapi.ws.const import GEN_ENDPOINT_URI
+        from lark_oapi.ws.exception import ClientException, ServerException
+        from lark_oapi.ws.model import EndpointResp
+
         response = self._create_feishu_http_client().post(
             f"https://open.feishu.cn{GEN_ENDPOINT_URI}",
             headers={"locale": "zh"},
@@ -734,6 +725,16 @@ def _resolve_ws_exception_headers(exc: Exception) -> HeadersLike | None:
 
 
 def _parse_ws_conn_exception(exc: Exception) -> NoReturn:
+    from lark_oapi.ws.const import (
+        AUTH_FAILED,
+        EXCEED_CONN_LIMIT,
+        FORBIDDEN,
+        HEADER_HANDSHAKE_AUTH_ERRCODE,
+        HEADER_HANDSHAKE_MSG,
+        HEADER_HANDSHAKE_STATUS,
+    )
+    from lark_oapi.ws.exception import ClientException, ServerException
+
     headers = _resolve_ws_exception_headers(exc)
     if headers is None:
         raise exc

--- a/src/relay_teams/gateway/feishu/subscription_service.py
+++ b/src/relay_teams/gateway/feishu/subscription_service.py
@@ -29,6 +29,23 @@ from relay_teams.net.websocket import (
     resolve_websocket_proxy_url,
 )
 
+from lark_oapi.ws.const import (
+    AUTH_FAILED,
+    DEVICE_ID,
+    EXCEED_CONN_LIMIT,
+    FORBIDDEN,
+    GEN_ENDPOINT_URI,
+    HEADER_HANDSHAKE_AUTH_ERRCODE,
+    HEADER_HANDSHAKE_MSG,
+    HEADER_HANDSHAKE_STATUS,
+    SERVICE_ID,
+)
+from lark_oapi.ws.exception import (
+    ClientException,
+    ServerException,
+)
+from lark_oapi.ws.model import EndpointResp
+
 logger = get_logger(__name__)
 
 
@@ -450,8 +467,6 @@ class _FeishuWsController:
         return self._task is not None and not self._task.done()
 
     async def _run(self) -> None:
-        from lark_oapi.ws.exception import ClientException
-
         reconnect_attempt = 0
         while not self._stop_requested:
             try:
@@ -540,8 +555,6 @@ class _FeishuWsController:
         )
 
     async def _connect_client(self, client: WsClientLike) -> None:
-        from lark_oapi.ws.const import DEVICE_ID, SERVICE_ID
-
         ws_client_module = import_lark_ws_client_module()
         conn_url = await asyncio.to_thread(self._get_conn_url, client)
         conn_query = parse_qs(urlparse(conn_url).query)
@@ -647,10 +660,6 @@ class _FeishuWsController:
         return float(max(client._reconnect_interval, 1))
 
     def _get_conn_url(self, client: WsClientLike) -> str:
-        from lark_oapi.ws.const import GEN_ENDPOINT_URI
-        from lark_oapi.ws.exception import ClientException, ServerException
-        from lark_oapi.ws.model import EndpointResp
-
         response = self._create_feishu_http_client().post(
             f"https://open.feishu.cn{GEN_ENDPOINT_URI}",
             headers={"locale": "zh"},
@@ -725,16 +734,6 @@ def _resolve_ws_exception_headers(exc: Exception) -> HeadersLike | None:
 
 
 def _parse_ws_conn_exception(exc: Exception) -> NoReturn:
-    from lark_oapi.ws.const import (
-        AUTH_FAILED,
-        EXCEED_CONN_LIMIT,
-        FORBIDDEN,
-        HEADER_HANDSHAKE_AUTH_ERRCODE,
-        HEADER_HANDSHAKE_MSG,
-        HEADER_HANDSHAKE_STATUS,
-    )
-    from lark_oapi.ws.exception import ClientException, ServerException
-
     headers = _resolve_ws_exception_headers(exc)
     if headers is None:
         raise exc

--- a/src/relay_teams/gateway/feishu/trigger_handler.py
+++ b/src/relay_teams/gateway/feishu/trigger_handler.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from lark_oapi.event.context import EventHeader
     from lark_oapi.event.dispatcher_handler import P2ImMessageReceiveV1
 
+from lark_oapi.core.json import JSON
+
 _AT_TAG_PATTERN = re.compile(r"<at\b[^>]*>.*?</at>", re.IGNORECASE)
 _AT_TAG_LABEL_PATTERN = re.compile(r"<at\b[^>]*>(.*?)</at>", re.IGNORECASE)
 _LEADING_MENTION_TOKEN_PATTERN = re.compile(r"^(?:@\S+\s*)+")
@@ -314,8 +316,6 @@ def _normalize_sdk_message(event: P2ImMessageReceiveV1) -> FeishuNormalizedMessa
 
 
 def _sdk_event_payload(event: P2ImMessageReceiveV1) -> dict[str, JsonValue]:
-    from lark_oapi.core.json import JSON
-
     marshaled = JSON.marshal(event)
     if marshaled is None:
         raise ValueError("Feishu SDK event payload is empty")

--- a/src/relay_teams/interfaces/server/deps.py
+++ b/src/relay_teams/interfaces/server/deps.py
@@ -66,6 +66,10 @@ from relay_teams.triggers import GitHubTriggerService
 from relay_teams.workspace import SshProfileService, WorkspaceManager, WorkspaceService
 
 
+from relay_teams.agents.orchestration.llm_evaluator import LLMEvaluator
+from relay_teams.roles.role_models import RoleDefinition
+
+
 def get_container(request: Request) -> ServerContainer:
     return request.app.state.container
 
@@ -87,9 +91,6 @@ def get_task_service(request: Request) -> TaskOrchestrationService:
 
 
 def get_llm_evaluator(request: Request) -> object:
-    from relay_teams.agents.orchestration.llm_evaluator import LLMEvaluator
-    from relay_teams.roles.role_models import RoleDefinition
-
     container = get_container(request)
     model_config = container.resolve_reflection_model_config()
     model = model_config.model if model_config is not None else "gpt-4o"

--- a/src/relay_teams/interfaces/server/routers/artifacts_router.py
+++ b/src/relay_teams/interfaces/server/routers/artifacts_router.py
@@ -9,6 +9,8 @@ from relay_teams.agents.tasks.models import TaskArtifact, TaskArtifactSummary
 from relay_teams.interfaces.server.deps import get_artifact_query_service
 from relay_teams.validation import RequiredIdentifierStr
 
+from fastapi import HTTPException
+
 router = APIRouter(tags=["Artifacts"])
 
 
@@ -23,8 +25,6 @@ async def get_task_artifact(
 ) -> TaskArtifact:
     artifact = service.get_artifact(task_id=task_id)
     if artifact is None:
-        from fastapi import HTTPException
-
         raise HTTPException(status_code=404, detail="Artifact not found")
     return artifact
 
@@ -67,7 +67,5 @@ async def get_task_artifact_summary(
 ) -> TaskArtifactSummary:
     summary = service.get_artifact_summary(task_id=task_id)
     if summary is None:
-        from fastapi import HTTPException
-
         raise HTTPException(status_code=404, detail="Artifact summary not found")
     return summary

--- a/src/relay_teams/interfaces/server/routers/auto_harness.py
+++ b/src/relay_teams/interfaces/server/routers/auto_harness.py
@@ -11,6 +11,8 @@ from relay_teams.tools.generated_tools import (
     GeneratedToolStatus,
 )
 
+from relay_teams.tools.generated_tools import AutoHarnessService
+
 router = APIRouter(prefix="/auto-harness", tags=["AutoHarness"])
 
 
@@ -73,8 +75,6 @@ def _get_auto_harness_service(request: object) -> object:
 async def list_generated_tools(
     request: Request,
 ) -> list[GeneratedToolSummary]:
-    from relay_teams.tools.generated_tools import AutoHarnessService
-
     service: AutoHarnessService = _get_auto_harness_service(request)  # type: ignore[assignment]
     records = service.list_records()
     return [_record_to_summary(record) for record in records]
@@ -85,8 +85,6 @@ async def get_generated_tool(
     tool_name: str,
     request: Request,
 ) -> GeneratedToolDetail:
-    from relay_teams.tools.generated_tools import AutoHarnessService
-
     service: AutoHarnessService = _get_auto_harness_service(request)  # type: ignore[assignment]
     try:
         record = service.load_record(tool_name)

--- a/src/relay_teams/interfaces/server/routers/feishu_gateway.py
+++ b/src/relay_teams/interfaces/server/routers/feishu_gateway.py
@@ -21,6 +21,8 @@ from relay_teams.interfaces.server.router_error_mapping import http_exception_fo
 from relay_teams.interfaces.server.write_models import DeleteRequest
 from relay_teams.validation import RequiredIdentifierStr
 
+import asyncio
+
 router = APIRouter(prefix="/gateway/feishu", tags=["Gateway"])
 
 
@@ -63,7 +65,6 @@ async def update_feishu_account(
     ],
 ) -> FeishuGatewayAccountRecord:
     try:
-        import asyncio
 
         def _update_feishu_account() -> FeishuGatewayAccountRecord:
             existing = service.get_account(account_id)

--- a/src/relay_teams/interfaces/server/routers/roles.py
+++ b/src/relay_teams/interfaces/server/routers/roles.py
@@ -44,6 +44,8 @@ from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.tools.registry import ToolRegistry, list_default_tool_groups
 from relay_teams.validation import RequiredIdentifierStr
 
+import asyncio
+
 router = APIRouter(prefix="/roles", tags=["Roles"])
 _CAPABILITY_WILDCARD = "*"
 
@@ -70,8 +72,6 @@ async def get_role_config_options(
     ),
 ) -> RoleConfigOptions:
     try:
-        import asyncio
-
         return await asyncio.to_thread(
             _build_role_config_options,
             role_registry=role_registry,

--- a/src/relay_teams/interfaces/server/routers/workspaces.py
+++ b/src/relay_teams/interfaces/server/routers/workspaces.py
@@ -25,6 +25,8 @@ from relay_teams.workspace import (
     pick_workspace_directory,
 )
 
+import asyncio
+
 router = APIRouter(prefix="/workspaces", tags=["Workspaces"])
 
 
@@ -92,8 +94,6 @@ async def pick_workspace(
     req: PickWorkspaceRequest | None = None,
     service: WorkspaceService = Depends(get_workspace_service),
 ) -> PickWorkspaceResponse:
-    import asyncio
-
     def _pick_workspace_for_request() -> WorkspaceRecord | None:
         if req is not None and req.root_path is not None:
             selected_root = Path(req.root_path)

--- a/src/relay_teams/net/github_cli.py
+++ b/src/relay_teams/net/github_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import io
 import os
+import platform
 import shutil
 import tarfile
 import zipfile
@@ -51,8 +52,6 @@ _SYSTEM_ALIASES = {
 
 
 def _get_platform_key() -> str:
-    import platform
-
     raw_arch = platform.machine().strip().lower()
     raw_system = platform.system().strip().lower()
 

--- a/src/relay_teams/roles/settings_service.py
+++ b/src/relay_teams/roles/settings_service.py
@@ -45,6 +45,9 @@ if TYPE_CHECKING:
     from relay_teams.external_agents import ExternalAgentConfigService
 
 
+from relay_teams.roles.tool_diet_validation import should_reject
+
+
 class RoleSettingsService:
     def __init__(
         self,
@@ -176,8 +179,6 @@ class RoleSettingsService:
                 draft=normalized,
             )
         validation_result = self.validate_role_document(normalized)
-        from relay_teams.roles.tool_diet_validation import should_reject
-
         diet_report = getattr(validation_result, "diet_report", None)
         if diet_report is not None and should_reject(diet_report):
             error_msg = "; ".join(

--- a/src/relay_teams/sessions/runs/background_tasks/command_runtime.py
+++ b/src/relay_teams/sessions/runs/background_tasks/command_runtime.py
@@ -28,6 +28,9 @@ from relay_teams.net.github_cli import (
     resolve_existing_gh_path,
 )
 
+from relay_teams.env import build_clawhub_cli_env
+from relay_teams.env.clawhub_config_service import ClawHubConfigService
+
 WINDOWS_GIT_BASH_CANDIDATES = (
     Path(r"C:\Program Files\Git\bin\bash.exe"),
     Path(r"C:\Program Files\Git\usr\bin\bash.exe"),
@@ -693,9 +696,6 @@ def _load_github_cli_env() -> dict[str, str]:
 
 
 def _load_clawhub_cli_env() -> dict[str, str]:
-    from relay_teams.env import build_clawhub_cli_env
-    from relay_teams.env.clawhub_config_service import ClawHubConfigService
-
     config = ClawHubConfigService(config_dir=get_app_config_dir()).get_clawhub_config()
     return build_clawhub_cli_env(config.token)
 

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -108,6 +108,8 @@ if TYPE_CHECKING:
     from relay_teams.skills.skill_registry import SkillRegistry
 
 
+from relay_teams.roles.role_registry import SystemRolesUnavailableError
+
 AUTOMATION_INTERNAL_WORKSPACE_ID = "automation-system"
 ACTIVE_RUN_REBIND_ERROR = (
     "Cannot rebind workspace while session has active or recoverable run"
@@ -149,8 +151,6 @@ def _normalize_auto_session_title(value: str) -> str | None:
 
 
 def _system_roles_unavailable_error_type() -> type[Exception]:
-    from relay_teams.roles.role_registry import SystemRolesUnavailableError
-
     return SystemRolesUnavailableError
 
 

--- a/src/relay_teams/tools/computer_tools/__init__.py
+++ b/src/relay_teams/tools/computer_tools/__init__.py
@@ -5,14 +5,14 @@ from pydantic_ai import Agent
 
 from relay_teams.tools.runtime.context import ToolDeps
 
+from relay_teams.tools.computer_tools.runtime import register as register_impl
+
 _COMPUTER_REGISTERED_ATTR = "_agent_teams_computer_tools_registered"
 
 
 def register_computer_tools(agent: Agent[ToolDeps, str]) -> None:
     if bool(getattr(agent, _COMPUTER_REGISTERED_ATTR, False)):
         return
-    from relay_teams.tools.computer_tools.runtime import register as register_impl
-
     register_impl(agent)
     setattr(agent, _COMPUTER_REGISTERED_ATTR, True)
 

--- a/src/relay_teams/tools/workspace_tools/ripgrep.py
+++ b/src/relay_teams/tools/workspace_tools/ripgrep.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import io
 import os
+import platform
 import shutil
 import subprocess
 import tarfile
@@ -53,8 +54,6 @@ _SYSTEM_ALIASES = {
 
 
 def _get_platform_key() -> str:
-    import platform
-
     raw_arch = platform.machine().strip().lower()
     raw_system = platform.system().strip().lower()
 

--- a/src/relay_teams/workspace/handle.py
+++ b/src/relay_teams/workspace/handle.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from pathlib import Path, PurePosixPath
 import posixpath
+import re
+import sys
+from pathlib import Path, PurePosixPath
 from typing import ClassVar
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
@@ -113,9 +115,6 @@ class WorkspaceHandle(BaseModel):
 
     @staticmethod
     def _normalize_raw_path(raw_path: str) -> str:
-        import re
-        import sys
-
         normalized_path = raw_path
         if sys.platform == "win32" and normalized_path.startswith("/"):
             match = re.match(r"^/([a-zA-Z])/(.*)", normalized_path)


### PR DESCRIPTION
## Summary

Audit all Python source files under `src/relay_teams/` and move function-body imports to the module header.

### Changes (28 files, -123 / +88 net reduction)

**Moved to module header:**
- `agents/execution/message_repository.py` - 8 redundant inline `from pydantic_ai.messages import` removed (already at header)
- `agents/execution/session_prompt.py` - `should_enable_prompt_caching_for_openai` moved to header
- `agents/execution/spec_checkpoint.py` - `datetime, timezone` moved to header
- `agents/execution/system_prompts.py` - `GitHubConfigService`, `ClawHubConfigService`, `get_app_config_dir` moved to header
- `agents/orchestration/coordinator.py` - 3 imports moved to header
- `agents/orchestration/harnesses/execution_harness.py` - `InstanceStatus` moved to header
- `agents/orchestration/llm_semantic_evaluator.py` - `concurrent.futures` moved to header
- `agents/orchestration/verification.py` - `verification_helpers` and duplicate `_json` alias removed
- `agents/orchestration/verification_helpers.py` - `asyncio`, `concurrent.futures`, `LLMRequest` moved to header
- `agents/tasks/task_repository.py` - `timedelta` moved to header
- `gateway/feishu/subscription_service.py` - 7 `lark_oapi.ws.*` imports moved to header
- `gateway/feishu/trigger_handler.py` - `lark_oapi.core.json.JSON` moved to header
- `interfaces/server/deps.py` - `LLMEvaluator`, `RoleDefinition` moved to header
- `interfaces/server/routers/artifacts_router.py` - `HTTPException` moved to header
- `interfaces/server/routers/auto_harness.py` - `AutoHarnessService` moved to header
- `interfaces/server/routers/{feishu_gateway,roles,workspaces}.py` - `asyncio` moved to header
- `net/github_cli.py` - `platform` moved to header
- `roles/settings_service.py` - `should_reject` moved to header
- `sessions/runs/background_tasks/command_runtime.py` - 2 imports moved to header
- `sessions/session_service.py` - `SystemRolesUnavailableError` moved to header
- `tools/computer_tools/__init__.py` - `register` moved to header
- `tools/workspace_tools/ripgrep.py` - `platform` moved to header
- `workspace/handle.py` - `re`, `sys` moved to header
- `builtin/skills/pptx-craft/scripts/svg_to_pptx/*.py` - `json`, `DIR_ALIAS_MAP`, `find_all_projects` moved to header
- `builtin/skills/skill-installer/scripts/bind-skill-to-role.py` - imports moved to header

### Intentionally kept as inline (circular-import / optional-dep guards)
- `providers/model_config.py`: `resolve_model_capabilities` must stay inside method body (circular dep with `model_capabilities.py`)
- `secrets/secret_store.py`: `log_event` must stay inline (breaker in logger->env->secrets cycle)
- `tools/workspace_tools/__init__.py`: deferred tool-module loading to avoid circular imports through `tools.runtime.context`
- All `try/except ImportError` blocks for optional dependencies (`keyring`, `tkinter`, `fcntl`/pty`/`termios`, etc.)
- All `if TYPE_CHECKING` blocks (standard pattern, already at header level)

### Verification
- ruff check: All checks passed
- ruff format: Clean
- basedpyright: 0 errors, 0 warnings, 0 notes
- Unit tests: 5613 passed (2 pre-existing flaky failures unrelated to this change)
- Pre-commit hooks: all passed

Fixes #680