### PR TITLE
refactor: move system_reminder modules into reminders package

### DIFF
--- a/src/relay_teams/agents/execution/agent_llm_session.py
+++ b/src/relay_teams/agents/execution/agent_llm_session.py
@@ -54,7 +54,7 @@ from relay_teams.providers.model_fallback import (
     LlmFallbackMiddleware,
 )
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
-from relay_teams.reminders import SystemReminderService
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.background_tasks import BackgroundTaskService

--- a/src/relay_teams/agents/execution/message_repository.py
+++ b/src/relay_teams/agents/execution/message_repository.py
@@ -46,7 +46,7 @@ from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )
 from relay_teams.logger import get_logger, log_event
-from relay_teams.system_reminder_text import is_rendered_system_reminder_text
+from relay_teams.reminders.text import is_rendered_system_reminder_text
 
 _SQLITE_SAFE_VARIABLE_LIMIT = 900
 

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -71,8 +71,8 @@ from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.reminders import (
     ContextPressureObservation,
     ReminderKind,
-    SystemReminderService,
 )
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.sessions.runs.assistant_errors import (
     AssistantRunError,
     AssistantRunErrorPayload,

--- a/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, Optional
 
 from pydantic import BaseModel, ConfigDict, JsonValue
 

--- a/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Literal, NamedTuple, Optional
+from typing import Literal, NamedTuple
 
 from pydantic import BaseModel, ConfigDict, JsonValue
 

--- a/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
@@ -42,7 +42,8 @@ from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.media import MediaAssetService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
-from relay_teams.reminders import ReminderDecision, SystemReminderService
+from relay_teams.reminders import ReminderDecision
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.memory.event_handler import MemoryEventHandler
 from relay_teams.roles.role_models import RoleDefinition

--- a/src/relay_teams/agents/orchestration/harnesses/llm_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/llm_harness.py
@@ -16,8 +16,8 @@ from relay_teams.reminders import (
     CompletionAttemptObservation,
     IncompleteTodoItem,
     ReminderDecision,
-    SystemReminderService,
 )
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_models import RunThinkingConfig
 from relay_teams.sessions.runs.todo_models import TodoItem, TodoStatus

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -53,7 +53,7 @@ from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.media import MediaAssetService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
-from relay_teams.reminders import SystemReminderService
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.memory.event_handler import MemoryEventHandler
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition

--- a/src/relay_teams/agents/orchestration/task_execution_service_factory.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service_factory.py
@@ -24,7 +24,7 @@ from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
-from relay_teams.reminders import SystemReminderService
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.skills.skill_registry import SkillRegistry

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -42,7 +42,7 @@ from relay_teams.monitors import MonitorService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.providers.model_config import ModelCapabilities, ModelEndpointConfig
 from relay_teams.providers.provider_contracts import LLMRequest
-from relay_teams.reminders import SystemReminderService
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry

--- a/src/relay_teams/external_agents/provider.py
+++ b/src/relay_teams/external_agents/provider.py
@@ -56,7 +56,7 @@ from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.providers.model_config import ModelEndpointConfig, ProviderType
 from relay_teams.providers.openai_support import build_model_request_headers
 from relay_teams.providers.provider_contracts import LLMProvider, LLMRequest
-from relay_teams.reminders import SystemReminderService
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.sessions.runs.enums import RunEventType

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -206,7 +206,8 @@ from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.sessions.runs.system_injection import SystemInjectionSink
 from relay_teams.sessions.session_repository import SessionRepository
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
-from relay_teams.reminders import ReminderStateRepository, SystemReminderService
+from relay_teams.reminders import ReminderStateRepository
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.agents.tasks.artifact_repository import TaskArtifactRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.providers.token_usage_repo import TokenUsageRepository

--- a/src/relay_teams/providers/openai_compatible.py
+++ b/src/relay_teams/providers/openai_compatible.py
@@ -53,7 +53,7 @@ from relay_teams.providers.provider_contracts import (
     ProviderCapabilities,
 )
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
-from relay_teams.reminders import SystemReminderService
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.background_tasks import BackgroundTaskService

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -61,7 +61,7 @@ from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
-from relay_teams.reminders import SystemReminderService
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
 from relay_teams.tools.runtime.context import (
     GatewaySessionLookupLike,

--- a/src/relay_teams/reminders/__init__.py
+++ b/src/relay_teams/reminders/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 from relay_teams.reminders.models import (
     CompletionAttemptObservation,
@@ -18,16 +16,6 @@ from relay_teams.reminders.state import ReminderStateRepository, ReminderRunStat
 from relay_teams.reminders.text import is_rendered_system_reminder_text
 from relay_teams.reminders.tool_effects import classify_tool_effect
 
-
-def __getattr__(name: str) -> Any:
-    if name == "SystemReminderService":
-        from relay_teams.reminders.service import SystemReminderService
-
-        globals()["SystemReminderService"] = SystemReminderService
-        return SystemReminderService
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
 __all__ = [
     "CompletionAttemptObservation",
     "ContextPressureObservation",
@@ -39,7 +27,6 @@ __all__ = [
     "ReminderStateRepository",
     "SystemReminderDeliveryMode",
     "SystemReminderPolicy",
-    "SystemReminderService",
     "ToolEffect",
     "ToolResultObservation",
     "classify_tool_effect",

--- a/src/relay_teams/reminders/__init__.py
+++ b/src/relay_teams/reminders/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from typing import Any
+
+from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 from relay_teams.reminders.models import (
     CompletionAttemptObservation,
     ContextPressureObservation,
@@ -11,11 +14,19 @@ from relay_teams.reminders.models import (
 )
 from relay_teams.reminders.policy import ReminderPolicyConfig, SystemReminderPolicy
 from relay_teams.reminders.renderer import render_system_reminder
-from relay_teams.reminders.service import SystemReminderService
 from relay_teams.reminders.state import ReminderStateRepository, ReminderRunState
+from relay_teams.reminders.text import is_rendered_system_reminder_text
 from relay_teams.reminders.tool_effects import classify_tool_effect
-from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
-from relay_teams.system_reminder_text import is_rendered_system_reminder_text
+
+
+def __getattr__(name: str) -> Any:
+    if name == "SystemReminderService":
+        from relay_teams.reminders.service import SystemReminderService
+
+        globals()["SystemReminderService"] = SystemReminderService
+        return SystemReminderService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "CompletionAttemptObservation",
@@ -26,9 +37,9 @@ __all__ = [
     "ReminderPolicyConfig",
     "ReminderRunState",
     "ReminderStateRepository",
+    "SystemReminderDeliveryMode",
     "SystemReminderPolicy",
     "SystemReminderService",
-    "SystemReminderDeliveryMode",
     "ToolEffect",
     "ToolResultObservation",
     "classify_tool_effect",

--- a/src/relay_teams/reminders/delivery.py
+++ b/src/relay_teams/reminders/delivery.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class SystemReminderDeliveryMode(str, Enum):
+    GUIDANCE = "guidance"
+    COMPLETION_GUARD = "completion_guard"

--- a/src/relay_teams/reminders/models.py
+++ b/src/relay_teams/reminders/models.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
-from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
+from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 
 
 class ReminderKind(str, Enum):

--- a/src/relay_teams/reminders/policy.py
+++ b/src/relay_teams/reminders/policy.py
@@ -12,7 +12,7 @@ from relay_teams.reminders.models import (
 from relay_teams.reminders.state import ReminderRunState, can_issue
 from relay_teams.reminders.tool_effects import classify_tool_effect
 from relay_teams.reminders.models import ToolEffect
-from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
+from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 
 
 class ReminderPolicyConfig(BaseModel):

--- a/src/relay_teams/reminders/renderer.py
+++ b/src/relay_teams/reminders/renderer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from relay_teams.system_reminder_text import (
+from relay_teams.reminders.text import (
     SYSTEM_REMINDER_INTERNAL_MARKER,
 )
 

--- a/src/relay_teams/reminders/text.py
+++ b/src/relay_teams/reminders/text.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+SYSTEM_REMINDER_INTERNAL_MARKER = (
+    "This is an internal runtime reminder for you to consider silently."
+)
+
+
+def is_rendered_system_reminder_text(content: str) -> bool:
+    text = content.strip()
+    return (
+        text.startswith("<system-reminder>")
+        and text.endswith("</system-reminder>")
+        and SYSTEM_REMINDER_INTERNAL_MARKER in text
+    )

--- a/src/relay_teams/sessions/runs/injection_classification.py
+++ b/src/relay_teams/sessions/runs/injection_classification.py
@@ -6,8 +6,8 @@ from json import dumps
 from relay_teams.media import user_prompt_content_to_text
 from relay_teams.sessions.runs.enums import InjectionSource
 from relay_teams.sessions.runs.run_models import InjectionMessage
-from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
-from relay_teams.system_reminder_text import is_rendered_system_reminder_text
+from relay_teams.reminders.delivery import SystemReminderDeliveryMode
+from relay_teams.reminders.text import is_rendered_system_reminder_text
 
 
 class InjectionDisposition(str, Enum):

--- a/src/relay_teams/sessions/runs/injection_queue.py
+++ b/src/relay_teams/sessions/runs/injection_queue.py
@@ -5,7 +5,7 @@ from threading import Lock
 from relay_teams.media import UserPromptContent, user_prompt_content_to_text
 from relay_teams.sessions.runs.enums import InjectionDeliveryMode, InjectionSource
 from relay_teams.sessions.runs.run_models import InjectionMessage
-from relay_teams.system_reminder_text import is_rendered_system_reminder_text
+from relay_teams.reminders.text import is_rendered_system_reminder_text
 
 
 class RunInjectionManager:

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -24,7 +24,7 @@ from relay_teams.monitors import MonitorService
 from relay_teams.notifications import NotificationService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.providers.model_config import ModelCapabilities
-from relay_teams.reminders import SystemReminderService
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -34,7 +34,8 @@ from relay_teams.mcp.mcp_models import McpToolSchema
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.persistence import close_live_sqlite_repositories_async
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
-from relay_teams.reminders import ReminderStateRepository, SystemReminderService
+from relay_teams.reminders import ReminderStateRepository
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.retrieval import RetrievalService, SqliteFts5RetrievalStore
 from relay_teams.roles.memory_repository import RoleMemoryRepository
 from relay_teams.roles.memory_service import RoleMemoryService

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -79,7 +79,7 @@ from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_models import InjectionMessage, RunEvent
 from relay_teams.sessions.runs.run_models import RunThinkingConfig
 from relay_teams.sessions.runs.assistant_errors import AssistantRunError
-from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
+from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )

--- a/tests/unit_tests/reminders/test_service.py
+++ b/tests/unit_tests/reminders/test_service.py
@@ -17,9 +17,9 @@ from relay_teams.reminders import (
     ReminderRunState,
     ReminderStateRepository,
     SystemReminderPolicy,
-    SystemReminderService,
     ToolResultObservation,
 )
+from relay_teams.reminders.service import SystemReminderService
 from relay_teams.sessions.runs.system_injection import (
     SystemInjectionResult,
     SystemInjectionSink,

--- a/tests/unit_tests/sessions/runs/test_system_injection_sink.py
+++ b/tests/unit_tests/sessions/runs/test_system_injection_sink.py
@@ -11,7 +11,7 @@ from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.enums import InjectionSource
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.system_injection import SystemInjectionSink
-from relay_teams.system_reminder_delivery import SystemReminderDeliveryMode
+from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 
 
 class _CapturingRunEventHub:


### PR DESCRIPTION
Fixes #694

Move the two orphan modules into the `reminders` sub-package where they logically belong:

- `relay_teams.system_reminder_delivery` -> `relay_teams.reminders.delivery`
- `relay_teams.system_reminder_text` -> `relay_teams.reminders.text`

All import references across src/ and tests/ updated. Pure restructure with no logic changes.

Also fixes a latent circular import: removed eager `SystemReminderService` import from `reminders/__init__.py` to break the `message_repository -> reminders.text -> service -> system_injection -> message_repository` cycle. All `SystemReminderService` callers now import directly from `reminders.service`.