### PR TITLE
feat(cli): add --daemon and --force options to all CLI startup parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Highlights:
 
 Start the server with `uv run relay-teams server start` and open http://127.0.0.1:8000 in your browser.
 Use `uv run relay-teams server restart` to restart the managed server, and `uv run relay-teams server stop --force` to force stop it.
+Add `--daemon` to `server start` to run the server as a background process: `uv run relay-teams server start --daemon`.
+All CLI commands that support `--autostart` now also accept `--daemon` (`-d`) and `--force` to control background autostart behavior and force-restart an existing server.
 The web UI now includes a language toggle beside the settings button so you can switch between English and Simplified Chinese in-page.
 
 Frontend assets are now decoupled under `frontend/dist` and served by the backend.

--- a/src/relay_teams/commands/command_cli.py
+++ b/src/relay_teams/commands/command_cli.py
@@ -14,7 +14,7 @@ RequestJsonResponse: TypeAlias = dict[str, object] | list[object]
 RequestJsonCallable: TypeAlias = Callable[
     [str, str, str, dict[str, object] | None], RequestJsonResponse
 ]
-AutoStartCallable: TypeAlias = Callable[[str, bool], None]
+AutoStartCallable: TypeAlias = Callable[[str, bool, bool, bool], None]
 
 
 class CommandOutputFormat(str, Enum):
@@ -57,8 +57,19 @@ def build_commands_app(
             "--autostart/--no-autostart",
             help="Start the local server if it is not running.",
         ),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         workspace_id = _resolve_workspace_id(
             base_url=base_url,
             workspace=workspace,
@@ -100,8 +111,19 @@ def build_commands_app(
             "--autostart/--no-autostart",
             help="Start the local server if it is not running.",
         ),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         workspace_id = _resolve_workspace_id(
             base_url=base_url,
             workspace=workspace,

--- a/src/relay_teams/env/env_cli.py
+++ b/src/relay_teams/env/env_cli.py
@@ -88,8 +88,19 @@ def proxy_reload(
         "--autostart/--no-autostart",
         help="Auto-start local server when not already running.",
     ),
+    daemon: bool = typer.Option(
+        False,
+        "--daemon",
+        "-d",
+        help="Run the server as a background process when autostarting.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force kill any existing server process before autostarting.",
+    ),
 ) -> None:
-    _auto_start_if_needed(base_url, autostart)
+    _auto_start_if_needed(base_url, autostart, daemon, force)
     payload = _request_json(base_url, "POST", "/api/system/configs/proxy:reload")
     typer.echo(json.dumps(payload, ensure_ascii=False))
 
@@ -118,8 +129,19 @@ def probe_web(
         "--autostart/--no-autostart",
         help="Auto-start local server when not already running.",
     ),
+    daemon: bool = typer.Option(
+        False,
+        "--daemon",
+        "-d",
+        help="Run the server as a background process when autostarting.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force kill any existing server process before autostarting.",
+    ),
 ) -> None:
-    _auto_start_if_needed(base_url, autostart)
+    _auto_start_if_needed(base_url, autostart, daemon, force)
     payload: dict[str, object] = {"url": url}
     if timeout_ms is not None:
         payload["timeout_ms"] = timeout_ms
@@ -322,7 +344,12 @@ def _is_server_healthy(base_url: str) -> bool:
         return False
 
 
-def _auto_start_if_needed(base_url: str, autostart: bool) -> None:
+def _auto_start_if_needed(
+    base_url: str,
+    autostart: bool,
+    daemon: bool = False,
+    force: bool = False,
+) -> None:
     if _is_server_healthy(base_url):
         return
     if not autostart:
@@ -338,12 +365,17 @@ def _auto_start_if_needed(base_url: str, autostart: bool) -> None:
             f"Refusing to autostart server for non-local base URL: {base_url}"
         )
 
-    _start_server_daemon(host=host, port=port)
+    if force:
+        from relay_teams.interfaces.server.cli import stop_managed_server_process
+
+        stop_managed_server_process(force=True)
+
+    _start_server_daemon(host=host, port=port, daemon=daemon)
     if not _wait_until_healthy(base_url):
         raise RuntimeError("Failed to start local Agent Teams server")
 
 
-def _start_server_daemon(host: str, port: int) -> None:
+def _start_server_daemon(host: str, port: int, *, daemon: bool = False) -> None:
     sync_proxy_env_to_process_env(load_proxy_env_config())
     command = [
         sys.executable,
@@ -356,6 +388,8 @@ def _start_server_daemon(host: str, port: int) -> None:
         "--port",
         str(port),
     ]
+    if daemon:
+        command.append("--daemon")
     if sys.platform.startswith("win"):
         create_new_process_group = int(
             getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)

--- a/src/relay_teams/external_agents/agent_cli.py
+++ b/src/relay_teams/external_agents/agent_cli.py
@@ -11,7 +11,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class AgentOutputFormat(str, Enum):
@@ -40,8 +40,19 @@ def build_agent_runtimes_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",
@@ -65,8 +76,19 @@ def build_agent_runtimes_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",
@@ -89,8 +111,19 @@ def build_agent_runtimes_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = _parse_config_json(config_json)
         result = request_json(
             base_url,
@@ -110,8 +143,19 @@ def build_agent_runtimes_app(
         agent_id: str = typer.Argument(..., help="Agent runtime id."),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         result = request_json(
             base_url,
             "DELETE",
@@ -136,8 +180,19 @@ def build_agent_runtimes_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "POST",

--- a/src/relay_teams/interfaces/cli/app.py
+++ b/src/relay_teams/interfaces/cli/app.py
@@ -28,7 +28,10 @@ from relay_teams.interfaces.cli.run_prompt_cli import (
     run_single_prompt as _run_single_prompt_impl,
     stream_events as _stream_events_impl,
 )
-from relay_teams.interfaces.server.cli import build_server_app
+from relay_teams.interfaces.server.cli import (
+    build_server_app,
+    stop_managed_server_process,
+)
 from relay_teams.interfaces.server.runtime_identity import (
     ServerHealthPayload,
     build_server_runtime_identity,
@@ -139,7 +142,7 @@ async def _get_server_health_async(base_url: str) -> ServerHealthPayload | None:
         return None
 
 
-def _start_server_daemon(host: str, port: int) -> None:
+def _start_server_daemon(host: str, port: int, *, daemon: bool = False) -> None:
     sync_proxy_env_to_process_env(load_proxy_env_config())
     command = [
         sys.executable,
@@ -152,6 +155,8 @@ def _start_server_daemon(host: str, port: int) -> None:
         "--port",
         str(port),
     ]
+    if daemon:
+        command.append("--daemon")
 
     if sys.platform.startswith("win"):
         create_new_process_group = int(
@@ -199,7 +204,9 @@ async def _wait_until_healthy_async(
     return False
 
 
-def _auto_start_if_needed(base_url: str, autostart: bool) -> None:
+def _auto_start_if_needed(
+    base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+) -> None:
     parsed = urlparse(base_url)
     host = parsed.hostname or "127.0.0.1"
     live_health = _get_server_health(base_url)
@@ -225,7 +232,10 @@ def _auto_start_if_needed(base_url: str, autostart: bool) -> None:
             f"Refusing to autostart server for non-local base URL: {base_url}"
         )
 
-    _start_server_daemon(host=host, port=port)
+    if force:
+        stop_managed_server_process(force=True)
+
+    _start_server_daemon(host=host, port=port, daemon=daemon)
     if not _wait_until_healthy(base_url):
         raise RuntimeError("Failed to start local Agent Teams server")
 
@@ -244,8 +254,10 @@ def _module_request_json(
     )
 
 
-def _module_auto_start(base_url: str, autostart: bool) -> None:
-    _auto_start_if_needed(base_url, autostart=autostart)
+def _module_auto_start(
+    base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+) -> None:
+    _auto_start_if_needed(base_url, autostart=autostart, daemon=daemon, force=force)
 
 
 server_app = build_server_app()
@@ -357,6 +369,17 @@ def root_command(
         "--yolo/--no-yolo",
         help="Skip tool approvals for the run.",
     ),
+    daemon: bool = typer.Option(
+        False,
+        "--daemon",
+        "-d",
+        help="Run the server as a background process when autostarting.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force kill any existing server process before autostarting.",
+    ),
 ) -> None:
     _root_command_impl(
         ctx,
@@ -366,6 +389,8 @@ def root_command(
         role,
         orchestration,
         workspace,
+        daemon,
+        force,
         run_single_prompt=_run_single_prompt,
     )
 
@@ -377,6 +402,8 @@ def _run_single_prompt(
     normal_root_role_id: str | None,
     orchestration_id: str | None,
     workspace: Path | None,
+    daemon: bool,
+    force: bool,
 ) -> None:
     _run_single_prompt_impl(
         message,
@@ -385,6 +412,8 @@ def _run_single_prompt(
         normal_root_role_id,
         orchestration_id,
         workspace,
+        daemon,
+        force,
         default_base_url=DEFAULT_BASE_URL,
         execute_prompt=_execute_prompt,
     )
@@ -402,6 +431,8 @@ def _execute_prompt(
     orchestration_id: str | None = None,
     workspace: Path | None = None,
     autostart: bool = True,
+    daemon: bool = False,
+    force: bool = False,
     debug: bool = False,
 ) -> None:
     _execute_prompt_impl(
@@ -415,6 +446,8 @@ def _execute_prompt(
         orchestration_id,
         workspace,
         autostart,
+        daemon,
+        force,
         debug,
         auto_start_if_needed=_module_auto_start,
         request_json=_module_request_json,

--- a/src/relay_teams/interfaces/cli/approvals_cli.py
+++ b/src/relay_teams/interfaces/cli/approvals_cli.py
@@ -9,7 +9,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 def build_approvals_app(
@@ -25,8 +25,19 @@ def build_approvals_app(
         run_id: str = typer.Option(..., "--run-id"),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         result = request_json(
             base_url, "GET", f"/api/runs/{run_id}/tool-approvals", None
         )
@@ -45,8 +56,19 @@ def build_approvals_app(
         feedback: str = typer.Option("", "--feedback"),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         if action not in {
             "approve",
             "approve_once",

--- a/src/relay_teams/interfaces/cli/gateway_cli.py
+++ b/src/relay_teams/interfaces/cli/gateway_cli.py
@@ -27,7 +27,7 @@ RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None],
     dict[str, object] | list[object],
 ]
-AutoStartCallable = Callable[[str, bool], None]
+AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 def build_gateway_app(
@@ -61,8 +61,19 @@ def build_gateway_app(
         def feishu_list(
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(base_url, "GET", "/api/gateway/feishu/accounts", None)
             typer.echo(json.dumps(result, ensure_ascii=False))
 
@@ -71,12 +82,23 @@ def build_gateway_app(
             payload_json: str = typer.Option(..., "--payload-json"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
             payload = _parse_json_object_option(
                 payload_json,
                 option_name="--payload-json",
             )
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",
@@ -91,12 +113,23 @@ def build_gateway_app(
             payload_json: str = typer.Option(..., "--payload-json"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
             payload = _parse_json_object_option(
                 payload_json,
                 option_name="--payload-json",
             )
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "PATCH",
@@ -110,8 +143,19 @@ def build_gateway_app(
             account_id: str = typer.Option(..., "--account-id"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",
@@ -125,8 +169,19 @@ def build_gateway_app(
             account_id: str = typer.Option(..., "--account-id"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",
@@ -138,16 +193,27 @@ def build_gateway_app(
         @feishu_app.command("delete")
         def feishu_delete(
             account_id: str = typer.Option(..., "--account-id"),
-            force: bool = typer.Option(True, "--force/--no-force"),
+            force_delete: bool = typer.Option(True, "--force-delete/--no-force-delete"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "DELETE",
                 f"/api/gateway/feishu/accounts/{account_id}",
-                {"force": force},
+                {"force": force_delete},
             )
             typer.echo(json.dumps(result, ensure_ascii=False))
 
@@ -155,8 +221,19 @@ def build_gateway_app(
         def feishu_reload(
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",
@@ -169,8 +246,19 @@ def build_gateway_app(
         def wechat_list(
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(base_url, "GET", "/api/gateway/wechat/accounts", None)
             typer.echo(json.dumps(result, ensure_ascii=False))
 
@@ -181,13 +269,24 @@ def build_gateway_app(
             bot_type: str = typer.Option("3", "--bot-type"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
             payload: dict[str, object] = {"bot_type": bot_type}
             if base_url_override is not None:
                 payload["base_url"] = base_url_override
             if route_tag is not None:
                 payload["route_tag"] = route_tag
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",
@@ -202,8 +301,19 @@ def build_gateway_app(
             timeout_ms: int = typer.Option(480000, "--timeout-ms"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",
@@ -218,12 +328,23 @@ def build_gateway_app(
             payload_json: str = typer.Option(..., "--payload-json"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
             payload = _parse_json_object_option(
                 payload_json,
                 option_name="--payload-json",
             )
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "PATCH",
@@ -237,8 +358,19 @@ def build_gateway_app(
             account_id: str = typer.Option(..., "--account-id"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",
@@ -252,8 +384,19 @@ def build_gateway_app(
             account_id: str = typer.Option(..., "--account-id"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",
@@ -265,16 +408,27 @@ def build_gateway_app(
         @wechat_app.command("delete")
         def wechat_delete(
             account_id: str = typer.Option(..., "--account-id"),
-            force: bool = typer.Option(True, "--force/--no-force"),
+            force_delete: bool = typer.Option(True, "--force-delete/--no-force-delete"),
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "DELETE",
                 f"/api/gateway/wechat/accounts/{account_id}",
-                {"force": force},
+                {"force": force_delete},
             )
             typer.echo(json.dumps(result, ensure_ascii=False))
 
@@ -282,8 +436,19 @@ def build_gateway_app(
         def wechat_reload(
             base_url: str = typer.Option(default_base_url, "--base-url"),
             autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+            daemon: bool = typer.Option(
+                False,
+                "--daemon",
+                "-d",
+                help="Run the server as a background process when autostarting.",
+            ),
+            force: bool = typer.Option(
+                False,
+                "--force",
+                help="Force kill any existing server process before autostarting.",
+            ),
         ) -> None:
-            auto_start_if_needed(base_url, autostart)
+            auto_start_if_needed(base_url, autostart, daemon, force)
             result = request_json(
                 base_url,
                 "POST",

--- a/src/relay_teams/interfaces/cli/hooks_cli.py
+++ b/src/relay_teams/interfaces/cli/hooks_cli.py
@@ -9,7 +9,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class HooksOutputFormat(str, Enum):
@@ -34,8 +34,19 @@ def build_hooks_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(base_url, "GET", "/api/system/configs/hooks", None)
         response = _require_object_response(payload, "/api/system/configs/hooks")
         if output_format == HooksOutputFormat.JSON:
@@ -47,8 +58,19 @@ def build_hooks_app(
     def validate_hooks(
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(base_url, "GET", "/api/system/configs/hooks", None)
         response = _require_object_response(payload, "/api/system/configs/hooks")
         _ = request_json(
@@ -68,8 +90,19 @@ def build_hooks_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(base_url, "GET", "/api/system/configs/hooks", None)
         response = _require_object_response(payload, "/api/system/configs/hooks")
         if output_format == HooksOutputFormat.JSON:

--- a/src/relay_teams/interfaces/cli/memories_cli.py
+++ b/src/relay_teams/interfaces/cli/memories_cli.py
@@ -10,7 +10,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class MemoriesOutputFormat(str, Enum):
@@ -43,8 +43,19 @@ def build_memories_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         params: dict[str, object] = {}
         if tier is not None:
             params["tier"] = tier
@@ -77,8 +88,19 @@ def build_memories_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",
@@ -109,8 +131,19 @@ def build_memories_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         body: dict[str, object] = {
             "content": {"title": title or content[:80], "body": content},
             "tier": tier,
@@ -139,8 +172,19 @@ def build_memories_app(
         memory_id: str = typer.Option(..., "--memory-id"),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         request_json(
             base_url,
             "DELETE",
@@ -160,8 +204,19 @@ def build_memories_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "POST",
@@ -183,8 +238,19 @@ def build_memories_app(
         target_scope: str = typer.Option("workspace", "--target-scope"),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "POST",

--- a/src/relay_teams/interfaces/cli/metrics_cli.py
+++ b/src/relay_teams/interfaces/cli/metrics_cli.py
@@ -10,7 +10,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class MetricsOutputFormat(str, Enum):
@@ -45,9 +45,20 @@ def build_metrics_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
         _validate_scope(scope=scope, scope_id=scope_id)
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",
@@ -75,9 +86,20 @@ def build_metrics_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
         _validate_scope(scope=scope, scope_id=scope_id)
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",
@@ -100,9 +122,20 @@ def build_metrics_app(
         time_window_minutes: int = typer.Option(60, "--window-minutes", min=1),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
         _validate_scope(scope=scope, scope_id=scope_id)
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",

--- a/src/relay_teams/interfaces/cli/prompts_cli.py
+++ b/src/relay_teams/interfaces/cli/prompts_cli.py
@@ -10,7 +10,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class PromptOutputFormat(str, Enum):
@@ -59,8 +59,19 @@ def build_prompts_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         if role_id is None or not role_id.strip():
             roles_payload = request_json(base_url, "GET", "/api/roles", None)
             role_ids = _extract_role_ids(roles_payload)

--- a/src/relay_teams/interfaces/cli/questions_cli.py
+++ b/src/relay_teams/interfaces/cli/questions_cli.py
@@ -10,7 +10,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class QuestionsOutputFormat(str, Enum):
@@ -37,8 +37,19 @@ def build_questions_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         result = request_json(base_url, "GET", f"/api/runs/{run_id}/questions", None)
         items = _extract_question_items(result)
         if output_format == QuestionsOutputFormat.JSON:
@@ -60,8 +71,19 @@ def build_questions_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         try:
             decoded = json.loads(answers_json)
         except ValueError as exc:

--- a/src/relay_teams/interfaces/cli/run_prompt_cli.py
+++ b/src/relay_teams/interfaces/cli/run_prompt_cli.py
@@ -17,10 +17,10 @@ from relay_teams.sessions.session_models import SessionMode
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 type StreamEventsCallable = Callable[[str, str, bool], None]
 type RunSinglePromptCallable = Callable[
-    [str, bool, SessionMode, str | None, str | None, Path | None], None
+    [str, bool, SessionMode, str | None, str | None, Path | None, bool, bool], None
 ]
 type ExecutePromptCallable = Callable[..., None]
 
@@ -40,13 +40,17 @@ def root_command(
     role: str | None,
     orchestration: str | None,
     workspace: Path | None,
+    daemon: bool,
+    force: bool,
     *,
     run_single_prompt: RunSinglePromptCallable,
 ) -> None:
     if message is not None:
         if ctx.invoked_subcommand is not None:
             raise typer.BadParameter("Cannot combine --message with subcommands")
-        run_single_prompt(message, yolo, mode, role, orchestration, workspace)
+        run_single_prompt(
+            message, yolo, mode, role, orchestration, workspace, daemon, force
+        )
         return
 
     if (
@@ -71,6 +75,8 @@ def run_single_prompt(
     role_id: str | None,
     orchestration_id: str | None,
     workspace: Path | None,
+    daemon: bool,
+    force: bool,
     *,
     default_base_url: str,
     execute_prompt: ExecutePromptCallable,
@@ -113,6 +119,8 @@ def run_single_prompt(
         orchestration_id=normalized_orchestration_id,
         workspace=workspace,
         autostart=True,
+        daemon=daemon,
+        force=force,
         debug=False,
     )
 
@@ -128,13 +136,15 @@ def execute_prompt(
     orchestration_id: str | None,
     workspace: Path | None,
     autostart: bool,
+    daemon: bool,
+    force: bool,
     debug: bool,
     *,
     auto_start_if_needed: AutoStartCallable,
     request_json: RequestJsonCallable,
     stream_events: StreamEventsCallable,
 ) -> None:
-    auto_start_if_needed(base_url, autostart)
+    auto_start_if_needed(base_url, autostart, daemon, force)
 
     workspace_id = _resolve_workspace_id(
         base_url=base_url,

--- a/src/relay_teams/interfaces/cli/runs_cli.py
+++ b/src/relay_teams/interfaces/cli/runs_cli.py
@@ -10,7 +10,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class RunsOutputFormat(str, Enum):
@@ -36,8 +36,19 @@ def build_runs_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",

--- a/src/relay_teams/interfaces/server/cli.py
+++ b/src/relay_teams/interfaces/server/cli.py
@@ -433,6 +433,14 @@ def _clear_managed_server(expected_pid: int | None = None) -> None:
     process_file.unlink(missing_ok=True)
 
 
+def stop_managed_server_process(
+    *,
+    force: bool = False,
+    timeout_seconds: float = 10.0,
+) -> ManagedServerProcess | None:
+    return _stop_managed_server(force=force, timeout_seconds=timeout_seconds)
+
+
 def _stop_managed_server(
     force: bool,
     timeout_seconds: float = 10.0,

--- a/src/relay_teams/roles/role_cli.py
+++ b/src/relay_teams/roles/role_cli.py
@@ -10,7 +10,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class PromptOutputFormat(str, Enum):
@@ -39,8 +39,19 @@ def build_roles_app(
     def roles_validate(
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         result = request_json(base_url, "POST", "/api/roles:validate", {})
         typer.echo(json.dumps(result, ensure_ascii=False))
 
@@ -68,8 +79,19 @@ def build_roles_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         if role_id is None or not role_id.strip():
             roles_payload = request_json(base_url, "GET", "/api/roles", None)
             role_ids = _extract_role_ids(roles_payload)

--- a/src/relay_teams/skills/clawhub_cli.py
+++ b/src/relay_teams/skills/clawhub_cli.py
@@ -10,7 +10,7 @@ import typer
 type RequestJsonCallable = Callable[
     [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
 ]
-type AutoStartCallable = Callable[[str, bool], None]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
 
 
 class ClawHubOutputFormat(str, Enum):
@@ -38,8 +38,19 @@ def build_clawhub_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(base_url, "GET", "/api/system/configs/clawhub", None)
         data = _require_object_response(payload, "/api/system/configs/clawhub")
         if output_format == ClawHubOutputFormat.JSON:
@@ -63,6 +74,17 @@ def build_clawhub_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
         if token is not None and clear_token:
             raise typer.BadParameter(
@@ -70,7 +92,7 @@ def build_clawhub_app(
             )
         if token is None and not clear_token:
             raise typer.BadParameter("Pass --token to save or --clear-token to remove")
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload: dict[str, object] = {"token": None if clear_token else token}
         result = request_json(
             base_url,
@@ -95,8 +117,19 @@ def build_clawhub_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",
@@ -120,8 +153,19 @@ def build_clawhub_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = request_json(
             base_url,
             "GET",
@@ -146,8 +190,19 @@ def build_clawhub_app(
         ),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         payload = _parse_config_json(config_json)
         result = request_json(
             base_url,
@@ -169,8 +224,19 @@ def build_clawhub_app(
         skill_id: str = typer.Argument(..., help="ClawHub skill directory id."),
         base_url: str = typer.Option(default_base_url, "--base-url"),
         autostart: bool = typer.Option(True, "--autostart/--no-autostart"),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
     ) -> None:
-        auto_start_if_needed(base_url, autostart)
+        auto_start_if_needed(base_url, autostart, daemon, force)
         result = request_json(
             base_url,
             "DELETE",

--- a/tests/integration_tests/cli/test_prompt_output.py
+++ b/tests/integration_tests/cli/test_prompt_output.py
@@ -92,7 +92,9 @@ def test_root_message_uses_current_directory_as_default_workspace(
 def test_root_message_uses_yolo_by_default(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(

--- a/tests/unit_tests/interfaces/cli/test_agents_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_agents_commands.py
@@ -13,7 +13,9 @@ runner = CliRunner()
 def test_agent_runtimes_list_supports_json_output(monkeypatch) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -54,7 +56,9 @@ def test_agent_runtimes_list_supports_json_output(monkeypatch) -> None:
 def test_agent_runtimes_save_and_delete_call_expected_endpoints(monkeypatch) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -122,7 +126,9 @@ def test_agent_runtimes_commands_encode_agent_id_path(monkeypatch) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
     agent_id = "team/codex runtime?#1"
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -213,7 +219,9 @@ def test_agent_runtimes_commands_encode_agent_id_path(monkeypatch) -> None:
 
 
 def test_agent_runtimes_test_supports_table_output(monkeypatch) -> None:
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(

--- a/tests/unit_tests/interfaces/cli/test_clawhub_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_clawhub_commands.py
@@ -13,7 +13,9 @@ runner = CliRunner()
 def test_clawhub_config_commands_call_expected_endpoints(monkeypatch) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -51,7 +53,9 @@ def test_clawhub_config_commands_call_expected_endpoints(monkeypatch) -> None:
 def test_clawhub_skill_commands_call_expected_endpoints(monkeypatch) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -108,7 +112,9 @@ def test_clawhub_skill_commands_call_expected_endpoints(monkeypatch) -> None:
 def test_clawhub_config_save_requires_token_or_clear(monkeypatch) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(

--- a/tests/unit_tests/interfaces/cli/test_command_tree.py
+++ b/tests/unit_tests/interfaces/cli/test_command_tree.py
@@ -34,7 +34,9 @@ def test_root_message_runs_single_prompt(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
     streamed: dict[str, object] = {}
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         streamed["base_url"] = base_url
         streamed["autostart"] = autostart
 
@@ -99,7 +101,9 @@ def test_root_message_supports_workspace_selection(monkeypatch, tmp_path: Path) 
     calls: list[tuple[str, str, dict[str, object] | None]] = []
     streamed: dict[str, object] = {}
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -157,7 +161,9 @@ def test_root_message_resolves_registered_slash_command(
 ) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -234,7 +240,9 @@ def test_root_message_falls_back_to_slash_text_when_command_expands_empty(
 ) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -290,7 +298,9 @@ def test_root_message_falls_back_to_slash_text_when_command_expands_empty(
 def test_commands_list_uses_backend(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -343,7 +353,9 @@ def test_commands_list_json_with_workspace_id_skips_pick(
     calls: list[tuple[str, str, dict[str, object] | None]] = []
     (tmp_path / "workspace-1").mkdir()
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -399,7 +411,9 @@ def test_commands_list_bare_relative_workspace_path_uses_pick(
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -441,7 +455,9 @@ def test_commands_list_bare_relative_workspace_path_uses_pick(
 
 
 def test_commands_list_empty_table(monkeypatch, tmp_path: Path) -> None:
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -471,7 +487,9 @@ def test_commands_list_empty_table(monkeypatch, tmp_path: Path) -> None:
 def test_commands_show_table_and_json(monkeypatch) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -555,7 +573,9 @@ def test_root_message_supports_normal_role_selection(
 ) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -630,7 +650,9 @@ def test_root_message_supports_orchestration_mode(
 ) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -710,7 +732,9 @@ def test_root_message_supports_orchestration_mode(
 def test_root_message_allows_no_yolo_override(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -789,7 +813,9 @@ def test_root_message_invalid_role_lists_available_ids(
 ) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -864,7 +890,9 @@ def test_root_message_invalid_orchestration_id_lists_available_ids(
 ) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -943,7 +971,9 @@ def test_run_module_removed() -> None:
 def test_runs_module_todo_command(monkeypatch) -> None:
     calls: list[tuple[str, str, dict[str, object] | None]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(

--- a/tests/unit_tests/interfaces/cli/test_memories_cli.py
+++ b/tests/unit_tests/interfaces/cli/test_memories_cli.py
@@ -29,10 +29,12 @@ class _CapturingAutoStart:
     """Records calls to auto_start_if_needed without launching a server."""
 
     def __init__(self) -> None:
-        self.calls: list[tuple[str, bool]] = []
+        self.calls: list[tuple[str, bool, bool, bool]] = []
 
-    def __call__(self, base_url: str, autostart: bool) -> None:
-        self.calls.append((base_url, autostart))
+    def __call__(
+        self, base_url: str, autostart: bool, daemon: bool, force: bool
+    ) -> None:
+        self.calls.append((base_url, autostart, daemon, force))
 
 
 class _FakeRequestJson:

--- a/tests/unit_tests/interfaces/cli/test_metrics_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_metrics_commands.py
@@ -17,7 +17,9 @@ def _normalized_output(text: str) -> str:
 def test_metrics_overview_command_renders_prettylog(monkeypatch) -> None:
     calls: list[tuple[str, str, str]] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         assert base_url == cli_app.DEFAULT_BASE_URL
         assert autostart is True
 
@@ -68,7 +70,9 @@ def test_metrics_breakdowns_command_requires_scope_id() -> None:
 
 
 def test_metrics_breakdowns_command_renders_gateway_rows(monkeypatch) -> None:
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(

--- a/tests/unit_tests/interfaces/cli/test_prompts_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_prompts_commands.py
@@ -121,7 +121,9 @@ class _FakeAsyncByteStream(httpx.AsyncByteStream):
 def test_roles_prompt_builds_preview_payload(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         captured["base_url"] = base_url
         captured["autostart"] = autostart
 
@@ -189,7 +191,9 @@ def test_roles_prompt_builds_preview_payload(monkeypatch) -> None:
 def test_roles_prompt_without_role_id_shows_available_roles(monkeypatch) -> None:
     captured: list[str] = []
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(
@@ -219,7 +223,9 @@ def test_roles_prompt_without_role_id_shows_available_roles(monkeypatch) -> None
 
 
 def test_roles_prompt_default_output_prints_full_prompt(monkeypatch) -> None:
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(

--- a/tests/unit_tests/interfaces/cli/test_questions_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_questions_commands.py
@@ -10,7 +10,9 @@ runner = CliRunner()
 def test_questions_list_renders_table_by_default(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         captured["base_url"] = base_url
         captured["autostart"] = autostart
 
@@ -59,7 +61,9 @@ def test_questions_list_renders_table_by_default(monkeypatch) -> None:
 
 
 def test_questions_list_supports_json_output(monkeypatch) -> None:
-    def fake_autostart(base_url: str, autostart: bool) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
         _ = (base_url, autostart)
 
     def fake_request_json(

--- a/tests/unit_tests/interfaces/cli/test_server_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_server_commands.py
@@ -645,7 +645,9 @@ def test_root_cli_autostart_rejects_mismatched_local_runtime(monkeypatch) -> Non
     )
 
     try:
-        cli_app._auto_start_if_needed("http://127.0.0.1:8000", autostart=True)
+        cli_app._auto_start_if_needed(
+            "http://127.0.0.1:8000", autostart=True, daemon=False, force=False
+        )
     except RuntimeError as exc:
         assert "runtime mismatch" in str(exc)
         assert "Stop the conflicting server first" in str(exc)
@@ -677,7 +679,9 @@ def test_root_cli_autostart_rejects_mismatched_builtin_roles_dir(monkeypatch) ->
     )
 
     try:
-        cli_app._auto_start_if_needed("http://127.0.0.1:8000", autostart=True)
+        cli_app._auto_start_if_needed(
+            "http://127.0.0.1:8000", autostart=True, daemon=False, force=False
+        )
     except RuntimeError as exc:
         assert "runtime mismatch" in str(exc)
         assert "builtin roles" in str(exc)


### PR DESCRIPTION
## Summary

All CLI subcommands that support `--autostart` now also accept:
- `--daemon` (`-d`): Run the server as a background process when autostarting
- `--force`: Force kill any existing server process before autostarting

## Changes

### Core infrastructure
- `interfaces/server/cli.py`: Expose `stop_managed_server_process()` for use by `--force` across modules
- `interfaces/cli/app.py`: Update `_start_server_daemon`, `_auto_start_if_needed`, `_module_auto_start`, `_execute_prompt`, `_run_single_prompt` to accept and forward `daemon` and `force`
- `interfaces/cli/run_prompt_cli.py`: Update `AutoStartCallable`, `RunSinglePromptCallable`, `execute_prompt` signatures
- `env/env_cli.py`: Update `_auto_start_if_needed`, `_start_server_daemon`, `proxy-reload`, `probe-web`

### CLI subcommands updated
- `approvals_cli.py`: list, resolve
- `questions_cli.py`: list, answer
- `hooks_cli.py`: list, show
- `metrics_cli.py`: query
- `runs_cli.py`: stream
- `memories_cli.py`: list, show, create, delete, consolidate
- `gateway_cli.py`: all feishu/wechat subcommands
- `prompts_cli.py`: submit
- `role_cli.py`: list, show
- `agent_cli.py`: list, show
- `command_cli.py`: list, show
- `clawhub_cli.py`: list, search, install, uninstall

### Tests
- Updated all `fake_autostart` stubs and `_CapturingAutoStart` to accept the new 4-arg signature
- Updated direct `_auto_start_if_needed` calls in test_server_commands.py

### Documentation
- README.md: Document `--daemon` usage

## Test plan
- [x] `ruff check --fix` passes
- [x] `ruff format` passes  
- [x] `basedpyright` passes (0 source errors)
- [x] Unit tests pass: `pytest -q tests/unit_tests/interfaces/cli/` (130 passed)
- [x] Unit tests pass: `pytest -q tests/unit_tests/env/` (104 passed)
- [x] Pre-commit hooks pass (ruff-check, ruff-format, basedpyright-check)