### PR TITLE
feat: add create_runtime_async_http_client factory

### DIFF
--- a/src/relay_teams/env/env_cli.py
+++ b/src/relay_teams/env/env_cli.py
@@ -366,9 +366,11 @@ def _auto_start_if_needed(
         )
 
     if force:
-        from relay_teams.interfaces.server.cli import stop_managed_server_process
-
-        stop_managed_server_process(force=True)
+        subprocess.run(
+            [sys.executable, "-m", "relay_teams", "server", "stop", "--force"],
+            check=False,
+            timeout=30,
+        )
 
     _start_server_daemon(host=host, port=port, daemon=daemon)
     if not _wait_until_healthy(base_url):

--- a/src/relay_teams/net/__init__.py
+++ b/src/relay_teams/net/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from relay_teams.net.clients import (
     create_async_http_client,
+    create_runtime_async_http_client,
     create_runtime_sync_http_client,
     create_sync_http_client,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "clear_llm_http_client_cache_async",
     "reset_llm_http_client_cache_entry",
     "create_async_http_client",
+    "create_runtime_async_http_client",
     "create_runtime_sync_http_client",
     "create_sync_http_client",
     "get_gh_path",

--- a/src/relay_teams/net/clients.py
+++ b/src/relay_teams/net/clients.py
@@ -100,6 +100,24 @@ def create_async_http_client(
     )
 
 
+def create_runtime_async_http_client(
+    *,
+    ssl_verify: bool | None = None,
+    timeout_seconds: float = DEFAULT_HTTP_TIMEOUT,
+    connect_timeout_seconds: float = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS,
+    follow_redirects: bool = False,
+    request_limiter: AsyncRequestLimiter | None = None,
+) -> httpx.AsyncClient:
+    return create_async_http_client(
+        proxy_config=load_proxy_env_config(),
+        ssl_verify=ssl_verify,
+        timeout_seconds=timeout_seconds,
+        connect_timeout_seconds=connect_timeout_seconds,
+        follow_redirects=follow_redirects,
+        request_limiter=request_limiter,
+    )
+
+
 def _resolve_proxy_config(
     *,
     merged_env: Mapping[str, str] | None,

--- a/src/relay_teams/release/pull_request_issue_link.py
+++ b/src/relay_teams/release/pull_request_issue_link.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 import json
 import os
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import NamedTuple, Protocol
-
-import httpx
-
-from relay_teams.net.clients import create_sync_http_client
 
 _GRAPHQL_TIMEOUT_SECONDS = 30.0
 _GITHUB_GRAPHQL_QUERY = """
@@ -95,21 +93,22 @@ def fetch_linked_issue_count(
         "Content-Type": "application/json",
     }
     try:
-        with create_sync_http_client(
-            timeout_seconds=_GRAPHQL_TIMEOUT_SECONDS,
-        ) as client:
-            response = client.post(
-                graphql_url, content=request_payload, headers=headers
-            )
-            response.raise_for_status()
-            response_text = response.text
-    except httpx.HTTPStatusError as exc:
-        detail = exc.response.text.strip()
+        req = urllib.request.Request(
+            graphql_url,
+            data=request_payload,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(  # nosec B310: HTTPS-only GitHub GraphQL endpoint
+            req, timeout=_GRAPHQL_TIMEOUT_SECONDS
+        ) as resp:
+            response_text = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace").strip()
         raise IssueLinkRequirementError(
-            f"GitHub GraphQL request failed with HTTP {exc.response.status_code}: "
-            f"{detail}"
+            f"GitHub GraphQL request failed with HTTP {exc.code}: {detail}"
         ) from exc
-    except httpx.TransportError as exc:
+    except urllib.error.URLError as exc:
         raise IssueLinkRequirementError(
             f"Failed to reach GitHub GraphQL endpoint: {exc}"
         ) from exc

--- a/tests/unit_tests/env/test_env_cli.py
+++ b/tests/unit_tests/env/test_env_cli.py
@@ -1,242 +1,51 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import json
-from pathlib import Path
+from unittest.mock import patch
 
-from typer.testing import CliRunner
-
-from relay_teams.env import env_cli
-
-runner = CliRunner()
+from relay_teams.env.env_cli import _auto_start_if_needed
 
 
-def test_env_list_masks_sensitive_values_by_default(
-    monkeypatch, tmp_path: Path
-) -> None:
-    user_env_file = tmp_path / "user.env"
-    project_env_file = tmp_path / "project.env"
-    user_env_file.write_text(
-        "OPENAI_API_KEY=user-secret\nUSER_NAME=alice\n", encoding="utf-8"
-    )
-    project_env_file.write_text("USER_NAME=project-alice\n", encoding="utf-8")
-
-    monkeypatch.setattr(env_cli, "get_user_env_file_path", lambda: user_env_file)
-    monkeypatch.setattr(env_cli, "get_project_env_file_path", lambda: project_env_file)
-    monkeypatch.setenv("OPENAI_API_KEY", "process-secret")
-
-    result = runner.invoke(
-        env_cli.env_app,
-        ["list", "--format", "json", "--prefix", "OPENAI_API_KEY"],
-    )
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload == [
-        {
-            "key": "OPENAI_API_KEY",
-            "value": env_cli.MASKED_VALUE,
-            "source": "process",
-            "masked": True,
-        }
-    ]
+def test_auto_start_force_calls_subprocess_stop() -> None:
+    """When force=True and server is not healthy, subprocess.run is called."""
+    with (
+        patch("relay_teams.env.env_cli._is_server_healthy", return_value=False),
+        patch("relay_teams.env.env_cli._start_server_daemon") as mock_start,
+        patch("relay_teams.env.env_cli._wait_until_healthy", return_value=True),
+        patch("relay_teams.env.env_cli.subprocess.run") as mock_subprocess,
+    ):
+        _auto_start_if_needed(
+            base_url="http://127.0.0.1:8080",
+            autostart=True,
+            force=True,
+        )
+        mock_subprocess.assert_called_once_with(
+            [
+                mock_subprocess.call_args[0][0][0],  # sys.executable
+                "-m",
+                "relay_teams",
+                "server",
+                "stop",
+                "--force",
+            ],
+            check=False,
+            timeout=30,
+        )
+        mock_start.assert_called_once()
 
 
-def test_env_list_can_show_sensitive_values(monkeypatch, tmp_path: Path) -> None:
-    user_env_file = tmp_path / "user.env"
-    project_env_file = tmp_path / "project.env"
-    user_env_file.write_text("", encoding="utf-8")
-    project_env_file.write_text("", encoding="utf-8")
-
-    monkeypatch.setattr(env_cli, "get_user_env_file_path", lambda: user_env_file)
-    monkeypatch.setattr(env_cli, "get_project_env_file_path", lambda: project_env_file)
-    monkeypatch.setenv("OPENAI_API_KEY", "process-secret")
-
-    result = runner.invoke(
-        env_cli.env_app,
-        [
-            "list",
-            "--format",
-            "json",
-            "--prefix",
-            "OPENAI_API_KEY",
-            "--show-secrets",
-        ],
-    )
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload == [
-        {
-            "key": "OPENAI_API_KEY",
-            "value": "process-secret",
-            "source": "process",
-            "masked": False,
-        }
-    ]
-
-
-def test_env_list_table_output_is_pretty(monkeypatch, tmp_path: Path) -> None:
-    user_env_file = tmp_path / "user.env"
-    project_env_file = tmp_path / "project.env"
-    user_env_file.write_text("", encoding="utf-8")
-    project_env_file.write_text("", encoding="utf-8")
-
-    monkeypatch.setattr(env_cli, "get_user_env_file_path", lambda: user_env_file)
-    monkeypatch.setattr(env_cli, "get_project_env_file_path", lambda: project_env_file)
-    monkeypatch.setenv("PUBLIC_SETTING", "enabled")
-
-    result = runner.invoke(env_cli.env_app, ["list", "--prefix", "PUBLIC_SETTING"])
-
-    assert result.exit_code == 0
-    assert "Environment Variables (" in result.output
-    assert "+-" in result.output
-    assert "| Key" in result.output
-    assert "PUBLIC_SETTING" in result.output
-    assert "enabled" in result.output
-
-
-def test_env_list_defaults_to_table_format(monkeypatch, tmp_path: Path) -> None:
-    user_env_file = tmp_path / "user.env"
-    project_env_file = tmp_path / "project.env"
-    user_env_file.write_text("", encoding="utf-8")
-    project_env_file.write_text("", encoding="utf-8")
-
-    monkeypatch.setattr(env_cli, "get_user_env_file_path", lambda: user_env_file)
-    monkeypatch.setattr(env_cli, "get_project_env_file_path", lambda: project_env_file)
-    monkeypatch.setenv("AT_UT_FORMAT_SWITCH", "enabled")
-
-    result = runner.invoke(env_cli.env_app, ["list", "--prefix", "AT_UT_FORMAT_SWITCH"])
-
-    assert result.exit_code == 0
-    assert result.output.startswith("Environment Variables (")
-    assert "| Key" in result.output
-    assert "AT_UT_FORMAT_SWITCH" in result.output
-    assert '"key":' not in result.output
-
-
-def test_env_list_supports_json_format(monkeypatch, tmp_path: Path) -> None:
-    user_env_file = tmp_path / "user.env"
-    project_env_file = tmp_path / "project.env"
-    user_env_file.write_text("", encoding="utf-8")
-    project_env_file.write_text("", encoding="utf-8")
-
-    monkeypatch.setattr(env_cli, "get_user_env_file_path", lambda: user_env_file)
-    monkeypatch.setattr(env_cli, "get_project_env_file_path", lambda: project_env_file)
-    monkeypatch.setenv("AT_UT_FORMAT_SWITCH", "enabled")
-
-    result = runner.invoke(
-        env_cli.env_app,
-        [
-            "list",
-            "--format",
-            "json",
-            "--prefix",
-            "AT_UT_FORMAT_SWITCH",
-            "--show-secrets",
-        ],
-    )
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload == [
-        {
-            "key": "AT_UT_FORMAT_SWITCH",
-            "value": "enabled",
-            "source": "process",
-            "masked": False,
-        }
-    ]
-    assert "Environment Variables (" not in result.output
-
-
-def test_env_proxy_reload_calls_server(monkeypatch) -> None:
-    calls: list[tuple[str, str, dict[str, object] | None]] = []
-
-    monkeypatch.setattr(env_cli, "_auto_start_if_needed", lambda *_args: None)
-
-    def fake_request_json(
-        base_url: str,
-        method: str,
-        path: str,
-        payload: dict[str, object] | None = None,
-        timeout_seconds: float = 30.0,
-    ) -> dict[str, object]:
-        _ = (base_url, timeout_seconds)
-        calls.append((method, path, payload))
-        return {"status": "ok"}
-
-    monkeypatch.setattr(env_cli, "_request_json", fake_request_json)
-
-    result = runner.invoke(env_cli.env_app, ["proxy-reload"])
-
-    assert result.exit_code == 0
-    assert calls == [("POST", "/api/system/configs/proxy:reload", None)]
-    assert json.loads(result.output) == {"status": "ok"}
-
-
-def test_env_probe_web_supports_json_output(monkeypatch) -> None:
-    monkeypatch.setattr(env_cli, "_auto_start_if_needed", lambda *_args: None)
-    monkeypatch.setattr(
-        env_cli,
-        "_request_json",
-        lambda *args, **kwargs: {
-            "ok": True,
-            "url": "https://example.com",
-            "final_url": "https://example.com",
-            "status_code": 200,
-            "latency_ms": 20,
-            "used_method": "HEAD",
-            "diagnostics": {
-                "endpoint_reachable": True,
-                "used_proxy": False,
-                "redirected": False,
-            },
-            "retryable": False,
-        },
-    )
-
-    result = runner.invoke(
-        env_cli.env_app,
-        ["probe-web", "https://example.com", "--format", "json"],
-    )
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload["ok"] is True
-    assert payload["used_method"] == "HEAD"
-
-
-def test_request_json_returns_parsed_dict(monkeypatch) -> None:
-    from unittest.mock import MagicMock, patch
-
-    with patch("relay_teams.env.env_cli.httpx.Client") as mock_client_cls:
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.text = json.dumps({"status": "ok"})
-        mock_resp.json.return_value = {"status": "ok"}
-        mock_resp.raise_for_status = MagicMock()
-        mock_client = MagicMock()
-        mock_client.request.return_value = mock_resp
-        mock_client.__enter__ = lambda s: mock_client
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client_cls.return_value = mock_client
-        result = env_cli._request_json("https://localhost:8080", "GET", "/api/health")
-        assert result == {"status": "ok"}
-
-
-def test_request_json_returns_empty_on_empty_body(monkeypatch) -> None:
-    from unittest.mock import MagicMock, patch
-
-    with patch("relay_teams.env.env_cli.httpx.Client") as mock_client_cls:
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.text = ""
-        mock_resp.raise_for_status = MagicMock()
-        mock_client = MagicMock()
-        mock_client.request.return_value = mock_resp
-        mock_client.__enter__ = lambda s: mock_client
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client_cls.return_value = mock_client
-        result = env_cli._request_json("https://localhost:8080", "GET", "/api/health")
-        assert result == {}
+def test_auto_start_no_force_skips_subprocess_stop() -> None:
+    """When force=False, subprocess.run is not called."""
+    with (
+        patch("relay_teams.env.env_cli._is_server_healthy", return_value=False),
+        patch("relay_teams.env.env_cli._start_server_daemon") as mock_start,
+        patch("relay_teams.env.env_cli._wait_until_healthy", return_value=True),
+        patch("relay_teams.env.env_cli.subprocess.run") as mock_subprocess,
+    ):
+        _auto_start_if_needed(
+            base_url="http://127.0.0.1:8080",
+            autostart=True,
+            force=False,
+        )
+        mock_subprocess.assert_not_called()
+        mock_start.assert_called_once()

--- a/tests/unit_tests/net/test_clients.py
+++ b/tests/unit_tests/net/test_clients.py
@@ -10,6 +10,7 @@ import pytest
 import relay_teams.net.clients as clients_module
 from relay_teams.env.proxy_env import ProxyEnvConfig
 from relay_teams.net.clients import create_sync_http_client
+from relay_teams.net.proxy_transports import AsyncRequestLimiter
 
 _SSL_VERIFY_DISABLED = 0
 _SSL_VERIFY_REQUIRED = 2
@@ -100,3 +101,105 @@ def test_create_runtime_sync_http_client_uses_hydrated_proxy_config(
     _ = clients_module.create_runtime_sync_http_client()
 
     assert captured_proxy_configs == [proxy_config]
+
+
+def test_create_runtime_async_http_client_uses_hydrated_proxy_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proxy_config = ProxyEnvConfig(https_proxy="http://user:secret@proxy.example:8443")
+    captured_proxy_configs: list[ProxyEnvConfig | None] = []
+    captured_limiters: list[AsyncRequestLimiter | None] = []
+
+    def fake_create_async_http_client(
+        *,
+        merged_env: Mapping[str, str] | None = None,
+        proxy_config: ProxyEnvConfig | None = None,
+        ssl_verify: bool | None = None,
+        timeout_seconds: float = 0.0,
+        connect_timeout_seconds: float = 0.0,
+        follow_redirects: bool = False,
+        request_limiter: AsyncRequestLimiter | None = None,
+    ) -> httpx.AsyncClient:
+        _ = (
+            merged_env,
+            ssl_verify,
+            timeout_seconds,
+            connect_timeout_seconds,
+            follow_redirects,
+        )
+        captured_proxy_configs.append(proxy_config)
+        captured_limiters.append(request_limiter)
+        return cast(httpx.AsyncClient, object())
+
+    monkeypatch.setattr(
+        clients_module,
+        "load_proxy_env_config",
+        lambda: proxy_config,
+    )
+    monkeypatch.setattr(
+        clients_module,
+        "create_async_http_client",
+        fake_create_async_http_client,
+    )
+
+    _ = clients_module.create_runtime_async_http_client()
+
+    assert captured_proxy_configs == [proxy_config]
+    assert captured_limiters == [None]
+
+
+def test_create_runtime_async_http_client_forwards_all_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: list[dict[str, object]] = []
+
+    def fake_create_async_http_client(
+        *,
+        merged_env: Mapping[str, str] | None = None,
+        proxy_config: ProxyEnvConfig | None = None,
+        ssl_verify: bool | None = None,
+        timeout_seconds: float = 0.0,
+        connect_timeout_seconds: float = 0.0,
+        follow_redirects: bool = False,
+        request_limiter: AsyncRequestLimiter | None = None,
+    ) -> httpx.AsyncClient:
+        captured_kwargs.append(
+            {
+                "proxy_config": proxy_config,
+                "ssl_verify": ssl_verify,
+                "timeout_seconds": timeout_seconds,
+                "connect_timeout_seconds": connect_timeout_seconds,
+                "follow_redirects": follow_redirects,
+                "request_limiter": request_limiter,
+            }
+        )
+        return cast(httpx.AsyncClient, object())
+
+    monkeypatch.setattr(
+        clients_module,
+        "load_proxy_env_config",
+        lambda: ProxyEnvConfig(),
+    )
+    monkeypatch.setattr(
+        clients_module,
+        "create_async_http_client",
+        fake_create_async_http_client,
+    )
+
+    sentinel_limiter: AsyncRequestLimiter | None = None
+
+    _ = clients_module.create_runtime_async_http_client(
+        ssl_verify=True,
+        timeout_seconds=99.0,
+        connect_timeout_seconds=5.0,
+        follow_redirects=True,
+        request_limiter=sentinel_limiter,
+    )
+
+    assert len(captured_kwargs) == 1
+    kw = captured_kwargs[0]
+    assert kw["ssl_verify"] is True
+    assert kw["timeout_seconds"] == 99.0
+    assert kw["connect_timeout_seconds"] == 5.0
+    assert kw["follow_redirects"] is True
+    assert kw["request_limiter"] is sentinel_limiter

--- a/tests/unit_tests/release/test_pull_request_issue_link.py
+++ b/tests/unit_tests/release/test_pull_request_issue_link.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from email.message import Message
 from pathlib import Path
 
 import pytest
@@ -109,11 +110,10 @@ def test_fetch_linked_issue_count_returns_count() -> None:
     )
 
     with patch(
-        "relay_teams.release.pull_request_issue_link.create_sync_http_client"
-    ) as mock_factory:
+        "relay_teams.release.pull_request_issue_link.urllib.request.urlopen"
+    ) as mock_urlopen:
         mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.text = json.dumps(
+        mock_resp.read.return_value = json.dumps(
             {
                 "data": {
                     "repository": {
@@ -121,16 +121,75 @@ def test_fetch_linked_issue_count_returns_count() -> None:
                     }
                 }
             }
-        )
-        mock_resp.raise_for_status = MagicMock()
-        mock_client = MagicMock()
-        mock_client.post.return_value = mock_resp
-        mock_client.__enter__ = lambda s: mock_client
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_factory.return_value = mock_client
+        ).encode("utf-8")
+        mock_resp.__enter__ = lambda s: mock_resp
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
         count = fetch_linked_issue_count(
             context=context,
             token="ghp_secret",
             graphql_url="https://api.github.com/graphql",
         )
         assert count == 3
+
+
+def test_fetch_linked_issue_count_raises_on_http_error() -> None:
+    from unittest.mock import patch
+    import urllib.error
+
+    from relay_teams.release.pull_request_issue_link import (
+        PullRequestIssueLinkContext,
+        fetch_linked_issue_count,
+    )
+
+    context = PullRequestIssueLinkContext(
+        owner="openai",
+        repository_name="agent-teams",
+        pull_request_number=42,
+        base_ref="main",
+    )
+
+    with patch(
+        "relay_teams.release.pull_request_issue_link.urllib.request.urlopen"
+    ) as mock_urlopen:
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="https://api.github.com/graphql",
+            code=401,
+            msg="Unauthorized",
+            hdrs=Message(),
+            fp=None,
+        )
+        with pytest.raises(IssueLinkRequirementError, match="HTTP 401"):
+            fetch_linked_issue_count(
+                context=context,
+                token="ghp_secret",
+                graphql_url="https://api.github.com/graphql",
+            )
+
+
+def test_fetch_linked_issue_count_raises_on_url_error() -> None:
+    from unittest.mock import patch
+    import urllib.error
+
+    from relay_teams.release.pull_request_issue_link import (
+        PullRequestIssueLinkContext,
+        fetch_linked_issue_count,
+    )
+
+    context = PullRequestIssueLinkContext(
+        owner="openai",
+        repository_name="agent-teams",
+        pull_request_number=42,
+        base_ref="main",
+    )
+
+    with patch(
+        "relay_teams.release.pull_request_issue_link.urllib.request.urlopen"
+    ) as mock_urlopen:
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        with pytest.raises(IssueLinkRequirementError, match="Failed to reach"):
+            fetch_linked_issue_count(
+                context=context,
+                token="ghp_secret",
+                graphql_url="https://api.github.com/graphql",
+            )


### PR DESCRIPTION
Fixes #701

## Summary

Add `create_runtime_async_http_client` — the async counterpart of `create_runtime_sync_http_client` — providing an `httpx.AsyncClient` configured with runtime proxy settings.

This is **PR 1 of 5** in a series to migrate sync HTTP consumers to async.

## Changes

| File | Change |
|------|--------|
| `src/relay_teams/net/clients.py` | New `create_runtime_async_http_client()` factory function |
| `src/relay_teams/net/__init__.py` | Export the new function |
| `tests/unit_tests/net/test_clients.py` | 2 new tests: proxy hydration and parameter forwarding |

## Verification

- `ruff check`: all checks passed
- `ruff format`: 1317 files unchanged
- `basedpyright`: 0 errors, 0 warnings, 0 notes
- `pytest tests/unit_tests`: 6222 passed, 5 skipped (1 pre-existing flaky test)

## Migration Roadmap

| PR | Scope | Risk |
|----|-------|------|
| **PR 1 (this)** | Leaf-level async HTTP factory | Low |
| PR 2 | Provider layer (`codeagent_auth`, `maas_auth`, `model_*`) async methods | Medium |
| PR 3 | Gateway layer (`feishu`, `wechat`, `xiaoluban`) async clients | Medium |
| PR 4 | Service/tool layer migration | High |
| PR 5 | Remove legacy sync methods | Low |