### PR TITLE
refactor: add async HTTP methods to Provider layer

### DIFF
--- a/src/relay_teams/providers/codeagent_auth.py
+++ b/src/relay_teams/providers/codeagent_auth.py
@@ -366,6 +366,28 @@ class CodeAgentTokenService:
             )
         return _build_polled_token_result(response)
 
+    async def poll_token(
+        self,
+        *,
+        session: CodeAgentOAuthSession,
+        ssl_verify: bool | None,
+        connect_timeout_seconds: float,
+    ) -> CodeAgentOAuthTokenResult | None:
+        async with create_async_http_client(
+            ssl_verify=ssl_verify,
+            timeout_seconds=connect_timeout_seconds,
+            connect_timeout_seconds=connect_timeout_seconds,
+        ) as client:
+            response = await client.post(
+                _get_token_url(session.base_url),
+                json={
+                    "clientCode": session.client_code,
+                    "redirectUrl": session.callback_url,
+                },
+                headers={"Content-Type": "application/json"},
+            )
+        return _build_polled_token_result(response)
+
     @staticmethod
     def _cache_key(*, base_url: str, auth_config: CodeAgentAuthConfig) -> str:
         cache_discriminator = (

--- a/src/relay_teams/providers/codeagent_auth.py
+++ b/src/relay_teams/providers/codeagent_auth.py
@@ -366,7 +366,8 @@ class CodeAgentTokenService:
             )
         return _build_polled_token_result(response)
 
-    async def poll_token(
+    # noinspection PyMethodMayBeStatic
+    async def poll_token(  # noqa: PLR6301
         self,
         *,
         session: CodeAgentOAuthSession,

--- a/src/relay_teams/providers/model_catalog.py
+++ b/src/relay_teams/providers/model_catalog.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from relay_teams.env.proxy_env import ProxyEnvConfig
 from relay_teams.logger import get_logger
 from relay_teams.media import MediaModality
-from relay_teams.net.clients import create_sync_http_client
+from relay_teams.net.clients import create_async_http_client, create_sync_http_client
 from relay_teams.providers.model_capabilities import resolve_model_capabilities
 from relay_teams.providers.model_config import ModelCapabilities, ProviderType
 
@@ -260,6 +260,112 @@ class ModelCatalogService:
             source_url=self._source_url,
             error_code=error_code,
             error_message=error_message,
+        )
+
+    # -- async counterparts --
+
+    async def get_catalog_async(self, *, refresh: bool = False) -> ModelCatalogResult:
+        cached = self._load_cache()
+        if cached is not None and not refresh:
+            return self._result_from_cache(
+                cached,
+                ok=True,
+                stale=self._is_stale(cached),
+            )
+
+        fetched = await self._fetch_catalog_async()
+        if fetched.ok:
+            envelope = _ModelCatalogCacheEnvelope(
+                source_url=self._source_url,
+                fetched_at=fetched.fetched_at or datetime.now(timezone.utc),
+                providers=fetched.providers,
+            )
+            try:
+                self._write_cache(envelope)
+            except OSError as exc:
+                LOGGER.warning(
+                    "Failed to write model catalog cache.",
+                    extra={
+                        "event": "providers.model_catalog.cache_write_failed",
+                        "cache_path": str(self._cache_path()),
+                        "error": str(exc),
+                    },
+                )
+            return self._result_from_cache(envelope, ok=True, stale=False)
+
+        if cached is None:
+            return fetched
+        return self._result_from_cache(
+            cached,
+            ok=False,
+            stale=True,
+            error_code=fetched.error_code,
+            error_message=fetched.error_message,
+        )
+
+    async def _fetch_catalog_async(self) -> ModelCatalogResult:
+        last_error: ModelCatalogResult | None = None
+        for _attempt in range(_MODEL_CATALOG_FETCH_ATTEMPTS):
+            result = await self._fetch_catalog_once_async()
+            if result.ok:
+                return result
+            last_error = result
+            if result.error_code not in {"network_timeout", "network_error"}:
+                return result
+        if last_error is not None:
+            return last_error
+        return self._error_result(
+            error_code="network_error",
+            error_message="Failed to fetch model catalog.",
+        )
+
+    async def _fetch_catalog_once_async(self) -> ModelCatalogResult:
+        try:
+            async with create_async_http_client(
+                proxy_config=self._get_proxy_config(),
+                timeout_seconds=_MODEL_CATALOG_TIMEOUT_SECONDS,
+                connect_timeout_seconds=_MODEL_CATALOG_TIMEOUT_SECONDS,
+                follow_redirects=True,
+            ) as client:
+                response = await client.get(self._source_url)
+        except httpx.TimeoutException as exc:
+            return self._error_result(
+                error_code="network_timeout",
+                error_message=str(exc) or "Timed out fetching model catalog.",
+            )
+        except httpx.RequestError as exc:
+            return self._error_result(
+                error_code="network_error",
+                error_message=str(exc) or "Failed to fetch model catalog.",
+            )
+
+        if response.status_code >= 400:
+            return self._error_result(
+                error_code="http_error",
+                error_message=(
+                    f"Model catalog source returned HTTP {response.status_code}."
+                ),
+            )
+
+        try:
+            payload: object = response.json()
+        except ValueError:
+            return self._error_result(
+                error_code="invalid_response",
+                error_message="Model catalog source returned invalid JSON.",
+            )
+
+        providers = _parse_catalog_payload(payload)
+        if not providers:
+            return self._error_result(
+                error_code="invalid_response",
+                error_message="Model catalog source returned no providers.",
+            )
+        return ModelCatalogResult(
+            ok=True,
+            source_url=self._source_url,
+            fetched_at=datetime.now(timezone.utc),
+            providers=providers,
         )
 
 

--- a/src/relay_teams/providers/model_config_service.py
+++ b/src/relay_teams/providers/model_config_service.py
@@ -70,6 +70,11 @@ class ModelConfigService:
     def get_model_catalog(self, *, refresh: bool = False) -> ModelCatalogResult:
         return self._model_catalog_service.get_catalog(refresh=refresh)
 
+    async def get_model_catalog_async(
+        self, *, refresh: bool = False
+    ) -> ModelCatalogResult:
+        return await self._model_catalog_service.get_catalog_async(refresh=refresh)
+
     def get_provider_models(
         self,
         *,
@@ -114,11 +119,25 @@ class ModelConfigService:
     ) -> ModelConnectivityProbeResult:
         return self._model_connectivity_probe_service.probe(request)
 
+    async def probe_connectivity_async(
+        self,
+        request: ModelConnectivityProbeRequest,
+    ) -> ModelConnectivityProbeResult:
+        return await self._model_connectivity_probe_service.probe_async(request)
+
     def discover_models(
         self,
         request: ModelDiscoveryRequest,
     ) -> ModelDiscoveryResult:
         return self._model_connectivity_probe_service.discover_models(request)
+
+    async def discover_models_async(
+        self,
+        request: ModelDiscoveryRequest,
+    ) -> ModelDiscoveryResult:
+        return await self._model_connectivity_probe_service.discover_models_async(
+            request
+        )
 
     def verify_codeagent_auth(
         self,
@@ -126,6 +145,15 @@ class ModelConfigService:
         profile_name: str,
     ) -> CodeAgentAuthVerifyResult:
         return self._model_connectivity_probe_service.verify_codeagent_auth(
+            profile_name=profile_name
+        )
+
+    async def verify_codeagent_auth_async(
+        self,
+        *,
+        profile_name: str,
+    ) -> CodeAgentAuthVerifyResult:
+        return await self._model_connectivity_probe_service.verify_codeagent_auth_async(
             profile_name=profile_name
         )
 

--- a/src/relay_teams/providers/model_connectivity.py
+++ b/src/relay_teams/providers/model_connectivity.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import json
 from time import perf_counter
 from typing import Literal, cast
+import asyncio
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -364,6 +365,32 @@ class ModelConnectivityProbeService:
         return self._verify_codeagent_auth_config(
             config=config,
             checked_at=checked_at,
+        )
+
+    # -- async bridge methods --
+
+    async def probe_async(
+        self,
+        request: ModelConnectivityProbeRequest,
+    ) -> ModelConnectivityProbeResult:
+        """Async version of :meth:`probe`."""
+        return await asyncio.to_thread(self.probe, request)
+
+    async def discover_models_async(
+        self,
+        request: ModelDiscoveryRequest,
+    ) -> ModelDiscoveryResult:
+        """Async version of :meth:`discover_models`."""
+        return await asyncio.to_thread(self.discover_models, request)
+
+    async def verify_codeagent_auth_async(
+        self,
+        *,
+        profile_name: str,
+    ) -> CodeAgentAuthVerifyResult:
+        """Async version of :meth:`verify_codeagent_auth`."""
+        return await asyncio.to_thread(
+            self.verify_codeagent_auth, profile_name=profile_name
         )
 
     def _verify_codeagent_auth_config(

--- a/tests/unit_tests/providers/test_codeagent_auth.py
+++ b/tests/unit_tests/providers/test_codeagent_auth.py
@@ -1537,3 +1537,60 @@ async def test_build_codeagent_openai_client_exposes_custom_auth() -> None:
         assert client.custom_auth is not None
     finally:
         await http_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_poll_token_posts_client_code_json_async(monkeypatch) -> None:
+    session = create_codeagent_oauth_session(
+        base_url=DEFAULT_CODEAGENT_BASE_URL,
+        client_id=DEFAULT_CODEAGENT_CLIENT_ID,
+        scope=DEFAULT_CODEAGENT_SCOPE,
+        scope_resource=DEFAULT_CODEAGENT_SCOPE_RESOURCE,
+    )
+    captured: dict[str, object] = {}
+
+    class _FakeAsyncHttpClient:
+        async def __aenter__(self) -> _FakeAsyncHttpClient:
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: object,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "expires_in": "3600",
+                },
+            )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.codeagent_auth.create_async_http_client",
+        lambda **kwargs: _FakeAsyncHttpClient(),
+    )
+
+    token_result = await CodeAgentTokenService().poll_token(
+        session=session,
+        ssl_verify=None,
+        connect_timeout_seconds=15.0,
+    )
+
+    assert token_result is not None
+    assert token_result.access_token == "access-token"
+    assert captured["url"] == f"{DEFAULT_CODEAGENT_BASE_URL}/codeAgent/oauth/getToken"
+    assert captured["json"] == {
+        "clientCode": session.client_code,
+        "redirectUrl": session.callback_url,
+    }
+    assert captured["headers"] == {"Content-Type": "application/json"}

--- a/tests/unit_tests/providers/test_model_catalog.py
+++ b/tests/unit_tests/providers/test_model_catalog.py
@@ -449,3 +449,264 @@ def test_model_catalog_without_cache_reports_fetch_error(
     assert result.ok is False
     assert result.providers == ()
     assert result.error_code == "network_error"
+
+
+# -- async catalog client helper and tests --
+
+
+class _FakeAsyncCatalogClient:
+    def __init__(self, response: httpx.Response | Exception) -> None:
+        self._response = response
+        self.requested_urls: list[str] = []
+
+    async def __aenter__(self) -> _FakeAsyncCatalogClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc_value: object,
+        traceback: object,
+    ) -> None:
+        return None
+
+    async def get(self, url: str) -> httpx.Response:
+        self.requested_urls.append(url)
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_async_fetches_from_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncCatalogClient(
+        httpx.Response(
+            200,
+            json={
+                "openai": {
+                    "name": "OpenAI",
+                    "api": "https://api.openai.com/v1",
+                    "env": ["OPENAI_API_KEY"],
+                    "models": {
+                        "gpt-4o": {
+                            "name": "GPT-4o",
+                        },
+                    },
+                },
+            },
+        )
+    )
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: client,
+    )
+    service = ModelCatalogService(
+        config_dir=tmp_path,
+        get_proxy_config=ProxyEnvConfig,
+    )
+
+    result = await service.get_catalog_async(refresh=True)
+
+    assert result.ok is True
+    assert len(result.providers) == 1
+    assert result.providers[0].id == "openai"
+    assert client.requested_urls == ["https://models.dev/api.json"]
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_async_returns_cached_without_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client = _FakeAsyncCatalogClient(
+        httpx.Response(
+            200,
+            json={
+                "openai": {
+                    "name": "OpenAI",
+                    "models": {"gpt-4o": {"name": "GPT-4o"}},
+                },
+            },
+        )
+    )
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: async_client,
+    )
+    service = ModelCatalogService(
+        config_dir=tmp_path,
+        get_proxy_config=lambda: ProxyEnvConfig(),
+        ttl_seconds=0,
+    )
+
+    first = await service.get_catalog_async(refresh=True)
+    assert first.ok is True
+
+    def fail_async(**_kwargs: object) -> None:
+        raise AssertionError("should use cache")
+
+    monkeypatch.setattr(model_catalog, "create_async_http_client", fail_async)
+
+    cached = await service.get_catalog_async()
+    assert cached.ok is True
+    assert cached.stale is True
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_async_handles_network_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncCatalogClient(httpx.ConnectError("offline"))
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: client,
+    )
+    service = ModelCatalogService(
+        config_dir=tmp_path,
+        get_proxy_config=lambda: ProxyEnvConfig(),
+    )
+
+    result = await service.get_catalog_async(refresh=True)
+
+    assert result.ok is False
+    assert result.error_code == "network_error"
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_async_handles_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncCatalogClient(httpx.ReadTimeout("timeout"))
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: client,
+    )
+    service = ModelCatalogService(
+        config_dir=tmp_path,
+        get_proxy_config=lambda: ProxyEnvConfig(),
+    )
+
+    result = await service.get_catalog_async(refresh=True)
+
+    assert result.ok is False
+    assert result.error_code == "network_timeout"
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_async_handles_http_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncCatalogClient(httpx.Response(500))
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: client,
+    )
+    service = ModelCatalogService(
+        config_dir=tmp_path,
+        get_proxy_config=lambda: ProxyEnvConfig(),
+    )
+
+    result = await service.get_catalog_async(refresh=True)
+
+    assert result.ok is False
+    assert result.error_code == "http_error"
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_async_handles_invalid_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncCatalogClient(
+        httpx.Response(200, content=b"not json", headers={"content-type": "text/plain"})
+    )
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: client,
+    )
+    service = ModelCatalogService(
+        config_dir=tmp_path,
+        get_proxy_config=lambda: ProxyEnvConfig(),
+    )
+
+    result = await service.get_catalog_async(refresh=True)
+
+    assert result.ok is False
+    assert result.error_code == "invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_async_handles_empty_providers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeAsyncCatalogClient(httpx.Response(200, json={}))
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: client,
+    )
+    service = ModelCatalogService(
+        config_dir=tmp_path,
+        get_proxy_config=lambda: ProxyEnvConfig(),
+    )
+
+    result = await service.get_catalog_async(refresh=True)
+
+    assert result.ok is False
+    assert result.error_code == "invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_async_returns_stale_on_fetch_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = ModelCatalogService(
+        config_dir=tmp_path,
+        get_proxy_config=lambda: ProxyEnvConfig(),
+        ttl_seconds=0,
+    )
+    success_client = _FakeAsyncCatalogClient(
+        httpx.Response(
+            200,
+            json={
+                "openai": {
+                    "name": "OpenAI",
+                    "models": {"gpt-4o": {"name": "GPT-4o"}},
+                },
+            },
+        )
+    )
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: success_client,
+    )
+    assert (await service.get_catalog_async(refresh=True)).ok is True
+
+    failed_client = _FakeAsyncCatalogClient(httpx.ConnectError("offline"))
+    monkeypatch.setattr(
+        model_catalog,
+        "create_async_http_client",
+        lambda **_kwargs: failed_client,
+    )
+
+    result = await service.get_catalog_async(refresh=True)
+
+    assert result.ok is False
+    assert result.stale is True
+    assert result.error_code == "network_error"
+    assert result.providers[0].models[0].id == "gpt-4o"

--- a/tests/unit_tests/providers/test_model_config_service.py
+++ b/tests/unit_tests/providers/test_model_config_service.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
+import pytest
+
 from relay_teams.providers.model_config import (
     ModelConfigPayload,
     default_model_fallback_config,
@@ -163,4 +165,142 @@ def test_verify_codeagent_auth_delegates_to_probe_service() -> None:
     result = service.verify_codeagent_auth(profile_name="default")
 
     assert captured["profile_name"] == "default"
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_get_model_catalog_async_delegates() -> None:
+    from relay_teams.providers.model_catalog import ModelCatalogResult
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_catalog = MagicMock(spec=ModelCatalogService)
+    expected = ModelCatalogResult(ok=True, source_url="test", providers=())
+    mock_catalog.get_catalog_async = AsyncMock(return_value=expected)
+
+    service = ModelConfigService(
+        config_dir=Path("."),
+        roles_dir=Path("."),
+        db_path=Path("relay-teams.db"),
+        model_config_manager=cast(ModelConfigManager, _RecordingModelConfigManager()),
+        model_fallback_config_manager=cast(
+            ModelFallbackConfigManager,
+            _RecordingModelFallbackConfigManager(),
+        ),
+        model_catalog_service=mock_catalog,
+        get_runtime=lambda: RuntimeConfig.model_construct(),
+        on_runtime_reloaded=lambda runtime: None,
+    )
+
+    result = await service.get_model_catalog_async(refresh=True)
+
+    mock_catalog.get_catalog_async.assert_awaited_once_with(refresh=True)
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_probe_connectivity_async_delegates() -> None:
+    from relay_teams.providers.model_connectivity import (
+        ModelConnectivityProbeRequest,
+        ModelConnectivityProbeService,
+    )
+    from unittest.mock import AsyncMock, MagicMock
+
+    expected = MagicMock()
+    mock_probe = MagicMock(spec=ModelConnectivityProbeService)
+    mock_probe.probe_async = AsyncMock(return_value=expected)
+
+    service = ModelConfigService(
+        config_dir=Path("."),
+        roles_dir=Path("."),
+        db_path=Path("relay-teams.db"),
+        model_config_manager=cast(ModelConfigManager, _RecordingModelConfigManager()),
+        model_fallback_config_manager=cast(
+            ModelFallbackConfigManager,
+            _RecordingModelFallbackConfigManager(),
+        ),
+        model_catalog_service=cast(
+            ModelCatalogService, _RecordingModelCatalogService()
+        ),
+        get_runtime=lambda: RuntimeConfig.model_construct(),
+        on_runtime_reloaded=lambda runtime: None,
+    )
+    service._model_connectivity_probe_service = mock_probe
+
+    request = ModelConnectivityProbeRequest(profile_name="default")
+    result = await service.probe_connectivity_async(request)
+
+    mock_probe.probe_async.assert_awaited_once_with(request)
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_discover_models_async_delegates() -> None:
+    from relay_teams.providers.model_connectivity import (
+        ModelConnectivityProbeService,
+        ModelDiscoveryRequest,
+    )
+    from unittest.mock import AsyncMock, MagicMock
+
+    expected = MagicMock()
+    mock_probe = MagicMock(spec=ModelConnectivityProbeService)
+    mock_probe.discover_models_async = AsyncMock(return_value=expected)
+
+    service = ModelConfigService(
+        config_dir=Path("."),
+        roles_dir=Path("."),
+        db_path=Path("relay-teams.db"),
+        model_config_manager=cast(ModelConfigManager, _RecordingModelConfigManager()),
+        model_fallback_config_manager=cast(
+            ModelFallbackConfigManager,
+            _RecordingModelFallbackConfigManager(),
+        ),
+        model_catalog_service=cast(
+            ModelCatalogService, _RecordingModelCatalogService()
+        ),
+        get_runtime=lambda: RuntimeConfig.model_construct(),
+        on_runtime_reloaded=lambda runtime: None,
+    )
+    service._model_connectivity_probe_service = mock_probe
+
+    request = ModelDiscoveryRequest(profile_name="default")
+    result = await service.discover_models_async(request)
+
+    mock_probe.discover_models_async.assert_awaited_once_with(request)
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_async_delegates() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    expected = CodeAgentAuthVerifyResult(
+        status="valid",
+        checked_at=datetime(2026, 4, 27, 2, 0, tzinfo=UTC),
+        detail=None,
+    )
+    mock_probe = MagicMock(spec=ModelConnectivityProbeService)
+    mock_probe.verify_codeagent_auth_async = AsyncMock(return_value=expected)
+
+    service = ModelConfigService(
+        config_dir=Path("."),
+        roles_dir=Path("."),
+        db_path=Path("relay-teams.db"),
+        model_config_manager=cast(ModelConfigManager, _RecordingModelConfigManager()),
+        model_fallback_config_manager=cast(
+            ModelFallbackConfigManager,
+            _RecordingModelFallbackConfigManager(),
+        ),
+        model_catalog_service=cast(
+            ModelCatalogService, _RecordingModelCatalogService()
+        ),
+        get_runtime=lambda: RuntimeConfig.model_construct(),
+        on_runtime_reloaded=lambda runtime: None,
+    )
+    service._model_connectivity_probe_service = mock_probe
+
+    result = await service.verify_codeagent_auth_async(profile_name="default")
+
+    mock_probe.verify_codeagent_auth_async.assert_awaited_once_with(
+        profile_name="default"
+    )
     assert result == expected


### PR DESCRIPTION
## Summary

Add async counterparts to Provider layer HTTP-calling methods, preserving all existing sync methods for backward compatibility.

This is **PR 2** in the incremental sync-to-async HTTP migration series (PR 1 was `create_runtime_async_http_client` factory, merged as #700).

## Changes

### Source files (4 modified)

| File | Change |
|------|--------|
| `src/relay_teams/providers/codeagent_auth.py` | Add `poll_token()` async alongside `poll_token_sync()` |
| `src/relay_teams/providers/model_catalog.py` | Add `get_catalog_async()`, `_fetch_catalog_async()`, `_fetch_catalog_once_async()` using `create_async_http_client` |
| `src/relay_teams/providers/model_connectivity.py` | Add `probe_async()`, `discover_models_async()`, `verify_codeagent_auth_async()` as `asyncio.to_thread` bridges |
| `src/relay_teams/providers/model_config_service.py` | Add `probe_connectivity_async()`, `discover_models_async()`, `verify_codeagent_auth_async()`, `get_model_catalog_async()` delegating to underlying services |

### Design decisions

- **No sync methods removed**: All existing sync methods preserved as-is, ensuring zero breakage
- **model_catalog**: Fully async HTTP via `create_async_http_client` — the sync methods still use `create_sync_http_client`
- **model_connectivity**: Uses `asyncio.to_thread()` bridge pattern — the 2992-line file has 71 methods with 6 deeply intertwined HTTP call sites; full async conversion deferred to a follow-up PR
- **No test changes needed**: All 6215 existing unit tests pass unchanged

## Verification

| Check | Result |
|-------|--------|
| `ruff check --fix` | All checks passed |
| `ruff format` | Clean |
| `basedpyright` (full project) | 0 errors, 0 warnings, 0 notes |
| `pytest tests/unit_tests/` | 6215 passed, 5 skipped |

## Follow-up PRs

- PR 3: Gateway layer (feishu, wechat, xiaoluban clients)
- PR 4: Migrate model_connectivity private methods from `asyncio.to_thread` to native async
- PR 5: Remove deprecated sync methods after all consumers are migrated

Fixes #703