### PR TITLE
docs: add May brainstorming notes

### DIFF
--- a/docs/research/brainstorming/头脑风暴-2026-5-6.md
+++ b/docs/research/brainstorming/头脑风暴-2026-5-6.md
@@ -1,0 +1,37 @@
+# 5月重点工作
+1. subagent UI入口归一   ---yexxx
+2. UI界面增加使用文档说明   ---yexxx
+3. UI设置页风格统一   ---SUN-CRay
+4. PPT制作、代码检视修复等场景支持首页快捷卡片输入   ---yexxx
+5. 工具使用优化（IM ask工具对接，shell安全策略增加开关）   ---zhzer
+6. 提供一个设置skill，通过CLI或者SDK完成relay teams的设置   ---yexxx
+7. CLI性能优化   ---yexxx
+8. subagent生命周期管理优化（创建，终止，恢复，状态同步）   ---zhzer
+9. 异常场景错误信息返回优化（比如有的异常信息中包含了给大模型的提示词The previous request could not continue because the API key is invalid. The conversation state already persisted is still valid.）   ---SUN-CRay
+10. subagent配置兼容claude code和opencode   ---zhzer
+11. 支持对接agentcenter/codehub/云捷等平台   ---zhzer
+12. 代码检视对超大MR的处理能力优化   ---liyanqi01
+13. 代码检视agent使用多个subagent进行检视（需要回合到内源）   ---liyanqi01
+14. 代码检视处理结果支持小鲁班或者welink通知   ---liyanqi01
+15. 代码检视agent支持一键部署脚本优化   ---liyanqi01
+16. 代码检视KPI看板   ---liyanqi01
+17. 内置codehub和云捷的MCP（不直接移植代码，使用时通过类似超链接的方式安装使用）   ---SUN-CRay
+18. 用户登录信息自动保存及获取，免去重复登录   ---zhzer
+19. claude code和opencode工具分析和筛选移植   ---zhzer
+20. 配置文件优化（支持UI设置配置信心直接保存到DB，同时兼容clude code和opencode的json配置模式）   ---SUN-CRay
+21. CI运行时长优化   ---SUN-CRay
+22. 并发session优化（跑长程任务导致后端繁忙，页面加载卡死）   ---yexxx
+23. 模块重构（超大类拆分，CI拦截）   ---liyanqi01
+24. 模块边界收编（比如网络访问，有的使用URL lib，有的自定义client，需要统一到net）   ---stevetdp
+25. 模块代码组织规整（比如agents，sessions等不够清晰）   ---stevetdp
+26. 实现独立memory功能（跨session，参考memory bank）   ---SUN-CRay
+27. 支持看板能力，承载事件驱动状态机，由多agent驱动状态机的并行处理（参考hermes agent等，https://paperclip.ing/#get-started, https://www.spectraidev.com/index.php, https://multica.ai, https://phodal.github.io/routa, https://github.com/openai/symphony, https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban）   ---yexxx
+28. 多agent编排，抽象agent runtime和agent，支持A2A通信，支持普通/编排模式下把外部agent作为subagent使用   ---stevetdp
+29. 日志增加审计追踪能力   ---stevetdp
+30. 自演进自迭代（通过skill、记忆或者自建工具将经验沉淀下来）   ---stevetdp
+31. benchmark体系强化（增加几种业界常用的）   ---zhzer
+32. 分析内源relay支持SDD还需补充哪些能力   ---zhzer
+33. welink个人助手穿刺   ---liyanqi01
+
+# 特性回合
+梳理relay teams当前哪些能力可以回合到内源relay


### PR DESCRIPTION
## Summary
- Add May 6 brainstorming notes for relay teams planning work.
- Capture priority work items, owners, and feature rollback notes.

Fixes #706

## Validation
- git diff --cached --check
- pre-commit hooks ran during commit: ruff-check skipped, ruff-format skipped, basedpyright-check skipped (docs-only change)