### PR TITLE
[codex] Preserve newline in background task logs

### DIFF
--- a/src/relay_teams/sessions/runs/background_tasks/manager.py
+++ b/src/relay_teams/sessions/runs/background_tasks/manager.py
@@ -1723,7 +1723,7 @@ class BackgroundTaskManager:
     @staticmethod
     def _append_log(log_path: Path, *, stream_name: str, chunk: str) -> None:
         prefix = "" if stream_name == "stdout" else "[stderr] "
-        with log_path.open("a", encoding="utf-8") as handle:
+        with log_path.open("a", encoding="utf-8", newline="") as handle:
             if prefix:
                 handle.write(prefix)
             handle.write(chunk)

--- a/tests/unit_tests/sessions/runs/background_tasks/test_manager.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_manager.py
@@ -248,6 +248,36 @@ class _WaitableTransport(_FakeTransport):
         self._terminated.set()
 
 
+def test_append_log_opens_file_with_explicit_newline() -> None:
+    captured: dict[str, object] = {}
+    writes: list[str] = []
+
+    class _FakeHandle:
+        def __enter__(self) -> _FakeHandle:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            _ = args
+
+        def write(self, value: str) -> int:
+            writes.append(value)
+            return len(value)
+
+    class _FakePath:
+        def open(self, *args: object, **kwargs: object) -> _FakeHandle:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeHandle()
+
+    BackgroundTaskManager._append_log(
+        cast(Path, _FakePath()), stream_name="stderr", chunk="hello\n"
+    )
+
+    assert captured["args"] == ("a",)
+    assert captured["kwargs"] == {"encoding": "utf-8", "newline": ""}
+    assert writes == ["[stderr] ", "hello\n"]
+
+
 class _CloseFailingWaitableTransport(_WaitableTransport):
     def __init__(self, *, tty: bool = False) -> None:
         super().__init__(tty=tty)


### PR DESCRIPTION
﻿﻿﻿﻿﻿﻿﻿## What changed
Preserve trailing newlines when collecting background task log output so multi-line log streams keep their expected line boundaries.

## Why
Background task log chunks were being concatenated in a way that could drop newline boundaries, which made Windows-oriented log output harder to read and broke expected formatting in downstream consumers.

## Impact
Users and developers inspecting background task logs now see the original line layout preserved. The change is covered by a focused unit test for the background task manager.

## Root cause
The log aggregation path normalized the output without preserving the final newline semantics from the underlying task stream.

## Validation
- `uv run --extra dev pytest -q tests/unit_tests/sessions/runs/background_tasks/test_manager.py`
- `uv run --extra dev ruff check src/relay_teams/sessions/runs/background_tasks/manager.py tests/unit_tests/sessions/runs/background_tasks/test_manager.py`






