### PR TITLE
Fix MCP async discovery and proxy handling

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -684,11 +684,22 @@ Response fields:
 Reloads effective proxy env into runtime.
 The reload source is the current effective merged environment, not only app-saved `.env` values.
 This updates process-level proxy variables for future HTTP requests and shell/MCP subprocesses, clears removed proxy keys, and refreshes MCP runtime state.
+Remote MCP discovery and connection clients use the per-server effective `env`
+proxy values instead of reading process-global proxy variables at connection
+time.
 
 ### `POST /system/configs/mcp:reload`
 
 Reloads MCP config into runtime.
 For stdio MCP servers launched through `uvx` or `uv tool run`, the backend clears the relevant `uv` package cache before rebuilding runtime state so newly added MCP tools are visible on the next load.
+Reloading MCP config reconciles the MCP discovery cache by server fingerprint:
+unchanged `ready`, `loading`, and `failed` entries are preserved, while new,
+enabled, or changed entries queue asynchronous tool discovery. The reload
+response does not wait for remote `initialize` or `tools/list` calls.
+The server also watches the app `mcp.json` file for external edits and triggers
+the same reload path after a debounced `mtime` / size change. Invalid JSON file
+edits are logged and ignored so the previous runtime registry and discovery
+cache stay active.
 If persisted MCP config is semantically invalid, the backend returns `400`.
 
 ### `POST /system/configs/skills:reload`
@@ -2982,10 +2993,44 @@ Response:
 ### `GET /mcp/servers`
 
 Lists effective MCP servers from app scope.
+Each server summary includes MCP discovery cache fields:
+- `discovery_status`: one of `disabled`, `pending`, `loading`, `ready`, or `failed`
+- `tool_count`
+- `last_checked_at`
+- `error`
 
 ### `GET /mcp/servers/{server_name}/tools`
 
-Lists tools exposed by one MCP server. Returned tool names are the effective callable names registered at runtime in the form `<server_name>_<tool_name>` so tools from different MCP servers cannot collide.
+Returns cached discovery state and cached tools for one MCP server. This endpoint
+does not open a live MCP connection. Unknown servers return `404`; known servers
+return `200` for `pending`, `loading`, `ready`, `failed`, and `disabled` states.
+Returned tool names are the effective callable names registered at runtime in
+the form `<server_name>_<tool_name>` so tools from different MCP servers cannot
+collide.
+
+Response fields:
+- `server`
+- `source`
+- `transport`
+- `enabled`
+- `tools`
+- `status`: one of `disabled`, `pending`, `loading`, `ready`, or `failed`
+- `last_checked_at`
+- `error`
+
+### `POST /mcp/servers/{server_name}/tools:refresh`
+
+Queues background discovery for one enabled MCP server and returns the current
+cached tool summary. This endpoint does not wait for `initialize` or
+`tools/list` to complete. It forces rediscovery even when the cached status is
+already `ready`. Unknown servers return `404`.
+
+### `POST /mcp/servers/{server_name}/test`
+
+Runs an explicit live connection test for one MCP server and may block while the
+server initializes and lists tools. This endpoint is intended for the user's
+manual "Test" action and is separate from the settings page's cached tool
+display.
 
 ## Gateway APIs
 

--- a/frontend/dist/js/components/settings/systemStatus.js
+++ b/frontend/dist/js/components/settings/systemStatus.js
@@ -13,10 +13,25 @@ const fetchConfigStatus = api.fetchConfigStatus;
 const fetchMcpServers = api.fetchMcpServers || fetchMcpServersFromConfigStatus;
 const fetchMcpServerTools = api.fetchMcpServerTools;
 const reloadMcpConfig = api.reloadMcpConfig;
+const refreshMcpServerTools = api.refreshMcpServerTools || postMcpServerToolsRefresh;
 const reloadSkillsConfig = api.reloadSkillsConfig;
 const setMcpServerEnabled = api.setMcpServerEnabled || putMcpServerEnabled;
 const testMcpServerConnection = api.testMcpServerConnection || postMcpServerConnectionTest;
 const updateMcpServer = api.updateMcpServer || putMcpServer;
+const DEFAULT_MCP_REFRESH_POLL_DELAYS_MS = [
+    1200,
+    1800,
+    2500,
+    3500,
+    5000,
+    7500,
+    10000,
+    10000,
+    10000,
+    10000,
+    10000,
+    10000,
+];
 
 const collapsedMcpServers = new Set();
 let lastLoadedMcpServerViews = [];
@@ -74,6 +89,13 @@ async function postMcpServerConnectionTest(serverName) {
     );
 }
 
+async function postMcpServerToolsRefresh(serverName) {
+    return requestMcpJson(
+        `/api/mcp/servers/${encodeURIComponent(serverName)}/tools:refresh`,
+        { method: 'POST' },
+    );
+}
+
 async function requestMcpJson(url, options) {
     const response = await fetch(url, options);
     const payload = await response.json().catch(() => ({}));
@@ -101,6 +123,7 @@ export function bindSystemStatusHandlers() {
     globalThis.__agentTeamsToggleMcpTools = toggleMcpTools;
     globalThis.__agentTeamsToggleAllMcpTools = toggleAllMcpTools;
     globalThis.__agentTeamsTestMcpServer = testMcpServer;
+    globalThis.__agentTeamsRefreshMcpTools = refreshMcpServerToolsFromPanel;
     globalThis.__agentTeamsSetMcpServerEnabled = setMcpServerEnabledFromPanel;
     globalThis.__agentTeamsEditMcpServer = editMcpServer;
     if (!languageBound && typeof document.addEventListener === 'function') {
@@ -288,6 +311,78 @@ async function testMcpServer(serverName) {
     renderMcpStatusPanel();
 }
 
+async function refreshMcpServerToolsFromPanel(serverName) {
+    const safeName = String(serverName || '').trim();
+    if (!safeName) {
+        return;
+    }
+    try {
+        const summary = await refreshMcpServerTools(safeName);
+        const serverView = createMcpServerViewFromToolsSummary(safeName, summary);
+        replaceMcpServerView(serverView);
+        renderMcpStatusPanel();
+        showToast({
+            title: t('settings.mcp.refresh_started'),
+            message: formatMessage('settings.mcp.refresh_started_message', { name: safeName }),
+            tone: 'success',
+        });
+        if (shouldPollMcpDiscovery(serverView)) {
+            void pollMcpServerDiscovery(safeName);
+        }
+    } catch (e) {
+        showToast({
+            title: t('settings.mcp.refresh_failed'),
+            message: e.message || t('settings.mcp.refresh_failed_message'),
+            tone: 'danger',
+        });
+    }
+}
+
+async function pollMcpServerDiscovery(serverName) {
+    for (const delayMs of getMcpRefreshPollDelays()) {
+        await delay(delayMs);
+        try {
+            const summary = await fetchMcpServerTools(serverName);
+            const serverView = createMcpServerViewFromToolsSummary(serverName, summary);
+            replaceMcpServerView(serverView);
+            renderMcpStatusPanel();
+            if (!shouldPollMcpDiscovery(serverView)) {
+                return;
+            }
+        } catch (e) {
+            logError(
+                'frontend.system_status.mcp_refresh_poll_failed',
+                'Failed to poll MCP discovery status',
+                errorToPayload(e, { server_name: serverName }),
+            );
+            return;
+        }
+    }
+
+    await loadMcpStatusPanel();
+}
+
+function shouldPollMcpDiscovery(serverView) {
+    return serverView?.enabled !== false
+        && (serverView?.discoveryStatus === 'loading' || serverView?.discoveryStatus === 'pending');
+}
+
+function getMcpRefreshPollDelays() {
+    const override = globalThis.__agentTeamsMcpRefreshPollDelaysMs;
+    if (Array.isArray(override)) {
+        return override
+            .map(value => Number(value))
+            .filter(value => Number.isFinite(value) && value >= 0);
+    }
+    return DEFAULT_MCP_REFRESH_POLL_DELAYS_MS;
+}
+
+function delay(ms) {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}
+
 async function setMcpServerEnabledFromPanel(serverName, enabled) {
     const safeName = String(serverName || '').trim();
     if (!safeName) {
@@ -334,11 +429,12 @@ async function hydrateMcpServerView(requestId, serverSummary) {
         return;
     }
 
-    lastLoadedMcpServerViews = lastLoadedMcpServerViews.map(existingView => (
-        existingView.name === serverView.name ? serverView : existingView
-    ));
+    replaceMcpServerView(serverView);
     pruneCollapsedServers(lastLoadedMcpServerViews.map(existingView => existingView.name));
     renderMcpStatusPanel();
+    if (shouldPollMcpDiscovery(serverView)) {
+        void pollMcpServerDiscovery(serverView.name);
+    }
 }
 
 async function loadMcpServerView(serverSummary) {
@@ -352,15 +448,7 @@ async function loadMcpServerView(serverSummary) {
     }
     try {
         const summary = await fetchMcpServerTools(serverName);
-        return {
-            name: serverName,
-            source: typeof summary?.source === 'string' ? summary.source : '',
-            transport: typeof summary?.transport === 'string' ? summary.transport : '',
-            enabled: summary?.enabled !== false,
-            tools: Array.isArray(summary?.tools) ? summary.tools : [],
-            errorMessage: '',
-            loading: false,
-        };
+        return createMcpServerViewFromToolsSummary(serverName, summary);
     } catch (e) {
         logError(
             'frontend.system_status.mcp_tools_load_failed',
@@ -373,6 +461,7 @@ async function loadMcpServerView(serverSummary) {
             transport: baseView.transport,
             enabled: baseView.enabled,
             tools: [],
+            discoveryStatus: 'failed',
             errorMessage: e?.message || t('settings.system.load_tools_failed_detail'),
             loading: false,
         };
@@ -384,8 +473,8 @@ function createLoadingMcpServerView(serverSummary) {
     return {
         ...baseView,
         tools: [],
-        errorMessage: '',
-        loading: baseView.enabled !== false,
+        errorMessage: baseView.errorMessage,
+        loading: baseView.enabled !== false && baseView.discoveryStatus === 'loading',
     };
 }
 
@@ -396,14 +485,40 @@ function createBaseMcpServerView(serverSummary) {
             source: '',
             transport: '',
             enabled: true,
+            discoveryStatus: 'pending',
+            errorMessage: '',
         };
     }
+    const status = normalizeMcpDiscoveryStatus(serverSummary?.discovery_status || serverSummary?.status);
     return {
         name: normalizeMcpServerName(serverSummary),
         source: typeof serverSummary?.source === 'string' ? serverSummary.source : '',
         transport: typeof serverSummary?.transport === 'string' ? serverSummary.transport : '',
         enabled: serverSummary?.enabled !== false,
+        discoveryStatus: status,
+        errorMessage: typeof serverSummary?.error === 'string' ? serverSummary.error : '',
     };
+}
+
+function createMcpServerViewFromToolsSummary(serverName, summary) {
+    const hasToolsArray = Array.isArray(summary?.tools);
+    const status = normalizeMcpDiscoveryStatus(summary?.status, hasToolsArray ? 'ready' : 'pending');
+    return {
+        name: serverName,
+        source: typeof summary?.source === 'string' ? summary.source : '',
+        transport: typeof summary?.transport === 'string' ? summary.transport : '',
+        enabled: summary?.enabled !== false,
+        tools: hasToolsArray ? summary.tools : [],
+        discoveryStatus: status,
+        errorMessage: typeof summary?.error === 'string' ? summary.error : '',
+        loading: status === 'loading',
+    };
+}
+
+function replaceMcpServerView(serverView) {
+    lastLoadedMcpServerViews = lastLoadedMcpServerViews.map(existingView => (
+        existingView.name === serverView.name ? serverView : existingView
+    ));
 }
 
 function normalizeMcpServerName(serverSummary) {
@@ -411,6 +526,14 @@ function normalizeMcpServerName(serverSummary) {
         return serverSummary;
     }
     return typeof serverSummary?.name === 'string' ? serverSummary.name : '';
+}
+
+function normalizeMcpDiscoveryStatus(value, fallback = 'pending') {
+    const normalized = String(value || '').trim().toLowerCase();
+    if (['disabled', 'pending', 'loading', 'ready', 'failed'].includes(normalized)) {
+        return normalized;
+    }
+    return fallback;
 }
 
 function renderMcpStatusPanel() {
@@ -513,6 +636,14 @@ function renderMcpServerCard(serverView) {
                         ${testState?.loading || serverView.enabled === false ? 'disabled' : ''}
                     >
                         ${testState?.loading ? t('settings.mcp.testing') : t('settings.action.test')}
+                    </button>
+                    <button
+                        class="mcp-status-toggle"
+                        type="button"
+                        onclick='globalThis.__agentTeamsRefreshMcpTools(${serializeForInlineScript(serverView.name)})'
+                        ${serverView.enabled === false || serverView.discoveryStatus === 'loading' ? 'disabled' : ''}
+                    >
+                        ${t('settings.action.refresh')}
                     </button>
                     <button
                         class="mcp-status-toggle"
@@ -890,6 +1021,12 @@ function renderMcpServerTools(serverView, collapsed) {
         `;
     }
 
+    if (serverView.discoveryStatus === 'pending') {
+        return `
+            <div class="mcp-tools-empty">${t('settings.system.discovery_pending')}</div>
+        `;
+    }
+
     if (serverView.tools.length === 0) {
         return `
             <div class="mcp-tools-empty">${t('settings.system.no_tools_exposed')}</div>
@@ -1028,7 +1165,10 @@ function getMcpServerStateLabel(serverView) {
     if (serverView.loading) {
         return t('settings.system.loading_state');
     }
-    if (serverView.errorMessage) {
+    if (serverView.discoveryStatus === 'pending') {
+        return t('settings.system.pending_state');
+    }
+    if (serverView.errorMessage || serverView.discoveryStatus === 'failed') {
         return t('settings.system.unavailable_state');
     }
     return t('settings.system.loaded_state');

--- a/frontend/dist/js/core/api.js
+++ b/frontend/dist/js/core/api.js
@@ -133,6 +133,7 @@ export {
     stopGitHubWebhookTunnel,
     reloadModelConfig,
     refreshModelCatalog,
+    refreshMcpServerTools,
     reloadProxyConfig,
     reloadMcpConfig,
     reloadSkillsConfig,

--- a/frontend/dist/js/core/api/index.js
+++ b/frontend/dist/js/core/api/index.js
@@ -102,6 +102,7 @@ export {
     reloadMcpConfig,
     reloadModelConfig,
     refreshModelCatalog,
+    refreshMcpServerTools,
     reloadProxyConfig,
     reloadSkillsConfig,
     saveClawHubConfig,

--- a/frontend/dist/js/core/api/system.js
+++ b/frontend/dist/js/core/api/system.js
@@ -633,6 +633,14 @@ export async function fetchMcpServerTools(serverName) {
     );
 }
 
+export async function refreshMcpServerTools(serverName) {
+    return requestJson(
+        `/api/mcp/servers/${encodeURIComponent(serverName)}/tools:refresh`,
+        { method: 'POST' },
+        `Failed to refresh MCP tools for ${serverName}`,
+    );
+}
+
 export async function reloadSkillsConfig() {
     const result = await requestJson(
         '/api/system/configs/skills:reload',

--- a/frontend/dist/js/utils/i18n.js
+++ b/frontend/dist/js/utils/i18n.js
@@ -648,6 +648,7 @@ const TRANSLATIONS = {
         'settings.action.edit': 'Edit',
         'settings.action.delete': 'Delete',
         'settings.action.cancel': 'Cancel',
+        'settings.action.refresh': 'Refresh',
         'media.preview_title': 'Image Preview',
         'media.preview_alt': 'Preview image',
         'media.preview_open': 'Open image preview',
@@ -1858,6 +1859,7 @@ const TRANSLATIONS = {
         'settings.action.edit': '编辑',
         'settings.action.delete': '删除',
         'settings.action.cancel': '取消',
+        'settings.action.refresh': '刷新',
         'media.preview_title': '图片预览',
         'media.preview_alt': '预览图片',
         'media.preview_open': '打开图片预览',
@@ -3316,9 +3318,11 @@ Object.assign(TRANSLATIONS['en-US'], {
     'settings.system.server_count_loading': '{count} servers configured, {loading} loading...',
     'settings.system.server_count_loaded': '{count} servers loaded',
     'settings.system.loading_tools': 'Loading tools...',
+    'settings.system.discovery_pending': 'Tool discovery is pending.',
     'settings.system.no_tools_exposed': 'No tools exposed by this MCP server.',
     'settings.system.no_description': 'No description provided.',
     'settings.system.loading_state': 'Loading...',
+    'settings.system.pending_state': 'Pending',
     'settings.system.unavailable_state': 'Unavailable',
     'settings.system.loaded_state': 'Loaded',
 });
@@ -3640,9 +3644,11 @@ Object.assign(TRANSLATIONS['zh-CN'], {
     'settings.system.server_count_loading': '已配置 {count} 个服务，{loading} 个加载中...',
     'settings.system.server_count_loaded': '已加载 {count} 个服务',
     'settings.system.loading_tools': '正在加载工具...',
+    'settings.system.discovery_pending': '工具发现正在等待执行。',
     'settings.system.no_tools_exposed': '这个 MCP 服务没有暴露任何工具。',
     'settings.system.no_description': '没有提供描述。',
     'settings.system.loading_state': '加载中...',
+    'settings.system.pending_state': '等待中',
     'settings.system.unavailable_state': '不可用',
     'settings.system.loaded_state': '已加载',
 });
@@ -4252,6 +4258,10 @@ Object.assign(TRANSLATIONS['en-US'], {
     'settings.mcp.testing': 'Testing...',
     'settings.mcp.test_ok': 'Connection succeeded. {count} tools loaded.',
     'settings.mcp.test_failed_message': 'Connection test failed.',
+    'settings.mcp.refresh_started': 'Discovery Started',
+    'settings.mcp.refresh_started_message': '{name} tool discovery was queued.',
+    'settings.mcp.refresh_failed': 'Refresh Failed',
+    'settings.mcp.refresh_failed_message': 'Failed to refresh MCP tools.',
 });
 
 Object.assign(TRANSLATIONS['zh-CN'], {
@@ -4285,6 +4295,10 @@ Object.assign(TRANSLATIONS['zh-CN'], {
     'settings.mcp.testing': '\u6d4b\u8bd5\u4e2d...',
     'settings.mcp.test_ok': '\u8fde\u63a5\u6210\u529f\uff0c\u5df2\u52a0\u8f7d {count} \u4e2a\u5de5\u5177\u3002',
     'settings.mcp.test_failed_message': '\u8fde\u63a5\u6d4b\u8bd5\u5931\u8d25\u3002',
+    'settings.mcp.refresh_started': '\u5df2\u5f00\u59cb\u53d1\u73b0',
+    'settings.mcp.refresh_started_message': '{name} \u7684\u5de5\u5177\u53d1\u73b0\u5df2\u5165\u961f\u3002',
+    'settings.mcp.refresh_failed': '\u5237\u65b0\u5931\u8d25',
+    'settings.mcp.refresh_failed_message': '\u5237\u65b0 MCP \u5de5\u5177\u5931\u8d25\u3002',
 });
 
 Object.assign(TRANSLATIONS['en-US'], {

--- a/src/relay_teams/agents/execution/agent_llm_session.py
+++ b/src/relay_teams/agents/execution/agent_llm_session.py
@@ -53,6 +53,7 @@ from relay_teams.providers.model_fallback import (
     DisabledLlmFallbackMiddleware,
     LlmFallbackMiddleware,
 )
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
 from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
@@ -123,6 +124,7 @@ class AgentLlmSession(
         tool_registry: ToolRegistry,
         mcp_registry: McpRegistry,
         skill_registry: SkillRegistry,
+        mcp_discovery_service: McpDiscoveryService | None,
         allowed_tools: tuple[str, ...],
         allowed_mcp_servers: tuple[str, ...],
         allowed_skills: tuple[str, ...],
@@ -178,6 +180,7 @@ class AgentLlmSession(
         self._conversation_microcompact_service = conversation_microcompact_service
         self._tool_registry = tool_registry
         self._mcp_registry = mcp_registry
+        self._mcp_discovery_service = mcp_discovery_service
         self._skill_registry = skill_registry
         self._allowed_tools = allowed_tools
         self._allowed_mcp_servers = allowed_mcp_servers

--- a/src/relay_teams/agents/execution/coordination_agent_builder.py
+++ b/src/relay_teams/agents/execution/coordination_agent_builder.py
@@ -8,6 +8,8 @@ from pydantic_ai import Agent
 from pydantic_ai.settings import ModelSettings
 
 from relay_teams.logger import get_logger, log_event
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
+from relay_teams.mcp.mcp_models import McpDiscoveryStatus
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.agents.execution.model_builder import (
     build_runtime_chat_model,
@@ -50,6 +52,7 @@ def build_coordination_agent(
     tool_registry: ToolRegistry,
     role_registry: RoleRegistry | None = None,
     mcp_registry: McpRegistry | None = None,
+    mcp_discovery_service: McpDiscoveryService | None = None,
     skill_registry: SkillRegistry | None = None,
 ) -> Agent[ToolDeps, str]:
     """Build the lean meta-orchestrator for collaboration management.
@@ -65,6 +68,11 @@ def build_coordination_agent(
             consumer="agents.execution.coordination_agent_builder",
         )
         for server_name in resolved_mcp_servers:
+            if not _mcp_server_is_ready_for_agent(
+                server_name,
+                discovery_service=mcp_discovery_service,
+            ):
+                continue
             is_runtime_failed = getattr(
                 mcp_registry,
                 "is_server_runtime_failed",
@@ -150,3 +158,28 @@ def build_coordination_agent(
         register(agent)
 
     return agent
+
+
+def _mcp_server_is_ready_for_agent(
+    server_name: str,
+    *,
+    discovery_service: McpDiscoveryService | None,
+) -> bool:
+    if discovery_service is None:
+        return True
+    summary = discovery_service.get_tools_summary(server_name)
+    if summary.status == McpDiscoveryStatus.READY:
+        return True
+    log_event(
+        LOGGER,
+        logging.INFO,
+        event="llm.mcp_toolset.skip_not_ready",
+        message=(
+            "Skipping MCP server that is not ready while building coordination agent"
+        ),
+        payload={
+            "server_name": server_name,
+            "discovery_status": summary.status.value,
+        },
+    )
+    return False

--- a/src/relay_teams/agents/execution/failure_reporting.py
+++ b/src/relay_teams/agents/execution/failure_reporting.py
@@ -35,6 +35,17 @@ from relay_teams.sessions.runs.recoverable_pause import (
 
 LOGGER = get_logger(__name__)
 
+_ENTERPRISE_PROXY_BLOCK_MARKERS = (
+    "<title>his proxy",
+    "his proxy notification",
+    "netentsec",
+    "swg,proxy",
+    "proxy notification",
+    "proxycontrolwarn",
+    "httpwarning_2907",
+    "blocked-by-allowlist",
+)
+
 
 class FailureMessageRepository(Protocol):
     def prune_conversation_history_to_safe_boundary(
@@ -403,6 +414,13 @@ class FailureHandlingService:
                 f"{error.message} Proxy authentication failed (HTTP 407). "
                 "Check HTTP_PROXY/HTTPS_PROXY credentials or set NO_PROXY for the model endpoint."
             )
+        if self.is_enterprise_proxy_block_failure(chain):
+            return (
+                "The model request was blocked by an enterprise proxy. "
+                "Check base_url, HTTP_PROXY/HTTPS_PROXY routing, proxy credentials, "
+                "or set NO_PROXY for the model endpoint.\n\n"
+                f"{self.model_api_proxy_block_detail(error)}"
+            )
         if self.is_connect_timeout(chain):
             return (
                 f"{error.message} Connection to the model endpoint timed out. "
@@ -572,6 +590,25 @@ class FailureHandlingService:
         return False
 
     @staticmethod
+    def is_enterprise_proxy_block_failure(chain: Sequence[BaseException]) -> bool:
+        for error in chain:
+            body = getattr(error, "body", None)
+            scan_values = [str(error)]
+            if isinstance(body, str):
+                scan_values.append(body)
+            elif isinstance(body, bytes):
+                scan_values.append(body.decode("utf-8", errors="ignore"))
+            elif body is not None:
+                scan_values.append(str(body))
+            if any(
+                marker in scan_value.casefold()
+                for scan_value in scan_values
+                for marker in _ENTERPRISE_PROXY_BLOCK_MARKERS
+            ):
+                return True
+        return False
+
+    @staticmethod
     def is_connect_timeout(chain: Sequence[BaseException]) -> bool:
         for error in chain:
             if error.__class__.__name__ == "ConnectTimeout":
@@ -591,6 +628,31 @@ class FailureHandlingService:
                 continue
             return message
         return None
+
+    def model_api_proxy_block_detail(self, error: ModelAPIError) -> str:
+        detail_lines = [
+            f"error_type: {error.__class__.__name__}",
+            f"message: {getattr(error, 'message', str(error))}",
+        ]
+        status_code = getattr(error, "status_code", None)
+        if status_code is not None:
+            detail_lines.append(f"status_code: {status_code}")
+        model_name = getattr(error, "model_name", None)
+        if model_name is not None:
+            detail_lines.append(f"model_name: {model_name}")
+        body = getattr(error, "body", None)
+        if body is not None:
+            detail_lines.append("body:")
+            detail_lines.append(self.raw_error_body_text(body))
+        return "\n".join(detail_lines)
+
+    @staticmethod
+    def raw_error_body_text(body: object) -> str:
+        if isinstance(body, str):
+            return body
+        if isinstance(body, bytes):
+            return body.decode("utf-8", errors="replace")
+        return dumps(body, ensure_ascii=False, default=str)
 
     def exception_diagnostic_item(
         self,

--- a/src/relay_teams/agents/execution/prompt_budgeting.py
+++ b/src/relay_teams/agents/execution/prompt_budgeting.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from collections.abc import Sequence
 
 from pydantic_ai.messages import ModelRequest, ModelResponse, UserPromptPart
@@ -14,13 +13,11 @@ from relay_teams.agents.execution.conversation_compaction import (
     build_conversation_compaction_budget,
 )
 from relay_teams.computer import describe_builtin_tool
-from relay_teams.logger import get_logger, log_event
-from relay_teams.mcp.mcp_models import McpToolSchema
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
+from relay_teams.mcp.mcp_models import McpDiscoveryStatus, McpToolInfo, McpToolSchema
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.providers.model_config import ModelEndpointConfig
 from relay_teams.providers.provider_contracts import LLMRequest
-
-LOGGER = get_logger(__name__)
 
 ESTIMATED_TOKEN_BYTES = 4
 ESTIMATED_TOKEN_OVERHEAD = 8
@@ -29,7 +26,8 @@ MIN_AVAILABLE_OUTPUT_TOKENS = 1
 BUILTIN_TOOL_CONTEXT_CHARS = 200
 EXTERNAL_TOOL_CONTEXT_CHARS = 600
 SKILL_CONTEXT_CHARS = 800
-MCP_SERVER_CONTEXT_FALLBACK_CHARS = 1_200
+MCP_SERVER_CONTEXT_FALLBACK_CHARS = 8_000
+MCP_DISCOVERED_TOOL_SCHEMA_RESERVE_CHARS = 1_200
 
 
 class PromptBudgetingService:
@@ -39,10 +37,12 @@ class PromptBudgetingService:
         config: ModelEndpointConfig,
         mcp_registry: McpRegistry,
         mcp_tool_context_token_cache: dict[str, int],
+        mcp_discovery_service: McpDiscoveryService | None = None,
     ) -> None:
         self._config = config
         self._mcp_registry = mcp_registry
         self._mcp_tool_context_token_cache = mcp_tool_context_token_cache
+        self._mcp_discovery_service = mcp_discovery_service
 
     async def estimate_compaction_budget(
         self,
@@ -181,35 +181,61 @@ class PromptBudgetingService:
             if cached_tokens is not None:
                 total_tokens += cached_tokens
                 continue
-            try:
-                tool_schemas = await self._mcp_registry.list_tool_schemas(server_name)
-            except Exception as exc:
-                fallback_tokens = self.estimated_mcp_context_tokens_fallback(
-                    allowed_mcp_servers=(server_name,),
-                )
-                total_tokens += fallback_tokens
-                log_event(
-                    LOGGER,
-                    logging.WARNING,
-                    event="llm.mcp_context_budget.estimate_failed",
-                    message=(
-                        "Failed to inspect MCP tool schemas for token budgeting; "
-                        "falling back to heuristic reserve"
-                    ),
-                    payload={
-                        "server_name": server_name,
-                        "fallback_tokens": fallback_tokens,
-                    },
-                    exc_info=exc,
-                )
-                continue
-            estimated_tokens = self.estimate_mcp_tool_schema_tokens(
-                server_name=server_name,
-                tool_schemas=tool_schemas,
+            discovered_tokens = self._estimated_discovered_mcp_context_tokens(
+                server_name=server_name
             )
-            self._mcp_tool_context_token_cache[server_name] = estimated_tokens
-            total_tokens += estimated_tokens
+            if discovered_tokens is not None:
+                self._mcp_tool_context_token_cache[server_name] = discovered_tokens
+                total_tokens += discovered_tokens
+                continue
+            total_tokens += self.estimated_mcp_context_tokens_fallback(
+                allowed_mcp_servers=(server_name,),
+            )
         return total_tokens
+
+    def _estimated_discovered_mcp_context_tokens(
+        self,
+        *,
+        server_name: str,
+    ) -> int | None:
+        if self._mcp_discovery_service is None:
+            return None
+        summary = self._mcp_discovery_service.get_tools_summary(server_name)
+        if summary.status != McpDiscoveryStatus.READY:
+            return None
+        return self.estimate_mcp_tool_info_tokens(
+            server_name=server_name,
+            tools=summary.tools,
+        )
+
+    @staticmethod
+    def estimate_mcp_tool_info_tokens(
+        *,
+        server_name: str,
+        tools: tuple[McpToolInfo, ...],
+    ) -> int:
+        if not tools:
+            return 0
+        serialized_payload = json.dumps(
+            [
+                {
+                    "server": server_name,
+                    "tool": tool.model_dump(mode="json"),
+                    "input_schema_reserve_chars": (
+                        MCP_DISCOVERED_TOOL_SCHEMA_RESERVE_CHARS
+                    ),
+                }
+                for tool in tools
+            ],
+            ensure_ascii=False,
+            sort_keys=True,
+        ).encode("utf-8")
+        reserved_chars = len(tools) * MCP_DISCOVERED_TOOL_SCHEMA_RESERVE_CHARS
+        return max(
+            1,
+            ((len(serialized_payload) + reserved_chars) // ESTIMATED_TOKEN_BYTES)
+            + ESTIMATED_TOKEN_OVERHEAD,
+        )
 
     def estimate_mcp_tool_schema_tokens(
         self,

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -56,6 +56,7 @@ from relay_teams.hooks import (
     UserPromptSubmitInput,
 )
 from relay_teams.logger import get_logger, log_event
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_models import McpToolSchema
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.media import (
@@ -359,6 +360,7 @@ class PromptHistoryService:
         conversation_compaction_service: ConversationCompactionService | None,
         conversation_microcompact_service: ConversationMicrocompactService | None,
         mcp_registry: McpRegistry,
+        mcp_discovery_service: McpDiscoveryService | None,
         mcp_tool_context_token_cache: dict[str, int],
         media_asset_service: object | None,
         hook_service: object | None,
@@ -378,6 +380,7 @@ class PromptHistoryService:
         self._conversation_compaction_service = conversation_compaction_service
         self._conversation_microcompact_service = conversation_microcompact_service
         self._mcp_registry = mcp_registry
+        self._mcp_discovery_service = mcp_discovery_service
         self._mcp_tool_context_token_cache = mcp_tool_context_token_cache
         self._media_asset_service = media_asset_service
         self._hook_service = hook_service
@@ -393,6 +396,7 @@ class PromptHistoryService:
             config=self._config,
             mcp_registry=self._mcp_registry,
             mcp_tool_context_token_cache=self._mcp_tool_context_token_cache,
+            mcp_discovery_service=self._mcp_discovery_service,
         )
 
     async def _get_history_for_conversation_async(

--- a/src/relay_teams/agents/execution/session_mixin_base.py
+++ b/src/relay_teams/agents/execution/session_mixin_base.py
@@ -49,6 +49,7 @@ from relay_teams.computer import ComputerActionDescriptor, ComputerRuntime
 from relay_teams.gateway.im.service import ImToolService
 from relay_teams.hooks import HookService
 from relay_teams.media import MediaAssetService, UserPromptContent
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.metrics import MetricRecorder
 from relay_teams.monitors import MonitorService
@@ -117,6 +118,7 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
     _conversation_microcompact_service: ConversationMicrocompactService | None
     _tool_registry: ToolRegistry
     _mcp_registry: McpRegistry
+    _mcp_discovery_service: McpDiscoveryService | None
     _skill_registry: SkillRegistry
     _allowed_tools: tuple[str, ...]
     _allowed_mcp_servers: tuple[str, ...]

--- a/src/relay_teams/agents/execution/session_prompt.py
+++ b/src/relay_teams/agents/execution/session_prompt.py
@@ -243,6 +243,7 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             tool_registry=self._tool_registry,
             role_registry=self._role_registry,
             mcp_registry=self._mcp_registry,
+            mcp_discovery_service=getattr(self, "_mcp_discovery_service", None),
             skill_registry=self._skill_registry,
         )
         return prepared_prompt, history, prepared_system_prompt, cast(object, agent)

--- a/src/relay_teams/agents/execution/session_support.py
+++ b/src/relay_teams/agents/execution/session_support.py
@@ -1900,6 +1900,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
                 None,
             ),
             mcp_registry=getattr(self, "_mcp_registry", McpRegistry()),
+            mcp_discovery_service=getattr(self, "_mcp_discovery_service", None),
             mcp_tool_context_token_cache=mcp_tool_context_token_cache,
             media_asset_service=getattr(self, "_media_asset_service", None),
             hook_service=getattr(self, "_hook_service", None),

--- a/src/relay_teams/agents/execution/system_prompts.py
+++ b/src/relay_teams/agents/execution/system_prompts.py
@@ -33,6 +33,8 @@ from relay_teams.hooks import (
     InstructionsLoadedInput,
 )
 from relay_teams.logger import get_logger, log_event
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
+from relay_teams.mcp.mcp_models import McpDiscoveryStatus
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_contracts import build_role_contract_prompt
@@ -601,6 +603,7 @@ async def build_runtime_system_prompt(
     role_registry: RoleRegistry | None = None,
     runtime_role_resolver: RuntimeRoleResolver | None = None,
     mcp_registry: McpRegistry | None = None,
+    mcp_discovery_service: McpDiscoveryService | None = None,
     instruction_resolver: PromptInstructionResolver | None = None,
     hook_service: RuntimePromptHookService | None = None,
     run_event_hub: RunEventHub | None = None,
@@ -610,6 +613,7 @@ async def build_runtime_system_prompt(
         role_registry=role_registry,
         runtime_role_resolver=runtime_role_resolver,
         mcp_registry=mcp_registry,
+        mcp_discovery_service=mcp_discovery_service,
         instruction_resolver=instruction_resolver,
         hook_service=hook_service,
         run_event_hub=run_event_hub,
@@ -623,6 +627,7 @@ async def build_runtime_system_prompt_result(
     role_registry: RoleRegistry | None = None,
     runtime_role_resolver: RuntimeRoleResolver | None = None,
     mcp_registry: McpRegistry | None = None,
+    mcp_discovery_service: McpDiscoveryService | None = None,
     instruction_resolver: PromptInstructionResolver | None = None,
     hook_service: RuntimePromptHookService | None = None,
     run_event_hub: RunEventHub | None = None,
@@ -702,6 +707,7 @@ async def build_runtime_system_prompt_result(
         role_registry=role_registry,
         runtime_role_resolver=runtime_role_resolver,
         mcp_registry=mcp_registry,
+        mcp_discovery_service=mcp_discovery_service,
         run_id=data.task.trace_id if data.task is not None else None,
         allowed_role_ids=topology.allowed_role_ids if topology is not None else (),
     )
@@ -734,6 +740,7 @@ async def build_available_roles_prompt(
     role_registry: RoleRegistry,
     runtime_role_resolver: RuntimeRoleResolver | None = None,
     mcp_registry: McpRegistry,
+    mcp_discovery_service: McpDiscoveryService | None = None,
     run_id: str | None = None,
     allowed_role_ids: tuple[str, ...] = (),
 ) -> str:
@@ -770,6 +777,7 @@ async def build_available_roles_prompt(
                     "static" if role.role_id in static_role_ids else "temporary"
                 ),
                 mcp_registry=mcp_registry,
+                mcp_discovery_service=mcp_discovery_service,
             )
             for role in roles
         ]
@@ -950,8 +958,13 @@ async def _build_available_role_block(
     role: RoleDefinition,
     role_source: str,
     mcp_registry: McpRegistry,
+    mcp_discovery_service: McpDiscoveryService | None,
 ) -> str:
-    mcp_tools = await _list_role_mcp_tools(role=role, mcp_registry=mcp_registry)
+    mcp_tools = await _list_role_mcp_tools(
+        role=role,
+        mcp_registry=mcp_registry,
+        mcp_discovery_service=mcp_discovery_service,
+    )
     runtime_tools = runtime_tools_for_role(
         role_registry=role_registry,
         role=role,
@@ -973,6 +986,7 @@ async def _list_role_mcp_tools(
     *,
     role: RoleDefinition,
     mcp_registry: McpRegistry,
+    mcp_discovery_service: McpDiscoveryService | None,
 ) -> tuple[str, ...]:
     resolved_server_names = mcp_registry.resolve_server_names(
         role.mcp_servers,
@@ -981,14 +995,49 @@ async def _list_role_mcp_tools(
     )
     if not resolved_server_names:
         return ()
-    summaries = await asyncio.gather(
-        *[mcp_registry.list_tools(server_name) for server_name in resolved_server_names]
-    )
+    if mcp_discovery_service is None:
+        live_tool_groups = await asyncio.gather(
+            *(
+                mcp_registry.list_tools(server_name)
+                for server_name in resolved_server_names
+            )
+        )
+        return tuple(
+            tool_name
+            for tool_group in live_tool_groups
+            for tool_name in _tool_names(tool_group)
+        )
     return tuple(
-        tool.name
-        for _server_name, tools in zip(resolved_server_names, summaries, strict=True)
-        for tool in tools
+        tool_name
+        for server_name in resolved_server_names
+        for tool_name in _ready_mcp_tools_for_prompt(
+            server_name,
+            discovery_service=mcp_discovery_service,
+        )
     )
+
+
+def _ready_mcp_tools_for_prompt(
+    server_name: str,
+    *,
+    discovery_service: McpDiscoveryService | None,
+) -> tuple[str, ...]:
+    if discovery_service is None:
+        return ()
+    summary = discovery_service.get_tools_summary(server_name)
+    if summary.status == McpDiscoveryStatus.READY:
+        return tuple(tool.name for tool in summary.tools)
+    log_event(
+        LOGGER,
+        logging.DEBUG,
+        event="llm.prompt.mcp_tools.skip_not_ready",
+        message="Skipping MCP tools that are not ready while building runtime prompt",
+        payload={
+            "server_name": server_name,
+            "discovery_status": summary.status.value,
+        },
+    )
+    return ()
 
 
 def _format_names(names: tuple[str, ...]) -> str:
@@ -1100,6 +1149,7 @@ class RuntimePromptBuilder(BaseModel):
     role_registry: RoleRegistry | None = None
     runtime_role_resolver: RuntimeRoleResolver | None = None
     mcp_registry: McpRegistry | None = None
+    mcp_discovery_service: McpDiscoveryService | None = None
     instruction_resolver: PromptInstructionResolver | None = None
     hook_service: RuntimePromptHookService | None = None
     run_event_hub: RunEventHub | None = None
@@ -1117,6 +1167,7 @@ class RuntimePromptBuilder(BaseModel):
             role_registry=self.role_registry,
             runtime_role_resolver=self.runtime_role_resolver,
             mcp_registry=self.mcp_registry,
+            mcp_discovery_service=self.mcp_discovery_service,
             instruction_resolver=self.instruction_resolver,
             hook_service=self.hook_service,
             run_event_hub=self.run_event_hub,

--- a/src/relay_teams/agents/orchestration/task_execution_service_factory.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service_factory.py
@@ -8,6 +8,7 @@ from relay_teams.agents.execution.prompt_instructions import PromptInstructionRe
 from relay_teams.agents.execution.system_prompts import RuntimePromptBuilder
 from relay_teams.agents.orchestration.task_execution_service import TaskExecutionService
 from relay_teams.media import MediaAssetService
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.providers.provider_contracts import LLMProvider
 from relay_teams.roles.memory_service import RoleMemoryService
@@ -57,6 +58,7 @@ def create_task_execution_service(
     skill_registry: SkillRegistry,
     skill_runtime_service: SkillRuntimeService | None,
     mcp_registry: McpRegistry,
+    mcp_discovery_service: McpDiscoveryService | None,
     injection_manager: RunInjectionManager,
     run_control_manager: RunControlManager,
     role_memory_service: RoleMemoryService | None = None,
@@ -88,6 +90,7 @@ def create_task_execution_service(
             ),
             hook_service=hook_service,
             run_event_hub=run_event_hub,
+            mcp_discovery_service=mcp_discovery_service,
         ),
         provider_factory=provider_factory,
         tool_registry=tool_registry,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -101,6 +101,8 @@ from relay_teams.interfaces.server.config_status_service import ConfigStatusServ
 from relay_teams.interfaces.server.ui_language_service import UiLanguageSettingsService
 from relay_teams.mcp.mcp_config_manager import McpConfigManager
 from relay_teams.mcp.config_reload_service import McpConfigReloadService
+from relay_teams.mcp.mcp_config_watcher import McpConfigFileWatcher
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.mcp.mcp_service import McpService
 from relay_teams.metrics import (
@@ -379,6 +381,10 @@ class ServerContainer:
         self.mcp_config_manager: McpConfigManager = McpConfigManager(
             app_config_dir=app_config_dir
         )
+        self.mcp_config_file_watcher: McpConfigFileWatcher = McpConfigFileWatcher(
+            config_path=self.mcp_config_manager.config_file_path(),
+            on_changed=self._reload_mcp_config_after_file_change,
+        )
         self.tool_registry: ToolRegistry = build_default_registry()
         self.auto_harness_service = AutoHarnessService(
             config_dir=app_config_dir,
@@ -397,11 +403,15 @@ class ServerContainer:
         self.mcp_registry: McpRegistry = self.mcp_config_manager.load_registry(
             extra_specs=self._plugin_mcp_specs
         )
+        self.mcp_discovery_service: McpDiscoveryService = McpDiscoveryService(
+            self.mcp_registry
+        )
         self.mcp_service: McpService = McpService(
             registry=self.mcp_registry,
             config_manager=self.mcp_config_manager,
             on_registry_changed=self.replace_mcp_registry,
             extra_specs=self._plugin_mcp_specs,
+            discovery_service=self.mcp_discovery_service,
         )
         self.command_registry: CommandRegistry = CommandRegistry(
             app_config_dir=app_config_dir,
@@ -785,6 +795,7 @@ class ServerContainer:
             prompt_builder=RuntimePromptBuilder(
                 role_registry=self.role_registry,
                 mcp_registry=self.mcp_registry,
+                mcp_discovery_service=self.mcp_discovery_service,
                 instruction_resolver=PromptInstructionResolver(
                     app_config_dir=runtime.paths.config_dir,
                     instructions=runtime.prompt_instructions.instructions,
@@ -1169,6 +1180,7 @@ class ServerContainer:
             subagent_reflection_service=self.subagent_reflection_service,
             tool_registry=self.tool_registry,
             mcp_registry=self.mcp_registry,
+            mcp_discovery_service=self.mcp_discovery_service,
             skill_registry=self.skill_registry,
             message_repo=self.message_repo,
             session_history_marker_repo=self.session_history_marker_repo,
@@ -1221,6 +1233,7 @@ class ServerContainer:
             skill_registry=self.skill_registry,
             skill_runtime_service=self.skill_runtime_service,
             mcp_registry=self.mcp_registry,
+            mcp_discovery_service=self.mcp_discovery_service,
             injection_manager=self.injection_manager,
             run_control_manager=self.run_control_manager,
             role_memory_service=self.role_memory_service,
@@ -1365,6 +1378,8 @@ class ServerContainer:
         )
 
     async def start(self) -> None:
+        self.mcp_discovery_service.start_warmup(self.mcp_registry)
+        self.mcp_config_file_watcher.start()
         self.run_service.bind_event_loop(asyncio.get_running_loop())
         self.background_task_service.bind_completion_sink(self.run_service)
         self.wechat_gateway_service.start()
@@ -1398,6 +1413,8 @@ class ServerContainer:
             )
         await self.external_acp_session_manager.close()
         await self.background_task_manager.close()
+        await self.mcp_config_file_watcher.stop()
+        await self.mcp_discovery_service.close()
         await self._close_async_repositories()
         await clear_llm_http_client_cache_async()
         return None
@@ -1454,6 +1471,7 @@ class ServerContainer:
         self.meta_agent.coordinator.prompt_builder = RuntimePromptBuilder(
             role_registry=self.role_registry,
             mcp_registry=self.mcp_registry,
+            mcp_discovery_service=self.mcp_discovery_service,
             instruction_resolver=PromptInstructionResolver(
                 app_config_dir=self.runtime.paths.config_dir,
                 instructions=self.runtime.prompt_instructions.instructions,
@@ -1508,6 +1526,9 @@ class ServerContainer:
 
     def _on_mcp_reloaded(self, mcp_registry: McpRegistry) -> None:
         self.replace_mcp_registry(mcp_registry)
+
+    def _reload_mcp_config_after_file_change(self) -> None:
+        self.mcp_config_reload_service.reload_mcp_config()
 
     def _reload_skills_config(self) -> None:
         self.skills_config_reload_service.reload_skills_config()

--- a/src/relay_teams/interfaces/server/deps.py
+++ b/src/relay_teams/interfaces/server/deps.py
@@ -37,6 +37,7 @@ from relay_teams.interfaces.server.config_status_service import ConfigStatusServ
 from relay_teams.interfaces.server.container import ServerContainer
 from relay_teams.interfaces.server.ui_language_service import UiLanguageSettingsService
 from relay_teams.mcp.config_reload_service import McpConfigReloadService
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.mcp.mcp_service import McpService
 from relay_teams.media import MediaAssetService
@@ -180,6 +181,10 @@ def get_mcp_service(request: Request) -> McpService:
 
 def get_mcp_registry(request: Request) -> McpRegistry:
     return get_container(request).mcp_registry
+
+
+def get_mcp_discovery_service(request: Request) -> McpDiscoveryService:
+    return get_container(request).mcp_discovery_service
 
 
 def get_proxy_config_service(request: Request) -> ProxyConfigService:

--- a/src/relay_teams/interfaces/server/routers/mcp.py
+++ b/src/relay_teams/interfaces/server/routers/mcp.py
@@ -93,11 +93,17 @@ async def list_mcp_server_tools(
         return await service.list_server_tools(server_name)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except Exception as exc:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Failed to load MCP tools for '{server_name}': {exc}",
-        ) from exc
+
+
+@router.post("/servers/{server_name}/tools:refresh")
+async def refresh_mcp_server_tools(
+    server_name: str,
+    service: McpService = Depends(get_mcp_service),
+) -> McpServerToolsSummary:
+    try:
+        return service.refresh_server_tools(server_name)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("/servers/{server_name}/test")

--- a/src/relay_teams/interfaces/server/routers/prompts.py
+++ b/src/relay_teams/interfaces/server/routers/prompts.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue, RootModel, model_v
 
 from relay_teams.agents.execution.prompt_instructions import PromptInstructionResolver
 from relay_teams.interfaces.server.deps import (
+    get_mcp_discovery_service,
     get_mcp_registry,
     get_role_registry,
     get_skill_registry,
@@ -25,6 +26,7 @@ from relay_teams.agents.execution.system_prompts import (
     compose_provider_system_prompt,
     compose_runtime_system_prompt,
 )
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.paths import get_app_config_dir
 from relay_teams.roles.role_models import RoleDefinition
@@ -98,6 +100,9 @@ async def preview_prompts(
     role_registry: Annotated[RoleRegistry, Depends(get_role_registry)],
     tool_registry: Annotated[ToolRegistry, Depends(get_tool_registry)],
     mcp_registry: Annotated[McpRegistry, Depends(get_mcp_registry)],
+    mcp_discovery_service: Annotated[
+        McpDiscoveryService, Depends(get_mcp_discovery_service)
+    ],
     skill_registry: Annotated[SkillRegistry, Depends(get_skill_registry)],
     skill_runtime_service: Annotated[
         SkillRuntimeService, Depends(get_skill_runtime_service)
@@ -162,6 +167,7 @@ async def preview_prompts(
     runtime_prompt_sections = await RuntimePromptBuilder(
         role_registry=role_registry,
         mcp_registry=mcp_registry,
+        mcp_discovery_service=mcp_discovery_service,
         instruction_resolver=PromptInstructionResolver(
             app_config_dir=get_app_config_dir()
         ),

--- a/src/relay_teams/mcp/__init__.py
+++ b/src/relay_teams/mcp/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from relay_teams.mcp.mcp_models import (
     McpConfigScope,
+    McpDiscoveryStatus,
     McpServerSpec,
     McpServerSummary,
     McpServerToolsSummary,
@@ -11,6 +12,7 @@ from relay_teams.mcp.mcp_models import (
 
 __all__ = [
     "McpConfigScope",
+    "McpDiscoveryStatus",
     "McpServerSpec",
     "McpServerSummary",
     "McpServerToolsSummary",

--- a/src/relay_teams/mcp/config_reload_service.py
+++ b/src/relay_teams/mcp/config_reload_service.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 import logging
+import re
 import subprocess
+from urllib.parse import unquote, urlparse
 
+from packaging.requirements import InvalidRequirement, Requirement
 from pydantic import JsonValue
 
 from relay_teams.logger import get_logger, log_event
@@ -121,7 +124,7 @@ def _resolve_uv_tool_package(args: tuple[str, ...]) -> str | None:
     for arg in args:
         if arg.startswith("--from="):
             resolved = arg.partition("=")[2].strip()
-            return resolved or None
+            return _normalize_uv_cache_package_target(resolved)
     for index, arg in enumerate(args):
         if arg != "--from":
             continue
@@ -129,13 +132,54 @@ def _resolve_uv_tool_package(args: tuple[str, ...]) -> str | None:
         if next_index >= len(args):
             return None
         resolved = args[next_index].strip()
-        return resolved or None
-    if not args:
+        return _normalize_uv_cache_package_target(resolved)
+    command_args = _strip_uv_tool_args(args)
+    if not command_args:
         return None
-    first_arg = args[0].strip()
+    first_arg = command_args[0].strip()
     if not first_arg or first_arg.startswith("-"):
         return None
-    return first_arg
+    return _normalize_uv_cache_package_target(first_arg)
+
+
+def _normalize_uv_cache_package_target(value: str) -> str | None:
+    raw_value = value.strip()
+    if not raw_value:
+        return None
+    requirement_name = _requirement_distribution_name(raw_value)
+    if requirement_name is not None:
+        return requirement_name
+    parsed = urlparse(raw_value)
+    if parsed.scheme and parsed.netloc:
+        candidate = unquote(Path(parsed.path).name)
+    else:
+        candidate = Path(raw_value).name
+    if not candidate:
+        return None
+    for suffix in (".tar.gz", ".tar.bz2", ".tar.xz"):
+        if candidate.casefold().endswith(suffix):
+            return _distribution_name_from_archive(candidate[: -len(suffix)])
+    return _distribution_name_from_archive(candidate)
+
+
+def _requirement_distribution_name(value: str) -> str | None:
+    try:
+        requirement = Requirement(value)
+    except InvalidRequirement:
+        return None
+    resolved = requirement.name.strip()
+    return resolved or None
+
+
+def _distribution_name_from_archive(stem: str) -> str | None:
+    normalized_stem = stem.strip()
+    if not normalized_stem:
+        return None
+    match = re.match(r"(?P<name>.+?)[_-]\d+(?:[._-].*)?$", normalized_stem)
+    if match is None:
+        return normalized_stem
+    resolved = match.group("name").strip()
+    return resolved or None
 
 
 def _required_server_config_string(
@@ -156,6 +200,14 @@ def _server_config_args(server_config: dict[str, JsonValue]) -> tuple[str, ...]:
 
 
 def _strip_uv_global_args(args: tuple[str, ...]) -> tuple[str, ...]:
+    return _strip_leading_uv_options(args)
+
+
+def _strip_uv_tool_args(args: tuple[str, ...]) -> tuple[str, ...]:
+    return _strip_leading_uv_options(args)
+
+
+def _strip_leading_uv_options(args: tuple[str, ...]) -> tuple[str, ...]:
     index = 0
     while index < len(args):
         arg = args[index]
@@ -186,8 +238,48 @@ _UV_OPTIONS_WITH_VALUE: frozenset[str] = frozenset(
         "--cache-dir",
         "--color",
         "--config-file",
+        "--config-setting",
+        "--config-settings-package",
+        "--constraints",
+        "--default-index",
         "--directory",
+        "--env-file",
+        "--exclude-newer",
+        "--exclude-newer-package",
+        "--extra-index-url",
+        "--find-links",
+        "--fork-strategy",
+        "--from",
+        "--index",
+        "--index-strategy",
+        "--index-url",
+        "--keyring-provider",
+        "--link-mode",
+        "--no-binary-package",
+        "--no-build-isolation-package",
+        "--no-build-package",
+        "--no-sources-package",
+        "--overrides",
+        "--prerelease",
         "--project",
+        "--python",
+        "--python-platform",
+        "--refresh-package",
+        "--reinstall-package",
+        "--resolution",
+        "--torch-backend",
+        "--upgrade-package",
+        "--with",
+        "--with-editable",
+        "--with-requirements",
+        "-b",
+        "-c",
+        "-C",
+        "-f",
+        "-i",
+        "-P",
+        "-p",
+        "-w",
     }
 )
 

--- a/src/relay_teams/mcp/mcp_config_manager.py
+++ b/src/relay_teams/mcp/mcp_config_manager.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 
 from pydantic import JsonValue
 
+import hashlib
 from json import dumps, loads
 from pathlib import Path
 from typing import cast
 
 from relay_teams.builtin import ensure_app_config_bootstrap
 from relay_teams.env import (
-    apply_proxy_env_to_process_env,
     extract_proxy_env_vars,
     load_merged_env_vars,
+    load_proxy_env_config,
     sync_app_env_to_process_env,
+    sync_proxy_env_to_process_env,
 )
 from relay_teams.logger import get_logger
 from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec
@@ -45,6 +47,9 @@ class McpConfigManager:
         self._app_config_dir: Path = app_config_dir.expanduser().resolve()
         self._user_home_dir: Path | None = user_home_dir
 
+    def config_file_path(self) -> Path:
+        return self._app_config_dir / _MCP_FILE_NAME
+
     def load_registry(
         self,
         *,
@@ -62,7 +67,11 @@ class McpConfigManager:
             merged_env = load_merged_env_vars(
                 extra_env_files=(self._app_config_dir / _ENV_FILE_NAME,),
             )
-            proxy_env = apply_proxy_env_to_process_env(merged_env)
+            proxy_config = load_proxy_env_config(
+                extra_env_files=(self._app_config_dir / _ENV_FILE_NAME,),
+            )
+            proxy_env = extract_proxy_env_vars(proxy_config.normalized_env())
+            sync_proxy_env_to_process_env(proxy_config)
             for spec in _load_specs_from_file(
                 file_path=self._app_config_dir / _MCP_FILE_NAME,
                 source=McpConfigScope.APP,
@@ -74,7 +83,14 @@ class McpConfigManager:
                     spec=spec,
                     proxy_env=proxy_env,
                 )
-            return McpRegistry(tuple(merged_specs.values()))
+            return McpRegistry(
+                tuple(merged_specs.values()),
+                proxy_env=proxy_env,
+                discovery_env_fingerprint=_fingerprint_env_for_discovery(
+                    merged_env=merged_env,
+                    proxy_env=proxy_env,
+                ),
+            )
 
     def add_server(
         self,
@@ -363,11 +379,31 @@ def json_dumps(payload: dict[str, JsonValue]) -> str:
     return dumps(payload, ensure_ascii=False, indent=2) + "\n"
 
 
+def _fingerprint_env_for_discovery(
+    *,
+    merged_env: dict[str, str],
+    proxy_env: dict[str, str],
+) -> str:
+    payload = {
+        "merged_env": merged_env,
+        "proxy_env": proxy_env,
+    }
+    serialized = dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
 def _apply_proxy_env_to_mcp_server_config(
     server_config: dict[str, JsonValue],
     proxy_env: dict[str, str],
 ) -> dict[str, JsonValue]:
     if not proxy_env:
+        return server_config
+    if _is_stdio_mcp_server_config(server_config):
         return server_config
 
     merged_config: dict[str, JsonValue] = dict(server_config)
@@ -384,6 +420,21 @@ def _apply_proxy_env_to_mcp_server_config(
         merged_env[key] = value
     merged_config["env"] = merged_env
     return merged_config
+
+
+def _is_stdio_mcp_server_config(server_config: dict[str, JsonValue]) -> bool:
+    raw_transport = server_config.get("transport")
+    if isinstance(raw_transport, str) and raw_transport.strip():
+        return raw_transport.strip() == "stdio"
+
+    raw_type = server_config.get("type")
+    if isinstance(raw_type, str) and raw_type.strip():
+        return raw_type.strip() == "local"
+
+    return isinstance(server_config.get("command"), str) and not isinstance(
+        server_config.get("url"),
+        str,
+    )
 
 
 def _apply_proxy_env_to_mcp_spec(

--- a/src/relay_teams/mcp/mcp_config_watcher.py
+++ b/src/relay_teams/mcp/mcp_config_watcher.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from json import loads
+import logging
+from pathlib import Path
+from typing import cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from relay_teams.logger import get_logger, log_event
+
+LOGGER = get_logger(__name__)
+_DEFAULT_POLL_INTERVAL_SECONDS = 2.0
+_DEFAULT_DEBOUNCE_SECONDS = 0.5
+
+
+class McpConfigFileStamp(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    mtime_ns: int = Field(ge=0)
+    size: int = Field(ge=0)
+
+
+class McpConfigFileWatcher:
+    def __init__(
+        self,
+        *,
+        config_path: Path,
+        on_changed: Callable[[], None],
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+        debounce_seconds: float = _DEFAULT_DEBOUNCE_SECONDS,
+    ) -> None:
+        self._config_path = config_path
+        self._on_changed = on_changed
+        self._poll_interval_seconds = max(0.1, poll_interval_seconds)
+        self._debounce_seconds = max(0.0, debounce_seconds)
+        self._last_stamp: McpConfigFileStamp | None = None
+        self._task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._last_stamp = self._read_stamp()
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._watch_loop())
+
+    async def stop(self) -> None:
+        task = self._task
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        self._task = None
+
+    async def _watch_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._poll_interval_seconds)
+            current_stamp = self._read_stamp()
+            if current_stamp == self._last_stamp:
+                continue
+            await asyncio.sleep(self._debounce_seconds)
+            stable_stamp = self._read_stamp()
+            if stable_stamp == self._last_stamp:
+                continue
+            self._last_stamp = stable_stamp
+            if not self._file_is_valid_json():
+                continue
+            try:
+                await asyncio.to_thread(self._on_changed)
+            except Exception as exc:
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="mcp.config.file_watch_reload_failed",
+                    message="Failed to reload MCP config after file change",
+                    payload={"config_path": str(self._config_path)},
+                    exc_info=exc,
+                )
+
+    def _read_stamp(self) -> McpConfigFileStamp | None:
+        try:
+            stat_result = self._config_path.stat()
+        except FileNotFoundError:
+            return None
+        return McpConfigFileStamp(
+            mtime_ns=stat_result.st_mtime_ns,
+            size=stat_result.st_size,
+        )
+
+    def _file_is_valid_json(self) -> bool:
+        if not self._config_path.exists():
+            return True
+        try:
+            cast(object, loads(self._config_path.read_text(encoding="utf-8-sig")))
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="mcp.config.file_watch_invalid_json",
+                message="Ignoring MCP config file change because JSON is invalid",
+                payload={"config_path": str(self._config_path)},
+                exc_info=exc,
+            )
+            return False
+        return True

--- a/src/relay_teams/mcp/mcp_discovery_service.py
+++ b/src/relay_teams/mcp/mcp_discovery_service.py
@@ -1,0 +1,477 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+import hashlib
+from json import dumps
+import logging
+
+from pydantic import BaseModel, ConfigDict, JsonValue
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
+    McpDiscoveryStatus,
+    McpServerSpec,
+    McpServerSummary,
+    McpServerToolsSummary,
+    McpToolInfo,
+)
+from relay_teams.mcp.mcp_registry import McpRegistry
+
+LOGGER = get_logger(__name__)
+_DEFAULT_DISCOVERY_CONCURRENCY = 3
+
+
+class McpDiscoveryRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    source: McpConfigScope
+    transport: str
+    enabled: bool
+    status: McpDiscoveryStatus
+    tools: tuple[McpToolInfo, ...] = ()
+    last_checked_at: datetime | None = None
+    error: str | None = None
+    generation: int
+    fingerprint: str
+
+
+class McpDiscoveryService:
+    def __init__(
+        self,
+        registry: McpRegistry,
+        *,
+        max_concurrency: int = _DEFAULT_DISCOVERY_CONCURRENCY,
+    ) -> None:
+        self._registry = registry
+        self._generation = 0
+        self._records: dict[str, McpDiscoveryRecord] = {}
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._semaphore = asyncio.Semaphore(max(1, max_concurrency))
+        self._reset_records(registry)
+
+    def start_warmup(self, registry: McpRegistry) -> None:
+        self._bind_current_loop()
+        self.replace_registry(registry)
+
+    def replace_registry(self, registry: McpRegistry) -> None:
+        if self._should_defer_to_bound_loop():
+            loop = self._loop
+            if loop is not None:
+                loop.call_soon_threadsafe(self._replace_registry_now, registry)
+            return
+        self._bind_current_loop()
+        self._replace_registry_now(registry)
+
+    def _replace_registry_now(self, registry: McpRegistry) -> None:
+        self._registry = registry
+        self._generation += 1
+        next_records: dict[str, McpDiscoveryRecord] = {}
+        specs_to_enqueue: list[McpServerSpec] = []
+        seen_names: set[str] = set()
+
+        for spec in registry.list_specs():
+            seen_names.add(spec.name)
+            existing = self._records.get(spec.name)
+            fingerprint = _fingerprint_spec(
+                spec,
+                registry.discovery_fingerprint_context(),
+            )
+            if not spec.enabled:
+                self._cancel_task(spec.name)
+                next_records[spec.name] = self._record_from_spec(
+                    spec,
+                    generation=self._generation,
+                )
+                continue
+
+            if existing is not None and existing.fingerprint == fingerprint:
+                next_records[spec.name] = existing.model_copy(
+                    update={
+                        "source": spec.source,
+                        "transport": _detect_transport(spec.server_config),
+                        "enabled": spec.enabled,
+                        "generation": self._generation,
+                    }
+                )
+                if existing.status == McpDiscoveryStatus.PENDING:
+                    specs_to_enqueue.append(spec)
+                if (
+                    existing.status == McpDiscoveryStatus.LOADING
+                    and not self._has_active_task(spec.name)
+                ):
+                    specs_to_enqueue.append(spec)
+                continue
+
+            self._cancel_task(spec.name)
+            next_records[spec.name] = self._record_from_spec(
+                spec,
+                generation=self._generation,
+            )
+            specs_to_enqueue.append(spec)
+
+        for removed_name in set(self._records).difference(seen_names):
+            self._cancel_task(removed_name)
+
+        self._records = next_records
+        self._enqueue_enabled_servers(registry, specs_to_enqueue, force=False)
+
+    async def close(self) -> None:
+        self._cancel_pending_tasks()
+        if self._tasks:
+            await asyncio.gather(*self._tasks.values(), return_exceptions=True)
+        self._tasks.clear()
+
+    def list_server_summaries(self) -> tuple[McpServerSummary, ...]:
+        return tuple(
+            McpServerSummary(
+                name=record.name,
+                source=record.source,
+                transport=record.transport,
+                enabled=record.enabled,
+                discovery_status=record.status,
+                tool_count=len(record.tools),
+                last_checked_at=record.last_checked_at,
+                error=record.error,
+            )
+            for record in self._sorted_records()
+        )
+
+    def get_tools_summary(self, name: str) -> McpServerToolsSummary:
+        normalized_name = name.strip()
+        record = self._records.get(normalized_name)
+        if record is None:
+            spec = self._registry.get_spec(normalized_name)
+            record = self._record_from_spec(spec, generation=self._generation)
+            self._records[spec.name] = record
+        return self._tools_summary_from_record(record)
+
+    def get_ready_tools(self, name: str) -> tuple[McpToolInfo, ...]:
+        summary = self.get_tools_summary(name)
+        if summary.status != McpDiscoveryStatus.READY:
+            return ()
+        return summary.tools
+
+    def is_ready(self, name: str) -> bool:
+        return self.get_tools_summary(name).status == McpDiscoveryStatus.READY
+
+    def refresh_server(self, name: str) -> McpServerToolsSummary:
+        normalized_name = name.strip()
+        spec = self._registry.get_spec(normalized_name)
+        record = self._record_from_spec(spec, generation=self._generation)
+        if not spec.enabled:
+            self._records[spec.name] = record
+            return self._tools_summary_from_record(record)
+        self._records[spec.name] = record.model_copy(
+            update={"status": McpDiscoveryStatus.LOADING, "error": None}
+        )
+        self._schedule_discovery(
+            self._registry,
+            spec,
+            fingerprint=record.fingerprint,
+            force=True,
+        )
+        return self.get_tools_summary(spec.name)
+
+    def mark_ready(self, name: str, tools: tuple[McpToolInfo, ...]) -> None:
+        normalized_name = name.strip()
+        self._cancel_task(normalized_name)
+        self._registry.mark_server_runtime_available(normalized_name)
+        record = self._records.get(normalized_name)
+        if record is None:
+            spec = self._registry.get_spec(normalized_name)
+            record = self._record_from_spec(spec, generation=self._generation)
+        self._records[normalized_name] = record.model_copy(
+            update={
+                "status": McpDiscoveryStatus.READY,
+                "tools": tools,
+                "last_checked_at": _now(),
+                "error": None,
+                "generation": self._generation,
+            }
+        )
+
+    def _reset_records(self, registry: McpRegistry) -> None:
+        self._records = {
+            spec.name: self._record_from_spec(spec, generation=self._generation)
+            for spec in registry.list_specs()
+        }
+
+    def _enqueue_enabled_servers(
+        self,
+        registry: McpRegistry,
+        specs: Iterable[McpServerSpec],
+        *,
+        force: bool,
+    ) -> None:
+        for spec in specs:
+            if spec.enabled:
+                record = self._records.get(spec.name)
+                fingerprint = (
+                    record.fingerprint
+                    if record is not None
+                    else _fingerprint_spec(
+                        spec,
+                        registry.discovery_fingerprint_context(),
+                    )
+                )
+                self._schedule_discovery(
+                    registry,
+                    spec,
+                    fingerprint=fingerprint,
+                    force=force,
+                )
+
+    def _schedule_discovery(
+        self,
+        registry: McpRegistry,
+        spec: McpServerSpec,
+        *,
+        fingerprint: str,
+        force: bool,
+    ) -> None:
+        name = spec.name
+        existing_task = self._tasks.get(name)
+        if existing_task is not None and not existing_task.done():
+            existing_record = self._records.get(name)
+            if (
+                not force
+                and existing_record is not None
+                and existing_record.fingerprint == fingerprint
+            ):
+                return
+            existing_task.cancel()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        record = self._records.get(name)
+        if record is not None:
+            self._records[name] = record.model_copy(
+                update={"status": McpDiscoveryStatus.LOADING, "error": None}
+            )
+        task = loop.create_task(self._discover_server(registry, name, fingerprint))
+        self._tasks[name] = task
+        task.add_done_callback(
+            lambda completed_task: self._discard_task(name, completed_task)
+        )
+
+    async def _discover_server(
+        self,
+        registry: McpRegistry,
+        name: str,
+        fingerprint: str,
+    ) -> None:
+        try:
+            async with self._semaphore:
+                if not self._task_is_current(name):
+                    return
+                if not self._record_fingerprint_matches(name, fingerprint):
+                    return
+                tools = await registry.list_tools_for_discovery(name)
+                if not self._task_is_current(name):
+                    return
+                if not self._record_fingerprint_matches(name, fingerprint):
+                    return
+                record = self._records.get(name)
+                if record is None:
+                    return
+                registry.mark_server_runtime_available(name)
+                self._records[name] = record.model_copy(
+                    update={
+                        "status": McpDiscoveryStatus.READY,
+                        "tools": tools,
+                        "last_checked_at": _now(),
+                        "error": None,
+                    }
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if not self._task_is_current(name):
+                return
+            if not self._record_fingerprint_matches(name, fingerprint):
+                return
+            self._mark_failed(name, exc)
+
+    def mark_failed(self, name: str, exc: Exception) -> None:
+        normalized_name = name.strip()
+        self._cancel_task(normalized_name)
+        if normalized_name not in self._records:
+            spec = self._registry.get_spec(normalized_name)
+            self._records[normalized_name] = self._record_from_spec(
+                spec,
+                generation=self._generation,
+            )
+        self._mark_failed(normalized_name, exc)
+
+    def _mark_failed(self, name: str, exc: Exception) -> None:
+        record = self._records.get(name)
+        if record is None:
+            return
+        error = _format_error(exc)
+        self._records[name] = record.model_copy(
+            update={
+                "status": McpDiscoveryStatus.FAILED,
+                "tools": (),
+                "last_checked_at": _now(),
+                "error": error,
+            }
+        )
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="mcp.discovery.failed",
+            message="MCP tool discovery failed",
+            payload={
+                "server_name": name,
+                "transport": record.transport,
+                "source": record.source.value,
+                "error": error,
+            },
+        )
+
+    def _record_from_spec(
+        self,
+        spec: McpServerSpec,
+        *,
+        generation: int,
+    ) -> McpDiscoveryRecord:
+        status = (
+            McpDiscoveryStatus.PENDING if spec.enabled else McpDiscoveryStatus.DISABLED
+        )
+        return McpDiscoveryRecord(
+            name=spec.name,
+            source=spec.source,
+            transport=_detect_transport(spec.server_config),
+            enabled=spec.enabled,
+            status=status,
+            generation=generation,
+            fingerprint=_fingerprint_spec(
+                spec,
+                self._registry.discovery_fingerprint_context(),
+            ),
+        )
+
+    @staticmethod
+    def _tools_summary_from_record(
+        record: McpDiscoveryRecord,
+    ) -> McpServerToolsSummary:
+        return McpServerToolsSummary(
+            server=record.name,
+            source=record.source,
+            transport=record.transport,
+            enabled=record.enabled,
+            tools=record.tools,
+            status=record.status,
+            last_checked_at=record.last_checked_at,
+            error=record.error,
+        )
+
+    def _sorted_records(self) -> tuple[McpDiscoveryRecord, ...]:
+        return tuple(self._records[name] for name in sorted(self._records))
+
+    def _cancel_pending_tasks(self) -> None:
+        for task in self._tasks.values():
+            if not task.done():
+                task.cancel()
+
+    def _cancel_task(self, name: str) -> None:
+        task = self._tasks.pop(name, None)
+        if task is not None and not task.done():
+            task.cancel()
+
+    def _discard_task(self, name: str, completed_task: asyncio.Task[None]) -> None:
+        if self._tasks.get(name) is completed_task:
+            del self._tasks[name]
+
+    def _has_active_task(self, name: str) -> bool:
+        task = self._tasks.get(name)
+        return task is not None and not task.done()
+
+    def _record_fingerprint_matches(self, name: str, fingerprint: str) -> bool:
+        record = self._records.get(name)
+        return record is not None and record.fingerprint == fingerprint
+
+    def _task_is_current(self, name: str) -> bool:
+        return self._tasks.get(name) is asyncio.current_task()
+
+    def _bind_current_loop(self) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._loop = loop
+
+    def _should_defer_to_bound_loop(self) -> bool:
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return False
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return True
+        return current_loop is not loop
+
+
+def _detect_transport(server_config: Mapping[str, object]) -> str:
+    raw_transport = server_config.get("transport")
+    if isinstance(raw_transport, str) and raw_transport.strip():
+        return raw_transport.strip()
+    raw_type = server_config.get("type")
+    if isinstance(raw_type, str) and raw_type.strip():
+        normalized_type = raw_type.strip()
+        if normalized_type == "local":
+            return "stdio"
+        if normalized_type == "remote":
+            raw_url = server_config.get("url")
+            return "sse" if isinstance(raw_url, str) and "/sse" in raw_url else "http"
+        return normalized_type
+    raw_command = server_config.get("command")
+    if isinstance(raw_command, str) and raw_command.strip():
+        return "stdio"
+    raw_url = server_config.get("url")
+    if isinstance(raw_url, str) and raw_url.strip():
+        return "sse" if "/sse" in raw_url else "http"
+    return "unknown"
+
+
+def _fingerprint_spec(
+    spec: McpServerSpec,
+    discovery_context: Mapping[str, JsonValue],
+) -> str:
+    payload: dict[str, JsonValue] = {
+        "name": spec.name,
+        "source": spec.source.value,
+        "enabled": spec.enabled,
+        "transport": _detect_transport(spec.server_config),
+        "server_config": spec.server_config,
+        "discovery_context": dict(discovery_context),
+    }
+    serialized = dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _format_error(exc: Exception) -> str:
+    root = _root_exception(exc)
+    return f"{type(root).__name__}: {root}"
+
+
+def _root_exception(exc: BaseException) -> BaseException:
+    if isinstance(exc, BaseExceptionGroup) and exc.exceptions:
+        return _root_exception(exc.exceptions[0])
+    return exc
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)

--- a/src/relay_teams/mcp/mcp_models.py
+++ b/src/relay_teams/mcp/mcp_models.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
@@ -10,6 +11,14 @@ class McpConfigScope(str, Enum):
     APP = "app"
     PLUGIN = "plugin"
     SESSION = "session"
+
+
+class McpDiscoveryStatus(str, Enum):
+    DISABLED = "disabled"
+    PENDING = "pending"
+    LOADING = "loading"
+    READY = "ready"
+    FAILED = "failed"
 
 
 class McpToolInfo(BaseModel):
@@ -44,6 +53,10 @@ class McpServerSummary(BaseModel):
     source: McpConfigScope
     transport: str
     enabled: bool = True
+    discovery_status: McpDiscoveryStatus = McpDiscoveryStatus.PENDING
+    tool_count: int = 0
+    last_checked_at: datetime | None = None
+    error: str | None = None
 
 
 class McpServerToolsSummary(BaseModel):
@@ -54,6 +67,9 @@ class McpServerToolsSummary(BaseModel):
     transport: str
     enabled: bool = True
     tools: tuple[McpToolInfo, ...] = ()
+    status: McpDiscoveryStatus = McpDiscoveryStatus.PENDING
+    last_checked_at: datetime | None = None
+    error: str | None = None
 
 
 class McpServerAddRequest(BaseModel):

--- a/src/relay_teams/mcp/mcp_registry.py
+++ b/src/relay_teams/mcp/mcp_registry.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
 import logging
-import os
 import re
 from typing import Protocol, cast
 
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+import httpx
+from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared.message import SessionMessage
 from pydantic import JsonValue
 from pydantic_ai.mcp import (
     MCPServer,
@@ -15,12 +20,16 @@ from pydantic_ai.mcp import (
     MCPServerStreamableHTTP,
 )
 
+from relay_teams.env.proxy_env import extract_proxy_env_vars, load_proxy_env_config
+from relay_teams.env.runtime_env import load_merged_env_vars
 from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_models import McpServerSpec, McpToolInfo, McpToolSchema
+from relay_teams.net.clients import create_async_http_client
 from relay_teams.trace import trace_span
 
 LOGGER = get_logger(__name__)
 _DEFAULT_STDIO_MCP_TIMEOUT_SECONDS = 15.0
+_DEFAULT_STDIO_MCP_DISCOVERY_TIMEOUT_SECONDS = 60.0
 _CAPABILITY_WILDCARD = "*"
 _ENV_REFERENCE_PATTERN = re.compile(
     r"\{\{(?P<template>[A-Za-z_][A-Za-z0-9_]*)}}"
@@ -36,6 +45,105 @@ class _ListedMcpTool(Protocol):
     inputSchema: object
 
 
+class ProxyAwareMCPServerSSE(MCPServerSSE):
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None,
+        proxy_env: Mapping[str, str],
+        server_id: str,
+        tool_prefix: str,
+        timeout: float,
+        read_timeout: float | None,
+    ) -> None:
+        super().__init__(
+            url=url,
+            headers=None,
+            id=server_id,
+            tool_prefix=tool_prefix,
+            timeout=timeout,
+            read_timeout=read_timeout,
+        )
+        self._relay_headers = headers
+        self._relay_proxy_env = dict(proxy_env)
+
+    @asynccontextmanager
+    async def client_streams(
+        self,
+    ) -> AsyncIterator[
+        tuple[
+            MemoryObjectReceiveStream[SessionMessage | Exception],
+            MemoryObjectSendStream[SessionMessage],
+        ]
+    ]:
+        def httpx_client_factory(
+            headers: dict[str, str] | None = None,
+            timeout: httpx.Timeout | None = None,
+            auth: httpx.Auth | None = None,
+        ) -> httpx.AsyncClient:
+            _ = headers, timeout, auth
+            return create_async_http_client(
+                merged_env=self._relay_proxy_env,
+                headers=self._relay_headers,
+                timeout=timeout,
+                timeout_seconds=self.timeout,
+            )
+
+        async with sse_client(
+            url=self.url,
+            timeout=self.timeout,
+            sse_read_timeout=self.read_timeout,
+            httpx_client_factory=httpx_client_factory,
+        ) as (read_stream, write_stream, *_):
+            yield read_stream, write_stream
+
+
+class ProxyAwareMCPServerStreamableHTTP(MCPServerStreamableHTTP):
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None,
+        proxy_env: Mapping[str, str],
+        server_id: str,
+        tool_prefix: str,
+        timeout: float,
+        read_timeout: float | None,
+    ) -> None:
+        super().__init__(
+            url=url,
+            headers=None,
+            id=server_id,
+            tool_prefix=tool_prefix,
+            timeout=timeout,
+            read_timeout=read_timeout,
+        )
+        self._relay_headers = headers
+        self._relay_proxy_env = dict(proxy_env)
+
+    @asynccontextmanager
+    async def client_streams(
+        self,
+    ) -> AsyncIterator[
+        tuple[
+            MemoryObjectReceiveStream[SessionMessage | Exception],
+            MemoryObjectSendStream[SessionMessage],
+        ]
+    ]:
+        async with create_async_http_client(
+            merged_env=self._relay_proxy_env,
+            headers=self._relay_headers,
+            timeout=httpx.Timeout(timeout=self.timeout, read=self.read_timeout),
+            timeout_seconds=self.timeout,
+        ) as http_client:
+            async with streamable_http_client(
+                self.url,
+                http_client=http_client,
+            ) as (read_stream, write_stream, *_):
+                yield read_stream, write_stream
+
+
 def get_mcp_tool_prefix(server_name: str) -> str:
     return server_name.strip()
 
@@ -48,10 +156,27 @@ def get_effective_mcp_tool_name(server_name: str, tool_name: str) -> str:
 
 
 class McpRegistry:
-    def __init__(self, specs: tuple[McpServerSpec, ...] = ()) -> None:
+    def __init__(
+        self,
+        specs: tuple[McpServerSpec, ...] = (),
+        *,
+        proxy_env: Mapping[str, str] | None = None,
+        discovery_env_fingerprint: str = "",
+    ) -> None:
         self._specs = {spec.name: spec for spec in specs}
+        self._proxy_env = dict(proxy_env or {})
+        self._discovery_env_fingerprint = discovery_env_fingerprint
         self._toolsets: dict[str, MCPServer] = {}
         self._runtime_failed_names: set[str] = set()
+
+    def discovery_fingerprint_context(self) -> dict[str, JsonValue]:
+        proxy_env_payload: dict[str, JsonValue] = {
+            key: value for key, value in self._proxy_env.items()
+        }
+        return {
+            "env": self._discovery_env_fingerprint,
+            "proxy_env": proxy_env_payload,
+        }
 
     def get_toolsets(self, names: tuple[str, ...]) -> tuple[MCPServer, ...]:
         with trace_span(
@@ -157,13 +282,51 @@ class McpRegistry:
         return spec
 
     async def list_tools(self, name: str) -> tuple[McpToolInfo, ...]:
+        return await self._list_tools(
+            name,
+            operation="list_tools",
+            update_runtime_state=True,
+            use_cached_toolset=True,
+            failure_level=logging.ERROR,
+            stdio_default_timeout_seconds=_DEFAULT_STDIO_MCP_TIMEOUT_SECONDS,
+        )
+
+    async def list_tools_for_discovery(self, name: str) -> tuple[McpToolInfo, ...]:
+        return await self._list_tools(
+            name,
+            operation="list_tools_for_discovery",
+            update_runtime_state=False,
+            use_cached_toolset=False,
+            failure_level=logging.DEBUG,
+            stdio_default_timeout_seconds=_DEFAULT_STDIO_MCP_DISCOVERY_TIMEOUT_SECONDS,
+        )
+
+    async def _list_tools(
+        self,
+        name: str,
+        *,
+        operation: str,
+        update_runtime_state: bool,
+        use_cached_toolset: bool,
+        failure_level: int,
+        stdio_default_timeout_seconds: float,
+    ) -> tuple[McpToolInfo, ...]:
         with trace_span(
             LOGGER,
             component="mcp.registry",
-            operation="list_tools",
-            attributes={"server_name": name},
+            operation=operation,
+            attributes={
+                "server_name": name,
+                "update_runtime_state": update_runtime_state,
+            },
+            failure_level=failure_level,
         ):
-            mcp_tools = await self._list_tool_objects(name)
+            mcp_tools = await self._list_tool_objects(
+                name,
+                update_runtime_state=update_runtime_state,
+                use_cached_toolset=use_cached_toolset,
+                stdio_default_timeout_seconds=stdio_default_timeout_seconds,
+            )
             return tuple(
                 McpToolInfo(
                     name=get_effective_mcp_tool_name(name, str(tool.name)),
@@ -197,15 +360,31 @@ class McpRegistry:
                 for tool in mcp_tools
             )
 
-    async def _list_tool_objects(self, name: str) -> tuple[_ListedMcpTool, ...]:
+    async def _list_tool_objects(
+        self,
+        name: str,
+        *,
+        update_runtime_state: bool = True,
+        use_cached_toolset: bool = True,
+        stdio_default_timeout_seconds: float = _DEFAULT_STDIO_MCP_TIMEOUT_SECONDS,
+    ) -> tuple[_ListedMcpTool, ...]:
         try:
-            toolset = self._get_or_create_toolset(name)
+            toolset = (
+                self._get_or_create_toolset(name)
+                if use_cached_toolset
+                else self._build_transient_toolset(
+                    name,
+                    stdio_default_timeout_seconds=stdio_default_timeout_seconds,
+                )
+            )
             async with toolset:
                 mcp_tools = await toolset.list_tools()
         except Exception:
-            self.mark_server_runtime_failed(name)
+            if update_runtime_state:
+                self.mark_server_runtime_failed(name)
             raise
-        self.mark_server_runtime_available(name)
+        if update_runtime_state:
+            self.mark_server_runtime_available(name)
         return cast("tuple[_ListedMcpTool, ...]", tuple(mcp_tools))
 
     def _get_or_create_toolset(self, name: str) -> MCPServer:
@@ -222,12 +401,32 @@ class McpRegistry:
             spec = self.get_spec(name)
             if not spec.enabled:
                 raise ValueError(f"MCP server is disabled: {name}")
-            toolset = build_mcp_server(spec)
+            toolset = build_mcp_server(spec, proxy_env=self._proxy_env)
             self._toolsets[name] = toolset
             return toolset
 
+    def _build_transient_toolset(
+        self,
+        name: str,
+        *,
+        stdio_default_timeout_seconds: float,
+    ) -> MCPServer:
+        spec = self.get_spec(name)
+        if not spec.enabled:
+            raise ValueError(f"MCP server is disabled: {name}")
+        return build_mcp_server(
+            spec,
+            proxy_env=self._proxy_env,
+            stdio_default_timeout_seconds=stdio_default_timeout_seconds,
+        )
 
-def build_mcp_server(spec: McpServerSpec) -> MCPServer:
+
+def build_mcp_server(
+    spec: McpServerSpec,
+    *,
+    proxy_env: Mapping[str, str] | None = None,
+    stdio_default_timeout_seconds: float = _DEFAULT_STDIO_MCP_TIMEOUT_SECONDS,
+) -> MCPServer:
     server_config = spec.server_config
     transport = _detect_transport(server_config)
     if transport == "stdio":
@@ -235,12 +434,12 @@ def build_mcp_server(spec: McpServerSpec) -> MCPServer:
         return MCPServerStdio(
             command=command,
             args=_string_list(server_config.get("args")),
-            env=_build_stdio_env(server_config),
+            env=_build_stdio_env(server_config, proxy_env=proxy_env),
             cwd=_optional_string(server_config.get("cwd")),
             tool_prefix=get_mcp_tool_prefix(spec.name),
             timeout=(
                 _optional_positive_float(server_config.get("timeout"))
-                or _DEFAULT_STDIO_MCP_TIMEOUT_SECONDS
+                or stdio_default_timeout_seconds
             ),
             read_timeout=(
                 _optional_positive_float(server_config.get("read_timeout")) or 300.0
@@ -249,19 +448,29 @@ def build_mcp_server(spec: McpServerSpec) -> MCPServer:
         )
     if transport == "sse":
         url = _required_string(server_config, "url")
-        return MCPServerSSE(
+        return ProxyAwareMCPServerSSE(
             url=url,
             headers=_string_dict(server_config.get("headers")),
-            id=spec.name,
+            proxy_env=_build_remote_env(server_config, proxy_env=proxy_env),
+            server_id=spec.name,
             tool_prefix=get_mcp_tool_prefix(spec.name),
+            timeout=_optional_positive_float(server_config.get("timeout")) or 5.0,
+            read_timeout=(
+                _optional_positive_float(server_config.get("read_timeout")) or 300.0
+            ),
         )
     if transport in ("http", "streamable-http"):
         url = _required_string(server_config, "url")
-        return MCPServerStreamableHTTP(
+        return ProxyAwareMCPServerStreamableHTTP(
             url=url,
             headers=_string_dict(server_config.get("headers")),
-            id=spec.name,
+            proxy_env=_build_remote_env(server_config, proxy_env=proxy_env),
+            server_id=spec.name,
             tool_prefix=get_mcp_tool_prefix(spec.name),
+            timeout=_optional_positive_float(server_config.get("timeout")) or 5.0,
+            read_timeout=(
+                _optional_positive_float(server_config.get("read_timeout")) or 300.0
+            ),
         )
     raise ValueError(f"Unsupported MCP transport: {transport}")
 
@@ -318,15 +527,57 @@ def _string_dict(value: JsonValue) -> dict[str, str] | None:
     return {str(key): str(item) for key, item in value.items() if isinstance(key, str)}
 
 
-def _build_stdio_env(server_config: Mapping[str, JsonValue]) -> dict[str, str]:
-    merged_env = dict(os.environ)
+def _build_stdio_env(
+    server_config: Mapping[str, JsonValue],
+    *,
+    proxy_env: Mapping[str, str] | None,
+) -> dict[str, str]:
     explicit_env = _string_dict(server_config.get("env")) or {}
-    explicit_env = {
-        key: _expand_env_references(value, merged_env)
+    reference_env = load_merged_env_vars()
+    inherited_env = dict(reference_env)
+    for key in extract_proxy_env_vars(reference_env):
+        inherited_env.pop(key, None)
+    app_proxy_env = _resolve_mcp_runtime_proxy_env(proxy_env)
+    expansion_reference_env = dict(reference_env)
+    expansion_reference_env.update(app_proxy_env)
+    expanded_explicit_env = {
+        key: _expand_env_references(value, expansion_reference_env)
         for key, value in explicit_env.items()
     }
-    merged_env.update(explicit_env)
-    return merged_env
+    explicit_proxy_env = extract_proxy_env_vars(expanded_explicit_env)
+    inherited_env.update(app_proxy_env)
+    inherited_env.update(explicit_proxy_env)
+    inherited_env.update(expanded_explicit_env)
+    return inherited_env
+
+
+def _build_remote_env(
+    server_config: Mapping[str, JsonValue],
+    *,
+    proxy_env: Mapping[str, str] | None,
+) -> dict[str, str]:
+    reference_env = load_merged_env_vars()
+    base_env = _resolve_mcp_runtime_proxy_env(proxy_env)
+    explicit_env = _string_dict(server_config.get("env")) or {}
+    expansion_reference_env = dict(reference_env)
+    expansion_reference_env.update(base_env)
+    expanded_explicit_env = {
+        key: _expand_env_references(value, expansion_reference_env)
+        for key, value in explicit_env.items()
+    }
+    base_env.update(extract_proxy_env_vars(expanded_explicit_env))
+    base_env.update(expanded_explicit_env)
+    return base_env
+
+
+def _resolve_mcp_runtime_proxy_env(
+    proxy_env: Mapping[str, str] | None,
+) -> dict[str, str]:
+    if proxy_env is not None:
+        return extract_proxy_env_vars(proxy_env)
+    return extract_proxy_env_vars(
+        load_proxy_env_config(include_process_env=False).normalized_env()
+    )
 
 
 def _expand_env_references(value: str, env_values: Mapping[str, str]) -> str:

--- a/src/relay_teams/mcp/mcp_service.py
+++ b/src/relay_teams/mcp/mcp_service.py
@@ -7,8 +7,10 @@ from pydantic import JsonValue
 
 from relay_teams.logger import get_logger
 from relay_teams.mcp.mcp_config_manager import McpConfigManager
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_models import (
     McpConfigScope,
+    McpDiscoveryStatus,
     McpServerAddResult,
     McpServerConfigResult,
     McpServerConnectionTestResult,
@@ -33,6 +35,7 @@ class McpService:
         config_manager: McpConfigManager | None = None,
         on_registry_changed: Callable[[McpRegistry], None] | None = None,
         extra_specs: tuple[McpServerSpec, ...] = (),
+        discovery_service: McpDiscoveryService | None = None,
     ) -> None:
         self._registry: McpRegistry = registry
         self._config_manager: McpConfigManager | None = config_manager
@@ -40,9 +43,12 @@ class McpService:
             on_registry_changed
         )
         self._extra_specs: tuple[McpServerSpec, ...] = extra_specs
+        self._discovery_service: McpDiscoveryService | None = discovery_service
 
     def replace_registry(self, registry: McpRegistry) -> None:
         self._registry = registry
+        if self._discovery_service is not None:
+            self._discovery_service.replace_registry(registry)
 
     def replace_extra_specs(self, extra_specs: tuple[McpServerSpec, ...]) -> None:
         self._extra_specs = extra_specs
@@ -53,9 +59,11 @@ class McpService:
         return self._config_manager.load_registry(extra_specs=self._extra_specs)
 
     def _publish_registry(self, registry: McpRegistry) -> None:
-        self.replace_registry(registry)
         if self._on_registry_changed is not None:
+            self._registry = registry
             self._on_registry_changed(registry)
+            return
+        self.replace_registry(registry)
 
     def list_servers(self) -> tuple[McpServerSummary, ...]:
         with trace_span(
@@ -63,12 +71,19 @@ class McpService:
             component="mcp.service",
             operation="list_servers",
         ):
+            if self._discovery_service is not None:
+                return self._discovery_service.list_server_summaries()
             return tuple(
                 McpServerSummary(
                     name=spec.name,
                     source=spec.source,
                     transport=_detect_transport(spec.server_config),
                     enabled=spec.enabled,
+                    discovery_status=(
+                        McpDiscoveryStatus.PENDING
+                        if spec.enabled
+                        else McpDiscoveryStatus.DISABLED
+                    ),
                 )
                 for spec in self._registry.list_specs()
             )
@@ -97,6 +112,11 @@ class McpService:
                     source=spec.source,
                     transport=_detect_transport(spec.server_config),
                     enabled=spec.enabled,
+                    discovery_status=(
+                        McpDiscoveryStatus.PENDING
+                        if spec.enabled
+                        else McpDiscoveryStatus.DISABLED
+                    ),
                 ),
                 config=config,
             )
@@ -109,6 +129,16 @@ class McpService:
             attributes={"server_name": name},
         ):
             spec = self._registry.get_spec(name)
+            if self._discovery_service is not None:
+                return self._discovery_service.get_tools_summary(name)
+            if not spec.enabled:
+                return McpServerToolsSummary(
+                    server=spec.name,
+                    source=spec.source,
+                    transport=_detect_transport(spec.server_config),
+                    enabled=spec.enabled,
+                    status=McpDiscoveryStatus.DISABLED,
+                )
             tools = await self._registry.list_tools(name)
             return McpServerToolsSummary(
                 server=spec.name,
@@ -116,6 +146,30 @@ class McpService:
                 transport=_detect_transport(spec.server_config),
                 enabled=spec.enabled,
                 tools=tools,
+                status=McpDiscoveryStatus.READY,
+            )
+
+    def refresh_server_tools(self, name: str) -> McpServerToolsSummary:
+        with trace_span(
+            LOGGER,
+            component="mcp.service",
+            operation="refresh_server_tools",
+            attributes={"server_name": name},
+        ):
+            self._registry.get_spec(name)
+            if self._discovery_service is not None:
+                return self._discovery_service.refresh_server(name)
+            spec = self._registry.get_spec(name)
+            return McpServerToolsSummary(
+                server=spec.name,
+                source=spec.source,
+                transport=_detect_transport(spec.server_config),
+                enabled=spec.enabled,
+                status=(
+                    McpDiscoveryStatus.PENDING
+                    if spec.enabled
+                    else McpDiscoveryStatus.DISABLED
+                ),
             )
 
     def add_server(
@@ -149,6 +203,11 @@ class McpService:
                     source=spec.source,
                     transport=_detect_transport(spec.server_config),
                     enabled=spec.enabled,
+                    discovery_status=(
+                        McpDiscoveryStatus.PENDING
+                        if spec.enabled
+                        else McpDiscoveryStatus.DISABLED
+                    ),
                 ),
                 config_path=str(config_path),
             )
@@ -178,6 +237,11 @@ class McpService:
                 source=spec.source,
                 transport=_detect_transport(spec.server_config),
                 enabled=spec.enabled,
+                discovery_status=(
+                    McpDiscoveryStatus.PENDING
+                    if spec.enabled
+                    else McpDiscoveryStatus.DISABLED
+                ),
             )
 
     def update_server(
@@ -206,6 +270,11 @@ class McpService:
                     source=spec.source,
                     transport=_detect_transport(spec.server_config),
                     enabled=spec.enabled,
+                    discovery_status=(
+                        McpDiscoveryStatus.PENDING
+                        if spec.enabled
+                        else McpDiscoveryStatus.DISABLED
+                    ),
                 ),
                 config=self._config_manager.get_server_config(name),
             )
@@ -222,6 +291,8 @@ class McpService:
             try:
                 tools = await self._registry.list_tools(name)
             except Exception as exc:
+                if self._discovery_service is not None:
+                    self._discovery_service.mark_failed(name, exc)
                 return McpServerConnectionTestResult(
                     server=spec.name,
                     source=spec.source,
@@ -230,6 +301,8 @@ class McpService:
                     ok=False,
                     error=str(exc),
                 )
+            if self._discovery_service is not None:
+                self._discovery_service.mark_ready(name, tools)
             return McpServerConnectionTestResult(
                 server=spec.name,
                 source=spec.source,

--- a/src/relay_teams/net/clients.py
+++ b/src/relay_teams/net/clients.py
@@ -25,7 +25,9 @@ def create_async_http_client(
     *,
     merged_env: Mapping[str, str] | None = None,
     proxy_config: ProxyEnvConfig | None = None,
+    headers: Mapping[str, str] | None = None,
     ssl_verify: bool | None = None,
+    timeout: httpx.Timeout | None = None,
     timeout_seconds: float = DEFAULT_HTTP_TIMEOUT,
     connect_timeout_seconds: float = DEFAULT_HTTP_CONNECT_TIMEOUT_SECONDS,
     follow_redirects: bool = False,
@@ -39,9 +41,17 @@ def create_async_http_client(
         proxy_config=resolved_proxy_config,
         explicit_ssl_verify=ssl_verify,
     )
+    resolved_headers = _resolve_headers(headers)
     return httpx.AsyncClient(
-        timeout=httpx.Timeout(timeout=timeout_seconds, connect=connect_timeout_seconds),
-        headers={"User-Agent": get_user_agent()},
+        timeout=(
+            timeout
+            if timeout is not None
+            else httpx.Timeout(
+                timeout=timeout_seconds,
+                connect=connect_timeout_seconds,
+            )
+        ),
+        headers=resolved_headers,
         trust_env=False,
         verify=resolved_ssl_verify,
         transport=AsyncProxyRoutingTransport(
@@ -83,3 +93,10 @@ def _resolve_proxy_config(
     if resolved_env is None:
         return resolve_proxy_env_config(base_env)
     return resolve_proxy_env_config(resolved_env)
+
+
+def _resolve_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
+    resolved_headers = {"User-Agent": get_user_agent()}
+    if headers is not None:
+        resolved_headers.update(dict(headers))
+    return resolved_headers

--- a/src/relay_teams/providers/llm_retry.py
+++ b/src/relay_teams/providers/llm_retry.py
@@ -26,6 +26,17 @@ except ImportError:  # pragma: no cover
 
 T = TypeVar("T")
 
+_ENTERPRISE_PROXY_BLOCK_MARKERS = (
+    "<title>his proxy",
+    "his proxy notification",
+    "netentsec",
+    "swg,proxy",
+    "proxy notification",
+    "proxycontrolwarn",
+    "httpwarning_2907",
+    "blocked-by-allowlist",
+)
+
 
 class LlmRetryErrorInfo(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -151,6 +162,14 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
     if invalid_json_error is not None:
         return invalid_json_error
     if isinstance(exc, ModelHTTPError):
+        if _is_enterprise_proxy_block_error(
+            message=str(exc),
+            body=getattr(exc, "body", None),
+        ):
+            return _enterprise_proxy_block_error_info(
+                message=str(exc),
+                status_code=exc.status_code,
+            )
         retryable = _is_retryable_status_code(exc.status_code)
         return LlmRetryErrorInfo(
             message=str(exc),
@@ -165,6 +184,15 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
             ),
         )
     if isinstance(exc, ModelAPIError):
+        if _is_enterprise_proxy_block_error(
+            message=str(exc),
+            body=getattr(exc, "body", None),
+        ):
+            parsed = _parse_message_metadata(str(exc))
+            return _enterprise_proxy_block_error_info(
+                message=str(exc),
+                status_code=parsed.status_code if parsed is not None else None,
+            )
         parsed = _parse_message_metadata(str(exc))
         if parsed is None:
             return None
@@ -229,6 +257,11 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
         body = getattr(exc, "body", None)
         error_payload = _extract_error_payload(body)
         status_code = getattr(exc, "status_code", None)
+        if _is_enterprise_proxy_block_error(message=str(exc), body=body):
+            return _enterprise_proxy_block_error_info(
+                message=error_payload.message or str(exc),
+                status_code=status_code,
+            )
         retry_override = _explicit_retry_override(headers)
         return LlmRetryErrorInfo(
             message=error_payload.message or str(exc),
@@ -263,6 +296,11 @@ def _extract_single_error_info(exc: BaseException) -> LlmRetryErrorInfo | None:
         status_code = fallback.status_code if fallback is not None else None
         if status_code is None:
             status_code = _status_code_from_error_code(resolved_error_code)
+        if _is_enterprise_proxy_block_error(message=str(exc), body=body):
+            return _enterprise_proxy_block_error_info(
+                message=error_payload.message or str(exc),
+                status_code=status_code,
+            )
         retry_override = _explicit_retry_override(getattr(exc, "headers", None))
         return LlmRetryErrorInfo(
             message=error_payload.message or str(exc),
@@ -302,6 +340,37 @@ def _extract_invalid_json_error_info(
         rate_limited=False,
         transport_error=False,
         timeout_error=False,
+    )
+
+
+def _enterprise_proxy_block_error_info(
+    *,
+    message: str,
+    status_code: int | None,
+) -> LlmRetryErrorInfo:
+    return LlmRetryErrorInfo(
+        message=message,
+        status_code=status_code,
+        error_code="proxy_blocked",
+        retryable=False,
+        rate_limited=False,
+        transport_error=True,
+        timeout_error=False,
+    )
+
+
+def _is_enterprise_proxy_block_error(*, message: str, body: object) -> bool:
+    scan_values = [message]
+    if isinstance(body, str):
+        scan_values.append(body)
+    elif isinstance(body, bytes):
+        scan_values.append(body.decode("utf-8", errors="ignore"))
+    elif body is not None:
+        scan_values.append(str(body))
+    return any(
+        marker in scan_value.casefold()
+        for scan_value in scan_values
+        for marker in _ENTERPRISE_PROXY_BLOCK_MARKERS
     )
 
 

--- a/src/relay_teams/providers/openai_compatible.py
+++ b/src/relay_teams/providers/openai_compatible.py
@@ -33,6 +33,7 @@ from relay_teams.hooks import HookService
 from relay_teams.media import ContentPart, MediaAssetService, MediaModality
 from relay_teams.metrics import MetricRecorder
 from relay_teams.monitors import MonitorService
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.net.llm_client import build_llm_http_client
 from relay_teams.notifications import NotificationService
@@ -144,6 +145,7 @@ class OpenAICompatibleProvider(LLMProvider):
         reminder_service: SystemReminderService | None = None,
         auto_harness_service: object | None = None,
         audit_service: AuditService | None = None,
+        mcp_discovery_service: McpDiscoveryService | None = None,
     ) -> None:
         self._config_ref = config
         self._media_asset_service = media_asset_service
@@ -180,6 +182,7 @@ class OpenAICompatibleProvider(LLMProvider):
             tool_registry=tool_registry,
             mcp_registry=mcp_registry,
             skill_registry=skill_registry,
+            mcp_discovery_service=mcp_discovery_service,
             allowed_tools=allowed_tools,
             allowed_mcp_servers=allowed_mcp_servers,
             allowed_skills=allowed_skills,

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -18,6 +18,7 @@ from relay_teams.agents.orchestration.task_orchestration_service import (
 )
 from relay_teams.media import MediaAssetService
 from relay_teams.monitors import MonitorService
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.metrics import MetricRecorder
 from relay_teams.notifications import NotificationService
@@ -128,6 +129,7 @@ def create_provider_factory(
     reminder_service: SystemReminderService | None = None,
     auto_harness_service: object | None = None,
     audit_service: AuditService | None = None,
+    mcp_discovery_service: McpDiscoveryService | None = None,
 ) -> Callable[[RoleDefinition, str | None], LLMProvider]:
     fallback_cooldown_registries: dict[tuple[str, ...], ProfileCooldownRegistry] = {}
     fallback_cooldown_registry_lock = Lock()
@@ -227,6 +229,7 @@ def create_provider_factory(
                 subagent_reflection_service=subagent_reflection_service,
                 tool_registry=tool_registry,
                 mcp_registry=mcp_registry,
+                mcp_discovery_service=mcp_discovery_service,
                 skill_registry=skill_registry,
                 allowed_tools=tool_registry.resolve_known(
                     runtime_tool_names,

--- a/src/relay_teams/sessions/runs/assistant_errors.py
+++ b/src/relay_teams/sessions/runs/assistant_errors.py
@@ -63,6 +63,13 @@ def _append_error_detail(message: str, detail: str) -> str:
     return f"{message} Details: {normalized_detail}"
 
 
+def _append_error_detail_block(message: str, detail: str) -> str:
+    normalized_detail = detail.strip()
+    if not normalized_detail:
+        return message
+    return f"{message}\n\nDetails:\n```text\n{normalized_detail}\n```"
+
+
 def _build_recovery_guidance_message(
     error_code: str,
     *,
@@ -87,6 +94,12 @@ def _build_recovery_guidance_message(
         return _append_error_detail(
             "The request failed before a usable response was received from the model endpoint. "
             "Check DNS resolution, outbound network connectivity, proxy or NO_PROXY settings, and whether the configured base_url is reachable at all.",
+            detail,
+        )
+    if error_code == "proxy_blocked":
+        return _append_error_detail_block(
+            "The model request reached an enterprise proxy block page instead of the model endpoint. "
+            "Check the configured base_url, HTTP_PROXY/HTTPS_PROXY routing, proxy credentials, and NO_PROXY entries for the model host.",
             detail,
         )
     if error_code == "auth_invalid":

--- a/src/relay_teams/trace/span.py
+++ b/src/relay_teams/trace/span.py
@@ -38,6 +38,7 @@ def trace_span(
     operation: str,
     attributes: dict[str, JsonValue] | None = None,
     level: int = logging.DEBUG,
+    failure_level: int | None = logging.ERROR,
     **context_updates: str | None,
 ) -> Generator[TraceContext, None, None]:
     parent_context = get_trace_context()
@@ -61,18 +62,19 @@ def trace_span(
         try:
             yield current_context
         except Exception as exc:
-            duration_ms = int((time.perf_counter() - started) * 1000)
-            _emit_trace_log(
-                logger=logger,
-                level=logging.ERROR,
-                event="trace.span.failed",
-                message=f"{component}.{operation} failed",
-                component=component,
-                operation=operation,
-                attributes=attributes,
-                duration_ms=duration_ms,
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
+            if failure_level is not None:
+                duration_ms = int((time.perf_counter() - started) * 1000)
+                _emit_trace_log(
+                    logger=logger,
+                    level=failure_level,
+                    event="trace.span.failed",
+                    message=f"{component}.{operation} failed",
+                    component=component,
+                    operation=operation,
+                    attributes=attributes,
+                    duration_ms=duration_ms,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
             raise
         duration_ms = int((time.perf_counter() - started) * 1000)
         _emit_trace_log(

--- a/tests/unit_tests/agents/execution/test_coordination_agent_builder.py
+++ b/tests/unit_tests/agents/execution/test_coordination_agent_builder.py
@@ -6,6 +6,12 @@ from typing import cast
 import pytest
 
 import relay_teams.agents.execution.coordination_agent_builder as coordination_agent
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
+from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
+    McpDiscoveryStatus,
+    McpServerToolsSummary,
+)
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.providers.model_config import ModelEndpointConfig
 from relay_teams.roles.role_models import RoleDefinition, RoleMode
@@ -123,6 +129,21 @@ class _MarkedFailedMcpRegistry(_FakeMcpRegistry):
         if server_names == ("broken",):
             raise AssertionError("failed MCP server should have been skipped")
         return tuple(f"toolset:{name}" for name in server_names)
+
+
+class _FakeMcpDiscoveryService:
+    def __init__(self, status: McpDiscoveryStatus) -> None:
+        self.status = status
+        self.calls: list[str] = []
+
+    def get_tools_summary(self, name: str) -> McpServerToolsSummary:
+        self.calls.append(name)
+        return McpServerToolsSummary(
+            server=name,
+            source=McpConfigScope.APP,
+            transport="stdio",
+            status=self.status,
+        )
 
 
 def _patch_runtime_chat_model_builder(
@@ -370,6 +391,85 @@ def test_build_coordination_agent_skips_mcp_servers_marked_runtime_failed(
         allowed_mcp_servers=("docs", "broken"),
         tool_registry=cast(ToolRegistry, fake_tool_registry),
         mcp_registry=cast(McpRegistry, fake_mcp_registry),
+    )
+
+    built_agent = cast(_FakeAgent, captured["agent"])
+    assert built_agent.kwargs["toolsets"] == ["toolset:docs"]
+    assert fake_mcp_registry.toolset_calls == [("docs",)]
+
+
+def test_build_coordination_agent_skips_mcp_toolsets_that_are_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    fake_tool_registry = _FakeToolRegistry()
+    fake_mcp_registry = _PartiallyFailingMcpRegistry()
+    discovery_service = _FakeMcpDiscoveryService(McpDiscoveryStatus.LOADING)
+
+    monkeypatch.setattr(
+        coordination_agent,
+        "build_llm_http_client",
+        lambda **_: object(),
+    )
+    _patch_runtime_chat_model_builder(monkeypatch, captured)
+
+    def _fake_agent(**kwargs: object) -> _FakeAgent:
+        agent = _FakeAgent(**kwargs)
+        captured["agent"] = agent
+        return agent
+
+    monkeypatch.setattr(coordination_agent, "Agent", _fake_agent)
+
+    coordination_agent.build_coordination_agent(
+        model_name="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        system_prompt="system",
+        allowed_tools=(),
+        allowed_mcp_servers=("docs",),
+        tool_registry=cast(ToolRegistry, fake_tool_registry),
+        mcp_registry=cast(McpRegistry, fake_mcp_registry),
+        mcp_discovery_service=cast(McpDiscoveryService, discovery_service),
+    )
+
+    built_agent = cast(_FakeAgent, captured["agent"])
+    assert built_agent.kwargs["toolsets"] == []
+    assert fake_mcp_registry.toolset_calls == []
+    assert discovery_service.calls == ["docs"]
+
+
+def test_build_coordination_agent_attaches_ready_mcp_toolsets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    fake_tool_registry = _FakeToolRegistry()
+    fake_mcp_registry = _PartiallyFailingMcpRegistry()
+    discovery_service = _FakeMcpDiscoveryService(McpDiscoveryStatus.READY)
+
+    monkeypatch.setattr(
+        coordination_agent,
+        "build_llm_http_client",
+        lambda **_: object(),
+    )
+    _patch_runtime_chat_model_builder(monkeypatch, captured)
+
+    def _fake_agent(**kwargs: object) -> _FakeAgent:
+        agent = _FakeAgent(**kwargs)
+        captured["agent"] = agent
+        return agent
+
+    monkeypatch.setattr(coordination_agent, "Agent", _fake_agent)
+
+    coordination_agent.build_coordination_agent(
+        model_name="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        system_prompt="system",
+        allowed_tools=(),
+        allowed_mcp_servers=("docs",),
+        tool_registry=cast(ToolRegistry, fake_tool_registry),
+        mcp_registry=cast(McpRegistry, fake_mcp_registry),
+        mcp_discovery_service=cast(McpDiscoveryService, discovery_service),
     )
 
     built_agent = cast(_FakeAgent, captured["agent"])

--- a/tests/unit_tests/agents/execution/test_failure_reporting.py
+++ b/tests/unit_tests/agents/execution/test_failure_reporting.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pydantic_ai.exceptions import ModelHTTPError
+
+from relay_teams.agents.execution.failure_reporting import FailureHandlingService
+
+
+class _BodyError(Exception):
+    def __init__(self, message: str, *, body: object) -> None:
+        super().__init__(message)
+        self.body = body
+
+
+def test_build_model_api_error_message_preserves_proxy_block_body() -> None:
+    body = (
+        "<!DOCTYPE html>\n"
+        '<html><head><meta name="keywords" content="SWG,Proxy,NetentSec" />'
+        "<title>HIS Proxy</title></head><body>blocked</body></html>"
+    )
+    service = object.__new__(FailureHandlingService)
+
+    message = FailureHandlingService.build_model_api_error_message(
+        service,
+        ModelHTTPError(
+            status_code=403,
+            model_name="deepseek-v4-flash",
+            body=body,
+        ),
+    )
+
+    assert "blocked by an enterprise proxy" in message
+    assert "status_code: 403" in message
+    assert "model_name: deepseek-v4-flash" in message
+    assert body in message
+
+
+def test_enterprise_proxy_block_detection_scans_bytes_body() -> None:
+    chain = (
+        _BodyError(
+            "Forbidden",
+            body=b'<html><head><meta name="keywords" content="SWG,Proxy" />',
+        ),
+    )
+
+    assert FailureHandlingService.is_enterprise_proxy_block_failure(chain) is True
+
+
+def test_enterprise_proxy_block_detection_scans_object_body() -> None:
+    chain = (
+        _BodyError(
+            "Forbidden",
+            body={"title": "ProxyControlWarn", "message": "blocked"},
+        ),
+    )
+
+    assert FailureHandlingService.is_enterprise_proxy_block_failure(chain) is True
+
+
+def test_enterprise_proxy_block_detection_does_not_match_this_proxy_text() -> None:
+    chain = (
+        _BodyError(
+            "Temporary failure",
+            body="this proxy path returned a transient upstream error",
+        ),
+    )
+
+    assert FailureHandlingService.is_enterprise_proxy_block_failure(chain) is False
+
+
+def test_raw_error_body_text_serializes_bytes_and_objects() -> None:
+    assert FailureHandlingService.raw_error_body_text(b"blocked") == "blocked"
+    assert (
+        FailureHandlingService.raw_error_body_text({"message": "blocked"})
+        == '{"message": "blocked"}'
+    )

--- a/tests/unit_tests/agents/execution/test_prompt_budgeting.py
+++ b/tests/unit_tests/agents/execution/test_prompt_budgeting.py
@@ -3,6 +3,19 @@ from __future__ import annotations
 
 import pytest
 
+from relay_teams.agents.execution.prompt_budgeting import (
+    MCP_SERVER_CONTEXT_FALLBACK_CHARS,
+    PromptBudgetingService,
+)
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
+from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
+    McpServerSpec,
+    McpToolInfo,
+    McpToolSchema,
+)
+from relay_teams.mcp.mcp_registry import McpRegistry
+
 from .agent_llm_session_test_support import (
     AgentLlmSession,
     ModelEndpointConfig,
@@ -11,6 +24,11 @@ from .agent_llm_session_test_support import (
     _build_request,
     _zero_mcp_context_tokens,
 )
+
+
+class _NoSchemaMcpRegistry(McpRegistry):
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        raise AssertionError("token budgeting should not connect to MCP servers")
 
 
 @pytest.mark.asyncio
@@ -93,3 +111,190 @@ async def test_safe_max_output_tokens_clamps_to_one_when_budget_is_exhausted() -
     )
 
     assert max_tokens == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_context_budget_uses_fallback_without_schema_lookup() -> None:
+    registry = _NoSchemaMcpRegistry(
+        (
+            McpServerSpec(
+                name="docs",
+                config={"mcpServers": {"docs": {"command": "uvx"}}},
+                server_config={"command": "uvx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    service = PromptBudgetingService(
+        config=ModelEndpointConfig(
+            model="gpt-test",
+            base_url="https://example.test/v1",
+            api_key="secret",
+        ),
+        mcp_registry=registry,
+        mcp_tool_context_token_cache={},
+    )
+
+    estimate = await service.estimated_mcp_context_tokens(
+        allowed_mcp_servers=("docs",),
+    )
+
+    assert estimate == service.estimated_mcp_context_tokens_fallback(
+        allowed_mcp_servers=("docs",)
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_context_budget_uses_cached_schema_estimate_before_fallback() -> None:
+    registry = _NoSchemaMcpRegistry(
+        (
+            McpServerSpec(
+                name="docs",
+                config={"mcpServers": {"docs": {"command": "uvx"}}},
+                server_config={"command": "uvx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    service = PromptBudgetingService(
+        config=ModelEndpointConfig(
+            model="gpt-test",
+            base_url="https://example.test/v1",
+            api_key="secret",
+        ),
+        mcp_registry=registry,
+        mcp_tool_context_token_cache={"docs": 1234},
+    )
+
+    estimate = await service.estimated_mcp_context_tokens(
+        allowed_mcp_servers=("docs",),
+    )
+
+    assert estimate == 1234
+
+
+@pytest.mark.asyncio
+async def test_mcp_context_budget_uses_discovered_tool_metadata_before_fallback() -> (
+    None
+):
+    registry = _NoSchemaMcpRegistry(
+        (
+            McpServerSpec(
+                name="docs",
+                config={"mcpServers": {"docs": {"command": "uvx"}}},
+                server_config={"command": "uvx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    discovery_service = McpDiscoveryService(registry)
+    discovery_service.mark_ready(
+        "docs",
+        (
+            McpToolInfo(name="read_file", description="Read a file."),
+            McpToolInfo(name="write_file", description="Write a file."),
+        ),
+    )
+    token_cache: dict[str, int] = {}
+    service = PromptBudgetingService(
+        config=ModelEndpointConfig(
+            model="gpt-test",
+            base_url="https://example.test/v1",
+            api_key="secret",
+        ),
+        mcp_registry=registry,
+        mcp_discovery_service=discovery_service,
+        mcp_tool_context_token_cache=token_cache,
+    )
+
+    estimate = await service.estimated_mcp_context_tokens(
+        allowed_mcp_servers=("docs",),
+    )
+
+    assert estimate == service.estimate_mcp_tool_info_tokens(
+        server_name="docs",
+        tools=discovery_service.get_ready_tools("docs"),
+    )
+    assert token_cache["docs"] == estimate
+    assert estimate < service.estimated_mcp_context_tokens_fallback(
+        allowed_mcp_servers=("docs",)
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_context_budget_fallback_does_not_exhaust_mid_sized_context() -> None:
+    registry = _NoSchemaMcpRegistry(
+        (
+            McpServerSpec(
+                name="docs",
+                config={"mcpServers": {"docs": {"command": "uvx"}}},
+                server_config={"command": "uvx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    service = PromptBudgetingService(
+        config=ModelEndpointConfig(
+            model="gpt-test",
+            base_url="https://example.test/v1",
+            api_key="secret",
+            context_window=22_000,
+        ),
+        mcp_registry=registry,
+        mcp_tool_context_token_cache={},
+    )
+    service._config.sampling.max_tokens = 4_096
+
+    max_tokens = await service.safe_max_output_tokens(
+        request=_build_request(user_prompt="hello"),
+        history=[],
+        system_prompt="System prompt",
+        reserve_user_prompt_tokens=True,
+        allowed_tools=(),
+        allowed_mcp_servers=("docs",),
+        allowed_skills=(),
+    )
+
+    assert max_tokens is not None
+    assert max_tokens > 1
+
+
+def test_mcp_context_budget_fallback_is_bounded_for_unknown_server() -> None:
+    service = PromptBudgetingService(
+        config=ModelEndpointConfig(
+            model="gpt-test",
+            base_url="https://example.test/v1",
+            api_key="secret",
+        ),
+        mcp_registry=McpRegistry(),
+        mcp_tool_context_token_cache={},
+    )
+    schemas = tuple(
+        McpToolSchema(
+            name=f"large_tool_{index}",
+            description="Tool with a larger schema payload.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    f"field_{field_index}": {
+                        "type": "string",
+                        "description": "x" * 400,
+                    }
+                    for field_index in range(8)
+                },
+            },
+        )
+        for index in range(10)
+    )
+
+    actual_schema_tokens = service.estimate_mcp_tool_schema_tokens(
+        server_name="docs",
+        tool_schemas=schemas,
+    )
+    fallback_tokens = service.estimated_mcp_context_tokens_fallback(
+        allowed_mcp_servers=("docs",)
+    )
+
+    assert MCP_SERVER_CONTEXT_FALLBACK_CHARS == 8_000
+    assert fallback_tokens > 0
+    assert actual_schema_tokens > fallback_tokens

--- a/tests/unit_tests/agents/execution/test_prompts.py
+++ b/tests/unit_tests/agents/execution/test_prompts.py
@@ -20,6 +20,7 @@ from relay_teams.agents.execution.user_prompts import (
 )
 from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
 from relay_teams.hooks import HookDecisionBundle, HookDecisionType, HookEventName
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec, McpToolInfo
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.secrets import AppSecretStore
@@ -222,6 +223,20 @@ class _FakeMcpRegistry(McpRegistry):
         return (McpToolInfo(name="docs_search", description="Search docs"),)
 
 
+class _NoRealtimeMcpRegistry(_FakeMcpRegistry):
+    async def list_tools(self, name: str) -> tuple[McpToolInfo, ...]:
+        raise AssertionError("prompt building should not connect to MCP servers")
+
+
+def _ready_fake_mcp_discovery(registry: McpRegistry) -> McpDiscoveryService:
+    service = McpDiscoveryService(registry)
+    service.mark_ready(
+        "docs",
+        (McpToolInfo(name="docs_search", description="Search docs"),),
+    )
+    return service
+
+
 def _coordinator_registry() -> RoleRegistry:
     registry = RoleRegistry()
     registry.register(
@@ -261,6 +276,7 @@ def _coordinator_registry() -> RoleRegistry:
 
 
 def test_runtime_system_prompt_for_coordinator_has_contract_and_context() -> None:
+    mcp_registry = _FakeMcpRegistry()
     prompt = asyncio.run(
         system_prompts.build_runtime_system_prompt(
             system_prompts.RuntimePromptBuildInput(
@@ -289,7 +305,8 @@ def test_runtime_system_prompt_for_coordinator_has_contract_and_context() -> Non
                 shared_state_snapshot=(("status", "ready"),),
             ),
             role_registry=_coordinator_registry(),
-            mcp_registry=_FakeMcpRegistry(),
+            mcp_registry=mcp_registry,
+            mcp_discovery_service=_ready_fake_mcp_discovery(mcp_registry),
         )
     )
 
@@ -440,6 +457,7 @@ def test_runtime_system_prompt_ignores_unknown_mcp_servers_in_available_roles() 
         )
     )
 
+    mcp_registry = _FakeMcpRegistry()
     prompt = asyncio.run(
         system_prompts.build_runtime_system_prompt(
             system_prompts.RuntimePromptBuildInput(
@@ -457,7 +475,66 @@ def test_runtime_system_prompt_ignores_unknown_mcp_servers_in_available_roles() 
                 shared_state_snapshot=(),
             ),
             role_registry=registry,
-            mcp_registry=_FakeMcpRegistry(),
+            mcp_registry=mcp_registry,
+            mcp_discovery_service=_ready_fake_mcp_discovery(mcp_registry),
+        )
+    )
+
+    assert "- MCP Tools: docs_search" in prompt
+
+
+def test_runtime_system_prompt_skips_unready_mcp_without_realtime_connection() -> None:
+    registry = _coordinator_registry()
+    mcp_registry = _NoRealtimeMcpRegistry()
+    discovery_service = McpDiscoveryService(mcp_registry)
+
+    prompt = asyncio.run(
+        system_prompts.build_runtime_system_prompt(
+            system_prompts.RuntimePromptBuildInput(
+                role=_role("Coordinator"),
+                task=_task(),
+                topology=RunTopologySnapshot(
+                    session_mode=SessionMode.ORCHESTRATION,
+                    main_agent_role_id="MainAgent",
+                    normal_root_role_id="MainAgent",
+                    coordinator_role_id="Coordinator",
+                    orchestration_preset_id="default",
+                    orchestration_prompt="Delegate by capability and finalize yourself.",
+                    allowed_role_ids=("writer_agent",),
+                ),
+                shared_state_snapshot=(),
+            ),
+            role_registry=registry,
+            mcp_registry=mcp_registry,
+            mcp_discovery_service=discovery_service,
+        )
+    )
+
+    assert "- MCP Tools: none" in prompt
+
+
+def test_runtime_system_prompt_lists_mcp_tools_live_without_discovery_service() -> None:
+    registry = _coordinator_registry()
+    mcp_registry = _FakeMcpRegistry()
+
+    prompt = asyncio.run(
+        system_prompts.build_runtime_system_prompt(
+            system_prompts.RuntimePromptBuildInput(
+                role=_role("Coordinator"),
+                task=_task(),
+                topology=RunTopologySnapshot(
+                    session_mode=SessionMode.ORCHESTRATION,
+                    main_agent_role_id="MainAgent",
+                    normal_root_role_id="MainAgent",
+                    coordinator_role_id="Coordinator",
+                    orchestration_preset_id="default",
+                    orchestration_prompt="Delegate by capability and finalize yourself.",
+                    allowed_role_ids=("writer_agent",),
+                ),
+                shared_state_snapshot=(),
+            ),
+            role_registry=registry,
+            mcp_registry=mcp_registry,
         )
     )
 

--- a/tests/unit_tests/frontend/test_system_status_ui.py
+++ b/tests/unit_tests/frontend/test_system_status_ui.py
@@ -39,24 +39,42 @@ const reloadedSkillsStatus = {
 
 const initialToolSummaries = {
     'time-mcp': {
+        server: 'time-mcp',
         source: 'project',
         transport: 'stdio',
+        enabled: true,
+        status: 'ready',
         tools: [
             { name: 'current_time', description: 'Return the current time.' },
             { name: 'format_timezone', description: '' },
         ],
     },
     'empty-mcp': {
+        server: 'empty-mcp',
         source: 'user',
         transport: 'http',
+        enabled: true,
+        status: 'ready',
+        tools: [],
+    },
+    'broken-mcp': {
+        server: 'broken-mcp',
+        source: 'project',
+        transport: 'stdio',
+        enabled: true,
+        status: 'failed',
+        error: 'Connection closed',
         tools: [],
     },
 };
 
 const reloadedToolSummaries = {
     'time-mcp': {
+        server: 'time-mcp',
         source: 'project',
         transport: 'stdio',
+        enabled: true,
+        status: 'ready',
         tools: [
             { name: 'format_time_range', description: 'Format a time range.' },
         ],
@@ -76,9 +94,6 @@ export async function fetchMcpServerTools(serverName) {
     const toolSummaries = globalThis.__reloadMcpCalls > 0
         ? reloadedToolSummaries
         : initialToolSummaries;
-    if (serverName === 'broken-mcp') {
-        throw new Error('Connection closed');
-    }
     return toolSummaries[serverName];
 }
 
@@ -102,6 +117,9 @@ export async function fetchMcpServers() {
         source: name === 'empty-mcp' ? 'user' : 'project',
         transport: name === 'empty-mcp' ? 'http' : 'stdio',
         enabled: name !== 'disabled-mcp',
+        discovery_status: name === 'broken-mcp' ? 'failed' : (name === 'slow-mcp' ? 'loading' : 'ready'),
+        tool_count: name === 'time-mcp' ? 2 : 0,
+        error: name === 'broken-mcp' ? 'Connection closed' : null,
     }));
 }
 
@@ -118,6 +136,11 @@ export async function setMcpServerEnabled(serverName, enabled) {
 export async function testMcpServerConnection(serverName) {
     globalThis.__testMcpServerCalls.push(serverName);
     return { server: serverName, ok: true, tool_count: 2, tools: [] };
+}
+
+export async function refreshMcpServerTools(serverName) {
+    globalThis.__refreshMcpToolsCalls.push(serverName);
+    return fetchMcpServerTools(serverName);
 }
 """.strip()
 
@@ -168,16 +191,7 @@ console.log(JSON.stringify({
     assert "2 tools hidden." in collapsed_html
     assert "current_time" not in collapsed_html
     assert payload["toolFetchCalls"] == ["time-mcp", "empty-mcp", "broken-mcp"]
-    assert log_entries == [
-        {
-            "eventName": "frontend.system_status.mcp_tools_load_failed",
-            "message": "Failed to load MCP tools",
-            "payload": {
-                "error_message": "Connection closed",
-                "server_name": "broken-mcp",
-            },
-        }
-    ]
+    assert log_entries == []
 
 
 def test_mcp_status_panel_shows_loading_shell_before_tools_finish(
@@ -232,8 +246,11 @@ await Promise.resolve();
 const loadingHtml = document.getElementById('mcp-status').innerHTML;
 
 globalThis.__resolveSlowTools({
+    server: 'slow-mcp',
     source: 'project',
     transport: 'stdio',
+    enabled: true,
+    status: 'ready',
     tools: [
         { name: 'slow_tool', description: 'Eventually available.' },
     ],
@@ -313,6 +330,105 @@ console.log(JSON.stringify({
             "message": "MCP config reloaded.",
             "tone": "success",
         }
+    ]
+
+
+def test_refresh_mcp_tools_polls_until_discovery_finishes(tmp_path: Path) -> None:
+    payload = _run_system_status_script(
+        tmp_path=tmp_path,
+        mock_api_source="""
+const status = {
+    mcp: {
+        servers: ['slow-mcp'],
+    },
+    skills: {
+        skills: [],
+    },
+};
+
+export async function fetchConfigStatus() {
+    globalThis.__fetchConfigStatusCalls += 1;
+    return status;
+}
+
+export async function fetchMcpServerTools(serverName) {
+    globalThis.__toolFetchCalls.push(serverName);
+    if (globalThis.__refreshMcpToolsCalls.length === 0) {
+        return {
+            server: serverName,
+            source: 'project',
+            transport: 'stdio',
+            enabled: true,
+            status: 'ready',
+            tools: [
+                { name: 'initial_tool', description: 'Loaded before refresh.' },
+            ],
+        };
+    }
+    globalThis.__slowRefreshReads += 1;
+    if (globalThis.__slowRefreshReads < 3) {
+        return {
+            server: serverName,
+            source: 'project',
+            transport: 'stdio',
+            enabled: true,
+            status: 'loading',
+            tools: [],
+        };
+    }
+    return {
+        server: serverName,
+        source: 'project',
+        transport: 'stdio',
+        enabled: true,
+        status: 'ready',
+        tools: [
+            { name: 'refreshed_tool', description: 'Loaded after polling.' },
+        ],
+    };
+}
+
+export async function reloadMcpConfig() {
+    globalThis.__reloadMcpCalls += 1;
+    return { status: 'ok' };
+}
+
+export async function reloadSkillsConfig() {
+    globalThis.__reloadSkillsCalls += 1;
+    return { status: 'ok' };
+}
+""".strip(),
+        runner_source="""
+const { bindSystemStatusHandlers, loadMcpStatusPanel } = await import('./systemStatus.mjs');
+
+installGlobals(createElements());
+globalThis.__agentTeamsMcpRefreshPollDelaysMs = [0, 0, 0];
+globalThis.__slowRefreshReads = 0;
+
+bindSystemStatusHandlers();
+await loadMcpStatusPanel();
+await globalThis.__agentTeamsRefreshMcpTools('slow-mcp');
+await new Promise(resolve => setTimeout(resolve, 0));
+await new Promise(resolve => setTimeout(resolve, 0));
+await new Promise(resolve => setTimeout(resolve, 0));
+
+console.log(JSON.stringify({
+    html: document.getElementById('mcp-status').innerHTML,
+    refreshCalls: globalThis.__refreshMcpToolsCalls,
+    toolFetchCalls: globalThis.__toolFetchCalls,
+}));
+""".strip(),
+    )
+
+    html = cast(str, payload["html"])
+    assert "refreshed_tool" in html
+    assert "Loaded after polling." in html
+    assert payload["refreshCalls"] == ["slow-mcp"]
+    assert payload["toolFetchCalls"] == [
+        "slow-mcp",
+        "slow-mcp",
+        "slow-mcp",
+        "slow-mcp",
     ]
 
 
@@ -1002,6 +1118,7 @@ function installGlobals(elements) {{
     globalThis.__reloadMcpCalls = 0;
     globalThis.__reloadSkillsCalls = 0;
     globalThis.__toolFetchCalls = [];
+    globalThis.__refreshMcpToolsCalls = [];
     globalThis.__addMcpServerCalls = [];
     globalThis.__setMcpServerEnabledCalls = [];
     globalThis.__testMcpServerCalls = [];

--- a/tests/unit_tests/interfaces/cli/test_mcp_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_mcp_commands.py
@@ -126,8 +126,26 @@ def test_mcp_list_supports_json_output(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert json.loads(result.output) == [
-        {"name": "filesystem", "source": "app", "transport": "stdio", "enabled": True},
-        {"name": "browser", "source": "app", "transport": "http", "enabled": True},
+        {
+            "name": "filesystem",
+            "source": "app",
+            "transport": "stdio",
+            "enabled": True,
+            "discovery_status": "pending",
+            "tool_count": 0,
+            "last_checked_at": None,
+            "error": None,
+        },
+        {
+            "name": "browser",
+            "source": "app",
+            "transport": "http",
+            "enabled": True,
+            "discovery_status": "pending",
+            "tool_count": 0,
+            "last_checked_at": None,
+            "error": None,
+        },
     ]
 
 
@@ -311,6 +329,10 @@ def test_mcp_add_supports_remote_config_json(monkeypatch) -> None:
         "source": "app",
         "transport": "http",
         "enabled": True,
+        "discovery_status": "pending",
+        "tool_count": 0,
+        "last_checked_at": None,
+        "error": None,
     }
 
 

--- a/tests/unit_tests/interfaces/server/test_mcp_router.py
+++ b/tests/unit_tests/interfaces/server/test_mcp_router.py
@@ -8,6 +8,7 @@ from relay_teams.interfaces.server.deps import get_mcp_service
 from relay_teams.interfaces.server.routers import mcp
 from relay_teams.mcp.mcp_models import (
     McpConfigScope,
+    McpDiscoveryStatus,
     McpServerAddResult,
     McpServerConfigResult,
     McpServerConnectionTestResult,
@@ -118,6 +119,16 @@ class _FakeMcpService:
             ),
         )
 
+    def refresh_server_tools(self, name: str) -> McpServerToolsSummary:
+        if name != "filesystem":
+            raise ValueError(f"Unknown MCP server: {name}")
+        return McpServerToolsSummary(
+            server="filesystem",
+            source=McpConfigScope.APP,
+            transport="stdio",
+            status=McpDiscoveryStatus.LOADING,
+        )
+
 
 def _create_test_client(fake_service: object) -> TestClient:
     app = FastAPI()
@@ -138,6 +149,10 @@ def test_list_mcp_servers() -> None:
             "source": "app",
             "transport": "stdio",
             "enabled": True,
+            "discovery_status": "pending",
+            "tool_count": 0,
+            "last_checked_at": None,
+            "error": None,
         }
     ]
 
@@ -161,6 +176,10 @@ def test_add_mcp_server() -> None:
             "source": "app",
             "transport": "stdio",
             "enabled": True,
+            "discovery_status": "pending",
+            "tool_count": 0,
+            "last_checked_at": None,
+            "error": None,
         },
         "config_path": "C:/Users/test/.relay-teams/mcp.json",
     }
@@ -231,6 +250,10 @@ def test_set_mcp_server_enabled() -> None:
         "source": "app",
         "transport": "stdio",
         "enabled": False,
+        "discovery_status": "pending",
+        "tool_count": 0,
+        "last_checked_at": None,
+        "error": None,
     }
 
 
@@ -275,6 +298,10 @@ def test_get_mcp_server_config() -> None:
             "source": "app",
             "transport": "stdio",
             "enabled": True,
+            "discovery_status": "pending",
+            "tool_count": 0,
+            "last_checked_at": None,
+            "error": None,
         },
         "config": {
             "transport": "stdio",
@@ -364,22 +391,20 @@ def test_list_mcp_server_tools() -> None:
         "transport": "stdio",
         "enabled": True,
         "tools": [{"name": "filesystem_read_file", "description": "Read a file"}],
+        "status": "pending",
+        "last_checked_at": None,
+        "error": None,
     }
 
 
-def test_list_mcp_server_tools_surfaces_connection_failures() -> None:
-    class _BrokenMcpService(_FakeMcpService):
-        async def list_server_tools(self, name: str) -> McpServerToolsSummary:
-            raise RuntimeError("Connection closed")
+def test_refresh_mcp_server_tools() -> None:
+    client = _create_test_client(_FakeMcpService())
 
-    client = _create_test_client(_BrokenMcpService())
+    response = client.post("/api/mcp/servers/filesystem/tools:refresh")
 
-    response = client.get("/api/mcp/servers/filesystem/tools")
-
-    assert response.status_code == 502
-    assert response.json() == {
-        "detail": "Failed to load MCP tools for 'filesystem': Connection closed"
-    }
+    assert response.status_code == 200
+    assert response.json()["server"] == "filesystem"
+    assert response.json()["status"] == "loading"
 
 
 def test_test_mcp_server_connection() -> None:

--- a/tests/unit_tests/interfaces/server/test_prompts_router.py
+++ b/tests/unit_tests/interfaces/server/test_prompts_router.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 import relay_teams.agents.execution.system_prompts as system_prompts
 from relay_teams.interfaces.server.deps import (
+    get_mcp_discovery_service,
     get_mcp_registry,
     get_role_registry,
     get_skill_registry,
@@ -19,6 +20,7 @@ from relay_teams.interfaces.server.deps import (
     get_workspace_service,
 )
 from relay_teams.interfaces.server.routers import prompts
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec, McpToolInfo
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.roles.role_models import RoleDefinition
@@ -270,6 +272,18 @@ class _FakeMcpRegistry(McpRegistry):
         )
 
 
+def _build_mcp_discovery_service() -> McpDiscoveryService:
+    service = McpDiscoveryService(_FakeMcpRegistry())
+    service.mark_ready(
+        "docs",
+        (
+            McpToolInfo(name="docs_read_file", description="Read a file"),
+            McpToolInfo(name="docs_search_docs", description="Search docs"),
+        ),
+    )
+    return service
+
+
 def _create_client(
     *,
     skill_runtime_service: _FakeSkillRuntimeService | None = None,
@@ -284,6 +298,7 @@ def _create_client(
     app.dependency_overrides[get_role_registry] = _build_role_registry
     app.dependency_overrides[get_tool_registry] = _build_tool_registry
     app.dependency_overrides[get_mcp_registry] = _FakeMcpRegistry
+    app.dependency_overrides[get_mcp_discovery_service] = _build_mcp_discovery_service
     app.dependency_overrides[get_skill_registry] = _FakeSkillRegistry
     app.dependency_overrides[get_skill_runtime_service] = lambda: (
         resolved_skill_runtime_service
@@ -409,6 +424,7 @@ def test_prompts_preview_uses_workspace_execution_root_when_workspace_is_provide
     app.dependency_overrides[get_role_registry] = _build_role_registry
     app.dependency_overrides[get_tool_registry] = _build_tool_registry
     app.dependency_overrides[get_mcp_registry] = _FakeMcpRegistry
+    app.dependency_overrides[get_mcp_discovery_service] = _build_mcp_discovery_service
     app.dependency_overrides[get_skill_registry] = _FakeSkillRegistry
     app.dependency_overrides[get_skill_runtime_service] = _FakeSkillRuntimeService
     app.dependency_overrides[get_workspace_service] = lambda: workspace_service
@@ -457,6 +473,7 @@ def test_prompts_preview_includes_project_instruction_files(tmp_path: Path) -> N
     app.dependency_overrides[get_role_registry] = _build_role_registry
     app.dependency_overrides[get_tool_registry] = _build_tool_registry
     app.dependency_overrides[get_mcp_registry] = _FakeMcpRegistry
+    app.dependency_overrides[get_mcp_discovery_service] = _build_mcp_discovery_service
     app.dependency_overrides[get_skill_registry] = _FakeSkillRegistry
     app.dependency_overrides[get_skill_runtime_service] = _FakeSkillRuntimeService
     app.dependency_overrides[get_workspace_service] = lambda: workspace_service

--- a/tests/unit_tests/mcp/test_config_reload_service.py
+++ b/tests/unit_tests/mcp/test_config_reload_service.py
@@ -135,6 +135,188 @@ def test_reload_mcp_config_cleans_uv_tool_run_package_from_from_flag(
     assert recorded_commands == [("uv", "cache", "clean", "--force", "context7-mcp")]
 
 
+def test_reload_mcp_config_strips_uvx_options_before_cache_target(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": [
+                        "--python",
+                        "3.12",
+                        "--with",
+                        "httpx",
+                        "mcp-server-filesystem",
+                    ],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [
+        ("uv", "cache", "clean", "--force", "mcp-server-filesystem")
+    ]
+
+
+def test_reload_mcp_config_cleans_uvx_from_url_by_distribution_name(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="codehub",
+                config={"mcpServers": {"codehub": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": [
+                        "--from",
+                        "https://example.com/packages/gov-codehub_0.3.0_1776053174.tar.gz",
+                        "mcp-server-codehub",
+                    ],
+                },
+                source=McpConfigScope.APP,
+            ),
+            McpServerSpec(
+                name="welink",
+                config={"mcpServers": {"welink": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": [
+                        "--from",
+                        "https://example.com/packages/welink_msg-1.0.8.tar.gz",
+                        "welink-msg",
+                    ],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert recorded_commands == [
+        ("uv", "cache", "clean", "--force", "gov-codehub"),
+        ("uv", "cache", "clean", "--force", "welink_msg"),
+    ]
+
+
+def test_reload_mcp_config_normalizes_requirement_specs_to_package_names(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir()
+    role_registry = RoleRegistry()
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="pinned",
+                config={"mcpServers": {"pinned": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": ["--from", "foo==1.2.3", "foo-server"],
+                },
+                source=McpConfigScope.APP,
+            ),
+            McpServerSpec(
+                name="dotted",
+                config={"mcpServers": {"dotted": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": ["foo.bar"],
+                },
+                source=McpConfigScope.APP,
+            ),
+            McpServerSpec(
+                name="direct",
+                config={"mcpServers": {"direct": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": [
+                        "--from",
+                        "bar-baz @ https://example.com/packages/bar_baz-1.0.0.tar.gz",
+                        "bar-baz-server",
+                    ],
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    manager = McpConfigManager(app_config_dir=app_config_dir)
+    monkeypatch.setattr(manager, "load_registry", lambda **_kwargs: registry)
+    recorded_commands: list[tuple[str, ...]] = []
+
+    def _fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        recorded_commands.append(tuple(args[0]))
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.config_reload_service.subprocess.run", _fake_run
+    )
+    service = McpConfigReloadService(
+        mcp_config_manager=manager,
+        role_registry=role_registry,
+        on_mcp_reloaded=lambda _registry: None,
+    )
+
+    service.reload_mcp_config()
+
+    assert sorted(recorded_commands) == sorted(
+        [
+            ("uv", "cache", "clean", "--force", "bar-baz"),
+            ("uv", "cache", "clean", "--force", "foo"),
+            ("uv", "cache", "clean", "--force", "foo.bar"),
+        ]
+    )
+
+
 def test_reload_mcp_config_falls_back_to_global_uv_cache_clean_when_package_unknown(
     monkeypatch,
     tmp_path: Path,

--- a/tests/unit_tests/mcp/test_mcp_config_manager.py
+++ b/tests/unit_tests/mcp/test_mcp_config_manager.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from pydantic_ai.mcp import MCPServerStdio
 
 import relay_teams.mcp.mcp_config_manager as config_manager
+from relay_teams.env import runtime_env
 from relay_teams.mcp.mcp_models import McpConfigScope
 from relay_teams.mcp.mcp_registry import build_mcp_server
 
@@ -44,6 +45,15 @@ def _set_test_app_config_dir(monkeypatch, config_dir: Path) -> None:
     )
 
 
+class _FakeProxySecretStore:
+    def __init__(self, password: str | None) -> None:
+        self._password = password
+
+    def get_password(self, config_dir: Path) -> str | None:
+        _ = config_dir
+        return self._password
+
+
 def test_load_registry_reads_app_scope_only(tmp_path: Path) -> None:
     app_config_dir = tmp_path / ".agent-teams"
     app_config_dir.mkdir(parents=True)
@@ -72,7 +82,7 @@ def test_load_registry_reads_app_scope_only(tmp_path: Path) -> None:
     assert registry.get_spec("shared").server_config["command"] == "app-shared"
 
 
-def test_load_registry_applies_proxy_env_to_all_mcp_server_configs(
+def test_load_registry_applies_proxy_env_to_remote_mcp_server_configs(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -92,6 +102,14 @@ def test_load_registry_applies_proxy_env_to_all_mcp_server_configs(
                     "filesystem": {
                         "command": "uvx",
                         "args": ["mcp-server-filesystem"],
+                    },
+                    "stdio_proxy": {
+                        "transport": "stdio",
+                        "command": "uvx",
+                        "args": ["mcp-server-filesystem"],
+                        "env": {
+                            "HTTP_PROXY": "http://stdio-proxy.internal:9000",
+                        },
                     },
                     "events": {
                         "transport": "sse",
@@ -124,7 +142,10 @@ def test_load_registry_applies_proxy_env_to_all_mcp_server_configs(
         "NPM_CONFIG_NOPROXY": "localhost,127.0.0.1",
         "npm_config_noproxy": "localhost,127.0.0.1",
     }
-    assert registry.get_spec("filesystem").server_config["env"] == expected_proxy_env
+    assert "env" not in registry.get_spec("filesystem").server_config
+    assert registry.get_spec("stdio_proxy").server_config["env"] == {
+        "HTTP_PROXY": "http://stdio-proxy.internal:9000",
+    }
     assert registry.get_spec("events").server_config["env"] == expected_proxy_env
     assert registry.get_spec("api").server_config["env"] == expected_proxy_env
     assert os.environ["HTTP_PROXY"] == "http://proxy.internal:8080"
@@ -135,6 +156,121 @@ def test_load_registry_applies_proxy_env_to_all_mcp_server_configs(
     assert os.environ["npm_config_proxy"] == "http://proxy.internal:8080"
     assert os.environ["npm_config_https_proxy"] == "http://proxy.internal:8080"
     assert os.environ["npm_config_noproxy"] == "localhost,127.0.0.1"
+
+
+def test_load_registry_hydrates_saved_proxy_password_for_mcp_runtime(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir(parents=True)
+    _set_test_app_config_dir(monkeypatch, app_config_dir)
+    monkeypatch.setattr(
+        "relay_teams.env.proxy_env.get_proxy_secret_store",
+        lambda: _FakeProxySecretStore("secret"),
+    )
+    (app_config_dir / ".env").write_text(
+        "HTTPS_PROXY=http://alice@proxy.internal:8443\n",
+        encoding="utf-8",
+    )
+    (app_config_dir / "mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "stdio": {
+                        "command": "uvx",
+                        "args": ["mcp-server-filesystem"],
+                    },
+                    "remote": {
+                        "transport": "http",
+                        "url": "https://example.com/mcp",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = config_manager.McpConfigManager(app_config_dir=app_config_dir)
+
+    registry = manager.load_registry()
+    remote_env = registry.get_spec("remote").server_config["env"]
+    stdio_toolset = registry.get_toolsets(("stdio",))[0]
+
+    assert isinstance(remote_env, dict)
+    assert remote_env["HTTPS_PROXY"] == "http://alice:secret@proxy.internal:8443"
+    assert (
+        remote_env["NPM_CONFIG_HTTPS_PROXY"]
+        == "http://alice:secret@proxy.internal:8443"
+    )
+    assert "env" not in registry.get_spec("stdio").server_config
+    assert isinstance(stdio_toolset, MCPServerStdio)
+    assert stdio_toolset.env is not None
+    assert stdio_toolset.env["HTTPS_PROXY"] == "http://alice:secret@proxy.internal:8443"
+    assert (
+        stdio_toolset.env["NPM_CONFIG_HTTPS_PROXY"]
+        == "http://alice:secret@proxy.internal:8443"
+    )
+    assert os.environ["HTTPS_PROXY"] == "http://alice:secret@proxy.internal:8443"
+
+
+def test_load_registry_preserves_process_proxy_for_mcp_runtime(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://process-proxy.internal:8443")
+    monkeypatch.setenv("NO_PROXY", "localhost,.internal")
+    monkeypatch.setitem(
+        runtime_env._PROCESS_ENV_BASELINE,
+        "HTTPS_PROXY",
+        "http://process-proxy.internal:8443",
+    )
+    monkeypatch.setitem(
+        runtime_env._PROCESS_ENV_BASELINE,
+        "NO_PROXY",
+        "localhost,.internal",
+    )
+    app_config_dir = tmp_path / ".agent-teams"
+    app_config_dir.mkdir(parents=True)
+    _set_test_app_config_dir(monkeypatch, app_config_dir)
+    (app_config_dir / "mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "stdio": {
+                        "command": "uvx",
+                        "args": ["mcp-server-filesystem"],
+                    },
+                    "remote": {
+                        "transport": "http",
+                        "url": "https://example.com/mcp",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = config_manager.McpConfigManager(app_config_dir=app_config_dir)
+
+    registry = manager.load_registry()
+    remote_env = registry.get_spec("remote").server_config["env"]
+    stdio_toolset = registry.get_toolsets(("stdio",))[0]
+
+    assert isinstance(remote_env, dict)
+    assert remote_env["HTTPS_PROXY"] == "http://process-proxy.internal:8443"
+    assert remote_env["NO_PROXY"] == "localhost,.internal"
+    assert remote_env["NPM_CONFIG_NOPROXY"] == "localhost,.internal"
+    assert "env" not in registry.get_spec("stdio").server_config
+    assert isinstance(stdio_toolset, MCPServerStdio)
+    assert stdio_toolset.env is not None
+    assert stdio_toolset.env["HTTPS_PROXY"] == "http://process-proxy.internal:8443"
+    assert stdio_toolset.env["NO_PROXY"] == "localhost,.internal"
+    assert stdio_toolset.env["NPM_CONFIG_NOPROXY"] == "localhost,.internal"
+    assert os.environ["HTTPS_PROXY"] == "http://process-proxy.internal:8443"
+    assert os.environ["NO_PROXY"] == "localhost,.internal"
 
 
 def test_load_registry_preserves_explicit_server_env_over_proxy_defaults(
@@ -617,7 +753,9 @@ def test_load_registry_ignores_invalid_mcp_servers_value(tmp_path: Path) -> None
     assert registry.list_names() == ()
 
 
-def test_load_registry_syncs_app_environment_for_stdio_mcp(tmp_path: Path) -> None:
+def test_load_registry_syncs_app_environment_for_stdio_mcp(
+    tmp_path: Path,
+) -> None:
     app_config_dir = tmp_path / ".agent-teams"
     app_config_dir.mkdir(parents=True)
     env_key = "MCP_SYNCED_APP_ENV"

--- a/tests/unit_tests/mcp/test_mcp_config_watcher.py
+++ b/tests/unit_tests/mcp/test_mcp_config_watcher.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from relay_teams.mcp.mcp_config_watcher import McpConfigFileWatcher
+
+
+@pytest.mark.asyncio
+async def test_mcp_config_file_watcher_reloads_on_file_change(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
+    changed = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def on_changed() -> None:
+        loop.call_soon_threadsafe(changed.set)
+
+    watcher = McpConfigFileWatcher(
+        config_path=config_path,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    watcher.start()
+    try:
+        config_path.write_text(
+            '{"mcpServers": {"docs": {"command": "npx"}}}',
+            encoding="utf-8",
+        )
+        await asyncio.wait_for(changed.wait(), timeout=1)
+    finally:
+        await watcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_mcp_config_file_watcher_ignores_invalid_json(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
+    changed = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def on_changed() -> None:
+        loop.call_soon_threadsafe(changed.set)
+
+    watcher = McpConfigFileWatcher(
+        config_path=config_path,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    watcher.start()
+    try:
+        config_path.write_text('{"mcpServers": ', encoding="utf-8")
+        await asyncio.sleep(0.08)
+        assert not changed.is_set()
+    finally:
+        await watcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_mcp_config_file_watcher_start_and_stop_are_idempotent(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
+    changed = asyncio.Event()
+
+    def on_changed() -> None:
+        changed.set()
+
+    watcher = McpConfigFileWatcher(
+        config_path=config_path,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    await watcher.stop()
+    watcher.start()
+    watcher.start()
+    await watcher.stop()
+
+    assert not changed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_mcp_config_file_watcher_tolerates_reload_callback_failure(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "mcp.json"
+    config_path.write_text('{"mcpServers": {}}', encoding="utf-8")
+    attempted = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def on_changed() -> None:
+        loop.call_soon_threadsafe(attempted.set)
+        raise RuntimeError("reload failed")
+
+    watcher = McpConfigFileWatcher(
+        config_path=config_path,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    watcher.start()
+    try:
+        config_path.write_text(
+            '{"mcpServers": {"docs": {"command": "npx"}}}',
+            encoding="utf-8",
+        )
+        await asyncio.wait_for(attempted.wait(), timeout=1)
+    finally:
+        await watcher.stop()
+
+
+def test_mcp_config_file_watcher_treats_missing_file_as_valid(
+    tmp_path: Path,
+) -> None:
+    watcher = McpConfigFileWatcher(
+        config_path=tmp_path / "mcp.json",
+        on_changed=lambda: None,
+    )
+
+    assert watcher._file_is_valid_json() is True

--- a/tests/unit_tests/mcp/test_mcp_discovery_service.py
+++ b/tests/unit_tests/mcp/test_mcp_discovery_service.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
+from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
+    McpDiscoveryStatus,
+    McpServerSpec,
+    McpToolInfo,
+)
+from relay_teams.mcp.mcp_registry import McpRegistry
+
+
+def _spec(name: str, *, enabled: bool = True, command: str = "npx") -> McpServerSpec:
+    return McpServerSpec(
+        name=name,
+        config={"mcpServers": {name: {"command": command}}},
+        server_config={"command": command},
+        source=McpConfigScope.APP,
+        enabled=enabled,
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_warmup_does_not_block(monkeypatch) -> None:
+    registry = McpRegistry((_spec("filesystem"),))
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "filesystem"
+        entered.set()
+        await release.wait()
+        return (McpToolInfo(name="filesystem_read_file", description="Read"),)
+
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+
+    summary = service.get_tools_summary("filesystem")
+    assert summary.status == McpDiscoveryStatus.LOADING
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    release.set()
+    await asyncio.sleep(0)
+    loaded = service.get_tools_summary("filesystem")
+    assert loaded.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in loaded.tools] == ["filesystem_read_file"]
+
+
+@pytest.mark.asyncio
+async def test_discovery_failure_is_cached(monkeypatch) -> None:
+    registry = McpRegistry((_spec("broken"),))
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "broken"
+        raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("broken")
+    assert summary.status == McpDiscoveryStatus.FAILED
+    assert summary.tools == ()
+    assert summary.error == "RuntimeError: connection failed"
+    assert registry.is_server_runtime_failed("broken") is False
+
+
+@pytest.mark.asyncio
+async def test_disabled_server_is_not_enqueued(monkeypatch) -> None:
+    registry = McpRegistry((_spec("disabled-docs", enabled=False),))
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        _ = name
+        raise AssertionError("Disabled MCP servers should not be discovered")
+
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("disabled-docs")
+    assert summary.status == McpDiscoveryStatus.DISABLED
+
+
+@pytest.mark.asyncio
+async def test_replaced_registry_ignores_old_task_result(monkeypatch) -> None:
+    old_registry = McpRegistry((_spec("docs"),))
+    new_registry = McpRegistry((_spec("docs", command="uvx"),))
+    release_old = asyncio.Event()
+
+    async def old_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        await release_old.wait()
+        return (McpToolInfo(name="old_tool", description="Old"),)
+
+    async def new_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        return (McpToolInfo(name="new_tool", description="New"),)
+
+    monkeypatch.setattr(old_registry, "list_tools_for_discovery", old_list_tools)
+    monkeypatch.setattr(new_registry, "list_tools_for_discovery", new_list_tools)
+    service = McpDiscoveryService(old_registry)
+
+    service.start_warmup(old_registry)
+    service.replace_registry(new_registry)
+    release_old.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("docs")
+    assert summary.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in summary.tools] == ["new_tool"]
+
+
+@pytest.mark.asyncio
+async def test_unchanged_ready_server_is_not_discovered_again(monkeypatch) -> None:
+    registry = McpRegistry((_spec("docs"),))
+    calls = 0
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        nonlocal calls
+        assert name == "docs"
+        calls += 1
+        return (McpToolInfo(name="docs_search", description="Search"),)
+
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+    await asyncio.sleep(0)
+    assert service.get_tools_summary("docs").status == McpDiscoveryStatus.READY
+
+    service.replace_registry(McpRegistry((_spec("docs"),)))
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("docs")
+    assert summary.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in summary.tools] == ["docs_search"]
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_env_fingerprint_change_rediscovers_ready_server(monkeypatch) -> None:
+    first_registry = McpRegistry(
+        (_spec("docs"),),
+        discovery_env_fingerprint="env-v1",
+    )
+    second_registry = McpRegistry(
+        (_spec("docs"),),
+        discovery_env_fingerprint="env-v2",
+    )
+    calls: list[str] = []
+
+    async def first_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        calls.append("first")
+        return (McpToolInfo(name="old_tool", description="Old"),)
+
+    async def second_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        calls.append("second")
+        return (McpToolInfo(name="new_tool", description="New"),)
+
+    monkeypatch.setattr(first_registry, "list_tools_for_discovery", first_list_tools)
+    monkeypatch.setattr(second_registry, "list_tools_for_discovery", second_list_tools)
+    service = McpDiscoveryService(first_registry)
+
+    service.start_warmup(first_registry)
+    await asyncio.sleep(0)
+    assert service.get_tools_summary("docs").status == McpDiscoveryStatus.READY
+
+    service.replace_registry(second_registry)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("docs")
+    assert summary.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in summary.tools] == ["new_tool"]
+    assert calls == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_unchanged_failed_server_is_not_retried_on_reload(monkeypatch) -> None:
+    registry = McpRegistry((_spec("broken"),))
+    calls = 0
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        nonlocal calls
+        assert name == "broken"
+        calls += 1
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+    await asyncio.sleep(0)
+    assert service.get_tools_summary("broken").status == McpDiscoveryStatus.FAILED
+
+    service.replace_registry(McpRegistry((_spec("broken"),)))
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("broken")
+    assert summary.status == McpDiscoveryStatus.FAILED
+    assert summary.error == "RuntimeError: offline"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_successful_discovery_clears_runtime_failed_state(monkeypatch) -> None:
+    registry = McpRegistry((_spec("docs"),))
+    registry.mark_server_runtime_failed("docs")
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        return (McpToolInfo(name="docs_search", description="Search"),)
+
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("docs")
+    assert summary.status == McpDiscoveryStatus.READY
+    assert registry.is_server_runtime_failed("docs") is False
+
+
+@pytest.mark.asyncio
+async def test_mark_ready_cancels_stale_discovery_result(monkeypatch) -> None:
+    registry = McpRegistry((_spec("docs"),))
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        entered.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        raise RuntimeError("late failure")
+
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    service.mark_ready(
+        "docs",
+        (McpToolInfo(name="docs_search", description="Search"),),
+    )
+    release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("docs")
+    assert summary.status == McpDiscoveryStatus.READY
+    assert summary.error is None
+    assert [tool.name for tool in summary.tools] == ["docs_search"]
+
+
+def test_malformed_server_config_is_reported_as_unknown_transport() -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="dirty",
+                config={"mcpServers": {"dirty": {}}},
+                server_config={},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    service = McpDiscoveryService(registry)
+
+    summary = service.get_tools_summary("dirty")
+    assert summary.transport == "unknown"
+    assert summary.status == McpDiscoveryStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_changed_server_is_discovered_again(monkeypatch) -> None:
+    first_registry = McpRegistry((_spec("docs"),))
+    second_registry = McpRegistry((_spec("docs", command="uvx"),))
+
+    async def first_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        return (McpToolInfo(name="old_tool", description="Old"),)
+
+    async def second_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        return (McpToolInfo(name="new_tool", description="New"),)
+
+    monkeypatch.setattr(first_registry, "list_tools_for_discovery", first_list_tools)
+    monkeypatch.setattr(second_registry, "list_tools_for_discovery", second_list_tools)
+    service = McpDiscoveryService(first_registry)
+
+    service.start_warmup(first_registry)
+    await asyncio.sleep(0)
+    assert [tool.name for tool in service.get_tools_summary("docs").tools] == [
+        "old_tool"
+    ]
+
+    service.replace_registry(second_registry)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("docs")
+    assert summary.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in summary.tools] == ["new_tool"]
+
+
+@pytest.mark.asyncio
+async def test_replace_registry_from_worker_thread_enqueues_on_bound_loop(
+    monkeypatch,
+) -> None:
+    first_registry = McpRegistry(())
+    second_registry = McpRegistry((_spec("docs"),))
+    discovered = asyncio.Event()
+
+    async def second_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "docs"
+        discovered.set()
+        return (McpToolInfo(name="docs_search", description="Search"),)
+
+    monkeypatch.setattr(second_registry, "list_tools_for_discovery", second_list_tools)
+    service = McpDiscoveryService(first_registry)
+    service.start_warmup(first_registry)
+
+    await asyncio.to_thread(service.replace_registry, second_registry)
+    await asyncio.wait_for(discovered.wait(), timeout=1)
+
+    summary = service.get_tools_summary("docs")
+    assert summary.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in summary.tools] == ["docs_search"]

--- a/tests/unit_tests/mcp/test_mcp_service.py
+++ b/tests/unit_tests/mcp/test_mcp_service.py
@@ -1,18 +1,27 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Mapping
+from contextlib import asynccontextmanager
+import logging
 from pathlib import Path
+from types import TracebackType
 
 import pytest
-from pydantic_ai.mcp import MCPServerStdio, MCPServerStreamableHTTP
+import httpx
+from pydantic_ai.mcp import MCPServerSSE, MCPServerStdio, MCPServerStreamableHTTP
 
+from relay_teams.env.proxy_env import ProxyEnvConfig
 from relay_teams.mcp.mcp_models import (
     McpConfigScope,
+    McpDiscoveryStatus,
     McpServerEnabledUpdateRequest,
     McpServerUpdateRequest,
     McpServerSpec,
     McpToolInfo,
 )
+from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry, build_mcp_server
 from relay_teams.mcp.mcp_service import McpService
 from relay_teams.trace import get_trace_context
@@ -68,6 +77,30 @@ def test_list_enabled_servers_filters_disabled_servers() -> None:
     servers = McpService(registry=registry).list_enabled_servers()
 
     assert [server.name for server in servers] == ["filesystem"]
+
+
+def test_list_servers_reads_discovery_summaries_when_available() -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    discovery_service = McpDiscoveryService(registry)
+    discovery_service.mark_ready(
+        "filesystem",
+        (McpToolInfo(name="filesystem_read_file", description="Read"),),
+    )
+    service = McpService(registry=registry, discovery_service=discovery_service)
+
+    servers = service.list_servers()
+
+    assert servers[0].discovery_status == McpDiscoveryStatus.READY
+    assert servers[0].tool_count == 1
 
 
 def test_list_servers_detects_type_aliases_and_unknown_transport() -> None:
@@ -143,7 +176,50 @@ def test_list_servers_binds_trace_context(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_server_tools_uses_registry_result(monkeypatch) -> None:
+async def test_list_server_tools_reads_cached_discovery_result(monkeypatch) -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    discovery_service = McpDiscoveryService(registry)
+    discovery_service.mark_ready(
+        "filesystem",
+        (
+            McpToolInfo(name="filesystem_read_file", description="Read a file"),
+            McpToolInfo(name="filesystem_write_file", description="Write a file"),
+        ),
+    )
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        _ = name
+        raise AssertionError("list_server_tools should read discovery cache")
+
+    monkeypatch.setattr(registry, "list_tools", fake_list_tools)
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpService(registry=registry, discovery_service=discovery_service)
+
+    summary = await service.list_server_tools("filesystem")
+
+    assert summary.server == "filesystem"
+    assert summary.transport == "stdio"
+    assert summary.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in summary.tools] == [
+        "filesystem_read_file",
+        "filesystem_write_file",
+    ]
+    assert get_trace_context().trace_id is None
+
+
+@pytest.mark.asyncio
+async def test_list_server_tools_without_discovery_service_lists_live_tools(
+    monkeypatch,
+) -> None:
     registry = McpRegistry(
         (
             McpServerSpec(
@@ -157,13 +233,7 @@ async def test_list_server_tools_uses_registry_result(monkeypatch) -> None:
 
     async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
         assert name == "filesystem"
-        context = get_trace_context()
-        assert context.trace_id is not None
-        assert context.span_id is not None
-        return (
-            McpToolInfo(name="filesystem_read_file", description="Read a file"),
-            McpToolInfo(name="filesystem_write_file", description="Write a file"),
-        )
+        return (McpToolInfo(name="filesystem_read_file", description="Read a file"),)
 
     monkeypatch.setattr(registry, "list_tools", fake_list_tools)
     service = McpService(registry=registry)
@@ -171,12 +241,59 @@ async def test_list_server_tools_uses_registry_result(monkeypatch) -> None:
     summary = await service.list_server_tools("filesystem")
 
     assert summary.server == "filesystem"
-    assert summary.transport == "stdio"
-    assert [tool.name for tool in summary.tools] == [
-        "filesystem_read_file",
-        "filesystem_write_file",
-    ]
-    assert get_trace_context().trace_id is None
+    assert summary.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in summary.tools] == ["filesystem_read_file"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_tools_enqueues_single_discovery(monkeypatch) -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "filesystem"
+        return (McpToolInfo(name="filesystem_read_file", description="Read a file"),)
+
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    discovery_service = McpDiscoveryService(registry)
+    service = McpService(registry=registry, discovery_service=discovery_service)
+
+    summary = service.refresh_server_tools("filesystem")
+
+    assert summary.server == "filesystem"
+    assert summary.status == McpDiscoveryStatus.LOADING
+    await asyncio.sleep(0)
+    loaded = await service.list_server_tools("filesystem")
+    assert loaded.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in loaded.tools] == ["filesystem_read_file"]
+
+
+def test_refresh_server_tools_without_discovery_service_returns_pending() -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    service = McpService(registry=registry)
+
+    summary = service.refresh_server_tools("filesystem")
+
+    assert summary.server == "filesystem"
+    assert summary.status == McpDiscoveryStatus.PENDING
+    assert summary.tools == ()
 
 
 @pytest.mark.asyncio
@@ -197,13 +314,17 @@ async def test_test_server_connection_returns_success(monkeypatch) -> None:
         return (McpToolInfo(name="filesystem_read_file", description="Read"),)
 
     monkeypatch.setattr(registry, "list_tools", fake_list_tools)
-    service = McpService(registry=registry)
+    discovery_service = McpDiscoveryService(registry)
+    service = McpService(registry=registry, discovery_service=discovery_service)
 
     result = await service.test_server_connection("filesystem")
+    cached_summary = await service.list_server_tools("filesystem")
 
     assert result.ok is True
     assert result.tool_count == 1
     assert [tool.name for tool in result.tools] == ["filesystem_read_file"]
+    assert cached_summary.status == McpDiscoveryStatus.READY
+    assert [tool.name for tool in cached_summary.tools] == ["filesystem_read_file"]
 
 
 @pytest.mark.asyncio
@@ -229,6 +350,41 @@ async def test_test_server_connection_captures_connection_error(monkeypatch) -> 
 
     assert result.ok is False
     assert result.error == "connection failed"
+
+
+@pytest.mark.asyncio
+async def test_test_server_connection_marks_discovery_failed_on_error(
+    monkeypatch,
+) -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    discovery_service = McpDiscoveryService(registry)
+    discovery_service.mark_ready(
+        "filesystem",
+        (McpToolInfo(name="filesystem_read_file", description="Read"),),
+    )
+
+    async def fake_list_tools(_name: str) -> tuple[McpToolInfo, ...]:
+        raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(registry, "list_tools", fake_list_tools)
+    service = McpService(registry=registry, discovery_service=discovery_service)
+
+    result = await service.test_server_connection("filesystem")
+    cached_summary = await service.list_server_tools("filesystem")
+
+    assert result.ok is False
+    assert cached_summary.status == McpDiscoveryStatus.FAILED
+    assert cached_summary.tools == ()
+    assert cached_summary.error == "RuntimeError: connection failed"
 
 
 class _FakeListedTool:
@@ -260,6 +416,22 @@ class _FailingAsyncToolset:
         return ()
 
 
+class _TimeoutAsyncToolset:
+    async def __aenter__(self) -> "_TimeoutAsyncToolset":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc: object,
+        tb: object,
+    ) -> None:
+        _ = exc_type, exc, tb
+
+    async def list_tools(self) -> tuple[_FakeListedTool, ...]:
+        raise TimeoutError()
+
+
 @pytest.mark.asyncio
 async def test_registry_list_tools_prefixes_server_name(monkeypatch) -> None:
     registry = McpRegistry(
@@ -273,7 +445,14 @@ async def test_registry_list_tools_prefixes_server_name(monkeypatch) -> None:
         )
     )
 
-    async def fake_list_tool_objects(_name: str) -> tuple[_FakeListedTool, ...]:
+    async def fake_list_tool_objects(
+        _name: str,
+        *,
+        update_runtime_state: bool = True,
+        use_cached_toolset: bool = True,
+        stdio_default_timeout_seconds: float = 15.0,
+    ) -> tuple[_FakeListedTool, ...]:
+        _ = update_runtime_state, use_cached_toolset, stdio_default_timeout_seconds
         return (
             _FakeListedTool(
                 name="read_file",
@@ -319,7 +498,7 @@ async def test_registry_marks_mcp_server_failed_after_background_load_error(
 
     monkeypatch.setattr(
         "relay_teams.mcp.mcp_registry.build_mcp_server",
-        lambda _spec: _FailingAsyncToolset(),
+        lambda _spec, **_kwargs: _FailingAsyncToolset(),
     )
 
     with pytest.raises(RuntimeError, match="MCP startup failed"):
@@ -329,7 +508,96 @@ async def test_registry_marks_mcp_server_failed_after_background_load_error(
     assert registry.get_toolsets(("broken",)) == ()
 
 
-def test_build_mcp_server_uses_longer_default_stdio_timeout() -> None:
+@pytest.mark.asyncio
+async def test_registry_discovery_tools_do_not_mark_server_runtime_failed(
+    monkeypatch,
+) -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="broken",
+                config={"mcpServers": {"broken": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    build_calls = 0
+
+    def fake_build_mcp_server(
+        spec: McpServerSpec,
+        *,
+        proxy_env: Mapping[str, str] | None = None,
+        stdio_default_timeout_seconds: float = 15.0,
+    ) -> _FailingAsyncToolset:
+        nonlocal build_calls
+        _ = spec, proxy_env, stdio_default_timeout_seconds
+        build_calls += 1
+        return _FailingAsyncToolset()
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.build_mcp_server",
+        fake_build_mcp_server,
+    )
+
+    with pytest.raises(RuntimeError, match="MCP startup failed"):
+        await registry.list_tools_for_discovery("broken")
+
+    assert registry.is_server_runtime_failed("broken") is False
+    assert build_calls == 1
+    assert len(registry.get_toolsets(("broken",))) == 1
+    assert build_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_discovery_failure_logs_warning_without_registry_error(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="slow",
+                config={"mcpServers": {"slow": {"command": "uvx"}}},
+                server_config={
+                    "command": "uvx",
+                    "args": ["--from", "slow-package", "slow-server"],
+                    "transport": "stdio",
+                },
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.build_mcp_server",
+        lambda _spec, **_kwargs: _TimeoutAsyncToolset(),
+    )
+    caplog.set_level(logging.DEBUG, logger="relay_teams.mcp.mcp_registry")
+    caplog.set_level(logging.WARNING, logger="relay_teams.mcp.mcp_discovery_service")
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("slow")
+    assert summary.status == McpDiscoveryStatus.FAILED
+    assert summary.error == "TimeoutError: "
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.ERROR and record.name.endswith("mcp.mcp_registry")
+    ] == []
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and record.name.endswith("mcp.mcp_discovery_service")
+    ] == ["MCP tool discovery failed"]
+
+
+def test_build_mcp_server_uses_runtime_default_stdio_timeout() -> None:
     server = build_mcp_server(
         McpServerSpec(
             name="context7",
@@ -343,6 +611,260 @@ def test_build_mcp_server_uses_longer_default_stdio_timeout() -> None:
     assert server.tool_prefix == "context7"
     assert server.timeout == 15.0
     assert server.read_timeout == 300.0
+
+
+def test_build_mcp_server_uses_discovery_default_stdio_timeout() -> None:
+    server = build_mcp_server(
+        McpServerSpec(
+            name="context7",
+            config={"mcpServers": {"context7": {"command": "npx"}}},
+            server_config={"command": "npx", "args": ["-y", "@upstash/context7-mcp"]},
+            source=McpConfigScope.SESSION,
+        ),
+        stdio_default_timeout_seconds=60.0,
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.timeout == 60.0
+    assert server.read_timeout == 300.0
+
+
+def test_build_mcp_server_explicit_stdio_timeout_overrides_discovery_default() -> None:
+    server = build_mcp_server(
+        McpServerSpec(
+            name="context7",
+            config={"mcpServers": {"context7": {"command": "npx"}}},
+            server_config={
+                "command": "npx",
+                "args": ["-y", "@upstash/context7-mcp"],
+                "timeout": 22,
+            },
+            source=McpConfigScope.SESSION,
+        ),
+        stdio_default_timeout_seconds=60.0,
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.timeout == 22.0
+    assert server.read_timeout == 300.0
+
+
+@pytest.mark.asyncio
+async def test_remote_sse_mcp_preserves_sdk_timeout(monkeypatch) -> None:
+    captured_timeouts: list[httpx.Timeout | None] = []
+    sdk_timeout = httpx.Timeout(timeout=5.0, read=300.0)
+
+    class _FakeAsyncClient:
+        pass
+
+    def fake_create_async_http_client(
+        *,
+        merged_env: Mapping[str, str] | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> _FakeAsyncClient:
+        _ = merged_env, headers, timeout_seconds
+        captured_timeouts.append(timeout)
+        return _FakeAsyncClient()
+
+    @asynccontextmanager
+    async def fake_sse_client(
+        url: str,
+        *,
+        timeout: float = 5.0,
+        sse_read_timeout: float | None = None,
+        httpx_client_factory,
+    ):
+        _ = url, timeout, sse_read_timeout
+        httpx_client_factory(timeout=sdk_timeout)
+        yield object(), object()
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.create_async_http_client",
+        fake_create_async_http_client,
+    )
+    monkeypatch.setattr("relay_teams.mcp.mcp_registry.sse_client", fake_sse_client)
+
+    server = build_mcp_server(
+        McpServerSpec(
+            name="remote",
+            config={"mcpServers": {"remote": {"url": "https://example.com/sse"}}},
+            server_config={"url": "https://example.com/sse"},
+            source=McpConfigScope.APP,
+        )
+    )
+
+    assert isinstance(server, MCPServerSSE)
+    async with server.client_streams():
+        pass
+
+    assert captured_timeouts == [sdk_timeout]
+
+
+@pytest.mark.asyncio
+async def test_remote_mcp_uses_server_specific_proxy_env(monkeypatch) -> None:
+    monkeypatch.setenv("HTTP_PROXY", "http://process-proxy.internal:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://process-proxy.internal:8443")
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.load_proxy_env_config",
+        lambda **_kwargs: ProxyEnvConfig(
+            http_proxy="http://app-proxy.internal:8080",
+            https_proxy="http://app-proxy.internal:8443",
+        ),
+    )
+    captured_envs: list[Mapping[str, str] | None] = []
+    captured_headers: list[Mapping[str, str] | None] = []
+    captured_timeouts: list[httpx.Timeout | None] = []
+
+    class _FakeAsyncClient:
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
+            _ = exc_type, exc, tb
+
+    def fake_create_async_http_client(
+        *,
+        merged_env: Mapping[str, str] | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> _FakeAsyncClient:
+        _ = timeout_seconds
+        captured_envs.append(merged_env)
+        captured_headers.append(headers)
+        captured_timeouts.append(timeout)
+        return _FakeAsyncClient()
+
+    @asynccontextmanager
+    async def fake_streamable_http_client(
+        url: str,
+        *,
+        http_client: httpx.AsyncClient,
+    ):
+        _ = url, http_client
+        yield object(), object()
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.create_async_http_client",
+        fake_create_async_http_client,
+    )
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.streamable_http_client",
+        fake_streamable_http_client,
+    )
+
+    server = build_mcp_server(
+        McpServerSpec(
+            name="remote",
+            config={"mcpServers": {"remote": {"url": "https://example.com/mcp"}}},
+            server_config={
+                "url": "https://example.com/mcp",
+                "env": {
+                    "HTTP_PROXY": "http://127.0.0.1:4879",
+                    "HTTPS_PROXY": "http://127.0.0.1:4879",
+                },
+                "headers": {"Authorization": "Bearer test-token"},
+            },
+            source=McpConfigScope.APP,
+        )
+    )
+
+    assert isinstance(server, MCPServerStreamableHTTP)
+    async with server.client_streams():
+        pass
+
+    assert captured_envs[0] is not None
+    assert captured_envs[0]["HTTP_PROXY"] == "http://127.0.0.1:4879"
+    assert captured_envs[0]["HTTPS_PROXY"] == "http://127.0.0.1:4879"
+    assert captured_headers == [{"Authorization": "Bearer test-token"}]
+    assert captured_timeouts[0] is not None
+    assert captured_timeouts[0].read == 300.0
+
+
+@pytest.mark.asyncio
+async def test_remote_mcp_without_server_proxy_uses_app_proxy_env(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HTTP_PROXY", "http://process-proxy.internal:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://process-proxy.internal:8443")
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.load_proxy_env_config",
+        lambda **_kwargs: ProxyEnvConfig(
+            http_proxy="http://app-proxy.internal:8080",
+            https_proxy="http://app-proxy.internal:8443",
+        ),
+    )
+    captured_envs: list[Mapping[str, str] | None] = []
+    captured_timeouts: list[httpx.Timeout | None] = []
+
+    class _FakeAsyncClient:
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
+            _ = exc_type, exc, tb
+
+    def fake_create_async_http_client(
+        *,
+        merged_env: Mapping[str, str] | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> _FakeAsyncClient:
+        _ = headers, timeout_seconds
+        captured_envs.append(merged_env)
+        captured_timeouts.append(timeout)
+        return _FakeAsyncClient()
+
+    @asynccontextmanager
+    async def fake_streamable_http_client(
+        url: str,
+        *,
+        http_client: httpx.AsyncClient,
+    ):
+        _ = url, http_client
+        yield object(), object()
+
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.create_async_http_client",
+        fake_create_async_http_client,
+    )
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.streamable_http_client",
+        fake_streamable_http_client,
+    )
+
+    server = build_mcp_server(
+        McpServerSpec(
+            name="remote",
+            config={"mcpServers": {"remote": {"url": "https://example.com/mcp"}}},
+            server_config={"url": "https://example.com/mcp"},
+            source=McpConfigScope.APP,
+        )
+    )
+
+    assert isinstance(server, MCPServerStreamableHTTP)
+    async with server.client_streams():
+        pass
+
+    assert captured_envs[0] is not None
+    assert captured_envs[0]["HTTP_PROXY"] != "http://process-proxy.internal:8080"
+    assert captured_envs[0]["HTTP_PROXY"] == "http://app-proxy.internal:8080"
+    assert captured_envs[0]["HTTPS_PROXY"] == "http://app-proxy.internal:8443"
+    assert captured_timeouts[0] is not None
+    assert captured_timeouts[0].read == 300.0
 
 
 def test_build_mcp_server_allows_stdio_timeout_override() -> None:
@@ -364,6 +886,30 @@ def test_build_mcp_server_allows_stdio_timeout_override() -> None:
     assert server.tool_prefix == "context7"
     assert server.timeout == 42.0
     assert server.read_timeout == 123.0
+
+
+def test_build_mcp_server_uses_default_remote_read_timeout() -> None:
+    sse_server = build_mcp_server(
+        McpServerSpec(
+            name="sse",
+            config={"mcpServers": {"sse": {"url": "https://example.com/sse"}}},
+            server_config={"transport": "sse", "url": "https://example.com/sse"},
+            source=McpConfigScope.APP,
+        )
+    )
+    http_server = build_mcp_server(
+        McpServerSpec(
+            name="http",
+            config={"mcpServers": {"http": {"url": "https://example.com/mcp"}}},
+            server_config={"transport": "http", "url": "https://example.com/mcp"},
+            source=McpConfigScope.APP,
+        )
+    )
+
+    assert isinstance(sse_server, MCPServerSSE)
+    assert isinstance(http_server, MCPServerStreamableHTTP)
+    assert sse_server.read_timeout == 300.0
+    assert http_server.read_timeout == 300.0
 
 
 def test_build_mcp_server_accepts_streamable_http_transport_alias() -> None:
@@ -415,11 +961,20 @@ def test_build_mcp_server_detects_remote_type_alias() -> None:
     assert isinstance(server, MCPServerStreamableHTTP)
 
 
-def test_build_mcp_server_stdio_inherits_process_env_and_prefers_explicit_env(
+def test_build_mcp_server_stdio_uses_app_proxy_defaults_with_explicit_overrides(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("MCP_PROCESS_ONLY", "from-process")
     monkeypatch.setenv("MCP_SHARED_ENV", "from-process")
+    monkeypatch.setenv("HTTP_PROXY", "http://process-proxy.internal:8080")
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.load_proxy_env_config",
+        lambda **_kwargs: ProxyEnvConfig(
+            http_proxy="http://app-proxy.internal:8080",
+            https_proxy="http://app-proxy.internal:8443",
+            no_proxy="localhost,127.0.0.1",
+        ),
+    )
 
     server = build_mcp_server(
         McpServerSpec(
@@ -431,6 +986,7 @@ def test_build_mcp_server_stdio_inherits_process_env_and_prefers_explicit_env(
                 "env": {
                     "MCP_SHARED_ENV": "from-spec",
                     "MCP_SPEC_ONLY": "from-spec",
+                    "HTTPS_PROXY": "http://server-proxy.internal:8443",
                 },
             },
             source=McpConfigScope.SESSION,
@@ -440,8 +996,53 @@ def test_build_mcp_server_stdio_inherits_process_env_and_prefers_explicit_env(
     assert isinstance(server, MCPServerStdio)
     assert server.env is not None
     assert server.env["MCP_PROCESS_ONLY"] == "from-process"
+    assert server.env["HTTP_PROXY"] != "http://process-proxy.internal:8080"
+    assert server.env["HTTP_PROXY"] == "http://app-proxy.internal:8080"
+    assert server.env["http_proxy"] == "http://app-proxy.internal:8080"
+    assert server.env["NO_PROXY"] == "localhost,127.0.0.1"
+    assert server.env["no_proxy"] == "localhost,127.0.0.1"
+    assert server.env["NODE_USE_ENV_PROXY"] == "1"
+    assert server.env["NPM_CONFIG_PROXY"] == "http://app-proxy.internal:8080"
+    assert server.env["npm_config_proxy"] == "http://app-proxy.internal:8080"
+    assert server.env["NPM_CONFIG_NOPROXY"] == "localhost,127.0.0.1"
+    assert server.env["npm_config_noproxy"] == "localhost,127.0.0.1"
     assert server.env["MCP_SHARED_ENV"] == "from-spec"
     assert server.env["MCP_SPEC_ONLY"] == "from-spec"
+    assert server.env["HTTPS_PROXY"] == "http://server-proxy.internal:8443"
+    assert server.env["https_proxy"] == "http://server-proxy.internal:8443"
+    assert server.env["NPM_CONFIG_HTTPS_PROXY"] == "http://server-proxy.internal:8443"
+    assert server.env["npm_config_https_proxy"] == "http://server-proxy.internal:8443"
+
+
+def test_build_mcp_server_stdio_ignores_process_only_proxy_env(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MCP_PROCESS_ONLY", "from-process")
+    monkeypatch.setenv("HTTP_PROXY", "http://process-proxy.internal:8080")
+    monkeypatch.setattr(
+        "relay_teams.mcp.mcp_registry.load_proxy_env_config",
+        lambda **_kwargs: ProxyEnvConfig(),
+    )
+
+    server = build_mcp_server(
+        McpServerSpec(
+            name="context7",
+            config={"mcpServers": {"context7": {"command": "npx"}}},
+            server_config={
+                "command": "npx",
+                "args": ["-y", "@upstash/context7-mcp"],
+            },
+            source=McpConfigScope.SESSION,
+        )
+    )
+
+    assert isinstance(server, MCPServerStdio)
+    assert server.env is not None
+    assert server.env["MCP_PROCESS_ONLY"] == "from-process"
+    assert "HTTP_PROXY" not in server.env
+    assert "http_proxy" not in server.env
+    assert "NPM_CONFIG_PROXY" not in server.env
+    assert "npm_config_proxy" not in server.env
 
 
 def test_build_mcp_server_stdio_expands_explicit_env_references(
@@ -578,17 +1179,39 @@ def test_list_servers_reports_enabled_state() -> None:
 
 def test_add_server_publishes_registry_updates_to_runtime_callback(
     tmp_path: Path,
+    monkeypatch,
 ) -> None:
     from relay_teams.mcp.mcp_config_manager import McpConfigManager
 
     app_config_dir = tmp_path / ".agent-teams"
     app_config_dir.mkdir(parents=True)
     manager = McpConfigManager(app_config_dir=app_config_dir)
+    discovery_service = McpDiscoveryService(McpRegistry(()))
     published_registries: list[McpRegistry] = []
+    replace_count = 0
+
+    original_replace_registry = discovery_service.replace_registry
+
+    def counted_replace_registry(registry: McpRegistry) -> None:
+        nonlocal replace_count
+        replace_count += 1
+        original_replace_registry(registry)
+
+    monkeypatch.setattr(
+        discovery_service,
+        "replace_registry",
+        counted_replace_registry,
+    )
+
+    def publish_registry(registry: McpRegistry) -> None:
+        published_registries.append(registry)
+        service.replace_registry(registry)
+
     service = McpService(
         registry=McpRegistry(()),
         config_manager=manager,
-        on_registry_changed=published_registries.append,
+        on_registry_changed=publish_registry,
+        discovery_service=discovery_service,
     )
 
     service.add_server(
@@ -600,6 +1223,7 @@ def test_add_server_publishes_registry_updates_to_runtime_callback(
     assert published_registries[0].get_spec("filesystem").server_config["command"] == (
         "npx"
     )
+    assert replace_count == 1
 
 
 def test_add_server_preserves_extra_specs_during_registry_reload(

--- a/tests/unit_tests/net/test_clients.py
+++ b/tests/unit_tests/net/test_clients.py
@@ -71,6 +71,17 @@ async def test_create_async_http_client_disables_ssl_verification_when_configure
     assert verify_mode == _SSL_VERIFY_DISABLED
 
 
+@pytest.mark.asyncio
+async def test_create_async_http_client_merges_custom_headers() -> None:
+    async with create_async_http_client(
+        merged_env={}, headers={"X-MCP-Server": "remote"}
+    ) as client:
+        headers = client.headers
+
+    assert headers["User-Agent"] == clients_module.get_user_agent()
+    assert headers["X-MCP-Server"] == "remote"
+
+
 def test_create_runtime_async_http_client_uses_hydrated_proxy_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_tests/plugins/test_phase1_runtime.py
+++ b/tests/unit_tests/plugins/test_phase1_runtime.py
@@ -413,7 +413,7 @@ def test_invalid_plugin_mcp_config_is_reported_and_skipped(tmp_path: Path) -> No
     assert "Invalid plugin MCP config" in diagnostic.message
 
 
-def test_plugin_mcp_specs_receive_app_proxy_env(tmp_path: Path) -> None:
+def test_plugin_stdio_mcp_specs_do_not_persist_app_proxy_env(tmp_path: Path) -> None:
     app_config_dir = tmp_path / "app"
     app_config_dir.mkdir()
     (app_config_dir / ".env").write_text(
@@ -432,9 +432,7 @@ def test_plugin_mcp_specs_receive_app_proxy_env(tmp_path: Path) -> None:
     )
 
     loaded = registry.get_spec("quality:docs")
-    env = loaded.server_config.get("env")
-    assert isinstance(env, dict)
-    assert env["HTTPS_PROXY"] == "http://proxy.local:8080"
+    assert "env" not in loaded.server_config
 
 
 def test_plugin_role_hooks_use_local_namespace(tmp_path: Path) -> None:

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -2647,7 +2647,7 @@ async def test_generate_reserves_context_for_registered_tools_and_skills(
 
 
 @pytest.mark.asyncio
-async def test_generate_scales_mcp_context_budget_with_actual_toolset_size(
+async def test_generate_uses_conservative_mcp_context_budget_without_schema_probe(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -2681,21 +2681,22 @@ async def test_generate_scales_mcp_context_budget_with_actual_toolset_size(
                 )
                 for index in range(10)
             ),
-        }
+        },
+        fail_on_list=True,
     )
-    provider_small, _ = _build_provider(
-        tmp_path / "mcp_budget_small.db",
+    provider_with_mcp, _ = _build_provider(
+        tmp_path / "mcp_budget_with_mcp.db",
         fake_hub,
         allowed_mcp_servers=("small",),
         mcp_registry=fake_registry,
     )
-    provider_large, _ = _build_provider(
-        tmp_path / "mcp_budget_large.db",
+    provider_without_mcp, _ = _build_provider(
+        tmp_path / "mcp_budget_without_mcp.db",
         fake_hub,
-        allowed_mcp_servers=("large",),
+        allowed_mcp_servers=(),
         mcp_registry=fake_registry,
     )
-    for provider in (provider_small, provider_large):
+    for provider in (provider_with_mcp, provider_without_mcp):
         updated_config = provider._config.model_copy(
             update={
                 "context_window": 100_300,
@@ -2720,27 +2721,27 @@ async def test_generate_scales_mcp_context_budget_with_actual_toolset_size(
 
     monkeypatch.setattr(llm_module, "build_coordination_agent", _fake_builder)
 
-    await provider_small.generate(
+    await provider_with_mcp.generate(
         LLMRequest(
-            run_id="run-mcp-budget-small",
-            trace_id="run-mcp-budget-small",
-            task_id="task-mcp-budget-small",
-            session_id="session-mcp-budget-small",
+            run_id="run-mcp-budget-with-mcp",
+            trace_id="run-mcp-budget-with-mcp",
+            task_id="task-mcp-budget-with-mcp",
+            session_id="session-mcp-budget-with-mcp",
             workspace_id="default",
-            instance_id="inst-mcp-budget-small",
+            instance_id="inst-mcp-budget-with-mcp",
             role_id="Coordinator",
             system_prompt="system",
             user_prompt="current turn",
         )
     )
-    await provider_large.generate(
+    await provider_without_mcp.generate(
         LLMRequest(
-            run_id="run-mcp-budget-large",
-            trace_id="run-mcp-budget-large",
-            task_id="task-mcp-budget-large",
-            session_id="session-mcp-budget-large",
+            run_id="run-mcp-budget-without-mcp",
+            trace_id="run-mcp-budget-without-mcp",
+            task_id="task-mcp-budget-without-mcp",
+            session_id="session-mcp-budget-without-mcp",
             workspace_id="default",
-            instance_id="inst-mcp-budget-large",
+            instance_id="inst-mcp-budget-without-mcp",
             role_id="Coordinator",
             system_prompt="system",
             user_prompt="current turn",
@@ -2748,11 +2749,12 @@ async def test_generate_scales_mcp_context_budget_with_actual_toolset_size(
     )
 
     assert len(captured_settings) == 2
-    small_budget = captured_settings[0]["max_tokens"]
-    large_budget = captured_settings[1]["max_tokens"]
-    assert isinstance(small_budget, int)
-    assert isinstance(large_budget, int)
-    assert large_budget < small_budget
+    with_mcp_budget = captured_settings[0]["max_tokens"]
+    without_mcp_budget = captured_settings[1]["max_tokens"]
+    assert isinstance(with_mcp_budget, int)
+    assert isinstance(without_mcp_budget, int)
+    assert with_mcp_budget < without_mcp_budget
+    assert fake_registry.list_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_llm_retry.py
+++ b/tests/unit_tests/providers/test_llm_retry.py
@@ -6,7 +6,7 @@ import json
 import httpx
 import pytest
 from openai import APIError, APIStatusError
-from pydantic_ai.exceptions import ModelAPIError
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 
 from relay_teams.providers.llm_retry import (
     compute_retry_delay_ms,
@@ -147,6 +147,43 @@ def test_extract_retry_error_info_marks_model_api_error_without_status_non_retry
     assert info.status_code is None
     assert info.error_code == "2062"
     assert info.retryable is False
+
+
+def test_extract_retry_error_info_maps_enterprise_proxy_block_to_proxy_blocked() -> (
+    None
+):
+    info = extract_retry_error_info(
+        ModelHTTPError(
+            status_code=403,
+            model_name="deepseek-v4-flash",
+            body=(
+                '<html><head><meta name="keywords" '
+                'content="SWG,Proxy,NetentSec" /><title>HIS Proxy</title></head></html>'
+            ),
+        )
+    )
+
+    assert info is not None
+    assert info.status_code == 403
+    assert info.error_code == "proxy_blocked"
+    assert info.retryable is False
+    assert info.transport_error is True
+
+
+def test_extract_retry_error_info_does_not_treat_this_proxy_as_his_proxy_block() -> (
+    None
+):
+    info = extract_retry_error_info(
+        ModelHTTPError(
+            status_code=503,
+            model_name="deepseek-v4-flash",
+            body="this proxy path returned a transient upstream error",
+        )
+    )
+
+    assert info is not None
+    assert info.error_code != "proxy_blocked"
+    assert info.retryable is True
 
 
 def test_extract_retry_error_info_marks_remote_protocol_interrupt_as_retryable() -> (

--- a/tests/unit_tests/sessions/runs/test_assistant_errors.py
+++ b/tests/unit_tests/sessions/runs/test_assistant_errors.py
@@ -75,6 +75,24 @@ def test_build_assistant_error_message_uses_auth_invalid_code() -> None:
     assert "API key is invalid" in message
 
 
+def test_build_assistant_error_message_includes_full_proxy_block_detail() -> None:
+    detail = (
+        "status_code: 403\n"
+        "model_name: deepseek-v4-flash\n"
+        "body:\n"
+        '<html><head><meta name="keywords" content="SWG,Proxy,NetentSec" /></head></html>'
+    )
+
+    message = build_assistant_error_message(
+        error_code="proxy_blocked",
+        error_message=detail,
+    )
+
+    assert "enterprise proxy block page" in message
+    assert "```text" in message
+    assert detail in message
+
+
 def test_build_assistant_error_message_uses_incomplete_todos_guidance() -> None:
     message = build_assistant_error_message(
         error_code="incomplete_todos",


### PR DESCRIPTION
## Summary
- move MCP tool discovery to an asynchronous in-memory cache with disabled/pending/loading/ready/failed states
- make MCP tools API read cached discovery state and add a refresh enqueue endpoint
- route remote MCP HTTP/SSE clients through project proxy-aware httpx clients using each server's effective env
- update the settings MCP tab to show cached discovery state and expose Refresh separately from Test

Fixes #725

## Validation
- uv run --extra dev pytest -q tests/unit_tests/mcp tests/unit_tests/interfaces/server/test_mcp_router.py
- uv run --extra dev basedpyright src/relay_teams/mcp src/relay_teams/net/clients.py src/relay_teams/interfaces/server/routers/mcp.py src/relay_teams/interfaces/server/container.py tests/unit_tests/mcp tests/unit_tests/interfaces/server/test_mcp_router.py
- node --check frontend/dist/js/components/settings/systemStatus.js
- node --check frontend/dist/js/core/api/system.js
- node --check frontend/dist/js/core/api.js
- node --check frontend/dist/js/core/api/index.js
- node --check frontend/dist/js/utils/i18n.js
- local proxy smoke: server-specific MCP proxy received the request while process-global proxy did not

## Notes
- Full `uv run --extra dev pytest -q tests/unit_tests` was attempted once and timed out after 304 seconds without a reported test failure.