### PR TITLE
Remove sync provider auth and gateway paths

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -308,6 +308,9 @@ Unknown profile fields and invalid profile ids are rejected at request validatio
 ### `POST /system/configs/model:probe`
 
 Tests model connectivity for a saved profile and/or draft override.
+The backend implementation is async-only for provider network I/O; routes call
+the async model connectivity service directly rather than dispatching sync probe
+work through a thread bridge.
 Draft overrides may include optional `ssl_verify`; effective TLS verification resolves as `override.ssl_verify` -> global `SSL_VERIFY` -> default `false`.
 Draft overrides may include `headers[]` and may omit `api_key` when headers are provided. MAAS draft overrides use `maas_auth` instead of `api_key` and perform a login before probing `/chat/completions`. CodeAgent draft overrides use `codeagent_auth`; `sso` reuses the saved OAuth session/tokens, while `password` logs in with username/password before probing.
 If `timeout_ms` is omitted, the backend uses the resolved profile `connect_timeout_seconds` value, or `15s` when no saved profile is involved.
@@ -315,6 +318,8 @@ If `timeout_ms` is omitted, the backend uses the resolved profile `connect_timeo
 ### `POST /system/configs/model:discover`
 
 Fetches the available model catalog for a saved profile and/or draft override.
+Catalog and provider discovery fetches use async HTTP clients. The public HTTP
+contract is unchanged, but there is no backend sync catalog fetch path.
 Draft overrides may omit `model`, but must provide `base_url` and `api_key` or `headers` when `profile_name` is omitted. For `provider = "maas"`, the override must provide `base_url` and `maas_auth`. For `provider = "codeagent"`, the override must provide `codeagent_auth`; the backend still forces the fixed CodeAgent base URL.
 When `profile_name` is provided, the request may override `base_url`, `api_key`, `headers`, and `ssl_verify` while reusing the saved credentials for any omitted fields.
 If `timeout_ms` is omitted, the backend uses the resolved profile `connect_timeout_seconds` value, or `15s` when no saved profile is involved.
@@ -335,6 +340,9 @@ For a small set of known provider/model pairs, the backend also applies a built-
 
 Verifies whether a saved CodeAgent profile still has usable auth state.
 The request body is `{ "profile_name": "<saved profile name>" }`.
+Verification resolves and refreshes CodeAgent tokens through the async token
+service and sends the lightweight verification request with the shared async
+HTTP client.
 The backend only accepts saved `codeagent` profiles for this endpoint. It validates the saved auth state by making a lightweight authenticated CodeAgent request with the currently available token. For SSO profiles it retries once through the refresh path after `401/403`. For password profiles it retries once by logging in again with the saved username/password.
 
 The response shape is:

--- a/docs/core/system-module-boundaries.md
+++ b/docs/core/system-module-boundaries.md
@@ -101,6 +101,11 @@ Boundary:
   created by the factories in `relay_teams.net.clients`. Gateway outbound HTTP
   is async-only and must use `create_async_http_client()` or
   `create_runtime_async_http_client()`; do not add gateway sync HTTP fallbacks.
+  Provider runtime network paths for MaaS, CodeAgent, model catalog fetch,
+  model probe, model discovery, and CodeAgent auth verification are also
+  async-only. The shared sync HTTP factory may remain for deliberate unrelated
+  synchronous boundaries, but it must not be reintroduced into those provider
+  paths.
 - `secrets/*`: secret persistence and masking.
 - `trace/*`: trace/span context propagation.
 

--- a/docs/integrations/xiaoluban-integration.md
+++ b/docs/integrations/xiaoluban-integration.md
@@ -121,6 +121,9 @@ still shows `http://127.0.0.1:8000`.
 Xiaoluban gateway outbound provider traffic uses the shared async net client
 factories for text notification, keep-alive, and utility-route requests. The
 gateway does not keep a duplicate synchronous HTTP path for those operations.
+Inbound forwarding callbacks are dispatched to `handle_im_inbound_async()` as
+the single service entry point; tests and internal callers should await the async
+method instead of using a sync wrapper.
 
 Once in forwarding mode, the following interactive commands are available:
 

--- a/docs/modules/gateway/async-http-runtime.md
+++ b/docs/modules/gateway/async-http-runtime.md
@@ -19,5 +19,10 @@ This contract applies to:
   lookup, and CDN upload.
 - Xiaoluban text notification, keep-alive, and utility-route requests.
 
+Xiaoluban inbound IM callback handling enters the gateway through
+`handle_im_inbound_async()`. The listener may enqueue that coroutine as a
+FastAPI background task, but it must not call a duplicate synchronous inbound
+handler.
+
 Non-gateway modules may still use the shared sync HTTP factory when they have a
 deliberate synchronous boundary. Gateway outbound HTTP is async-only.

--- a/docs/modules/providers/codeagent-provider-design.md
+++ b/docs/modules/providers/codeagent-provider-design.md
@@ -125,6 +125,10 @@ CodeAgent does not reuse top-level `maas_auth`.
 ## Model Discovery And Chat Requests
 
 CodeAgent model discovery and chat requests use the same provider auth resolver as save-time verification and runtime execution.
+Token polling, refresh, password login, request auth, model discovery, chat
+probe, and auth verification are async-only backend paths. CodeAgent provider
+code must use the shared async HTTP client and `httpx.Auth.async_auth_flow`;
+there is no separate sync token or sync auth-flow implementation.
 
 ### Model Discovery
 

--- a/docs/modules/providers/maas-provider-design.md
+++ b/docs/modules/providers/maas-provider-design.md
@@ -81,6 +81,7 @@ MAAS 使用 `MaaSAuthConfig`，包含 `username` 和 `password` 两个字段。
 - 在内存中缓存 MAAS auth context
 - 支持临近过期刷新，在 `401/403` 时强制刷新一次
 - 构造 MAAS 推理请求使用的鉴权对象
+- 仅维护异步登录、token 获取和 `httpx.Auth.async_auth_flow` 路径；不再保留同步登录或同步 token 方法
 
 ### 6.3 OpenAI-compatible 复用层
 
@@ -109,7 +110,7 @@ MAAS 使用 `MaaSAuthConfig`，包含 `username` 和 `password` 两个字段。
 ### 7.1 主推理链路
 
 1. 读取 profile，得到 `model`、固定 `base_url` 和 `maas_auth`。
-2. 调用 `MaaSTokenService.get_token_sync()` 或异步版本。
+2. 调用 `MaaSTokenService.get_token()` 异步获取 token。
 3. 若本地没有有效 token，则先发起登录。
 4. 登录成功后在内存中缓存 auth context。
 5. 调用 `POST {base_url}/chat/completions`。

--- a/docs/modules/providers/model-connectivity-retry-design.md
+++ b/docs/modules/providers/model-connectivity-retry-design.md
@@ -31,6 +31,10 @@
 ### 3.1.1 `POST /api/system/configs/model:probe`
 
 用途：探测当前生效配置或候选配置是否能成功完成最小模型调用。
+实现要求：模型探测、模型发现、MaaS 登录、CodeAgent token 解析/刷新和
+CodeAgent auth verification 均走原生 async 路径，并使用
+`create_async_http_client()`。不要通过 `asyncio.to_thread()` 包装同步网络探测，
+也不要在 provider connectivity 中重新引入同步 HTTP 客户端。
 
 请求体（建议）：
 

--- a/src/relay_teams/gateway/xiaoluban/im_listener.py
+++ b/src/relay_teams/gateway/xiaoluban/im_listener.py
@@ -26,7 +26,7 @@ XIAOLUBAN_IM_PUBLIC_HOST_ENV = "RELAY_TEAMS_XIAOLUBAN_IM_PUBLIC_HOST"
 
 
 class XiaolubanImInboundHandler(Protocol):
-    def handle_im_inbound(
+    async def handle_im_inbound_async(
         self,
         *,
         account_id: str,
@@ -208,7 +208,7 @@ class XiaolubanImListenerService:
             },
         )
         background_tasks.add_task(
-            self._service.handle_im_inbound,
+            self._service.handle_im_inbound_async,
             account_id=account_id,
             message=req,
         )

--- a/src/relay_teams/gateway/xiaoluban/service.py
+++ b/src/relay_teams/gateway/xiaoluban/service.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
-import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple, Protocol, cast
@@ -292,16 +292,6 @@ class XiaolubanGatewayService:
 
         return await asyncio.to_thread(self.update_im_config, account_id, request)
 
-    def handle_im_inbound(
-        self,
-        *,
-        account_id: str,
-        message: XiaolubanInboundMessage,
-    ) -> None:
-        asyncio.run(
-            self.handle_im_inbound_async(account_id=account_id, message=message)
-        )
-
     async def handle_im_inbound_async(
         self,
         *,
@@ -325,7 +315,9 @@ class XiaolubanGatewayService:
                 workspace_id = ""
                 session_id = message.session_id
                 try:
-                    account = self._repository.get_account(account_id)
+                    account = await asyncio.to_thread(
+                        self._repository.get_account, account_id
+                    )
                     workspace_id = str(account.im_config.workspace_id or "")
                 except KeyError as lookup_exc:
                     log_event(
@@ -691,25 +683,12 @@ class XiaolubanGatewayService:
             )
             + f":{uuid4().hex[:8]}"
         )
-        gateway_session = self._gateway_session_service.resolve_or_create_session(
-            channel_type=GatewayChannelType.XIAOLUBAN,
-            external_session_id=new_external_id,
+        gateway_session = await asyncio.to_thread(
+            self._resolve_new_im_gateway_session,
+            account_id=account_id,
+            message=message,
             workspace_id=workspace_id,
-            metadata={
-                "source_provider": XIAOLUBAN_PLATFORM,
-                "source_kind": "im",
-                "xiaoluban_account_id": account_id,
-            },
-            cwd=None,
-            capabilities={},
-            channel_state={
-                "account_id": account_id,
-                "receiver": message.receiver,
-                "sender": message.sender,
-                "xiaoluban_session_id": message.session_id,
-            },
-            peer_user_id=message.sender or None,
-            peer_chat_id=message.receiver or None,
+            external_session_id=new_external_id,
         )
         conversation_key = self._im_conversation_key(
             account_id=account_id,
@@ -749,8 +728,10 @@ class XiaolubanGatewayService:
                 text="服务暂不可用，请稍后重试",
             )
             return None
-        gateway_sessions, internal_sessions = self._list_workspace_sessions(
-            account_id, workspace_id
+        gateway_sessions, internal_sessions = await asyncio.to_thread(
+            self._list_workspace_sessions,
+            account_id,
+            workspace_id,
         )
         if not arg:
             combined = _merge_and_sort_session_list(gateway_sessions, internal_sessions)
@@ -773,7 +754,8 @@ class XiaolubanGatewayService:
                 text=body,
             )
             return None
-        matched = self._find_session_for_resume(
+        matched = await asyncio.to_thread(
+            self._find_session_for_resume,
             arg,
             gateway_sessions,
             internal_sessions,
@@ -866,6 +848,38 @@ class XiaolubanGatewayService:
                 )
         return None
 
+    def _resolve_new_im_gateway_session(
+        self,
+        *,
+        account_id: str,
+        message: XiaolubanInboundMessage,
+        workspace_id: str,
+        external_session_id: str,
+    ) -> GatewaySessionRecord:
+        gateway_session_service = self._gateway_session_service
+        if gateway_session_service is None:
+            raise RuntimeError("xiaoluban_im_runtime_unavailable")
+        return gateway_session_service.resolve_or_create_session(
+            channel_type=GatewayChannelType.XIAOLUBAN,
+            external_session_id=external_session_id,
+            workspace_id=workspace_id,
+            metadata={
+                "source_provider": XIAOLUBAN_PLATFORM,
+                "source_kind": "im",
+                "xiaoluban_account_id": account_id,
+            },
+            cwd=None,
+            capabilities={},
+            channel_state={
+                "account_id": account_id,
+                "receiver": message.receiver,
+                "sender": message.sender,
+                "xiaoluban_session_id": message.session_id,
+            },
+            peer_user_id=message.sender or None,
+            peer_chat_id=message.receiver or None,
+        )
+
     def _ensure_gateway_session_for_internal_id(
         self,
         internal_session_id: str,
@@ -874,9 +888,10 @@ class XiaolubanGatewayService:
         workspace_id: str,
         message: XiaolubanInboundMessage,
     ) -> GatewaySessionRecord | None:
-        if self._gateway_session_service is None:
+        gateway_session_service = self._gateway_session_service
+        if gateway_session_service is None:
             raise RuntimeError("xiaoluban_im_runtime_unavailable")
-        existing = self._gateway_session_service.get_by_internal_session_id(
+        existing = gateway_session_service.get_by_internal_session_id(
             internal_session_id
         )
         xlb_prefix = f"xiaoluban:{account_id}:{workspace_id}:"
@@ -892,22 +907,20 @@ class XiaolubanGatewayService:
         ):
             if existing.external_session_id.startswith(xlb_prefix):
                 try:
-                    return (
-                        self._gateway_session_service.resolve_or_bind_internal_session(
-                            channel_type=GatewayChannelType.XIAOLUBAN,
-                            external_session_id=existing.external_session_id,
-                            internal_session_id=internal_session_id,
-                            workspace_id=workspace_id,
-                            channel_state=channel_state,
-                            capabilities={},
-                            peer_user_id=message.sender or None,
-                            peer_chat_id=message.receiver or None,
-                        )
+                    return gateway_session_service.resolve_or_bind_internal_session(
+                        channel_type=GatewayChannelType.XIAOLUBAN,
+                        external_session_id=existing.external_session_id,
+                        internal_session_id=internal_session_id,
+                        workspace_id=workspace_id,
+                        channel_state=channel_state,
+                        capabilities={},
+                        peer_user_id=message.sender or None,
+                        peer_chat_id=message.receiver or None,
                     )
                 except (KeyError, ValueError):
                     return None
         external_id = f"{xlb_prefix}internal:{internal_session_id}"
-        return self._gateway_session_service.resolve_or_bind_internal_session(
+        return gateway_session_service.resolve_or_bind_internal_session(
             channel_type=GatewayChannelType.XIAOLUBAN,
             external_session_id=external_id,
             internal_session_id=internal_session_id,
@@ -973,18 +986,21 @@ class XiaolubanGatewayService:
         account_id: str,
         message: XiaolubanInboundMessage,
     ) -> None:
-        if self._gateway_session_service is None:
+        gateway_session_service = self._gateway_session_service
+        if gateway_session_service is None:
             raise RuntimeError("xiaoluban_im_runtime_unavailable")
         if self._run_service is None and self._session_ingress_service is None:
             raise RuntimeError("xiaoluban_im_runtime_unavailable")
-        account = self._repository.get_account(account_id)
+        account = await asyncio.to_thread(self._repository.get_account, account_id)
         if account.status != XiaolubanAccountStatus.ENABLED:
             raise RuntimeError("xiaoluban_account_disabled")
         workspace_id = account.im_config.workspace_id
         if workspace_id is None:
             raise RuntimeError("xiaoluban_im_workspace_missing")
-        self._validate_im_workspace(workspace_id)
-        token = self._secret_store.get_token(self._config_dir, account_id)
+        await asyncio.to_thread(self._validate_im_workspace, workspace_id)
+        token = await asyncio.to_thread(
+            self._secret_store.get_token, self._config_dir, account_id
+        )
         if token is None:
             raise RuntimeError("missing_xiaoluban_token")
         await self._keep_alive_if_possible(account, token, message)
@@ -1016,7 +1032,8 @@ class XiaolubanGatewayService:
             if result is None:
                 return
             text = result
-        external_session_id = self._resolve_effective_external_session_id(
+        external_session_id = await asyncio.to_thread(
+            self._resolve_effective_external_session_id,
             account_id=account_id,
             message=message,
             workspace_id=workspace_id,
@@ -1037,7 +1054,8 @@ class XiaolubanGatewayService:
                 "external_session_id": external_session_id,
             },
         )
-        gateway_session = self._gateway_session_service.resolve_or_create_session(
+        gateway_session = await asyncio.to_thread(
+            gateway_session_service.resolve_or_create_session,
             channel_type=GatewayChannelType.XIAOLUBAN,
             external_session_id=external_session_id,
             workspace_id=workspace_id,
@@ -1073,7 +1091,10 @@ class XiaolubanGatewayService:
                 "external_session_id": external_session_id,
             },
         )
-        if self._active_run_id(gateway_session.internal_session_id) is not None:
+        active_run_id = await asyncio.to_thread(
+            self._active_run_id, gateway_session.internal_session_id
+        )
+        if active_run_id is not None:
             await self.send_notification_message(
                 account_id=account_id,
                 workspace_id=workspace_id,
@@ -1092,7 +1113,7 @@ class XiaolubanGatewayService:
                 source_kind="im",
             ),
         )
-        run_id = self._start_im_run(intent)
+        run_id = await asyncio.to_thread(self._start_im_run, intent)
         if run_id is None:
             await self.send_notification_message(
                 account_id=account_id,
@@ -1103,12 +1124,14 @@ class XiaolubanGatewayService:
                 receiver_uid=reply_target,
             )
             return
-        self._mark_im_terminal_notification_suppressed(run_id)
-        self._gateway_session_service.bind_active_run(
+        await asyncio.to_thread(self._mark_im_terminal_notification_suppressed, run_id)
+        await asyncio.to_thread(
+            gateway_session_service.bind_active_run,
             gateway_session.gateway_session_id,
             run_id,
         )
-        self._register_im_reply(
+        await asyncio.to_thread(
+            self._register_im_reply,
             account_id=account_id,
             gateway_session_id=gateway_session.gateway_session_id,
             workspace_id=workspace_id,
@@ -1116,7 +1139,7 @@ class XiaolubanGatewayService:
             run_id=run_id,
             reply_target=reply_target,
         )
-        self._ensure_poller_started()
+        await asyncio.to_thread(self._ensure_poller_started)
         log_event(
             LOGGER,
             logging.INFO,
@@ -1242,6 +1265,9 @@ class XiaolubanGatewayService:
                 )
 
     def _drain_im_replies(self) -> None:
+        asyncio.run(self._drain_im_replies_async())
+
+    async def _drain_im_replies_async(self) -> None:
         self._cleanup_im_terminal_suppression()
         with self._pending_im_replies_lock:
             pending = list(self._pending_im_replies.items())
@@ -1250,15 +1276,13 @@ class XiaolubanGatewayService:
                 terminal_text = self._terminal_text_for_run(run_id)
                 if not terminal_text:
                     continue
-                asyncio.run(
-                    self.send_notification_message(
-                        account_id=ctx.account_id,
-                        workspace_id=ctx.workspace_id,
-                        session_id=ctx.session_id,
-                        status="completed",
-                        body=terminal_text,
-                        receiver_uid=ctx.reply_target,
-                    )
+                await self.send_notification_message(
+                    account_id=ctx.account_id,
+                    workspace_id=ctx.workspace_id,
+                    session_id=ctx.session_id,
+                    status="completed",
+                    body=terminal_text,
+                    receiver_uid=ctx.reply_target,
                 )
                 with self._pending_im_replies_lock:
                     self._pending_im_replies.pop(run_id, None)

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -404,14 +404,14 @@ async def get_model_catalog(
     refresh: bool = Query(default=False),
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelCatalogResult:
-    return await asyncio.to_thread(service.get_model_catalog, refresh=refresh)
+    return await service.get_model_catalog_async(refresh=refresh)
 
 
 @router.post("/configs/model/catalog:refresh")
 async def refresh_model_catalog(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> ModelCatalogResult:
-    return await asyncio.to_thread(service.get_model_catalog, refresh=True)
+    return await service.get_model_catalog_async(refresh=True)
 
 
 class ModelProfileRequest(ModelProfileConfigPayload):
@@ -556,7 +556,7 @@ def start_codeagent_oauth(
 
 
 @router.get("/configs/model/codeagent/oauth/{auth_session_id}")
-def get_codeagent_oauth_session_status(
+async def get_codeagent_oauth_session_status(
     auth_session_id: str,
 ) -> CodeAgentOAuthSessionResponse:
     session = get_codeagent_oauth_session(auth_session_id)
@@ -564,7 +564,7 @@ def get_codeagent_oauth_session_status(
         raise HTTPException(status_code=404, detail="CodeAgent OAuth session not found")
     if not session.completed:
         try:
-            token_result = get_codeagent_token_service().poll_token_sync(
+            token_result = await get_codeagent_token_service().poll_token(
                 session=session,
                 ssl_verify=None,
                 connect_timeout_seconds=15.0,
@@ -620,9 +620,8 @@ async def verify_codeagent_auth(
     service: ModelConfigService = Depends(get_model_config_service),
 ) -> CodeAgentAuthVerifyResponse:
     try:
-        result = await asyncio.to_thread(
-            service.verify_codeagent_auth,
-            profile_name=req.profile_name,
+        result = await service.verify_codeagent_auth_async(
+            profile_name=req.profile_name
         )
         return CodeAgentAuthVerifyResponse.model_validate(
             result.model_dump(mode="json")
@@ -695,7 +694,7 @@ async def probe_model_connectivity(
     try:
         return await call_maybe_async_in_network_probe_thread(
             "model.probe_connectivity",
-            service.probe_connectivity,
+            service.probe_connectivity_async,
             req,
         )
     except ValueError as exc:
@@ -710,7 +709,7 @@ async def discover_model_catalog(
     try:
         return await call_maybe_async_in_network_probe_thread(
             "model.discover_models",
-            service.discover_models,
+            service.discover_models_async,
             req,
         )
     except ValueError as exc:

--- a/src/relay_teams/providers/codeagent_auth.py
+++ b/src/relay_teams/providers/codeagent_auth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-from collections.abc import AsyncGenerator, Generator, Mapping
+from collections.abc import AsyncGenerator, Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from secrets import token_hex, token_urlsafe
@@ -15,7 +15,7 @@ import httpx
 from openai import AsyncOpenAI
 from pydantic import BaseModel, ConfigDict, Field
 
-from relay_teams.net.clients import create_async_http_client, create_sync_http_client
+from relay_teams.net.clients import create_async_http_client
 from relay_teams.providers.maas_auth import (
     MaaSAuthConfig,
     MaaSLoginError,
@@ -124,91 +124,11 @@ class CodeAgentOAuthError(RuntimeError):
 class CodeAgentTokenService:
     def __init__(self) -> None:
         self._tokens: dict[str, _CodeAgentTokenRecord] = {}
-        self._sync_locks: dict[str, Lock] = {}
         self._async_locks: dict[str, asyncio.Lock] = {}
 
     def clear(self) -> None:
         self._tokens.clear()
-        self._sync_locks.clear()
         self._async_locks.clear()
-
-    def get_token_sync(
-        self,
-        *,
-        base_url: str,
-        auth_config: CodeAgentAuthConfig,
-        ssl_verify: bool | None,
-        connect_timeout_seconds: float,
-        force_refresh: bool = False,
-    ) -> str:
-        return self.get_token_result_sync(
-            base_url=base_url,
-            auth_config=auth_config,
-            ssl_verify=ssl_verify,
-            connect_timeout_seconds=connect_timeout_seconds,
-            force_refresh=force_refresh,
-        ).access_token
-
-    def get_token_result_sync(
-        self,
-        *,
-        base_url: str,
-        auth_config: CodeAgentAuthConfig,
-        ssl_verify: bool | None,
-        connect_timeout_seconds: float,
-        force_refresh: bool = False,
-    ) -> CodeAgentOAuthTokenResult:
-        cache_key = self._cache_key(base_url=base_url, auth_config=auth_config)
-        cached = self._tokens.get(cache_key)
-        if (
-            not force_refresh
-            and cached is not None
-            and not self._should_refresh(cached.token_result)
-        ):
-            return cached.token_result
-        lock = self._sync_locks.setdefault(cache_key, Lock())
-        with lock:
-            cached = self._tokens.get(cache_key)
-            if (
-                not force_refresh
-                and cached is not None
-                and not self._should_refresh(cached.token_result)
-            ):
-                return cached.token_result
-            if auth_config.auth_method == CodeAgentAuthMethod.PASSWORD:
-                result = self._login_with_password_sync(
-                    auth_config=auth_config,
-                    ssl_verify=ssl_verify,
-                    connect_timeout_seconds=connect_timeout_seconds,
-                    force_refresh=force_refresh,
-                )
-                self._store_token_result(
-                    cache_key=cache_key,
-                    auth_config=auth_config,
-                    token_result=result,
-                )
-                return result
-            config_token_result = self._token_result_from_config(auth_config)
-            if not force_refresh and config_token_result is not None:
-                self._tokens[cache_key] = _CodeAgentTokenRecord(
-                    token_result=config_token_result
-                )
-                return config_token_result
-            result = self.refresh_token_sync(
-                base_url=base_url,
-                auth_config=self._build_refresh_auth_config(
-                    auth_config=auth_config,
-                    cached=cached,
-                ),
-                ssl_verify=ssl_verify,
-                connect_timeout_seconds=connect_timeout_seconds,
-            )
-            self._store_token_result(
-                cache_key=cache_key,
-                auth_config=auth_config,
-                token_result=result,
-            )
-            return result
 
     async def get_token(
         self,
@@ -290,33 +210,6 @@ class CodeAgentTokenService:
             )
             return result
 
-    def refresh_token_sync(
-        self,
-        *,
-        base_url: str,
-        auth_config: CodeAgentAuthConfig,
-        ssl_verify: bool | None,
-        connect_timeout_seconds: float,
-    ) -> CodeAgentOAuthTokenResult:
-        if auth_config.refresh_token is None:
-            raise CodeAgentOAuthError(
-                "CodeAgent refresh token is not configured.",
-                status_code=None,
-            )
-        with create_sync_http_client(
-            ssl_verify=ssl_verify,
-            timeout_seconds=connect_timeout_seconds,
-            connect_timeout_seconds=connect_timeout_seconds,
-        ) as client:
-            response = client.post(
-                _refresh_token_url(base_url),
-                json=_refresh_token_payload(auth_config),
-                headers={"Content-Type": "application/json"},
-            )
-        return _build_token_result(
-            response, fallback_refresh_token=auth_config.refresh_token
-        )
-
     async def refresh_token(
         self,
         *,
@@ -343,28 +236,6 @@ class CodeAgentTokenService:
         return _build_token_result(
             response, fallback_refresh_token=auth_config.refresh_token
         )
-
-    def poll_token_sync(
-        self,
-        *,
-        session: CodeAgentOAuthSession,
-        ssl_verify: bool | None,
-        connect_timeout_seconds: float,
-    ) -> CodeAgentOAuthTokenResult | None:
-        with create_sync_http_client(
-            ssl_verify=ssl_verify,
-            timeout_seconds=connect_timeout_seconds,
-            connect_timeout_seconds=connect_timeout_seconds,
-        ) as client:
-            response = client.post(
-                _get_token_url(session.base_url),
-                json={
-                    "clientCode": session.client_code,
-                    "redirectUrl": session.callback_url,
-                },
-                headers={"Content-Type": "application/json"},
-            )
-        return _build_polled_token_result(response)
 
     # noinspection PyMethodMayBeStatic
     async def poll_token(  # noqa: PLR6301
@@ -411,40 +282,6 @@ class CodeAgentTokenService:
             )
         )
         return hashlib.sha256(raw.encode("utf-8")).hexdigest()
-
-    @staticmethod
-    def _login_with_password_sync(
-        *,
-        auth_config: CodeAgentAuthConfig,
-        ssl_verify: bool | None,
-        connect_timeout_seconds: float,
-        force_refresh: bool,
-    ) -> CodeAgentOAuthTokenResult:
-        if auth_config.username is None or auth_config.password is None:
-            raise CodeAgentOAuthError(
-                "CodeAgent username/password is not configured.",
-                status_code=None,
-            )
-        try:
-            auth_context = get_maas_token_service().get_auth_context_sync(
-                auth_config=MaaSAuthConfig(
-                    username=auth_config.username,
-                    password=auth_config.password,
-                ),
-                ssl_verify=ssl_verify,
-                connect_timeout_seconds=connect_timeout_seconds,
-                force_refresh=force_refresh,
-            )
-        except MaaSLoginError as exc:
-            raise CodeAgentOAuthError(
-                str(exc) or "CodeAgent password login failed.",
-                status_code=exc.status_code,
-            ) from exc
-        return CodeAgentOAuthTokenResult(
-            access_token=auth_context.token,
-            refresh_token=auth_context.token,
-            expires_at=datetime.now(UTC) + _CODEAGENT_TOKEN_TTL,
-        )
 
     @staticmethod
     async def _login_with_password(
@@ -564,37 +401,6 @@ class CodeAgentRequestAuth(httpx.Auth):
         self._ssl_verify = ssl_verify
         self._connect_timeout_seconds = connect_timeout_seconds
         self._token_service = token_service
-
-    def sync_auth_flow(
-        self,
-        request: httpx.Request,
-    ) -> Generator[httpx.Request, httpx.Response, None]:
-        token = self._token_service.get_token_sync(
-            base_url=self._base_url,
-            auth_config=self._auth_config,
-            ssl_verify=self._ssl_verify,
-            connect_timeout_seconds=self._connect_timeout_seconds,
-        )
-        response = yield _clone_request_with_codeagent_headers(
-            request,
-            base_url=self._base_url,
-            token=token,
-        )
-        if response.status_code not in {401, 403}:
-            return
-        response.close()
-        retry_token = self._token_service.get_token_sync(
-            base_url=self._base_url,
-            auth_config=self._auth_config,
-            ssl_verify=self._ssl_verify,
-            connect_timeout_seconds=self._connect_timeout_seconds,
-            force_refresh=True,
-        )
-        yield _clone_request_with_codeagent_headers(
-            response.request,
-            base_url=self._base_url,
-            token=retry_token,
-        )
 
     async def async_auth_flow(
         self,

--- a/src/relay_teams/providers/maas_auth.py
+++ b/src/relay_teams/providers/maas_auth.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-from collections.abc import AsyncGenerator, Generator, Mapping
+from collections.abc import AsyncGenerator, Mapping
 from datetime import UTC, datetime, timedelta
-from threading import Lock
 
 import httpx
 from openai import AsyncOpenAI
 from pydantic import BaseModel, ConfigDict, Field
 
-from relay_teams.net.clients import create_async_http_client, create_sync_http_client
+from relay_teams.net.clients import create_async_http_client
 from relay_teams.providers.model_config import (
     DEFAULT_MAAS_APP_ID,
     DEFAULT_MAAS_LOGIN_URL,
@@ -64,61 +63,11 @@ class MaaSLoginError(RuntimeError):
 class MaaSTokenService:
     def __init__(self) -> None:
         self._tokens: dict[str, _MaaSTokenRecord] = {}
-        self._sync_locks: dict[str, Lock] = {}
         self._async_locks: dict[str, asyncio.Lock] = {}
 
     def clear(self) -> None:
         self._tokens.clear()
-        self._sync_locks.clear()
         self._async_locks.clear()
-
-    def get_token_sync(
-        self,
-        *,
-        auth_config: MaaSAuthConfig,
-        ssl_verify: bool | None,
-        connect_timeout_seconds: float,
-        force_refresh: bool = False,
-    ) -> str:
-        return self.get_auth_context_sync(
-            auth_config=auth_config,
-            ssl_verify=ssl_verify,
-            connect_timeout_seconds=connect_timeout_seconds,
-            force_refresh=force_refresh,
-        ).token
-
-    def get_auth_context_sync(
-        self,
-        *,
-        auth_config: MaaSAuthConfig,
-        ssl_verify: bool | None,
-        connect_timeout_seconds: float,
-        force_refresh: bool = False,
-    ) -> MaaSAuthContext:
-        cache_key = self._cache_key(auth_config)
-        cached = self._tokens.get(cache_key)
-        if (
-            not force_refresh
-            and cached is not None
-            and not self._should_refresh(cached)
-        ):
-            return cached.auth_context
-        lock = self._sync_locks.setdefault(cache_key, Lock())
-        with lock:
-            cached = self._tokens.get(cache_key)
-            if (
-                not force_refresh
-                and cached is not None
-                and not self._should_refresh(cached)
-            ):
-                return cached.auth_context
-            record = self._login_sync(
-                auth_config=auth_config,
-                ssl_verify=ssl_verify,
-                connect_timeout_seconds=connect_timeout_seconds,
-            )
-            self._tokens[cache_key] = record
-            return record.auth_context
 
     async def get_token(
         self,
@@ -180,25 +129,6 @@ class MaaSTokenService:
     def _should_refresh(record: _MaaSTokenRecord) -> bool:
         return datetime.now(UTC) + _MAAS_REFRESH_SKEW >= record.expires_at
 
-    def _login_sync(
-        self,
-        *,
-        auth_config: MaaSAuthConfig,
-        ssl_verify: bool | None,
-        connect_timeout_seconds: float,
-    ) -> _MaaSTokenRecord:
-        with create_sync_http_client(
-            ssl_verify=ssl_verify,
-            timeout_seconds=connect_timeout_seconds,
-            connect_timeout_seconds=connect_timeout_seconds,
-        ) as client:
-            response = client.post(
-                DEFAULT_MAAS_LOGIN_URL,
-                headers={"Content-Type": "application/json"},
-                json=_maas_login_payload(auth_config),
-            )
-        return _build_token_record(response)
-
     async def _login_async(
         self,
         *,
@@ -234,35 +164,6 @@ class MaaSRequestAuth(httpx.Auth):
         self._ssl_verify = ssl_verify
         self._connect_timeout_seconds = connect_timeout_seconds
         self._token_service = token_service
-
-    def sync_auth_flow(
-        self,
-        request: httpx.Request,
-    ) -> Generator[httpx.Request, httpx.Response, None]:
-        token = self._token_service.get_token_sync(
-            auth_config=self._auth_config,
-            ssl_verify=self._ssl_verify,
-            connect_timeout_seconds=self._connect_timeout_seconds,
-        )
-        response = yield _clone_request_with_maas_headers(
-            request,
-            token=token,
-            app_id=DEFAULT_MAAS_APP_ID,
-        )
-        if response.status_code not in {401, 403}:
-            return
-        response.close()
-        retry_token = self._token_service.get_token_sync(
-            auth_config=self._auth_config,
-            ssl_verify=self._ssl_verify,
-            connect_timeout_seconds=self._connect_timeout_seconds,
-            force_refresh=True,
-        )
-        yield _clone_request_with_maas_headers(
-            response.request,
-            token=retry_token,
-            app_id=DEFAULT_MAAS_APP_ID,
-        )
 
     async def async_auth_flow(
         self,

--- a/src/relay_teams/providers/model_catalog.py
+++ b/src/relay_teams/providers/model_catalog.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from json import dumps, loads
@@ -13,7 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from relay_teams.env.proxy_env import ProxyEnvConfig
 from relay_teams.logger import get_logger
 from relay_teams.media import MediaModality
-from relay_teams.net.clients import create_async_http_client, create_sync_http_client
+from relay_teams.net.clients import create_async_http_client
 from relay_teams.providers.model_capabilities import resolve_model_capabilities
 from relay_teams.providers.model_config import ModelCapabilities, ProviderType
 
@@ -92,110 +93,6 @@ class ModelCatalogService:
         self._source_url = source_url
         self._ttl_seconds = ttl_seconds
 
-    def get_catalog(self, *, refresh: bool = False) -> ModelCatalogResult:
-        cached = self._load_cache()
-        if cached is not None and not refresh:
-            return self._result_from_cache(
-                cached,
-                ok=True,
-                stale=self._is_stale(cached),
-            )
-
-        fetched = self._fetch_catalog()
-        if fetched.ok:
-            envelope = _ModelCatalogCacheEnvelope(
-                source_url=self._source_url,
-                fetched_at=fetched.fetched_at or datetime.now(timezone.utc),
-                providers=fetched.providers,
-            )
-            try:
-                self._write_cache(envelope)
-            except OSError as exc:
-                LOGGER.warning(
-                    "Failed to write model catalog cache.",
-                    extra={
-                        "event": "providers.model_catalog.cache_write_failed",
-                        "cache_path": str(self._cache_path()),
-                        "error": str(exc),
-                    },
-                )
-            return self._result_from_cache(envelope, ok=True, stale=False)
-
-        if cached is None:
-            return fetched
-        return self._result_from_cache(
-            cached,
-            ok=False,
-            stale=True,
-            error_code=fetched.error_code,
-            error_message=fetched.error_message,
-        )
-
-    def _fetch_catalog(self) -> ModelCatalogResult:
-        last_error: ModelCatalogResult | None = None
-        for _attempt in range(_MODEL_CATALOG_FETCH_ATTEMPTS):
-            result = self._fetch_catalog_once()
-            if result.ok:
-                return result
-            last_error = result
-            if result.error_code not in {"network_timeout", "network_error"}:
-                return result
-        if last_error is not None:
-            return last_error
-        return self._error_result(
-            error_code="network_error",
-            error_message="Failed to fetch model catalog.",
-        )
-
-    def _fetch_catalog_once(self) -> ModelCatalogResult:
-        try:
-            with create_sync_http_client(
-                proxy_config=self._get_proxy_config(),
-                timeout_seconds=_MODEL_CATALOG_TIMEOUT_SECONDS,
-                connect_timeout_seconds=_MODEL_CATALOG_TIMEOUT_SECONDS,
-                follow_redirects=True,
-            ) as client:
-                response = client.get(self._source_url)
-        except httpx.TimeoutException as exc:
-            return self._error_result(
-                error_code="network_timeout",
-                error_message=str(exc) or "Timed out fetching model catalog.",
-            )
-        except httpx.RequestError as exc:
-            return self._error_result(
-                error_code="network_error",
-                error_message=str(exc) or "Failed to fetch model catalog.",
-            )
-
-        if response.status_code >= 400:
-            return self._error_result(
-                error_code="http_error",
-                error_message=(
-                    f"Model catalog source returned HTTP {response.status_code}."
-                ),
-            )
-
-        try:
-            payload: object = response.json()
-        except ValueError:
-            return self._error_result(
-                error_code="invalid_response",
-                error_message="Model catalog source returned invalid JSON.",
-            )
-
-        providers = _parse_catalog_payload(payload)
-        if not providers:
-            return self._error_result(
-                error_code="invalid_response",
-                error_message="Model catalog source returned no providers.",
-            )
-        return ModelCatalogResult(
-            ok=True,
-            source_url=self._source_url,
-            fetched_at=datetime.now(timezone.utc),
-            providers=providers,
-        )
-
     def _load_cache(self) -> _ModelCatalogCacheEnvelope | None:
         cache_path = self._cache_path()
         if not cache_path.exists():
@@ -262,10 +159,8 @@ class ModelCatalogService:
             error_message=error_message,
         )
 
-    # -- async counterparts --
-
     async def get_catalog_async(self, *, refresh: bool = False) -> ModelCatalogResult:
-        cached = self._load_cache()
+        cached = await asyncio.to_thread(self._load_cache)
         if cached is not None and not refresh:
             return self._result_from_cache(
                 cached,
@@ -281,7 +176,7 @@ class ModelCatalogService:
                 providers=fetched.providers,
             )
             try:
-                self._write_cache(envelope)
+                await asyncio.to_thread(self._write_cache, envelope)
             except OSError as exc:
                 LOGGER.warning(
                     "Failed to write model catalog cache.",

--- a/src/relay_teams/providers/model_config_service.py
+++ b/src/relay_teams/providers/model_config_service.py
@@ -67,9 +67,6 @@ class ModelConfigService:
     def get_model_fallback_config(self) -> ModelFallbackConfig:
         return self._model_fallback_config_manager.get_model_fallback_config()
 
-    def get_model_catalog(self, *, refresh: bool = False) -> ModelCatalogResult:
-        return self._model_catalog_service.get_catalog(refresh=refresh)
-
     async def get_model_catalog_async(
         self, *, refresh: bool = False
     ) -> ModelCatalogResult:
@@ -113,23 +110,11 @@ class ModelConfigService:
         self._model_fallback_config_manager.save_model_fallback_config(config)
         self.reload_model_config()
 
-    def probe_connectivity(
-        self,
-        request: ModelConnectivityProbeRequest,
-    ) -> ModelConnectivityProbeResult:
-        return self._model_connectivity_probe_service.probe(request)
-
     async def probe_connectivity_async(
         self,
         request: ModelConnectivityProbeRequest,
     ) -> ModelConnectivityProbeResult:
         return await self._model_connectivity_probe_service.probe_async(request)
-
-    def discover_models(
-        self,
-        request: ModelDiscoveryRequest,
-    ) -> ModelDiscoveryResult:
-        return self._model_connectivity_probe_service.discover_models(request)
 
     async def discover_models_async(
         self,
@@ -137,15 +122,6 @@ class ModelConfigService:
     ) -> ModelDiscoveryResult:
         return await self._model_connectivity_probe_service.discover_models_async(
             request
-        )
-
-    def verify_codeagent_auth(
-        self,
-        *,
-        profile_name: str,
-    ) -> CodeAgentAuthVerifyResult:
-        return self._model_connectivity_probe_service.verify_codeagent_auth(
-            profile_name=profile_name
         )
 
     async def verify_codeagent_auth_async(

--- a/src/relay_teams/providers/model_connectivity.py
+++ b/src/relay_teams/providers/model_connectivity.py
@@ -6,14 +6,13 @@ from datetime import datetime, timezone
 import json
 from time import perf_counter
 from typing import Literal, cast
-import asyncio
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from relay_teams.logger import get_logger
 from relay_teams.media import MediaModality
-from relay_teams.net.clients import create_sync_http_client
+from relay_teams.net.clients import create_async_http_client
 from relay_teams.providers.codeagent_auth import (
     CodeAgentOAuthError,
     build_codeagent_request_headers,
@@ -245,7 +244,7 @@ class ModelConnectivityProbeService:
     ) -> None:
         self._get_runtime: Callable[[], RuntimeConfig] = get_runtime
 
-    def probe(
+    async def probe_async(
         self,
         request: ModelConnectivityProbeRequest,
     ) -> ModelConnectivityProbeResult:
@@ -254,22 +253,22 @@ class ModelConnectivityProbeService:
         if resolved_config.provider == ProviderType.ECHO:
             return self._build_echo_result(resolved_config)
         if resolved_config.provider == ProviderType.MAAS:
-            return self._probe_maas(
+            return await self._probe_maas_async(
                 config=resolved_config,
                 timeout_ms=timeout_ms,
             )
         if resolved_config.provider == ProviderType.CODEAGENT:
-            return self._probe_codeagent(
+            return await self._probe_codeagent_async(
                 config=resolved_config,
                 timeout_ms=timeout_ms,
             )
         if _uses_openai_compatible_transport(resolved_config.provider):
-            return self._probe_openai_compatible(
+            return await self._probe_openai_compatible_async(
                 config=resolved_config,
                 timeout_ms=timeout_ms,
             )
         if _uses_anthropic_transport(resolved_config.provider):
-            return self._probe_anthropic(
+            return await self._probe_anthropic_async(
                 config=resolved_config,
                 temperature=(
                     request.override.temperature
@@ -283,7 +282,7 @@ class ModelConnectivityProbeService:
             f"Connectivity probe is not supported for provider '{resolved_config.provider.value}'."
         )
 
-    def discover_models(
+    async def discover_models_async(
         self,
         request: ModelDiscoveryRequest,
     ) -> ModelDiscoveryResult:
@@ -307,25 +306,25 @@ class ModelConnectivityProbeService:
                 models=("echo",),
             )
         if resolved_config.provider == ProviderType.MAAS:
-            return self._discover_maas_models(
+            return await self._discover_maas_models_async(
                 config=resolved_config,
                 timeout_ms=timeout_ms,
                 metadata_policy=request.metadata_policy,
             )
         if resolved_config.provider == ProviderType.CODEAGENT:
-            return self._discover_codeagent_models(
+            return await self._discover_codeagent_models_async(
                 config=resolved_config,
                 timeout_ms=timeout_ms,
                 metadata_policy=request.metadata_policy,
             )
         if _uses_openai_compatible_transport(resolved_config.provider):
-            return self._discover_openai_compatible_models(
+            return await self._discover_openai_compatible_models_async(
                 config=resolved_config,
                 timeout_ms=timeout_ms,
                 metadata_policy=request.metadata_policy,
             )
         if _uses_anthropic_transport(resolved_config.provider):
-            return self._discover_anthropic_models(
+            return await self._discover_anthropic_models_async(
                 config=resolved_config,
                 timeout_ms=timeout_ms,
                 metadata_policy=request.metadata_policy,
@@ -334,7 +333,7 @@ class ModelConnectivityProbeService:
             f"Model discovery is not supported for provider '{resolved_config.provider.value}'."
         )
 
-    def verify_codeagent_auth(
+    async def verify_codeagent_auth_async(
         self,
         *,
         profile_name: str,
@@ -362,50 +361,24 @@ class ModelConnectivityProbeService:
                 f"Model profile '{profile_name}' does not have CodeAgent auth configured."
             )
         checked_at = datetime.now(timezone.utc)
-        return self._verify_codeagent_auth_config(
+        return await self._verify_codeagent_auth_config_async(
             config=config,
             checked_at=checked_at,
         )
 
-    # -- async bridge methods --
-
-    async def probe_async(
-        self,
-        request: ModelConnectivityProbeRequest,
-    ) -> ModelConnectivityProbeResult:
-        """Async version of :meth:`probe`."""
-        return await asyncio.to_thread(self.probe, request)
-
-    async def discover_models_async(
-        self,
-        request: ModelDiscoveryRequest,
-    ) -> ModelDiscoveryResult:
-        """Async version of :meth:`discover_models`."""
-        return await asyncio.to_thread(self.discover_models, request)
-
-    async def verify_codeagent_auth_async(
-        self,
-        *,
-        profile_name: str,
-    ) -> CodeAgentAuthVerifyResult:
-        """Async version of :meth:`verify_codeagent_auth`."""
-        return await asyncio.to_thread(
-            self.verify_codeagent_auth, profile_name=profile_name
-        )
-
-    def _verify_codeagent_auth_config(
+    async def _verify_codeagent_auth_config_async(
         self,
         *,
         config: ModelEndpointConfig,
         checked_at: datetime,
     ) -> CodeAgentAuthVerifyResult:
-        token_or_result = self._get_codeagent_token_for_verify(
+        token_or_result = await self._get_codeagent_token_for_verify_async(
             config=config,
             checked_at=checked_at,
         )
         if isinstance(token_or_result, CodeAgentAuthVerifyResult):
             return token_or_result
-        response_or_result = self._send_codeagent_auth_verify_request(
+        response_or_result = await self._send_codeagent_auth_verify_request_async(
             config=config,
             checked_at=checked_at,
             token=token_or_result,
@@ -414,23 +387,20 @@ class ModelConnectivityProbeService:
             return response_or_result
         response = response_or_result
         if 200 <= response.status_code < 300:
-            return CodeAgentAuthVerifyResult(
-                status="valid",
-                checked_at=checked_at,
-            )
+            return CodeAgentAuthVerifyResult(status="valid", checked_at=checked_at)
         if response.status_code not in {401, 403}:
             return self._build_codeagent_auth_verify_http_error_result(
                 checked_at=checked_at,
                 response=response,
             )
-        retry_token_or_result = self._get_codeagent_token_for_verify(
+        retry_token_or_result = await self._get_codeagent_token_for_verify_async(
             config=config,
             checked_at=checked_at,
             force_refresh=True,
         )
         if isinstance(retry_token_or_result, CodeAgentAuthVerifyResult):
             return retry_token_or_result
-        retry_response_or_result = self._send_codeagent_auth_verify_request(
+        retry_response_or_result = await self._send_codeagent_auth_verify_request_async(
             config=config,
             checked_at=checked_at,
             token=retry_token_or_result,
@@ -439,10 +409,7 @@ class ModelConnectivityProbeService:
             return retry_response_or_result
         retry_response = retry_response_or_result
         if 200 <= retry_response.status_code < 300:
-            return CodeAgentAuthVerifyResult(
-                status="valid",
-                checked_at=checked_at,
-            )
+            return CodeAgentAuthVerifyResult(status="valid", checked_at=checked_at)
         if retry_response.status_code in {401, 403}:
             return CodeAgentAuthVerifyResult(
                 status="reauth_required",
@@ -482,9 +449,7 @@ class ModelConnectivityProbeService:
         if base_config is None:
             override = request.override
             if override is None:
-                raise ValueError(
-                    "Override config is required when profile_name is omitted."
-                )
+                raise ValueError("Provide profile_name, override, or both.")
             override_provider = override.provider or ProviderType.OPENAI_COMPATIBLE
             missing_fields: list[str] = []
             if override.model is None:
@@ -892,7 +857,7 @@ class ModelConnectivityProbeService:
             ),
         )
 
-    def _probe_maas(
+    async def _probe_maas_async(
         self,
         *,
         config: ModelEndpointConfig,
@@ -915,7 +880,7 @@ class ModelConnectivityProbeService:
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
         try:
-            token = get_maas_token_service().get_token_sync(
+            token = await get_maas_token_service().get_token(
                 auth_config=config.maas_auth,
                 ssl_verify=config.ssl_verify,
                 connect_timeout_seconds=timeout_ms / 1000,
@@ -946,7 +911,7 @@ class ModelConnectivityProbeService:
 
         headers["X-Auth-Token"] = token
         headers["app-id"] = DEFAULT_MAAS_APP_ID
-        response = self._post_probe_request(
+        response = await self._post_probe_request_async(
             config=config,
             endpoint=endpoint,
             headers=headers,
@@ -960,7 +925,7 @@ class ModelConnectivityProbeService:
 
         if response.status_code in {401, 403}:
             try:
-                refreshed_token = get_maas_token_service().get_token_sync(
+                refreshed_token = await get_maas_token_service().get_token(
                     auth_config=config.maas_auth,
                     ssl_verify=config.ssl_verify,
                     connect_timeout_seconds=timeout_ms / 1000,
@@ -991,7 +956,7 @@ class ModelConnectivityProbeService:
                 )
             retry_headers = dict(headers)
             retry_headers["X-Auth-Token"] = refreshed_token
-            response = self._post_probe_request(
+            response = await self._post_probe_request_async(
                 config=config,
                 endpoint=endpoint,
                 headers=retry_headers,
@@ -1010,7 +975,7 @@ class ModelConnectivityProbeService:
             started=started,
         )
 
-    def _probe_openai_compatible(
+    async def _probe_openai_compatible_async(
         self,
         *,
         config: ModelEndpointConfig,
@@ -1030,34 +995,17 @@ class ModelConnectivityProbeService:
         }
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
-        try:
-            with create_sync_http_client(
-                timeout_seconds=timeout_ms / 1000,
-                connect_timeout_seconds=timeout_ms / 1000,
-                ssl_verify=config.ssl_verify,
-            ) as client:
-                response = client.post(
-                    endpoint,
-                    headers=headers,
-                    json=payload,
-                )
-        except httpx.TimeoutException as exc:
-            return self._build_transport_error_result(
-                config=config,
-                checked_at=checked_at,
-                started=started,
-                error_code="network_timeout",
-                error_message=str(exc) or "Connection timed out.",
-            )
-        except httpx.RequestError as exc:
-            return self._build_transport_error_result(
-                config=config,
-                checked_at=checked_at,
-                started=started,
-                error_code="network_error",
-                error_message=str(exc) or "Failed to reach model endpoint.",
-            )
-
+        response = await self._post_probe_request_async(
+            config=config,
+            endpoint=endpoint,
+            headers=headers,
+            payload=payload,
+            checked_at=checked_at,
+            started=started,
+            timeout_ms=timeout_ms,
+        )
+        if isinstance(response, ModelConnectivityProbeResult):
+            return response
         return self._build_probe_result_from_response(
             config=config,
             response=response,
@@ -1065,7 +1013,7 @@ class ModelConnectivityProbeService:
             started=started,
         )
 
-    def _probe_anthropic(
+    async def _probe_anthropic_async(
         self,
         *,
         config: ModelEndpointConfig,
@@ -1086,7 +1034,7 @@ class ModelConnectivityProbeService:
             payload["temperature"] = temperature
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
-        response = self._post_probe_request(
+        response = await self._post_probe_request_async(
             config=config,
             endpoint=endpoint,
             headers=headers,
@@ -1104,7 +1052,7 @@ class ModelConnectivityProbeService:
             started=started,
         )
 
-    def _probe_codeagent(
+    async def _probe_codeagent_async(
         self,
         *,
         config: ModelEndpointConfig,
@@ -1123,7 +1071,7 @@ class ModelConnectivityProbeService:
         }
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
-        token_or_result = self._get_codeagent_token_for_probe(
+        token_or_result = await self._get_codeagent_token_for_probe_async(
             config=config,
             checked_at=checked_at,
             started=started,
@@ -1136,7 +1084,7 @@ class ModelConnectivityProbeService:
             content_type="application/json",
             accept="text/event-stream",
         )
-        response = self._post_probe_request(
+        response = await self._post_probe_request_async(
             config=config,
             endpoint=endpoint,
             headers=headers,
@@ -1148,7 +1096,7 @@ class ModelConnectivityProbeService:
         if isinstance(response, ModelConnectivityProbeResult):
             return response
         if response.status_code in {401, 403}:
-            retry_token_or_result = self._get_codeagent_token_for_probe(
+            retry_token_or_result = await self._get_codeagent_token_for_probe_async(
                 config=config,
                 checked_at=checked_at,
                 started=started,
@@ -1157,15 +1105,14 @@ class ModelConnectivityProbeService:
             )
             if isinstance(retry_token_or_result, ModelConnectivityProbeResult):
                 return retry_token_or_result
-            retry_headers = build_codeagent_request_headers(
-                token=retry_token_or_result,
-                content_type="application/json",
-                accept="text/event-stream",
-            )
-            response = self._post_probe_request(
+            response = await self._post_probe_request_async(
                 config=config,
                 endpoint=endpoint,
-                headers=retry_headers,
+                headers=build_codeagent_request_headers(
+                    token=retry_token_or_result,
+                    content_type="application/json",
+                    accept="text/event-stream",
+                ),
                 payload=payload,
                 checked_at=checked_at,
                 started=started,
@@ -1180,7 +1127,7 @@ class ModelConnectivityProbeService:
             started=started,
         )
 
-    def _discover_maas_models(
+    async def _discover_maas_models_async(
         self,
         *,
         config: ModelDiscoveryResolvedConfig,
@@ -1191,38 +1138,37 @@ class ModelConnectivityProbeService:
             raise ValueError("MAAS model discovery requires maas_auth configuration.")
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
-        auth_context_or_result = self._get_maas_model_discovery_auth_context(
-            config=config,
-            checked_at=checked_at,
-            started=started,
-            timeout_ms=timeout_ms,
+        auth_context_or_result = (
+            await self._get_maas_model_discovery_auth_context_async(
+                config=config,
+                checked_at=checked_at,
+                started=started,
+                timeout_ms=timeout_ms,
+            )
         )
         if isinstance(auth_context_or_result, ModelDiscoveryResult):
             return auth_context_or_result
         auth_context = auth_context_or_result
-
         department = auth_context.department
         assert department is not None
         headers = {
             "Content-Type": "application/json",
             "X-Auth-Token": auth_context.token,
         }
-        payload = self._build_maas_model_discovery_payload(department=department)
-        response = self._post_model_discovery_request(
+        response = await self._post_model_discovery_request_async(
             config=config,
             endpoint=DEFAULT_MAAS_DISCOVERY_URL,
             headers=headers,
-            payload=payload,
+            payload=self._build_maas_model_discovery_payload(department=department),
             checked_at=checked_at,
             started=started,
             timeout_ms=timeout_ms,
         )
         if isinstance(response, ModelDiscoveryResult):
             return response
-
         if response.status_code in {401, 403}:
             refreshed_auth_context_or_result = (
-                self._get_maas_model_discovery_auth_context(
+                await self._get_maas_model_discovery_auth_context_async(
                     config=config,
                     checked_at=checked_at,
                     started=started,
@@ -1233,26 +1179,23 @@ class ModelConnectivityProbeService:
             if isinstance(refreshed_auth_context_or_result, ModelDiscoveryResult):
                 return refreshed_auth_context_or_result
             refreshed_auth_context = refreshed_auth_context_or_result
-
             refreshed_department = refreshed_auth_context.department
             assert refreshed_department is not None
             retry_headers = dict(headers)
             retry_headers["X-Auth-Token"] = refreshed_auth_context.token
-            retry_payload = self._build_maas_model_discovery_payload(
-                department=refreshed_department
-            )
-            response = self._post_model_discovery_request(
+            response = await self._post_model_discovery_request_async(
                 config=config,
                 endpoint=DEFAULT_MAAS_DISCOVERY_URL,
                 headers=retry_headers,
-                payload=retry_payload,
+                payload=self._build_maas_model_discovery_payload(
+                    department=refreshed_department
+                ),
                 checked_at=checked_at,
                 started=started,
                 timeout_ms=timeout_ms,
             )
             if isinstance(response, ModelDiscoveryResult):
                 return response
-
         return self._build_model_discovery_result_from_response(
             config=config,
             response=response,
@@ -1261,7 +1204,7 @@ class ModelConnectivityProbeService:
             metadata_policy=metadata_policy,
         )
 
-    def _discover_openai_compatible_models(
+    async def _discover_openai_compatible_models_async(
         self,
         *,
         config: ModelDiscoveryResolvedConfig,
@@ -1282,119 +1225,25 @@ class ModelConnectivityProbeService:
         )
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
-        try:
-            with create_sync_http_client(
-                timeout_seconds=timeout_ms / 1000,
-                connect_timeout_seconds=timeout_ms / 1000,
-                ssl_verify=config.ssl_verify,
-            ) as client:
-                response = client.get(
-                    endpoint,
-                    headers=headers,
-                )
-        except httpx.TimeoutException as exc:
-            return self._build_model_discovery_transport_error_result(
-                config=config,
-                checked_at=checked_at,
-                started=started,
-                error_code="network_timeout",
-                error_message=str(exc) or "Connection timed out.",
-            )
-        except httpx.RequestError as exc:
-            return self._build_model_discovery_transport_error_result(
-                config=config,
-                checked_at=checked_at,
-                started=started,
-                error_code="network_error",
-                error_message=str(exc) or "Failed to reach model endpoint.",
-            )
-
-        latency_ms = self._latency_ms(started)
-        response_payload = self._response_payload(response)
-        if response.status_code >= 400:
-            error_message = (
-                self._extract_error_message(response_payload) or response.text
-            )
-            return self._build_model_discovery_http_error_result(
-                config=config,
-                checked_at=checked_at,
-                latency_ms=latency_ms,
-                status_code=response.status_code,
-                error_message=error_message or "Model discovery failed.",
-            )
-
-        if response_payload is _INVALID_RESPONSE_PAYLOAD:
-            return ModelDiscoveryResult(
-                ok=False,
-                provider=config.provider,
-                base_url=config.base_url,
-                latency_ms=latency_ms,
-                checked_at=checked_at,
-                diagnostics=ModelConnectivityDiagnostics(
-                    endpoint_reachable=True,
-                    auth_valid=True,
-                    rate_limited=False,
-                ),
-                error_code="invalid_response",
-                error_message="Provider returned invalid JSON.",
-                retryable=False,
-            )
-
-        if not isinstance(response_payload, dict | list):
-            return ModelDiscoveryResult(
-                ok=False,
-                provider=config.provider,
-                base_url=config.base_url,
-                latency_ms=latency_ms,
-                checked_at=checked_at,
-                diagnostics=ModelConnectivityDiagnostics(
-                    endpoint_reachable=True,
-                    auth_valid=True,
-                    rate_limited=False,
-                ),
-                error_code="invalid_response",
-                error_message="Provider returned a non-object JSON payload.",
-                retryable=False,
-            )
-
-        model_entries = self._extract_model_entries(
-            payload=response_payload,
-            provider=config.provider,
+        response = await self._get_model_discovery_request_async(
+            config=config,
+            endpoint=endpoint,
+            headers=headers,
+            checked_at=checked_at,
+            started=started,
+            timeout_ms=timeout_ms,
+        )
+        if isinstance(response, ModelDiscoveryResult):
+            return response
+        return self._build_model_discovery_result_from_response(
+            config=config,
+            response=response,
+            checked_at=checked_at,
+            started=started,
             metadata_policy=metadata_policy,
         )
-        if model_entries is None:
-            return ModelDiscoveryResult(
-                ok=False,
-                provider=config.provider,
-                base_url=config.base_url,
-                latency_ms=latency_ms,
-                checked_at=checked_at,
-                diagnostics=ModelConnectivityDiagnostics(
-                    endpoint_reachable=True,
-                    auth_valid=True,
-                    rate_limited=False,
-                ),
-                error_code="invalid_response",
-                error_message="Provider returned an invalid model catalog payload.",
-                retryable=False,
-            )
 
-        return ModelDiscoveryResult(
-            ok=True,
-            provider=config.provider,
-            base_url=config.base_url,
-            latency_ms=latency_ms,
-            checked_at=checked_at,
-            diagnostics=ModelConnectivityDiagnostics(
-                endpoint_reachable=True,
-                auth_valid=True,
-                rate_limited=False,
-            ),
-            models=tuple(entry.model for entry in model_entries),
-            model_entries=model_entries,
-        )
-
-    def _discover_anthropic_models(
+    async def _discover_anthropic_models_async(
         self,
         *,
         config: ModelDiscoveryResolvedConfig,
@@ -1414,7 +1263,7 @@ class ModelConnectivityProbeService:
         )
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
-        response = self._get_model_discovery_request(
+        response = await self._get_model_discovery_request_async(
             config=config,
             endpoint=endpoint,
             headers=headers,
@@ -1432,7 +1281,7 @@ class ModelConnectivityProbeService:
             metadata_policy=metadata_policy,
         )
 
-    def _discover_codeagent_models(
+    async def _discover_codeagent_models_async(
         self,
         *,
         config: ModelDiscoveryResolvedConfig,
@@ -1446,7 +1295,7 @@ class ModelConnectivityProbeService:
         endpoint = f"{config.base_url.rstrip('/')}/chat/modles?checkUserPermission=TRUE"
         started = perf_counter()
         checked_at = datetime.now(timezone.utc)
-        token_or_result = self._get_codeagent_token_for_discovery(
+        token_or_result = await self._get_codeagent_token_for_discovery_async(
             config=config,
             checked_at=checked_at,
             started=started,
@@ -1454,11 +1303,10 @@ class ModelConnectivityProbeService:
         )
         if isinstance(token_or_result, ModelDiscoveryResult):
             return token_or_result
-        headers = build_codeagent_request_headers(token=token_or_result)
-        response = self._get_model_discovery_request(
+        response = await self._get_model_discovery_request_async(
             config=config,
             endpoint=endpoint,
-            headers=headers,
+            headers=build_codeagent_request_headers(token=token_or_result),
             checked_at=checked_at,
             started=started,
             timeout_ms=timeout_ms,
@@ -1466,7 +1314,7 @@ class ModelConnectivityProbeService:
         if isinstance(response, ModelDiscoveryResult):
             return response
         if response.status_code in {401, 403}:
-            retry_token_or_result = self._get_codeagent_token_for_discovery(
+            retry_token_or_result = await self._get_codeagent_token_for_discovery_async(
                 config=config,
                 checked_at=checked_at,
                 started=started,
@@ -1475,7 +1323,7 @@ class ModelConnectivityProbeService:
             )
             if isinstance(retry_token_or_result, ModelDiscoveryResult):
                 return retry_token_or_result
-            response = self._get_model_discovery_request(
+            response = await self._get_model_discovery_request_async(
                 config=config,
                 endpoint=endpoint,
                 headers=build_codeagent_request_headers(token=retry_token_or_result),
@@ -1493,7 +1341,7 @@ class ModelConnectivityProbeService:
             metadata_policy=metadata_policy,
         )
 
-    def _get_maas_model_discovery_auth_context(
+    async def _get_maas_model_discovery_auth_context_async(
         self,
         *,
         config: ModelDiscoveryResolvedConfig,
@@ -1504,7 +1352,7 @@ class ModelConnectivityProbeService:
     ) -> MaaSAuthContext | ModelDiscoveryResult:
         auth_config = cast(MaaSAuthConfig, config.maas_auth)
         try:
-            auth_context = get_maas_token_service().get_auth_context_sync(
+            auth_context = await get_maas_token_service().get_auth_context(
                 auth_config=auth_config,
                 ssl_verify=config.ssl_verify,
                 connect_timeout_seconds=timeout_ms / 1000,
@@ -1533,11 +1381,10 @@ class ModelConnectivityProbeService:
                 started=started,
                 error=exc,
             )
-
         if auth_context.department is not None:
             return auth_context
         if not force_refresh:
-            return self._get_maas_model_discovery_auth_context(
+            return await self._get_maas_model_discovery_auth_context_async(
                 config=config,
                 checked_at=checked_at,
                 started=started,
@@ -1589,7 +1436,7 @@ class ModelConnectivityProbeService:
             "department": department,
         }
 
-    def _post_model_discovery_request(
+    async def _post_model_discovery_request_async(
         self,
         *,
         config: ModelDiscoveryResolvedConfig,
@@ -1601,16 +1448,12 @@ class ModelConnectivityProbeService:
         timeout_ms: int,
     ) -> httpx.Response | ModelDiscoveryResult:
         try:
-            with create_sync_http_client(
+            async with create_async_http_client(
                 timeout_seconds=timeout_ms / 1000,
                 connect_timeout_seconds=timeout_ms / 1000,
                 ssl_verify=config.ssl_verify,
             ) as client:
-                return client.post(
-                    endpoint,
-                    headers=headers,
-                    json=payload,
-                )
+                return await client.post(endpoint, headers=headers, json=payload)
         except httpx.TimeoutException as exc:
             return self._build_model_discovery_transport_error_result(
                 config=config,
@@ -1628,7 +1471,7 @@ class ModelConnectivityProbeService:
                 error_message=str(exc) or "Failed to reach model endpoint.",
             )
 
-    def _get_model_discovery_request(
+    async def _get_model_discovery_request_async(
         self,
         *,
         config: ModelDiscoveryResolvedConfig,
@@ -1639,15 +1482,12 @@ class ModelConnectivityProbeService:
         timeout_ms: int,
     ) -> httpx.Response | ModelDiscoveryResult:
         try:
-            with create_sync_http_client(
+            async with create_async_http_client(
                 timeout_seconds=timeout_ms / 1000,
                 connect_timeout_seconds=timeout_ms / 1000,
                 ssl_verify=config.ssl_verify,
             ) as client:
-                return client.get(
-                    endpoint,
-                    headers=headers,
-                )
+                return await client.get(endpoint, headers=headers)
         except httpx.TimeoutException as exc:
             return self._build_model_discovery_transport_error_result(
                 config=config,
@@ -1759,7 +1599,7 @@ class ModelConnectivityProbeService:
             model_entries=model_entries,
         )
 
-    def _post_probe_request(
+    async def _post_probe_request_async(
         self,
         *,
         config: ModelEndpointConfig,
@@ -1771,16 +1611,12 @@ class ModelConnectivityProbeService:
         timeout_ms: int,
     ) -> httpx.Response | ModelConnectivityProbeResult:
         try:
-            with create_sync_http_client(
+            async with create_async_http_client(
                 timeout_seconds=timeout_ms / 1000,
                 connect_timeout_seconds=timeout_ms / 1000,
                 ssl_verify=config.ssl_verify,
             ) as client:
-                return client.post(
-                    endpoint,
-                    headers=headers,
-                    json=payload,
-                )
+                return await client.post(endpoint, headers=headers, json=payload)
         except httpx.TimeoutException as exc:
             return self._build_transport_error_result(
                 config=config,
@@ -1846,7 +1682,7 @@ class ModelConnectivityProbeService:
             retryable=retryable,
         )
 
-    def _get_codeagent_token_for_probe(
+    async def _get_codeagent_token_for_probe_async(
         self,
         *,
         config: ModelEndpointConfig,
@@ -1859,7 +1695,7 @@ class ModelConnectivityProbeService:
             auth_config = self._resolve_codeagent_auth_for_request(
                 self._require_codeagent_auth_config(config.codeagent_auth)
             )
-            return get_codeagent_token_service().get_token_sync(
+            return await get_codeagent_token_service().get_token(
                 base_url=config.base_url,
                 auth_config=auth_config,
                 ssl_verify=config.ssl_verify,
@@ -1890,7 +1726,7 @@ class ModelConnectivityProbeService:
                 error=exc,
             )
 
-    def _get_codeagent_token_for_verify(
+    async def _get_codeagent_token_for_verify_async(
         self,
         *,
         config: ModelEndpointConfig,
@@ -1901,7 +1737,7 @@ class ModelConnectivityProbeService:
             auth_config = self._resolve_codeagent_auth_for_request(
                 self._require_codeagent_auth_config(config.codeagent_auth)
             )
-            return get_codeagent_token_service().get_token_sync(
+            return await get_codeagent_token_service().get_token(
                 base_url=config.base_url,
                 auth_config=auth_config,
                 ssl_verify=config.ssl_verify,
@@ -1931,7 +1767,7 @@ class ModelConnectivityProbeService:
                 detail=str(exc) or "CodeAgent OAuth request failed.",
             )
 
-    def _get_codeagent_token_for_discovery(
+    async def _get_codeagent_token_for_discovery_async(
         self,
         *,
         config: ModelDiscoveryResolvedConfig,
@@ -1944,7 +1780,7 @@ class ModelConnectivityProbeService:
             auth_config = self._resolve_codeagent_auth_for_request(
                 self._require_codeagent_auth_config(config.codeagent_auth)
             )
-            return get_codeagent_token_service().get_token_sync(
+            return await get_codeagent_token_service().get_token(
                 base_url=config.base_url,
                 auth_config=auth_config,
                 ssl_verify=config.ssl_verify,
@@ -2031,7 +1867,7 @@ class ModelConnectivityProbeService:
         return auth_config
 
     @staticmethod
-    def _send_codeagent_auth_verify_request(
+    async def _send_codeagent_auth_verify_request_async(
         *,
         config: ModelEndpointConfig,
         checked_at: datetime,
@@ -2039,12 +1875,12 @@ class ModelConnectivityProbeService:
     ) -> httpx.Response | CodeAgentAuthVerifyResult:
         endpoint = f"{config.base_url.rstrip('/')}/chat/modles?checkUserPermission=TRUE"
         try:
-            with create_sync_http_client(
+            async with create_async_http_client(
                 timeout_seconds=config.connect_timeout_seconds,
                 connect_timeout_seconds=config.connect_timeout_seconds,
                 ssl_verify=config.ssl_verify,
             ) as client:
-                return client.get(
+                return await client.get(
                     endpoint,
                     headers=build_codeagent_request_headers(token=token),
                 )

--- a/tests/unit_tests/gateway/test_xiaoluban_im.py
+++ b/tests/unit_tests/gateway/test_xiaoluban_im.py
@@ -88,7 +88,8 @@ def test_xiaoluban_account_create_persists_im_config_in_one_request(
     assert loaded.im_config.workspace_id == "im-workspace"
 
 
-def test_xiaoluban_account_update_persists_im_config_in_one_request(
+@pytest.mark.asyncio
+async def test_xiaoluban_account_update_persists_im_config_in_one_request(
     tmp_path: Path,
 ) -> None:
     service = _build_service(tmp_path)
@@ -112,7 +113,8 @@ def test_xiaoluban_account_update_persists_im_config_in_one_request(
     assert loaded.im_config.workspace_id == "im-workspace"
 
 
-def test_handle_im_inbound_starts_run_and_replies_terminal_output(
+@pytest.mark.asyncio
+async def test_handle_im_inbound_starts_run_and_replies_terminal_output(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -137,7 +139,7 @@ def test_handle_im_inbound_starts_run_and_replies_terminal_output(
         XiaolubanImConfigUpdateInput(workspace_id="im-workspace"),
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="inspect this repo",
@@ -154,7 +156,7 @@ def test_handle_im_inbound_starts_run_and_replies_terminal_output(
     assert fake_ingress.requests[0].intent.intent == "inspect this repo"
     assert fake_ingress.requests[0].intent.session_id == "session-1"
     assert fake_client.keep_alive_calls == [("uidself", "session-1")]
-    service._drain_im_replies()
+    await service._drain_im_replies_async()
     assert fake_client.sent_messages[-1] == (
         _formatted_xiaoluban_text(
             session_id="session-1",
@@ -166,7 +168,8 @@ def test_handle_im_inbound_starts_run_and_replies_terminal_output(
     assert service.should_suppress_xiaoluban_terminal_notification("run-1") is True
 
 
-def test_handle_im_inbound_reuses_gateway_session_for_same_xiaoluban_session(
+@pytest.mark.asyncio
+async def test_handle_im_inbound_reuses_gateway_session_for_same_xiaoluban_session(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -180,7 +183,7 @@ def test_handle_im_inbound_reuses_gateway_session_for_same_xiaoluban_session(
     )
 
     for text in ("first task", "second task"):
-        service.handle_im_inbound(
+        await service.handle_im_inbound_async(
             account_id=account.account_id,
             message=XiaolubanInboundMessage(
                 content=text,
@@ -206,7 +209,10 @@ def test_handle_im_inbound_reuses_gateway_session_for_same_xiaoluban_session(
     ]
 
 
-def test_handle_im_inbound_empty_input_sends_hint_without_run(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_handle_im_inbound_empty_input_sends_hint_without_run(
+    tmp_path: Path,
+) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -217,7 +223,7 @@ def test_handle_im_inbound_empty_input_sends_hint_without_run(tmp_path: Path) ->
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="   ",
@@ -238,7 +244,8 @@ def test_handle_im_inbound_empty_input_sends_hint_without_run(tmp_path: Path) ->
     )
 
 
-def test_handle_im_inbound_busy_session_replies_without_second_run(
+@pytest.mark.asyncio
+async def test_handle_im_inbound_busy_session_replies_without_second_run(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -251,7 +258,7 @@ def test_handle_im_inbound_busy_session_replies_without_second_run(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="inspect this repo",
@@ -272,7 +279,8 @@ def test_handle_im_inbound_busy_session_replies_without_second_run(
     )
 
 
-def test_handle_im_inbound_rejected_submit_replies_busy(
+@pytest.mark.asyncio
+async def test_handle_im_inbound_rejected_submit_replies_busy(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -285,7 +293,7 @@ def test_handle_im_inbound_rejected_submit_replies_busy(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="inspect this repo",
@@ -642,7 +650,8 @@ class _FakeIngressService:
         )
 
 
-def test_handle_im_inbound_fallback_session_id_without_session_id_param(
+@pytest.mark.asyncio
+async def test_handle_im_inbound_fallback_session_id_without_session_id_param(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -655,7 +664,7 @@ def test_handle_im_inbound_fallback_session_id_without_session_id_param(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="inspect this repo",
@@ -740,14 +749,18 @@ def test_get_im_callback_auth_token_disabled_account(tmp_path: Path) -> None:
         service.get_im_callback_auth_token(account.account_id)
 
 
-def test_should_suppress_empty_run_id(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_should_suppress_empty_run_id(tmp_path: Path) -> None:
     service = _build_service(tmp_path)
 
     assert service.should_suppress_xiaoluban_terminal_notification("") is False
     assert service.should_suppress_xiaoluban_terminal_notification(None) is False
 
 
-def test_handle_im_inbound_missing_gateway_session_service(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_handle_im_inbound_missing_gateway_session_service(
+    tmp_path: Path,
+) -> None:
     service = XiaolubanGatewayService(
         config_dir=tmp_path,
         repository=XiaolubanAccountRepository(tmp_path / "xiaoluban.db"),
@@ -769,7 +782,7 @@ def test_handle_im_inbound_missing_gateway_session_service(tmp_path: Path) -> No
         XiaolubanImConfigUpdateInput(workspace_id="im-workspace"),
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="hello",
@@ -780,7 +793,8 @@ def test_handle_im_inbound_missing_gateway_session_service(tmp_path: Path) -> No
     )
 
 
-def test_handle_im_inbound_missing_run_and_ingress(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_handle_im_inbound_missing_run_and_ingress(tmp_path: Path) -> None:
     fake_gateway_sessions = _FakeGatewaySessionService()
     service = XiaolubanGatewayService(
         config_dir=tmp_path,
@@ -803,7 +817,7 @@ def test_handle_im_inbound_missing_run_and_ingress(tmp_path: Path) -> None:
         XiaolubanImConfigUpdateInput(workspace_id="im-workspace"),
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="hello",
@@ -814,7 +828,8 @@ def test_handle_im_inbound_missing_run_and_ingress(tmp_path: Path) -> None:
     )
 
 
-def test_handle_im_inbound_missing_workspace_id(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_handle_im_inbound_missing_workspace_id(tmp_path: Path) -> None:
     fake_gateway_sessions = _FakeGatewaySessionService()
     service = XiaolubanGatewayService(
         config_dir=tmp_path,
@@ -834,7 +849,7 @@ def test_handle_im_inbound_missing_workspace_id(tmp_path: Path) -> None:
         )
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="hello",
@@ -845,7 +860,8 @@ def test_handle_im_inbound_missing_workspace_id(tmp_path: Path) -> None:
     )
 
 
-def test_handle_im_inbound_missing_token(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_handle_im_inbound_missing_token(tmp_path: Path) -> None:
     fake_store = _FakeSecretStore()
     fake_gateway_sessions = _FakeGatewaySessionService()
     service = XiaolubanGatewayService(
@@ -871,7 +887,7 @@ def test_handle_im_inbound_missing_token(tmp_path: Path) -> None:
     )
     fake_store.tokens.clear()
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="hello",
@@ -882,7 +898,8 @@ def test_handle_im_inbound_missing_token(tmp_path: Path) -> None:
     )
 
 
-def test_start_im_run_via_run_service(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_start_im_run_via_run_service(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     event_log = _FakeEventLog()
@@ -909,7 +926,7 @@ def test_start_im_run_via_run_service(tmp_path: Path) -> None:
         XiaolubanImConfigUpdateInput(workspace_id="im-workspace"),
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="hello",
@@ -1022,7 +1039,8 @@ def test_resolve_im_config_requires_workspace_id(tmp_path: Path) -> None:
         )
 
 
-def test_resolve_im_config_default_without_workspace_id(
+@pytest.mark.asyncio
+async def test_resolve_im_config_default_without_workspace_id(
     tmp_path: Path,
 ) -> None:
     service = _build_service(tmp_path)
@@ -1032,7 +1050,8 @@ def test_resolve_im_config_default_without_workspace_id(
     assert result.workspace_id is None
 
 
-def test_start_im_run_via_create_detached_run(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_start_im_run_via_create_detached_run(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     event_log = _FakeEventLog()
@@ -1059,7 +1078,7 @@ def test_start_im_run_via_create_detached_run(tmp_path: Path) -> None:
         XiaolubanImConfigUpdateInput(workspace_id="im-workspace"),
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="hello",
@@ -1077,7 +1096,8 @@ def test_start_im_run_via_create_detached_run(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_command_new_creates_session_and_sends_reply(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_command_new_creates_session_and_sends_reply(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1088,7 +1108,7 @@ def test_command_new_creates_session_and_sends_reply(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/new",
@@ -1107,7 +1127,8 @@ def test_command_new_creates_session_and_sends_reply(tmp_path: Path) -> None:
     assert resolved_ids[0].startswith(base_id + ":")
 
 
-def test_command_new_with_task_creates_session_and_starts_run(
+@pytest.mark.asyncio
+async def test_command_new_with_task_creates_session_and_starts_run(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1120,7 +1141,7 @@ def test_command_new_with_task_creates_session_and_starts_run(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/new 帮我看一下这个项目",
@@ -1139,7 +1160,8 @@ def test_command_new_with_task_creates_session_and_starts_run(
     assert resolved_ids[0].startswith(base_id + ":")
 
 
-def test_command_new_routes_subsequent_messages(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_command_new_routes_subsequent_messages(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1150,7 +1172,7 @@ def test_command_new_routes_subsequent_messages(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/new",
@@ -1159,7 +1181,7 @@ def test_command_new_routes_subsequent_messages(tmp_path: Path) -> None:
             session_id="welink-session-1",
         ),
     )
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="继续做任务",
@@ -1178,7 +1200,8 @@ def test_command_new_routes_subsequent_messages(tmp_path: Path) -> None:
     assert fake_ingress.requests[0].intent.intent == "继续做任务"
 
 
-def test_command_resume_lists_sessions(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_command_resume_lists_sessions(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1189,7 +1212,7 @@ def test_command_resume_lists_sessions(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/new",
@@ -1199,7 +1222,7 @@ def test_command_resume_lists_sessions(tmp_path: Path) -> None:
         ),
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/resume",
@@ -1214,7 +1237,8 @@ def test_command_resume_lists_sessions(tmp_path: Path) -> None:
     assert "/resume" in list_message
 
 
-def test_command_resume_by_session_id_switches_session(
+@pytest.mark.asyncio
+async def test_command_resume_by_session_id_switches_session(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1227,7 +1251,7 @@ def test_command_resume_by_session_id_switches_session(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/new",
@@ -1239,7 +1263,7 @@ def test_command_resume_by_session_id_switches_session(
     new_call = fake_gateway_sessions.resolved_calls[0]
     target_internal_id = new_call.internal_session_id
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content=f"/resume {target_internal_id}",
@@ -1252,7 +1276,7 @@ def test_command_resume_by_session_id_switches_session(
     switch_reply = fake_client.sent_messages[-1][0]
     assert "已切换到会话" in switch_reply
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="在旧会话继续",
@@ -1264,7 +1288,8 @@ def test_command_resume_by_session_id_switches_session(
     assert fake_ingress.requests[0].intent.session_id == target_internal_id
 
 
-def test_command_resume_by_index_switches_session(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_command_resume_by_index_switches_session(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1275,7 +1300,7 @@ def test_command_resume_by_index_switches_session(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/new",
@@ -1285,7 +1310,7 @@ def test_command_resume_by_index_switches_session(tmp_path: Path) -> None:
         ),
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/resume 1",
@@ -1298,7 +1323,8 @@ def test_command_resume_by_index_switches_session(tmp_path: Path) -> None:
     assert "已切换到会话" in fake_client.sent_messages[-1][0]
 
 
-def test_command_resume_binds_existing_internal_session(
+@pytest.mark.asyncio
+async def test_command_resume_binds_existing_internal_session(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1318,7 +1344,7 @@ def test_command_resume_binds_existing_internal_session(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/resume session-existing",
@@ -1327,7 +1353,7 @@ def test_command_resume_binds_existing_internal_session(
             session_id="welink-session-1",
         ),
     )
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="继续这个会话",
@@ -1349,7 +1375,8 @@ def test_command_resume_binds_existing_internal_session(
     assert fake_ingress.requests[0].intent.session_id == "session-existing"
 
 
-def test_command_resume_ignores_stale_gateway_session(
+@pytest.mark.asyncio
+async def test_command_resume_ignores_stale_gateway_session(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1370,7 +1397,7 @@ def test_command_resume_ignores_stale_gateway_session(
         internal_session_id="session-stale",
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/resume session-stale",
@@ -1384,7 +1411,8 @@ def test_command_resume_ignores_stale_gateway_session(
     assert fake_gateway_sessions.bound_internal_calls == []
 
 
-def test_command_resume_rejects_stale_existing_gateway_binding(
+@pytest.mark.asyncio
+async def test_command_resume_rejects_stale_existing_gateway_binding(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1420,7 +1448,8 @@ def test_command_resume_rejects_stale_existing_gateway_binding(
     assert result is None
 
 
-def test_command_resume_invalid_session_shows_error(
+@pytest.mark.asyncio
+async def test_command_resume_invalid_session_shows_error(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1433,7 +1462,7 @@ def test_command_resume_invalid_session_shows_error(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/resume nonexistent",
@@ -1446,7 +1475,8 @@ def test_command_resume_invalid_session_shows_error(
     assert "未找到会话" in fake_client.sent_messages[-1][0]
 
 
-def test_command_help_shows_help_text(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_command_help_shows_help_text(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1457,7 +1487,7 @@ def test_command_help_shows_help_text(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/help",
@@ -1473,7 +1503,8 @@ def test_command_help_shows_help_text(tmp_path: Path) -> None:
     assert "/help" in help_message
 
 
-def test_slash_only_command_shows_help(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_slash_only_command_shows_help(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1484,7 +1515,7 @@ def test_slash_only_command_shows_help(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/   ",
@@ -1500,7 +1531,8 @@ def test_slash_only_command_shows_help(tmp_path: Path) -> None:
     assert fake_ingress.requests == []
 
 
-def test_normal_message_sends_ack_after_run_submit(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_normal_message_sends_ack_after_run_submit(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1511,7 +1543,7 @@ def test_normal_message_sends_ack_after_run_submit(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="帮我分析一下",
@@ -1527,7 +1559,8 @@ def test_normal_message_sends_ack_after_run_submit(tmp_path: Path) -> None:
     assert len(fake_ingress.requests) == 1
 
 
-def test_processing_ack_failure_keeps_terminal_reply_registered(
+@pytest.mark.asyncio
+async def test_processing_ack_failure_keeps_terminal_reply_registered(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient(fail_send_when_contains="处理中")
@@ -1540,7 +1573,7 @@ def test_processing_ack_failure_keeps_terminal_reply_registered(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="帮我分析一下",
@@ -1553,7 +1586,7 @@ def test_processing_ack_failure_keeps_terminal_reply_registered(
     assert len(fake_ingress.requests) == 1
     assert fake_gateway_sessions.bound_runs == [("gws-session-1", "run-1")]
     assert fake_client.sent_messages == []
-    service._drain_im_replies()
+    await service._drain_im_replies_async()
     assert fake_client.sent_messages[-1] == (
         _formatted_xiaoluban_text(
             session_id="session-1",
@@ -1564,7 +1597,10 @@ def test_processing_ack_failure_keeps_terminal_reply_registered(
     )
 
 
-def test_submit_rejection_sends_busy_without_processing_ack(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_submit_rejection_sends_busy_without_processing_ack(
+    tmp_path: Path,
+) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService(reject_submit=True)
@@ -1575,7 +1611,7 @@ def test_submit_rejection_sends_busy_without_processing_ack(tmp_path: Path) -> N
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="帮我分析一下",
@@ -1591,7 +1627,8 @@ def test_submit_rejection_sends_busy_without_processing_ack(tmp_path: Path) -> N
     assert "处理中" not in fake_client.sent_messages[-1][0]
 
 
-def test_non_slash_text_not_treated_as_command(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_non_slash_text_not_treated_as_command(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1602,7 +1639,7 @@ def test_non_slash_text_not_treated_as_command(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="用 /new 语法 ...",
@@ -1618,7 +1655,8 @@ def test_non_slash_text_not_treated_as_command(tmp_path: Path) -> None:
     assert fake_gateway_sessions.resolved_calls[0].external_session_id == base_id
 
 
-def test_command_new_without_platform_session_id_isolated_by_peer(
+@pytest.mark.asyncio
+async def test_command_new_without_platform_session_id_isolated_by_peer(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1631,7 +1669,7 @@ def test_command_new_without_platform_session_id_isolated_by_peer(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/new",
@@ -1640,7 +1678,7 @@ def test_command_new_without_platform_session_id_isolated_by_peer(
             session_id="",
         ),
     )
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="sender b task",
@@ -1659,7 +1697,8 @@ def test_command_new_without_platform_session_id_isolated_by_peer(
     assert fake_ingress.requests[0].intent.intent == "sender b task"
 
 
-def test_command_resume_without_existing_sessions(
+@pytest.mark.asyncio
+async def test_command_resume_without_existing_sessions(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1672,7 +1711,7 @@ def test_command_resume_without_existing_sessions(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/resume",
@@ -1761,7 +1800,8 @@ async def test_command_resume_replies_unavailable_without_gateway_sessions(
     assert fake_client.sent_messages[-1][1] == "uidself"
 
 
-def test_command_resume_by_prefix_match(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_command_resume_by_prefix_match(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService()
@@ -1772,7 +1812,7 @@ def test_command_resume_by_prefix_match(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/new",
@@ -1784,7 +1824,7 @@ def test_command_resume_by_prefix_match(tmp_path: Path) -> None:
     target_internal_id = fake_gateway_sessions.resolved_calls[0].internal_session_id
     prefix = target_internal_id[:6]
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content=f"/resume {prefix}",
@@ -1797,7 +1837,8 @@ def test_command_resume_by_prefix_match(tmp_path: Path) -> None:
     assert "已切换到会话" in fake_client.sent_messages[-1][0]
 
 
-def test_handle_im_inbound_unknown_command_routes_as_task(
+@pytest.mark.asyncio
+async def test_handle_im_inbound_unknown_command_routes_as_task(
     tmp_path: Path,
 ) -> None:
     fake_client = _FakeXiaolubanClient()
@@ -1810,7 +1851,7 @@ def test_handle_im_inbound_unknown_command_routes_as_task(
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="/some-unknown-command 参数",
@@ -1824,7 +1865,8 @@ def test_handle_im_inbound_unknown_command_routes_as_task(
     assert fake_ingress.requests[0].intent.intent == "/some-unknown-command 参数"
 
 
-def test_handle_im_inbound_busy_does_not_send_ack(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_handle_im_inbound_busy_does_not_send_ack(tmp_path: Path) -> None:
     fake_client = _FakeXiaolubanClient()
     fake_gateway_sessions = _FakeGatewaySessionService()
     fake_ingress = _FakeIngressService(active_run_id="run-active")
@@ -1835,7 +1877,7 @@ def test_handle_im_inbound_busy_does_not_send_ack(tmp_path: Path) -> None:
         session_ingress_service=fake_ingress,
     )
 
-    service.handle_im_inbound(
+    await service.handle_im_inbound_async(
         account_id=account.account_id,
         message=XiaolubanInboundMessage(
             content="帮我分析一下",

--- a/tests/unit_tests/gateway/test_xiaoluban_im_listener.py
+++ b/tests/unit_tests/gateway/test_xiaoluban_im_listener.py
@@ -21,7 +21,7 @@ class _FakeInboundHandler:
         self.calls: list[tuple[str, XiaolubanInboundMessage]] = []
         self.callback_tokens: dict[str, str] = {}
 
-    def handle_im_inbound(
+    async def handle_im_inbound_async(
         self,
         *,
         account_id: str,

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from collections.abc import Awaitable
 from typing import Callable, cast
 from datetime import UTC, datetime, timedelta
 from urllib.parse import parse_qs, urlparse
@@ -145,6 +146,8 @@ class _FakeSystemService:
             None
         )
         self.last_verified_codeagent_profile_name: str | None = None
+        self.last_model_probe_request: ModelConnectivityProbeRequest | None = None
+        self.last_model_discovery_request: ModelDiscoveryRequest | None = None
         self.codeagent_auth_verify_result = CodeAgentAuthVerifyResult(
             status="valid",
             checked_at=datetime.now(UTC),
@@ -292,6 +295,11 @@ class _FakeSystemService:
             stale=refresh,
             providers=(),
         )
+
+    async def get_model_catalog_async(
+        self, *, refresh: bool = False
+    ) -> ModelCatalogResult:
+        return self.get_model_catalog(refresh=refresh)
 
     def save_model_profile(
         self,
@@ -733,6 +741,15 @@ class _FakeSystemService:
             }
         )
 
+    async def probe_connectivity_async(
+        self,
+        request: ModelConnectivityProbeRequest,
+    ) -> ModelConnectivityProbeResult:
+        self.last_model_probe_request = request
+        result = self.probe_connectivity(request)
+        assert isinstance(result, ModelConnectivityProbeResult)
+        return result
+
     def probe(
         self,
         request: object,
@@ -762,6 +779,8 @@ class _FakeSystemService:
         self,
         _request: object,
     ) -> ModelDiscoveryResult:
+        assert isinstance(_request, ModelDiscoveryRequest)
+        self.last_model_discovery_request = _request
         return ModelDiscoveryResult.model_validate(
             {
                 "ok": True,
@@ -779,6 +798,12 @@ class _FakeSystemService:
             }
         )
 
+    async def discover_models_async(
+        self,
+        request: ModelDiscoveryRequest,
+    ) -> ModelDiscoveryResult:
+        return self.discover_models(request)
+
     def verify_codeagent_auth(
         self,
         *,
@@ -786,6 +811,13 @@ class _FakeSystemService:
     ) -> CodeAgentAuthVerifyResult:
         self.last_verified_codeagent_profile_name = profile_name
         return self.codeagent_auth_verify_result
+
+    async def verify_codeagent_auth_async(
+        self,
+        *,
+        profile_name: str,
+    ) -> CodeAgentAuthVerifyResult:
+        return self.verify_codeagent_auth(profile_name=profile_name)
 
     def probe_webhook_connectivity(
         self,
@@ -1302,7 +1334,6 @@ def test_sync_system_read_routes_run_service_calls_in_threadpool(monkeypatch) ->
         "get_model_config",
         "get_model_profiles",
         "get_model_fallback_config",
-        "get_model_catalog",
         "get_provider_models",
         "get_notification_config",
         "get_saved_proxy_config",
@@ -1504,7 +1535,6 @@ def test_sync_system_write_routes_run_service_calls_in_threadpool(monkeypatch) -
         "delete_skill",
         "save_orchestration_config",
         "reload_model_config",
-        "get_model_catalog",
         "reload_proxy_config",
         "reload_mcp_config",
         "reload_skills_config",
@@ -2424,29 +2454,30 @@ def test_probe_model_connectivity() -> None:
     assert payload["token_usage"]["total_tokens"] == 9
 
 
-def test_probe_model_connectivity_runs_service_call_in_threadpool(
+def test_probe_model_connectivity_runs_service_call_in_network_probe_wrapper(
     monkeypatch,
 ) -> None:
     calls: list[ModelConnectivityProbeRequest] = []
 
-    async def fake_to_thread(
+    async def fake_network_probe(
         operation: str,
         func: Callable[
             [ModelConnectivityProbeRequest],
-            ModelConnectivityProbeResult,
+            Awaitable[ModelConnectivityProbeResult],
         ],
         request: ModelConnectivityProbeRequest,
     ) -> ModelConnectivityProbeResult:
         assert operation == "model.probe_connectivity"
         calls.append(request)
-        return func(request)
+        return await func(request)
 
     monkeypatch.setattr(
         system,
         "call_maybe_async_in_network_probe_thread",
-        fake_to_thread,
+        fake_network_probe,
     )
-    client = _create_test_client(_FakeSystemService())
+    service = _FakeSystemService()
+    client = _create_test_client(service)
 
     response = client.post(
         "/api/system/configs/model:probe",
@@ -2455,6 +2486,8 @@ def test_probe_model_connectivity_runs_service_call_in_threadpool(
 
     assert response.status_code == 200
     assert [call.profile_name for call in calls] == ["default"]
+    assert service.last_model_probe_request is not None
+    assert service.last_model_probe_request.profile_name == "default"
 
 
 def test_discover_model_catalog() -> None:
@@ -2477,26 +2510,27 @@ def test_discover_model_catalog() -> None:
     assert payload["models"] == ["fake-chat-model", "reasoning-model"]
 
 
-def test_discover_model_catalog_runs_service_call_in_threadpool(
+def test_discover_model_catalog_runs_service_call_in_network_probe_wrapper(
     monkeypatch,
 ) -> None:
     calls: list[ModelDiscoveryRequest] = []
 
-    async def fake_to_thread(
+    async def fake_network_probe(
         operation: str,
-        func: Callable[[ModelDiscoveryRequest], ModelDiscoveryResult],
+        func: Callable[[ModelDiscoveryRequest], Awaitable[ModelDiscoveryResult]],
         request: ModelDiscoveryRequest,
     ) -> ModelDiscoveryResult:
         assert operation == "model.discover_models"
         calls.append(request)
-        return func(request)
+        return await func(request)
 
     monkeypatch.setattr(
         system,
         "call_maybe_async_in_network_probe_thread",
-        fake_to_thread,
+        fake_network_probe,
     )
-    client = _create_test_client(_FakeSystemService())
+    service = _FakeSystemService()
+    client = _create_test_client(service)
 
     response = client.post(
         "/api/system/configs/model:discover",
@@ -2505,6 +2539,8 @@ def test_discover_model_catalog_runs_service_call_in_threadpool(
 
     assert response.status_code == 200
     assert [call.profile_name for call in calls] == ["default"]
+    assert service.last_model_discovery_request is not None
+    assert service.last_model_discovery_request.profile_name == "default"
 
 
 def test_reload_model_config_returns_bad_request_for_invalid_config() -> None:
@@ -3238,7 +3274,7 @@ def test_codeagent_oauth_status_polls_until_token_available(monkeypatch) -> None
         def __init__(self) -> None:
             self.calls = 0
 
-        def poll_token_sync(
+        async def poll_token(
             self,
             *,
             session: object,
@@ -3331,7 +3367,7 @@ def test_codeagent_oauth_status_returns_bad_gateway_for_transport_errors(
     request = httpx.Request("POST", "https://codeagent.example/codeAgentPro")
 
     class _FakeCodeAgentTokenService:
-        def poll_token_sync(
+        async def poll_token(
             self,
             *,
             session: object,
@@ -3369,7 +3405,7 @@ def test_codeagent_oauth_status_returns_gateway_timeout_for_poll_timeouts(
     request = httpx.Request("POST", "https://codeagent.example/codeAgentPro")
 
     class _FakeCodeAgentTokenService:
-        def poll_token_sync(
+        async def poll_token(
             self,
             *,
             session: object,
@@ -3406,7 +3442,7 @@ def test_codeagent_oauth_status_preserves_explicit_oauth_error_status(
     payload = start_response.json()
 
     class _FakeCodeAgentTokenService:
-        def poll_token_sync(
+        async def poll_token(
             self,
             *,
             session: object,
@@ -3456,7 +3492,7 @@ def test_verify_codeagent_auth_returns_service_result() -> None:
 
 def test_verify_codeagent_auth_returns_bad_request_for_validation_errors() -> None:
     class _InvalidCodeAgentService(_FakeSystemService):
-        def verify_codeagent_auth(
+        async def verify_codeagent_auth_async(
             self,
             *,
             profile_name: str,

--- a/tests/unit_tests/providers/test_codeagent_auth.py
+++ b/tests/unit_tests/providers/test_codeagent_auth.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from threading import Lock
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
@@ -95,7 +94,8 @@ def test_codeagent_token_result_tracks_token_expiry() -> None:
     assert token_result.expires_at == expires_at
 
 
-def test_poll_token_sync_posts_client_code_json(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_poll_token_posts_client_code_json(monkeypatch) -> None:
     session = create_codeagent_oauth_session(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         client_id=DEFAULT_CODEAGENT_CLIENT_ID,
@@ -105,13 +105,13 @@ def test_poll_token_sync_posts_client_code_json(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     class _FakeHttpClient:
-        def __enter__(self) -> "_FakeHttpClient":
+        async def __aenter__(self) -> "_FakeHttpClient":
             return self
 
-        def __exit__(self, *exc_info: object) -> None:
+        async def __aexit__(self, *exc_info: object) -> None:
             return None
 
-        def post(
+        async def post(
             self,
             url: str,
             *,
@@ -131,11 +131,11 @@ def test_poll_token_sync_posts_client_code_json(monkeypatch) -> None:
             )
 
     monkeypatch.setattr(
-        "relay_teams.providers.codeagent_auth.create_sync_http_client",
+        "relay_teams.providers.codeagent_auth.create_async_http_client",
         lambda **kwargs: _FakeHttpClient(),
     )
 
-    token_result = CodeAgentTokenService().poll_token_sync(
+    token_result = await CodeAgentTokenService().poll_token(
         session=session,
         ssl_verify=None,
         connect_timeout_seconds=15.0,
@@ -151,7 +151,8 @@ def test_poll_token_sync_posts_client_code_json(monkeypatch) -> None:
     assert captured["headers"] == {"Content-Type": "application/json"}
 
 
-def test_poll_token_sync_returns_none_until_token_available(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_poll_token_returns_none_until_token_available(monkeypatch) -> None:
     session = create_codeagent_oauth_session(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         client_id=DEFAULT_CODEAGENT_CLIENT_ID,
@@ -160,13 +161,13 @@ def test_poll_token_sync_returns_none_until_token_available(monkeypatch) -> None
     )
 
     class _FakeHttpClient:
-        def __enter__(self) -> "_FakeHttpClient":
+        async def __aenter__(self) -> "_FakeHttpClient":
             return self
 
-        def __exit__(self, *exc_info: object) -> None:
+        async def __aexit__(self, *exc_info: object) -> None:
             return None
 
-        def post(
+        async def post(
             self,
             url: str,
             *,
@@ -179,12 +180,12 @@ def test_poll_token_sync_returns_none_until_token_available(monkeypatch) -> None
             return httpx.Response(200, json={"message": "pending"})
 
     monkeypatch.setattr(
-        "relay_teams.providers.codeagent_auth.create_sync_http_client",
+        "relay_teams.providers.codeagent_auth.create_async_http_client",
         lambda **kwargs: _FakeHttpClient(),
     )
 
     assert (
-        CodeAgentTokenService().poll_token_sync(
+        await CodeAgentTokenService().poll_token(
             session=session,
             ssl_verify=None,
             connect_timeout_seconds=15.0,
@@ -193,7 +194,8 @@ def test_poll_token_sync_returns_none_until_token_available(monkeypatch) -> None
     )
 
 
-def test_poll_token_sync_raises_for_http_error_response(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_poll_token_raises_for_http_error_response(monkeypatch) -> None:
     session = create_codeagent_oauth_session(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         client_id=DEFAULT_CODEAGENT_CLIENT_ID,
@@ -202,13 +204,13 @@ def test_poll_token_sync_raises_for_http_error_response(monkeypatch) -> None:
     )
 
     class _FakeHttpClient:
-        def __enter__(self) -> "_FakeHttpClient":
+        async def __aenter__(self) -> "_FakeHttpClient":
             return self
 
-        def __exit__(self, *exc_info: object) -> None:
+        async def __aexit__(self, *exc_info: object) -> None:
             return None
 
-        def post(
+        async def post(
             self,
             url: str,
             *,
@@ -222,19 +224,20 @@ def test_poll_token_sync_raises_for_http_error_response(monkeypatch) -> None:
             )
 
     monkeypatch.setattr(
-        "relay_teams.providers.codeagent_auth.create_sync_http_client",
+        "relay_teams.providers.codeagent_auth.create_async_http_client",
         lambda **kwargs: _FakeHttpClient(),
     )
 
     with pytest.raises(CodeAgentOAuthError, match="oauth upstream unavailable"):
-        CodeAgentTokenService().poll_token_sync(
+        await CodeAgentTokenService().poll_token(
             session=session,
             ssl_verify=None,
             connect_timeout_seconds=15.0,
         )
 
 
-def test_codeagent_token_service_uses_configured_access_token_first(
+@pytest.mark.asyncio
+async def test_codeagent_token_service_uses_configured_access_token_first(
     monkeypatch,
 ) -> None:
     def build_client(**kwargs: object) -> object:
@@ -242,11 +245,11 @@ def test_codeagent_token_service_uses_configured_access_token_first(
         raise AssertionError("refresh endpoint should not be called")
 
     monkeypatch.setattr(
-        "relay_teams.providers.codeagent_auth.create_sync_http_client",
+        "relay_teams.providers.codeagent_auth.create_async_http_client",
         build_client,
     )
 
-    token = CodeAgentTokenService().get_token_sync(
+    token = await CodeAgentTokenService().get_token(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         auth_config=CodeAgentAuthConfig(
             access_token="fresh-access-token",
@@ -259,13 +262,14 @@ def test_codeagent_token_service_uses_configured_access_token_first(
     assert token == "fresh-access-token"
 
 
-def test_codeagent_token_service_password_login_reuses_maas_token_service(
+@pytest.mark.asyncio
+async def test_codeagent_token_service_password_login_reuses_maas_token_service(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
 
     class _FakeMaaSTokenService:
-        def get_auth_context_sync(
+        async def get_auth_context(
             self,
             *,
             auth_config: object,
@@ -285,7 +289,7 @@ def test_codeagent_token_service_password_login_reuses_maas_token_service(
         lambda: _FakeMaaSTokenService(),
     )
 
-    token = CodeAgentTokenService().get_token_sync(
+    token = await CodeAgentTokenService().get_token(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         auth_config=CodeAgentAuthConfig(
             auth_method=CodeAgentAuthMethod.PASSWORD,
@@ -305,14 +309,15 @@ def test_codeagent_token_service_password_login_reuses_maas_token_service(
     assert captured["force_refresh"] is False
 
 
-def test_codeagent_token_service_password_login_sync_requires_username_and_password() -> (
+@pytest.mark.asyncio
+async def test_codeagent_token_service_password_login_requires_username_and_password() -> (
     None
 ):
     with pytest.raises(
         CodeAgentOAuthError,
         match="CodeAgent username/password is not configured.",
     ):
-        CodeAgentTokenService().get_token_result_sync(
+        await CodeAgentTokenService().get_token_result(
             base_url=DEFAULT_CODEAGENT_BASE_URL,
             auth_config=CodeAgentAuthConfig(
                 auth_method=CodeAgentAuthMethod.PASSWORD,
@@ -323,11 +328,12 @@ def test_codeagent_token_service_password_login_sync_requires_username_and_passw
         )
 
 
-def test_codeagent_token_service_password_login_sync_maps_maas_login_error(
+@pytest.mark.asyncio
+async def test_codeagent_token_service_password_login_maps_maas_login_error(
     monkeypatch,
 ) -> None:
     class _FailingMaaSTokenService:
-        def get_auth_context_sync(
+        def get_auth_context(
             self,
             *,
             auth_config: object,
@@ -345,7 +351,7 @@ def test_codeagent_token_service_password_login_sync_maps_maas_login_error(
     )
 
     with pytest.raises(CodeAgentOAuthError, match="password login denied") as exc_info:
-        CodeAgentTokenService().get_token_result_sync(
+        await CodeAgentTokenService().get_token_result(
             base_url=DEFAULT_CODEAGENT_BASE_URL,
             auth_config=CodeAgentAuthConfig(
                 auth_method=CodeAgentAuthMethod.PASSWORD,
@@ -359,7 +365,8 @@ def test_codeagent_token_service_password_login_sync_maps_maas_login_error(
     assert exc_info.value.status_code == 401
 
 
-def test_codeagent_token_service_get_token_result_sync_uses_cached_result() -> None:
+@pytest.mark.asyncio
+async def test_codeagent_token_service_get_token_result_uses_cached_result() -> None:
     service = CodeAgentTokenService()
     auth_config = CodeAgentAuthConfig(refresh_token="refresh-token")
     token_result = CodeAgentOAuthTokenResult(
@@ -375,7 +382,7 @@ def test_codeagent_token_service_get_token_result_sync_uses_cached_result() -> N
         token_result=token_result
     )
 
-    result = service.get_token_result_sync(
+    result = await service.get_token_result(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         auth_config=auth_config,
         ssl_verify=None,
@@ -398,50 +405,6 @@ def test_codeagent_token_service_token_result_from_config_skips_password_auth() 
         )
         is None
     )
-
-
-def test_codeagent_token_service_get_token_result_sync_rechecks_cache_inside_lock(
-    monkeypatch,
-) -> None:
-    service = CodeAgentTokenService()
-    auth_config = CodeAgentAuthConfig(refresh_token="refresh-token")
-    cache_key = service._cache_key(
-        base_url=DEFAULT_CODEAGENT_BASE_URL,
-        auth_config=auth_config,
-    )
-    token_result = CodeAgentOAuthTokenResult(
-        access_token="late-access-token",
-        refresh_token="late-refresh-token",
-        expires_at=datetime.now(UTC) + timedelta(hours=1),
-    )
-
-    class _PrimingLock:
-        def __enter__(self) -> "_PrimingLock":
-            service._tokens[cache_key] = codeagent_auth_module._CodeAgentTokenRecord(
-                token_result=token_result
-            )
-            return self
-
-        def __exit__(self, *exc_info: object) -> None:
-            return None
-
-    monkeypatch.setattr(
-        service,
-        "refresh_token_sync",
-        lambda **_kwargs: (_ for _ in ()).throw(
-            AssertionError("refresh endpoint should not be called")
-        ),
-    )
-    service._sync_locks[cache_key] = cast(Lock, _PrimingLock())
-
-    result = service.get_token_result_sync(
-        base_url=DEFAULT_CODEAGENT_BASE_URL,
-        auth_config=auth_config,
-        ssl_verify=None,
-        connect_timeout_seconds=15.0,
-    )
-
-    assert result == token_result
 
 
 def test_codeagent_token_service_cache_key_includes_secret_owner_id() -> None:
@@ -471,7 +434,8 @@ def test_codeagent_token_service_cache_key_includes_secret_owner_id() -> None:
     assert profile_a_key != profile_b_key
 
 
-def test_codeagent_token_service_refreshes_with_rotated_refresh_token(
+@pytest.mark.asyncio
+async def test_codeagent_token_service_refreshes_with_rotated_refresh_token(
     monkeypatch,
 ) -> None:
     clear_codeagent_oauth_session_store()
@@ -507,13 +471,13 @@ def test_codeagent_token_service_refreshes_with_rotated_refresh_token(
     )
 
     class _FakeHttpClient:
-        def __enter__(self) -> "_FakeHttpClient":
+        async def __aenter__(self) -> "_FakeHttpClient":
             return self
 
-        def __exit__(self, *exc_info: object) -> None:
+        async def __aexit__(self, *exc_info: object) -> None:
             return None
 
-        def post(
+        async def post(
             self,
             url: str,
             *,
@@ -529,12 +493,12 @@ def test_codeagent_token_service_refreshes_with_rotated_refresh_token(
             return httpx.Response(200, json=next(refresh_responses))
 
     monkeypatch.setattr(
-        "relay_teams.providers.codeagent_auth.create_sync_http_client",
+        "relay_teams.providers.codeagent_auth.create_async_http_client",
         lambda **kwargs: _FakeHttpClient(),
     )
 
     service = CodeAgentTokenService()
-    token_result = service.get_token_result_sync(
+    token_result = await service.get_token_result(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         auth_config=CodeAgentAuthConfig(
             refresh_token="stale-refresh-token",
@@ -544,7 +508,7 @@ def test_codeagent_token_service_refreshes_with_rotated_refresh_token(
         connect_timeout_seconds=15.0,
         force_refresh=True,
     )
-    refreshed_again = service.get_token_result_sync(
+    refreshed_again = await service.get_token_result(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         auth_config=CodeAgentAuthConfig(
             refresh_token="stale-refresh-token",
@@ -570,7 +534,8 @@ def test_codeagent_token_service_refreshes_with_rotated_refresh_token(
     clear_codeagent_token_service_cache()
 
 
-def test_codeagent_token_service_persists_rotated_tokens_for_secret_owner(
+@pytest.mark.asyncio
+async def test_codeagent_token_service_persists_rotated_tokens_for_secret_owner(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -591,13 +556,13 @@ def test_codeagent_token_service_persists_rotated_tokens_for_secret_owner(
             )
 
     class _FakeHttpClient:
-        def __enter__(self) -> "_FakeHttpClient":
+        async def __aenter__(self) -> "_FakeHttpClient":
             return self
 
-        def __exit__(self, *exc_info: object) -> None:
+        async def __aexit__(self, *exc_info: object) -> None:
             return None
 
-        def post(
+        async def post(
             self,
             url: str,
             *,
@@ -619,11 +584,11 @@ def test_codeagent_token_service_persists_rotated_tokens_for_secret_owner(
         lambda: _FakeSecretStore(),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.codeagent_auth.create_sync_http_client",
+        "relay_teams.providers.codeagent_auth.create_async_http_client",
         lambda **kwargs: _FakeHttpClient(),
     )
 
-    token_result = CodeAgentTokenService().get_token_result_sync(
+    token_result = await CodeAgentTokenService().get_token_result(
         base_url=DEFAULT_CODEAGENT_BASE_URL,
         auth_config=CodeAgentAuthConfig(
             refresh_token="stale-refresh-token",
@@ -704,19 +669,6 @@ def test_build_codeagent_request_headers_uses_access_token() -> None:
     assert headers["Accept"] == "text/event-stream"
     assert headers["X-snap-traceid"]
     assert headers["X-session-id"].startswith("ses_")
-
-
-def test_codeagent_token_service_refresh_token_sync_requires_refresh_token() -> None:
-    with pytest.raises(
-        CodeAgentOAuthError,
-        match="CodeAgent refresh token is not configured.",
-    ):
-        CodeAgentTokenService().refresh_token_sync(
-            base_url=DEFAULT_CODEAGENT_BASE_URL,
-            auth_config=CodeAgentAuthConfig(),
-            ssl_verify=None,
-            connect_timeout_seconds=15.0,
-        )
 
 
 @pytest.mark.asyncio
@@ -1076,88 +1028,6 @@ def test_codeagent_token_service_store_token_result_persists_when_session_missin
             "stored-refresh-token",
         ),
     ]
-
-
-def test_codeagent_request_auth_sync_flow_retries_after_unauthorized() -> None:
-    calls: list[bool] = []
-
-    class _FakeTokenService:
-        def get_token_sync(
-            self,
-            *,
-            base_url: str,
-            auth_config: CodeAgentAuthConfig,
-            ssl_verify: bool | None,
-            connect_timeout_seconds: float,
-            force_refresh: bool = False,
-        ) -> str:
-            _ = (base_url, auth_config, ssl_verify, connect_timeout_seconds)
-            calls.append(force_refresh)
-            return "retry-token" if force_refresh else "initial-token"
-
-    request = httpx.Request(
-        "POST",
-        "https://codeagent.example/codeAgentPro/chat/completions",
-        content=b'{"model":"codeagent-chat"}',
-    )
-    auth = codeagent_auth_module.CodeAgentRequestAuth(
-        base_url=DEFAULT_CODEAGENT_BASE_URL,
-        auth_config=CodeAgentAuthConfig(refresh_token="refresh-token"),
-        ssl_verify=None,
-        connect_timeout_seconds=15.0,
-        token_service=cast(CodeAgentTokenService, _FakeTokenService()),
-    )
-
-    flow = auth.sync_auth_flow(request)
-    first_request = next(flow)
-    retry_request = flow.send(httpx.Response(401, request=first_request))
-
-    assert first_request.headers["X-Auth-Token"] == "initial-token"
-    assert retry_request.headers["X-Auth-Token"] == "retry-token"
-    assert calls == [False, True]
-
-    with pytest.raises(StopIteration):
-        flow.send(httpx.Response(200, request=retry_request))
-
-
-def test_codeagent_request_auth_sync_flow_stops_after_success() -> None:
-    calls: list[bool] = []
-
-    class _FakeTokenService:
-        def get_token_sync(
-            self,
-            *,
-            base_url: str,
-            auth_config: CodeAgentAuthConfig,
-            ssl_verify: bool | None,
-            connect_timeout_seconds: float,
-            force_refresh: bool = False,
-        ) -> str:
-            _ = (base_url, auth_config, ssl_verify, connect_timeout_seconds)
-            calls.append(force_refresh)
-            return "initial-token"
-
-    request = httpx.Request(
-        "POST",
-        "https://codeagent.example/codeAgentPro/chat/completions",
-        content=b'{"model":"codeagent-chat"}',
-    )
-    auth = codeagent_auth_module.CodeAgentRequestAuth(
-        base_url=DEFAULT_CODEAGENT_BASE_URL,
-        auth_config=CodeAgentAuthConfig(refresh_token="refresh-token"),
-        ssl_verify=None,
-        connect_timeout_seconds=15.0,
-        token_service=cast(CodeAgentTokenService, _FakeTokenService()),
-    )
-
-    flow = auth.sync_auth_flow(request)
-    first_request = next(flow)
-
-    with pytest.raises(StopIteration):
-        flow.send(httpx.Response(200, request=first_request))
-
-    assert first_request.headers["X-Auth-Token"] == "initial-token"
-    assert calls == [False]
 
 
 @pytest.mark.asyncio
@@ -1520,7 +1390,7 @@ def test_get_codeagent_token_service_returns_default_singleton() -> None:
 
 @pytest.mark.asyncio
 async def test_build_codeagent_openai_client_exposes_custom_auth() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx.AsyncClient(trust_env=False)
     try:
         client = codeagent_auth_module.build_codeagent_openai_client(
             base_url=DEFAULT_CODEAGENT_BASE_URL,

--- a/tests/unit_tests/providers/test_maas_auth.py
+++ b/tests/unit_tests/providers/test_maas_auth.py
@@ -5,6 +5,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 
 import httpx
+import pytest
 
 from relay_teams.providers.maas_auth import (
     MaaSTokenService,
@@ -13,18 +14,18 @@ from relay_teams.providers.maas_auth import (
 from relay_teams.providers.model_config import MaaSAuthConfig
 
 
-class _FakeSyncHttpClient:
+class _FakeAsyncHttpClient:
     def __init__(self, response: httpx.Response) -> None:
         self._response = response
         self.calls = 0
 
-    def __enter__(self) -> _FakeSyncHttpClient:
+    async def __aenter__(self) -> _FakeAsyncHttpClient:
         return self
 
-    def __exit__(self, *_args: object) -> None:
+    async def __aexit__(self, *_args: object) -> None:
         return None
 
-    def post(
+    async def post(
         self,
         url: str,
         *,
@@ -39,7 +40,7 @@ class _FakeSyncHttpClient:
 
 
 def test_build_maas_openai_client_disables_sdk_retries() -> None:
-    http_client = httpx.AsyncClient()
+    http_client = httpx.AsyncClient(trust_env=False)
     try:
         client = build_maas_openai_client(
             base_url="https://maas.example/api/v2",
@@ -57,10 +58,11 @@ def test_build_maas_openai_client_disables_sdk_retries() -> None:
         asyncio.run(http_client.aclose())
 
 
-def test_get_auth_context_sync_extracts_department_from_direct_field(
+@pytest.mark.asyncio
+async def test_get_auth_context_extracts_department_from_direct_field(
     monkeypatch,
 ) -> None:
-    client = _FakeSyncHttpClient(
+    client = _FakeAsyncHttpClient(
         httpx.Response(
             200,
             json={
@@ -72,11 +74,11 @@ def test_get_auth_context_sync_extracts_department_from_direct_field(
     service = MaaSTokenService()
 
     monkeypatch.setattr(
-        "relay_teams.providers.maas_auth.create_sync_http_client",
+        "relay_teams.providers.maas_auth.create_async_http_client",
         lambda **_kwargs: client,
     )
 
-    auth_context = service.get_auth_context_sync(
+    auth_context = await service.get_auth_context(
         auth_config=MaaSAuthConfig(
             username="relay-user",
             password="relay-password",
@@ -90,8 +92,9 @@ def test_get_auth_context_sync_extracts_department_from_direct_field(
     assert client.calls == 1
 
 
-def test_get_auth_context_sync_falls_back_to_department_segments(monkeypatch) -> None:
-    client = _FakeSyncHttpClient(
+@pytest.mark.asyncio
+async def test_get_auth_context_falls_back_to_department_segments(monkeypatch) -> None:
+    client = _FakeAsyncHttpClient(
         httpx.Response(
             200,
             json={
@@ -107,11 +110,11 @@ def test_get_auth_context_sync_falls_back_to_department_segments(monkeypatch) ->
     service = MaaSTokenService()
 
     monkeypatch.setattr(
-        "relay_teams.providers.maas_auth.create_sync_http_client",
+        "relay_teams.providers.maas_auth.create_async_http_client",
         lambda **_kwargs: client,
     )
 
-    auth_context = service.get_auth_context_sync(
+    auth_context = await service.get_auth_context(
         auth_config=MaaSAuthConfig(
             username="relay-user",
             password="relay-password",
@@ -124,8 +127,9 @@ def test_get_auth_context_sync_falls_back_to_department_segments(monkeypatch) ->
     assert client.calls == 1
 
 
-def test_get_auth_context_sync_refreshes_one_hour_before_expiry(monkeypatch) -> None:
-    client = _FakeSyncHttpClient(
+@pytest.mark.asyncio
+async def test_get_auth_context_refreshes_one_hour_before_expiry(monkeypatch) -> None:
+    client = _FakeAsyncHttpClient(
         httpx.Response(
             200,
             json={
@@ -137,7 +141,7 @@ def test_get_auth_context_sync_refreshes_one_hour_before_expiry(monkeypatch) -> 
     service = MaaSTokenService()
 
     monkeypatch.setattr(
-        "relay_teams.providers.maas_auth.create_sync_http_client",
+        "relay_teams.providers.maas_auth.create_async_http_client",
         lambda **_kwargs: client,
     )
 
@@ -147,7 +151,7 @@ def test_get_auth_context_sync_refreshes_one_hour_before_expiry(monkeypatch) -> 
             password="relay-password",
         )
     )
-    service._tokens[cache_key] = service._login_sync(
+    service._tokens[cache_key] = await service._login_async(
         auth_config=MaaSAuthConfig(
             username="relay-user",
             password="relay-password",
@@ -158,7 +162,7 @@ def test_get_auth_context_sync_refreshes_one_hour_before_expiry(monkeypatch) -> 
     assert client.calls == 1
 
     service._tokens[cache_key].expires_at = datetime.now(UTC) + timedelta(minutes=59)
-    service.get_auth_context_sync(
+    await service.get_auth_context(
         auth_config=MaaSAuthConfig(
             username="relay-user",
             password="relay-password",
@@ -169,7 +173,7 @@ def test_get_auth_context_sync_refreshes_one_hour_before_expiry(monkeypatch) -> 
     assert client.calls == 2
 
     service._tokens[cache_key].expires_at = datetime.now(UTC) + timedelta(minutes=61)
-    service.get_auth_context_sync(
+    await service.get_auth_context(
         auth_config=MaaSAuthConfig(
             username="relay-user",
             password="relay-password",
@@ -180,8 +184,9 @@ def test_get_auth_context_sync_refreshes_one_hour_before_expiry(monkeypatch) -> 
     assert client.calls == 2
 
 
-def test_get_auth_context_sync_reuses_cached_department(monkeypatch) -> None:
-    client = _FakeSyncHttpClient(
+@pytest.mark.asyncio
+async def test_get_auth_context_reuses_cached_department(monkeypatch) -> None:
+    client = _FakeAsyncHttpClient(
         httpx.Response(
             200,
             json={
@@ -193,11 +198,11 @@ def test_get_auth_context_sync_reuses_cached_department(monkeypatch) -> None:
     service = MaaSTokenService()
 
     monkeypatch.setattr(
-        "relay_teams.providers.maas_auth.create_sync_http_client",
+        "relay_teams.providers.maas_auth.create_async_http_client",
         lambda **_kwargs: client,
     )
 
-    first = service.get_auth_context_sync(
+    first = await service.get_auth_context(
         auth_config=MaaSAuthConfig(
             username="relay-user",
             password="relay-password",
@@ -205,7 +210,7 @@ def test_get_auth_context_sync_reuses_cached_department(monkeypatch) -> None:
         ssl_verify=None,
         connect_timeout_seconds=15,
     )
-    second = service.get_auth_context_sync(
+    second = await service.get_auth_context(
         auth_config=MaaSAuthConfig(
             username="relay-user",
             password="relay-password",

--- a/tests/unit_tests/providers/test_model_catalog.py
+++ b/tests/unit_tests/providers/test_model_catalog.py
@@ -17,10 +17,10 @@ class _FakeCatalogClient:
         self._response = response
         self.requested_urls: list[str] = []
 
-    def __enter__(self) -> "_FakeCatalogClient":
+    async def __aenter__(self) -> "_FakeCatalogClient":
         return self
 
-    def __exit__(
+    async def __aexit__(
         self,
         exc_type: object,
         exc_value: object,
@@ -28,14 +28,15 @@ class _FakeCatalogClient:
     ) -> None:
         return None
 
-    def get(self, url: str) -> httpx.Response:
+    async def get(self, url: str) -> httpx.Response:
         self.requested_urls.append(url)
         if isinstance(self._response, Exception):
             raise self._response
         return self._response
 
 
-def test_model_catalog_fetches_models_dev_payload(
+@pytest.mark.asyncio
+async def test_model_catalog_fetches_models_dev_payload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -71,7 +72,7 @@ def test_model_catalog_fetches_models_dev_payload(
     )
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: client,
     )
     service = ModelCatalogService(
@@ -79,7 +80,7 @@ def test_model_catalog_fetches_models_dev_payload(
         get_proxy_config=ProxyEnvConfig,
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is True
     assert client.requested_urls == ["https://models.dev/api.json"]
@@ -94,7 +95,8 @@ def test_model_catalog_fetches_models_dev_payload(
     assert provider.models[0].input_modalities[0].value == "image"
 
 
-def test_model_catalog_marks_anthropic_compatible_marketplace_provider(
+@pytest.mark.asyncio
+async def test_model_catalog_marks_anthropic_compatible_marketplace_provider(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -118,7 +120,7 @@ def test_model_catalog_marks_anthropic_compatible_marketplace_provider(
     )
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: client,
     )
     service = ModelCatalogService(
@@ -126,14 +128,15 @@ def test_model_catalog_marks_anthropic_compatible_marketplace_provider(
         get_proxy_config=ProxyEnvConfig,
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is True
     assert result.providers[0].runtime_provider == ProviderType.ANTHROPIC
     assert result.providers[0].models[0].context_window == 204800
 
 
-def test_model_catalog_marks_anthropic_api_path_as_anthropic_provider(
+@pytest.mark.asyncio
+async def test_model_catalog_marks_anthropic_api_path_as_anthropic_provider(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -151,7 +154,7 @@ def test_model_catalog_marks_anthropic_api_path_as_anthropic_provider(
     )
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: client,
     )
     service = ModelCatalogService(
@@ -159,13 +162,14 @@ def test_model_catalog_marks_anthropic_api_path_as_anthropic_provider(
         get_proxy_config=ProxyEnvConfig,
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is True
     assert result.providers[0].runtime_provider == ProviderType.ANTHROPIC
 
 
-def test_model_catalog_marks_anthropic_api_root_as_anthropic_provider(
+@pytest.mark.asyncio
+async def test_model_catalog_marks_anthropic_api_root_as_anthropic_provider(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -183,7 +187,7 @@ def test_model_catalog_marks_anthropic_api_root_as_anthropic_provider(
     )
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: client,
     )
     service = ModelCatalogService(
@@ -191,13 +195,14 @@ def test_model_catalog_marks_anthropic_api_root_as_anthropic_provider(
         get_proxy_config=ProxyEnvConfig,
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is True
     assert result.providers[0].runtime_provider == ProviderType.ANTHROPIC
 
 
-def test_model_catalog_uses_proxy_config_and_30_second_timeout(
+@pytest.mark.asyncio
+async def test_model_catalog_uses_proxy_config_and_30_second_timeout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -219,13 +224,13 @@ def test_model_catalog_uses_proxy_config_and_30_second_timeout(
         captured_kwargs.append(kwargs)
         return client
 
-    monkeypatch.setattr(model_catalog, "create_sync_http_client", create_client)
+    monkeypatch.setattr(model_catalog, "create_async_http_client", create_client)
     service = ModelCatalogService(
         config_dir=tmp_path,
         get_proxy_config=lambda: proxy_config,
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is True
     assert len(captured_kwargs) == 1
@@ -234,7 +239,8 @@ def test_model_catalog_uses_proxy_config_and_30_second_timeout(
     assert captured_kwargs[0]["connect_timeout_seconds"] == 30.0
 
 
-def test_model_catalog_returns_fetched_data_when_cache_write_fails(
+@pytest.mark.asyncio
+async def test_model_catalog_returns_fetched_data_when_cache_write_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -253,7 +259,7 @@ def test_model_catalog_returns_fetched_data_when_cache_write_fails(
     )
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: client,
     )
     service = ModelCatalogService(
@@ -261,13 +267,14 @@ def test_model_catalog_returns_fetched_data_when_cache_write_fails(
         get_proxy_config=lambda: ProxyEnvConfig(),
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is True
     assert result.providers[0].models[0].id == "gpt-4o"
 
 
-def test_model_catalog_retries_transient_network_errors(
+@pytest.mark.asyncio
+async def test_model_catalog_retries_transient_network_errors(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -292,20 +299,21 @@ def test_model_catalog_retries_transient_network_errors(
         created_clients.append(client)
         return client
 
-    monkeypatch.setattr(model_catalog, "create_sync_http_client", create_client)
+    monkeypatch.setattr(model_catalog, "create_async_http_client", create_client)
     service = ModelCatalogService(
         config_dir=tmp_path,
         get_proxy_config=lambda: ProxyEnvConfig(),
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is True
     assert len(created_clients) == 2
     assert result.providers[0].models[0].id == "gpt-4o"
 
 
-def test_model_catalog_uses_fresh_cache_without_fetching(
+@pytest.mark.asyncio
+async def test_model_catalog_uses_fresh_cache_without_fetching(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -331,24 +339,25 @@ def test_model_catalog_uses_fresh_cache_without_fetching(
     )
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: first_client,
     )
-    assert service.get_catalog(refresh=True).ok is True
+    assert (await service.get_catalog_async(refresh=True)).ok is True
 
     def fail_fetch(**_kwargs: object) -> _FakeCatalogClient:
         raise AssertionError("fresh cache should avoid network")
 
-    monkeypatch.setattr(model_catalog, "create_sync_http_client", fail_fetch)
+    monkeypatch.setattr(model_catalog, "create_async_http_client", fail_fetch)
 
-    cached = service.get_catalog()
+    cached = await service.get_catalog_async()
 
     assert cached.ok is True
     assert cached.cache_age_seconds is not None
     assert cached.providers[0].models[0].id == "gpt-4o"
 
 
-def test_model_catalog_returns_stale_cache_when_refresh_fails(
+@pytest.mark.asyncio
+async def test_model_catalog_returns_stale_cache_when_refresh_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -370,19 +379,19 @@ def test_model_catalog_returns_stale_cache_when_refresh_fails(
     )
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: success_client,
     )
-    assert service.get_catalog(refresh=True).ok is True
+    assert (await service.get_catalog_async(refresh=True)).ok is True
 
     failed_client = _FakeCatalogClient(httpx.ConnectError("offline"))
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: failed_client,
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is False
     assert result.stale is True
@@ -390,7 +399,8 @@ def test_model_catalog_returns_stale_cache_when_refresh_fails(
     assert result.providers[0].models[0].id == "gpt-4o"
 
 
-def test_model_catalog_prefers_stale_cache_without_fetching(
+@pytest.mark.asyncio
+async def test_model_catalog_prefers_stale_cache_without_fetching(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -412,31 +422,32 @@ def test_model_catalog_prefers_stale_cache_without_fetching(
     )
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: success_client,
     )
-    assert service.get_catalog(refresh=True).ok is True
+    assert (await service.get_catalog_async(refresh=True)).ok is True
 
     def fail_fetch(**_kwargs: object) -> _FakeCatalogClient:
         raise AssertionError("cached catalog should be returned before refresh")
 
-    monkeypatch.setattr(model_catalog, "create_sync_http_client", fail_fetch)
+    monkeypatch.setattr(model_catalog, "create_async_http_client", fail_fetch)
 
-    result = service.get_catalog()
+    result = await service.get_catalog_async()
 
     assert result.ok is True
     assert result.stale is True
     assert result.providers[0].models[0].id == "gpt-4o"
 
 
-def test_model_catalog_without_cache_reports_fetch_error(
+@pytest.mark.asyncio
+async def test_model_catalog_without_cache_reports_fetch_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     failed_client = _FakeCatalogClient(httpx.ConnectError("offline"))
     monkeypatch.setattr(
         model_catalog,
-        "create_sync_http_client",
+        "create_async_http_client",
         lambda **_kwargs: failed_client,
     )
     service = ModelCatalogService(
@@ -444,7 +455,7 @@ def test_model_catalog_without_cache_reports_fetch_error(
         get_proxy_config=lambda: ProxyEnvConfig(),
     )
 
-    result = service.get_catalog(refresh=True)
+    result = await service.get_catalog_async(refresh=True)
 
     assert result.ok is False
     assert result.providers == ()

--- a/tests/unit_tests/providers/test_model_config_service.py
+++ b/tests/unit_tests/providers/test_model_config_service.py
@@ -60,7 +60,7 @@ class _RecordingModelFallbackConfigManager:
 
 
 class _RecordingModelCatalogService:
-    def get_catalog(self, *, refresh: bool = False) -> ModelCatalogResult:
+    async def get_catalog_async(self, *, refresh: bool = False) -> ModelCatalogResult:
         return ModelCatalogResult(
             ok=True,
             source_url="https://models.dev/api.json",
@@ -128,7 +128,8 @@ def test_save_model_config_preserves_omitted_optional_fields() -> None:
     }
 
 
-def test_verify_codeagent_auth_delegates_to_probe_service() -> None:
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_async_delegates_to_probe_service() -> None:
     service = ModelConfigService(
         config_dir=Path("."),
         roles_dir=Path("."),
@@ -152,7 +153,7 @@ def test_verify_codeagent_auth_delegates_to_probe_service() -> None:
     captured: dict[str, object] = {}
 
     class _FakeProbeService:
-        def verify_codeagent_auth(
+        async def verify_codeagent_auth_async(
             self, *, profile_name: str
         ) -> CodeAgentAuthVerifyResult:
             captured["profile_name"] = profile_name
@@ -162,7 +163,7 @@ def test_verify_codeagent_auth_delegates_to_probe_service() -> None:
         ModelConnectivityProbeService, _FakeProbeService()
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert captured["profile_name"] == "default"
     assert result == expected

--- a/tests/unit_tests/providers/test_model_connectivity.py
+++ b/tests/unit_tests/providers/test_model_connectivity.py
@@ -49,13 +49,13 @@ class _FakeHttpClient:
         self._error = error
         self._captured = captured if captured is not None else {}
 
-    def __enter__(self) -> _FakeHttpClient:
+    async def __aenter__(self) -> _FakeHttpClient:
         return self
 
-    def __exit__(self, *_args: object) -> None:
+    async def __aexit__(self, *_args: object) -> None:
         return None
 
-    def post(
+    async def post(
         self,
         url: str,
         *,
@@ -70,7 +70,7 @@ class _FakeHttpClient:
         assert self._response is not None
         return self._response
 
-    def get(
+    async def get(
         self,
         url: str,
         *,
@@ -94,13 +94,13 @@ class _QueuedHttpClient:
         self._responses = responses
         self._captured = captured if captured is not None else {}
 
-    def __enter__(self) -> _QueuedHttpClient:
+    async def __aenter__(self) -> _QueuedHttpClient:
         return self
 
-    def __exit__(self, *_args: object) -> None:
+    async def __aexit__(self, *_args: object) -> None:
         return None
 
-    def get(
+    async def get(
         self,
         url: str,
         *,
@@ -130,7 +130,7 @@ class _FakeMaaSTokenService:
         self._captured = captured
         self._departments = departments or ["Relay/Department"] * len(tokens)
 
-    def get_token_sync(
+    async def get_token(
         self,
         *,
         auth_config: MaaSAuthConfig,
@@ -138,14 +138,16 @@ class _FakeMaaSTokenService:
         connect_timeout_seconds: float,
         force_refresh: bool = False,
     ) -> str:
-        return self.get_auth_context_sync(
-            auth_config=auth_config,
-            ssl_verify=ssl_verify,
-            connect_timeout_seconds=connect_timeout_seconds,
-            force_refresh=force_refresh,
+        return (
+            await self.get_auth_context(
+                auth_config=auth_config,
+                ssl_verify=ssl_verify,
+                connect_timeout_seconds=connect_timeout_seconds,
+                force_refresh=force_refresh,
+            )
         ).token
 
-    def get_auth_context_sync(
+    async def get_auth_context(
         self,
         *,
         auth_config: MaaSAuthConfig,
@@ -178,7 +180,7 @@ class _FakeCodeAgentTokenService:
         self._tokens = tokens
         self._captured = captured
 
-    def get_token_sync(
+    async def get_token(
         self,
         *,
         base_url: str,
@@ -202,12 +204,13 @@ class _FakeCodeAgentTokenService:
         return self._tokens.pop(0)
 
 
-def test_probe_uses_saved_profile_and_returns_usage(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_uses_saved_profile_and_returns_usage(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -227,7 +230,7 @@ def test_probe_uses_saved_profile_and_returns_usage(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(profile_name="default", timeout_ms=3200)
     )
 
@@ -245,11 +248,12 @@ def test_probe_uses_saved_profile_and_returns_usage(monkeypatch) -> None:
     assert payload["top_p"] == pytest.approx(0.95)
 
 
-def test_probe_preserves_zero_valued_usage_fields(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_preserves_zero_valued_usage_fields(monkeypatch) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -266,7 +270,9 @@ def test_probe_preserves_zero_valued_usage_fields(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(ModelConnectivityProbeRequest(profile_name="default"))
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(profile_name="default")
+    )
 
     assert result.ok is True
     assert result.token_usage is not None
@@ -275,14 +281,15 @@ def test_probe_preserves_zero_valued_usage_fields(monkeypatch) -> None:
     assert result.token_usage.total_tokens == 0
 
 
-def test_probe_uses_profile_connect_timeout_when_request_timeout_omitted(
+@pytest.mark.asyncio
+async def test_probe_uses_profile_connect_timeout_when_request_timeout_omitted(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -291,18 +298,21 @@ def test_probe_uses_profile_connect_timeout_when_request_timeout_omitted(
         ),
     )
 
-    result = service.probe(ModelConnectivityProbeRequest(profile_name="default"))
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(profile_name="default")
+    )
 
     assert result.ok is True
     assert captured["timeout_seconds"] == pytest.approx(17.5)
 
 
-def test_probe_merges_override_with_saved_profile(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_merges_override_with_saved_profile(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -311,7 +321,7 @@ def test_probe_merges_override_with_saved_profile(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             profile_name="default",
             override=ModelConnectivityProbeOverride(
@@ -330,12 +340,13 @@ def test_probe_merges_override_with_saved_profile(monkeypatch) -> None:
     assert payload["model"] == "draft-model"
 
 
-def test_probe_uses_model_ssl_override_before_global_default(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_uses_model_ssl_override_before_global_default(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -344,7 +355,7 @@ def test_probe_uses_model_ssl_override_before_global_default(monkeypatch) -> Non
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             profile_name="default",
             override=ModelConnectivityProbeOverride(ssl_verify=False),
@@ -355,15 +366,16 @@ def test_probe_uses_model_ssl_override_before_global_default(monkeypatch) -> Non
     assert captured["ssl_verify"] is False
 
 
-def test_probe_returns_timeout_error(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_returns_timeout_error(monkeypatch) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(error=httpx.ReadTimeout("timed out")),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(profile_name="default", timeout_ms=2000)
     )
 
@@ -373,11 +385,12 @@ def test_probe_returns_timeout_error(monkeypatch) -> None:
     assert result.diagnostics.endpoint_reachable is False
 
 
-def test_probe_returns_auth_error_for_unauthorized_response(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_returns_auth_error_for_unauthorized_response(monkeypatch) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 401,
@@ -386,7 +399,9 @@ def test_probe_returns_auth_error_for_unauthorized_response(monkeypatch) -> None
         ),
     )
 
-    result = service.probe(ModelConnectivityProbeRequest(profile_name="default"))
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(profile_name="default")
+    )
 
     assert result.ok is False
     assert result.error_code == "auth_invalid"
@@ -395,12 +410,13 @@ def test_probe_returns_auth_error_for_unauthorized_response(monkeypatch) -> None
     assert result.error_message == "Invalid API key."
 
 
-def test_probe_accepts_editor_default_timeout(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_accepts_editor_default_timeout(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -409,7 +425,7 @@ def test_probe_accepts_editor_default_timeout(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 model="draft-model",
@@ -425,11 +441,12 @@ def test_probe_accepts_editor_default_timeout(monkeypatch) -> None:
     assert captured["timeout_seconds"] == pytest.approx(15.0)
 
 
-def test_probe_requires_base_url_for_openai_override() -> None:
+@pytest.mark.asyncio
+async def test_probe_requires_base_url_for_openai_override() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="base_url"):
-        service.probe(
+        await service.probe_async(
             ModelConnectivityProbeRequest(
                 override=ModelConnectivityProbeOverride(
                     provider=ProviderType.OPENAI_COMPATIBLE,
@@ -440,11 +457,54 @@ def test_probe_requires_base_url_for_openai_override() -> None:
         )
 
 
-def test_probe_requires_codeagent_auth_for_codeagent_override() -> None:
+@pytest.mark.asyncio
+async def test_probe_rejects_unknown_profile_name() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    with pytest.raises(ValueError, match="missing-profile"):
+        await service.probe_async(
+            ModelConnectivityProbeRequest(profile_name="missing-profile")
+        )
+
+
+@pytest.mark.asyncio
+async def test_probe_requires_auth_material_for_openai_override() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    with pytest.raises(ValueError, match="api_key or headers"):
+        await service.probe_async(
+            ModelConnectivityProbeRequest(
+                override=ModelConnectivityProbeOverride(
+                    provider=ProviderType.OPENAI_COMPATIBLE,
+                    model="draft-model",
+                    base_url="https://draft.test/v1",
+                )
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_probe_requires_maas_auth_for_maas_override() -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    with pytest.raises(ValueError, match="maas_auth"):
+        await service.probe_async(
+            ModelConnectivityProbeRequest(
+                override=ModelConnectivityProbeOverride(
+                    provider=ProviderType.MAAS,
+                    model="maas-chat",
+                    base_url="https://maas.example/api/v2",
+                )
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_probe_requires_codeagent_auth_for_codeagent_override() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="codeagent_auth"):
-        service.probe(
+        await service.probe_async(
             ModelConnectivityProbeRequest(
                 override=ModelConnectivityProbeOverride(
                     provider=ProviderType.CODEAGENT,
@@ -454,23 +514,25 @@ def test_probe_requires_codeagent_auth_for_codeagent_override() -> None:
         )
 
 
-def test_probe_codeagent_override_reports_all_missing_required_fields() -> None:
+@pytest.mark.asyncio
+async def test_probe_codeagent_override_reports_all_missing_required_fields() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="model, codeagent_auth"):
-        service.probe(
+        await service.probe_async(
             ModelConnectivityProbeRequest(
                 override=ModelConnectivityProbeOverride(provider=ProviderType.CODEAGENT)
             )
         )
 
 
-def test_probe_supports_bigmodel_provider(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_supports_bigmodel_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -479,7 +541,7 @@ def test_probe_supports_bigmodel_provider(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.BIGMODEL,
@@ -498,7 +560,8 @@ def test_probe_supports_bigmodel_provider(monkeypatch) -> None:
     )
 
 
-def test_probe_supports_anthropic_provider(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_supports_anthropic_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(
         get_runtime=lambda: _runtime_config(
@@ -510,7 +573,7 @@ def test_probe_supports_anthropic_provider(monkeypatch) -> None:
     )
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -526,7 +589,9 @@ def test_probe_supports_anthropic_provider(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(ModelConnectivityProbeRequest(profile_name="default"))
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(profile_name="default")
+    )
 
     assert result.ok is True
     assert result.provider == ProviderType.ANTHROPIC
@@ -542,7 +607,8 @@ def test_probe_supports_anthropic_provider(monkeypatch) -> None:
     assert headers["anthropic-version"] == "2023-06-01"
 
 
-def test_probe_anthropic_profile_override_preserves_saved_base_url(
+@pytest.mark.asyncio
+async def test_probe_anthropic_profile_override_preserves_saved_base_url(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -556,7 +622,7 @@ def test_probe_anthropic_profile_override_preserves_saved_base_url(
     )
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -572,7 +638,7 @@ def test_probe_anthropic_profile_override_preserves_saved_base_url(
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             profile_name="default",
             override=ModelConnectivityProbeOverride(temperature=0.2),
@@ -585,19 +651,20 @@ def test_probe_anthropic_profile_override_preserves_saved_base_url(
     assert payload["temperature"] == 0.2
 
 
-def test_probe_anthropic_returns_network_error_for_request_exception(
+@pytest.mark.asyncio
+async def test_probe_anthropic_returns_network_error_for_request_exception(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             error=httpx.ConnectError("failed to reach anthropic endpoint"),
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.ANTHROPIC,
@@ -614,12 +681,13 @@ def test_probe_anthropic_returns_network_error_for_request_exception(
     assert result.retryable is True
 
 
-def test_probe_allows_header_only_override(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_allows_header_only_override(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -628,7 +696,7 @@ def test_probe_allows_header_only_override(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 model="draft-model",
@@ -648,7 +716,8 @@ def test_probe_allows_header_only_override(monkeypatch) -> None:
     assert headers["Authorization"] == "Bearer header-only"
 
 
-def test_probe_supports_maas_provider(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_supports_maas_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
@@ -657,7 +726,7 @@ def test_probe_supports_maas_provider(monkeypatch) -> None:
         lambda: _FakeMaaSTokenService(["maas-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -667,7 +736,7 @@ def test_probe_supports_maas_provider(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -690,7 +759,8 @@ def test_probe_supports_maas_provider(monkeypatch) -> None:
     assert token_calls[0]["force_refresh"] is False
 
 
-def test_probe_supports_codeagent_provider_with_oauth_session(
+@pytest.mark.asyncio
+async def test_probe_supports_codeagent_provider_with_oauth_session(
     monkeypatch,
 ) -> None:
     clear_codeagent_oauth_session_store()
@@ -716,7 +786,7 @@ def test_probe_supports_codeagent_provider_with_oauth_session(
         lambda: _FakeCodeAgentTokenService(["session-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -726,7 +796,7 @@ def test_probe_supports_codeagent_provider_with_oauth_session(
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -761,7 +831,10 @@ def test_probe_supports_codeagent_provider_with_oauth_session(
     clear_codeagent_oauth_session_store()
 
 
-def test_probe_codeagent_accepts_event_stream_success_without_json(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_codeagent_accepts_event_stream_success_without_json(
+    monkeypatch,
+) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
@@ -770,7 +843,7 @@ def test_probe_codeagent_accepts_event_stream_success_without_json(monkeypatch) 
         lambda: _FakeCodeAgentTokenService(["session-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -784,7 +857,7 @@ def test_probe_codeagent_accepts_event_stream_success_without_json(monkeypatch) 
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -800,7 +873,8 @@ def test_probe_codeagent_accepts_event_stream_success_without_json(monkeypatch) 
     assert result.token_usage is None
 
 
-def test_probe_codeagent_rejects_event_stream_error_payload(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_codeagent_rejects_event_stream_error_payload(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
@@ -809,7 +883,7 @@ def test_probe_codeagent_rejects_event_stream_error_payload(monkeypatch) -> None
         lambda: _FakeCodeAgentTokenService(["session-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -823,7 +897,7 @@ def test_probe_codeagent_rejects_event_stream_error_payload(monkeypatch) -> None
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -840,7 +914,8 @@ def test_probe_codeagent_rejects_event_stream_error_payload(monkeypatch) -> None
     assert result.error_message == "invalid codeagent model"
 
 
-def test_probe_codeagent_rejects_event_stream_top_level_message_payload(
+@pytest.mark.asyncio
+async def test_probe_codeagent_rejects_event_stream_top_level_message_payload(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
@@ -850,7 +925,7 @@ def test_probe_codeagent_rejects_event_stream_top_level_message_payload(
         lambda: _FakeCodeAgentTokenService(["session-access-token"], {}),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -860,7 +935,7 @@ def test_probe_codeagent_rejects_event_stream_top_level_message_payload(
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -877,42 +952,8 @@ def test_probe_codeagent_rejects_event_stream_top_level_message_payload(
     assert result.error_message == "invalid codeagent model"
 
 
-def test_probe_codeagent_rejects_invalid_event_stream_payload(monkeypatch) -> None:
-    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
-
-    monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
-        lambda: _FakeCodeAgentTokenService(["session-access-token"], {}),
-    )
-    monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
-        lambda **_kwargs: _FakeHttpClient(
-            response=httpx.Response(
-                200,
-                headers={"content-type": "text/event-stream"},
-                text="event: ping\n\n",
-            ),
-        ),
-    )
-
-    result = service.probe(
-        ModelConnectivityProbeRequest(
-            override=ModelConnectivityProbeOverride(
-                provider=ProviderType.CODEAGENT,
-                model="codeagent-chat",
-                codeagent_auth=CodeAgentAuthConfig(
-                    refresh_token="refresh-token",
-                ),
-            )
-        )
-    )
-
-    assert result.ok is False
-    assert result.error_code == "invalid_response"
-    assert result.error_message == "Provider returned invalid SSE payload."
-
-
-def test_probe_codeagent_rejects_plain_text_event_stream_heartbeat(
+@pytest.mark.asyncio
+async def test_probe_codeagent_rejects_invalid_event_stream_payload(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
@@ -922,17 +963,17 @@ def test_probe_codeagent_rejects_plain_text_event_stream_heartbeat(
         lambda: _FakeCodeAgentTokenService(["session-access-token"], {}),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
                 headers={"content-type": "text/event-stream"},
-                text="data: ping\n\n",
+                text="event: ping\n\n",
             ),
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -949,7 +990,46 @@ def test_probe_codeagent_rejects_plain_text_event_stream_heartbeat(
     assert result.error_message == "Provider returned invalid SSE payload."
 
 
-def test_probe_prefers_fresh_codeagent_oauth_session_over_saved_refresh_token(
+@pytest.mark.asyncio
+async def test_probe_codeagent_rejects_plain_text_event_stream_heartbeat(
+    monkeypatch,
+) -> None:
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_codeagent_token_service",
+        lambda: _FakeCodeAgentTokenService(["session-access-token"], {}),
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_async_http_client",
+        lambda **_kwargs: _FakeHttpClient(
+            response=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                text="data: ping\n\n",
+            ),
+        ),
+    )
+
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(
+            override=ModelConnectivityProbeOverride(
+                provider=ProviderType.CODEAGENT,
+                model="codeagent-chat",
+                codeagent_auth=CodeAgentAuthConfig(
+                    refresh_token="refresh-token",
+                ),
+            )
+        )
+    )
+
+    assert result.ok is False
+    assert result.error_code == "invalid_response"
+    assert result.error_message == "Provider returned invalid SSE payload."
+
+
+@pytest.mark.asyncio
+async def test_probe_prefers_fresh_codeagent_oauth_session_over_saved_refresh_token(
     monkeypatch,
 ) -> None:
     clear_codeagent_oauth_session_store()
@@ -986,7 +1066,7 @@ def test_probe_prefers_fresh_codeagent_oauth_session_over_saved_refresh_token(
         lambda: _FakeCodeAgentTokenService(["fresh-session-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -996,7 +1076,7 @@ def test_probe_prefers_fresh_codeagent_oauth_session_over_saved_refresh_token(
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             profile_name="codeagent-profile",
             override=ModelConnectivityProbeOverride(
@@ -1014,7 +1094,10 @@ def test_probe_prefers_fresh_codeagent_oauth_session_over_saved_refresh_token(
     clear_codeagent_oauth_session_store()
 
 
-def test_probe_merges_saved_maas_password_when_override_omits_it(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_merges_saved_maas_password_when_override_omits_it(
+    monkeypatch,
+) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(
         get_runtime=lambda: _runtime_config(
@@ -1035,7 +1118,7 @@ def test_probe_merges_saved_maas_password_when_override_omits_it(monkeypatch) ->
         lambda: _FakeMaaSTokenService(["maas-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -1045,7 +1128,7 @@ def test_probe_merges_saved_maas_password_when_override_omits_it(monkeypatch) ->
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             profile_name="maas-profile",
             override=ModelConnectivityProbeOverride(
@@ -1060,11 +1143,14 @@ def test_probe_merges_saved_maas_password_when_override_omits_it(monkeypatch) ->
     assert token_calls[0]["password"] == "saved-password"
 
 
-def test_probe_returns_maas_auth_error_for_invalid_credentials(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_returns_maas_auth_error_for_invalid_credentials(
+    monkeypatch,
+) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _InvalidCredentialsTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             auth_config: MaaSAuthConfig,
@@ -1082,7 +1168,7 @@ def test_probe_returns_maas_auth_error_for_invalid_credentials(monkeypatch) -> N
         lambda: _InvalidCredentialsTokenService(),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -1102,11 +1188,12 @@ def test_probe_returns_maas_auth_error_for_invalid_credentials(monkeypatch) -> N
     assert result.diagnostics.auth_valid is False
 
 
-def test_probe_returns_retryable_maas_login_service_error(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_returns_retryable_maas_login_service_error(monkeypatch) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _UnavailableTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             auth_config: MaaSAuthConfig,
@@ -1124,7 +1211,7 @@ def test_probe_returns_retryable_maas_login_service_error(monkeypatch) -> None:
         lambda: _UnavailableTokenService(),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -1144,7 +1231,10 @@ def test_probe_returns_retryable_maas_login_service_error(monkeypatch) -> None:
     assert result.diagnostics.auth_valid is True
 
 
-def test_probe_refreshes_maas_token_after_unauthorized_response(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_refreshes_maas_token_after_unauthorized_response(
+    monkeypatch,
+) -> None:
     captured: dict[str, object] = {"requests": []}
     responses = [
         httpx.Response(401, json={"error": {"message": "expired"}}),
@@ -1165,11 +1255,11 @@ def test_probe_refreshes_maas_token_after_unauthorized_response(monkeypatch) -> 
         return _FakeHttpClient(captured=local_capture, response=responses.pop(0))
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         build_client,
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -1194,7 +1284,178 @@ def test_probe_refreshes_maas_token_after_unauthorized_response(monkeypatch) -> 
     assert token_calls[1]["force_refresh"] is True
 
 
-def test_discover_models_supports_maas_provider(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_reports_maas_refresh_timeout_after_unauthorized_response(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    class _TimeoutOnRefreshMaaSTokenService(_FakeMaaSTokenService):
+        async def get_token(
+            self,
+            *,
+            auth_config: MaaSAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> str:
+            if force_refresh:
+                raise httpx.ReadTimeout("refresh timed out")
+            return await super().get_token(
+                auth_config=auth_config,
+                ssl_verify=ssl_verify,
+                connect_timeout_seconds=connect_timeout_seconds,
+                force_refresh=force_refresh,
+            )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_maas_token_service",
+        lambda: _TimeoutOnRefreshMaaSTokenService(["expired-token"], captured),
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_async_http_client",
+        lambda **kwargs: _FakeHttpClient(
+            captured=captured,
+            response=httpx.Response(401, json={"error": {"message": "expired"}}),
+        ),
+    )
+
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(
+            override=ModelConnectivityProbeOverride(
+                provider=ProviderType.MAAS,
+                model="maas-chat",
+                base_url="https://maas.example/api/v2",
+                maas_auth=MaaSAuthConfig(
+                    username="relay-user",
+                    password="relay-password",
+                ),
+            )
+        )
+    )
+
+    assert result.ok is False
+    assert result.error_code == "network_timeout"
+    token_calls = cast(list[dict[str, object]], captured["maas_token_calls"])
+    assert token_calls[0]["force_refresh"] is False
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_maas_refresh_request_error_after_unauthorized_response(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    class _RequestErrorOnRefreshMaaSTokenService(_FakeMaaSTokenService):
+        async def get_token(
+            self,
+            *,
+            auth_config: MaaSAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> str:
+            if force_refresh:
+                raise httpx.ConnectError("refresh failed")
+            return await super().get_token(
+                auth_config=auth_config,
+                ssl_verify=ssl_verify,
+                connect_timeout_seconds=connect_timeout_seconds,
+                force_refresh=force_refresh,
+            )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_maas_token_service",
+        lambda: _RequestErrorOnRefreshMaaSTokenService(["expired-token"], captured),
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_async_http_client",
+        lambda **kwargs: _FakeHttpClient(
+            captured=captured,
+            response=httpx.Response(401, json={"error": {"message": "expired"}}),
+        ),
+    )
+
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(
+            override=ModelConnectivityProbeOverride(
+                provider=ProviderType.MAAS,
+                model="maas-chat",
+                base_url="https://maas.example/api/v2",
+                maas_auth=MaaSAuthConfig(
+                    username="relay-user",
+                    password="relay-password",
+                ),
+            )
+        )
+    )
+
+    assert result.ok is False
+    assert result.error_code == "network_error"
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_maas_refresh_login_error_after_unauthorized_response(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    service = ModelConnectivityProbeService(get_runtime=_runtime_config)
+
+    class _LoginErrorOnRefreshMaaSTokenService(_FakeMaaSTokenService):
+        async def get_token(
+            self,
+            *,
+            auth_config: MaaSAuthConfig,
+            ssl_verify: bool | None,
+            connect_timeout_seconds: float,
+            force_refresh: bool = False,
+        ) -> str:
+            if force_refresh:
+                raise MaaSLoginError(
+                    "refresh rejected",
+                    status_code=401,
+                )
+            return await super().get_token(
+                auth_config=auth_config,
+                ssl_verify=ssl_verify,
+                connect_timeout_seconds=connect_timeout_seconds,
+                force_refresh=force_refresh,
+            )
+
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.get_maas_token_service",
+        lambda: _LoginErrorOnRefreshMaaSTokenService(["expired-token"], captured),
+    )
+    monkeypatch.setattr(
+        "relay_teams.providers.model_connectivity.create_async_http_client",
+        lambda **kwargs: _FakeHttpClient(
+            captured=captured,
+            response=httpx.Response(401, json={"error": {"message": "expired"}}),
+        ),
+    )
+
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(
+            override=ModelConnectivityProbeOverride(
+                provider=ProviderType.MAAS,
+                model="maas-chat",
+                base_url="https://maas.example/api/v2",
+                maas_auth=MaaSAuthConfig(
+                    username="relay-user",
+                    password="relay-password",
+                ),
+            )
+        )
+    )
+
+    assert result.ok is False
+    assert result.error_code == "auth_invalid"
+
+
+@pytest.mark.asyncio
+async def test_discover_models_supports_maas_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
@@ -1203,7 +1464,7 @@ def test_discover_models_supports_maas_provider(monkeypatch) -> None:
         lambda: _FakeMaaSTokenService(["maas-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -1231,7 +1492,7 @@ def test_discover_models_supports_maas_provider(monkeypatch) -> None:
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -1270,7 +1531,8 @@ def test_discover_models_supports_maas_provider(monkeypatch) -> None:
     )
 
 
-def test_discover_models_supports_codeagent_provider_with_oauth_session(
+@pytest.mark.asyncio
+async def test_discover_models_supports_codeagent_provider_with_oauth_session(
     monkeypatch,
 ) -> None:
     clear_codeagent_oauth_session_store()
@@ -1296,7 +1558,7 @@ def test_discover_models_supports_codeagent_provider_with_oauth_session(
         lambda: _FakeCodeAgentTokenService(["session-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -1309,7 +1571,7 @@ def test_discover_models_supports_codeagent_provider_with_oauth_session(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -1344,11 +1606,12 @@ def test_discover_models_supports_codeagent_provider_with_oauth_session(
     clear_codeagent_oauth_session_store()
 
 
-def test_discover_models_requires_base_url_for_openai_override() -> None:
+@pytest.mark.asyncio
+async def test_discover_models_requires_base_url_for_openai_override() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="base_url"):
-        service.discover_models(
+        await service.discover_models_async(
             ModelDiscoveryRequest(
                 override=ModelConnectivityProbeOverride(
                     provider=ProviderType.OPENAI_COMPATIBLE,
@@ -1359,11 +1622,12 @@ def test_discover_models_requires_base_url_for_openai_override() -> None:
         )
 
 
-def test_discover_models_requires_codeagent_auth_for_codeagent_override() -> None:
+@pytest.mark.asyncio
+async def test_discover_models_requires_codeagent_auth_for_codeagent_override() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="codeagent_auth"):
-        service.discover_models(
+        await service.discover_models_async(
             ModelDiscoveryRequest(
                 override=ModelConnectivityProbeOverride(
                     provider=ProviderType.CODEAGENT,
@@ -1373,11 +1637,14 @@ def test_discover_models_requires_codeagent_auth_for_codeagent_override() -> Non
         )
 
 
-def test_discover_models_codeagent_override_reports_missing_codeagent_auth() -> None:
+@pytest.mark.asyncio
+async def test_discover_models_codeagent_override_reports_missing_codeagent_auth() -> (
+    None
+):
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="codeagent_auth"):
-        service.discover_models(
+        await service.discover_models_async(
             ModelDiscoveryRequest(
                 override=ModelConnectivityProbeOverride(
                     provider=ProviderType.CODEAGENT,
@@ -1387,7 +1654,8 @@ def test_discover_models_codeagent_override_reports_missing_codeagent_auth() -> 
         )
 
 
-def test_probe_codeagent_returns_network_error_for_request_exception(
+@pytest.mark.asyncio
+async def test_probe_codeagent_returns_network_error_for_request_exception(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -1398,7 +1666,7 @@ def test_probe_codeagent_returns_network_error_for_request_exception(
         lambda: _FakeCodeAgentTokenService(["codeagent-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -1408,7 +1676,7 @@ def test_probe_codeagent_returns_network_error_for_request_exception(
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -1425,13 +1693,14 @@ def test_probe_codeagent_returns_network_error_for_request_exception(
     assert result.retryable is True
 
 
-def test_probe_codeagent_returns_invalid_response_for_oauth_error_without_http_status(
+@pytest.mark.asyncio
+async def test_probe_codeagent_returns_invalid_response_for_oauth_error_without_http_status(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -1457,7 +1726,7 @@ def test_probe_codeagent_returns_invalid_response_for_oauth_error_without_http_s
         lambda: _FailingCodeAgentTokenService(),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -1474,13 +1743,14 @@ def test_probe_codeagent_returns_invalid_response_for_oauth_error_without_http_s
     assert result.retryable is False
 
 
-def test_probe_codeagent_maps_codeagent_auth_invalid_error_without_http_status(
+@pytest.mark.asyncio
+async def test_probe_codeagent_maps_codeagent_auth_invalid_error_without_http_status(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -1507,7 +1777,7 @@ def test_probe_codeagent_maps_codeagent_auth_invalid_error_without_http_status(
         lambda: _FailingCodeAgentTokenService(),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -1525,7 +1795,8 @@ def test_probe_codeagent_maps_codeagent_auth_invalid_error_without_http_status(
     assert result.retryable is False
 
 
-def test_discover_models_codeagent_returns_timeout_for_request_exception(
+@pytest.mark.asyncio
+async def test_discover_models_codeagent_returns_timeout_for_request_exception(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -1536,7 +1807,7 @@ def test_discover_models_codeagent_returns_timeout_for_request_exception(
         lambda: _FakeCodeAgentTokenService(["codeagent-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -1546,7 +1817,7 @@ def test_discover_models_codeagent_returns_timeout_for_request_exception(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -1563,13 +1834,14 @@ def test_discover_models_codeagent_returns_timeout_for_request_exception(
     assert result.retryable is True
 
 
-def test_discover_models_codeagent_returns_invalid_response_for_oauth_error(
+@pytest.mark.asyncio
+async def test_discover_models_codeagent_returns_invalid_response_for_oauth_error(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -1595,7 +1867,7 @@ def test_discover_models_codeagent_returns_invalid_response_for_oauth_error(
         lambda: _FailingCodeAgentTokenService(),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -1612,7 +1884,8 @@ def test_discover_models_codeagent_returns_invalid_response_for_oauth_error(
     assert result.retryable is False
 
 
-def test_verify_codeagent_auth_returns_valid_when_saved_token_request_succeeds(
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_returns_valid_when_saved_token_request_succeeds(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -1630,7 +1903,7 @@ def test_verify_codeagent_auth_returns_valid_when_saved_token_request_succeeds(
     )
 
     class _TokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -1664,14 +1937,14 @@ def test_verify_codeagent_auth_returns_valid_when_saved_token_request_succeeds(
         )
     ]
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _QueuedHttpClient(
             captured=captured,
             responses=responses,
         ),
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert result.status == "valid"
     assert result.detail is None
@@ -1696,27 +1969,30 @@ def test_verify_codeagent_auth_returns_valid_when_saved_token_request_succeeds(
     assert headers["User-Agent"] == "AgentKernel/1.0"
 
 
-def test_verify_codeagent_auth_raises_for_missing_profile() -> None:
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_raises_for_missing_profile() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(
         ValueError,
         match="Model profile 'missing' was not found in runtime config.",
     ):
-        service.verify_codeagent_auth(profile_name="missing")
+        await service.verify_codeagent_auth_async(profile_name="missing")
 
 
-def test_verify_codeagent_auth_raises_for_non_codeagent_profile() -> None:
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_raises_for_non_codeagent_profile() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(
         ValueError,
         match="Model profile 'default' is not a CodeAgent profile.",
     ):
-        service.verify_codeagent_auth(profile_name="default")
+        await service.verify_codeagent_auth_async(profile_name="default")
 
 
-def test_verify_codeagent_auth_raises_without_codeagent_auth() -> None:
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_raises_without_codeagent_auth() -> None:
     invalid_config = ModelEndpointConfig.model_construct(
         provider=ProviderType.CODEAGENT,
         model="codeagent-chat",
@@ -1749,10 +2025,11 @@ def test_verify_codeagent_auth_raises_without_codeagent_auth() -> None:
         ValueError,
         match="Model profile 'default' does not have CodeAgent auth configured.",
     ):
-        service.verify_codeagent_auth(profile_name="default")
+        await service.verify_codeagent_auth_async(profile_name="default")
 
 
-def test_verify_codeagent_auth_returns_error_when_token_refresh_times_out(
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_returns_error_when_token_refresh_times_out(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(
@@ -1766,7 +2043,7 @@ def test_verify_codeagent_auth_returns_error_when_token_refresh_times_out(
     )
 
     class _TimeoutTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -1789,13 +2066,14 @@ def test_verify_codeagent_auth_returns_error_when_token_refresh_times_out(
         lambda: _TimeoutTokenService(),
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert result.status == "error"
     assert result.detail == "token request timed out"
 
 
-def test_verify_codeagent_auth_returns_error_when_verify_request_times_out(
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_returns_error_when_verify_request_times_out(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -1814,19 +2092,20 @@ def test_verify_codeagent_auth_returns_error_when_verify_request_times_out(
         lambda: _FakeCodeAgentTokenService(["codeagent-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             error=httpx.ReadTimeout("verify request timed out")
         ),
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert result.status == "error"
     assert result.detail == "verify request timed out"
 
 
-def test_verify_codeagent_auth_returns_error_when_verify_request_fails(
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_returns_error_when_verify_request_fails(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -1845,19 +2124,20 @@ def test_verify_codeagent_auth_returns_error_when_verify_request_fails(
         lambda: _FakeCodeAgentTokenService(["codeagent-access-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             error=httpx.ConnectError("failed to reach codeagent")
         ),
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert result.status == "error"
     assert result.detail == "failed to reach codeagent"
 
 
-def test_verify_codeagent_auth_returns_error_for_redirect_response(
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_returns_error_for_redirect_response(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -1875,7 +2155,7 @@ def test_verify_codeagent_auth_returns_error_for_redirect_response(
     )
 
     class _TokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -1909,14 +2189,14 @@ def test_verify_codeagent_auth_returns_error_for_redirect_response(
         )
     ]
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _QueuedHttpClient(
             captured=captured,
             responses=responses,
         ),
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert result.status == "error"
     assert result.detail == "Failed to verify CodeAgent authentication."
@@ -1932,7 +2212,8 @@ def test_verify_codeagent_auth_returns_error_for_redirect_response(
     ]
 
 
-def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -1947,7 +2228,7 @@ def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
     )
 
     class _SuccessfulCodeAgentTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -1981,14 +2262,14 @@ def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
         ),
     ]
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _QueuedHttpClient(
             captured=captured,
             responses=responses,
         ),
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert result.status == "valid"
     assert result.detail is None
@@ -2010,7 +2291,8 @@ def test_verify_codeagent_auth_returns_valid_after_successful_refresh(
     ]
 
 
-def test_verify_codeagent_auth_returns_error_when_refresh_redirects(
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_returns_error_when_refresh_redirects(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -2025,7 +2307,7 @@ def test_verify_codeagent_auth_returns_error_when_refresh_redirects(
     )
 
     class _SuccessfulCodeAgentTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -2059,14 +2341,14 @@ def test_verify_codeagent_auth_returns_error_when_refresh_redirects(
         ),
     ]
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _QueuedHttpClient(
             captured=captured,
             responses=responses,
         ),
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert result.status == "error"
     assert result.detail == "Failed to verify CodeAgent authentication."
@@ -2088,7 +2370,8 @@ def test_verify_codeagent_auth_returns_error_when_refresh_redirects(
     ]
 
 
-def test_verify_codeagent_auth_returns_reauth_required_after_refresh_denied(
+@pytest.mark.asyncio
+async def test_verify_codeagent_auth_returns_reauth_required_after_refresh_denied(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -2106,7 +2389,7 @@ def test_verify_codeagent_auth_returns_reauth_required_after_refresh_denied(
     )
 
     class _FailingRefreshTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -2142,26 +2425,27 @@ def test_verify_codeagent_auth_returns_reauth_required_after_refresh_denied(
         httpx.Response(401, json={"detail": "expired access token"}),
     ]
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _QueuedHttpClient(
             captured=captured,
             responses=responses,
         ),
     )
 
-    result = service.verify_codeagent_auth(profile_name="default")
+    result = await service.verify_codeagent_auth_async(profile_name="default")
 
     assert result.status == "reauth_required"
     assert result.detail == "未识别到用户认证信息"
 
 
-def test_discover_models_codeagent_oauth_http_error_is_retryable_for_server_errors(
+@pytest.mark.asyncio
+async def test_discover_models_codeagent_oauth_http_error_is_retryable_for_server_errors(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -2187,7 +2471,7 @@ def test_discover_models_codeagent_oauth_http_error_is_retryable_for_server_erro
         lambda: _FailingCodeAgentTokenService(),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.CODEAGENT,
@@ -2205,13 +2489,14 @@ def test_discover_models_codeagent_oauth_http_error_is_retryable_for_server_erro
     assert result.diagnostics.auth_valid is True
 
 
-def test_get_codeagent_token_for_probe_returns_timeout_when_token_service_times_out(
+@pytest.mark.asyncio
+async def test_get_codeagent_token_for_probe_async_returns_timeout_when_token_service_times_out(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _TimeoutingCodeAgentTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -2234,7 +2519,7 @@ def test_get_codeagent_token_for_probe_returns_timeout_when_token_service_times_
         lambda: _TimeoutingCodeAgentTokenService(),
     )
 
-    result = service._get_codeagent_token_for_probe(
+    result = await service._get_codeagent_token_for_probe_async(
         config=ModelEndpointConfig(
             provider=ProviderType.CODEAGENT,
             model="codeagent-chat",
@@ -2251,13 +2536,14 @@ def test_get_codeagent_token_for_probe_returns_timeout_when_token_service_times_
     assert result.error_code == "network_timeout"
 
 
-def test_get_codeagent_token_for_discovery_returns_network_error_when_token_service_fails(
+@pytest.mark.asyncio
+async def test_get_codeagent_token_for_discovery_async_returns_network_error_when_token_service_fails(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     class _FailingCodeAgentTokenService:
-        def get_token_sync(
+        async def get_token(
             self,
             *,
             base_url: str,
@@ -2280,7 +2566,7 @@ def test_get_codeagent_token_for_discovery_returns_network_error_when_token_serv
         lambda: _FailingCodeAgentTokenService(),
     )
 
-    result = service._get_codeagent_token_for_discovery(
+    result = await service._get_codeagent_token_for_discovery_async(
         config=ModelDiscoveryResolvedConfig(
             provider=ProviderType.CODEAGENT,
             base_url=DEFAULT_CODEAGENT_BASE_URL,
@@ -2628,7 +2914,8 @@ def test_extract_codeagent_model_entries_skips_blank_model_ids() -> None:
     assert tuple(entry.model for entry in entries) == ("codeagent-chat",)
 
 
-def test_discover_models_merges_saved_maas_password_when_override_omits_it(
+@pytest.mark.asyncio
+async def test_discover_models_merges_saved_maas_password_when_override_omits_it(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -2651,7 +2938,7 @@ def test_discover_models_merges_saved_maas_password_when_override_omits_it(
         lambda: _FakeMaaSTokenService(["maas-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -2664,7 +2951,7 @@ def test_discover_models_merges_saved_maas_password_when_override_omits_it(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             profile_name="maas-profile",
             override=ModelConnectivityProbeOverride(
@@ -2679,7 +2966,8 @@ def test_discover_models_merges_saved_maas_password_when_override_omits_it(
     assert token_calls[0]["password"] == "saved-password"
 
 
-def test_discover_models_refreshes_maas_token_after_unauthorized_response(
+@pytest.mark.asyncio
+async def test_discover_models_refreshes_maas_token_after_unauthorized_response(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {"requests": []}
@@ -2702,11 +2990,11 @@ def test_discover_models_refreshes_maas_token_after_unauthorized_response(
         return _FakeHttpClient(captured=local_capture, response=responses.pop(0))
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         build_client,
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -2730,7 +3018,8 @@ def test_discover_models_refreshes_maas_token_after_unauthorized_response(
     assert token_calls[1]["force_refresh"] is True
 
 
-def test_discover_models_refreshes_maas_auth_when_department_missing(
+@pytest.mark.asyncio
+async def test_discover_models_refreshes_maas_auth_when_department_missing(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -2746,7 +3035,7 @@ def test_discover_models_refreshes_maas_auth_when_department_missing(
         lambda: token_service,
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -2759,7 +3048,7 @@ def test_discover_models_refreshes_maas_auth_when_department_missing(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -2780,7 +3069,8 @@ def test_discover_models_refreshes_maas_auth_when_department_missing(
     assert token_calls[1]["force_refresh"] is True
 
 
-def test_discover_models_returns_invalid_response_when_maas_department_missing(
+@pytest.mark.asyncio
+async def test_discover_models_returns_invalid_response_when_maas_department_missing(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -2795,7 +3085,7 @@ def test_discover_models_returns_invalid_response_when_maas_department_missing(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -2818,12 +3108,15 @@ def test_discover_models_returns_invalid_response_when_maas_department_missing(
     assert token_calls[1]["force_refresh"] is True
 
 
-def test_discover_models_uses_saved_profile_and_parses_catalog(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_uses_saved_profile_and_parses_catalog(
+    monkeypatch,
+) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -2843,7 +3136,7 @@ def test_discover_models_uses_saved_profile_and_parses_catalog(monkeypatch) -> N
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(profile_name="default", timeout_ms=2800)
     )
 
@@ -2861,11 +3154,14 @@ def test_discover_models_uses_saved_profile_and_parses_catalog(monkeypatch) -> N
     )
 
 
-def test_discover_models_projects_input_modalities_from_catalog(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_projects_input_modalities_from_catalog(
+    monkeypatch,
+) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -2883,7 +3179,9 @@ def test_discover_models_projects_input_modalities_from_catalog(monkeypatch) -> 
         ),
     )
 
-    result = service.discover_models(ModelDiscoveryRequest(profile_name="default"))
+    result = await service.discover_models_async(
+        ModelDiscoveryRequest(profile_name="default")
+    )
 
     assert result.ok is True
     assert result.model_entries[0].model == "gpt-4o-mini"
@@ -2894,13 +3192,14 @@ def test_discover_models_projects_input_modalities_from_catalog(monkeypatch) -> 
     assert result.model_entries[1].capabilities.input.image is True
 
 
-def test_discover_models_extracts_context_window_when_provider_returns_it(
+@pytest.mark.asyncio
+async def test_discover_models_extracts_context_window_when_provider_returns_it(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -2923,7 +3222,9 @@ def test_discover_models_extracts_context_window_when_provider_returns_it(
         ),
     )
 
-    result = service.discover_models(ModelDiscoveryRequest(profile_name="default"))
+    result = await service.discover_models_async(
+        ModelDiscoveryRequest(profile_name="default")
+    )
 
     assert result.ok is True
     assert result.models == ("fake-chat-model", "reasoning-model")
@@ -2933,11 +3234,12 @@ def test_discover_models_extracts_context_window_when_provider_returns_it(
     assert result.model_entries[1].context_window == 128000
 
 
-def test_discover_models_extracts_endpoint_only_metadata(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_extracts_endpoint_only_metadata(monkeypatch) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -2963,7 +3265,7 @@ def test_discover_models_extracts_endpoint_only_metadata(monkeypatch) -> None:
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             profile_name="default",
             metadata_policy="endpoint_only",
@@ -2984,11 +3286,14 @@ def test_discover_models_extracts_endpoint_only_metadata(monkeypatch) -> None:
     assert entries["bool-limit-model"].output_limit is None
 
 
-def test_discover_models_extracts_moonshot_endpoint_only_metadata(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_extracts_moonshot_endpoint_only_metadata(
+    monkeypatch,
+) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -3016,7 +3321,7 @@ def test_discover_models_extracts_moonshot_endpoint_only_metadata(monkeypatch) -
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.OPENAI_COMPATIBLE,
@@ -3042,13 +3347,14 @@ def test_discover_models_extracts_moonshot_endpoint_only_metadata(monkeypatch) -
     assert result.model_entries[1].input_modalities == ()
 
 
-def test_discover_models_leaves_minimax_openai_endpoint_only_metadata_empty(
+@pytest.mark.asyncio
+async def test_discover_models_leaves_minimax_openai_endpoint_only_metadata_empty(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -3073,7 +3379,7 @@ def test_discover_models_leaves_minimax_openai_endpoint_only_metadata_empty(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.OPENAI_COMPATIBLE,
@@ -3093,13 +3399,14 @@ def test_discover_models_leaves_minimax_openai_endpoint_only_metadata_empty(
         assert entry.capabilities.input.image is None
 
 
-def test_discover_models_leaves_xiaomi_mimo_endpoint_only_metadata_empty(
+@pytest.mark.asyncio
+async def test_discover_models_leaves_xiaomi_mimo_endpoint_only_metadata_empty(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -3127,7 +3434,7 @@ def test_discover_models_leaves_xiaomi_mimo_endpoint_only_metadata_empty(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.OPENAI_COMPATIBLE,
@@ -3147,13 +3454,14 @@ def test_discover_models_leaves_xiaomi_mimo_endpoint_only_metadata_empty(
         assert entry.capabilities.input.image is None
 
 
-def test_discover_models_leaves_bigmodel_endpoint_only_metadata_empty(
+@pytest.mark.asyncio
+async def test_discover_models_leaves_bigmodel_endpoint_only_metadata_empty(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -3178,7 +3486,7 @@ def test_discover_models_leaves_bigmodel_endpoint_only_metadata_empty(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.BIGMODEL,
@@ -3198,11 +3506,14 @@ def test_discover_models_leaves_bigmodel_endpoint_only_metadata_empty(
         assert entry.capabilities.input.image is None
 
 
-def test_discover_models_falls_back_to_known_context_window_rules(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_falls_back_to_known_context_window_rules(
+    monkeypatch,
+) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -3217,7 +3528,9 @@ def test_discover_models_falls_back_to_known_context_window_rules(monkeypatch) -
         ),
     )
 
-    result = service.discover_models(ModelDiscoveryRequest(profile_name="default"))
+    result = await service.discover_models_async(
+        ModelDiscoveryRequest(profile_name="default")
+    )
 
     assert result.ok is True
     assert result.models == ("gpt-4o-mini", "kimi-k2.5")
@@ -3225,14 +3538,15 @@ def test_discover_models_falls_back_to_known_context_window_rules(monkeypatch) -
     assert result.model_entries[1].context_window == 256000
 
 
-def test_discover_models_allows_saved_api_key_with_override_base_url(
+@pytest.mark.asyncio
+async def test_discover_models_allows_saved_api_key_with_override_base_url(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -3242,7 +3556,7 @@ def test_discover_models_allows_saved_api_key_with_override_base_url(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             profile_name="default",
             override=ModelConnectivityProbeOverride(base_url="https://draft.test/v1"),
@@ -3257,12 +3571,13 @@ def test_discover_models_allows_saved_api_key_with_override_base_url(
     assert captured["timeout_seconds"] == pytest.approx(17.5)
 
 
-def test_discover_models_supports_bigmodel_provider(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_supports_bigmodel_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -3272,7 +3587,7 @@ def test_discover_models_supports_bigmodel_provider(monkeypatch) -> None:
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.BIGMODEL,
@@ -3288,12 +3603,13 @@ def test_discover_models_supports_bigmodel_provider(monkeypatch) -> None:
     assert captured["url"] == "https://open.bigmodel.cn/api/coding/paas/v4/models"
 
 
-def test_discover_models_supports_anthropic_provider(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_supports_anthropic_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -3311,7 +3627,7 @@ def test_discover_models_supports_anthropic_provider(monkeypatch) -> None:
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.ANTHROPIC,
@@ -3329,19 +3645,20 @@ def test_discover_models_supports_anthropic_provider(monkeypatch) -> None:
     assert headers["x-api-key"] == "draft-api-key"
 
 
-def test_discover_models_anthropic_returns_network_error_for_request_exception(
+@pytest.mark.asyncio
+async def test_discover_models_anthropic_returns_network_error_for_request_exception(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             error=httpx.ConnectError("failed to reach anthropic model list"),
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.ANTHROPIC,
@@ -3357,11 +3674,14 @@ def test_discover_models_anthropic_returns_network_error_for_request_exception(
     assert result.retryable is True
 
 
-def test_discover_models_supports_anthropic_endpoint_only_metadata(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_supports_anthropic_endpoint_only_metadata(
+    monkeypatch,
+) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -3378,7 +3698,7 @@ def test_discover_models_supports_anthropic_endpoint_only_metadata(monkeypatch) 
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.ANTHROPIC,
@@ -3395,13 +3715,14 @@ def test_discover_models_supports_anthropic_endpoint_only_metadata(monkeypatch) 
     assert result.model_entries[0].output_limit == 8192
 
 
-def test_discover_models_leaves_minimax_anthropic_endpoint_only_metadata_empty(
+@pytest.mark.asyncio
+async def test_discover_models_leaves_minimax_anthropic_endpoint_only_metadata_empty(
     monkeypatch,
 ) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(
                 200,
@@ -3428,7 +3749,7 @@ def test_discover_models_leaves_minimax_anthropic_endpoint_only_metadata_empty(
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.ANTHROPIC,
@@ -3448,12 +3769,13 @@ def test_discover_models_leaves_minimax_anthropic_endpoint_only_metadata_empty(
         assert entry.capabilities.input.image is None
 
 
-def test_discover_models_allows_header_only_override(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_allows_header_only_override(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -3463,7 +3785,7 @@ def test_discover_models_allows_header_only_override(monkeypatch) -> None:
         ),
     )
 
-    result = service.discover_models(
+    result = await service.discover_models_async(
         ModelDiscoveryRequest(
             override=ModelConnectivityProbeOverride(
                 base_url="https://draft.test/v1",
@@ -3482,24 +3804,28 @@ def test_discover_models_allows_header_only_override(monkeypatch) -> None:
     assert headers["Authorization"] == "Bearer discovery-header"
 
 
-def test_discover_models_returns_invalid_response_error(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_discover_models_returns_invalid_response_error(monkeypatch) -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **_kwargs: _FakeHttpClient(
             response=httpx.Response(200, json={"items": [{"id": "missing-data"}]})
         ),
     )
 
-    result = service.discover_models(ModelDiscoveryRequest(profile_name="default"))
+    result = await service.discover_models_async(
+        ModelDiscoveryRequest(profile_name="default")
+    )
 
     assert result.ok is False
     assert result.error_code == "invalid_response"
     assert result.retryable is False
 
 
-def test_probe_maas_supports_event_stream_wrapped_json(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_maas_supports_event_stream_wrapped_json(monkeypatch) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
@@ -3508,7 +3834,7 @@ def test_probe_maas_supports_event_stream_wrapped_json(monkeypatch) -> None:
         lambda: _FakeMaaSTokenService(["maas-token"], captured),
     )
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -3525,7 +3851,7 @@ def test_probe_maas_supports_event_stream_wrapped_json(monkeypatch) -> None:
         ),
     )
 
-    result = service.probe(
+    result = await service.probe_async(
         ModelConnectivityProbeRequest(
             override=ModelConnectivityProbeOverride(
                 provider=ProviderType.MAAS,
@@ -3544,21 +3870,26 @@ def test_probe_maas_supports_event_stream_wrapped_json(monkeypatch) -> None:
     assert result.token_usage.total_tokens == 3
 
 
-def test_probe_requires_source_config() -> None:
+@pytest.mark.asyncio
+async def test_probe_requires_source_config() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="Provide profile_name, override, or both."):
-        service.probe(ModelConnectivityProbeRequest())
+        await service.probe_async(ModelConnectivityProbeRequest())
 
 
-def test_discover_models_requires_source_config() -> None:
+@pytest.mark.asyncio
+async def test_discover_models_requires_source_config() -> None:
     service = ModelConnectivityProbeService(get_runtime=_runtime_config)
 
     with pytest.raises(ValueError, match="Provide profile_name, override, or both."):
-        service.discover_models(ModelDiscoveryRequest())
+        await service.discover_models_async(ModelDiscoveryRequest())
 
 
-def test_probe_resolves_default_alias_to_runtime_default_profile(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_probe_resolves_default_alias_to_runtime_default_profile(
+    monkeypatch,
+) -> None:
     captured: dict[str, object] = {}
     service = ModelConnectivityProbeService(
         get_runtime=lambda: _runtime_config(
@@ -3568,7 +3899,7 @@ def test_probe_resolves_default_alias_to_runtime_default_profile(monkeypatch) ->
     )
 
     monkeypatch.setattr(
-        "relay_teams.providers.model_connectivity.create_sync_http_client",
+        "relay_teams.providers.model_connectivity.create_async_http_client",
         lambda **kwargs: (
             captured.update(kwargs)
             or _FakeHttpClient(
@@ -3577,7 +3908,9 @@ def test_probe_resolves_default_alias_to_runtime_default_profile(monkeypatch) ->
         ),
     )
 
-    result = service.probe(ModelConnectivityProbeRequest(profile_name="default"))
+    result = await service.probe_async(
+        ModelConnectivityProbeRequest(profile_name="default")
+    )
 
     assert result.ok is True
     assert captured["url"] == "https://example.test/v1/chat/completions"


### PR DESCRIPTION
## Summary
- remove sync MaaS and CodeAgent auth/token paths now that async siblings exist
- switch model catalog/config/connectivity and system routes to async-only provider network calls
- convert Xiaoluban inbound gateway handling to async and update provider/gateway docs

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests/api tests/integration_tests/cli

Closes #707