### PR TITLE
Fix automation run detail timing

### DIFF
--- a/frontend/dist/js/components/projectView.js
+++ b/frontend/dist/js/components/projectView.js
@@ -1027,6 +1027,25 @@ function formatIsoToLocalTime(isoValue, timezone) {
     return `${parts.hour}:${parts.minute}`;
 }
 
+function formatAutomationUtcDateTime(value, fallback) {
+    const rawValue = String(value || '').trim();
+    if (!rawValue) {
+        return fallback;
+    }
+    const date = new Date(rawValue);
+    if (Number.isNaN(date.getTime())) {
+        return rawValue;
+    }
+    return [
+        date.getUTCFullYear(),
+        String(date.getUTCMonth() + 1).padStart(2, '0'),
+        String(date.getUTCDate()).padStart(2, '0'),
+    ].join('-') + ' ' + [
+        String(date.getUTCHours()).padStart(2, '0'),
+        String(date.getUTCMinutes()).padStart(2, '0'),
+    ].join(':') + ' UTC';
+}
+
 function createDefaultOneShotDate(timezone) {
     const now = new Date();
     const parts = getFormatterParts(now, timezone);
@@ -4839,8 +4858,8 @@ function renderAutomationHomeDetail(detail) {
                                 ? resolveAutomationPresetDisplayName(orchestrationPresetId, orchestrationPresets)
                                 : resolveAutomationRoleDisplayName(normalRootRoleId, normalRoles)
                         )}</strong></div>
-                        <div><span>${escapeHtml(t('automation.detail.next_run'))}</span><strong>${escapeHtml(String(project?.next_run_at || t('automation.detail.not_scheduled')))}</strong></div>
-                        <div><span>${escapeHtml(t('automation.detail.last_run'))}</span><strong>${escapeHtml(String(project?.last_run_started_at || t('automation.detail.never')))}</strong></div>
+                        <div><span>${escapeHtml(t('automation.detail.next_run'))}</span><strong>${escapeHtml(formatAutomationUtcDateTime(project?.next_run_at, t('automation.detail.not_scheduled')))}</strong></div>
+                        <div><span>${escapeHtml(t('automation.detail.last_run'))}</span><strong>${escapeHtml(formatAutomationUtcDateTime(project?.last_run_started_at, t('automation.detail.never')))}</strong></div>
                     </div>
                 </section>
                 <section class="automation-flat-section automation-meta-section">
@@ -6187,8 +6206,8 @@ function renderAutomationProjectView(project, sessions, workspaceRecord = null, 
     const timezone = String(project?.timezone || 'UTC').trim() || 'UTC';
     const workspaceId = String(project?.workspace_id || '').trim() || 'automation-system';
     const workspaceRootPath = String(workspaceRecord?.root_path || '').trim() || t('automation.workspace.missing');
-    const nextRunAt = String(project?.next_run_at || '').trim() || t('automation.detail.not_scheduled');
-    const lastRunAt = String(project?.last_run_started_at || '').trim() || t('automation.detail.never');
+    const nextRunAt = formatAutomationUtcDateTime(project?.next_run_at, t('automation.detail.not_scheduled'));
+    const lastRunAt = formatAutomationUtcDateTime(project?.last_run_started_at, t('automation.detail.never'));
     const lastError = String(project?.last_error || '').trim() || t('automation.detail.none');
     const deliveryBinding = project?.delivery_binding && typeof project.delivery_binding === 'object'
         ? project.delivery_binding

--- a/src/relay_teams/automation/automation_service.py
+++ b/src/relay_teams/automation/automation_service.py
@@ -635,9 +635,27 @@ class AutomationService:
 
     async def run_now_async(self, automation_project_id: str) -> dict[str, JsonValue]:
         project = await self._repository.get_async(automation_project_id)
-        execution_handle = await self._materialize_execution_async(
-            project, reason="manual"
+        execution_task = asyncio.create_task(
+            self._materialize_execution_async(project, reason="manual")
         )
+        try:
+            execution_handle = await asyncio.shield(execution_task)
+        except asyncio.CancelledError:
+            try:
+                _ = await _await_execution_after_cancellation(execution_task)
+            except Exception as exc:
+                log_event(
+                    LOGGER,
+                    logging.ERROR,
+                    event="automation.run_now.cancelled_start_failed",
+                    message="Automation run startup failed after caller cancellation",
+                    payload={
+                        "automation_project_id": automation_project_id,
+                        "error": str(exc),
+                    },
+                    exc_info=exc,
+                )
+            raise
         return {
             "automation_project_id": automation_project_id,
             "session_id": execution_handle.session_id,
@@ -1252,6 +1270,25 @@ class AutomationService:
                 created_at=occurred_at,
             )
         )
+
+
+async def _await_execution_after_cancellation(
+    task: asyncio.Task[AutomationExecutionHandle],
+) -> AutomationExecutionHandle:
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            _clear_current_task_cancellation_requests()
+    return task.result()
+
+
+def _clear_current_task_cancellation_requests() -> None:
+    current_task = asyncio.current_task()
+    if current_task is None:
+        return
+    while current_task.cancelling():
+        current_task.uncancel()
 
 
 def _validate_timezone(timezone_name: str) -> str:

--- a/tests/unit_tests/automation/test_automation_service.py
+++ b/tests/unit_tests/automation/test_automation_service.py
@@ -494,6 +494,96 @@ def test_async_run_now_uses_session_ingress_service(tmp_path: Path) -> None:
     asyncio.run(exercise())
 
 
+def test_async_run_now_finishes_startup_when_caller_is_cancelled(
+    tmp_path: Path,
+) -> None:
+    service, run_service, _ = _build_service(tmp_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def wait_for_release(run_id: str) -> None:
+        started.set()
+        await release.wait()
+        run_service.ensure_run_started(run_id)
+
+    run_service.ensure_run_started_async = wait_for_release
+
+    async def exercise() -> None:
+        created = await service.create_project_async(
+            AutomationProjectCreateInput(
+                name="cancelled-report",
+                workspace_id="default",
+                prompt="Draft a report after caller cancellation.",
+                schedule_mode=AutomationScheduleMode.CRON,
+                cron_expression="0 1 * * *",
+                timezone="UTC",
+            )
+        )
+        task = asyncio.create_task(service.run_now_async(created.automation_project_id))
+
+        await started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            _ = await task
+
+        updated = await service.get_project_async(created.automation_project_id)
+        assert updated.last_session_id is not None
+        assert updated.last_run_started_at is not None
+        assert len(run_service.create_calls) == 1
+        assert run_service.started_run_ids == ["run-1"]
+
+    asyncio.run(exercise())
+
+
+def test_async_run_now_logs_startup_failure_when_cancelled_caller_waits(
+    tmp_path: Path,
+) -> None:
+    service, run_service, _ = _build_service(tmp_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fail_after_release(run_id: str) -> None:
+        _ = run_id
+        started.set()
+        await release.wait()
+        raise RuntimeError("startup exploded")
+
+    run_service.ensure_run_started_async = fail_after_release
+
+    async def exercise() -> None:
+        created = await service.create_project_async(
+            AutomationProjectCreateInput(
+                name="cancelled-failure-report",
+                workspace_id="default",
+                prompt="Draft a report after failed startup.",
+                schedule_mode=AutomationScheduleMode.CRON,
+                cron_expression="0 1 * * *",
+                timezone="UTC",
+            )
+        )
+        task = asyncio.create_task(service.run_now_async(created.automation_project_id))
+
+        await started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            _ = await task
+
+        updated = await service.get_project_async(created.automation_project_id)
+        assert updated.last_error == "startup exploded"
+        assert len(run_service.create_calls) == 1
+        assert run_service.started_run_ids == []
+
+    asyncio.run(exercise())
+
+
 def test_async_run_now_offloads_bound_session_execution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/frontend/test_project_view_ui.py
+++ b/tests/unit_tests/frontend/test_project_view_ui.py
@@ -4043,8 +4043,8 @@ export async function fetchAutomationProject() {
         schedule_mode: "cron",
         cron_expression: "0 9 * * *",
         timezone: "Asia/Shanghai",
-        next_run_at: "2026-03-14T09:00:00Z",
-        last_run_started_at: "2026-03-14T08:00:00Z",
+        next_run_at: "2026-05-07T08:30:00+08:00",
+        last_run_started_at: "",
         delivery_events: [],
     };
 }
@@ -4168,8 +4168,25 @@ export async function updateAutomationProject() {
     )
     assert "automation-prompt-card" not in content_html
     assert "automation-prompt-inline" in content_html
+    assert "2026-05-07 00:30 UTC" in content_html
+    assert "Never" in content_html
     assert "feature-card automation-runs-card" not in content_html
     assert "automation-flat-section automation-runs-section" in content_html
+
+
+def test_project_view_formats_automation_project_detail_times_as_utc() -> None:
+    source = Path("frontend/dist/js/components/projectView.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "function formatAutomationUtcDateTime" in source
+    assert (
+        "const nextRunAt = formatAutomationUtcDateTime(project?.next_run_at" in source
+    )
+    assert (
+        "const lastRunAt = formatAutomationUtcDateTime(project?.last_run_started_at"
+        in source
+    )
 
 
 def test_project_view_keeps_automation_detail_visible_when_session_config_helpers_fail(


### PR DESCRIPTION
## Summary

- Render automation project next/recent run timestamps as concise UTC strings in detail views.
- Shield manual automation run startup from caller cancellation so startup can finish cleanly.
- Add regression coverage for UTC display and cancelled startup behavior.

Closes #730

## Validation

- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests`
