### PR TITLE
Fix large session event loop starvation

### DIFF
--- a/src/relay_teams/agents/execution/message_repository.py
+++ b/src/relay_teams/agents/execution/message_repository.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
+
 from pydantic import JsonValue
 
 import json
@@ -1438,15 +1440,10 @@ class MessageRepository(SharedSqliteRepository):
             include_cleared=False,
             include_hidden_from_context=False,
         )
-        allowed_ids = _safe_row_ids(filtered_rows)
-        result: list[ModelMessage] = []
-        for row in filtered_rows:
-            row_id = row["id"]
-            if not isinstance(row_id, int) or row_id not in allowed_ids:
-                continue
-            msgs = _validate_message_row(row)
-            result.extend(msgs)
-        return _truncate_model_history_to_safe_boundary(result)
+        return await asyncio.to_thread(
+            _validated_history_from_rows,
+            tuple(filtered_rows),
+        )
 
     def _prune_to_safe_boundary(
         self,
@@ -1765,7 +1762,10 @@ class MessageRepository(SharedSqliteRepository):
             filtered_rows = await self._filter_rows_for_active_segments_async(
                 filtered_rows
             )
-        filtered_rows = _drop_duplicate_tool_outcome_rows(filtered_rows)
+        filtered_rows = await asyncio.to_thread(
+            _drop_duplicate_tool_outcome_rows,
+            tuple(filtered_rows),
+        )
         if include_hidden_from_context:
             return filtered_rows
         return self._filter_rows_for_visible_context(filtered_rows)
@@ -2328,6 +2328,20 @@ def _validate_message_row(row: sqlite3.Row) -> list[ModelMessage]:
             },
         )
         return []
+
+
+def _validated_history_from_rows(
+    rows: Sequence[sqlite3.Row],
+) -> list[ModelMessage]:
+    allowed_ids = _safe_row_ids(rows)
+    result: list[ModelMessage] = []
+    for row in rows:
+        row_id = row["id"]
+        if not isinstance(row_id, int) or row_id not in allowed_ids:
+            continue
+        msgs = _validate_message_row(row)
+        result.extend(msgs)
+    return _truncate_model_history_to_safe_boundary(result)
 
 
 def _row_id(row: sqlite3.Row) -> int:

--- a/src/relay_teams/agents/execution/prompt_budgeting.py
+++ b/src/relay_teams/agents/execution/prompt_budgeting.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections.abc import Sequence
@@ -105,8 +106,10 @@ class PromptBudgetingService:
         context_window = self._config.context_window
         if context_window is None or context_window <= 0:
             return configured_max_tokens
-        estimator = ConversationTokenEstimator()
-        estimated_history_tokens = estimator.estimate_history_tokens(history)
+        estimated_history_tokens = await asyncio.to_thread(
+            ConversationTokenEstimator().estimate_history_tokens,
+            tuple(history),
+        )
         budget = await self.estimate_compaction_budget(
             request=request,
             history=history,

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Protocol, cast, runtime_checkable
@@ -579,15 +580,16 @@ class PromptHistoryService:
             allowed_mcp_servers=allowed_mcp_servers,
             allowed_skills=allowed_skills,
         )
-        estimated_before_microcompact = (
-            ConversationTokenEstimator().estimate_history_tokens(history)
+        estimated_before_microcompact = await self._estimate_history_tokens_async(
+            history
         )
         estimated_after_microcompact = estimated_before_microcompact
         compacted_message_count = 0
         compacted_part_count = 0
         if self._conversation_microcompact_service is not None:
-            microcompact_result = self._conversation_microcompact_service.apply(
-                history=history,
+            microcompact_result = await asyncio.to_thread(
+                self._conversation_microcompact_service.apply,
+                history=tuple(history),
                 budget=budget,
             )
             history = list(microcompact_result.messages)
@@ -1036,6 +1038,15 @@ class PromptHistoryService:
             allowed_skills=allowed_skills,
         )
 
+    @staticmethod
+    async def _estimate_history_tokens_async(
+        history: Sequence[ModelRequest | ModelResponse],
+    ) -> int:
+        return await asyncio.to_thread(
+            ConversationTokenEstimator().estimate_history_tokens,
+            tuple(history),
+        )
+
     async def safe_max_output_tokens(
         self,
         *,
@@ -1114,8 +1125,9 @@ class PromptHistoryService:
     ) -> list[ModelRequest | ModelResponse]:
         if self._conversation_compaction_service is None:
             return history
-        plan = self._conversation_compaction_service.plan_compaction(
-            history=history,
+        plan = await asyncio.to_thread(
+            self._conversation_compaction_service.plan_compaction,
+            history=tuple(history),
             budget=budget,
         )
         if not plan.should_compact:
@@ -1196,7 +1208,7 @@ class PromptHistoryService:
                     message_count_before=len(history),
                     message_count_after=len(compacted_history),
                     estimated_tokens_before=estimated_tokens_before_microcompact or 0,
-                    estimated_tokens_after=ConversationTokenEstimator().estimate_history_tokens(
+                    estimated_tokens_after=await self._estimate_history_tokens_async(
                         compacted_history
                     ),
                 ),
@@ -1216,7 +1228,7 @@ class PromptHistoryService:
                     message_count_before=len(history),
                     message_count_after=len(compacted_history),
                     estimated_tokens_before=estimated_tokens_before_microcompact or 0,
-                    estimated_tokens_after=ConversationTokenEstimator().estimate_history_tokens(
+                    estimated_tokens_after=await self._estimate_history_tokens_async(
                         compacted_history
                     ),
                     threshold_tokens=plan.threshold_tokens,

--- a/src/relay_teams/agents/orchestration/harnesses/control_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/control_harness.py
@@ -251,11 +251,11 @@ class TaskControlHarness:
         """Append an artifact entry. Returns entry count or None if repo unavailable."""
         if self._artifact_repo is None:
             return None
-        artifact = self._artifact_repo.get_artifact(task_id)
+        artifact = await asyncio.to_thread(self._artifact_repo.get_artifact, task_id)
         if artifact is None:
             return None
-        self._artifact_repo.append_entry(task_id, entry)
-        updated = self._artifact_repo.get_artifact(task_id)
+        await asyncio.to_thread(self._artifact_repo.append_entry, task_id, entry)
+        updated = await asyncio.to_thread(self._artifact_repo.get_artifact, task_id)
         return len(updated.entries) if updated else None
 
     async def _maybe_enqueue_retry(self, task: TaskEnvelope) -> None:

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -398,11 +398,13 @@ class TaskExecutionService(BaseModel):
         # OP-3: Create artifact container (spec phase).
         if self.artifact_repo is not None:
             try:
-                self.artifact_repo.ensure_artifact(
+                await asyncio.to_thread(
+                    self.artifact_repo.ensure_artifact,
                     task_id=task.task_id,
                     spec_artifact_id=task.spec_artifact_id or "",
                 )
-                self.artifact_repo.append_entry(
+                await asyncio.to_thread(
+                    self.artifact_repo.append_entry,
                     task_id=task.task_id,
                     entry=TaskArtifactEntry(
                         entry_id=f"start-{task.task_id}",
@@ -439,7 +441,8 @@ class TaskExecutionService(BaseModel):
             # OP-3: Append implementation phase entry.
             if self.artifact_repo is not None:
                 try:
-                    self.artifact_repo.append_entry(
+                    await asyncio.to_thread(
+                        self.artifact_repo.append_entry,
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"impl-{task.task_id}",
@@ -543,7 +546,8 @@ class TaskExecutionService(BaseModel):
             # OP-3: Append verification phase entry.
             if self.artifact_repo is not None:
                 try:
-                    self.artifact_repo.append_entry(
+                    await asyncio.to_thread(
+                        self.artifact_repo.append_entry,
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"verify-{task.task_id}",
@@ -568,7 +572,8 @@ class TaskExecutionService(BaseModel):
             # OP-3: Append delivery phase entry and update summary.
             if self.artifact_repo is not None:
                 try:
-                    self.artifact_repo.append_entry(
+                    await asyncio.to_thread(
+                        self.artifact_repo.append_entry,
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"delivery-{task.task_id}",
@@ -581,8 +586,10 @@ class TaskExecutionService(BaseModel):
                             payload_json="{}",
                         ),
                     )
-                    self.artifact_repo.update_summary(
-                        task_id=task.task_id, summary=result
+                    await asyncio.to_thread(
+                        self.artifact_repo.update_summary,
+                        task_id=task.task_id,
+                        summary=result,
                     )
                 except Exception as exc:
                     log_event(

--- a/src/relay_teams/agents/tasks/artifact_repository.py
+++ b/src/relay_teams/agents/tasks/artifact_repository.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import RLock
+from typing import TypeVar, cast
 
 from relay_teams.agents.tasks.enums import TaskArtifactPhase
 from relay_teams.logger import get_logger
@@ -14,6 +17,14 @@ from relay_teams.agents.tasks.models import (
     TaskArtifactSummary,
     VerificationEvidenceBundle,
 )
+from relay_teams.persistence.db import (
+    BlockingSqliteConnection,
+    SQLITE_BUSY_TIMEOUT_MS,
+    SQLITE_TIMEOUT_SECONDS,
+    run_sqlite_write_with_retry,
+)
+
+ResultT = TypeVar("ResultT")
 
 _CREATE_TABLES_SQL = """\
 CREATE TABLE IF NOT EXISTS task_artifacts (
@@ -53,19 +64,48 @@ class TaskArtifactRepository:
 
     def __init__(self, db_path: Path | str) -> None:
         self._db_path = Path(db_path)
+        self._lock = RLock()
         self._init_tables()
 
     def _init_tables(self) -> None:
-        conn = sqlite3.connect(str(self._db_path))
-        try:
+        def operation(conn: sqlite3.Connection) -> None:
             conn.executescript(_CREATE_TABLES_SQL)
-            conn.commit()
+
+        self._run_write(operation_name="init_tables", operation=operation)
+
+    def _connect(self) -> sqlite3.Connection:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self._db_path), timeout=SQLITE_TIMEOUT_SECONDS)
+        conn.row_factory = sqlite3.Row
+        conn.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA temp_store = MEMORY")
+        conn.execute("PRAGMA synchronous = NORMAL")
+        _enable_wal_if_available(conn)
+        return conn
+
+    def _run_write(
+        self,
+        *,
+        operation_name: str,
+        operation: Callable[[sqlite3.Connection], ResultT],
+    ) -> ResultT:
+        conn = self._connect()
+        try:
+            return run_sqlite_write_with_retry(
+                conn=cast(BlockingSqliteConnection, conn),
+                db_path=self._db_path,
+                operation=lambda: operation(conn),
+                lock=self._lock,
+                repository_name=type(self).__name__,
+                operation_name=operation_name,
+            )
         finally:
             conn.close()
 
     def get_artifact(self, task_id: str) -> TaskArtifact | None:
         """Load the full artifact including all entries."""
-        conn = sqlite3.connect(str(self._db_path))
+        conn = self._connect()
         try:
             row = conn.execute(
                 "SELECT * FROM task_artifacts WHERE task_id = ?",
@@ -74,28 +114,13 @@ class TaskArtifactRepository:
             if row is None:
                 return None
 
-            columns = [
-                desc[0]
-                for desc in conn.execute(
-                    "SELECT * FROM task_artifacts WHERE task_id = ?",
-                    (task_id,),
-                ).description
-            ]
-            artifact_row = dict(zip(columns, row))
+            artifact_row = dict(row)
 
             entry_rows = conn.execute(
                 "SELECT * FROM task_artifact_entries WHERE task_id = ? ORDER BY id ASC",
                 (task_id,),
             ).fetchall()
-            columns_e = [
-                desc[0]
-                for desc in conn.execute(
-                    "SELECT * FROM task_artifact_entries "
-                    "WHERE task_id = ? ORDER BY id ASC",
-                    (task_id,),
-                ).description
-            ]
-            entries = [self._row_to_entry(dict(zip(columns_e, r))) for r in entry_rows]
+            entries = [self._row_to_entry(dict(row)) for row in entry_rows]
 
             evidence_bundle = None
             eb_json = artifact_row.get("evidence_bundle_json")
@@ -150,31 +175,22 @@ class TaskArtifactRepository:
 
     def ensure_artifact(self, task_id: str, spec_artifact_id: str) -> TaskArtifact:
         """Create the artifact record if it does not exist."""
-        existing = self.get_artifact(task_id)
-        if existing is not None:
-            return existing
-
         now = datetime.now(tz=timezone.utc).isoformat()
-        conn = sqlite3.connect(str(self._db_path))
-        try:
+
+        def operation(conn: sqlite3.Connection) -> None:
             conn.execute(
-                "INSERT INTO task_artifacts "
+                "INSERT OR IGNORE INTO task_artifacts "
                 "(task_id, spec_artifact_id, summary, "
                 "created_at, updated_at) "
                 "VALUES (?, ?, '', ?, ?)",
                 (task_id, spec_artifact_id, now, now),
             )
-            conn.commit()
-        finally:
-            conn.close()
 
-        return TaskArtifact(
-            task_id=task_id,
-            spec_artifact_id=spec_artifact_id,
-            entries=[],
-            created_at=now,
-            updated_at=now,
-        )
+        self._run_write(operation_name="ensure_artifact", operation=operation)
+        artifact = self.get_artifact(task_id)
+        if artifact is None:
+            raise RuntimeError(f"Failed to create task artifact for task_id={task_id}")
+        return artifact
 
     def append_entry(
         self,
@@ -182,8 +198,8 @@ class TaskArtifactRepository:
         entry: TaskArtifactEntry,
     ) -> int:
         """Append an entry to the artifact."""
-        conn = sqlite3.connect(str(self._db_path))
-        try:
+
+        def operation(conn: sqlite3.Connection) -> int:
             conn.execute(
                 "INSERT INTO task_artifact_entries "
                 "(entry_id, task_id, phase, timestamp, role_id, "
@@ -208,12 +224,9 @@ class TaskArtifactRepository:
                 "UPDATE task_artifacts SET updated_at = ? WHERE task_id = ?",
                 (now, task_id),
             )
-            conn.commit()
-            cursor = conn.execute("SELECT last_insert_rowid()")
-            row_id = cursor.fetchone()[0]
-            return row_id
-        finally:
-            conn.close()
+            return _last_insert_row_id(conn)
+
+        return self._run_write(operation_name="append_entry", operation=operation)
 
     def update_evidence_bundle(
         self,
@@ -222,17 +235,16 @@ class TaskArtifactRepository:
     ) -> None:
         """Update the evidence bundle for an artifact."""
         now = datetime.now(tz=timezone.utc).isoformat()
-        conn = sqlite3.connect(str(self._db_path))
-        try:
+
+        def operation(conn: sqlite3.Connection) -> None:
             conn.execute(
                 "UPDATE task_artifacts "
                 "SET evidence_bundle_json = ?, updated_at = ? "
                 "WHERE task_id = ?",
                 (bundle.model_dump_json(), now, task_id),
             )
-            conn.commit()
-        finally:
-            conn.close()
+
+        self._run_write(operation_name="update_evidence_bundle", operation=operation)
 
     def update_summary(
         self,
@@ -241,16 +253,15 @@ class TaskArtifactRepository:
     ) -> None:
         """Update the summary text for an artifact."""
         now = datetime.now(tz=timezone.utc).isoformat()
-        conn = sqlite3.connect(str(self._db_path))
-        try:
+
+        def operation(conn: sqlite3.Connection) -> None:
             conn.execute(
                 "UPDATE task_artifacts SET summary = ?, updated_at = ? "
                 "WHERE task_id = ?",
                 (summary, now, task_id),
             )
-            conn.commit()
-        finally:
-            conn.close()
+
+        self._run_write(operation_name="update_summary", operation=operation)
 
     def query_entries(
         self,
@@ -265,7 +276,7 @@ class TaskArtifactRepository:
 
         Returns (entries, total_count).
         """
-        conn = sqlite3.connect(str(self._db_path))
+        conn = self._connect()
         try:
             conditions: list[str] = ["task_id = ?"]
             params: list[object] = [task_id]
@@ -292,16 +303,7 @@ class TaskArtifactRepository:
                 f"ORDER BY id ASC LIMIT ? OFFSET ?",
                 tuple(params),
             ).fetchall()
-            col_names = [
-                desc[0]
-                for desc in conn.execute(
-                    f"SELECT * FROM task_artifact_entries "
-                    f"WHERE {where} "
-                    f"ORDER BY id ASC LIMIT ? OFFSET ?",
-                    tuple(params),
-                ).description
-            ]
-            entries = [self._row_to_entry(dict(zip(col_names, r))) for r in rows]
+            entries = [self._row_to_entry(dict(row)) for row in rows]
             return entries, total
         finally:
             conn.close()
@@ -345,3 +347,20 @@ class TaskArtifactRepository:
             payload_json=payload,
             linked_evidence_ids=linked,
         )
+
+
+def _enable_wal_if_available(conn: sqlite3.Connection) -> None:
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+    except sqlite3.OperationalError:
+        get_logger(__name__).debug(
+            "WAL mode is unavailable for task artifacts; using default journal mode"
+        )
+
+
+def _last_insert_row_id(conn: sqlite3.Connection) -> int:
+    cursor = conn.execute("SELECT last_insert_rowid()")
+    row_id = cursor.fetchone()[0]
+    if not isinstance(row_id, int):
+        raise RuntimeError("SQLite last_insert_rowid returned a non-integer")
+    return row_id

--- a/tests/unit_tests/agents/execution/test_message_repository.py
+++ b/tests/unit_tests/agents/execution/test_message_repository.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 import json
 from pathlib import Path
+import sqlite3
+import time
 from typing import cast
 
 import pytest
 from pydantic_ai.messages import (
     ImageUrl,
+    ModelMessage,
     ModelRequest,
     ModelResponse,
     TextPart,
@@ -21,6 +26,7 @@ from relay_teams.agents.execution.message_repository import (
     MessageRepository,
     _is_system_reminder_projection_message,
 )
+from relay_teams.agents.execution import message_repository as message_repo_module
 from relay_teams.reminders import render_system_reminder
 from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
@@ -103,6 +109,96 @@ def test_message_repo_sanitizes_stale_task_status_error_on_read(tmp_path: Path) 
     history_task_status = history_part.content["data"]["task_status"]["ask_time"]
     assert history_task_status["status"] == "completed"
     assert "error" not in history_task_status
+
+
+def test_validated_history_skips_rows_outside_safe_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "message_repo_safe_boundary.db"
+    repo = MessageRepository(db_path)
+    repo.append(
+        session_id="session-1",
+        workspace_id="default",
+        conversation_id="conversation-1",
+        agent_role_id="time",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        messages=[
+            ModelRequest(parts=[UserPromptPart(content="keep")]),
+            ModelRequest(parts=[UserPromptPart(content="drop")]),
+        ],
+    )
+    rows = tuple(repo._conn.execute("SELECT id, message_json FROM messages").fetchall())
+    assert len(rows) == 2
+    first_id = rows[0]["id"]
+    assert isinstance(first_id, int)
+
+    def safe_first_row_only(_rows: Sequence[sqlite3.Row]) -> set[int]:
+        return {first_id}
+
+    def validate_row(row: sqlite3.Row) -> list[ModelMessage]:
+        return [ModelRequest(parts=[UserPromptPart(content=f"row-{row['id']}")])]
+
+    monkeypatch.setattr(message_repo_module, "_safe_row_ids", safe_first_row_only)
+    monkeypatch.setattr(message_repo_module, "_validate_message_row", validate_row)
+
+    history = message_repo_module._validated_history_from_rows(rows)
+
+    assert len(history) == 1
+    assert isinstance(history[0], ModelRequest)
+    assert history[0].parts[0].content == f"row-{first_id}"
+
+
+@pytest.mark.asyncio
+async def test_async_history_replay_validation_does_not_block_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "message_repo_async_replay.db"
+    repo = MessageRepository(db_path)
+    message_count = 30
+    repo.append(
+        session_id="session-1",
+        workspace_id="default",
+        conversation_id="conversation-1",
+        agent_role_id="time",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        messages=[
+            ModelRequest(parts=[UserPromptPart(content=f"query {index}")])
+            for index in range(message_count)
+        ],
+    )
+
+    def slow_validate_message_row(_row: sqlite3.Row) -> list[ModelMessage]:
+        time.sleep(0.01)
+        return [ModelRequest(parts=[UserPromptPart(content="validated")])]
+
+    monkeypatch.setattr(
+        message_repo_module,
+        "_validate_message_row",
+        slow_validate_message_row,
+    )
+
+    samples: list[float] = []
+    previous = time.perf_counter()
+    replay_task = asyncio.create_task(
+        repo.get_history_for_conversation_async("conversation-1")
+    )
+    while not replay_task.done():
+        await asyncio.sleep(0.02)
+        now = time.perf_counter()
+        samples.append(now - previous)
+        previous = now
+
+    history = await replay_task
+
+    assert len(history) == message_count
+    assert samples
+    assert max(samples) < 0.2
 
 
 def test_message_repo_hides_duplicate_task_objective_messages(tmp_path: Path) -> None:

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -20,7 +20,9 @@ from relay_teams.agents.instances.instance_repository import AgentInstanceReposi
 from relay_teams.agents.instances.models import create_subagent_instance
 from relay_teams.agents.orchestration.harnesses.tool_harness import TaskToolHarness
 from relay_teams.agents.orchestration.task_execution_service import TaskExecutionService
+from relay_teams.agents.tasks.artifact_repository import TaskArtifactRepository
 from relay_teams.agents.tasks.enums import TaskStatus
+from relay_teams.agents.tasks.enums import TaskArtifactPhase
 from relay_teams.agents.tasks.events import EventType
 from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
 from relay_teams.agents.tasks.task_repository import TaskRepository
@@ -285,6 +287,7 @@ class _PartiallyFailingToolSchemaMcpRegistry(McpRegistry):
 def _build_service(
     db_path: Path,
     provider: object,
+    artifact_repo: TaskArtifactRepository | None = None,
 ) -> tuple[
     TaskExecutionService,
     TaskRepository,
@@ -328,6 +331,7 @@ def _build_service(
         skill_registry=_StaticSkillRegistry(),
         mcp_registry=McpRegistry(),
         run_intent_repo=RunIntentRepository(db_path),
+        artifact_repo=artifact_repo,
     )
     return service, task_repo, agent_repo, message_repo
 
@@ -481,6 +485,42 @@ async def test_execute_omits_objective_when_task_history_exists(
 
     assert result.output == "ok"
     assert provider.prompts == [None]
+
+
+@pytest.mark.asyncio
+async def test_execute_records_task_artifact_entries(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "task_execution_service_artifacts.db"
+    artifact_repo = TaskArtifactRepository(tmp_path / "task_artifacts.db")
+    provider = _CapturingProvider()
+    service, task_repo, agent_repo, message_repo = _build_service(
+        db_path,
+        provider,
+        artifact_repo=artifact_repo,
+    )
+    task, instance_id = _seed_task(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+    )
+
+    result = await service.execute(
+        instance_id=instance_id,
+        role_id="time",
+        task=task,
+    )
+
+    artifact = artifact_repo.get_artifact(task.task_id)
+    assert result.output == "ok"
+    assert artifact is not None
+    assert artifact.summary == "ok"
+    assert tuple(entry.phase for entry in artifact.entries) == (
+        TaskArtifactPhase.SPEC,
+        TaskArtifactPhase.EXECUTION,
+        TaskArtifactPhase.VERIFICATION,
+        TaskArtifactPhase.DELIVERY,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/tasks/test_artifact_repository.py
+++ b/tests/unit_tests/agents/tasks/test_artifact_repository.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+import sqlite3
+from typing import cast
 
 import pytest
 
 from relay_teams.agents.tasks.artifact_repository import (
     TaskArtifactRepository,
+    _enable_wal_if_available,
+    _last_insert_row_id,
 )
 from relay_teams.agents.tasks.enums import TaskArtifactPhase, VerificationEvidenceKind
 from relay_teams.agents.tasks.models import (
@@ -34,6 +39,19 @@ def test_ensure_artifact_idempotent(repo: TaskArtifactRepository):
     assert a1.task_id == a2.task_id
 
 
+def test_ensure_artifact_raises_when_insert_cannot_be_read(
+    repo: TaskArtifactRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_artifact(_task_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(repo, "get_artifact", missing_artifact)
+
+    with pytest.raises(RuntimeError, match="Failed to create task artifact"):
+        repo.ensure_artifact("task-1", "spec-1")
+
+
 def test_get_artifact_missing(repo: TaskArtifactRepository):
     assert repo.get_artifact("nonexistent") is None
 
@@ -53,6 +71,61 @@ def test_append_entry(repo: TaskArtifactRepository):
     )
     row_id = repo.append_entry("task-1", entry)
     assert row_id > 0
+
+
+class _WalFailingConnection:
+    def execute(self, sql: str) -> object:
+        if sql == "PRAGMA journal_mode = WAL":
+            raise sqlite3.OperationalError("readonly filesystem")
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+
+class _CursorWithNonIntegerRowId:
+    def fetchone(self) -> tuple[str]:
+        return ("not-an-int",)
+
+
+class _NonIntegerRowIdConnection:
+    def execute(self, sql: str) -> _CursorWithNonIntegerRowId:
+        assert sql == "SELECT last_insert_rowid()"
+        return _CursorWithNonIntegerRowId()
+
+
+def test_enable_wal_logs_and_continues_when_wal_unavailable() -> None:
+    _enable_wal_if_available(cast(sqlite3.Connection, _WalFailingConnection()))
+
+
+def test_last_insert_row_id_rejects_non_integer_value() -> None:
+    with pytest.raises(RuntimeError, match="non-integer"):
+        _last_insert_row_id(cast(sqlite3.Connection, _NonIntegerRowIdConnection()))
+
+
+def test_concurrent_append_entry_uses_sqlite_retry_coordination(tmp_path: Path) -> None:
+    db_path = tmp_path / "concurrent_artifacts.db"
+    repo = TaskArtifactRepository(db_path)
+    repo.ensure_artifact("task-1", "spec-1")
+
+    def append_entry(index: int) -> int:
+        worker_repo = TaskArtifactRepository(db_path)
+        return worker_repo.append_entry(
+            "task-1",
+            TaskArtifactEntry(
+                entry_id=f"entry-{index}",
+                phase=TaskArtifactPhase.EXECUTION,
+                timestamp="2024-01-01T00:00:00",
+                event_type="tool_call",
+                description=f"Ran shell command {index}",
+            ),
+        )
+
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        row_ids = tuple(executor.map(append_entry, range(36)))
+
+    entries, total = repo.query_entries(task_id="task-1")
+    assert len(row_ids) == 36
+    assert all(row_id > 0 for row_id in row_ids)
+    assert total == 36
+    assert len(entries) == 36
 
 
 def test_get_artifact_with_entries(repo: TaskArtifactRepository):


### PR DESCRIPTION
## Summary

- move large async history replay validation and tool outcome filtering off the backend event loop
- move large-history token estimation, microcompact, and compaction planning off the event loop
- route task artifact writes through SQLite retry coordination and offload artifact persistence from async run execution paths
- add regression tests for slow history replay responsiveness and concurrent artifact appends

Fixes #733

## Validation

- uv run --extra dev pytest -q tests/unit_tests/agents/execution/test_message_repository.py::test_async_history_replay_validation_does_not_block_event_loop tests/unit_tests/test_async_wrapper_coverage.py::test_sqlite_sync_bridge_has_no_runtime_callers
- uv run --extra dev pytest -q tests/unit_tests/agents/tasks/test_artifact_repository.py tests/unit_tests/agents/tasks/test_artifact_lifecycle.py tests/unit_tests/agents/tasks/test_artifact_snapshot.py tests/unit_tests/interfaces/server/test_artifacts_router.py tests/unit_tests/agents/execution/test_message_repository.py::test_async_history_replay_validation_does_not_block_event_loop tests/unit_tests/test_async_wrapper_coverage.py::test_sqlite_sync_bridge_has_no_runtime_callers
- uv run --extra dev pytest -q tests/integration_tests/api/test_session_tool_call_pressure.py::test_normal_mode_session_concurrent_tool_calls_do_not_starve_backend -vv
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright src tests
- reproduced 8000-message / ~32 MB session: health probe scheduled at 150 ms started at 156 ms after fix, below the 1.5 s busy timeout
