### PR TITLE
Limit debug log volume

### DIFF
--- a/src/relay_teams/builtin/logging/logger.ini
+++ b/src/relay_teams/builtin/logging/logger.ini
@@ -3,3 +3,5 @@ backend_level = INFO
 frontend_level = INFO
 debug_level = DEBUG
 console = true
+max_file_mb = 256
+third_party_debug = false

--- a/src/relay_teams/logger/logger.py
+++ b/src/relay_teams/logger/logger.py
@@ -7,13 +7,13 @@ import copy
 import configparser
 import json
 import logging
-import os
 import re
 import shutil
 import sys
 import traceback
-from datetime import UTC, datetime
+from datetime import UTC, datetime, time as datetime_time
 from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
+from math import isfinite
 from pathlib import Path
 from queue import SimpleQueue
 from threading import Lock
@@ -39,8 +39,12 @@ DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_DEBUG_LOG_LEVEL = "DEBUG"
 DEFAULT_LOG_CONSOLE = "1"
 DEFAULT_BACKUP_COUNT = 14
+DEFAULT_MAX_LOG_FILE_MB = "256"
+DEFAULT_THIRD_PARTY_DEBUG = "0"
 _LOGGER_INI_NAME = "logger.ini"
 DEFAULT_LOG_REDACTION_PLACEHOLDER = "***"
+_MAX_LOG_FILE_MB_ENV = "AGENT_TEAMS_LOG_MAX_FILE_MB"
+_THIRD_PARTY_DEBUG_ENV = "AGENT_TEAMS_LOG_THIRD_PARTY_DEBUG"
 _REDACTION_KEYS_ADD_ENV = "AGENT_TEAMS_LOG_REDACTION_KEYS_ADD"
 _REDACTION_KEYS_REPLACE_ENV = "AGENT_TEAMS_LOG_REDACTION_KEYS_REPLACE"
 _REDACTION_PATTERNS_ADD_ENV = "AGENT_TEAMS_LOG_REDACTION_PATTERNS_ADD"
@@ -69,6 +73,8 @@ _HEADER_TOKEN_PATTERN = re.compile(
 )
 _URL_PATTERN = re.compile(r"\b(?:https?|wss?)://[^\s\"'<>]+", re.IGNORECASE)
 _OPENAI_TOKEN_PATTERN = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+_NOISY_THIRD_PARTY_LOGGERS = ("aiosqlite", "httpcore", "httpx")
+_SIZE_ROLLOVER_SUFFIX_RE = re.compile(r"^\d{4}-\d{2}-\d{2}\.\d+$")
 
 _RUNTIME_ENV_VALUES: dict[str, str] | None = None
 _LOGGING_LOCK = Lock()
@@ -126,7 +132,7 @@ def _trace_log_record_factory(*args: object, **kwargs: object) -> logging.LogRec
         "parent_span_id": context.parent_span_id,
     }
     for field_name, field_value in context_fields.items():
-        if field_value is not None and not hasattr(record, field_name):
+        if field_value is not None and field_name not in record.__dict__:
             setattr(record, field_name, field_value)
     return record
 
@@ -143,12 +149,20 @@ class _LoggingRuntime:
         backend_queue_handler: QueueHandler,
         frontend_queue_handler: QueueHandler,
         managed_handlers: tuple[logging.Handler, ...],
+        managed_logger_levels: tuple["_ManagedLoggerLevel", ...],
     ) -> None:
         self.backend_listener = backend_listener
         self.frontend_listener = frontend_listener
         self.backend_queue_handler = backend_queue_handler
         self.frontend_queue_handler = frontend_queue_handler
         self.managed_handlers = managed_handlers
+        self.managed_logger_levels = managed_logger_levels
+
+
+class _ManagedLoggerLevel:
+    def __init__(self, *, logger: logging.Logger, level: int) -> None:
+        self.logger = logger
+        self.level = level
 
 
 class StructuredQueueHandler(QueueHandler):
@@ -179,9 +193,19 @@ class _BackendLogFilter(logging.Filter):
 
 
 class _DebugLogFilter(logging.Filter):
+    def __init__(self, *, include_third_party_debug: bool) -> None:
+        super().__init__()
+        self._include_third_party_debug = include_third_party_debug
+
     @override
     def filter(self, record: logging.LogRecord) -> bool:
-        return _resolve_log_source(record) == "backend"
+        if _resolve_log_source(record) != "backend":
+            return False
+        if record.levelno != logging.DEBUG:
+            return True
+        if self._include_third_party_debug:
+            return True
+        return _is_project_logger(record.name)
 
 
 def _is_noisy_httpx_access_log(record: logging.LogRecord) -> bool:
@@ -275,6 +299,12 @@ def configure_logging(
             default_name=logger_settings.frontend_level,
         )
         debug_level = _resolve_debug_log_level(default_name=logger_settings.debug_level)
+        max_file_bytes = _resolve_max_file_bytes(
+            default_name=logger_settings.max_file_mb
+        )
+        include_third_party_debug = _third_party_debug_enabled(
+            default_enabled=logger_settings.third_party_debug_enabled
+        )
 
         backend_formatter = HumanReadableFormatter()
         debug_formatter = HumanReadableFormatter()
@@ -284,18 +314,23 @@ def configure_logging(
             path=log_dir / DEFAULT_BACKEND_LOG_FILENAME,
             level=backend_level,
             formatter=backend_formatter,
+            max_bytes=max_file_bytes,
         )
         backend_file_handler.addFilter(_BackendLogFilter())
         debug_file_handler = _build_file_handler(
             path=log_dir / DEFAULT_DEBUG_LOG_FILENAME,
             level=debug_level,
             formatter=debug_formatter,
+            max_bytes=max_file_bytes,
         )
-        debug_file_handler.addFilter(_DebugLogFilter())
+        debug_file_handler.addFilter(
+            _DebugLogFilter(include_third_party_debug=include_third_party_debug)
+        )
         frontend_file_handler = _build_file_handler(
             path=log_dir / DEFAULT_FRONTEND_LOG_FILENAME,
             level=frontend_level,
             formatter=frontend_formatter,
+            max_bytes=max_file_bytes,
         )
 
         console_handler: logging.Handler | None = None
@@ -352,6 +387,9 @@ def configure_logging(
         frontend_root.addHandler(frontend_queue_handler)
 
         _configure_uvicorn_loggers()
+        managed_logger_levels = _configure_third_party_loggers(
+            include_debug=include_third_party_debug
+        )
 
         managed_handlers: list[logging.Handler] = [
             backend_queue_handler,
@@ -369,6 +407,7 @@ def configure_logging(
             backend_queue_handler=backend_queue_handler,
             frontend_queue_handler=frontend_queue_handler,
             managed_handlers=tuple(managed_handlers),
+            managed_logger_levels=managed_logger_levels,
         )
         _log_redaction_warnings(redaction_warnings)
 
@@ -392,6 +431,9 @@ def shutdown_logging() -> None:
 
     for handler in runtime.managed_handlers:
         handler.close()
+
+    for managed_logger_level in runtime.managed_logger_levels:
+        managed_logger_level.logger.setLevel(managed_logger_level.level)
 
     _LOGGING_RUNTIME = None
 
@@ -669,11 +711,15 @@ class _LoggerSettings:
         frontend_level: str | None = None,
         debug_level: str | None = None,
         console_enabled: bool | None = None,
+        max_file_mb: str | None = None,
+        third_party_debug_enabled: bool | None = None,
     ) -> None:
         self.backend_level = backend_level
         self.frontend_level = frontend_level
         self.debug_level = debug_level
         self.console_enabled = console_enabled
+        self.max_file_mb = max_file_mb
+        self.third_party_debug_enabled = third_party_debug_enabled
 
 
 def _console_enabled(
@@ -723,6 +769,55 @@ def _resolve_debug_log_level(*, default_name: str | None = None) -> int:
     return logging.DEBUG
 
 
+def _resolve_max_file_bytes(*, default_name: str | None = None) -> int:
+    raw = _get_runtime_env_value(
+        _MAX_LOG_FILE_MB_ENV,
+        default_name or DEFAULT_MAX_LOG_FILE_MB,
+    ).strip()
+    if not raw:
+        return int(DEFAULT_MAX_LOG_FILE_MB) * 1024 * 1024
+    try:
+        value = float(raw)
+    except ValueError:
+        return int(DEFAULT_MAX_LOG_FILE_MB) * 1024 * 1024
+    if not isfinite(value):
+        return int(DEFAULT_MAX_LOG_FILE_MB) * 1024 * 1024
+    if value <= 0:
+        return 0
+    value_bytes = value * 1024 * 1024
+    if not isfinite(value_bytes):
+        return int(DEFAULT_MAX_LOG_FILE_MB) * 1024 * 1024
+    return max(1, int(value_bytes))
+
+
+def _third_party_debug_enabled(*, default_enabled: bool | None = None) -> bool:
+    default_name = (
+        DEFAULT_THIRD_PARTY_DEBUG
+        if default_enabled is None
+        else str(default_enabled).lower()
+    )
+    raw = _get_runtime_env_value(_THIRD_PARTY_DEBUG_ENV, default_name)
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    if default_enabled is not None:
+        return default_enabled
+    return DEFAULT_THIRD_PARTY_DEBUG.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_bool_setting(value: str | None, *, fallback: bool) -> bool:
+    if value is None:
+        return fallback
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return fallback
+
+
 def _load_logger_settings(config_dir: Path) -> _LoggerSettings:
     logger_ini_path = config_dir / _LOGGER_INI_NAME
     if not logger_ini_path.exists():
@@ -741,11 +836,19 @@ def _load_logger_settings(config_dir: Path) -> _LoggerSettings:
     console_enabled: bool | None = None
     if "console" in section:
         console_enabled = section.getboolean("console", fallback=True)
+    third_party_debug_enabled: bool | None = None
+    if "third_party_debug" in section:
+        third_party_debug_enabled = _parse_bool_setting(
+            section.get("third_party_debug"),
+            fallback=False,
+        )
     return _LoggerSettings(
         backend_level=section.get("backend_level"),
         frontend_level=section.get("frontend_level"),
         debug_level=section.get("debug_level"),
         console_enabled=console_enabled,
+        max_file_mb=section.get("max_file_mb"),
+        third_party_debug_enabled=third_party_debug_enabled,
     )
 
 
@@ -759,12 +862,134 @@ class _WindowsSafeTimedRotatingFileHandler(TimedRotatingFileHandler):
     handle is never invalidated.
     """
 
+    def __init__(
+        self,
+        filename: str,
+        when: str = "h",
+        interval: int = 1,
+        backup_count: int = 0,
+        encoding: str | None = None,
+        delay: bool = False,
+        utc: bool = False,
+        at_time: datetime_time | None = None,
+        errors: str | None = None,
+        *,
+        max_bytes: int = 0,
+    ) -> None:
+        super().__init__(
+            filename,
+            when,
+            interval,
+            backup_count,
+            encoding,
+            delay,
+            utc,
+            at_time,
+            errors,
+        )
+        self.max_bytes = max_bytes
+        self._backup_count = backup_count
+        self._rollover_reason = "time"
+
+    @override
+    def shouldRollover(self, record: logging.LogRecord) -> int:
+        if super().shouldRollover(record):
+            self._rollover_reason = "time"
+            return 1
+        if self.max_bytes <= 0:
+            return 0
+        if self.stream is None:
+            self.stream = self._open()
+        message = f"{self.format(record)}\n"
+        self.stream.seek(0, 2)
+        encoding = self.encoding or "utf-8"
+        projected_size = self.stream.tell() + len(
+            message.encode(encoding, errors="replace")
+        )
+        if projected_size >= self.max_bytes:
+            self._rollover_reason = "size"
+            return 1
+        return 0
+
+    @override
+    def doRollover(self) -> None:
+        if self._rollover_reason != "size":
+            super().doRollover()
+            return
+
+        self._rollover_reason = "time"
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        source_path = Path(self.baseFilename)
+        if source_path.exists():
+            self.rotate(str(source_path), str(self._next_size_rollover_path()))
+
+        for filename in self.getFilesToDelete():
+            Path(filename).unlink(missing_ok=True)
+
+        if not self.delay:
+            self.stream = self._open()
+
+    @override
+    def getFilesToDelete(self) -> list[str]:
+        if self._backup_count <= 0:
+            return []
+        base_path = Path(self.baseFilename)
+        rotated_prefix = f"{base_path.name}."
+        rotated_files = [
+            path
+            for path in base_path.parent.iterdir()
+            if path.is_file()
+            and path.name.startswith(rotated_prefix)
+            and self._is_rotated_log_suffix(path.name.removeprefix(rotated_prefix))
+        ]
+        if len(rotated_files) <= self._backup_count:
+            return []
+        rotated_files.sort(
+            key=lambda path: self._rotated_log_sort_key(
+                path.name.removeprefix(rotated_prefix)
+            )
+        )
+        return [str(path) for path in rotated_files[: -self._backup_count]]
+
+    def _is_rotated_log_suffix(self, suffix: str) -> bool:
+        return (
+            self.extMatch.fullmatch(suffix) is not None
+            or _SIZE_ROLLOVER_SUFFIX_RE.fullmatch(suffix) is not None
+        )
+
+    @staticmethod
+    def _rotated_log_sort_key(suffix: str) -> tuple[str, int, str]:
+        if _SIZE_ROLLOVER_SUFFIX_RE.fullmatch(suffix) is not None:
+            date_part, index_part = suffix.rsplit(".", maxsplit=1)
+            return date_part, int(index_part), suffix
+        return suffix, sys.maxsize, suffix
+
+    def _next_size_rollover_path(self) -> Path:
+        base_path = Path(self.baseFilename)
+        suffix = datetime.now(UTC).strftime("%Y-%m-%d")
+        rotated_prefix = f"{base_path.name}.{suffix}."
+        existing_indexes = [
+            int(path.name.removeprefix(rotated_prefix))
+            for path in base_path.parent.iterdir()
+            if path.is_file()
+            and path.name.startswith(rotated_prefix)
+            and path.name.removeprefix(rotated_prefix).isdigit()
+        ]
+        next_index = max(existing_indexes, default=0) + 1
+        if next_index < 10000:
+            return base_path.with_name(f"{base_path.name}.{suffix}.{next_index}")
+        return base_path.with_name(f"{base_path.name}.{suffix}.overflow")
+
     def rotate(self, source: str, dest: str) -> None:
         if sys.platform != "win32" or callable(self.rotator):
             super().rotate(source, dest)
             return
-        if os.path.exists(dest):
-            os.remove(dest)
+        destination_path = Path(dest)
+        if destination_path.exists():
+            destination_path.unlink()
         shutil.copy2(source, dest)
         with open(source, "w", encoding="utf-8"):
             pass
@@ -775,14 +1000,16 @@ def _build_file_handler(
     path: Path,
     level: int,
     formatter: logging.Formatter,
+    max_bytes: int = 0,
 ) -> _WindowsSafeTimedRotatingFileHandler:
     handler = _WindowsSafeTimedRotatingFileHandler(
         filename=str(path),
         when="midnight",
         interval=1,
-        backupCount=DEFAULT_BACKUP_COUNT,
+        backup_count=DEFAULT_BACKUP_COUNT,
         encoding="utf-8",
         utc=True,
+        max_bytes=max_bytes,
     )
     handler.setLevel(level)
     handler.setFormatter(formatter)
@@ -861,6 +1088,30 @@ def _configure_uvicorn_loggers() -> None:
         logger.handlers.clear()
         logger.propagate = True
         logger.setLevel(logging.DEBUG)
+
+
+def _configure_third_party_loggers(
+    *,
+    include_debug: bool,
+) -> tuple[_ManagedLoggerLevel, ...]:
+    managed_levels: list[_ManagedLoggerLevel] = []
+    for logger_name in _NOISY_THIRD_PARTY_LOGGERS:
+        logger = logging.getLogger(logger_name)
+        managed_levels.append(_ManagedLoggerLevel(logger=logger, level=logger.level))
+        target_level = (
+            logging.NOTSET if include_debug else max(logger.level, logging.INFO)
+        )
+        logger.setLevel(target_level)
+    return tuple(managed_levels)
+
+
+def _is_project_logger(name: str) -> bool:
+    return (
+        name == BACKEND_LOGGER_NAMESPACE
+        or name.startswith(f"{BACKEND_LOGGER_NAMESPACE}.")
+        or name == "relay_teams"
+        or name.startswith("relay_teams.")
+    )
 
 
 def _redact_string(value: str, *, settings: _RedactionSettings) -> str:

--- a/tests/unit_tests/logger/test_logging.py
+++ b/tests/unit_tests/logger/test_logging.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+import time
+from datetime import UTC, datetime
 from pathlib import Path
 from threading import Thread
 from typing import cast
@@ -210,6 +212,167 @@ def test_httpx_error_logs_remain_in_backend_log(tmp_path: Path) -> None:
         snapshot.restore()
 
 
+def test_third_party_debug_logs_are_excluded_by_default(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    try:
+        configure_logging(config_dir=config_dir)
+        logging.getLogger("aiosqlite").debug("executing SELECT 1")
+        logging.getLogger("relay_teams.custom").debug("project debug detail")
+        logging.getLogger("aiosqlite").warning("sqlite warning remains visible")
+
+        shutdown_logging()
+
+        backend_text = (config_dir / "log" / "backend.log").read_text(encoding="utf-8")
+        debug_text = (config_dir / "log" / "debug.log").read_text(encoding="utf-8")
+        assert "executing SELECT 1" not in debug_text
+        assert "project debug detail" in debug_text
+        assert "sqlite warning remains visible" in backend_text
+        assert "sqlite warning remains visible" in debug_text
+    finally:
+        snapshot.restore()
+
+
+def test_third_party_debug_logs_can_be_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    monkeypatch.setenv("AGENT_TEAMS_LOG_THIRD_PARTY_DEBUG", "true")
+    try:
+        configure_logging(config_dir=config_dir)
+        logging.getLogger("aiosqlite").debug("executing SELECT 1")
+
+        shutdown_logging()
+
+        debug_text = (config_dir / "log" / "debug.log").read_text(encoding="utf-8")
+        assert "executing SELECT 1" in debug_text
+    finally:
+        snapshot.restore()
+
+
+def test_frontend_events_are_excluded_from_debug_log(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    snapshot = _RootLoggerSnapshot.take()
+    try:
+        configure_logging(config_dir=config_dir)
+        frontend_logger = get_logger("tests.unit.frontend.event", source="frontend")
+        frontend_logger.error("frontend event detail")
+
+        shutdown_logging()
+
+        debug_text = (config_dir / "log" / "debug.log").read_text(encoding="utf-8")
+        frontend_text = (config_dir / "log" / "frontend.log").read_text(
+            encoding="utf-8"
+        )
+        assert "frontend event detail" not in debug_text
+        assert "frontend event detail" in frontend_text
+    finally:
+        snapshot.restore()
+
+
+def test_max_file_bytes_env_handles_blank_invalid_and_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        logger_module,
+        "_RUNTIME_ENV_VALUES",
+        {"AGENT_TEAMS_LOG_MAX_FILE_MB": ""},
+    )
+    assert logger_module._resolve_max_file_bytes() == 256 * 1024 * 1024
+
+    monkeypatch.setattr(
+        logger_module,
+        "_RUNTIME_ENV_VALUES",
+        {"AGENT_TEAMS_LOG_MAX_FILE_MB": "not-a-number"},
+    )
+    assert logger_module._resolve_max_file_bytes() == 256 * 1024 * 1024
+
+    monkeypatch.setattr(
+        logger_module,
+        "_RUNTIME_ENV_VALUES",
+        {"AGENT_TEAMS_LOG_MAX_FILE_MB": "nan"},
+    )
+    assert logger_module._resolve_max_file_bytes() == 256 * 1024 * 1024
+
+    monkeypatch.setattr(
+        logger_module,
+        "_RUNTIME_ENV_VALUES",
+        {"AGENT_TEAMS_LOG_MAX_FILE_MB": "inf"},
+    )
+    assert logger_module._resolve_max_file_bytes() == 256 * 1024 * 1024
+
+    monkeypatch.setattr(
+        logger_module,
+        "_RUNTIME_ENV_VALUES",
+        {"AGENT_TEAMS_LOG_MAX_FILE_MB": "1e308"},
+    )
+    assert logger_module._resolve_max_file_bytes() == 256 * 1024 * 1024
+
+    monkeypatch.setattr(
+        logger_module,
+        "_RUNTIME_ENV_VALUES",
+        {"AGENT_TEAMS_LOG_MAX_FILE_MB": "0"},
+    )
+    assert logger_module._resolve_max_file_bytes() == 0
+
+
+def test_third_party_debug_invalid_env_uses_explicit_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        logger_module,
+        "_RUNTIME_ENV_VALUES",
+        {"AGENT_TEAMS_LOG_THIRD_PARTY_DEBUG": "maybe"},
+    )
+    assert logger_module._third_party_debug_enabled(default_enabled=True)
+    assert not logger_module._third_party_debug_enabled(default_enabled=False)
+
+
+def test_third_party_debug_uses_config_default_when_env_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(logger_module, "_RUNTIME_ENV_VALUES", {})
+    assert logger_module._third_party_debug_enabled(default_enabled=True)
+    assert not logger_module._third_party_debug_enabled(default_enabled=False)
+
+
+def test_invalid_third_party_debug_ini_value_falls_back_to_false(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".agent-teams"
+    config_dir.mkdir()
+    (config_dir / "logger.ini").write_text(
+        "[agent_teams]\nthird_party_debug = maybe\n",
+        encoding="utf-8",
+    )
+
+    settings = logger_module._load_logger_settings(config_dir)
+
+    assert settings.third_party_debug_enabled is False
+
+
+def test_third_party_logger_configuration_preserves_stricter_levels() -> None:
+    aiosqlite_logger = logging.getLogger("aiosqlite")
+    original_level = aiosqlite_logger.level
+    try:
+        aiosqlite_logger.setLevel(logging.WARNING)
+
+        managed_levels = logger_module._configure_third_party_loggers(
+            include_debug=False
+        )
+
+        assert aiosqlite_logger.level == logging.WARNING
+        assert any(
+            managed_level.logger is aiosqlite_logger
+            and managed_level.level == logging.WARNING
+            for managed_level in managed_levels
+        )
+    finally:
+        aiosqlite_logger.setLevel(original_level)
+
+
 def test_log_level_filters_lower_priority_events(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -347,6 +510,276 @@ def test_windows_safe_handler_removes_existing_dest_before_copy(
 
     assert dest.read_text(encoding="utf-8") == "new content"
     assert log_file.read_text(encoding="utf-8") == ""
+
+
+def test_windows_safe_handler_rotates_when_size_limit_is_reached(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "size.log"
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        backup_count=3,
+        encoding="utf-8",
+        utc=True,
+        max_bytes=40,
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = logging.getLogger("tests.unit.size.rotation")
+    original_handlers = tuple(logger.handlers)
+    original_level = logger.level
+    original_propagate = logger.propagate
+    try:
+        logger.handlers.clear()
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+
+        logger.info("short line")
+        logger.info("this line is long enough to trigger size rollover")
+
+        handler.close()
+
+        rotated_files = tuple(tmp_path.glob("size.log.*.1"))
+        assert len(rotated_files) == 1
+        assert rotated_files[0].read_text(encoding="utf-8").strip() == "short line"
+        assert "this line is long enough" in log_file.read_text(encoding="utf-8")
+    finally:
+        logger.handlers.clear()
+        for original_handler in original_handlers:
+            logger.addHandler(original_handler)
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+        handler.close()
+
+
+def test_windows_safe_handler_skips_size_rollover_when_disabled(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "size-disabled.log"
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        encoding="utf-8",
+        utc=True,
+        max_bytes=0,
+    )
+    try:
+        record = logging.makeLogRecord(
+            {
+                "name": "tests.unit.size.disabled",
+                "levelno": logging.INFO,
+                "levelname": "INFO",
+                "msg": "short line",
+            }
+        )
+
+        assert handler.shouldRollover(record) == 0
+    finally:
+        handler.close()
+
+
+def test_windows_safe_handler_opens_delayed_stream_for_size_check(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "delayed-size.log"
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        encoding="utf-8",
+        delay=True,
+        utc=True,
+        max_bytes=100,
+    )
+    try:
+        record = logging.makeLogRecord(
+            {
+                "name": "tests.unit.size.delayed",
+                "levelno": logging.INFO,
+                "levelname": "INFO",
+                "msg": "short line",
+            }
+        )
+
+        assert handler.stream is None
+        assert handler.shouldRollover(record) == 0
+        assert handler.stream is not None
+    finally:
+        handler.close()
+
+
+def test_windows_safe_handler_uses_time_rollover_when_due(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "time.log"
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        encoding="utf-8",
+        utc=True,
+        max_bytes=100,
+    )
+    try:
+        handler.rolloverAt = 0
+        record = logging.makeLogRecord(
+            {
+                "name": "tests.unit.time.rollover",
+                "levelno": logging.INFO,
+                "levelname": "INFO",
+                "msg": "short line",
+            }
+        )
+
+        assert handler.shouldRollover(record) == 1
+        assert handler._rollover_reason == "time"
+    finally:
+        handler.close()
+
+
+def test_windows_safe_handler_time_rollover_delegates_to_base(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "time-delegate.log"
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        encoding="utf-8",
+        utc=True,
+    )
+    try:
+        with patch("logging.handlers.TimedRotatingFileHandler.doRollover") as rollover:
+            handler.doRollover()
+
+        rollover.assert_called_once_with()
+    finally:
+        handler.close()
+
+
+def test_windows_safe_handler_get_files_to_delete_honors_backup_count(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "retention.log"
+    log_file.write_text("active", encoding="utf-8")
+    manual_file = tmp_path / "retention.log.2026-05-07.manual"
+    manual_file.write_text("manual", encoding="utf-8")
+    time.sleep(0.02)
+    old_file = tmp_path / "retention.log.2026-05-01.1"
+    keep_file = tmp_path / "retention.log.2026-05-07.1"
+    old_file.write_text("old", encoding="utf-8")
+    time.sleep(0.02)
+    keep_file.write_text("keep", encoding="utf-8")
+    time.sleep(0.02)
+    old_file.touch()
+
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        backup_count=1,
+        encoding="utf-8",
+        utc=True,
+    )
+    try:
+        assert handler.getFilesToDelete() == [str(old_file)]
+        assert manual_file.exists()
+    finally:
+        handler.close()
+
+
+def test_windows_safe_handler_keeps_timed_backup_after_same_day_size_chunks(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "retention-order.log"
+    log_file.write_text("active", encoding="utf-8")
+    first_chunk = tmp_path / "retention-order.log.2026-05-07.1"
+    second_chunk = tmp_path / "retention-order.log.2026-05-07.2"
+    timed_backup = tmp_path / "retention-order.log.2026-05-07"
+    first_chunk.write_text("first", encoding="utf-8")
+    second_chunk.write_text("second", encoding="utf-8")
+    timed_backup.write_text("timed", encoding="utf-8")
+
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        backup_count=1,
+        encoding="utf-8",
+        utc=True,
+    )
+    try:
+        assert handler.getFilesToDelete() == [str(first_chunk), str(second_chunk)]
+    finally:
+        handler.close()
+
+
+def test_windows_safe_handler_uses_next_highest_size_rollover_index(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "next-index.log"
+    log_file.write_text("active", encoding="utf-8")
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    second_chunk = tmp_path / f"next-index.log.{today}.2"
+    second_chunk.write_text("second", encoding="utf-8")
+
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        backup_count=1,
+        encoding="utf-8",
+        utc=True,
+    )
+    try:
+        assert handler._next_size_rollover_path() == (
+            tmp_path / f"next-index.log.{today}.3"
+        )
+    finally:
+        handler.close()
+
+
+def test_windows_safe_handler_get_files_to_delete_returns_empty_without_backups(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "no-retention.log"
+    log_file.write_text("active", encoding="utf-8")
+    rotated_file = tmp_path / "no-retention.log.2026-05-07.1"
+    rotated_file.write_text("old", encoding="utf-8")
+
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        backup_count=0,
+        encoding="utf-8",
+        utc=True,
+    )
+    try:
+        assert handler.getFilesToDelete() == []
+    finally:
+        handler.close()
+
+
+def test_windows_safe_handler_size_rollover_deletes_expired_backups(
+    tmp_path: Path,
+) -> None:
+    log_file = tmp_path / "delete-expired.log"
+    log_file.write_text("active", encoding="utf-8")
+    expired_file = tmp_path / "delete-expired.log.2026-05-07.1"
+    expired_file.write_text("expired", encoding="utf-8")
+    handler = _WindowsSafeTimedRotatingFileHandler(
+        filename=str(log_file),
+        when="midnight",
+        backup_count=1,
+        encoding="utf-8",
+        utc=True,
+        max_bytes=1,
+    )
+    try:
+        handler._rollover_reason = "size"
+        with patch.object(
+            handler, "getFilesToDelete", return_value=[str(expired_file)]
+        ):
+            handler.doRollover()
+
+        assert not expired_file.exists()
+    finally:
+        handler.close()
 
 
 def test_default_redaction_masks_sensitive_message_and_payload_values(


### PR DESCRIPTION
## Summary
- filter third-party DEBUG noise from debug.log by default while keeping project DEBUG diagnostics
- add configurable max log file size rotation with a 256 MiB default
- document the new default logger settings and add regression coverage

## Validation
- uv run --extra dev ruff check --fix src/relay_teams/logger/logger.py tests/unit_tests/logger/test_logging.py
- uv run --extra dev ruff format --no-cache --force-exclude src/relay_teams/logger/logger.py tests/unit_tests/logger/test_logging.py
- uv run --extra dev basedpyright src/relay_teams/logger/logger.py tests/unit_tests/logger/test_logging.py
- uv run --extra dev pytest -q tests/unit_tests/logger/test_logging.py
- uv run --extra dev pytest -q tests/unit_tests/logger/test_logging.py --cov=src/relay_teams --cov=src/relay_teams_evals --cov-report=xml:coverage.xml
- uv run --extra dev diff-cover coverage.xml --config-file pyproject.toml --diff-file .tmp/diff-cover-copy-aware.diff
- uv run --extra dev ruff check --no-cache --force-exclude .
- uv run --extra dev ruff format --check --no-cache --force-exclude .
- uv run --extra dev basedpyright
- changed-files spec-compliance gate run locally

Fixes #736