### PR TITLE
Add AI Engineer sources to research prompts

### DIFF
--- a/src/relay_teams/builtin/roles/daily-ai-report.md
+++ b/src/relay_teams/builtin/roles/daily-ai-report.md
@@ -140,6 +140,16 @@ skills:
 - [alphaxiv](https://www.alphaxiv.org/)
 - [Block AI](https://block.xyz/ai)
 - [Block AI News](https://block.xyz/news/ai)
+- [AI Engineer](https://www.ai.engineer/)
+- [AI Engineer Europe](https://www.ai.engineer/europe)
+
+## 会议与演讲内容
+
+- 将 AI Engineer 作为高质量技术演讲内容来源，重点跟踪 AI 工程实践、Agent、开发工具、基础设施、评测和产品化经验。
+- `ai.engineer`
+  Site: <https://www.ai.engineer/>
+- `ai.engineer/europe`
+  Site: <https://www.ai.engineer/europe>
 
 ## X 账号信源
 

--- a/src/relay_teams/builtin/skills/deepresearch/news_source.md
+++ b/src/relay_teams/builtin/skills/deepresearch/news_source.md
@@ -4,6 +4,17 @@
 - [AI Brief 中文](https://ai-brief.liziran.com/zh/)
 - [Block AI](https://block.xyz/ai)
 - [Block AI News](https://block.xyz/news/ai)
+- [AI Engineer](https://www.ai.engineer/)
+- [AI Engineer Europe](https://www.ai.engineer/europe)
+
+## 会议与演讲内容
+
+- `ai.engineer`
+  Site: <https://www.ai.engineer/>
+  用途：AI Engineer 会议、World's Fair、Summit 等技术演讲和活动内容。
+- `ai.engineer/europe`
+  Site: <https://www.ai.engineer/europe>
+  用途：AI Engineer Europe 的议程、演讲主题、讲者和相关会议内容。
 
 ## RSS 博客池
 

--- a/tests/unit_tests/builtin/test_resources.py
+++ b/tests/unit_tests/builtin/test_resources.py
@@ -41,3 +41,15 @@ def test_deepresearch_news_sources_include_block_ai_source_entries() -> None:
     assert "- [Block AI](https://block.xyz/ai)" in content
     assert "- [Block AI News](https://block.xyz/news/ai)" in content
     assert "RSS: <https://engineering.block.xyz/blog/rss.xml>" in content
+
+
+def test_deepresearch_news_sources_include_ai_engineer_talk_sources() -> None:
+    news_source_path = get_builtin_skills_dir() / "deepresearch" / "news_source.md"
+
+    content = news_source_path.read_text(encoding="utf-8")
+
+    assert "- [AI Engineer](https://www.ai.engineer/)" in content
+    assert "- [AI Engineer Europe](https://www.ai.engineer/europe)" in content
+    assert "## 会议与演讲内容" in content
+    assert "Site: <https://www.ai.engineer/>" in content
+    assert "Site: <https://www.ai.engineer/europe>" in content

--- a/tests/unit_tests/roles/test_daily_ai_report_role_content.py
+++ b/tests/unit_tests/roles/test_daily_ai_report_role_content.py
@@ -25,3 +25,15 @@ def test_daily_ai_report_role_includes_block_ai_sources() -> None:
     assert "- [Block AI News](https://block.xyz/news/ai)" in content
     assert "RSS: <https://engineering.block.xyz/blog/rss.xml>" in content
     assert "- `blocks`" in content
+
+
+def test_daily_ai_report_role_includes_ai_engineer_talk_sources() -> None:
+    role_path = get_builtin_roles_dir() / "daily-ai-report.md"
+
+    content = role_path.read_text(encoding="utf-8")
+
+    assert "- [AI Engineer](https://www.ai.engineer/)" in content
+    assert "- [AI Engineer Europe](https://www.ai.engineer/europe)" in content
+    assert "## 会议与演讲内容" in content
+    assert "Site: <https://www.ai.engineer/>" in content
+    assert "Site: <https://www.ai.engineer/europe>" in content


### PR DESCRIPTION
## Summary
- add AI Engineer and AI Engineer Europe as fixed AI research sources for deepresearch
- add the same conference/talk source guidance to daily-ai-report
- cover both prompts with source presence tests

Fixes #737

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests/builtin/test_resources.py tests/unit_tests/roles/test_daily_ai_report_role_content.py
- uv run --extra dev pytest -q tests/unit_tests (fails on pre-existing Windows/environment issues: sqlite temp db file locks in orchestration wakeup tests, asyncio subprocess NotImplementedError in external_agents CLI client tests, path separator assertion in clawhub connectivity, plus unrelated spec/verification failures)