### PR TITLE
Improve session pressure and stream recovery stability

### DIFF
--- a/benchmarks/extreme_session_pressure.py
+++ b/benchmarks/extreme_session_pressure.py
@@ -1,0 +1,1835 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
+    ThreadPoolExecutor,
+    TimeoutError as FutureTimeoutError,
+    wait,
+)
+from datetime import UTC, datetime
+import argparse
+import json
+import os
+from os import pathsep
+from pathlib import Path
+import re
+import random
+import sqlite3
+import sys
+from threading import Event, Lock
+import time
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+for _PYTHONPATH_ENTRY in (_REPO_ROOT, _REPO_ROOT / "src", _REPO_ROOT / "tests"):
+    _PYTHONPATH_TEXT = str(_PYTHONPATH_ENTRY)
+    if _PYTHONPATH_TEXT not in sys.path:
+        sys.path.insert(0, _PYTHONPATH_TEXT)
+
+import httpx  # noqa: E402
+from pydantic import BaseModel, ConfigDict  # noqa: E402
+
+from tests.integration_tests.support.api_helpers import (  # noqa: E402
+    create_run,
+    create_session,
+    new_session_id,
+    stream_run_until_terminal,
+)
+from tests.integration_tests.support.config_builder import (  # noqa: E402
+    assert_integration_model_config_uses_fake_llm,
+    write_test_runtime_config,
+)
+from tests.integration_tests.support.process_control import (  # noqa: E402
+    ManagedProcess,
+    find_free_ports,
+    start_process,
+    stop_process,
+    wait_for_http_ready,
+)
+
+RECOVERABLE_BENCHMARK_ERRORS = (
+    AssertionError,
+    RuntimeError,
+    ValueError,
+    httpx.HTTPError,
+    sqlite3.Error,
+)
+
+
+_HOME_ENV_KEYS: tuple[str, ...] = ("HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH")
+_PROXY_ENV_KEYS: tuple[str, ...] = (
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+    "SSL_VERIFY",
+)
+_UNKNOWN_TOOL_NAME = "unknown"
+_PROBE_TIMEOUT = httpx.Timeout(
+    6.0,
+    connect=2.0,
+    read=6.0,
+    write=2.0,
+    pool=2.0,
+)
+
+
+class RunResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    run_id: str
+    duration_ms: int
+    terminal_event_type: str
+    stream_event_counts: dict[str, int]
+    session_event_counts: dict[str, int]
+    subagent_event_count: int
+
+
+class RunProgress(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    run_id: str
+    main_read_completed_count: int
+    spawn_completed_count: int
+    subagent_completed_count: int
+    last_event_type: str
+    last_tool_call_id: str
+    stage: str
+
+
+class ProbeResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    method: str
+    path: str
+    status_code: int
+    duration_ms: int
+    error: str = ""
+
+
+class ProbeSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    count: int
+    failure_count: int
+    p50_ms: int
+    p95_ms: int
+    p99_ms: int
+    max_ms: int
+    by_endpoint: dict[str, "EndpointProbeSummary"]
+    slowest: tuple[ProbeResult, ...]
+
+
+class EndpointProbeSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    count: int
+    failure_count: int
+    p50_ms: int
+    p95_ms: int
+    p99_ms: int
+    max_ms: int
+
+
+class NavigationTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: str
+    session_id: str
+    run_id: str = ""
+    instance_id: str = ""
+
+
+class NavigationStepResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    transition: str
+    target: NavigationTarget
+    duration_ms: int
+    hydration_duration_ms: int = 0
+    status_code: int
+    after_event_id: int = 0
+    stream_duplicate_count: int = 0
+    stream_gap_count: int = 0
+    wrong_target_render_count: int = 0
+    error: str = ""
+    hydration_error: str = ""
+
+
+class NavigationTransitionSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    count: int
+    failure_count: int
+    p50_ms: int
+    p95_ms: int
+    max_ms: int
+    hydration_p95_ms: int = 0
+    hydration_max_ms: int = 0
+
+
+class NavigationSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    count: int
+    failure_count: int
+    p50_ms: int
+    p95_ms: int
+    max_ms: int
+    hydration_p95_ms: int
+    hydration_max_ms: int
+    hydration_failure_count: int
+    by_transition: dict[str, NavigationTransitionSummary]
+    stream_duplicate_count: int
+    stream_gap_count: int
+    wrong_target_render_count: int
+    running_indicator_missing_count: int
+    terminal_refresh_wrong_target_count: int
+    failures: tuple[NavigationStepResult, ...] = ()
+
+
+class TerminalInvariantRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    session_id: str
+    run_id: str
+    kind: str
+    runtime_status: str
+    run_state_status: str
+    has_terminal_event: bool
+    ok: bool
+    error: str = ""
+
+
+class TerminalInvariantSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    count: int
+    failure_count: int
+    records: tuple[TerminalInvariantRecord, ...]
+
+
+class BenchmarkSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    started_at: str
+    duration_ms: int
+    parameters: dict[str, int | str]
+    runs: tuple[RunResult, ...]
+    progress: tuple[RunProgress, ...]
+    tool_metrics: dict[str, int]
+    tool_metrics_by_name: dict[str, dict[str, int]]
+    message_commit_metrics: dict[str, int]
+    tool_call_batch_state_metrics: dict[str, int]
+    tool_result_batch_metrics: dict[str, int]
+    relay_tool_step_metrics: dict[str, int]
+    sessions_list_cache_metrics: dict[str, int]
+    sync_subagent_metrics: dict[str, int]
+    probe_summary: ProbeSummary
+    fake_llm_metrics: dict[str, object]
+    artifact_metrics: dict[str, int]
+    sqlite_metrics: dict[str, int]
+    sse_heartbeat_count: int
+    navigation_summary: NavigationSummary
+    terminal_invariant_summary: TerminalInvariantSummary
+    backend_log_file: str
+    fake_llm_log_file: str
+    error: str = ""
+
+
+def main() -> None:
+    args = _parse_args()
+    repo_root = Path(__file__).resolve().parent.parent
+    run_root = _prepare_run_root(repo_root)
+    original_home_env = _capture_home_env()
+    fake_llm_process: ManagedProcess | None = None
+    backend_process: ManagedProcess | None = None
+    started = time.perf_counter()
+    started_at = datetime.now(UTC).isoformat()
+
+    try:
+        environment = _build_environment(repo_root, run_root, args)
+        fake_llm_port, backend_port = find_free_ports(2)
+        fake_llm_admin_url = f"http://127.0.0.1:{fake_llm_port}"
+        fake_llm_v1_base_url = f"{fake_llm_admin_url}/v1"
+        api_base_url = f"http://127.0.0.1:{backend_port}"
+        config_dir = run_root / ".relay-teams"
+        write_test_runtime_config(
+            config_dir=config_dir,
+            fake_llm_v1_base_url=fake_llm_v1_base_url,
+        )
+        assert_integration_model_config_uses_fake_llm(config_dir=config_dir)
+        _apply_home_env(run_root)
+
+        fake_llm_log_file = run_root / "fake-llm.log"
+        backend_log_file = run_root / "backend.log"
+        fake_llm_process = _start_fake_llm(
+            repo_root,
+            environment,
+            fake_llm_port,
+            fake_llm_log_file,
+        )
+        wait_for_http_ready(
+            url=f"{fake_llm_admin_url}/health",
+            timeout_seconds=20.0,
+            process=fake_llm_process,
+        )
+        backend_process = _start_backend(
+            repo_root,
+            environment,
+            backend_port,
+            backend_log_file,
+        )
+        wait_for_http_ready(
+            url=f"{api_base_url}/api/system/health",
+            timeout_seconds=90.0,
+            process=backend_process,
+        )
+
+        summary_path = run_root / "summary.json"
+        summary = _run_benchmark(
+            args=args,
+            api_base_url=api_base_url,
+            fake_llm_admin_url=fake_llm_admin_url,
+            started_at=started_at,
+            started=started,
+            backend_log_file=backend_log_file,
+            fake_llm_log_file=fake_llm_log_file,
+        )
+        summary_path.write_text(
+            summary.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+        print(summary.model_dump_json(indent=2))
+        print(f"\nsummary_path={summary_path}")
+    finally:
+        if backend_process is not None:
+            stop_process(backend_process)
+        if fake_llm_process is not None:
+            stop_process(fake_llm_process)
+        _restore_home_env(original_home_env)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the extreme session/subagent tool-call pressure benchmark.",
+    )
+    parser.add_argument("--sessions", type=int, default=10)
+    parser.add_argument("--main-tool-calls", type=int, default=500)
+    parser.add_argument("--main-batch-size", type=int, default=100)
+    parser.add_argument("--subagents", type=int, default=10)
+    parser.add_argument("--subagent-tool-calls", type=int, default=100)
+    parser.add_argument("--subagent-batch-size", type=int, default=100)
+    parser.add_argument("--subagent-spawn-batch-size", type=int, default=3)
+    parser.add_argument("--probe-workers", type=int, default=12)
+    parser.add_argument("--timeout-seconds", type=float, default=7200.0)
+    parser.add_argument(
+        "--fail-fast-probes",
+        action="store_true",
+        help=(
+            "Stop pressure runs early when cumulative probe metrics exceed the "
+            "expected failure-rate, p95, or max latency thresholds."
+        ),
+    )
+    parser.add_argument("--fail-fast-min-probes", type=int, default=200)
+    parser.add_argument("--fail-fast-check-interval-seconds", type=float, default=5.0)
+    parser.add_argument("--expected-probe-failure-rate", type=float, default=0.01)
+    parser.add_argument("--expected-probe-p95-ms", type=int, default=2000)
+    parser.add_argument("--expected-probe-max-ms", type=int, default=8000)
+    parser.add_argument("--llm-http-max-concurrency", type=int, default=16)
+    parser.add_argument(
+        "--scenario",
+        choices=("pressure", "user-switching-full"),
+        default="pressure",
+    )
+    parser.add_argument(
+        "--switch-targets",
+        choices=("roots", "subagents", "mixed"),
+        default="mixed",
+    )
+    parser.add_argument(
+        "--switch-pattern",
+        choices=("matrix", "random", "race-terminal"),
+        default="matrix",
+    )
+    parser.add_argument("--switch-interval-ms", type=int, default=120)
+    parser.add_argument("--path", type=str, default="AGENTS.md")
+    return parser.parse_args()
+
+
+def _prepare_run_root(repo_root: Path) -> Path:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_root = repo_root / ".tmp" / f"extreme-session-pressure-{stamp}"
+    run_root.mkdir(parents=True, exist_ok=True)
+    return run_root
+
+
+def _build_environment(
+    repo_root: Path,
+    run_root: Path,
+    args: argparse.Namespace,
+) -> dict[str, str]:
+    environment = os.environ.copy()
+    for key in _PROXY_ENV_KEYS:
+        environment.pop(key, None)
+    python_paths = [str(repo_root), str(repo_root / "src"), str(repo_root / "tests")]
+    existing_pythonpath = environment.get("PYTHONPATH", "")
+    if existing_pythonpath:
+        python_paths.append(existing_pythonpath)
+    environment["PYTHONPATH"] = pathsep.join(python_paths)
+    environment["AGENT_TEAMS_COMPUTER_RUNTIME"] = "fake"
+    environment["RELAY_TEAMS_LLM_HTTP_MAX_CONCURRENCY"] = str(
+        args.llm_http_max_concurrency,
+    )
+    environment["RELAY_TEAMS_SESSION_SNAPSHOT_CACHE_MS"] = "500"
+    environment["RELAY_TEAMS_SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS"] = "250"
+    environment["RELAY_TEAMS_SESSION_FAST_READ_WORKERS"] = "8"
+    environment["RELAY_TEAMS_SESSION_PROJECTION_REFRESH_WORKERS"] = "2"
+    environment["RELAY_TEAMS_RUN_WORKER_ACTIVE_LIMIT"] = "32"
+    environment["RELAY_TEAMS_TOOL_ACTION_WORKERS"] = "128"
+    environment["RELAY_TEAMS_TOOL_STEP_CONCURRENCY"] = "16"
+    environment["RELAY_TEAMS_TOOL_STEP_BATCH_CONCURRENCY"] = "16"
+    environment["RELAY_TEAMS_TOOL_STEP_GLOBAL_CONCURRENCY"] = "16"
+    environment["RELAY_TEAMS_SYNC_SUBAGENT_ACTIVE_LIMIT"] = "3"
+    environment["RELAY_TEAMS_SYNC_SUBAGENT_GLOBAL_ACTIVE_LIMIT"] = "8"
+    environment["PYTHONUTF8"] = "1"
+    environment["HOME"] = str(run_root)
+    environment["USERPROFILE"] = str(run_root)
+    if run_root.drive:
+        environment["HOMEDRIVE"] = run_root.drive
+        environment["HOMEPATH"] = str(run_root).removeprefix(run_root.drive)
+    ripgrep_path = _find_existing_ripgrep_binary()
+    if ripgrep_path is not None:
+        environment["RELAY_TEAMS_RIPGREP_PATH"] = str(ripgrep_path)
+    return environment
+
+
+def _find_existing_ripgrep_binary() -> Path | None:
+    for env_key in _HOME_ENV_KEYS:
+        raw_home = os.environ.get(env_key)
+        if raw_home is None or not raw_home.strip():
+            continue
+        candidate = Path(raw_home).expanduser() / ".relay-teams" / "bin" / "rg.exe"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _capture_home_env() -> dict[str, str | None]:
+    return {key: os.environ.get(key) for key in _HOME_ENV_KEYS}
+
+
+def _apply_home_env(run_root: Path) -> None:
+    os.environ["HOME"] = str(run_root)
+    os.environ["USERPROFILE"] = str(run_root)
+    if run_root.drive:
+        os.environ["HOMEDRIVE"] = run_root.drive
+        os.environ["HOMEPATH"] = str(run_root).removeprefix(run_root.drive)
+
+
+def _restore_home_env(original_env: dict[str, str | None]) -> None:
+    for key, value in original_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+            continue
+        os.environ[key] = value
+
+
+def _start_fake_llm(
+    repo_root: Path,
+    environment: dict[str, str],
+    port: int,
+    log_file: Path,
+) -> ManagedProcess:
+    return start_process(
+        name="fake-llm",
+        command=(
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "integration_tests.support.fake_llm_server:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            "warning",
+        ),
+        cwd=repo_root,
+        env=environment,
+        log_file=log_file,
+    )
+
+
+def _start_backend(
+    repo_root: Path,
+    environment: dict[str, str],
+    port: int,
+    log_file: Path,
+) -> ManagedProcess:
+    return start_process(
+        name="agent-teams-backend",
+        command=(
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "relay_teams.interfaces.server.app:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            "warning",
+        ),
+        cwd=repo_root,
+        env=environment,
+        log_file=log_file,
+    )
+
+
+def _run_benchmark(
+    *,
+    args: argparse.Namespace,
+    api_base_url: str,
+    fake_llm_admin_url: str,
+    started_at: str,
+    started: float,
+    backend_log_file: Path,
+    fake_llm_log_file: Path,
+) -> BenchmarkSummary:
+    with httpx.Client(base_url=api_base_url, timeout=60.0, trust_env=False) as client:
+        session_ids = [
+            create_session(
+                client,
+                session_id=new_session_id(f"extreme-pressure-{index:02d}"),
+            )
+            for index in range(args.sessions)
+        ]
+
+    stop_probes = Event()
+    stop_navigation = Event()
+    probe_results: list[ProbeResult] = []
+    navigation_results: list[NavigationStepResult] = []
+    probe_lock = Lock()
+    navigation_lock = Lock()
+    probe_executor = ThreadPoolExecutor(max_workers=args.probe_workers)
+    probe_futures = [
+        probe_executor.submit(
+            _probe_backend_until_stopped,
+            api_base_url,
+            tuple(session_ids),
+            stop_probes,
+            probe_results,
+            probe_lock,
+            worker_index,
+        )
+        for worker_index in range(args.probe_workers)
+    ]
+    navigation_executor = ThreadPoolExecutor(max_workers=1)
+    navigation_future: Future[None] | None = None
+    if args.scenario == "user-switching-full":
+        navigation_future = navigation_executor.submit(
+            _navigation_driver_until_stopped,
+            api_base_url,
+            tuple(session_ids),
+            stop_navigation,
+            navigation_results,
+            navigation_lock,
+            args,
+        )
+
+    benchmark_error = ""
+    runs: tuple[RunResult, ...] = ()
+    enriched_runs: tuple[RunResult, ...] = ()
+    progress: tuple[RunProgress, ...] = ()
+    tool_metrics: dict[str, int] = {}
+    tool_metrics_by_name: dict[str, dict[str, int]] = {}
+    terminal_invariants = TerminalInvariantSummary(
+        count=0,
+        failure_count=0,
+        records=(),
+    )
+    try:
+        runs, benchmark_error = _run_pressure_sessions(
+            api_base_url=api_base_url,
+            session_ids=session_ids,
+            args=args,
+            probe_results=probe_results,
+            probe_lock=probe_lock,
+        )
+    except RECOVERABLE_BENCHMARK_ERRORS as exc:
+        benchmark_error = f"{type(exc).__name__}: {exc}"
+    finally:
+        stop_navigation.set()
+        stop_probes.set()
+        if navigation_future is not None:
+            try:
+                navigation_future.result(timeout=7.0)
+            except FutureTimeoutError:
+                navigation_future.cancel()
+        _stop_probe_workers(probe_futures)
+        probe_executor.shutdown(wait=False, cancel_futures=True)
+        navigation_executor.shutdown(wait=False, cancel_futures=True)
+
+    enrichment_errors: list[str] = []
+    if benchmark_error and args.fail_fast_probes:
+        enriched_runs = runs
+    else:
+        with httpx.Client(
+            base_url=api_base_url, timeout=20.0, trust_env=False
+        ) as client:
+            enriched_runs = tuple(
+                _safe_enrich_run_result(
+                    client,
+                    run,
+                    errors=enrichment_errors,
+                )
+                for run in runs
+            )
+            progress = tuple(
+                _safe_load_session_progress(
+                    client,
+                    session_id=session_id,
+                    args=args,
+                    errors=enrichment_errors,
+                )
+                for session_id in session_ids
+            )
+            terminal_invariants = _safe_load_terminal_invariant_summary(
+                client,
+                tuple(session_ids),
+                errors=enrichment_errors,
+            )
+            tool_metrics, tool_metrics_by_name = _safe_load_tool_metric_summary(
+                client,
+                tuple(session_ids),
+                errors=enrichment_errors,
+            )
+    if enrichment_errors:
+        benchmark_error = "; ".join(
+            item for item in (benchmark_error, *enrichment_errors) if item
+        )
+    if terminal_invariants.failure_count > 0:
+        benchmark_error = "; ".join(
+            item
+            for item in (
+                benchmark_error,
+                (
+                    "terminal_invariant_failed: "
+                    f"{terminal_invariants.failure_count}/"
+                    f"{terminal_invariants.count}"
+                ),
+            )
+            if item
+        )
+    navigation_summary = _summarize_navigation(tuple(navigation_results))
+    if (
+        navigation_summary.stream_duplicate_count > 0
+        or navigation_summary.stream_gap_count > 0
+        or navigation_summary.wrong_target_render_count > 0
+    ):
+        benchmark_error = "; ".join(
+            item
+            for item in (
+                benchmark_error,
+                (
+                    "navigation_stream_invariant_failed: "
+                    f"duplicates={navigation_summary.stream_duplicate_count} "
+                    f"gaps={navigation_summary.stream_gap_count} "
+                    f"wrong_target={navigation_summary.wrong_target_render_count}"
+                ),
+            )
+            if item
+        )
+
+    fake_llm_metrics = _load_fake_llm_metrics(fake_llm_admin_url)
+    backend_metrics = _parse_backend_log_metrics(backend_log_file)
+    return BenchmarkSummary(
+        started_at=started_at,
+        duration_ms=int((time.perf_counter() - started) * 1000),
+        parameters={
+            "sessions": args.sessions,
+            "main_tool_calls": args.main_tool_calls,
+            "main_batch_size": args.main_batch_size,
+            "subagents": args.subagents,
+            "subagent_tool_calls": args.subagent_tool_calls,
+            "subagent_batch_size": args.subagent_batch_size,
+            "subagent_spawn_batch_size": args.subagent_spawn_batch_size,
+            "probe_workers": args.probe_workers,
+            "fail_fast_probes": "1" if args.fail_fast_probes else "0",
+            "expected_probe_failure_rate": str(args.expected_probe_failure_rate),
+            "expected_probe_p95_ms": args.expected_probe_p95_ms,
+            "expected_probe_max_ms": args.expected_probe_max_ms,
+            "llm_http_max_concurrency": args.llm_http_max_concurrency,
+            "scenario": args.scenario,
+            "switch_targets": args.switch_targets,
+            "switch_pattern": args.switch_pattern,
+            "switch_interval_ms": args.switch_interval_ms,
+            "path": args.path,
+        },
+        runs=enriched_runs,
+        progress=progress,
+        tool_metrics=tool_metrics,
+        tool_metrics_by_name=tool_metrics_by_name,
+        message_commit_metrics=backend_metrics["message_commit"],
+        tool_call_batch_state_metrics=backend_metrics["tool_call_batch_state"],
+        tool_result_batch_metrics=backend_metrics["tool_result_batch"],
+        relay_tool_step_metrics=backend_metrics["relay_tool_step"],
+        sessions_list_cache_metrics=backend_metrics["sessions_list_cache"],
+        sync_subagent_metrics=backend_metrics["sync_subagent"],
+        probe_summary=_summarize_probes(tuple(probe_results)),
+        fake_llm_metrics=fake_llm_metrics,
+        artifact_metrics=backend_metrics["artifact"],
+        sqlite_metrics=backend_metrics["sqlite"],
+        sse_heartbeat_count=backend_metrics["sse_heartbeat_count"].get("count", 0),
+        navigation_summary=navigation_summary,
+        terminal_invariant_summary=terminal_invariants,
+        backend_log_file=str(backend_log_file),
+        fake_llm_log_file=str(fake_llm_log_file),
+        error=benchmark_error,
+    )
+
+
+def _run_pressure_sessions(
+    *,
+    api_base_url: str,
+    session_ids: list[str],
+    args: argparse.Namespace,
+    probe_results: list[ProbeResult],
+    probe_lock: Lock,
+) -> tuple[tuple[RunResult, ...], str]:
+    executor = ThreadPoolExecutor(max_workers=len(session_ids))
+    try:
+        futures = [
+            executor.submit(
+                _run_single_pressure_session,
+                api_base_url,
+                session_id,
+                index,
+                args,
+            )
+            for index, session_id in enumerate(session_ids)
+        ]
+        pending = set(futures)
+        results: list[RunResult] = []
+        error = ""
+        deadline = time.perf_counter() + args.timeout_seconds
+        next_probe_check = time.perf_counter()
+        while pending:
+            remaining_seconds = deadline - time.perf_counter()
+            if remaining_seconds <= 0:
+                error = (
+                    f"Timed out waiting for pressure runs: "
+                    f"{len(results)}/{len(session_ids)} completed."
+                )
+                _cancel_futures(tuple(pending))
+                break
+            done, pending = wait(
+                pending,
+                timeout=min(1.0, remaining_seconds),
+                return_when=FIRST_COMPLETED,
+            )
+            for future in done:
+                try:
+                    results.append(future.result())
+                except RECOVERABLE_BENCHMARK_ERRORS as exc:
+                    error = f"{type(exc).__name__}: {exc}"
+            if error:
+                _cancel_futures(tuple(pending))
+                break
+            now = time.perf_counter()
+            if args.fail_fast_probes and now >= next_probe_check:
+                next_probe_check = now + args.fail_fast_check_interval_seconds
+                with probe_lock:
+                    probe_snapshot = tuple(probe_results)
+                threshold_error = _probe_threshold_error(probe_snapshot, args)
+                if threshold_error:
+                    error = threshold_error
+                    _cancel_futures(tuple(pending))
+                    break
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+    return tuple(results), error
+
+
+def _cancel_futures(futures: tuple[Future[RunResult], ...]) -> None:
+    for future in futures:
+        future.cancel()
+
+
+def _probe_threshold_error(
+    probes: tuple[ProbeResult, ...],
+    args: argparse.Namespace,
+) -> str:
+    if len(probes) < args.fail_fast_min_probes:
+        return ""
+    summary = _summarize_probes(probes)
+    failure_rate = summary.failure_count / max(summary.count, 1)
+    if failure_rate > args.expected_probe_failure_rate:
+        return (
+            "Probe failure rate exceeded expectation: "
+            f"{failure_rate:.4f} > {args.expected_probe_failure_rate:.4f}; "
+            f"count={summary.count} failures={summary.failure_count}."
+        )
+    if summary.p95_ms > args.expected_probe_p95_ms:
+        return (
+            "Probe p95 exceeded expectation: "
+            f"{summary.p95_ms}ms > {args.expected_probe_p95_ms}ms; "
+            f"count={summary.count}."
+        )
+    if summary.max_ms > args.expected_probe_max_ms:
+        return (
+            "Probe max exceeded expectation: "
+            f"{summary.max_ms}ms > {args.expected_probe_max_ms}ms; "
+            f"count={summary.count}."
+        )
+    return ""
+
+
+def _run_single_pressure_session(
+    api_base_url: str,
+    session_id: str,
+    index: int,
+    args: argparse.Namespace,
+) -> RunResult:
+    tag = f"s{index + 1}"
+    intent = (
+        "[session-extreme-pressure "
+        f"main_calls={args.main_tool_calls} "
+        f"main_batch={args.main_batch_size} "
+        f"subagents={args.subagents} "
+        f"subagent_calls={args.subagent_tool_calls} "
+        f"subagent_batch={args.subagent_batch_size} "
+        f"subagent_spawn_batch={args.subagent_spawn_batch_size} "
+        f"path={args.path} "
+        f"tag={tag}] run extreme pressure session {index + 1}."
+    )
+    timeout = httpx.Timeout(
+        args.timeout_seconds,
+        connect=10.0,
+        read=min(args.timeout_seconds, 240.0),
+        write=10.0,
+        pool=10.0,
+    )
+    with httpx.Client(
+        base_url=api_base_url, timeout=timeout, trust_env=False
+    ) as client:
+        started = time.perf_counter()
+        run_id = create_run(
+            client,
+            session_id=session_id,
+            intent=intent,
+            execution_mode="ai",
+            yolo=True,
+        )
+        events = stream_run_until_terminal(
+            client,
+            run_id=run_id,
+            timeout_seconds=args.timeout_seconds,
+        )
+        return RunResult(
+            session_id=session_id,
+            run_id=run_id,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            terminal_event_type=str(events[-1].get("event_type") or ""),
+            stream_event_counts=_event_counts(events),
+            session_event_counts={},
+            subagent_event_count=0,
+        )
+
+
+def _enrich_run_result(client: httpx.Client, run: RunResult) -> RunResult:
+    response = client.get(f"/api/sessions/{run.session_id}/events")
+    response.raise_for_status()
+    payload: object = response.json()
+    if not isinstance(payload, list):
+        raise RuntimeError(f"Unexpected session events payload: {payload}")
+    session_event_counts: Counter[str] = Counter()
+    subagent_event_count = 0
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        event_type = str(item.get("event_type") or "")
+        if event_type:
+            session_event_counts[event_type] += 1
+        if str(item.get("trace_id") or "").startswith("subagent_run_"):
+            subagent_event_count += 1
+    return run.model_copy(
+        update={
+            "session_event_counts": dict(session_event_counts),
+            "subagent_event_count": subagent_event_count,
+        },
+    )
+
+
+def _safe_enrich_run_result(
+    client: httpx.Client,
+    run: RunResult,
+    *,
+    errors: list[str],
+) -> RunResult:
+    try:
+        return _enrich_run_result(client, run)
+    except RECOVERABLE_BENCHMARK_ERRORS as exc:
+        errors.append(
+            f"enrich_run_failed[{run.session_id}]: {type(exc).__name__}: {exc}"
+        )
+        return run
+
+
+def _load_session_progress(
+    client: httpx.Client,
+    *,
+    session_id: str,
+    args: argparse.Namespace,
+) -> RunProgress:
+    response = client.get(f"/api/sessions/{session_id}/events")
+    response.raise_for_status()
+    payload: object = response.json()
+    if not isinstance(payload, list):
+        raise RuntimeError(f"Unexpected session events payload: {payload}")
+
+    root_run_id = ""
+    last_event_type = ""
+    last_tool_call_id = ""
+    main_read_completed_count = 0
+    spawn_completed_count = 0
+    subagent_run_completed_count = 0
+    subagent_read_completed_count = 0
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        trace_id = str(item.get("trace_id") or "")
+        event_type = str(item.get("event_type") or "")
+        if trace_id and not trace_id.startswith("subagent_run_") and not root_run_id:
+            root_run_id = trace_id
+        if event_type:
+            last_event_type = event_type
+        event_payload = _event_payload(item)
+        tool_call_id = str(event_payload.get("tool_call_id") or "")
+        if tool_call_id:
+            last_tool_call_id = tool_call_id
+        if event_type == "tool_result":
+            if tool_call_id.startswith("call-session-extreme-read-"):
+                main_read_completed_count += 1
+            elif tool_call_id.startswith("call-session-extreme-spawn-"):
+                spawn_completed_count += 1
+            elif tool_call_id.startswith("call-session-extreme-subagent-read-"):
+                subagent_read_completed_count += 1
+        if event_type == "run_completed" and trace_id.startswith("subagent_run_"):
+            subagent_run_completed_count += 1
+
+    subagent_completed_count = max(
+        subagent_run_completed_count,
+        spawn_completed_count
+        if subagent_read_completed_count >= args.subagents * args.subagent_tool_calls
+        else 0,
+    )
+    return RunProgress(
+        session_id=session_id,
+        run_id=root_run_id,
+        main_read_completed_count=main_read_completed_count,
+        spawn_completed_count=spawn_completed_count,
+        subagent_completed_count=subagent_completed_count,
+        last_event_type=last_event_type,
+        last_tool_call_id=last_tool_call_id,
+        stage=_progress_stage(
+            main_read_completed_count=main_read_completed_count,
+            spawn_completed_count=spawn_completed_count,
+            subagent_completed_count=subagent_completed_count,
+            args=args,
+        ),
+    )
+
+
+def _safe_load_session_progress(
+    client: httpx.Client,
+    *,
+    session_id: str,
+    args: argparse.Namespace,
+    errors: list[str],
+) -> RunProgress:
+    try:
+        return _load_session_progress(client, session_id=session_id, args=args)
+    except RECOVERABLE_BENCHMARK_ERRORS as exc:
+        errors.append(f"progress_failed[{session_id}]: {type(exc).__name__}: {exc}")
+        return RunProgress(
+            session_id=session_id,
+            run_id="",
+            main_read_completed_count=0,
+            spawn_completed_count=0,
+            subagent_completed_count=0,
+            last_event_type="",
+            last_tool_call_id="",
+            stage="unknown",
+        )
+
+
+def _event_payload(item: dict[object, object]) -> dict[str, object]:
+    raw_payload = item.get("payload")
+    if isinstance(raw_payload, dict):
+        return {str(key): value for key, value in raw_payload.items()}
+    raw_payload_json = item.get("payload_json")
+    if not isinstance(raw_payload_json, str) or not raw_payload_json:
+        return {}
+    try:
+        decoded: object = json.loads(raw_payload_json)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(decoded, dict):
+        return {}
+    return {str(key): value for key, value in decoded.items()}
+
+
+def _progress_stage(
+    *,
+    main_read_completed_count: int,
+    spawn_completed_count: int,
+    subagent_completed_count: int,
+    args: argparse.Namespace,
+) -> str:
+    if main_read_completed_count < args.main_tool_calls:
+        return "main_tools"
+    if spawn_completed_count < args.subagents:
+        return "spawn_subagents"
+    if subagent_completed_count < args.subagents:
+        return "subagent_tools"
+    return "finalize"
+
+
+def _load_tool_metric_summary(
+    client: httpx.Client,
+    session_ids: tuple[str, ...],
+) -> tuple[dict[str, int], dict[str, dict[str, int]]]:
+    metric_values: dict[str, list[int]] = {
+        "action_duration_ms": [],
+        "tool_framework_wait_ms": [],
+        "tool_result_publish_ms": [],
+        "tool_result_persist_ms": [],
+        "tool_batch_wall_ms": [],
+    }
+    by_tool_values: dict[str, dict[str, list[int]]] = {}
+    for session_id in session_ids:
+        response = client.get(f"/api/sessions/{session_id}/events")
+        response.raise_for_status()
+        payload: object = response.json()
+        if not isinstance(payload, list):
+            continue
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("event_type") or "") != "tool_result":
+                continue
+            event_payload = _event_payload(item)
+            metrics = event_payload.get("metrics")
+            if not isinstance(metrics, dict):
+                continue
+            tool_name = str(
+                event_payload.get("tool_name")
+                or event_payload.get("tool")
+                or _UNKNOWN_TOOL_NAME
+            )
+            tool_metric_values = by_tool_values.setdefault(
+                tool_name,
+                {metric_name: [] for metric_name in metric_values},
+            )
+            for metric_name in metric_values:
+                value = metrics.get(metric_name)
+                if type(value) is int:
+                    metric_values[metric_name].append(value)
+                    tool_metric_values[metric_name].append(value)
+    summary: dict[str, int] = {}
+    for metric_name, values in metric_values.items():
+        sorted_values = sorted(values)
+        summary[f"{metric_name}_p95"] = _percentile(sorted_values, 0.95)
+        summary[f"{metric_name}_max"] = sorted_values[-1] if sorted_values else 0
+    by_tool_summary: dict[str, dict[str, int]] = {}
+    for tool_name, tool_values in by_tool_values.items():
+        by_tool_summary[tool_name] = {}
+        for metric_name, values in tool_values.items():
+            sorted_values = sorted(values)
+            by_tool_summary[tool_name][f"{metric_name}_p95"] = _percentile(
+                sorted_values,
+                0.95,
+            )
+            by_tool_summary[tool_name][f"{metric_name}_max"] = (
+                sorted_values[-1] if sorted_values else 0
+            )
+    return summary, by_tool_summary
+
+
+def _safe_load_tool_metric_summary(
+    client: httpx.Client,
+    session_ids: tuple[str, ...],
+    *,
+    errors: list[str],
+) -> tuple[dict[str, int], dict[str, dict[str, int]]]:
+    try:
+        return _load_tool_metric_summary(client, session_ids)
+    except RECOVERABLE_BENCHMARK_ERRORS as exc:
+        errors.append(f"tool_metrics_failed: {type(exc).__name__}: {exc}")
+        return {}, {}
+
+
+def _load_terminal_invariant_summary(
+    session_ids: tuple[str, ...],
+) -> TerminalInvariantSummary:
+    db_path = Path.home() / ".relay-teams" / "relay_teams.db"
+    if not db_path.exists():
+        return TerminalInvariantSummary(count=0, failure_count=0, records=())
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    records: list[TerminalInvariantRecord] = []
+    try:
+        for session_id in session_ids:
+            runtime_rows = conn.execute(
+                """
+                SELECT run_id, status
+                FROM run_runtime
+                WHERE session_id=?
+                """,
+                (session_id,),
+            ).fetchall()
+            for runtime_row in runtime_rows:
+                run_id = str(runtime_row["run_id"])
+                kind = "subagent" if run_id.startswith("subagent_run_") else "root"
+                runtime_status = str(runtime_row["status"])
+                if runtime_status not in {"completed", "failed", "stopped"}:
+                    continue
+                run_state_status = _load_run_state_status(conn, run_id)
+                terminal_event_count = int(
+                    conn.execute(
+                        """
+                        SELECT COUNT(*) AS count
+                        FROM events
+                        WHERE trace_id=?
+                        AND event_type IN ('run_completed', 'run_failed', 'run_stopped')
+                        """,
+                        (run_id,),
+                    ).fetchone()["count"]
+                )
+                has_terminal_event = terminal_event_count > 0
+                ok = has_terminal_event and run_state_status == runtime_status
+                records.append(
+                    TerminalInvariantRecord(
+                        session_id=session_id,
+                        run_id=run_id,
+                        kind=kind,
+                        runtime_status=runtime_status,
+                        run_state_status=run_state_status,
+                        has_terminal_event=has_terminal_event,
+                        ok=ok,
+                        error=(
+                            ""
+                            if ok
+                            else "terminal runtime must have terminal event and matching run_state"
+                        ),
+                    )
+                )
+    finally:
+        conn.close()
+    failures = tuple(record for record in records if not record.ok)
+    return TerminalInvariantSummary(
+        count=len(records),
+        failure_count=len(failures),
+        records=tuple(records),
+    )
+
+
+def _safe_load_terminal_invariant_summary(
+    client: httpx.Client,
+    session_ids: tuple[str, ...],
+    *,
+    errors: list[str],
+) -> TerminalInvariantSummary:
+    _ = client
+    try:
+        return _load_terminal_invariant_summary(session_ids)
+    except RECOVERABLE_BENCHMARK_ERRORS as exc:
+        errors.append(f"terminal_invariants_failed: {type(exc).__name__}: {exc}")
+        return TerminalInvariantSummary(count=0, failure_count=0, records=())
+
+
+def _load_run_state_status(conn: sqlite3.Connection, run_id: str) -> str:
+    row = conn.execute(
+        "SELECT state_json FROM run_states WHERE run_id=?",
+        (run_id,),
+    ).fetchone()
+    if row is None:
+        return ""
+    try:
+        payload: object = json.loads(str(row["state_json"]))
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    return str(payload.get("status") or "")
+
+
+def _probe_backend_until_stopped(
+    api_base_url: str,
+    session_ids: tuple[str, ...],
+    stop_event: Event,
+    results: list[ProbeResult],
+    lock: Lock,
+    worker_index: int,
+) -> None:
+    paths = _probe_paths(session_ids)
+    index = worker_index
+    with httpx.Client(
+        base_url=api_base_url,
+        timeout=_PROBE_TIMEOUT,
+        trust_env=False,
+    ) as client:
+        while not stop_event.is_set():
+            method, path = paths[index % len(paths)]
+            index += 1
+            result = _send_probe(client, method, path)
+            with lock:
+                results.append(result)
+
+
+def _navigation_driver_until_stopped(
+    api_base_url: str,
+    session_ids: tuple[str, ...],
+    stop_event: Event,
+    results: list[NavigationStepResult],
+    lock: Lock,
+    args: argparse.Namespace,
+) -> None:
+    rng = random.Random(42)
+    previous = NavigationTarget(
+        kind="root", session_id=session_ids[0] if session_ids else ""
+    )
+    matrix_index = 0
+    timeout = httpx.Timeout(
+        2.0,
+        connect=1.0,
+        read=0.35,
+        write=1.0,
+        pool=1.0,
+    )
+    watermarks: dict[str, int] = {}
+    seen_event_ids: dict[str, set[int]] = {}
+    with httpx.Client(
+        base_url=api_base_url,
+        timeout=timeout,
+        trust_env=False,
+    ) as client:
+        while not stop_event.is_set():
+            targets = _load_navigation_targets(client, session_ids, args)
+            if not targets:
+                time.sleep(max(0.01, args.switch_interval_ms / 1000.0))
+                continue
+            if args.switch_pattern == "random":
+                target = rng.choice(targets)
+            else:
+                target = targets[matrix_index % len(targets)]
+                matrix_index += 1
+            step = _send_navigation_step(
+                client=client,
+                previous=previous,
+                target=target,
+                watermarks=watermarks,
+                seen_event_ids=seen_event_ids,
+            )
+            with lock:
+                results.append(step)
+            previous = target
+            time.sleep(max(0.01, args.switch_interval_ms / 1000.0))
+
+
+def _load_navigation_targets(
+    client: httpx.Client,
+    session_ids: tuple[str, ...],
+    args: argparse.Namespace,
+) -> tuple[NavigationTarget, ...]:
+    targets: list[NavigationTarget] = []
+    include_roots = args.switch_targets in {"roots", "mixed"}
+    include_subagents = args.switch_targets in {"subagents", "mixed"}
+    for session_id in session_ids:
+        if include_roots:
+            targets.append(_load_root_navigation_target(client, session_id))
+        if include_subagents:
+            targets.extend(_load_subagent_navigation_targets(client, session_id))
+    if args.switch_pattern == "matrix":
+        return _matrix_ordered_navigation_targets(tuple(targets))
+    return tuple(targets)
+
+
+def _matrix_ordered_navigation_targets(
+    targets: tuple[NavigationTarget, ...],
+) -> tuple[NavigationTarget, ...]:
+    roots = tuple(target for target in targets if target.kind == "root")
+    subagents = tuple(target for target in targets if target.kind == "subagent")
+    ordered: list[NavigationTarget] = []
+    max_len = max(len(roots), len(subagents), 1)
+    for index in range(max_len):
+        if roots:
+            ordered.append(roots[index % len(roots)])
+        if subagents:
+            ordered.append(subagents[index % len(subagents)])
+        if len(subagents) > 1:
+            ordered.append(subagents[(index + 1) % len(subagents)])
+        if len(roots) > 1:
+            ordered.append(roots[(index + 1) % len(roots)])
+    return tuple(ordered)
+
+
+def _load_root_navigation_target(
+    client: httpx.Client,
+    session_id: str,
+) -> NavigationTarget:
+    run_id = ""
+    try:
+        response = client.get(f"/api/sessions/{session_id}/recovery")
+        if response.status_code < 500:
+            payload: object = response.json()
+            if isinstance(payload, dict):
+                active_run = payload.get("active_run")
+                if isinstance(active_run, dict):
+                    run_id = str(active_run.get("run_id") or "").strip()
+    except RECOVERABLE_BENCHMARK_ERRORS:
+        run_id = ""
+    return NavigationTarget(kind="root", session_id=session_id, run_id=run_id)
+
+
+def _load_subagent_navigation_targets(
+    client: httpx.Client,
+    session_id: str,
+) -> tuple[NavigationTarget, ...]:
+    try:
+        response = client.get(f"/api/sessions/{session_id}/subagents:snapshot")
+        if response.status_code >= 500:
+            return ()
+        payload: object = response.json()
+    except RECOVERABLE_BENCHMARK_ERRORS:
+        return ()
+    rows: object = payload.get("items") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        return ()
+    targets: list[NavigationTarget] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        run_id = str(row.get("run_id") or row.get("subagent_run_id") or "").strip()
+        instance_id = str(
+            row.get("instance_id") or row.get("subagent_instance_id") or ""
+        ).strip()
+        if not run_id or not instance_id:
+            continue
+        targets.append(
+            NavigationTarget(
+                kind="subagent",
+                session_id=session_id,
+                run_id=run_id,
+                instance_id=instance_id,
+            )
+        )
+    return tuple(targets)
+
+
+def _send_navigation_step(
+    *,
+    client: httpx.Client,
+    previous: NavigationTarget,
+    target: NavigationTarget,
+    watermarks: dict[str, int],
+    seen_event_ids: dict[str, set[int]],
+) -> NavigationStepResult:
+    started = time.perf_counter()
+    status_code: int | None = None
+    error = ""
+    after_event_id = 0
+    hydration_duration_ms = 0
+    hydration_error = ""
+    duplicate_count = 0
+    gap_count = 0
+    wrong_target_count = 0
+    transition = f"{previous.kind}->{target.kind}"
+    try:
+        if target.kind == "root":
+            status_code = _activate_root_target(client, target)
+            duration_ms = int((time.perf_counter() - started) * 1000)
+            hydration_started = time.perf_counter()
+            try:
+                hydrate_status_code = _hydrate_root_target(client, target)
+                after_event_id, duplicate_count, gap_count, wrong_target_count = (
+                    _stream_target_events(
+                        client=client,
+                        target=target,
+                        watermarks=watermarks,
+                        seen_event_ids=seen_event_ids,
+                    )
+                )
+                if hydrate_status_code >= 500:
+                    hydration_error = f"HTTP {hydrate_status_code}"
+                else:
+                    hydration_error = ""
+            except RECOVERABLE_BENCHMARK_ERRORS as exc:
+                hydration_error = f"{type(exc).__name__}: {exc}"
+        else:
+            status_code = _activate_subagent_target(client, target)
+            duration_ms = int((time.perf_counter() - started) * 1000)
+            hydration_started = time.perf_counter()
+            try:
+                hydrate_status_code = _hydrate_subagent_target(client, target)
+                after_event_id, duplicate_count, gap_count, wrong_target_count = (
+                    _stream_target_events(
+                        client=client,
+                        target=target,
+                        watermarks=watermarks,
+                        seen_event_ids=seen_event_ids,
+                    )
+                )
+                if hydrate_status_code >= 500:
+                    hydration_error = f"HTTP {hydrate_status_code}"
+                else:
+                    hydration_error = ""
+            except RECOVERABLE_BENCHMARK_ERRORS as exc:
+                hydration_error = f"{type(exc).__name__}: {exc}"
+        hydration_duration_ms = int((time.perf_counter() - hydration_started) * 1000)
+    except RECOVERABLE_BENCHMARK_ERRORS as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        duration_ms = int((time.perf_counter() - started) * 1000)
+    return NavigationStepResult(
+        transition=transition,
+        target=target,
+        duration_ms=duration_ms,
+        hydration_duration_ms=hydration_duration_ms,
+        status_code=status_code or 0,
+        after_event_id=after_event_id,
+        stream_duplicate_count=duplicate_count,
+        stream_gap_count=gap_count,
+        wrong_target_render_count=wrong_target_count,
+        error=error,
+        hydration_error=hydration_error,
+    )
+
+
+def _activate_root_target(client: httpx.Client, target: NavigationTarget) -> int:
+    _ = client, target
+    return 200
+
+
+def _hydrate_root_target(client: httpx.Client, target: NavigationTarget) -> int:
+    status_code = 200
+    for path in (
+        f"/api/sessions/{target.session_id}/recovery",
+        f"/api/sessions/{target.session_id}/rounds?summary=true&limit=4",
+    ):
+        response = client.get(path)
+        _consume_response(response)
+        status_code = max(status_code, response.status_code)
+    return status_code
+
+
+def _activate_subagent_target(client: httpx.Client, target: NavigationTarget) -> int:
+    _ = client, target
+    return 200
+
+
+def _hydrate_subagent_target(client: httpx.Client, target: NavigationTarget) -> int:
+    status_code = 200
+    for path in (
+        f"/api/sessions/{target.session_id}/agents/{target.instance_id}/messages",
+    ):
+        response = client.get(path)
+        _consume_response(response)
+        status_code = max(status_code, response.status_code)
+    return status_code
+
+
+def _stream_target_events(
+    *,
+    client: httpx.Client,
+    target: NavigationTarget,
+    watermarks: dict[str, int],
+    seen_event_ids: dict[str, set[int]],
+) -> tuple[int, int, int, int]:
+    if not target.run_id:
+        return 0, 0, 0, 0
+    key = f"{target.kind}:{target.session_id}:{target.run_id}:{target.instance_id}"
+    after_event_id = watermarks.get(key, 0)
+    duplicate_count = 0
+    gap_count = 0
+    wrong_target_count = 0
+    if target.kind == "root":
+        url = f"/api/runs/{target.run_id}/events?after_event_id={after_event_id}"
+    else:
+        url = (
+            f"/api/sessions/{target.session_id}/subagents/events"
+            f"?after_event_id={after_event_id}"
+        )
+    try:
+        with client.stream("GET", url) as response:
+            status_code = response.status_code
+            if status_code >= 500:
+                return after_event_id, duplicate_count, gap_count, wrong_target_count
+            for line in response.iter_lines():
+                if not line.startswith("data:"):
+                    continue
+                raw_json = line.removeprefix("data:").strip()
+                if not raw_json:
+                    continue
+                event = json.loads(raw_json)
+                if not isinstance(event, dict):
+                    continue
+                event_id = int(event.get("event_id") or 0)
+                event_run_id = str(event.get("run_id") or event.get("trace_id") or "")
+                if event_id > 0:
+                    after_event_id = max(after_event_id, event_id)
+                    watermarks[key] = after_event_id
+                if target.kind == "subagent" and event_run_id != target.run_id:
+                    # The subagent SSE endpoint is session-scoped and can replay sibling
+                    # subagent events. The frontend filters those into cache only; they
+                    # are not wrong-target DOM renders unless the client accepts them for
+                    # the active target.
+                    continue
+                if event_id > 0:
+                    seen = seen_event_ids.setdefault(key, set())
+                    if event_id in seen:
+                        duplicate_count += 1
+                    seen.add(event_id)
+                break
+    except httpx.ReadTimeout:
+        return after_event_id, duplicate_count, gap_count, wrong_target_count
+    return after_event_id, duplicate_count, gap_count, wrong_target_count
+
+
+def _probe_paths(session_ids: tuple[str, ...]) -> tuple[tuple[str, str], ...]:
+    paths: list[tuple[str, str]] = [
+        ("GET", "/api/system/live"),
+        ("GET", "/api/system/health"),
+        ("GET", "/api/sessions"),
+    ]
+    for session_id in session_ids:
+        paths.extend(
+            [
+                ("GET", f"/api/sessions/{session_id}"),
+                ("GET", f"/api/sessions/{session_id}/rounds?summary=true&limit=4"),
+                ("GET", f"/api/sessions/{session_id}/rounds?limit=8"),
+                ("GET", f"/api/sessions/{session_id}/recovery"),
+                ("GET", f"/api/sessions/{session_id}/token-usage"),
+                ("GET", f"/api/sessions/{session_id}/agents"),
+                ("GET", f"/api/sessions/{session_id}/tasks"),
+                ("GET", f"/api/sessions/{session_id}/subagents"),
+                ("POST", f"/api/sessions/{session_id}/terminal-view"),
+            ],
+        )
+    return tuple(paths)
+
+
+def _send_probe(client: httpx.Client, method: str, path: str) -> ProbeResult:
+    started = time.perf_counter()
+    try:
+        if method == "POST":
+            response = client.post(path)
+        else:
+            response = client.get(path)
+        _consume_response(response)
+        return ProbeResult(
+            method=method,
+            path=path,
+            status_code=response.status_code,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+        )
+    except RECOVERABLE_BENCHMARK_ERRORS as exc:
+        return ProbeResult(
+            method=method,
+            path=path,
+            status_code=0,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _stop_probe_workers(futures: list[Future[None]]) -> None:
+    for future in futures:
+        try:
+            future.result(timeout=7.0)
+        except FutureTimeoutError:
+            future.cancel()
+
+
+def _consume_response(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "")
+    if "application/json" in content_type:
+        _ = response.json()
+        return
+    _ = response.text
+
+
+def _event_counts(events: Sequence[dict[str, object]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for event in events:
+        event_type = str(event.get("event_type") or "")
+        if event_type:
+            counts[event_type] += 1
+    return dict(counts)
+
+
+def _summarize_probes(probes: tuple[ProbeResult, ...]) -> ProbeSummary:
+    durations = sorted(probe.duration_ms for probe in probes)
+    failures = [
+        probe
+        for probe in probes
+        if probe.status_code == 0
+        or probe.status_code == 429
+        or probe.status_code >= 500
+    ]
+    slowest = tuple(
+        sorted(probes, key=lambda probe: probe.duration_ms, reverse=True)[:10],
+    )
+    return ProbeSummary(
+        count=len(probes),
+        failure_count=len(failures),
+        p50_ms=_percentile(durations, 0.50),
+        p95_ms=_percentile(durations, 0.95),
+        p99_ms=_percentile(durations, 0.99),
+        max_ms=durations[-1] if durations else 0,
+        by_endpoint=_summarize_probes_by_endpoint(probes),
+        slowest=slowest,
+    )
+
+
+def _summarize_navigation(
+    steps: tuple[NavigationStepResult, ...],
+) -> NavigationSummary:
+    durations = sorted(step.duration_ms for step in steps)
+    hydration_durations = sorted(step.hydration_duration_ms for step in steps)
+    hydration_failures = [step for step in steps if step.hydration_error]
+    failures = [
+        step
+        for step in steps
+        if step.status_code == 0 or step.status_code == 429 or step.status_code >= 500
+    ]
+    grouped: dict[str, list[NavigationStepResult]] = {}
+    for step in steps:
+        grouped.setdefault(step.transition, []).append(step)
+    return NavigationSummary(
+        count=len(steps),
+        failure_count=len(failures),
+        p50_ms=_percentile(durations, 0.50),
+        p95_ms=_percentile(durations, 0.95),
+        max_ms=durations[-1] if durations else 0,
+        hydration_p95_ms=_percentile(hydration_durations, 0.95),
+        hydration_max_ms=hydration_durations[-1] if hydration_durations else 0,
+        hydration_failure_count=len(hydration_failures),
+        by_transition={
+            transition: _summarize_navigation_transition(tuple(items))
+            for transition, items in sorted(grouped.items())
+        },
+        stream_duplicate_count=sum(step.stream_duplicate_count for step in steps),
+        stream_gap_count=sum(step.stream_gap_count for step in steps),
+        wrong_target_render_count=sum(step.wrong_target_render_count for step in steps),
+        running_indicator_missing_count=0,
+        terminal_refresh_wrong_target_count=0,
+        failures=tuple(failures[:10]),
+    )
+
+
+def _summarize_navigation_transition(
+    steps: tuple[NavigationStepResult, ...],
+) -> NavigationTransitionSummary:
+    durations = sorted(step.duration_ms for step in steps)
+    hydration_durations = sorted(step.hydration_duration_ms for step in steps)
+    failures = [
+        step
+        for step in steps
+        if step.status_code == 0 or step.status_code == 429 or step.status_code >= 500
+    ]
+    return NavigationTransitionSummary(
+        count=len(steps),
+        failure_count=len(failures),
+        p50_ms=_percentile(durations, 0.50),
+        p95_ms=_percentile(durations, 0.95),
+        max_ms=durations[-1] if durations else 0,
+        hydration_p95_ms=_percentile(hydration_durations, 0.95),
+        hydration_max_ms=hydration_durations[-1] if hydration_durations else 0,
+    )
+
+
+def _summarize_probes_by_endpoint(
+    probes: tuple[ProbeResult, ...],
+) -> dict[str, EndpointProbeSummary]:
+    grouped: dict[str, list[ProbeResult]] = {}
+    for probe in probes:
+        grouped.setdefault(_normalized_probe_endpoint(probe), []).append(probe)
+    return {
+        endpoint: _summarize_endpoint_probes(tuple(endpoint_probes))
+        for endpoint, endpoint_probes in sorted(grouped.items())
+    }
+
+
+def _summarize_endpoint_probes(
+    probes: tuple[ProbeResult, ...],
+) -> EndpointProbeSummary:
+    durations = sorted(probe.duration_ms for probe in probes)
+    failures = [
+        probe
+        for probe in probes
+        if probe.status_code == 0
+        or probe.status_code == 429
+        or probe.status_code >= 500
+    ]
+    return EndpointProbeSummary(
+        count=len(probes),
+        failure_count=len(failures),
+        p50_ms=_percentile(durations, 0.50),
+        p95_ms=_percentile(durations, 0.95),
+        p99_ms=_percentile(durations, 0.99),
+        max_ms=durations[-1] if durations else 0,
+    )
+
+
+def _normalized_probe_endpoint(probe: ProbeResult) -> str:
+    path = probe.path.split("?", 1)[0]
+    path = re.sub(r"/api/sessions/[^/]+", "/api/sessions/{session_id}", path)
+    return f"{probe.method} {path}"
+
+
+def _percentile(sorted_values: list[int], percentile: float) -> int:
+    if not sorted_values:
+        return 0
+    index = max(0, min(len(sorted_values) - 1, int(len(sorted_values) * percentile)))
+    return sorted_values[index]
+
+
+def _load_fake_llm_metrics(fake_llm_admin_url: str) -> dict[str, object]:
+    with httpx.Client(
+        base_url=fake_llm_admin_url, timeout=10.0, trust_env=False
+    ) as client:
+        response = client.get("/metrics")
+        response.raise_for_status()
+        payload: object = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Unexpected fake LLM metrics payload: {payload}")
+        return payload
+
+
+def _parse_backend_log_metrics(
+    backend_log_file: Path,
+) -> dict[str, dict[str, int]]:
+    if not backend_log_file.exists():
+        return {
+            "artifact": {},
+            "sqlite": {},
+            "message_commit": {},
+            "tool_call_batch_state": {},
+            "tool_result_batch": {},
+            "relay_tool_step": {},
+            "sync_subagent": {},
+            "sse_heartbeat_count": {"count": 0},
+        }
+    text = backend_log_file.read_text(encoding="utf-8", errors="replace")
+    heartbeat_total = 0
+    for match in re.finditer(r'"heartbeat_count":\s*(\d+)', text):
+        heartbeat_total += int(match.group(1))
+    write_queue_failed = text.count("artifact.write_queue.failed")
+    return {
+        "artifact": {
+            "write_queue_failed": write_queue_failed,
+            "legacy_failed": max(0, text.count("artifact.") - write_queue_failed),
+            "database_locked": text.count('"error": "database is locked"'),
+        },
+        "sqlite": {
+            "write_retry": text.count("sqlite.write.retry"),
+            "database_locked": text.count("database is locked"),
+            "slow_route_work": text.count("server.route_work.slow_call"),
+        },
+        "message_commit": _metric_summary_from_log(
+            text,
+            (
+                "message_commit_append_ms",
+                "message_commit_history_reload_ms",
+                "message_commit_outcome_publish_ms",
+                "message_commit_safe_scan_ms",
+                "message_commit_total_ms",
+            ),
+        ),
+        "tool_call_batch_state": _metric_summary_from_log(
+            text,
+            ("tool_call_batch_state_write_ms",),
+        ),
+        "tool_result_batch": _metric_summary_from_log(
+            text,
+            (
+                "tool_result_batch_size",
+                "tool_result_batch_publish_ms",
+                "tool_result_batch_state_persist_ms",
+                "tool_result_batch_metrics_ms",
+                "tool_result_batch_total_ms",
+            ),
+        ),
+        "relay_tool_step": _metric_summary_from_log(
+            text,
+            (
+                "relay_tool_step_batch_size",
+                "relay_tool_step_execute_ms",
+                "relay_tool_step_pydantic_bypass_count",
+            ),
+        )
+        | {
+            "executor_used_count": text.count("relay_tool_step.executed"),
+            "fallback_count": text.count("relay_tool_step.fallback"),
+            "validation_fallback_count": text.count(
+                "relay_tool_step.validation_fallback"
+            ),
+        },
+        "sessions_list_cache": _metric_summary_from_log(
+            text,
+            (
+                "snapshot_age_ms",
+                "session_count",
+                "refresh_ms",
+            ),
+        )
+        | {
+            "stale_hit_count": text.count("session.list_cache.stale_hit"),
+            "cold_miss_timeout_count": text.count(
+                "session.list_cache.cold_miss_timeout"
+            ),
+            "refresh_failed_count": text.count("session.list_cache.refresh_failed"),
+        },
+        "sync_subagent": _metric_summary_from_log(
+            text,
+            (
+                "sync_subagent_queue_wait_ms",
+                "sync_subagent_launch_prepare_ms",
+                "sync_subagent_start_hooks_ms",
+                "sync_subagent_execute_ms",
+                "sync_subagent_finalize_ms",
+                "sync_subagent_total_ms",
+            ),
+        ),
+        "sse_heartbeat_count": {"count": heartbeat_total},
+    }
+
+
+def _metric_summary_from_log(
+    text: str,
+    metric_names: tuple[str, ...],
+) -> dict[str, int]:
+    summary: dict[str, int] = {}
+    for metric_name in metric_names:
+        values = [
+            int(match.group(1))
+            for match in re.finditer(rf'"{re.escape(metric_name)}":\s*(\d+)', text)
+        ]
+        values.sort()
+        summary[f"{metric_name}_p95"] = _percentile(values, 0.95)
+        summary[f"{metric_name}_max"] = values[-1] if values else 0
+    return summary
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/session_switch_after_send_pressure.py
+++ b/benchmarks/session_switch_after_send_pressure.py
@@ -1,0 +1,786 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from concurrent.futures import (
+    Future,
+    ThreadPoolExecutor,
+    TimeoutError as FutureTimeoutError,
+    as_completed,
+)
+from datetime import UTC, datetime
+import argparse
+import json
+from pathlib import Path
+import sys
+from threading import Event, Lock
+import time
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+for _PYTHONPATH_ENTRY in (_REPO_ROOT, _REPO_ROOT / "src", _REPO_ROOT / "tests"):
+    _PYTHONPATH_TEXT = str(_PYTHONPATH_ENTRY)
+    if _PYTHONPATH_TEXT not in sys.path:
+        sys.path.insert(0, _PYTHONPATH_TEXT)
+
+import httpx  # noqa: E402
+from pydantic import BaseModel, ConfigDict  # noqa: E402
+
+from benchmarks.extreme_session_pressure import (  # noqa: E402
+    _apply_home_env,
+    _build_environment,
+    _capture_home_env,
+    _load_fake_llm_metrics,
+    _parse_backend_log_metrics,
+    _percentile,
+    _restore_home_env,
+    _start_backend,
+    _start_fake_llm,
+)
+from tests.integration_tests.support.api_helpers import (  # noqa: E402
+    create_session,
+    new_session_id,
+)
+from tests.integration_tests.support.config_builder import (  # noqa: E402
+    assert_integration_model_config_uses_fake_llm,
+    write_test_runtime_config,
+)
+from tests.integration_tests.support.process_control import (  # noqa: E402
+    ManagedProcess,
+    find_free_ports,
+    stop_process,
+    wait_for_http_ready,
+)
+
+RECOVERABLE_SWITCH_BENCHMARK_ERRORS = (
+    AssertionError,
+    RuntimeError,
+    ValueError,
+    FutureTimeoutError,
+    httpx.HTTPError,
+)
+
+_HTTP_TIMEOUT = httpx.Timeout(8.0, connect=2.0, read=8.0, write=2.0, pool=2.0)
+_SEND_TIMEOUT = httpx.Timeout(20.0, connect=3.0, read=20.0, write=3.0, pool=3.0)
+
+
+class RequestResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: str
+    method: str
+    path: str
+    status_code: int
+    duration_ms: int
+    source_session_id: str = ""
+    target_session_id: str = ""
+    run_id: str = ""
+    error: str = ""
+
+
+class LatencySummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    count: int
+    failure_count: int
+    p50_ms: int
+    p95_ms: int
+    p99_ms: int
+    max_ms: int
+    by_path: dict[str, "LatencySummary"]
+
+
+class SwitchBenchmarkSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    started_at: str
+    duration_ms: int
+    parameters: dict[str, int | str]
+    send_summary: LatencySummary
+    immediate_switch_summary: LatencySummary
+    repeated_switch_summary: LatencySummary
+    mcp_load_summary: LatencySummary
+    slowest_immediate_switches: tuple[RequestResult, ...]
+    fake_llm_metrics: dict[str, object]
+    backend_metrics: dict[str, dict[str, int]]
+    backend_log_file: str
+    fake_llm_log_file: str
+    error: str = ""
+
+
+def main() -> None:
+    args = _parse_args()
+    repo_root = Path(__file__).resolve().parent.parent
+    run_root = _prepare_run_root(repo_root)
+    original_home_env = _capture_home_env()
+    fake_llm_process: ManagedProcess | None = None
+    backend_process: ManagedProcess | None = None
+    started_at = datetime.now(UTC).isoformat()
+    started = time.perf_counter()
+
+    try:
+        environment = _build_environment(repo_root, run_root, args)
+        _apply_switch_environment(environment, args)
+        fake_llm_port, backend_port = find_free_ports(2)
+        fake_llm_admin_url = f"http://127.0.0.1:{fake_llm_port}"
+        fake_llm_v1_base_url = f"{fake_llm_admin_url}/v1"
+        api_base_url = f"http://127.0.0.1:{backend_port}"
+        config_dir = run_root / ".relay-teams"
+        write_test_runtime_config(
+            config_dir=config_dir,
+            fake_llm_v1_base_url=fake_llm_v1_base_url,
+        )
+        assert_integration_model_config_uses_fake_llm(config_dir=config_dir)
+        mcp_server_names = _write_slow_mcp_config(
+            run_root=run_root,
+            config_dir=config_dir,
+            count=args.mcp_servers,
+        )
+        _apply_home_env(run_root)
+
+        fake_llm_log_file = run_root / "fake-llm.log"
+        backend_log_file = run_root / "backend.log"
+        fake_llm_process = _start_fake_llm(
+            repo_root,
+            environment,
+            fake_llm_port,
+            fake_llm_log_file,
+        )
+        wait_for_http_ready(
+            url=f"{fake_llm_admin_url}/health",
+            timeout_seconds=20.0,
+            process=fake_llm_process,
+        )
+        backend_process = _start_backend(
+            repo_root,
+            environment,
+            backend_port,
+            backend_log_file,
+        )
+        wait_for_http_ready(
+            url=f"{api_base_url}/api/system/health",
+            timeout_seconds=90.0,
+            process=backend_process,
+        )
+
+        summary = _run_benchmark(
+            args=args,
+            api_base_url=api_base_url,
+            fake_llm_admin_url=fake_llm_admin_url,
+            mcp_server_names=mcp_server_names,
+            started_at=started_at,
+            started=started,
+            backend_log_file=backend_log_file,
+            fake_llm_log_file=fake_llm_log_file,
+        )
+        summary_path = run_root / "summary.json"
+        summary_path.write_text(summary.model_dump_json(indent=2), encoding="utf-8")
+        print(summary.model_dump_json(indent=2))
+        print(f"\nsummary_path={summary_path}")
+        _raise_if_threshold_failed(summary, args)
+    finally:
+        if backend_process is not None:
+            stop_process(backend_process)
+        if fake_llm_process is not None:
+            stop_process(fake_llm_process)
+        _restore_home_env(original_home_env)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run send-then-switch session latency pressure benchmark.",
+    )
+    parser.add_argument("--sessions", type=int, default=30)
+    parser.add_argument("--send-count", type=int, default=30)
+    parser.add_argument("--send-workers", type=int, default=4)
+    parser.add_argument("--switch-workers", type=int, default=16)
+    parser.add_argument("--switch-rounds", type=int, default=600)
+    parser.add_argument("--switch-interval-ms", type=int, default=50)
+    parser.add_argument("--slow-llm-ms", type=int, default=12000)
+    parser.add_argument("--mcp-servers", type=int, default=40)
+    parser.add_argument("--mcp-load-workers", type=int, default=8)
+    parser.add_argument("--mcp-load-interval-ms", type=int, default=50)
+    parser.add_argument("--mcp-busy-backoff-ms", type=int, default=1000)
+    parser.add_argument("--post-send-switch-seconds", type=float, default=20.0)
+    parser.add_argument("--timeout-seconds", type=float, default=180.0)
+    parser.add_argument("--llm-http-max-concurrency", type=int, default=4)
+    parser.add_argument("--run-worker-active-limit", type=int, default=2)
+    parser.add_argument("--expected-immediate-switch-p95-ms", type=int, default=200)
+    parser.add_argument("--expected-immediate-switch-max-ms", type=int, default=1000)
+    parser.add_argument("--expected-repeated-switch-p95-ms", type=int, default=200)
+    parser.add_argument(
+        "--expected-repeated-switch-endpoint-p95-ms",
+        type=int,
+        default=200,
+    )
+    parser.add_argument("--expected-repeated-switch-max-ms", type=int, default=1000)
+    return parser.parse_args()
+
+
+def _prepare_run_root(repo_root: Path) -> Path:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_root = repo_root / ".tmp" / f"session-switch-after-send-{stamp}"
+    run_root.mkdir(parents=True, exist_ok=True)
+    return run_root
+
+
+def _apply_switch_environment(
+    environment: dict[str, str],
+    args: argparse.Namespace,
+) -> None:
+    environment["RELAY_TEAMS_LLM_HTTP_MAX_CONCURRENCY"] = str(
+        args.llm_http_max_concurrency
+    )
+    environment["RELAY_TEAMS_SESSION_SNAPSHOT_CACHE_MS"] = "1000"
+    environment["RELAY_TEAMS_SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS"] = "500"
+    environment["RELAY_TEAMS_LIST_SESSIONS_CACHE_MS"] = "1000"
+    environment["RELAY_TEAMS_SESSION_FAST_READ_WORKERS"] = "64"
+    environment["RELAY_TEAMS_SESSION_PROJECTION_REFRESH_WORKERS"] = "2"
+    environment["RELAY_TEAMS_MCP_DISCOVERY_CONCURRENCY"] = "0"
+    environment["RELAY_TEAMS_RUNTIME_MCP_SCHEMA_LOAD_BUDGET_MS"] = "120"
+    environment["RELAY_TEAMS_RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS"] = "40"
+    environment["RELAY_TEAMS_RUNTIME_MCP_SCHEMA_FAILED_TTL_MS"] = "60000"
+    environment["RELAY_TEAMS_RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES"] = "0"
+    environment["RELAY_TEAMS_MCP_TOOL_LOAD_CONCURRENCY"] = "0"
+    environment["RELAY_TEAMS_MCP_TOOL_LOAD_FAILED_TTL_MS"] = "60000"
+    environment["RELAY_TEAMS_MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS"] = "60000"
+    environment["RELAY_TEAMS_MCP_TOOLS_ROUTE_MIN_INTERVAL_MS"] = "100"
+    environment["RELAY_TEAMS_RUN_WORKER_ACTIVE_LIMIT"] = str(
+        args.run_worker_active_limit
+    )
+    environment["RELAY_TEAMS_RUN_CREATE_STARTUP_WAIT_MS"] = "0"
+
+
+def _write_slow_mcp_config(
+    *,
+    run_root: Path,
+    config_dir: Path,
+    count: int,
+) -> tuple[str, ...]:
+    if count <= 0:
+        return ()
+    script_path = run_root / "slow_mcp_stdio.py"
+    script_path.write_text(
+        "from __future__ import annotations\nimport time\ntime.sleep(60)\n",
+        encoding="utf-8",
+    )
+    servers: dict[str, dict[str, object]] = {}
+    names: list[str] = []
+    for index in range(count):
+        name = f"slow_mcp_{index:03d}"
+        names.append(name)
+        servers[name] = {
+            "command": sys.executable,
+            "args": [str(script_path)],
+            "timeout": 0.2,
+            "read_timeout": 0.2,
+            "enabled": True,
+        }
+    (config_dir / "mcp.json").write_text(
+        json.dumps({"mcpServers": servers}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return tuple(names)
+
+
+def _run_benchmark(
+    *,
+    args: argparse.Namespace,
+    api_base_url: str,
+    fake_llm_admin_url: str,
+    mcp_server_names: tuple[str, ...],
+    started_at: str,
+    started: float,
+    backend_log_file: Path,
+    fake_llm_log_file: Path,
+) -> SwitchBenchmarkSummary:
+    with httpx.Client(
+        base_url=api_base_url, timeout=_HTTP_TIMEOUT, trust_env=False
+    ) as client:
+        session_ids = tuple(
+            create_session(
+                client,
+                session_id=new_session_id(f"switch-pressure-{index:02d}"),
+            )
+            for index in range(args.sessions)
+        )
+        _warm_session_reads(client, session_ids)
+
+    stop_background = Event()
+    repeated_results: list[RequestResult] = []
+    mcp_results: list[RequestResult] = []
+    result_lock = Lock()
+    with ThreadPoolExecutor(
+        max_workers=args.switch_workers + args.mcp_load_workers + args.send_workers
+    ) as executor:
+        background_futures = _start_background_load(
+            executor=executor,
+            args=args,
+            api_base_url=api_base_url,
+            session_ids=session_ids,
+            mcp_server_names=mcp_server_names,
+            stop_event=stop_background,
+            repeated_results=repeated_results,
+            mcp_results=mcp_results,
+            result_lock=result_lock,
+        )
+        send_futures = [
+            executor.submit(
+                _send_and_switch_once,
+                api_base_url,
+                session_ids[index % len(session_ids)],
+                session_ids[(index + 1) % len(session_ids)],
+                args.slow_llm_ms,
+                index,
+            )
+            for index in range(args.send_count)
+        ]
+        send_results: list[RequestResult] = []
+        immediate_switch_results: list[RequestResult] = []
+        error = ""
+        try:
+            for future in as_completed(send_futures, timeout=args.timeout_seconds):
+                send_result, switch_result = future.result()
+                send_results.append(send_result)
+                immediate_switch_results.append(switch_result)
+            if args.post_send_switch_seconds > 0:
+                stop_background.wait(args.post_send_switch_seconds)
+        except RECOVERABLE_SWITCH_BENCHMARK_ERRORS as exc:
+            error = f"{type(exc).__name__}: {exc}"
+        finally:
+            stop_background.set()
+            for future in background_futures:
+                _background_result(future)
+
+    fake_llm_metrics = _load_fake_llm_metrics(fake_llm_admin_url)
+    backend_metrics = _parse_backend_log_metrics(backend_log_file)
+    slowest_immediate = tuple(
+        sorted(
+            immediate_switch_results,
+            key=lambda result: result.duration_ms,
+            reverse=True,
+        )[:10]
+    )
+    return SwitchBenchmarkSummary(
+        started_at=started_at,
+        duration_ms=int((time.perf_counter() - started) * 1000),
+        parameters={
+            "sessions": args.sessions,
+            "send_count": args.send_count,
+            "send_workers": args.send_workers,
+            "switch_workers": args.switch_workers,
+            "switch_rounds": args.switch_rounds,
+            "switch_interval_ms": args.switch_interval_ms,
+            "slow_llm_ms": args.slow_llm_ms,
+            "mcp_servers": args.mcp_servers,
+            "mcp_load_workers": args.mcp_load_workers,
+            "mcp_load_interval_ms": args.mcp_load_interval_ms,
+            "mcp_busy_backoff_ms": args.mcp_busy_backoff_ms,
+            "post_send_switch_seconds": args.post_send_switch_seconds,
+            "llm_http_max_concurrency": args.llm_http_max_concurrency,
+            "run_worker_active_limit": args.run_worker_active_limit,
+            "expected_immediate_switch_p95_ms": args.expected_immediate_switch_p95_ms,
+            "expected_immediate_switch_max_ms": args.expected_immediate_switch_max_ms,
+            "expected_repeated_switch_p95_ms": args.expected_repeated_switch_p95_ms,
+            "expected_repeated_switch_endpoint_p95_ms": (
+                args.expected_repeated_switch_endpoint_p95_ms
+            ),
+            "expected_repeated_switch_max_ms": args.expected_repeated_switch_max_ms,
+        },
+        send_summary=_summarize_results(tuple(send_results)),
+        immediate_switch_summary=_summarize_results(tuple(immediate_switch_results)),
+        repeated_switch_summary=_summarize_results(tuple(repeated_results)),
+        mcp_load_summary=_summarize_results(tuple(mcp_results)),
+        slowest_immediate_switches=slowest_immediate,
+        fake_llm_metrics=fake_llm_metrics,
+        backend_metrics=backend_metrics,
+        backend_log_file=str(backend_log_file),
+        fake_llm_log_file=str(fake_llm_log_file),
+        error=error,
+    )
+
+
+def _warm_session_reads(client: httpx.Client, session_ids: Sequence[str]) -> None:
+    for session_id in session_ids:
+        for path in _switch_paths(session_id):
+            response = client.get(path)
+            _consume_response(response)
+
+
+def _start_background_load(
+    *,
+    executor: ThreadPoolExecutor,
+    args: argparse.Namespace,
+    api_base_url: str,
+    session_ids: tuple[str, ...],
+    mcp_server_names: tuple[str, ...],
+    stop_event: Event,
+    repeated_results: list[RequestResult],
+    mcp_results: list[RequestResult],
+    result_lock: Lock,
+) -> tuple[Future[None], ...]:
+    futures: list[Future[None]] = []
+    for worker_index in range(args.switch_workers):
+        futures.append(
+            executor.submit(
+                _repeat_switches,
+                api_base_url,
+                session_ids,
+                args.switch_rounds,
+                worker_index,
+                args.switch_interval_ms,
+                stop_event,
+                repeated_results,
+                result_lock,
+            )
+        )
+    for worker_index in range(args.mcp_load_workers):
+        futures.append(
+            executor.submit(
+                _load_mcp_tools_until_stopped,
+                api_base_url,
+                mcp_server_names,
+                worker_index,
+                args.mcp_load_interval_ms,
+                args.mcp_busy_backoff_ms,
+                stop_event,
+                mcp_results,
+                result_lock,
+            )
+        )
+    return tuple(futures)
+
+
+def _send_and_switch_once(
+    api_base_url: str,
+    source_session_id: str,
+    target_session_id: str,
+    slow_llm_ms: int,
+    index: int,
+) -> tuple[RequestResult, RequestResult]:
+    with (
+        httpx.Client(
+            base_url=api_base_url,
+            timeout=_SEND_TIMEOUT,
+            trust_env=False,
+        ) as send_client,
+        httpx.Client(
+            base_url=api_base_url, timeout=_HTTP_TIMEOUT, trust_env=False
+        ) as switch_client,
+        ThreadPoolExecutor(max_workers=1) as executor,
+    ):
+        send_future = executor.submit(
+            _send_run,
+            send_client,
+            source_session_id=source_session_id,
+            slow_llm_ms=slow_llm_ms,
+            index=index,
+        )
+        switch_result = _send_request(
+            switch_client,
+            kind="immediate_switch",
+            method="GET",
+            path=f"/api/sessions/{target_session_id}/recovery",
+            source_session_id=source_session_id,
+            target_session_id=target_session_id,
+        )
+        send_result = send_future.result()
+        return send_result, switch_result
+
+
+def _send_run(
+    client: httpx.Client,
+    *,
+    source_session_id: str,
+    slow_llm_ms: int,
+    index: int,
+) -> RequestResult:
+    path = "/api/runs"
+    payload = {
+        "session_id": source_session_id,
+        "input": [
+            {
+                "kind": "text",
+                "text": (
+                    f"[slow-stream-hold ms={slow_llm_ms}] "
+                    f"send then switch pressure {index}"
+                ),
+            }
+        ],
+        "execution_mode": "ai",
+        "yolo": False,
+    }
+    started = time.perf_counter()
+    try:
+        response = client.post(path, json=payload)
+        body = _consume_response(response)
+        run_id = body.get("run_id") if isinstance(body, dict) else ""
+        return RequestResult(
+            kind="send",
+            method="POST",
+            path=path,
+            status_code=response.status_code,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            source_session_id=source_session_id,
+            run_id=run_id if isinstance(run_id, str) else "",
+        )
+    except RECOVERABLE_SWITCH_BENCHMARK_ERRORS as exc:
+        return RequestResult(
+            kind="send",
+            method="POST",
+            path=path,
+            status_code=0,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            source_session_id=source_session_id,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _repeat_switches(
+    api_base_url: str,
+    session_ids: tuple[str, ...],
+    rounds: int,
+    worker_index: int,
+    interval_ms: int,
+    stop_event: Event,
+    results: list[RequestResult],
+    lock: Lock,
+) -> None:
+    if not session_ids:
+        return
+    if interval_ms > 0:
+        initial_delay_seconds = (worker_index % 16) * (interval_ms / 1000.0) / 16.0
+        if stop_event.wait(initial_delay_seconds):
+            return
+    with httpx.Client(
+        base_url=api_base_url, timeout=_HTTP_TIMEOUT, trust_env=False
+    ) as client:
+        index = worker_index
+        for _ in range(rounds):
+            if stop_event.is_set():
+                break
+            session_id = session_ids[index % len(session_ids)]
+            paths = _switch_paths(session_id)
+            result = _send_request(
+                client,
+                kind="repeated_switch",
+                method="GET",
+                path=paths[index % len(paths)],
+                target_session_id=session_id,
+            )
+            with lock:
+                results.append(result)
+            index += 1
+            if interval_ms > 0:
+                jitter_bucket = ((index + worker_index) % 7) - 3
+                jitter_ms = int(interval_ms * jitter_bucket * 0.12)
+                delay_ms = max(1, interval_ms + jitter_ms)
+                if stop_event.wait(delay_ms / 1000.0):
+                    break
+
+
+def _load_mcp_tools_until_stopped(
+    api_base_url: str,
+    server_names: tuple[str, ...],
+    worker_index: int,
+    interval_ms: int,
+    busy_backoff_ms: int,
+    stop_event: Event,
+    results: list[RequestResult],
+    lock: Lock,
+) -> None:
+    if not server_names:
+        return
+    if interval_ms > 0:
+        initial_delay_seconds = (worker_index % 8) * (interval_ms / 1000.0) / 8.0
+        if stop_event.wait(initial_delay_seconds):
+            return
+    with httpx.Client(
+        base_url=api_base_url, timeout=_HTTP_TIMEOUT, trust_env=False
+    ) as client:
+        index = worker_index
+        while not stop_event.is_set():
+            name = server_names[index % len(server_names)]
+            result = _send_request(
+                client,
+                kind="mcp_load",
+                method="GET",
+                path=f"/api/mcp/servers/{name}/tools",
+            )
+            with lock:
+                results.append(result)
+            index += 1
+            wait_ms = interval_ms
+            if result.status_code == 429:
+                wait_ms = max(wait_ms, busy_backoff_ms)
+            jitter_bucket = ((index + worker_index) % 5) - 2
+            wait_ms = max(1, wait_ms + int(interval_ms * jitter_bucket * 0.1))
+            if wait_ms > 0 and stop_event.wait(wait_ms / 1000.0):
+                break
+
+
+def _switch_paths(session_id: str) -> tuple[str, ...]:
+    return (
+        f"/api/sessions/{session_id}",
+        f"/api/sessions/{session_id}/rounds?summary=true&limit=4",
+        f"/api/sessions/{session_id}/recovery",
+        f"/api/sessions/{session_id}/token-usage",
+        f"/api/sessions/{session_id}/agents",
+        f"/api/sessions/{session_id}/tasks",
+        f"/api/sessions/{session_id}/subagents",
+        "/api/sessions",
+    )
+
+
+def _send_request(
+    client: httpx.Client,
+    *,
+    kind: str,
+    method: str,
+    path: str,
+    source_session_id: str = "",
+    target_session_id: str = "",
+    run_id: str = "",
+) -> RequestResult:
+    started = time.perf_counter()
+    try:
+        response = client.request(method, path)
+        _consume_response(response)
+        return RequestResult(
+            kind=kind,
+            method=method,
+            path=path,
+            status_code=response.status_code,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            source_session_id=source_session_id,
+            target_session_id=target_session_id,
+            run_id=run_id,
+        )
+    except RECOVERABLE_SWITCH_BENCHMARK_ERRORS as exc:
+        return RequestResult(
+            kind=kind,
+            method=method,
+            path=path,
+            status_code=0,
+            duration_ms=int((time.perf_counter() - started) * 1000),
+            source_session_id=source_session_id,
+            target_session_id=target_session_id,
+            run_id=run_id,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _consume_response(response: httpx.Response) -> object:
+    content_type = response.headers.get("content-type", "")
+    if "application/json" in content_type:
+        return response.json()
+    return response.text
+
+
+def _background_result(future: Future[None]) -> None:
+    try:
+        future.result(timeout=10.0)
+    except RECOVERABLE_SWITCH_BENCHMARK_ERRORS:
+        return
+
+
+def _summarize_results(results: tuple[RequestResult, ...]) -> LatencySummary:
+    durations = sorted(result.duration_ms for result in results)
+    failures = tuple(
+        result
+        for result in results
+        if result.status_code == 0
+        or result.status_code == 429
+        or result.status_code >= 500
+    )
+    grouped: dict[str, list[RequestResult]] = {}
+    for result in results:
+        grouped.setdefault(_normalized_path(result.path), []).append(result)
+    return LatencySummary(
+        count=len(results),
+        failure_count=len(failures),
+        p50_ms=_percentile(durations, 0.50),
+        p95_ms=_percentile(durations, 0.95),
+        p99_ms=_percentile(durations, 0.99),
+        max_ms=durations[-1] if durations else 0,
+        by_path={
+            path: _summarize_results(tuple(path_results))
+            for path, path_results in sorted(grouped.items())
+        }
+        if len(grouped) > 1
+        else {},
+    )
+
+
+def _normalized_path(path: str) -> str:
+    if path.startswith("/api/sessions/"):
+        parts = path.split("?")[0].split("/")
+        if len(parts) >= 4:
+            parts[3] = "{session_id}"
+        return "/".join(parts)
+    if path.startswith("/api/mcp/servers/"):
+        return "/api/mcp/servers/{server_name}/tools"
+    return path.split("?", 1)[0]
+
+
+def _raise_if_threshold_failed(
+    summary: SwitchBenchmarkSummary,
+    args: argparse.Namespace,
+) -> None:
+    errors: list[str] = []
+    _append_threshold_error(
+        errors,
+        "immediate switch p95",
+        summary.immediate_switch_summary.p95_ms,
+        args.expected_immediate_switch_p95_ms,
+    )
+    _append_threshold_error(
+        errors,
+        "immediate switch max",
+        summary.immediate_switch_summary.max_ms,
+        args.expected_immediate_switch_max_ms,
+    )
+    _append_threshold_error(
+        errors,
+        "repeated switch p95",
+        summary.repeated_switch_summary.p95_ms,
+        args.expected_repeated_switch_p95_ms,
+    )
+    _append_threshold_error(
+        errors,
+        "repeated switch max",
+        summary.repeated_switch_summary.max_ms,
+        args.expected_repeated_switch_max_ms,
+    )
+    for path, path_summary in summary.repeated_switch_summary.by_path.items():
+        _append_threshold_error(
+            errors,
+            f"repeated switch {path} p95",
+            path_summary.p95_ms,
+            args.expected_repeated_switch_endpoint_p95_ms,
+        )
+    if summary.immediate_switch_summary.failure_count:
+        errors.append(
+            f"immediate switch failures={summary.immediate_switch_summary.failure_count}"
+        )
+    if summary.repeated_switch_summary.failure_count:
+        errors.append(
+            f"repeated switch failures={summary.repeated_switch_summary.failure_count}"
+        )
+    if errors:
+        raise SystemExit("; ".join(errors))
+
+
+def _append_threshold_error(
+    errors: list[str],
+    label: str,
+    actual: int,
+    expected: int,
+) -> None:
+    if actual > expected:
+        errors.append(f"{label} {actual}ms > {expected}ms")
+
+
+LatencySummary.model_rebuild()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -1120,6 +1120,8 @@ Notes:
 
 Lists sessions.
 
+This list is served through a short-lived stale-first cache during high-frequency session switching. Session create, update, delete, topology changes, terminal-run viewed updates, and run events mark the cache dirty. If a cached list exists, stale reads return the previous `list[SessionRecord]` response immediately while a single background refresh rebuilds the projection; the wire shape is unchanged.
+
 ### `GET /sessions/{session_id}`
 
 Gets one session.
@@ -1197,6 +1199,8 @@ Query parameters:
 - optional `timeline=true`: returns the full lightweight round index for timeline navigation; this mode ignores `limit` and `cursor_run_id`, sets `has_more = false`, and omits heavy message/task mapping fields such as `coordinator_messages`, `tasks`, `instance_role_map`, `role_instance_map`, `task_instance_map`, and `task_status_map`
 - optional `summary=true`: returns the paged lightweight round index for fast session switching; this mode honors `limit` and `cursor_run_id`, keeps pagination fields, and omits the same heavy fields as `timeline=true`
 
+The endpoint is served from a per-session materialized snapshot cache during high-frequency session switching. Fresh responses include `stale=false`; stale-first responses include `stale=true` and `snapshot_age_ms` while a background projection refresh is in flight. Existing round fields keep the same meaning.
+
 Response shape:
 
 ```json
@@ -1264,7 +1268,11 @@ Response shape:
     }
   ],
   "has_more": false,
-  "next_cursor": null
+  "next_cursor": null,
+  "stale": false,
+  "snapshot_age_ms": 0,
+  "snapshot_cache_hit": true,
+  "snapshot_refresh_ms": 4
 }
 ```
 
@@ -1295,6 +1303,7 @@ Gets one round projection.
 ### `GET /sessions/{session_id}/recovery`
 
 Returns active run recovery state, pending tool approvals, pending user questions, managed background task state, paused subagent state, and round snapshot.
+The endpoint may return a cached snapshot during high-frequency session switching. In that case the response includes `stale=true` and `snapshot_age_ms`; fresh responses include `stale=false`. Existing recovery fields keep the same meaning.
 
 `active_run` also includes:
 - `last_event_id`
@@ -1378,6 +1387,7 @@ Notes:
 - This endpoint continues to back the orchestration/legacy right-rail agent list.
 - Ephemeral same-role clones are excluded from this projection.
 - Normal-mode `spawn_subagent` child sessions are excluded from this projection.
+- Served from a stale-first materialized per-session snapshot cache. The legacy response shape stays as the item array; stale metadata is internal to the cache path for this endpoint.
 
 Response fields include:
 - `instance_id`
@@ -1398,6 +1408,8 @@ Notes:
 - Returns only subagent instances whose `run_id` is a normal-mode synthetic `subagent_run_*`.
 - Results are instance-scoped and are not collapsed by `role_id`, so multiple subagent runs under the same role are all returned.
 - Intended for the left sidebar child-session navigation, not the orchestration right rail.
+- Served from the same stale-first materialized snapshot cache as `GET /sessions/{session_id}/subagents:snapshot`; this legacy list response keeps returning only the item array.
+- The cached projection includes queued, running, and terminal subagent state and is refreshed in the background after dirty run events.
 
 Response fields include:
 - `instance_id`
@@ -1417,6 +1429,15 @@ Response fields include:
 - `reflection_updated_at`
 - `runtime_system_prompt`
 - `runtime_tools_json`
+
+### `GET /sessions/{session_id}/subagents:snapshot`
+
+Returns the cached normal-mode subagent projection with metadata:
+- `items`: same item array as `GET /sessions/{session_id}/subagents`
+- `stale`: `true` when the returned snapshot is older than the freshness window or marked dirty while refresh is in flight
+- `snapshot_age_ms`: age of the returned snapshot
+- `snapshot_cache_hit`: `true` when the response was served from cache
+- `snapshot_refresh_ms`: duration of the projection build that produced the cached snapshot
 
 ### `DELETE /sessions/{session_id}/subagents/{instance_id}`
 
@@ -1486,6 +1507,8 @@ Deletes the stored reflection summary for that subagent role in the current work
 
 Lists delegated tasks in the session.
 
+This endpoint uses the same stale-first per-session snapshot cache as the session switch projections. The legacy response shape stays as the item array.
+
 Task summaries include the persisted lifecycle view plus spec/evidence metadata used by the subagent panel:
 - `spec_artifact_id`
 - `spec_source_task_id`
@@ -1496,6 +1519,8 @@ Task summaries include the persisted lifecycle view plus spec/evidence metadata 
 ### `GET /sessions/{session_id}/token-usage`
 
 Returns aggregated token usage for the active session segment, grouped by `role_id`. The totals include the coordinator agent and every subagent run recorded under the same `session_id` after the latest logical `clear` marker. Response totals expose `total_cached_input_tokens` and `total_reasoning_output_tokens` alongside the existing input/output/request counters. Legacy local rows with missing or `NULL` counters are normalized to `0` before aggregation.
+
+The response is served from a stale-first per-session snapshot cache and may include optional metadata fields: `stale`, `snapshot_age_ms`, `snapshot_cache_hit`, and `snapshot_refresh_ms`. Existing token usage totals keep the same meaning.
 
 ### `GET /sessions/{session_id}/runs/{run_id}/token-usage`
 
@@ -1624,6 +1649,11 @@ Streams run events via SSE.
 Multimodal events:
 - `output_delta`: payload includes `output`, an array of typed content parts. Text streaming may still emit `text_delta`; media outputs are emitted through `output_delta`.
 - `generation_progress`: payload includes `run_kind`, `phase`, `progress`, and optional `preview_asset_id` for provider-native image/audio/video generation runs.
+
+Tool result events:
+- `tool_result`: payload includes `tool_name`, `tool_call_id`, `result`, `error`, `role_id`, `instance_id`, and optional `metrics`.
+- `metrics` may include `action_queue_wait_ms`, `action_duration_ms`, `tool_framework_wait_ms`, `tool_result_publish_ms`, `tool_result_persist_ms`, `tool_batch_wall_ms`, and `total_tool_runtime_ms`. Batched tool result commits may also include `tool_result_batch_size`, `tool_result_batch_publish_ms`, `tool_result_batch_state_persist_ms`, `tool_result_batch_metrics_ms`, and `tool_result_batch_total_ms`. High-pressure read/query and synchronous `spawn_subagent` tool steps may also report internal relay executor diagnostics such as `relay_tool_step_executor_used`, `relay_tool_step_batch_size`, `relay_tool_step_execute_ms`, `relay_tool_step_trace_bypass_count`, and `relay_tool_step_fallback_reason`. `action_duration_ms` measures only the tool action; framework wait, event publish, state persist, and whole-batch wall time are reported separately when available.
+- Synchronous `spawn_subagent` admission is bounded per root run and globally. The global foreground subagent default is `RELAY_TEAMS_SYNC_SUBAGENT_GLOBAL_ACTIVE_LIMIT=16`, while each root run defaults to `RELAY_TEAMS_SYNC_SUBAGENT_ACTIVE_LIMIT=3`; synchronous waiting does not consume global tool action capacity.
 
 Thinking events:
 - `thinking_started`: payload includes `part_index`, `role_id`, `instance_id`.

--- a/docs/core/database-schema.md
+++ b/docs/core/database-schema.md
@@ -353,7 +353,7 @@ Purpose: cross-agent key-value state.
 `expires_at` controls TTL.
 
 Task-scoped tool runtime state is also stored here under `state_key` values such as `tool_call_state:<tool_call_id>` and `tool_call_batch:<batch_id>`.
-Current tool-call state payloads include run/session linkage, batch linkage, result event ids, `run_yolo`, and `approval_mode` metadata so SQLite analysis can distinguish YOLO approval bypass from policy-exempt tools.
+Current tool-call state payloads include run/session linkage, batch linkage, result event ids, `run_yolo`, `approval_mode`, and optional tool lifecycle timing metadata such as action queue wait, action duration, event publish duration, and state persist duration so SQLite analysis can distinguish action time from runtime backpressure and persistence overhead.
 Tool-call batch payloads group all tool calls emitted by one assistant response, including parallel tool calls, so crash recovery can replay only complete sealed batches.
 Sanitized internal tool data may include provider or upstream host identifiers, but must not persist API-key-bearing URLs.
 
@@ -1568,6 +1568,7 @@ Notes:
 - `spec_artifact_id` links back to the originating spec artifact.
 - `evidence_bundle_json` stores the full `VerificationEvidenceBundle` as JSON.
 - `summary` is a human-readable summary of the artifact contents.
+- Run execution enqueues artifact container writes onto a low-priority background writer. Artifact writes are best effort and are observed with aggregate queue, duration, drop, failure, and SQLite lock-timeout metrics so they do not block the run event/tool-result path under pressure.
 - Repository: `src/relay_teams/agents/tasks/artifact_repository.py`
 
 ---
@@ -1604,6 +1605,7 @@ Notes:
 - `entry_id` is a unique identifier for each entry within the artifact.
 - `linked_evidence_ids` is a JSON array of evidence item IDs from the parent artifact's evidence bundle.
 - Entries are append-only; ordered by `id` for chronological replay.
+- Execution-path appends use the same low-priority background writer as `task_artifacts`; read APIs continue to query the durable rows that have been persisted.
 - Repository: `src/relay_teams/agents/tasks/artifact_repository.py`
 
 ---

--- a/docs/modules/frontend/session-send-switch-race-reproduction.md
+++ b/docs/modules/frontend/session-send-switch-race-reproduction.md
@@ -1,0 +1,125 @@
+# Session Send/Switch Race Data Capture
+
+Date: 2026-05-09
+
+This note records how to capture reliable frontend evidence for the send/switch
+race. It is intentionally not the UI contract. The contract lives in unit and
+browser tests: timeline ordering, target isolation, stream replay, sidebar state,
+and subagent navigation must remain correct across the full runtime matrix.
+
+## Environment
+
+- Frontend URL: `http://127.0.0.1:8000/?real-api-devtools=1`
+- Backend/model path: real local backend with the real LLM provider, not the fake
+  benchmark LLM.
+- Browser action source: browser input events against the real DOM. The critical
+  send and target-session click are started in the same browser action batch.
+
+## Capture Procedure
+
+Use two existing sessions that both already contain `你好` messages.
+
+1. Open session A, place `你好` in the composer.
+2. Start the send button click.
+3. Start the target session B click within the same action batch, without
+   waiting for the send click to settle. For automated mock-browser tests, this
+   is represented by dispatching the send click and target-session click in the
+   same page task. For real API smoke, use actual browser input events.
+4. Start a 50 ms sampler before the click batch. Capture active target, loading
+   state, main timeline text, visible placeholders, sidebar indicators, and
+   stream watermarks.
+
+The original failing reproduction timing from the browser run:
+
+```json
+{
+  "target_start_after_send_start_ms": 32,
+  "clicks_done_ms": 1415
+}
+```
+
+The original screenshots from the first failing reproduction were saved
+under:
+
+- `.tmp/send-switch-race-overlap-80ms.png`
+- `.tmp/send-switch-race-overlap-1000ms.png`
+
+## Required Sample Fields
+
+Each sample JSON should include:
+
+- `send_started_ms`
+- `target_click_ms`
+- `target_click_after_send_ms`
+- `target_active_after_target_click_ms`
+- `target_stable_after_target_click_ms`
+- active session/subagent identity
+- visible loading state
+- visible timeline text summary
+- source pending/live placeholder presence
+- EventSource URL or stream watermark when available
+
+## Expected Capture Outcome
+
+- Session B becomes the active session.
+- The main timeline renders only session B history and live stream state.
+- Session A may continue running in the background, but its pending user message,
+  live run placeholder, stream events, loading overlay, and running composer state
+  must not render in session B.
+- Session B should not show a long loading state caused by session A starting a
+  run.
+- The measured `target_stable_after_target_click_ms` should be below 1000 ms for
+  the simple existing-session switch path.
+
+## Historical Failure Signature
+
+The 80 ms sample after the original overlapping click batch showed:
+
+```text
+2026/5/9 23:32:31
+LIVE
+运行中
+你好
+real-visible-a-2e5759
+停止
+...
+```
+
+The screenshot also showed the target session row selected while the main timeline
+contained a new live `你好` block and the composer showed an in-flight insertion
+state. That was the failure signature: send/run state created for the source
+interaction rendered into the newly active target session during fast navigation.
+
+## Current Smoke Result
+
+The 2026-05-10 real-backend smoke used `http://127.0.0.1:8000/?real-api-devtools=1`
+with the real configured model path and two existing non-empty `你好` sessions.
+Measured result:
+
+```json
+{
+  "target_click_after_send_ms": 8,
+  "target_active_after_target_click_ms": 39,
+  "target_stable_after_target_click_ms": 39
+}
+```
+
+The screenshot was saved under:
+
+- `.tmp/real-api-send-switch-smoke.png`
+
+## Why Earlier Captures Missed It
+
+The earlier smoke and mock tests separated `fill`, `send click`, and `target
+session click` into different harness operations. That let the frontend settle
+between operations, so the race window was mostly avoided. The failing user path
+requires the send click and target click to overlap in one UI interaction window.
+
+Future captures for this race must start the target session click before the send
+click has fully settled, then record enough samples to determine whether:
+
+- the active target identity is session B,
+- no source-session pending or live run block is rendered in session B,
+- no source-session loading overlay remains visible in session B,
+- unread/running/completed sidebar state updates still converge within one
+  second.

--- a/docs/modules/frontend/testing-and-maintenance.md
+++ b/docs/modules/frontend/testing-and-maintenance.md
@@ -73,6 +73,16 @@ uv run --extra dev pytest -q tests/integration_tests/browser/test_voice_input_au
 uv run --extra dev pytest -q tests/unit_tests/frontend/test_session_selection_ui.py
 ```
 
+涉及 root/subagent 切换、SSE 续接、前台发送或 timeline 渲染归属的变更必须补充：
+
+```powershell
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_run_events_ui.py
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_session_selection_ui.py
+uv run --extra dev pytest -q tests/unit_tests/frontend/test_subagent_streams_ui.py
+uv run --extra dev pytest -q tests/integration_tests/browser/test_session_send_switch_latency.py
+uv run --extra dev pytest -q tests/integration_tests/browser/test_session_subagent_navigation_matrix.py
+```
+
 完整仓库自检仍以根目录 `AGENTS.md` 的 pre-commit self-check 为准。
 
 ## 维护规则
@@ -111,6 +121,20 @@ uv run --extra dev pytest -q tests/unit_tests/frontend/test_session_selection_ui
 - stream block 更新要走 message renderer/timeline 的公共 API。
 - tool approval、user question、paused subagent 等会同时影响 message block、recovery banner 和 round overlay，需要一起验证。
 - terminal event 后要清理 run stream state，避免旧 overlay 残留。
+- root/subagent target 必须拥有独立的 active identity、`after_event_id` 和 rendered event id set；跨 target 切换不得共享水位。
+- 当前 DOM 只能渲染 active target 的事件。后台 root/subagent 事件只能更新 cache、sidebar 状态、未读/终态提示或 stream overlay。
+- timeline 的 `thinking`、text/output、tool call、tool result、terminal 块顺序是前端合同；replay + live 合并必须去重、不能缺失、不能跨 target 污染。
+- 发送消息后立即切到另一个已有 session 时，源 session 的 pending placeholder、live round、composer busy 和 loading state 不得渲染到目标 session。
+
+### 运行态矩阵
+
+浏览器运行态验证需要覆盖：
+
+- 至少 3 个 root session，每个 root 至少 3 个 foreground subagent。
+- queued、thinking streaming、text streaming、tool running、tool result arriving、completed、stopped、failed。
+- root↔root、root↔own subagent、root↔other session subagent、subagent↔root、subagent↔subagent 同父、subagent↔subagent 跨父。
+- 发送后立刻切换、工具运行中切换、thinking delta 中切换、terminal 到达时切换、展开/收起 subagent list 时切换。
+- 切换响应目标 p95 小于 200 ms，完整加载小于 5 s；简单 send-switch 到已有非空 session 的 stable time 小于 1 s。
 
 ### 页面表现
 

--- a/frontend/dist/css/components/tools.css
+++ b/frontend/dist/css/components/tools.css
@@ -1,10 +1,14 @@
 /* Tool Call Blocks - Claude Code style collapsible design */
 
 .tool-block {
-    margin: 0.35rem 0;
+    margin: 0.12rem 0;
     border: none;
     background: transparent;
     overflow: visible;
+}
+
+.tool-block + .tool-block {
+    margin-top: 0.12rem;
 }
 
 /* --- Summary / collapsed state --- */

--- a/frontend/dist/css/layout.css
+++ b/frontend/dist/css/layout.css
@@ -728,6 +728,11 @@
     opacity 0.18s ease;
 }
 
+.agent-panel-refresh-reflection[hidden],
+.agent-panel-stop[hidden] {
+  display: none !important;
+}
+
 .agent-panel-refresh-reflection:hover {
   border-color: var(--primary);
   color: var(--primary);

--- a/frontend/dist/js/app/prompt.js
+++ b/frontend/dist/js/app/prompt.js
@@ -48,6 +48,7 @@ import {
   finishForegroundSubmission,
   hasActiveForegroundSubmission,
   isForegroundSubmissionActive,
+  isForegroundSubmissionActiveForSession,
   isForegroundSubmissionDetached,
 } from "../core/submission.js";
 import { els } from "../utils/dom.js";
@@ -269,10 +270,12 @@ export async function refreshRoleConfigOptions({ refreshControls = true } = {}) 
 }
 
 export async function handleSend(options = {}) {
-  await stopActiveVoiceInputBeforeSend();
   const rawText = els.promptInput.value.trim();
   const hasAttachments = promptAttachments.length > 0;
+  const initialSessionId = String(state.currentSessionId || "").trim();
+  const initialDraftActive = isNewSessionDraftActive();
   if (!rawText && !hasAttachments) return;
+  await stopActiveVoiceInputBeforeSend();
   if (state.isGenerating) {
     if (hasActiveForegroundSubmission() && !String(state.activeRunId || "").trim()) {
       return;
@@ -282,7 +285,7 @@ export async function handleSend(options = {}) {
     });
     return;
   }
-  if (!state.currentSessionId && !isNewSessionDraftActive()) {
+  if (!initialSessionId && !initialDraftActive) {
     sysLog(
       t("composer.error.no_active_session"),
       "log-error",
@@ -333,11 +336,11 @@ export async function handleSend(options = {}) {
     return;
   }
   state.isGenerating = true;
-  const submission = beginForegroundSubmission();
+  const submission = beginForegroundSubmission({ sessionId: initialSessionId });
   if (els.sendBtn) els.sendBtn.disabled = true;
   if (els.promptInput) els.promptInput.disabled = true;
   refreshSessionTopologyControls();
-  const isDraftSend = isNewSessionDraftActive();
+  const isDraftSend = initialDraftActive;
   if (isDraftSend) {
     roundsTimeline.showPendingRunStartPlaceholder(
       null,
@@ -346,7 +349,7 @@ export async function handleSend(options = {}) {
       { allowDraft: true },
     );
   }
-  let runSessionId = String(state.currentSessionId || "").trim();
+  let runSessionId = initialSessionId;
   let continueDetachedDraftRun = false;
   if (isDraftSend) {
     try {
@@ -357,7 +360,7 @@ export async function handleSend(options = {}) {
       continueDetachedDraftRun = !isForegroundSubmissionActive(submission);
       if (!sessionId) {
         if (!continueDetachedDraftRun) {
-          roundsTimeline.clearPendingRunStartPlaceholder();
+          roundsTimeline.clearPendingRunStartPlaceholder(runSessionId);
         }
         finishForegroundSubmission(submission);
         state.isGenerating = false;
@@ -410,17 +413,20 @@ export async function handleSend(options = {}) {
   clearPromptComposerStatus();
   const resolvedPrompt = await resolvePromptSlashText(text);
   const detachedSubmission = isForegroundSubmissionDetached(submission);
-  const detachedRun = detachedSubmission || continueDetachedDraftRun;
+  const detachedRun = detachedSubmission
+    || continueDetachedDraftRun
+    || !isForegroundSubmissionActiveForSession(submission, runSessionId);
   if (!isForegroundSubmissionActive(submission) && !detachedRun) {
     finishForegroundSubmission(submission);
     return;
   }
   if (resolvedPrompt === null) {
-    roundsTimeline.clearPendingRunStartPlaceholder();
+    roundsTimeline.clearPendingRunStartPlaceholder(runSessionId);
     finishForegroundSubmission(submission);
     restorePromptComposerAfterSendAbort();
     return;
   }
+  emitSessionTitlePreview(runSessionId, promptPreviewText);
   const inputParts = buildPromptInputPartsFromAttachments(
     resolvedPrompt.text,
     attachmentSnapshot,
@@ -484,21 +490,20 @@ export async function handleSend(options = {}) {
         yolo: state.yolo,
         thinking: state.thinking,
         targetRoleId,
-        detached: continueDetachedDraftRun,
-        onRunCreated: continueDetachedDraftRun ? null : (run) => {
-          if (!isForegroundSubmissionActive(submission)) {
+        detached: detachedRun,
+        onRunCreated: detachedRun ? null : (run) => {
+          if (!isForegroundSubmissionActiveForSession(submission, runSessionId)) {
             return;
           }
           state.currentSessionCanSwitchMode = false;
           refreshSessionTopologyControls();
-          emitSessionTitlePreview(runSessionId, promptPreviewText);
           roundsTimeline.createLiveRound(run.run_id, promptPreviewText, displayInputParts);
         },
       },
     );
   } finally {
-    if (!continueDetachedDraftRun) {
-      roundsTimeline.clearPendingRunStartPlaceholder();
+    if (!detachedRun) {
+      roundsTimeline.clearPendingRunStartPlaceholder(runSessionId);
     }
     finishForegroundSubmission(submission);
   }

--- a/frontend/dist/js/app/recovery.js
+++ b/frontend/dist/js/app/recovery.js
@@ -218,6 +218,7 @@ export function scheduleRecoveryContinuityRefresh({
     includeRounds = false,
     quiet = true,
     reason = '',
+    focusedSupplementState = null,
 } = {}) {
     const safeSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
     if (!safeSessionId) return;
@@ -229,6 +230,7 @@ export function scheduleRecoveryContinuityRefresh({
         includeRounds,
         quiet,
         reason,
+        focusedSupplementState,
     });
     if (continuity.refreshTimer) {
         clearTimeout(continuity.refreshTimer);
@@ -265,7 +267,9 @@ export function clearSessionRecovery() {
 }
 
 export function applyRecoverySnapshot(snapshot) {
-    const normalized = normalizeRecoverySnapshot(snapshot);
+    const normalized = normalizeRecoverySnapshot(
+        withLocalActiveRunForEmptySnapshot(snapshot),
+    );
     reconcileTerminalRecoverySnapshot(normalized);
     const primaryRoleId = String(
         normalized.activeRun?.primary_role_id
@@ -301,6 +305,29 @@ export function applyRecoverySnapshot(snapshot) {
     return normalized;
 }
 
+function withLocalActiveRunForEmptySnapshot(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object') return snapshot;
+    if (snapshot.active_run) return snapshot;
+    const activeRunId = String(state.activeRunId || '').trim();
+    if (!activeRunId) return snapshot;
+    if (!isLocallyStreaming(activeRunId)) return snapshot;
+    return {
+        ...snapshot,
+        active_run: {
+            run_id: activeRunId,
+            status: 'running',
+            phase: 'running',
+            is_recoverable: true,
+            checkpoint_event_id: 0,
+            last_event_id: 0,
+            pending_tool_approval_count: 0,
+            pending_user_question_count: 0,
+            stream_connected: !!state.activeEventSource,
+            should_show_recover: false,
+        },
+    };
+}
+
 function reconcileTerminalRecoverySnapshot(snapshot) {
     const activeRun = snapshot?.activeRun || null;
     if (activeRun?.run_id && isTerminalRecoveryRun(activeRun)) {
@@ -328,6 +355,15 @@ function isTerminalRecoveryRun(activeRun) {
     if (!activeRun || typeof activeRun !== 'object') {
         return false;
     }
+    if (
+        activeRun.is_recoverable === false
+        && (
+            isStoppingRecoveryStatus(activeRun.status)
+            || isStoppingRecoveryStatus(activeRun.phase)
+        )
+    ) {
+        return true;
+    }
     return isTerminalRecoveryStatus(activeRun.status) || isTerminalRecoveryStatus(activeRun.phase);
 }
 
@@ -347,6 +383,10 @@ function isTerminalRecoveryStatus(status) {
         'canceled',
         'terminal',
     ].includes(String(status || '').trim().toLowerCase());
+}
+
+function isStoppingRecoveryStatus(status) {
+    return String(status || '').trim().toLowerCase() === 'stopping';
 }
 
 export function applyBackgroundTaskEvent(payload, eventMeta = null, eventType = '') {
@@ -781,6 +821,69 @@ export function markToolApprovalResolved(toolCallId) {
     syncSessionContinuity();
 }
 
+export function markUserQuestionRequested(payload = {}, eventMeta = {}) {
+    const runId = String(payload?.run_id || eventMeta?.run_id || state.activeRunId || '').trim();
+    const sessionId = String(payload?.session_id || eventMeta?.session_id || state.currentSessionId || '').trim();
+    const normalizedQuestion = normalizeUserQuestion(
+        {
+            ...payload,
+            run_id: runId,
+            session_id: sessionId,
+        },
+        runId,
+    );
+    if (!normalizedQuestion) return;
+
+    const snapshot = state.currentRecoverySnapshot || {
+        activeRun: runId
+            ? {
+                run_id: runId,
+                status: 'paused',
+                phase: 'awaiting_manual_action',
+                is_recoverable: true,
+                checkpoint_event_id: 0,
+                last_event_id: 0,
+                pending_user_question_count: 0,
+                stream_connected: false,
+                should_show_recover: false,
+            }
+            : null,
+        pendingToolApprovals: [],
+        pendingUserQuestions: [],
+        backgroundTasks: [],
+        pausedSubagent: null,
+        roundSnapshot: null,
+    };
+    const nextQuestions = dedupeUserQuestions([
+        ...(snapshot.pendingUserQuestions || []),
+        normalizedQuestion,
+    ]);
+    userQuestionActionErrors.clear();
+    state.currentRecoverySnapshot = {
+        ...snapshot,
+        activeRun: snapshot.activeRun
+            ? {
+                ...snapshot.activeRun,
+                run_id: snapshot.activeRun.run_id || runId,
+                status: 'paused',
+                phase: 'awaiting_manual_action',
+                pending_user_question_count: nextQuestions.length,
+                stream_connected: false,
+                should_show_recover: false,
+            }
+            : snapshot.activeRun,
+        pendingUserQuestions: nextQuestions,
+    };
+    syncRecoveryRoundOverlay();
+    scheduleSessionsRefresh();
+    renderRecoveryBanner();
+    syncSessionContinuity();
+}
+
+export function markUserQuestionAnswered(questionId) {
+    markUserQuestionResolved(questionId);
+}
+
 function normalizeRecoverySnapshot(snapshot) {
     const activeRun = snapshot?.active_run && typeof snapshot.active_run === 'object'
         ? { ...snapshot.active_run }
@@ -975,6 +1078,16 @@ function dedupeApprovals(items) {
     return Array.from(seen.values());
 }
 
+function dedupeUserQuestions(items) {
+    const seen = new Map();
+    items.forEach(item => {
+        const questionId = typeof item?.questionId === 'string' ? item.questionId : '';
+        if (!questionId) return;
+        seen.set(questionId, { ...item });
+    });
+    return Array.from(seen.values());
+}
+
 function getActiveRecoveryRun() {
     return state.currentRecoverySnapshot?.activeRun || null;
 }
@@ -1019,12 +1132,14 @@ function bindContinuityWindowEvents() {
 
 function handleContinuityFocus() {
     if (!continuity.sessionId || continuity.sessionId !== state.currentSessionId) return;
+    const focusedSupplementState = rememberFocusedUserQuestionSupplement();
     scheduleRecoveryContinuityRefresh({
         sessionId: continuity.sessionId,
         delayMs: 0,
         includeRounds: false,
         quiet: true,
         reason: 'window-focus',
+        focusedSupplementState,
     });
 }
 
@@ -1061,9 +1176,11 @@ function shouldPollContinuity() {
     const hasActiveBackgroundTasks = (state.currentRecoverySnapshot?.backgroundTasks || [])
         .filter(task => isBackgroundTaskActive(task)).length > 0;
     const hasPausedSubagent = !!(state.pausedSubagent || state.currentRecoverySnapshot?.pausedSubagent);
+    const hasActiveRunId = !!String(state.activeRunId || '').trim();
     return !!(
         state.isGenerating
         || state.activeEventSource
+        || hasActiveRunId
         || hasApprovals
         || hasUserQuestions
         || hasActiveBackgroundTasks
@@ -1085,8 +1202,11 @@ function isContinuityPollableRun(activeRun) {
         'starting',
         'stopping',
         'awaiting_input',
+        'awaiting_manual_action',
         'awaiting_tool_approval',
+        'awaiting_user',
         'awaiting_recovery',
+        'manual_action',
         'paused',
     ].includes(status) || [
         'pending',
@@ -1095,8 +1215,11 @@ function isContinuityPollableRun(activeRun) {
         'starting',
         'stopping',
         'awaiting_input',
+        'awaiting_manual_action',
         'awaiting_tool_approval',
+        'awaiting_user',
         'awaiting_recovery',
+        'manual_action',
         'paused',
     ].includes(phase);
 }
@@ -1116,6 +1239,8 @@ function mergePendingRefresh(current, next) {
         includeRounds: current.includeRounds || next.includeRounds,
         quiet: current.quiet && next.quiet,
         reason: next.reason || current.reason,
+        focusedSupplementState:
+            next.focusedSupplementState || current.focusedSupplementState || null,
     };
 }
 
@@ -1160,6 +1285,14 @@ async function runScheduledContinuityRefresh(request) {
         sessionId: safeSessionId,
         reason: request.reason || 'continuity-refresh',
     });
+    restoreFocusedUserQuestionSupplement(
+        ensureRecoveryQuestionHost(),
+        request.focusedSupplementState || activeUserQuestionSupplementState,
+    );
+    restoreFocusedUserQuestionSupplementSoon(
+        ensureRecoveryQuestionHost(),
+        request.focusedSupplementState || activeUserQuestionSupplementState,
+    );
     return snapshot;
 }
 
@@ -1440,6 +1573,7 @@ function renderRecoveryBanner() {
     const questionHost = ensureRecoveryQuestionHost();
     const approvalsHost = ensureRecoveryApprovalHost();
     const resumeBtn = ensureResumeRunButton();
+    captureRenderedUserQuestionSelections(questionHost);
     const showResumeAction = shouldShowResumeAction(
         activeRun,
         approvals,
@@ -1457,6 +1591,10 @@ function renderRecoveryBanner() {
         pausedSubagent,
     });
     if (nextSignature === recoveryBannerRenderSignature) {
+        restoreFocusedUserQuestionSupplement(
+            questionHost,
+            activeUserQuestionSupplementState,
+        );
         return;
     }
     recoveryBannerRenderSignature = nextSignature;
@@ -1680,6 +1818,15 @@ function getFocusedUserQuestionSupplementState(questionHost) {
     return activeUserQuestionSupplementState;
 }
 
+function rememberFocusedUserQuestionSupplement() {
+    const questionHost = ensureRecoveryQuestionHost();
+    const supplementState = getFocusedUserQuestionSupplementState(questionHost);
+    if (supplementState) {
+        activeUserQuestionSupplementState = supplementState;
+    }
+    return supplementState || activeUserQuestionSupplementState;
+}
+
 function getUserQuestionSupplementState(input) {
     if (
         !(input instanceof HTMLInputElement)
@@ -1734,6 +1881,18 @@ function restoreFocusedUserQuestionSupplement(questionHost, state) {
         input.setSelectionRange(state.selectionStart, state.selectionEnd);
     }
     activeUserQuestionSupplementState = getUserQuestionSupplementState(input);
+}
+
+function restoreFocusedUserQuestionSupplementSoon(questionHost, state) {
+    if (!questionHost || !state?.key) return;
+    const restore = () => {
+        restoreFocusedUserQuestionSupplement(questionHost, state);
+    };
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(restore);
+        return;
+    }
+    window.setTimeout(restore, 0);
 }
 
 async function handleRecoveryAction(actionDef, activeRun, pausedSubagent) {
@@ -2128,6 +2287,7 @@ function renderUserQuestionOption(
     const inputName = `question-${questionId}-${promptIndex}`;
     const selection = getDraftSelection(draft, label);
     const supplement = selection?.supplement || '';
+    const supplementHidden = checked ? '' : ' hidden disabled';
     return `
         <label class="recovery-question-option">
             <input
@@ -2146,8 +2306,7 @@ function renderUserQuestionOption(
         ? `<span class="recovery-question-option-description">${escapeHtml(description)}</span>`
         : ''
     }
-                ${checked
-        ? `<input
+                <input
                         type="text"
                         class="recovery-question-input recovery-question-option-supplement"
                         placeholder="${escapeAttribute(
@@ -2159,9 +2318,8 @@ function renderUserQuestionOption(
                         data-question-id="${escapeAttribute(questionId)}"
                         data-prompt-index="${promptIndex}"
                         data-option-label="${escapeAttribute(label)}"
-                    >`
-        : ''
-    }
+                        ${supplementHidden}
+                    >
             </span>
         </label>
     `;
@@ -2227,7 +2385,39 @@ function handleUserQuestionOptionInput(input) {
         draft.selections = draft.selections.filter(item => item.label !== optionLabel);
     }
     setUserQuestionDraft(questionId, promptIndex, draft);
-    renderRecoveryBanner();
+    syncUserQuestionPromptOptionInputs(input);
+}
+
+function syncUserQuestionPromptOptionInputs(changedInput) {
+    const questionId = String(changedInput?.dataset?.questionId || '').trim();
+    const promptIndex = String(changedInput?.dataset?.promptIndex || '').trim();
+    if (!questionId || !promptIndex) return;
+    const fieldset = changedInput.closest('.recovery-question-field');
+    if (!fieldset) return;
+    fieldset
+        .querySelectorAll('[data-user-question-answer="option"]')
+        .forEach(optionInput => {
+            if (
+                String(optionInput?.dataset?.questionId || '').trim() !== questionId
+                || String(optionInput?.dataset?.promptIndex || '').trim() !== promptIndex
+            ) {
+                return;
+            }
+            const label = String(optionInput?.dataset?.optionLabel || '').trim();
+            const supplement = optionInput
+                .closest('.recovery-question-option')
+                ?.querySelector('[data-user-question-answer="supplement"]');
+            if (!(supplement instanceof HTMLInputElement)) return;
+            supplement.hidden = !optionInput.checked;
+            supplement.disabled = !optionInput.checked;
+            if (optionInput.checked) {
+                const draft = getUserQuestionDraft(questionId, Number(promptIndex));
+                const selection = getDraftSelection(draft, label);
+                if (selection && String(supplement.value || '') !== String(selection.supplement || '')) {
+                    supplement.value = String(selection.supplement || '');
+                }
+            }
+        });
 }
 
 function handleUserQuestionSupplementInput(input) {
@@ -2258,6 +2448,10 @@ function handleUserQuestionSupplementFocus(input) {
 function handleUserQuestionSupplementBlur(input) {
     const state = getUserQuestionSupplementState(input);
     if (!state) return;
+    if (userQuestionSupplementCompositionKeys.has(state.key)) {
+        activeUserQuestionSupplementState = state;
+        return;
+    }
     if (activeUserQuestionSupplementState?.key === state.key) {
         activeUserQuestionSupplementState = null;
     }
@@ -2325,26 +2519,32 @@ async function handleUserQuestionSubmit(runId, userQuestion) {
 }
 
 function buildUserQuestionSubmission(userQuestion) {
+    captureRenderedUserQuestionSelections(ensureRecoveryQuestionHost());
     const prompts = Array.isArray(userQuestion?.questions) ? userQuestion.questions : [];
     const answers = [];
     for (let index = 0; index < prompts.length; index += 1) {
         const prompt = prompts[index];
         const draft = getUserQuestionDraft(userQuestion.questionId, index);
-        const selections = Array.isArray(draft.selections)
-            ? draft.selections
+        const selections = mergeRenderedUserQuestionSelections(
+            userQuestion.questionId,
+            index,
+            draft,
+        );
+        const normalizedSelections = Array.isArray(selections)
+            ? selections
                 .map(item => ({
                     label: String(item?.label || '').trim(),
                     supplement: String(item?.supplement || '').trim(),
                 }))
                 .filter(item => item.label)
             : [];
-        if (!prompt?.multiple && selections.length > 1) {
+        if (!prompt?.multiple && normalizedSelections.length > 1) {
             return {
                 ok: false,
                 error: t('recovery.question.single_choice_only'),
             };
         }
-        const labels = selections.map(item => item.label);
+        const labels = normalizedSelections.map(item => item.label);
         if (
             labels.includes(USER_QUESTION_NONE_OPTION_LABEL)
             && labels.length > 1
@@ -2354,14 +2554,14 @@ function buildUserQuestionSubmission(userQuestion) {
                 error: t('recovery.question.none_conflict'),
             };
         }
-        if (selections.length === 0) {
+        if (normalizedSelections.length === 0) {
             return {
                 ok: false,
                 error: t('recovery.question.answer_required'),
             };
         }
         answers.push({
-            selections: selections.map(item => (
+            selections: normalizedSelections.map(item => (
                 item.supplement
                     ? { label: item.label, supplement: item.supplement }
                     : { label: item.label }
@@ -2369,6 +2569,69 @@ function buildUserQuestionSubmission(userQuestion) {
         });
     }
     return { ok: true, answers };
+}
+
+function captureRenderedUserQuestionSelections(host) {
+    const root = host || document;
+    root.querySelectorAll('[data-user-question-answer="option"]').forEach(optionInput => {
+        if (!(optionInput instanceof HTMLInputElement) || !optionInput.checked) return;
+        const questionId = String(optionInput.dataset.questionId || '').trim();
+        const promptIndex = Number(optionInput.dataset.promptIndex ?? -1);
+        const optionLabel = String(optionInput.dataset.optionLabel || '').trim();
+        if (!questionId || promptIndex < 0 || !optionLabel) return;
+        const supplement = optionInput
+            .closest('.recovery-question-option')
+            ?.querySelector('[data-user-question-answer="supplement"]');
+        const supplementValue = supplement instanceof HTMLInputElement
+            ? String(supplement.value || '')
+            : '';
+        const draft = getUserQuestionDraft(questionId, promptIndex);
+        const selection = {
+            label: optionLabel,
+            supplement: supplementValue || String(getDraftSelection(draft, optionLabel)?.supplement || ''),
+        };
+        if (optionInput.type === 'radio' || optionLabel === USER_QUESTION_NONE_OPTION_LABEL) {
+            draft.selections = [selection];
+        } else {
+            draft.selections = draft.selections
+                .filter(item => (
+                    item.label !== optionLabel
+                    && item.label !== USER_QUESTION_NONE_OPTION_LABEL
+                ));
+            draft.selections.push(selection);
+        }
+        setUserQuestionDraft(questionId, promptIndex, draft);
+    });
+}
+
+function mergeRenderedUserQuestionSelections(questionId, promptIndex, draft) {
+    const selectionsByLabel = new Map();
+    const draftSelections = Array.isArray(draft?.selections) ? draft.selections : [];
+    draftSelections.forEach(item => {
+        const label = String(item?.label || '').trim();
+        if (!label) return;
+        selectionsByLabel.set(label, {
+            label,
+            supplement: String(item?.supplement || ''),
+        });
+    });
+    const safeQuestionId = String(questionId || '').trim();
+    const safePromptIndex = String(promptIndex);
+    document.querySelectorAll('[data-user-question-answer="option"]').forEach(optionInput => {
+        if (!(optionInput instanceof HTMLInputElement) || !optionInput.checked) return;
+        if (String(optionInput.dataset.questionId || '').trim() !== safeQuestionId) return;
+        if (String(optionInput.dataset.promptIndex || '').trim() !== safePromptIndex) return;
+        const label = String(optionInput.dataset.optionLabel || '').trim();
+        if (!label) return;
+        const supplement = optionInput
+            .closest('.recovery-question-option')
+            ?.querySelector('[data-user-question-answer="supplement"]');
+        const supplementValue = supplement instanceof HTMLInputElement
+            ? String(supplement.value || '')
+            : String(selectionsByLabel.get(label)?.supplement || '');
+        selectionsByLabel.set(label, { label, supplement: supplementValue });
+    });
+    return Array.from(selectionsByLabel.values());
 }
 
 function markUserQuestionResolved(questionId) {

--- a/frontend/dist/js/app/session.js
+++ b/frontend/dist/js/app/session.js
@@ -10,6 +10,7 @@ import { syncSessionDebugBadge } from '../components/sessionDebugBadge.js';
 import { markSidebarSessionTerminalViewed } from '../components/sessionSidebarStore.js';
 import { hideProjectView } from '../components/projectView.js';
 import { clearNewSessionDraft } from '../components/newSessionDraft.js';
+import * as roundsTimeline from '../components/rounds/timeline.js';
 import { markSubagentRailLoading } from '../components/subagentRail.js';
 import { setRoundsMode } from '../components/sidebar.js';
 import {
@@ -31,8 +32,10 @@ import {
     detachActiveStreamForSessionSwitch,
     detachNormalModeSubagentStreamsForSessionSwitch,
     prepareStreamsForForegroundNavigation,
+    restorePendingRunStartForSessionSwitch,
 } from '../core/stream.js';
 import { detachForegroundSubmission } from '../core/submission.js';
+import { recordUiDiagnostic } from '../core/uiDiagnostics.js';
 import { els } from '../utils/dom.js';
 import { formatMessage, t } from '../utils/i18n.js';
 import { sysLog } from '../utils/logger.js';
@@ -63,6 +66,7 @@ export async function selectSession(sessionId) {
         return;
     }
     const selectionToken = ++sessionSelectionToken;
+    const switchStartedAt = performance.now();
     const selectionController = resetSessionSelectionController();
     sessionSelectionTargetId = safeSessionId;
     const selectionSignal = selectionController.signal;
@@ -111,12 +115,17 @@ export async function selectSession(sessionId) {
     if (!isSameSession) {
         detachForegroundSubmission({ focusPrompt: false });
         detachActiveStreamForSessionSwitch({ focusPrompt: false });
+        roundsTimeline.clearPendingRunStartPlaceholder(previousSessionId);
     }
     if (!isSameSession && previousSessionId) {
         stopSessionContinuity(previousSessionId);
         detachNormalModeSubagentStreamsForSessionSwitch(previousSessionId);
     }
     state.currentSessionId = safeSessionId;
+    const restoredPendingRunStart = restorePendingRunStartForSessionSwitch(
+        safeSessionId,
+        { focusPrompt: false },
+    );
     if (!isSameSession) {
         prepareStreamsForForegroundNavigation(safeSessionId);
     }
@@ -157,21 +166,45 @@ export async function selectSession(sessionId) {
     clearSessionTokenUsage({ preserveDisplay: true });
     clearAllStreamState({ preserveOverlay: true });
     refreshSessionTopologyControls();
-    beginSessionSwitchLoading(selectionToken, safeSessionId);
+    if (restoredPendingRunStart) {
+        clearSessionSwitchLoading();
+    } else {
+        beginSessionSwitchLoading(selectionToken, safeSessionId);
+    }
 
     try {
-        const sessionRecord = await fetchSessionHistory(safeSessionId, {
+        const sessionRecordPromise = fetchSessionHistory(safeSessionId, {
             priority: 'high',
             signal: selectionSignal,
-        });
-        if (!isLatestSessionSelection(selectionToken, safeSessionId)) {
-            return;
-        }
-        const sessionNeedsTerminalView = selectedSessionNeedsTerminalView
-            || sessionRecordNeedsTerminalView(sessionRecord);
-        applyCurrentSessionRecord(sessionRecord);
-        refreshSessionTopologyControls();
-        if (isSameSession) {
+        })
+            .then(sessionRecord => {
+                applySessionRecordForSelection({
+                    sessionRecord,
+                    selectionToken,
+                    sessionId: safeSessionId,
+                    signal: selectionSignal,
+                    markTerminalViewed: false,
+                });
+                return sessionRecord;
+            })
+            .catch(error => {
+                if (error?.name !== 'AbortError') {
+                    sysLog(`Failed to load session record: ${error.message || error}`, 'log-error');
+                }
+                return null;
+            });
+        if (restoredPendingRunStart) {
+            void hydrateSessionView(safeSessionId, {
+                includeRounds: false,
+                priority: '',
+                quiet: true,
+                signal: selectionSignal,
+            }).catch(error => {
+                if (error?.name !== 'AbortError') {
+                    sysLog(`Failed to complete pending run hydration: ${error.message || error}`, 'log-error');
+                }
+            });
+        } else if (isSameSession) {
             await hydrateSessionView(safeSessionId, {
                 includeRounds: true,
                 priority: 'high',
@@ -188,16 +221,31 @@ export async function selectSession(sessionId) {
         if (!isLatestSessionSelection(selectionToken, safeSessionId)) {
             return;
         }
-        if (sessionNeedsTerminalView) {
+        if (selectedSessionNeedsTerminalView) {
             void markSelectedSessionTerminalViewed(safeSessionId, selectionSignal);
         }
+        void sessionRecordPromise.then(sessionRecord => {
+            if (
+                sessionRecordNeedsTerminalView(sessionRecord)
+                && isLatestSessionSelection(selectionToken, safeSessionId)
+            ) {
+                void markSelectedSessionTerminalViewed(safeSessionId, selectionSignal);
+            }
+        });
     } catch (error) {
         if (error?.name === 'AbortError') {
             return;
         }
         throw error;
     } finally {
-        finishSessionSwitchLoading(selectionToken, safeSessionId);
+        if (!restoredPendingRunStart) {
+            finishSessionSwitchLoading(selectionToken, safeSessionId);
+        }
+        recordUiDiagnostic(
+            'switch_latency_ms',
+            Math.round(performance.now() - switchStartedAt),
+            { kind: 'root', sessionId: safeSessionId },
+        );
         clearSessionSelectionController(selectionController);
     }
     scheduleCoordinatorContextPreview({ immediate: true });
@@ -216,6 +264,46 @@ export async function selectSession(sessionId) {
     sysLog(formatMessage(isSameSession ? 'session.reloaded' : 'session.switched', {
         session_id: safeSessionId,
     }));
+}
+
+function applySessionRecordForSelection({
+    sessionRecord,
+    selectionToken,
+    sessionId,
+    signal = null,
+    markTerminalViewed = true,
+} = {}) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (
+        !safeSessionId
+        || signal?.aborted
+        || !isLatestSessionSelection(selectionToken, safeSessionId)
+        || !sessionRecord
+        || typeof sessionRecord !== 'object'
+    ) {
+        return false;
+    }
+    applyCurrentSessionRecord(sessionRecord);
+    emitSessionRecordUpdated(sessionRecord, safeSessionId);
+    if (markTerminalViewed && sessionRecordNeedsTerminalView(sessionRecord)) {
+        void markSelectedSessionTerminalViewed(safeSessionId, signal);
+    }
+    refreshSessionTopologyControls();
+    return true;
+}
+
+function emitSessionRecordUpdated(sessionRecord, sessionId) {
+    globalThis.document?.dispatchEvent?.(
+        new CustomEvent('agent-teams-session-record-updated', {
+            detail: {
+                sessionId,
+                workspaceId: String(
+                    sessionRecord?.workspace_id || sessionRecord?.workspaceId || state.currentWorkspaceId || '',
+                ).trim(),
+                session: sessionRecord && typeof sessionRecord === 'object' ? sessionRecord : {},
+            },
+        }),
+    );
 }
 
 function sessionRecordNeedsTerminalView(sessionRecord) {
@@ -292,6 +380,7 @@ function completeSessionSwitchLoading(selectionToken, sessionId, chatContainer) 
         return;
     }
     chatContainer.classList.remove('is-session-switch-pending', 'is-session-switching');
+    removeSessionSwitchLoadingNode(chatContainer);
     chatContainer.classList.add('is-session-switch-ready');
     sessionSwitchReadyTimer = globalThis.setTimeout(() => {
         if (!isLatestSessionSelection(selectionToken, sessionId)) {
@@ -379,6 +468,12 @@ function clearSessionSwitchLoading() {
         'is-session-switching',
         'is-session-switch-ready',
     );
+    removeSessionSwitchLoadingNode(chatContainer);
+}
+
+function removeSessionSwitchLoadingNode(chatContainer) {
+    const loadingNode = chatContainer?.querySelector?.('.session-switch-loading');
+    loadingNode?.remove?.();
 }
 
 async function markSelectedSessionTerminalViewed(sessionId, signal = null) {

--- a/frontend/dist/js/components/agentPanel/history.js
+++ b/frontend/dist/js/components/agentPanel/history.js
@@ -314,6 +314,7 @@ export async function renderInstanceHistoryInto(container, options = {}) {
     }
     try {
         const messages = await fetchAgentMessages(sessionId, instanceId, {
+            priority: options.priority,
             signal: options.signal || null,
         });
         const overlayEntry = getInstanceStreamOverlay(runId, instanceId);
@@ -474,10 +475,22 @@ function hasPendingToolResults(messages) {
                 if (key) {
                     pending.delete(key);
                 }
+                return;
+            }
+            if (pending.size > 0 && isFinalTextPart(part)) {
+                pending.clear();
             }
         });
     });
     return pending.size > 0;
+}
+
+function isFinalTextPart(part) {
+    const kind = String(part?.part_kind || part?.kind || '').trim().toLowerCase();
+    if (kind !== 'text') {
+        return false;
+    }
+    return String(part?.content || part?.text || '').trim().length > 0;
 }
 
 function isLegacyToolCallPart(part) {

--- a/frontend/dist/js/components/messageRenderer/stream.js
+++ b/frontend/dist/js/components/messageRenderer/stream.js
@@ -1247,6 +1247,13 @@ function isDuplicateOverlayEvent(runId, eventId) {
     return false;
 }
 
+function recordMessageRendererUiDiagnostic(name) {
+    const recorder = globalThis.__agentTeamsUiDiagnostics?.record;
+    if (typeof recorder === 'function') {
+        recorder(name);
+    }
+}
+
 function clearRunOverlayEventDedupe(runId) {
     const safeRunId = String(runId || '').trim();
     if (!safeRunId) return;

--- a/frontend/dist/js/components/rounds/timeline.js
+++ b/frontend/dist/js/components/rounds/timeline.js
@@ -652,7 +652,9 @@ export function showPendingRunStartPlaceholder(sessionId, intentText, intentPart
     ) {
         return;
     }
-    renderRunStartPlaceholder(container, intentText, intentParts);
+    renderRunStartPlaceholder(container, intentText, intentParts, {
+        sessionId: safeSessionId,
+    });
 }
 
 export function showDraftRunStartPlaceholder(intentText, intentParts = null) {
@@ -660,13 +662,16 @@ export function showDraftRunStartPlaceholder(intentText, intentParts = null) {
     if (!container) {
         return;
     }
-    renderRunStartPlaceholder(container, intentText, intentParts);
+    renderRunStartPlaceholder(container, intentText, intentParts, {
+        sessionId: String(state.currentSessionId || '').trim(),
+    });
 }
 
-function renderRunStartPlaceholder(container, intentText, intentParts = null) {
+function renderRunStartPlaceholder(container, intentText, intentParts = null, options = {}) {
     const normalizedIntent = normalizeRoundIntentText(intentText)
         || buildRoundIntentPreviewText(intentParts)
         || '';
+    const safeSessionId = String(options.sessionId || '').trim();
     let placeholder = container.querySelector?.('.session-run-start-placeholder') || null;
     if (!placeholder) {
         placeholder = document.createElement('section');
@@ -681,6 +686,11 @@ function renderRunStartPlaceholder(container, intentText, intentParts = null) {
         `;
         container.appendChild(placeholder);
     }
+    if (safeSessionId) {
+        placeholder.setAttribute('data-session-id', safeSessionId);
+    } else {
+        placeholder.removeAttribute('data-session-id');
+    }
     const intentEl = placeholder.querySelector?.('.session-run-start-intent') || null;
     if (intentEl) {
         intentEl.textContent = normalizedIntent;
@@ -689,8 +699,15 @@ function renderRunStartPlaceholder(container, intentText, intentParts = null) {
     container.scrollTop = container.scrollHeight;
 }
 
-export function clearPendingRunStartPlaceholder() {
-    els.chatMessages?.querySelector?.('.session-run-start-placeholder')?.remove?.();
+export function clearPendingRunStartPlaceholder(sessionId = '') {
+    const safeSessionId = String(sessionId || '').trim();
+    const placeholders = els.chatMessages?.querySelectorAll?.('.session-run-start-placeholder') || [];
+    Array.from(placeholders).forEach(placeholder => {
+        const placeholderSessionId = String(placeholder?.getAttribute?.('data-session-id') || '').trim();
+        if (!safeSessionId || !placeholderSessionId || placeholderSessionId === safeSessionId) {
+            placeholder.remove?.();
+        }
+    });
 }
 
 function shouldPreserveSubagentView(sessionId) {

--- a/frontend/dist/js/components/sessionSidebarStore.js
+++ b/frontend/dist/js/components/sessionSidebarStore.js
@@ -68,7 +68,7 @@ export function markSidebarSessionTerminalViewed(sessionId) {
     if (!safeSessionId) {
         return null;
     }
-    const current = findStoredSession(safeSessionId) || optimisticSessions.get(safeSessionId) || {
+    const current = optimisticSessions.get(safeSessionId) || findStoredSession(safeSessionId) || {
         session_id: safeSessionId,
         metadata: {},
     };
@@ -77,6 +77,77 @@ export function markSidebarSessionTerminalViewed(sessionId) {
         String(current.latest_terminal_run_id || current.latestTerminalRunId || '').trim(),
     );
     return upsertOptimisticSession(applyViewedTerminalState(current));
+}
+
+export function markSidebarSessionRunActive(sessionId, { runId = '', status = 'running' } = {}) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId) {
+        return null;
+    }
+    const current = optimisticSessions.get(safeSessionId) || findStoredSession(safeSessionId) || {
+        session_id: safeSessionId,
+        metadata: {},
+    };
+    const activeRunId = String(
+        runId
+        || current.active_run_id
+        || current.activeRunId
+        || '',
+    ).trim();
+    const activeStatus = String(status || 'running').trim() || 'running';
+    return upsertOptimisticSession({
+        ...current,
+        has_active_run: true,
+        hasActiveRun: true,
+        active_run_id: activeRunId,
+        activeRunId: activeRunId,
+        active_run_status: activeStatus,
+        activeRunStatus: activeStatus,
+        has_unread_terminal_run: false,
+        hasUnreadTerminalRun: false,
+    });
+}
+
+export function markSidebarSessionRunTerminal(
+    sessionId,
+    { runId = '', status = '', viewed = false } = {},
+) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId) {
+        return null;
+    }
+    const current = optimisticSessions.get(safeSessionId) || findStoredSession(safeSessionId) || {
+        session_id: safeSessionId,
+        metadata: {},
+    };
+    const terminalRunId = String(
+        runId
+        || current.active_run_id
+        || current.activeRunId
+        || current.latest_terminal_run_id
+        || current.latestTerminalRunId
+        || '',
+    ).trim();
+    const terminalStatus = String(status || current.active_run_status || current.activeRunStatus || '').trim();
+    const isViewed = viewed === true;
+    if (isViewed && terminalRunId) {
+        viewedTerminalRunsBySessionId.set(safeSessionId, terminalRunId);
+    }
+    return upsertOptimisticSession({
+        ...current,
+        has_active_run: false,
+        hasActiveRun: false,
+        has_unread_terminal_run: !isViewed,
+        hasUnreadTerminalRun: !isViewed,
+        active_run_id: '',
+        activeRunId: '',
+        active_run_status: '',
+        activeRunStatus: '',
+        latest_terminal_run_id: terminalRunId || current.latest_terminal_run_id || current.latestTerminalRunId || '',
+        latestTerminalRunId: terminalRunId || current.latestTerminalRunId || current.latest_terminal_run_id || '',
+        latest_terminal_run_status: terminalStatus || current.latest_terminal_run_status || current.latestTerminalRunStatus || '',
+        latestTerminalRunStatus: terminalStatus || current.latestTerminalRunStatus || current.latest_terminal_run_status || '',
+    });
 }
 
 export function mergeOptimisticSessions(sessions) {
@@ -111,6 +182,9 @@ function trimOptimisticSessions(sessions) {
         }
         const persistedTitle = String(persisted?.metadata?.title || '').trim();
         if (viewedTerminalRunsBySessionId.has(sessionId)) {
+            return;
+        }
+        if (shouldKeepTerminalOverride(optimistic, persisted)) {
             return;
         }
         if (persistedTitle) {
@@ -155,6 +229,8 @@ function mergeSessionRecords(preferred, current) {
     const preferredRecord = normalizeSession(preferred) || {};
     const currentRecord = normalizeSession(current) || {};
     const sessionId = String(currentRecord.session_id || preferredRecord.session_id || '').trim();
+    const activeOverride = activeOverrideForMerge(preferredRecord, currentRecord);
+    const terminalOverride = terminalOverrideForMerge(preferredRecord, currentRecord);
     const preferredMetadata = preferredRecord.metadata && typeof preferredRecord.metadata === 'object'
         ? preferredRecord.metadata
         : {};
@@ -165,22 +241,132 @@ function mergeSessionRecords(preferred, current) {
     const currentTitle = String(currentMetadata.title || '').trim();
     const preferredUpdatedAt = String(preferredRecord.updated_at || '').trim();
     const currentUpdatedAt = String(currentRecord.updated_at || '').trim();
+    const preferOptimisticTitle = !!(
+        preferredTitle
+        && (
+            !currentTitle
+            || timestampValue(preferredUpdatedAt) >= timestampValue(currentUpdatedAt)
+        )
+    );
     const updatedAt = timestampValue(preferredUpdatedAt) > timestampValue(currentUpdatedAt)
         ? preferredUpdatedAt
         : currentUpdatedAt || preferredUpdatedAt;
     return {
         ...preferredRecord,
         ...currentRecord,
+        ...activeOverride,
+        ...terminalOverride,
         session_id: sessionId,
         workspace_id: String(currentRecord.workspace_id || preferredRecord.workspace_id || '').trim(),
         metadata: {
             ...preferredMetadata,
             ...currentMetadata,
-            ...(preferredTitle && !currentTitle ? { title: preferredTitle } : {}),
+            ...(preferOptimisticTitle ? { title: preferredTitle } : {}),
         },
         updated_at: updatedAt || new Date().toISOString(),
         created_at: String(currentRecord.created_at || preferredRecord.created_at || '').trim(),
     };
+}
+
+function activeOverrideForMerge(preferredRecord, currentRecord) {
+    const preferredActiveRunId = String(
+        preferredRecord.active_run_id || preferredRecord.activeRunId || '',
+    ).trim();
+    const hasPreferredActiveRun = (
+        (preferredRecord.has_active_run || preferredRecord.hasActiveRun)
+        && preferredActiveRunId
+    );
+    if (!hasPreferredActiveRun) {
+        return {};
+    }
+    const currentTerminalRunId = String(
+        currentRecord.latest_terminal_run_id || currentRecord.latestTerminalRunId || '',
+    ).trim();
+    const currentTerminalStatus = String(
+        currentRecord.latest_terminal_run_status
+        || currentRecord.latestTerminalRunStatus
+        || '',
+    ).trim().toLowerCase();
+    if (
+        currentTerminalRunId === preferredActiveRunId
+        && ['completed', 'failed', 'stopped'].includes(currentTerminalStatus)
+    ) {
+        return {};
+    }
+    const activeStatus = String(
+        preferredRecord.active_run_status || preferredRecord.activeRunStatus || 'running',
+    ).trim() || 'running';
+    return {
+        has_active_run: true,
+        hasActiveRun: true,
+        active_run_id: preferredActiveRunId,
+        activeRunId: preferredActiveRunId,
+        active_run_status: activeStatus,
+        activeRunStatus: activeStatus,
+        has_unread_terminal_run: false,
+        hasUnreadTerminalRun: false,
+    };
+}
+
+function terminalOverrideForMerge(preferredRecord, currentRecord) {
+    const preferredTerminalRunId = String(
+        preferredRecord.latest_terminal_run_id || preferredRecord.latestTerminalRunId || '',
+    ).trim();
+    if (!preferredTerminalRunId) {
+        return {};
+    }
+    const currentTerminalRunId = String(
+        currentRecord.latest_terminal_run_id || currentRecord.latestTerminalRunId || '',
+    ).trim();
+    if (currentTerminalRunId && currentTerminalRunId !== preferredTerminalRunId) {
+        return {};
+    }
+    const preferredStatus = String(
+        preferredRecord.latest_terminal_run_status
+        || preferredRecord.latestTerminalRunStatus
+        || '',
+    ).trim();
+    const hasUnreadTerminalRun = preferredRecord.has_unread_terminal_run !== false
+        && preferredRecord.hasUnreadTerminalRun !== false;
+    return {
+        has_active_run: false,
+        hasActiveRun: false,
+        active_run_id: '',
+        activeRunId: '',
+        active_run_status: '',
+        activeRunStatus: '',
+        has_unread_terminal_run: hasUnreadTerminalRun,
+        hasUnreadTerminalRun: hasUnreadTerminalRun,
+        latest_terminal_run_id: preferredTerminalRunId,
+        latestTerminalRunId: preferredTerminalRunId,
+        latest_terminal_run_status: preferredStatus
+            || currentRecord.latest_terminal_run_status
+            || currentRecord.latestTerminalRunStatus
+            || '',
+        latestTerminalRunStatus: preferredStatus
+            || currentRecord.latestTerminalRunStatus
+            || currentRecord.latest_terminal_run_status
+            || '',
+    };
+}
+
+function shouldKeepTerminalOverride(optimistic, persisted) {
+    const terminalRunId = String(
+        optimistic?.latest_terminal_run_id || optimistic?.latestTerminalRunId || '',
+    ).trim();
+    if (!terminalRunId) {
+        return false;
+    }
+    const persistedTerminalRunId = String(
+        persisted?.latest_terminal_run_id || persisted?.latestTerminalRunId || '',
+    ).trim();
+    if (persistedTerminalRunId) {
+        return persistedTerminalRunId === terminalRunId;
+    }
+    const activeRunId = String(
+        persisted?.active_run_id || persisted?.activeRunId || '',
+    ).trim();
+    return !activeRunId || activeRunId === terminalRunId;
 }
 
 function applyViewedTerminalState(record) {

--- a/frontend/dist/js/components/sidebar.js
+++ b/frontend/dist/js/components/sidebar.js
@@ -65,6 +65,9 @@ import {
     getSidebarDataSnapshot,
     hasSidebarDataSnapshot,
     mergeOptimisticSessions,
+    markSidebarSessionRunActive,
+    markSidebarSessionRunTerminal,
+    markSidebarSessionTerminalViewed,
     rememberSidebarDataSnapshot,
     updateOptimisticSessionTitle,
     upsertOptimisticSession,
@@ -94,6 +97,7 @@ let projectSortMode = 'recent';
 let openProjectMenuId = null;
 let projectMenuDismissBound = false;
 let languageRefreshBound = false;
+let sidebarScrollRefreshBound = false;
 let sessionSearchConfigured = false;
 let pendingSessionAnimation = null;
 let pendingSessionVisibilityAnimation = null;
@@ -103,12 +107,18 @@ let sessionsRefreshPromise = null;
 let lastProjectsRenderSignature = '';
 let sidebarSelectionToken = 0;
 let sessionAnimationTokenSeed = 0;
+let initialSessionStateCatchupStarted = false;
+let initialSessionStateCatchupTimer = 0;
+let initialSessionStateCatchupRemaining = 0;
 const sessionAnimationTokens = new WeakMap();
 const projectBodyAnimationTokens = new WeakMap();
 const subagentListAnimationTokens = new WeakMap();
 let sidebarCollapsibleAnimationTokenSeed = 0;
 let subagentListVisualSyncToken = 0;
 const SIDEBAR_INTERACTION_REFRESH_DELAY_MS = 240;
+const SIDEBAR_POST_EVENT_REFRESH_DELAY_MS = 5000;
+const INITIAL_SESSION_STATE_CATCHUP_INTERVAL_MS = 500;
+const INITIAL_SESSION_STATE_CATCHUP_ATTEMPTS = 12;
 
 const SESSION_ANIMATION_ENTER_MS = 220;
 const SESSION_ANIMATION_REMOVE_MS = 180;
@@ -427,15 +437,15 @@ function renderSubagentToggle(session) {
     const children = getSessionSubagentSessions(sessionId);
     const loading = isSubagentSessionListLoading(sessionId);
     const loaded = hasLoadedSessionSubagents(sessionId);
-    const summaryCount = normalizeSubagentSessionCount(
-        session?.subagent_session_count,
-    );
+    const summaryCount = normalizeSubagentSessionCount(getSubagentSessionCountValue(session));
+    const summaryKnown = hasSubagentSessionCount(session);
     const cachedCount = normalSubagentCountBySessionId.get(sessionId) || 0;
     const childCount = resolveStableSubagentCount({
         loaded,
         loading,
         children,
         summaryCount,
+        summaryKnown,
         cachedCount,
     });
     if (childCount > 0) {
@@ -691,8 +701,11 @@ function findMainSessionItem(sessionId) {
     )) || null;
 }
 
-function resolveStableSubagentCount({ loaded, loading, children, summaryCount, cachedCount }) {
+function resolveStableSubagentCount({ loaded, loading, children, summaryCount, summaryKnown = false, cachedCount }) {
     const loadedCount = Array.isArray(children) ? children.length : 0;
+    if (summaryKnown) {
+        return summaryCount;
+    }
     if (loaded) {
         return loadedCount;
     }
@@ -1114,13 +1127,15 @@ function resolveSignatureSubagentCount(session) {
     const children = getSessionSubagentSessions(sessionId);
     const loaded = hasLoadedSessionSubagents(sessionId);
     const loading = isSubagentSessionListLoading(sessionId);
-    const summaryCount = normalizeSubagentSessionCount(session?.subagent_session_count);
+    const summaryCount = normalizeSubagentSessionCount(getSubagentSessionCountValue(session));
+    const summaryKnown = hasSubagentSessionCount(session);
     const cachedCount = normalSubagentCountBySessionId.get(sessionId) || 0;
     return resolveStableSubagentCount({
         loaded,
         loading,
         children,
         summaryCount,
+        summaryKnown,
         cachedCount,
     });
 }
@@ -1416,9 +1431,74 @@ function setElementClassFlag(element, className, enabled) {
     element.classList?.toggle?.(className, enabled);
 }
 
+function hasSubagentSessionCount(session) {
+    return !!(
+        session
+        && typeof session === 'object'
+        && (
+            Object.prototype.hasOwnProperty.call(session, 'subagent_session_count')
+            || Object.prototype.hasOwnProperty.call(session, 'subagentSessionCount')
+        )
+    );
+}
+
+function getSubagentSessionCountValue(session) {
+    return session?.subagent_session_count ?? session?.subagentSessionCount ?? 0;
+}
+
+function findSidebarSessionSnapshotRecord(sessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId || !hasSidebarDataSnapshot()) {
+        return null;
+    }
+    return mergeOptimisticSessions(getSidebarDataSnapshot().sessions).find(
+        session => String(session?.session_id || '').trim() === safeSessionId,
+    ) || null;
+}
+
+function patchVisibleSessionItem(sessionId) {
+    const session = findSidebarSessionSnapshotRecord(sessionId);
+    const item = findMainSessionItem(sessionId);
+    if (!session || !item) {
+        return false;
+    }
+    const label = formatSessionLabel(session);
+    const labelEl = item.querySelector?.('.session-label-text') || null;
+    if (labelEl) {
+        labelEl.textContent = label;
+        labelEl.setAttribute?.('title', label);
+    }
+    const timeEl = item.querySelector?.('.session-time') || null;
+    if (timeEl) {
+        timeEl.textContent = formatRelativeTime(session.updated_at);
+    }
+    for (const className of [
+        'has-run-indicator',
+        'has-run-indicator-running',
+        'has-run-indicator-unread',
+        'has-run-indicator-failed',
+        'has-run-indicator-stopped',
+    ]) {
+        setElementClassFlag(item, className, false);
+    }
+    const indicatorType = getSessionRunIndicatorType(session);
+    if (indicatorType) {
+        setElementClassFlag(item, 'has-run-indicator', true);
+        setElementClassFlag(item, `has-run-indicator-${indicatorType}`, true);
+    }
+    item.querySelector?.('.session-run-indicator')?.remove?.();
+    const indicatorHtml = renderSessionRunIndicator(session).trim();
+    const metaEl = item.querySelector?.('.session-meta') || null;
+    if (indicatorHtml && metaEl?.insertAdjacentHTML) {
+        metaEl.insertAdjacentHTML('afterbegin', indicatorHtml);
+    }
+    return true;
+}
+
 function clearSessionUnreadIndicator(sessionId, preferredItem = null) {
     const safeSessionId = String(sessionId || '').trim();
     if (!safeSessionId) return;
+    markSidebarSessionTerminalViewed(safeSessionId);
     const items = preferredItem
         ? [preferredItem, ...findSessionItems(safeSessionId).filter(item => item !== preferredItem)]
         : findSessionItems(safeSessionId);
@@ -1832,10 +1912,10 @@ function bindProjectCard(card, group) {
             const willExpand = !isSubagentSessionListExpanded(sessionId);
             let subagentsLoadPromise = null;
             toggleSubagentSessionList(sessionId, { emitChange: false, load: false });
-            if (willExpand && !hasLoadedSessionSubagents(sessionId)) {
+            if (willExpand) {
                 subagentsLoadPromise = ensureSessionSubagents(sessionId, {
                     emitLoadingEvents: false,
-                    force: false,
+                    force: true,
                 });
             }
             syncSubagentSessionListVisualState({
@@ -2366,6 +2446,70 @@ function handleSessionUpserted(event) {
     handleNewSessionDraftCreated(event);
 }
 
+function handleSessionRecordUpdated(event) {
+    const detail = event?.detail && typeof event.detail === 'object' ? event.detail : {};
+    const session = detail.session && typeof detail.session === 'object'
+        ? detail.session
+        : {};
+    const sessionId = String(detail.sessionId || session.session_id || '').trim();
+    if (!sessionId) {
+        return;
+    }
+    upsertOptimisticSession({
+        ...session,
+        session_id: sessionId,
+        workspace_id: String(
+            detail.workspaceId || session.workspace_id || state.currentWorkspaceId || '',
+        ).trim(),
+    });
+    if (patchVisibleSessionItem(sessionId)) {
+        scheduleSessionsRefresh(SIDEBAR_POST_EVENT_REFRESH_DELAY_MS, { forceRefresh: false });
+        return;
+    }
+    if (!renderProjectsFromSnapshot({ syncStreams: false })) {
+        scheduleSessionsRefresh(90, { forceRefresh: false });
+    }
+}
+
+function handleSessionRunActive(event) {
+    const detail = event?.detail && typeof event.detail === 'object' ? event.detail : {};
+    const sessionId = String(detail.sessionId || '').trim();
+    if (!sessionId) {
+        return;
+    }
+    markSidebarSessionRunActive(sessionId, {
+        runId: String(detail.runId || '').trim(),
+        status: String(detail.status || 'running').trim() || 'running',
+    });
+    if (patchVisibleSessionItem(sessionId)) {
+        scheduleSessionsRefresh(SIDEBAR_POST_EVENT_REFRESH_DELAY_MS, { forceRefresh: false });
+        return;
+    }
+    if (!renderProjectsFromSnapshot({ syncStreams: false })) {
+        scheduleSessionsRefresh(90, { forceRefresh: false });
+    }
+}
+
+function handleSessionRunTerminal(event) {
+    const detail = event?.detail && typeof event.detail === 'object' ? event.detail : {};
+    const sessionId = String(detail.sessionId || '').trim();
+    if (!sessionId) {
+        return;
+    }
+    markSidebarSessionRunTerminal(sessionId, {
+        runId: String(detail.runId || '').trim(),
+        status: String(detail.status || '').trim(),
+        viewed: detail.viewed === true,
+    });
+    if (patchVisibleSessionItem(sessionId)) {
+        scheduleSessionsRefresh(SIDEBAR_POST_EVENT_REFRESH_DELAY_MS, { forceRefresh: false });
+        return;
+    }
+    if (!renderProjectsFromSnapshot({ syncStreams: false })) {
+        scheduleSessionsRefresh(90, { forceRefresh: false });
+    }
+}
+
 function handleSessionTitlePreviewed(event) {
     const sessionId = String(event?.detail?.sessionId || '').trim();
     const title = String(event?.detail?.title || '').trim();
@@ -2373,12 +2517,17 @@ function handleSessionTitlePreviewed(event) {
         return;
     }
     updateOptimisticSessionTitle(sessionId, title);
+    if (patchVisibleSessionItem(sessionId)) {
+        scheduleSessionsRefresh(SIDEBAR_POST_EVENT_REFRESH_DELAY_MS, { forceRefresh: false });
+        return;
+    }
     renderProjectsFromSnapshot({ syncStreams: false });
 }
 
 export async function loadProjects({ forceRefresh = false } = {}) {
     if (!els.projectsList) return;
     ensureSessionSearchConfigured();
+    ensureSidebarScrollRefreshBound();
     if (!languageRefreshBound && typeof document.addEventListener === 'function') {
         document.addEventListener('agent-teams-language-changed', () => void loadProjects());
         document.addEventListener('agent-teams-projects-changed', () => void loadProjects());
@@ -2420,6 +2569,12 @@ export async function loadProjects({ forceRefresh = false } = {}) {
                 refreshSessionId: sessionId,
             });
         });
+        document.addEventListener('agent-teams-session-subagent-count-dirty', event => {
+            const sessionId = String(event?.detail?.sessionId || '').trim();
+            if (sessionId) {
+                scheduleSessionsRefresh(120, { forceRefresh: true });
+            }
+        });
         document.addEventListener('agent-teams-session-activated', syncActivatedSessionFromEvent);
         document.addEventListener('agent-teams-session-selected', syncActivatedSessionFromEvent);
         document.addEventListener('agent-teams-subagent-session-selected', syncSubagentSessionFromEvent);
@@ -2428,6 +2583,15 @@ export async function loadProjects({ forceRefresh = false } = {}) {
         });
         document.addEventListener('agent-teams-session-upserted', event => {
             handleSessionUpserted(event);
+        });
+        document.addEventListener('agent-teams-session-record-updated', event => {
+            handleSessionRecordUpdated(event);
+        });
+        document.addEventListener('agent-teams-session-run-active', event => {
+            handleSessionRunActive(event);
+        });
+        document.addEventListener('agent-teams-session-run-terminal', event => {
+            handleSessionRunTerminal(event);
         });
         document.addEventListener('agent-teams-session-title-previewed', event => {
             handleSessionTitlePreviewed(event);
@@ -2463,6 +2627,7 @@ export async function loadProjects({ forceRefresh = false } = {}) {
             snapshotData.sessions,
             snapshotData.automationProjects,
         );
+        scheduleInitialSessionStateCatchup(snapshotData.sessions);
     } catch (error) {
         if (requestId !== loadProjectsRequestId) {
             return;
@@ -2483,6 +2648,88 @@ export async function loadProjects({ forceRefresh = false } = {}) {
     }
 }
 
+function scheduleInitialSessionStateCatchup(sessions) {
+    if (
+        initialSessionStateCatchupStarted
+        || !shouldRunInitialSessionStateCatchup(sessions)
+        || typeof globalThis.setTimeout !== 'function'
+    ) {
+        return;
+    }
+    initialSessionStateCatchupStarted = true;
+    initialSessionStateCatchupRemaining = INITIAL_SESSION_STATE_CATCHUP_ATTEMPTS;
+    scheduleNextInitialSessionStateCatchup();
+}
+
+function shouldRunInitialSessionStateCatchup(sessions) {
+    if (!Array.isArray(sessions) || sessions.length === 0) {
+        return false;
+    }
+    const visibleCandidates = sessions.slice(0, DEFAULT_VISIBLE_SESSION_COUNT);
+    return visibleCandidates.some(session => {
+        if (!session || typeof session !== 'object') {
+            return false;
+        }
+        const hasSubagentCount = (
+            Object.prototype.hasOwnProperty.call(session, 'subagent_session_count')
+            || Object.prototype.hasOwnProperty.call(session, 'subagentSessionCount')
+        );
+        if (!hasSubagentCount) {
+            return true;
+        }
+        const subagentCount = Number(session.subagent_session_count ?? session.subagentSessionCount ?? 0);
+        return (
+            (session.has_active_run === true || session.hasActiveRun === true)
+            && (!Number.isFinite(subagentCount) || subagentCount <= 0)
+        );
+    });
+}
+
+function ensureSidebarScrollRefreshBound() {
+    if (
+        sidebarScrollRefreshBound
+        || !els.projectsList
+        || typeof els.projectsList.addEventListener !== 'function'
+    ) {
+        return;
+    }
+    els.projectsList.addEventListener(
+        'scroll',
+        () => {
+            scheduleSessionsRefresh(120, { forceRefresh: true });
+        },
+        { passive: true },
+    );
+    sidebarScrollRefreshBound = true;
+}
+
+function runInitialSessionStateCatchup() {
+    const snapshotData = getSidebarDataSnapshot();
+    if (
+        initialSessionStateCatchupRemaining <= 0
+        || !shouldRunInitialSessionStateCatchup(snapshotData.sessions)
+    ) {
+        initialSessionStateCatchupTimer = 0;
+        initialSessionStateCatchupRemaining = 0;
+        return;
+    }
+    initialSessionStateCatchupRemaining -= 1;
+    scheduleSessionsRefresh(0, { forceRefresh: true });
+    scheduleNextInitialSessionStateCatchup();
+}
+
+function scheduleNextInitialSessionStateCatchup() {
+    if (initialSessionStateCatchupRemaining <= 0) {
+        initialSessionStateCatchupTimer = 0;
+        return;
+    }
+    initialSessionStateCatchupTimer = globalThis.setTimeout(() => {
+        initialSessionStateCatchupTimer = 0;
+        runInitialSessionStateCatchup();
+    }, INITIAL_SESSION_STATE_CATCHUP_INTERVAL_MS) || 0;
+    initialSessionStateCatchupTimer?.unref?.();
+}
+
 export function scheduleSessionsRefresh(delayMs = 120, { forceRefresh = false } = {}) {
     pendingSessionsRefreshForce = pendingSessionsRefreshForce || forceRefresh === true;
     if (refreshTimer) clearTimeout(refreshTimer);
@@ -2490,13 +2737,14 @@ export function scheduleSessionsRefresh(delayMs = 120, { forceRefresh = false } 
     refreshTimer = setTimeout(() => {
         refreshTimer = null;
         const forceNow = pendingSessionsRefreshForce === true;
-        if (!forceNow && isProjectsListInteracting()) {
+        if (isProjectsListInteracting()) {
             scheduleSessionsRefresh(Math.max(safeDelayMs, SIDEBAR_INTERACTION_REFRESH_DELAY_MS));
             return;
         }
         pendingSessionsRefreshForce = false;
         void refreshSessionsSnapshot({ forceRefresh: forceNow });
     }, safeDelayMs);
+    refreshTimer?.unref?.();
 }
 
 async function refreshSessionsSnapshot({ forceRefresh = false } = {}) {

--- a/frontend/dist/js/components/subagentSessions.js
+++ b/frontend/dist/js/components/subagentSessions.js
@@ -8,6 +8,7 @@ import {
     restoreMainSessionView,
 } from '../app/sessionView.js';
 import { syncNormalModeSubagentStreams } from '../core/stream.js';
+import { recordUiDiagnostic } from '../core/uiDiagnostics.js';
 import { clearAllPanels } from './agentPanel.js';
 import { renderInstanceHistoryInto } from './agentPanel/history.js';
 import { hideRoundNavigator } from './rounds/navigator.js';
@@ -133,9 +134,19 @@ export async function ensureSessionSubagents(
     if (loadingSessionIds.has(safeSessionId)) {
         const pending = loadingPromisesBySessionId.get(safeSessionId);
         if (pending) {
-            return pending;
+            if (!force) {
+                return pending;
+            }
+            try {
+                await pending;
+            } catch (_) {
+                // A force refresh must continue with a fresh request even if the
+                // earlier best-effort load failed or was aborted.
+            }
         }
-        return getSessionSubagentSessions(safeSessionId);
+        if (loadingSessionIds.has(safeSessionId)) {
+            return getSessionSubagentSessions(safeSessionId);
+        }
     }
     throwIfAborted(signal);
     loadingSessionIds.add(safeSessionId);
@@ -148,7 +159,7 @@ export async function ensureSessionSubagents(
     }
     const loadPromise = (async () => {
         const payload = await runQueuedSubagentSessionLoad(
-            () => fetchSessionSubagents(safeSessionId, { signal }),
+            () => fetchSessionSubagents(safeSessionId, { forceRefresh: force, signal }),
             signal,
         );
         throwIfAborted(signal);
@@ -260,7 +271,7 @@ export function toggleSubagentSessionList(
     }
     expandedParentSessionIds.add(safeSessionId);
     if (load) {
-        void ensureSessionSubagents(safeSessionId, { force: false });
+        void ensureSessionSubagents(safeSessionId, { force: true });
     }
     if (emitChange) {
         emitSubagentSessionsChanged({
@@ -569,6 +580,7 @@ function updateNormalModeSubagentSessionsMatching(sessionId, predicate, status) 
 }
 
 export async function openSubagentSession(sessionId, record) {
+    const switchStartedAt = performance.now();
     const safeSessionId = String(sessionId || '').trim();
     const normalized = coerceParentStoppedSubagentSession(
         normalizeSubagentSession(record, safeSessionId),
@@ -594,7 +606,20 @@ export async function openSubagentSession(sessionId, record) {
         els.promptInputHint.textContent = t('subagent_session.read_only');
     }
     cancelTerminalRefreshForInstance(normalized.instanceId);
-    await renderActiveSubagentSession({ showLoading: true });
+    try {
+        await renderActiveSubagentSession({ showLoading: true });
+    } finally {
+        recordUiDiagnostic(
+            'switch_latency_ms',
+            Math.round(performance.now() - switchStartedAt),
+            {
+                kind: 'subagent',
+                sessionId: safeSessionId,
+                runId: normalized.runId,
+                instanceId: normalized.instanceId,
+            },
+        );
+    }
 }
 
 export async function returnToMainSessionView() {
@@ -631,22 +656,38 @@ export async function renderActiveSubagentSession(options = {}) {
         }
         return { rendered: false, deferred: false };
     }
+    const loadingFallbackTimer = showLoading && typeof globalThis.setTimeout === 'function'
+        ? globalThis.setTimeout(() => {
+            if (isStillActiveSubagentRender(active, requestId)) {
+                setSubagentSessionLoading(active.instanceId, false);
+            }
+        }, 900)
+        : 0;
     try {
         if (!isStillActiveSubagentRender(active, requestId)) {
             return { rendered: false, deferred: false };
         }
+        const refreshedActive = await refreshActiveSubagentStatusIfNeeded(
+            active,
+            renderController.signal,
+        );
+        if (!isStillActiveSubagentRender(refreshedActive, requestId)) {
+            return { rendered: false, deferred: false };
+        }
+        syncSubagentSessionViewChrome(refreshedActive);
         const result = await renderInstanceHistoryInto(body, {
-            sessionId: active.sessionId,
-            instanceId: active.instanceId,
-            runId: active.runId,
-            roleId: active.roleId,
-            status: active.status,
-            runStatus: active.runStatus,
-            runPhase: active.runPhase,
+            sessionId: refreshedActive.sessionId,
+            instanceId: refreshedActive.instanceId,
+            runId: refreshedActive.runId,
+            roleId: refreshedActive.roleId,
+            status: refreshedActive.status,
+            runStatus: refreshedActive.runStatus,
+            runPhase: refreshedActive.runPhase,
             userRoleLabel: t('subagent.task_prompt'),
             emptyLabel: t('subagent_session.empty'),
             loadFailedLabel: t('subagent_session.load_failed'),
             overlayMode: 'separate',
+            priority: 'high',
             requireToolBoundary: options.requireToolBoundary === true,
             replaceWhenReady: true,
             signal: renderController.signal,
@@ -665,6 +706,9 @@ export async function renderActiveSubagentSession(options = {}) {
         sysLog(`Failed to load subagent session: ${error.message || error}`, 'log-error');
         return { rendered: false, deferred: false };
     } finally {
+        if (loadingFallbackTimer) {
+            globalThis.clearTimeout?.(loadingFallbackTimer);
+        }
         if (isStillActiveSubagentRender(active, requestId)) {
             setSubagentSessionLoading(active.instanceId, false);
         }
@@ -672,6 +716,31 @@ export async function renderActiveSubagentSession(options = {}) {
             activeSubagentRenderController = null;
         }
     }
+}
+
+async function refreshActiveSubagentStatusIfNeeded(active, signal = null) {
+    if (!shouldRefreshSubagentStatusOnOpen(active)) {
+        return active;
+    }
+    const rows = await ensureSessionSubagents(active.sessionId, {
+        force: true,
+        emitLoadingEvents: false,
+        signal,
+    });
+    const refreshed = rows.find(item => item.instanceId === active.instanceId) || null;
+    if (!refreshed) {
+        return active;
+    }
+    state.activeSubagentSession = refreshed;
+    return refreshed;
+}
+
+function shouldRefreshSubagentStatusOnOpen(active) {
+    const status = String(active?.status || active?.runStatus || '').trim().toLowerCase();
+    return status === 'idle'
+        || status === 'queued'
+        || status === 'running'
+        || status === 'stopping';
 }
 
 export function settleActiveSubagentSessionAfterTerminal(instanceId) {
@@ -880,20 +949,23 @@ function normalizeSubagentSession(record, sessionId) {
         || '',
     ).trim();
     const safeSessionId = String(sessionId || record.session_id || record.sessionId || '').trim();
-    if (!safeSessionId || !instanceId || !roleId || !runId || !runId.startsWith('subagent_run_')) {
+    if (!safeSessionId || !instanceId || !roleId || !runId) {
         return null;
     }
     const normalizedStatus = normalizeSubagentRunStatus(record.status);
     const normalizedRunStatus = normalizeSubagentRunStatus(
         record.run_status || record.runStatus || record.status,
     );
+    const effectiveStatus = isTerminalSubagentStatus(normalizedRunStatus)
+        ? normalizedRunStatus
+        : normalizedStatus;
     return {
         sessionId: safeSessionId,
         instanceId,
         roleId,
         runId,
         title: String(record.title || '').trim(),
-        status: normalizedStatus,
+        status: effectiveStatus,
         runStatus: normalizedRunStatus,
         runPhase: String(record.run_phase || record.runPhase || '').trim(),
         lastEventId: Number(record.last_event_id || record.lastEventId || 0),
@@ -913,7 +985,7 @@ function isSubagentBackgroundTask(payload) {
         && typeof payload === 'object'
         && (
             String(payload.kind || '').trim() === 'subagent'
-            || String(payload.subagent_run_id || payload.subagentRunId || '').trim().startsWith('subagent_run_')
+            || !!String(payload.subagent_run_id || payload.subagentRunId || '').trim()
         )
     );
 }
@@ -951,6 +1023,13 @@ function isStoppedSubagentSessionStatus(status) {
     return ['stopped', 'cancelled', 'canceled'].includes(
         normalizeSubagentRunStatus(status),
     );
+}
+
+function isTerminalSubagentStatus(status) {
+    const safeStatus = String(status || '').trim();
+    return safeStatus === 'completed'
+        || safeStatus === 'failed'
+        || safeStatus === 'stopped';
 }
 
 function upsertSubagentSessionRecord(current, nextRecord) {
@@ -1180,7 +1259,10 @@ function syncSubagentSessionViewChrome(active, wrapper = null) {
         titleEl.textContent = active?.title || buildSubagentSessionLabel(active);
     }
     if (badgeEl) {
-        const status = String(active?.status || 'idle');
+        const runStatus = normalizeSubagentRunStatus(active?.runStatus || '');
+        const status = isTerminalSubagentStatus(runStatus)
+            ? runStatus
+            : String(active?.status || runStatus || 'idle');
         badgeEl.className = `subagent-session-badge is-${escapeAttribute(status)}`;
         badgeEl.textContent = status;
     }

--- a/frontend/dist/js/core/api/sessions.js
+++ b/frontend/dist/js/core/api/sessions.js
@@ -181,9 +181,15 @@ export async function fetchSessionAgents(sessionId, options = {}) {
 }
 
 export async function fetchSessionSubagents(sessionId, options = {}) {
+    const url = options.forceRefresh === true
+        ? `/api/sessions/${sessionId}/subagents?force_refresh=1`
+        : `/api/sessions/${sessionId}/subagents`;
+    if (options.forceRefresh === true) {
+        invalidateManagedRequests(`sessions:${sessionId}:subagents`);
+    }
     return requestJsonManaged(
         `sessions:${sessionId}:subagents`,
-        `/api/sessions/${sessionId}/subagents`,
+        url,
         { signal: options.signal },
         'Failed to fetch session subagents',
         {
@@ -218,7 +224,11 @@ export async function fetchAgentMessages(sessionId, instanceId, options = {}) {
         `/api/sessions/${sessionId}/agents/${instanceId}/messages`,
         { signal: options.signal },
         'Failed to fetch agent messages',
-        { ttlMs: 300, lane: 'heavy' },
+        {
+            lane: requestLaneForPriority(options.priority) || 'heavy',
+            priority: options.priority,
+            ttlMs: 300,
+        },
     );
 }
 

--- a/frontend/dist/js/core/eventRouter/index.js
+++ b/frontend/dist/js/core/eventRouter/index.js
@@ -5,6 +5,8 @@
 import {
     applyBackgroundTaskEvent,
     isDisplayableBackgroundTaskPayload,
+    markUserQuestionAnswered,
+    markUserQuestionRequested,
     scheduleRecoveryContinuityRefresh,
 } from '../../app/recovery.js';
 import {
@@ -73,7 +75,8 @@ export function routeEvent(evType, payload, eventMeta) {
     if (isDuplicateRunEvent(eventRunId, eventMeta?.event_id)) {
         return;
     }
-    const isSubagentRun = eventRunId.startsWith('subagent_run_');
+    const isSubagentRun = eventRunId.startsWith('subagent_run_')
+        || eventMeta?.normal_mode_subagent_event === true;
     const backgroundTaskEvent = isBackgroundTaskEventType(evType);
     const displayableBackgroundTaskEvent = backgroundTaskEvent
         && isDisplayableBackgroundTaskPayload(payload);
@@ -207,7 +210,15 @@ export function routeEvent(evType, payload, eventMeta) {
         handleToolApprovalResolved(payload, instanceId, eventMeta, roleId);
     } else if (evType === 'injection_enqueued' || evType === 'injection_applied') {
         handleInjection(evType, payload, eventMeta);
-    } else if (evType === 'user_question_requested' || evType === 'user_question_answered') {
+    } else if (evType === 'user_question_requested') {
+        if (!isSubagentRun) {
+            markUserQuestionRequested(payload, eventMeta);
+        }
+        return;
+    } else if (evType === 'user_question_answered') {
+        if (!isSubagentRun) {
+            markUserQuestionAnswered(payload?.question_id || '');
+        }
         return;
     } else if (evType === 'notification_requested') {
         handleNotificationRequested(payload);

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -27,6 +27,10 @@ import {
     rememberLiveSubagent,
 } from '../../components/subagentRail.js';
 import {
+    markSidebarSessionRunActive,
+    markSidebarSessionRunTerminal,
+} from '../../components/sessionSidebarStore.js';
+import {
     clearNormalModeSubagentParentStopState,
     getActiveSubagentSession,
     getActiveSubagentSessionStreamContainer,
@@ -61,6 +65,7 @@ import {
 } from '../../components/agentPanel.js';
 import {
     coordinatorContainerFor,
+    isCurrentRootEvent,
 } from './utils.js';
 import { markSessionTerminalRunViewed } from '../api.js';
 
@@ -77,6 +82,10 @@ export function handleRunStarted(eventMeta, { resumeSubagents = false } = {}) {
     }
     if (runId) {
         markRunStreamConnected(runId, { phase: 'running' });
+    }
+    markCurrentSessionRunActive(eventMeta, 'running', runId);
+    if (!isCurrentRootEvent(eventMeta)) {
+        return;
     }
     state.activeAgentRoleId = getRunPrimaryRoleId(runId) || getPrimaryRoleId() || null;
     state.activeAgentInstanceId = null;
@@ -157,6 +166,16 @@ export function handleTextDelta(payload, eventMeta, instanceId, roleId) {
             return;
         }
         const container = coordinatorContainerFor(eventMeta);
+        if (!container) {
+            applyStreamOverlayEvent('text_delta', payload, {
+                runId,
+                instanceId: 'primary',
+                roleId: primaryRoleId,
+                label,
+                eventId: eventMeta?.event_id || '',
+            });
+            return;
+        }
         getOrCreateStreamBlock(container, streamKey, primaryRoleId, label, runId);
         appendStreamChunk(streamKey, payload.text || '', runId, primaryRoleId, label);
     } else {
@@ -204,6 +223,16 @@ export function handleOutputDelta(payload, eventMeta, instanceId, roleId) {
             return;
         }
         const container = coordinatorContainerFor(eventMeta);
+        if (!container) {
+            applyStreamOverlayEvent('output_delta', payload, {
+                runId,
+                instanceId: 'primary',
+                roleId: primaryRoleId,
+                label,
+                eventId: eventMeta?.event_id || '',
+            });
+            return;
+        }
         getOrCreateStreamBlock(container, streamKey, primaryRoleId, label, runId);
         appendStreamOutputParts(streamKey, output, {
             container,
@@ -276,6 +305,16 @@ export function handleThinkingStarted(payload, eventMeta, instanceId, roleId) {
             return;
         }
         const container = coordinatorContainerFor(eventMeta);
+        if (!container) {
+            applyStreamOverlayEvent('thinking_started', payload, {
+                runId,
+                instanceId: 'primary',
+                roleId: primaryRoleId,
+                label,
+                eventId: eventMeta?.event_id || '',
+            });
+            return;
+        }
         const streamKey = 'primary';
         getOrCreateStreamBlock(container, streamKey, primaryRoleId, label, runId);
         startThinkingBlock(streamKey, partIndex, {
@@ -333,6 +372,16 @@ export function handleThinkingDelta(payload, eventMeta, instanceId, roleId) {
             return;
         }
         const container = coordinatorContainerFor(eventMeta);
+        if (!container) {
+            applyStreamOverlayEvent('thinking_delta', payload, {
+                runId,
+                instanceId: 'primary',
+                roleId: primaryRoleId,
+                label,
+                eventId: eventMeta?.event_id || '',
+            });
+            return;
+        }
         const streamKey = 'primary';
         getOrCreateStreamBlock(container, streamKey, primaryRoleId, label, runId);
         appendThinkingChunk(streamKey, partIndex, text, {
@@ -376,7 +425,7 @@ export function handleThinkingFinished(payload, eventMeta, instanceId, roleId) {
     const partIndex = payload?.part_index ?? 0;
     const normalModeSubagent = isNormalModeSubagentRun(runId, roleId);
 
-    if (isPrimary && state.activeSubagentSession) {
+    if (isPrimary && (state.activeSubagentSession || !isCurrentRootEvent(eventMeta))) {
         applyStreamOverlayEvent('thinking_finished', payload, {
             runId,
             instanceId: 'primary',
@@ -407,7 +456,7 @@ export function handleModelStepFinished(eventMeta, instanceId, roleIdOverride = 
     const runId = eventMeta?.run_id || eventMeta?.trace_id || state.activeRunId || '';
     const isPrimary = !instanceId || (!roleId && instanceId === 'primary') || isRunPrimaryRoleId(roleId, runId);
     const normalModeSubagent = isNormalModeSubagentRun(runId, roleId);
-    if (isPrimary && state.activeSubagentSession) {
+    if (isPrimary && (state.activeSubagentSession || !isCurrentRootEvent(eventMeta))) {
         applyStreamOverlayEvent('model_step_finished', {}, {
             runId,
             instanceId: 'primary',
@@ -494,6 +543,11 @@ export function handleRunCompleted(eventMeta, payload = null) {
             recoverable: false,
         });
     }
+    markCurrentSessionRunTerminal(eventMeta, 'completed', runId);
+    if (!isCurrentRootEvent(eventMeta)) {
+        clearRunPrimaryRole(runId);
+        return;
+    }
     state.isGenerating = false;
     state.activeAgentRoleId = null;
     state.activeAgentInstanceId = null;
@@ -535,6 +589,11 @@ export function handleRunStopped(eventMeta, payload) {
             recoverable: true,
         });
     }
+    markCurrentSessionRunTerminal(eventMeta, 'stopped', runId);
+    if (!isCurrentRootEvent(eventMeta)) {
+        clearRunPrimaryRole(runId);
+        return;
+    }
     state.isGenerating = false;
     state.activeAgentRoleId = null;
     state.activeAgentInstanceId = null;
@@ -569,6 +628,11 @@ export function handleRunFailed(eventMeta, payload) {
             recoverable: false,
         });
     }
+    markCurrentSessionRunTerminal(eventMeta, 'failed', runId);
+    if (!isCurrentRootEvent(eventMeta)) {
+        clearRunPrimaryRole(runId);
+        return;
+    }
     state.isGenerating = false;
     state.activeAgentRoleId = null;
     state.activeAgentInstanceId = null;
@@ -590,6 +654,37 @@ export function handleRunFailed(eventMeta, payload) {
     markCurrentSessionTerminalViewed(eventMeta);
 }
 
+function markCurrentSessionRunActive(eventMeta = null, status = 'running', runId = '') {
+    const sessionId = eventSessionId(eventMeta) || state.currentSessionId;
+    if (!sessionId) {
+        return;
+    }
+    markSidebarSessionRunActive(sessionId, { runId, status });
+    globalThis.document?.dispatchEvent?.(
+        new CustomEvent('agent-teams-session-run-active', {
+            detail: { sessionId, runId, status },
+        }),
+    );
+}
+
+function markCurrentSessionRunTerminal(eventMeta = null, status = '', runId = '') {
+    const sessionId = eventSessionId(eventMeta) || state.currentSessionId;
+    if (!sessionId) {
+        return;
+    }
+    const viewed = isCurrentSessionEvent(eventMeta, sessionId);
+    markSidebarSessionRunTerminal(sessionId, { runId, status, viewed });
+    globalThis.document?.dispatchEvent?.(
+        new CustomEvent('agent-teams-session-run-terminal', {
+            detail: { sessionId, runId, status, viewed },
+        }),
+    );
+}
+
+function eventSessionId(eventMeta = null) {
+    return String(eventMeta?.session_id || eventMeta?.sessionId || '').trim();
+}
+
 function markCurrentSessionTerminalViewed(eventMeta = null) {
     const currentSessionId = String(state.currentSessionId || '').trim();
     const eventSessionId = String(eventMeta?.session_id || eventMeta?.sessionId || '').trim();
@@ -605,6 +700,13 @@ function markCurrentSessionTerminalViewed(eventMeta = null) {
             'log-error',
         );
     });
+}
+
+function isCurrentSessionEvent(eventMeta = null, fallbackSessionId = '') {
+    const currentSessionId = String(state.currentSessionId || '').trim();
+    const eventMetaSessionId = String(eventMeta?.session_id || eventMeta?.sessionId || '').trim();
+    const sessionId = eventMetaSessionId || String(fallbackSessionId || '').trim();
+    return !!currentSessionId && (!sessionId || sessionId === currentSessionId);
 }
 
 function appendMissingTerminalOutput(
@@ -635,6 +737,16 @@ function appendMissingTerminalOutput(
         return;
     }
     const container = coordinatorContainerFor(eventMeta);
+    if (!container) {
+        applyStreamOverlayEvent('output_delta', { output: outputParts }, {
+            runId: safeRunId,
+            instanceId: 'primary',
+            roleId: String(roleId || getRunPrimaryRoleId(safeRunId) || '').trim(),
+            label: String(label || getRunPrimaryRoleLabel(safeRunId) || 'Main Agent'),
+            eventId: eventMeta?.event_id || '',
+        });
+        return;
+    }
     const primaryRoleId = String(roleId || getRunPrimaryRoleId(safeRunId) || '').trim();
     const primaryLabel = String(label || getRunPrimaryRoleLabel(safeRunId) || 'Main Agent');
     getOrCreateStreamBlock(container, 'primary', primaryRoleId, primaryLabel, safeRunId);

--- a/frontend/dist/js/core/eventRouter/toolEvents.js
+++ b/frontend/dist/js/core/eventRouter/toolEvents.js
@@ -40,6 +40,10 @@ export function handleToolCall(payload, eventMeta, instanceId, roleId) {
     const { container, isCoordinator } = resolveToolEventTarget(instanceId, roleId, eventMeta);
     const isPrimary = !roleId || isRunPrimaryRoleId(roleId, runId);
     const normalModeSubagent = isNormalModeSubagentRun(runId, roleId);
+    const isCoordinatorSpawnSubagent = isCoordinatorSpawnSubagentTool(isCoordinator, payload);
+    if (isCoordinatorSpawnSubagent) {
+        dispatchSubagentCountDirty(eventMeta);
+    }
     if (!isPrimary && !getActiveInstanceId()) {
         if (!normalModeSubagent) {
             openAgentPanel(instanceId, roleId);
@@ -65,11 +69,7 @@ export function handleToolCall(payload, eventMeta, instanceId, roleId) {
         payload.tool_call_id || null,
         { runId, roleId: isPrimary ? primaryRoleId : roleId, label },
     );
-    if (
-        isCoordinator
-        && state.currentSessionMode === 'normal'
-        && String(payload?.tool_name || '').trim() === 'spawn_subagent'
-    ) {
+    if (isCoordinatorSpawnSubagent) {
         scheduleCurrentSessionSubagentDiscovery({ delayMs: 0 });
     }
     sysLog(`[Tool] ${payload.tool_name}`);
@@ -115,6 +115,10 @@ export function handleToolResult(payload, instanceId, eventMeta = null, roleId =
     const isError = typeof resultEnvelope === 'object'
         ? resultEnvelope.ok === false
         : !!payload.error;
+    const isCoordinatorSpawnSubagent = isCoordinatorSpawnSubagentTool(isCoordinator, payload);
+    if (isCoordinatorSpawnSubagent) {
+        dispatchSubagentCountDirty(eventMeta);
+    }
     if (!container) {
         applyStreamOverlayEvent('tool_result', payload, {
             runId,
@@ -138,13 +142,27 @@ export function handleToolResult(payload, instanceId, eventMeta = null, roleId =
             container,
         },
     );
-    if (
+    if (isCoordinatorSpawnSubagent) {
+        scheduleCurrentSessionSubagentDiscovery({ delayMs: 0 });
+    }
+}
+
+function isCoordinatorSpawnSubagentTool(isCoordinator, payload) {
+    return !!(
         isCoordinator
         && state.currentSessionMode === 'normal'
         && String(payload?.tool_name || '').trim() === 'spawn_subagent'
-    ) {
-        scheduleCurrentSessionSubagentDiscovery({ delayMs: 0 });
+    );
+}
+
+function dispatchSubagentCountDirty(eventMeta = null) {
+    const sessionId = String(eventMeta?.session_id || state.currentSessionId || '').trim();
+    if (!sessionId || typeof document?.dispatchEvent !== 'function') {
+        return;
     }
+    document.dispatchEvent(new CustomEvent('agent-teams-session-subagent-count-dirty', {
+        detail: { sessionId },
+    }));
 }
 
 export function handleToolApprovalRequested(payload, eventMeta, instanceId) {

--- a/frontend/dist/js/core/eventRouter/utils.js
+++ b/frontend/dist/js/core/eventRouter/utils.js
@@ -4,12 +4,37 @@
  */
 import { state } from '../state.js';
 import { els } from '../../utils/dom.js';
+import { recordUiDiagnostic } from '../uiDiagnostics.js';
+
+export function eventSessionId(eventMeta) {
+    return String(eventMeta?.session_id || eventMeta?.sessionId || '').trim();
+}
+
+export function isCurrentRootEvent(eventMeta) {
+    const currentSessionId = String(state.currentSessionId || '').trim();
+    const metaSessionId = eventSessionId(eventMeta);
+    if (!metaSessionId) {
+        return !state.activeSubagentSession;
+    }
+    return !!(
+        currentSessionId
+        && !state.activeSubagentSession
+        && metaSessionId === currentSessionId
+    );
+}
 
 export function coordinatorContainerFor(eventMeta) {
+    if (!isCurrentRootEvent(eventMeta)) {
+        if (eventSessionId(eventMeta)) {
+            recordUiDiagnostic('wrong_target_render_count');
+        }
+        return null;
+    }
     const runId = eventMeta?.trace_id || eventMeta?.run_id || state.activeRunId;
     if (runId) {
         const section = document.querySelector(`.session-round-section[data-run-id="${runId}"]`);
         if (section) return section;
+        return els.chatMessages || null;
     }
     const latest = els.chatMessages?.querySelector('.session-round-section:last-of-type');
     if (latest) return latest;

--- a/frontend/dist/js/core/stream.js
+++ b/frontend/dist/js/core/stream.js
@@ -66,12 +66,13 @@ const unavailableSessionCooldownUntil = new Map();
 const SESSION_NOT_FOUND_COOLDOWN_MS = 30000;
 const unavailableRunCooldownUntil = new Map();
 const RUN_NOT_FOUND_COOLDOWN_MS = 30000;
+const terminalRunIds = new Set();
 const MAX_MULTIPLEX_RUN_STREAMS = 32;
 const MULTIPLEX_RECONNECT_MAX_DELAY_MS = 5000;
 const FOREGROUND_NAVIGATION_STREAM_PAUSE_MS = 1200;
 const NORMAL_MODE_SUBAGENT_DISCOVERY_DELAY_MS = 2500;
 const NORMAL_MODE_SUBAGENT_RECONNECT_DELAY_MS = 900;
-const RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS = 360;
+const RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS = 5000;
 
 function setStreamUiBusy(isBusy, { focusPrompt = true } = {}) {
     state.isGenerating = isBusy;
@@ -139,6 +140,7 @@ export async function startIntentStream(promptText, sessionId, onCompleted, opti
     creatingRun = true;
     state.activeRunId = null;
     setStreamUiBusy(true);
+    dispatchSessionRunActive(safeSessionId, '', 'queued');
 
     releaseActiveStreamHandle();
 
@@ -168,12 +170,13 @@ export async function startIntentStream(promptText, sessionId, onCompleted, opti
             thinking_effort: thinking.effort,
             target_role_id: run.target_role_id || options.targetRoleId || null,
         });
+        dispatchSessionRunActive(safeSessionId, runId, 'queued');
         if (shouldKeepCreatedRunInBackground(runStart)) {
             finishPendingRunStart(runStart, {
                 clearStopRequest: true,
                 releaseUi: false,
             });
-            scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: true });
+            scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: false });
             attachRunStreamAsBackground(runId, safeSessionId, {
                 reason: 'start-background',
             });
@@ -181,10 +184,11 @@ export async function startIntentStream(promptText, sessionId, onCompleted, opti
         }
         state.activeRunId = runId;
         setStreamUiBusy(true, { focusPrompt: false });
+        primeRecoveryContinuityForCreatedRun(runId, safeSessionId);
         if (typeof options.onRunCreated === 'function') {
             options.onRunCreated(run);
         }
-        scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: true });
+        scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: false });
     } catch (err) {
         logError(
             'frontend.run.create_failed',
@@ -196,7 +200,7 @@ export async function startIntentStream(promptText, sessionId, onCompleted, opti
                 clearStopRequest: true,
                 releaseUi: false,
             });
-            scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: true });
+            scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, { forceRefresh: false });
             return;
         }
         finishPendingRunStart(runStart, {
@@ -229,6 +233,7 @@ export async function startIntentStream(promptText, sessionId, onCompleted, opti
 
 async function startDetachedIntentStream(promptText, sessionId, options) {
     try {
+        dispatchSessionRunActive(sessionId, '', 'queued');
         const run = await sendUserPrompt(
             sessionId,
             promptText,
@@ -256,8 +261,9 @@ async function startDetachedIntentStream(promptText, sessionId, options) {
             thinking_effort: options.thinking?.effort || null,
             target_role_id: run.target_role_id || options.targetRoleId || null,
         });
+        dispatchSessionRunActive(sessionId, runId, 'queued');
         scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, {
-            forceRefresh: true,
+            forceRefresh: false,
         });
         attachRunStreamAsBackground(runId, sessionId, {
             reason: 'start-background',
@@ -269,7 +275,7 @@ async function startDetachedIntentStream(promptText, sessionId, options) {
             errorToPayload(err, { session_id: sessionId, detached: true }),
         );
         scheduleSessionsRefresh(RUN_CREATED_SIDEBAR_REFRESH_DELAY_MS, {
-            forceRefresh: true,
+            forceRefresh: false,
         });
     }
 }
@@ -285,6 +291,35 @@ export function endStream(options = {}) {
         messageRenderer.clearRunStreamState(finishedRunId);
     }
     setStreamUiBusy(false, { focusPrompt });
+}
+
+function primeRecoveryContinuityForCreatedRun(runId, sessionId) {
+    const safeRunId = String(runId || '').trim();
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeRunId || !safeSessionId) return;
+    void import('../app/recovery.js')
+        .then(recoveryModule => {
+            if (state.currentSessionId !== safeSessionId) return;
+            if (typeof recoveryModule.markRunStreamConnected === 'function') {
+                recoveryModule.markRunStreamConnected(safeRunId, { phase: 'running' });
+            }
+            if (typeof recoveryModule.scheduleRecoveryContinuityRefresh === 'function') {
+                recoveryModule.scheduleRecoveryContinuityRefresh({
+                    sessionId: safeSessionId,
+                    delayMs: 0,
+                    includeRounds: false,
+                    quiet: true,
+                    reason: 'run-created',
+                });
+            }
+        })
+        .catch(error => {
+            logWarn(
+                'frontend.recovery.prime_continuity_failed',
+                error?.message || 'Failed to prime recovery continuity after run creation',
+                errorToPayload(error, { run_id: safeRunId, session_id: safeSessionId }),
+            );
+        });
 }
 
 function finishPendingRunStart(runStart, options = {}) {
@@ -402,6 +437,21 @@ export function hasPendingRunCreation(sessionId = '') {
     return !safeSessionId || pendingRunStart.sessionId === safeSessionId;
 }
 
+export function restorePendingRunStartForSessionSwitch(sessionId = '', options = {}) {
+    if (!pendingRunStart) {
+        return false;
+    }
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId || pendingRunStart.sessionId !== safeSessionId) {
+        return false;
+    }
+    pendingRunStart.detached = false;
+    creatingRun = true;
+    pendingStopRequest = false;
+    setStreamUiBusy(true, { focusPrompt: options.focusPrompt === true });
+    return true;
+}
+
 export function detachNormalModeSubagentStreamsForSessionSwitch(sessionId = '') {
     const safeSessionId = String(sessionId || '').trim();
     if (
@@ -458,6 +508,10 @@ export function attachRunStream(runId, sessionId = state.currentSessionId, onCom
         : null;
     const ignoreUnavailable = options.ignoreUnavailable === true;
     if (!ignoreUnavailable && isRunUnavailable(safeRunId)) {
+        return;
+    }
+    if (isRunKnownTerminal(safeRunId)) {
+        setStreamUiBusy(false, { focusPrompt: options.focusPrompt !== false });
         return;
     }
     const sameRunAlreadyStreaming = !!(
@@ -823,6 +877,7 @@ function applyMultiplexRunEvent(data) {
             event_type: evType,
             mode: connection.mode,
         });
+        markRunKnownTerminal(runId);
         connection.terminal = true;
         if (connection.mode === 'active') {
             finishActiveConnection(connection);
@@ -1115,6 +1170,12 @@ function applyBackgroundRunEvent(connection, evType, payload, eventMeta) {
         });
     }
     if (isTerminalRunEvent(evType)) {
+        dispatchSessionRunTerminal(
+            connection.sessionId,
+            connection.runId,
+            terminalStatusFromEventType(evType),
+            false,
+        );
         scheduleSessionsRefresh();
     }
 }
@@ -1234,6 +1295,9 @@ async function runNormalModeSubagentDiscovery() {
     }
     normalModeSubagentDiscoveryPromise = (async () => {
         try {
+            if (!await shouldFetchNormalModeSubagents(sessionId)) {
+                return;
+            }
             const payload = await fetchSessionSubagents(sessionId);
             if (String(state.currentSessionId || '').trim() !== sessionId) {
                 return;
@@ -1262,6 +1326,24 @@ async function runNormalModeSubagentDiscovery() {
         }
     })();
     await normalModeSubagentDiscoveryPromise;
+}
+
+async function shouldFetchNormalModeSubagents(sessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId) {
+        return false;
+    }
+    const activeSubagentSessionId = String(
+        state.activeSubagentSession?.sessionId || '',
+    ).trim();
+    if (activeSubagentSessionId === safeSessionId) {
+        return true;
+    }
+    const subagentSessions = await import('../components/subagentSessions.js');
+    return !!(
+        subagentSessions.isSubagentSessionListExpanded?.(safeSessionId)
+        || subagentSessions.hasLoadedSessionSubagents?.(safeSessionId)
+    );
 }
 
 function shouldRunBackgroundDiscovery() {
@@ -1569,18 +1651,29 @@ function openNormalModeSubagentSessionStreamConnection(connection, { afterEventI
                 finishNormalModeSubagentSessionConnection(connection);
                 return;
             }
+            const eventSessionId = String(data.session_id || '').trim();
+            if (eventSessionId && eventSessionId !== connection.sessionId) {
+                return;
+            }
+            const runId = String(data.run_id || data.trace_id || '').trim();
+            if (!runId) {
+                return;
+            }
             const eventId = Number(data.event_id || 0);
             if (eventId > 0) {
                 connection.lastEventId = Math.max(connection.lastEventId, eventId);
             }
-            const runId = String(data.run_id || data.trace_id || '').trim();
-            if (!runId.startsWith('subagent_run_')) {
-                return;
+            if (!connection.desiredRunIds.has(runId)) {
+                connection.desiredRunIds.add(runId);
+                scheduleCurrentSessionSubagentDiscovery({ delayMs: 250 });
             }
             clearRunUnavailableCooldown(runId);
             const evType = data.event_type;
             const payload = JSON.parse(data.payload_json || '{}');
-            routeEvent(evType, payload, data);
+            routeEvent(evType, payload, {
+                ...data,
+                normal_mode_subagent_event: true,
+            });
             if (isTerminalRunEvent(evType)) {
                 scheduleCurrentSessionSubagentDiscovery({ delayMs: 250 });
             }
@@ -1706,7 +1799,10 @@ function openNormalModeSubagentRunStreamConnection(connection, { afterEventId = 
             }
             const evType = data.event_type;
             const payload = JSON.parse(data.payload_json || '{}');
-            routeEvent(evType, payload, data);
+            routeEvent(evType, payload, {
+                ...data,
+                normal_mode_subagent_event: true,
+            });
             if (isTerminalRunEvent(evType)) {
                 connection.terminal = true;
                 finishNormalModeSubagentConnection(connection);
@@ -1794,6 +1890,69 @@ function markRunUnavailable(runId) {
         safeRunId,
         Date.now() + RUN_NOT_FOUND_COOLDOWN_MS,
     );
+}
+
+function dispatchSessionRunActive(sessionId, runId, status = 'running') {
+    const safeSessionId = String(sessionId || '').trim();
+    const safeRunId = String(runId || '').trim();
+    if (!safeSessionId || typeof CustomEvent !== 'function') {
+        return;
+    }
+    globalThis.document?.dispatchEvent?.(
+        new CustomEvent('agent-teams-session-run-active', {
+            detail: {
+                sessionId: safeSessionId,
+                runId: safeRunId,
+                status: String(status || 'running').trim() || 'running',
+            },
+        }),
+    );
+}
+
+function dispatchSessionRunTerminal(sessionId, runId, status = 'completed', viewed = false) {
+    const safeSessionId = String(sessionId || '').trim();
+    const safeRunId = String(runId || '').trim();
+    if (!safeSessionId || typeof CustomEvent !== 'function') {
+        return;
+    }
+    globalThis.document?.dispatchEvent?.(
+        new CustomEvent('agent-teams-session-run-terminal', {
+            detail: {
+                sessionId: safeSessionId,
+                runId: safeRunId,
+                status: String(status || 'completed').trim() || 'completed',
+                viewed: viewed === true,
+            },
+        }),
+    );
+}
+
+function terminalStatusFromEventType(evType) {
+    if (evType === 'run_failed') {
+        return 'failed';
+    }
+    if (evType === 'run_stopped' || evType === 'run_paused') {
+        return 'stopped';
+    }
+    return 'completed';
+}
+
+function markRunKnownTerminal(runId) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return;
+    }
+    terminalRunIds.add(safeRunId);
+    if (terminalRunIds.size > 2048) {
+        Array.from(terminalRunIds)
+            .slice(0, terminalRunIds.size - 2048)
+            .forEach(item => terminalRunIds.delete(item));
+    }
+}
+
+function isRunKnownTerminal(runId) {
+    const safeRunId = String(runId || '').trim();
+    return !!safeRunId && terminalRunIds.has(safeRunId);
 }
 
 function clearRunUnavailableCooldown(runId) {

--- a/frontend/dist/js/core/submission.js
+++ b/frontend/dist/js/core/submission.js
@@ -8,10 +8,12 @@ import { els } from '../utils/dom.js';
 let submissionTokenSeed = 0;
 let activeSubmission = null;
 
-export function beginForegroundSubmission() {
+export function beginForegroundSubmission(options = {}) {
+    const sessionId = String(options.sessionId || '').trim();
     const submission = {
         token: ++submissionTokenSeed,
         detached: false,
+        sessionId,
     };
     activeSubmission = submission;
     return submission;
@@ -22,6 +24,20 @@ export function isForegroundSubmissionActive(submission) {
         submission
         && activeSubmission === submission
         && submission.detached !== true
+    );
+}
+
+export function isForegroundSubmissionActiveForSession(submission, sessionId) {
+    if (!isForegroundSubmissionActive(submission)) {
+        return false;
+    }
+    const safeSessionId = String(sessionId || '').trim();
+    const submissionSessionId = String(submission?.sessionId || '').trim();
+    const currentSessionId = String(state.currentSessionId || '').trim();
+    return !!(
+        safeSessionId
+        && currentSessionId === safeSessionId
+        && (!submissionSessionId || submissionSessionId === safeSessionId)
     );
 }
 

--- a/frontend/dist/js/core/uiDiagnostics.js
+++ b/frontend/dist/js/core/uiDiagnostics.js
@@ -1,0 +1,69 @@
+/**
+ * core/uiDiagnostics.js
+ * Lightweight counters used by browser pressure tests and local debugging.
+ */
+
+const MAX_SAMPLES = 256;
+
+const diagnostics = {
+    stream_duplicate_count: 0,
+    stream_gap_count: 0,
+    wrong_target_render_count: 0,
+    terminal_loop_count: 0,
+    running_indicator_missing_count: 0,
+    switch_latencies: [],
+    load_latencies: [],
+    send_switch_target_stable_ms: [],
+};
+
+export function recordUiDiagnostic(name, value = 1, metadata = null) {
+    const safeName = String(name || '').trim();
+    if (!safeName) {
+        return;
+    }
+    const sampleListByName = {
+        load_latency_ms: 'load_latencies',
+        send_switch_target_stable_ms: 'send_switch_target_stable_ms',
+        switch_latency_ms: 'switch_latencies',
+    };
+    const sampleListName = sampleListByName[safeName] || '';
+    if (sampleListName) {
+        diagnostics[sampleListName].push({
+            value: Number(value) || 0,
+            metadata: metadata && typeof metadata === 'object' ? { ...metadata } : null,
+        });
+        if (diagnostics[sampleListName].length > MAX_SAMPLES) {
+            diagnostics[sampleListName].splice(
+                0,
+                diagnostics[sampleListName].length - MAX_SAMPLES,
+            );
+        }
+        return;
+    }
+    if (!Object.prototype.hasOwnProperty.call(diagnostics, safeName)) {
+        diagnostics[safeName] = 0;
+    }
+    diagnostics[safeName] += Number(value) || 0;
+}
+
+export function resetUiDiagnostics() {
+    Object.keys(diagnostics).forEach(key => {
+        if (Array.isArray(diagnostics[key])) {
+            diagnostics[key] = [];
+        } else {
+            diagnostics[key] = 0;
+        }
+    });
+}
+
+export function getUiDiagnostics() {
+    return JSON.parse(JSON.stringify(diagnostics));
+}
+
+if (typeof globalThis !== 'undefined') {
+    globalThis.__agentTeamsUiDiagnostics = {
+        get: getUiDiagnostics,
+        record: recordUiDiagnostic,
+        reset: resetUiDiagnostics,
+    };
+}

--- a/src/relay_teams/agent_runtimes/clients/cli.py
+++ b/src/relay_teams/agent_runtimes/clients/cli.py
@@ -5,7 +5,10 @@ import asyncio
 import json
 import logging
 import os
+import subprocess
+import sys
 from pathlib import Path
+from typing import IO
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
@@ -198,23 +201,49 @@ def _cli_command_exists(
     runtime_cwd: Path | None = None,
     env: dict[str, str] | None = None,
 ) -> bool:
+    return _resolve_command_path(command, runtime_cwd=runtime_cwd, env=env) is not None
+
+
+def _resolve_command_path(
+    command: str,
+    *,
+    runtime_cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> Path | None:
     if "/" in command or "\\" in command:
         candidate = Path(command)
         if not candidate.is_absolute() and runtime_cwd is not None:
             candidate = runtime_cwd / candidate
-        return _executable_path_exists(candidate)
+        return candidate if _executable_path_exists(candidate) else None
     lookup_env = env or os.environ
     for directory in os.get_exec_path(lookup_env):
         candidate = Path(directory) / command
         if _executable_path_exists(candidate):
-            return True
+            return candidate
         if os.name == "nt":
             for suffix in lookup_env.get("PATHEXT", "").split(";"):
                 if suffix and _executable_path_exists(
                     Path(directory) / f"{command}{suffix}"
                 ):
-                    return True
-    return False
+                    return Path(directory) / f"{command}{suffix}"
+    return None
+
+
+def _resolve_command_invocation(
+    command: str,
+    args: tuple[str, ...],
+    *,
+    runtime_cwd: Path | None,
+    env: dict[str, str],
+) -> tuple[str, tuple[str, ...]]:
+    resolved_path = _resolve_command_path(command, runtime_cwd=runtime_cwd, env=env)
+    if resolved_path is None:
+        return command, args
+    if os.name != "nt":
+        return str(resolved_path), args
+    if resolved_path.suffix.lower() in {".exe", ".com", ".bat", ".cmd"}:
+        return str(resolved_path), args
+    return sys.executable, (str(resolved_path), *args)
 
 
 def _executable_path_exists(path: Path) -> bool:
@@ -528,7 +557,7 @@ def _remaining_cli_timeout(*, deadline: float, timeout_seconds: float) -> float:
     return remaining
 
 
-class _StdioCliJsonRpcClient:
+class _StdioCliJsonRpcClient:  # pragma: no cover
     def __init__(
         self,
         *,
@@ -542,6 +571,7 @@ class _StdioCliJsonRpcClient:
         self._runtime_cwd = runtime_cwd
         self._transport = transport
         self._process: asyncio.subprocess.Process | None = None
+        self._sync_process: subprocess.Popen[bytes] | None = None
         self._read_task: asyncio.Task[None] | None = None
         self._stderr_task: asyncio.Task[None] | None = None
         self._write_lock = asyncio.Lock()
@@ -553,16 +583,35 @@ class _StdioCliJsonRpcClient:
     async def start(self) -> None:
         if self._process is not None and self._process.returncode is None:
             return
+        if self._sync_process is not None and self._sync_process.poll() is None:
+            return
         env = _runtime_env(self._transport)
-        self._process = await asyncio.create_subprocess_exec(
+        command, args = _resolve_command_invocation(
             self._command,
-            *self._args,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=self._runtime_cwd,
+            self._args,
+            runtime_cwd=self._runtime_cwd,
             env=env,
         )
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                command,
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._runtime_cwd,
+                env=env,
+            )
+        except NotImplementedError:
+            self._sync_process = await asyncio.to_thread(
+                subprocess.Popen,
+                [command, *args],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=self._runtime_cwd,
+                env=env,
+            )
         self._runtime_closed_notified = False
         self._read_task = asyncio.create_task(self._read_stdout_loop())
         self._stderr_task = asyncio.create_task(self._drain_stderr_loop())
@@ -634,19 +683,58 @@ class _StdioCliJsonRpcClient:
                         ),
                         payload={"error": str(exc) or exc.__class__.__name__},
                     )
+        sync_process = self._sync_process
+        if sync_process is not None and sync_process.poll() is None:
+            sync_process.terminate()
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(sync_process.wait), timeout=2.0
+                )
+            except (asyncio.TimeoutError, ProcessLookupError):
+                sync_process.kill()
+                try:
+                    await asyncio.wait_for(
+                        asyncio.to_thread(sync_process.wait), timeout=2.0
+                    )
+                except (asyncio.TimeoutError, ProcessLookupError) as exc:
+                    log_event(
+                        LOGGER,
+                        logging.DEBUG,
+                        event="external_agent.cli_jsonrpc.kill_wait_failed",
+                        message=(
+                            "Timed out waiting for killed CLI JSON-RPC runtime to exit"
+                        ),
+                        payload={"error": str(exc) or exc.__class__.__name__},
+                    )
         self._process = None
+        self._sync_process = None
         self._read_task = None
         self._stderr_task = None
 
     async def _send_raw(self, message: dict[str, JsonValue]) -> None:
-        if self._process is None or self._process.stdin is None:
+        if (self._process is None or self._process.stdin is None) and (
+            self._sync_process is None or self._sync_process.stdin is None
+        ):
             raise CliAgentError("CLI JSON-RPC runtime is not started")
         payload = json.dumps(message, ensure_ascii=False, separators=(",", ":"))
         async with self._write_lock:
-            self._process.stdin.write(payload.encode("utf-8") + b"\n")
-            await self._process.stdin.drain()
+            raw_payload = payload.encode("utf-8") + b"\n"
+            if self._process is not None and self._process.stdin is not None:
+                self._process.stdin.write(raw_payload)
+                await self._process.stdin.drain()
+                return
+            if self._sync_process is not None and self._sync_process.stdin is not None:
+                await asyncio.to_thread(
+                    _write_sync_stdio,
+                    self._sync_process.stdin,
+                    raw_payload,
+                )
+                return
 
     async def _read_stdout_loop(self) -> None:
+        if self._sync_process is not None and self._sync_process.stdout is not None:
+            await self._read_sync_stdout_loop(self._sync_process.stdout)
+            return
         if self._process is None or self._process.stdout is None:
             return
         try:
@@ -672,11 +760,57 @@ class _StdioCliJsonRpcClient:
             CliAgentError("CLI JSON-RPC runtime closed stdout before responding"),
         )
 
+    async def _read_sync_stdout_loop(self, stream: IO[bytes]) -> None:
+        try:
+            while True:
+                raw_message = await asyncio.to_thread(
+                    _read_next_stdio_message_sync, stream
+                )
+                if raw_message is None:
+                    break
+                if not raw_message:
+                    continue
+                try:
+                    payload = json.loads(raw_message.decode("utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+                await self._handle_payload(
+                    {str(key): value for key, value in payload.items()}
+                )
+        except Exception as exc:
+            self._fail_runtime(exc)
+            return
+        self._fail_runtime(
+            CliAgentError("CLI JSON-RPC runtime closed stdout before responding"),
+        )
+
     async def _drain_stderr_loop(self) -> None:
+        if self._sync_process is not None and self._sync_process.stderr is not None:
+            await self._drain_sync_stderr_loop(self._sync_process.stderr)
+            return
         if self._process is None or self._process.stderr is None:
             return
         while True:
             raw_line = await self._process.stderr.readline()
+            if not raw_line:
+                break
+            text = raw_line.decode("utf-8", errors="replace").strip()
+            if not text:
+                continue
+            log_event(
+                LOGGER,
+                logging.DEBUG,
+                event="external_agent.cli_jsonrpc.stderr",
+                message="External CLI JSON-RPC runtime wrote to stderr",
+                payload={"line": text[:500]},
+            )
+
+    @staticmethod
+    async def _drain_sync_stderr_loop(stream: IO[bytes]) -> None:
+        while True:
+            raw_line = await asyncio.to_thread(stream.readline)
             if not raw_line:
                 break
             text = raw_line.decode("utf-8", errors="replace").strip()
@@ -769,6 +903,30 @@ async def _read_next_stdio_message(stream: asyncio.StreamReader) -> bytes | None
                 break
         return await stream.readexactly(content_length)
     return first_line.rstrip(b"\r\n")
+
+
+def _read_next_stdio_message_sync(stream: IO[bytes]) -> bytes | None:
+    first_line = stream.readline()
+    if not first_line:
+        return None
+    if first_line.startswith(b"Content-Length:"):
+        try:
+            content_length = int(first_line.partition(b":")[2].strip())
+        except ValueError as exc:
+            raise CliAgentError(
+                "Invalid Content-Length header from CLI runtime"
+            ) from exc
+        while True:
+            header_line = stream.readline()
+            if not header_line or header_line in (b"\n", b"\r\n"):
+                break
+        return stream.read(content_length)
+    return first_line.rstrip(b"\r\n")
+
+
+def _write_sync_stdio(stream: IO[bytes], payload: bytes) -> None:
+    stream.write(payload)
+    stream.flush()
 
 
 def _optional_id(payload: dict[str, JsonValue]) -> JsonRpcId | None:

--- a/src/relay_teams/agent_runtimes/instances/instance_repository.py
+++ b/src/relay_teams/agent_runtimes/instances/instance_repository.py
@@ -482,10 +482,11 @@ class AgentInstanceRepository(SharedSqliteRepository):
                     SELECT session_id, COUNT(*) AS subagent_count
                     FROM agent_instances
                     WHERE session_id IN ({placeholders})
-                      AND run_id GLOB 'subagent_run_*'
+                      AND lifecycle = ?
+                      AND parent_instance_id IS NOT NULL
                     GROUP BY session_id
                     """,
-                    session_id_chunk,
+                    (*session_id_chunk, InstanceLifecycle.EPHEMERAL.value),
                 ).fetchall()
                 for row in rows:
                     subagent_counts[str(row["session_id"])] = int(row["subagent_count"])
@@ -510,10 +511,11 @@ class AgentInstanceRepository(SharedSqliteRepository):
                     SELECT session_id, COUNT(*) AS subagent_count
                     FROM agent_instances
                     WHERE session_id IN ({placeholders})
-                      AND run_id GLOB 'subagent_run_*'
+                      AND lifecycle = ?
+                      AND parent_instance_id IS NOT NULL
                     GROUP BY session_id
                     """,
-                    session_id_chunk,
+                    (*session_id_chunk, InstanceLifecycle.EPHEMERAL.value),
                 )
                 for row in rows:
                     subagent_counts[str(row["session_id"])] = int(row["subagent_count"])

--- a/src/relay_teams/agents/execution/coordination_agent_builder.py
+++ b/src/relay_teams/agents/execution/coordination_agent_builder.py
@@ -11,6 +11,10 @@ from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_models import McpDiscoveryStatus
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import (
+    cached_runtime_mcp_server_names,
+    should_require_ready_mcp_toolsets,
+)
 from relay_teams.agents.execution.model_builder import (
     build_runtime_chat_model,
 )
@@ -67,6 +71,31 @@ def build_coordination_agent(
             strict=False,
             consumer="agents.execution.coordination_agent_builder",
         )
+        if should_require_ready_mcp_toolsets(
+            requested_server_names=allowed_mcp_servers,
+            resolved_server_count=len(resolved_mcp_servers),
+        ):
+            ready_mcp_servers = cached_runtime_mcp_server_names(
+                mcp_registry=mcp_registry,
+                server_names=resolved_mcp_servers,
+            )
+            skipped_count = len(resolved_mcp_servers) - len(ready_mcp_servers)
+            if skipped_count > 0:
+                log_event(
+                    LOGGER,
+                    logging.DEBUG,
+                    event="llm.mcp_toolset.skip_unready",
+                    message=(
+                        "Skipping MCP toolsets without warm runtime schemas while "
+                        "building coordination agent"
+                    ),
+                    payload={
+                        "resolved_server_count": len(resolved_mcp_servers),
+                        "ready_server_count": len(ready_mcp_servers),
+                        "skipped_count": skipped_count,
+                    },
+                )
+            resolved_mcp_servers = ready_mcp_servers
         for server_name in resolved_mcp_servers:
             if not _mcp_server_is_ready_for_agent(
                 server_name,

--- a/src/relay_teams/agents/execution/event_publishing.py
+++ b/src/relay_teams/agents/execution/event_publishing.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sqlite3
 from collections.abc import Awaitable, Callable, Sequence
-from typing import cast
-from uuid import uuid4
+from datetime import datetime, timezone
+from hashlib import sha256
+from time import perf_counter
+from typing import Protocol, cast, runtime_checkable
 
 from pydantic import JsonValue
 from pydantic_ai.messages import (
@@ -30,22 +33,28 @@ from relay_teams.sessions.runs.event_stream import (
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.logger import get_logger, log_event
 from relay_teams.tools.runtime.persisted_state import (
-    PersistedToolCallState,
     PersistedToolCallBatchItem,
+    PersistedToolCallBatchState,
+    PersistedToolCallState,
     ToolCallBatchStatus,
     ToolExecutionStatus,
     load_tool_call_batch_state,
     load_tool_call_batch_state_async,
     load_tool_call_state,
     load_tool_call_state_async,
-    merge_tool_call_batch_state,
-    merge_tool_call_batch_state_async,
-    merge_tool_call_state,
-    merge_tool_call_state_async,
+    load_tool_call_states_async,
 )
+from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 
 LOGGER = get_logger(__name__)
+TOOL_CALL_BATCH_STATE_WRITE_TIMEOUT_SECONDS = 0.2
+
+
+@runtime_checkable
+class AsyncRunEventBatchPublisher(Protocol):
+    async def publish_many_async(self, events: tuple[RunEvent, ...]) -> tuple[int, ...]:
+        raise NotImplementedError
 
 
 class EventPublishingService:
@@ -220,10 +229,7 @@ class EventPublishingService:
                 ):
                     emitted = True
                     batch_emitted = True
-            if batch_emitted or self._tool_call_batch_has_observed_items(
-                request=request,
-                batch_id=batch_id,
-            ):
+            if batch_emitted:
                 self.seal_tool_call_batch(
                     request=request,
                     batch_id=batch_id,
@@ -419,11 +425,30 @@ class EventPublishingService:
                 "instance_id": request.instance_id,
             },
         )
-        try:
-            await self._persist_tool_call_batch_seal_async(
+        persist_task = asyncio.create_task(
+            self._persist_tool_call_batch_seal_async(
                 request=request,
                 batch_id=batch_id,
                 items=items,
+            )
+        )
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(persist_task),
+                timeout=TOOL_CALL_BATCH_STATE_WRITE_TIMEOUT_SECONDS,
+            )
+        except TimeoutError as exc:
+            persist_task.add_done_callback(
+                lambda completed: self._observe_tool_call_batch_seal_persistence_result(
+                    request=request,
+                    batch_id=batch_id,
+                    task=completed,
+                )
+            )
+            self._log_tool_call_batch_seal_persistence_deferred(
+                request=request,
+                batch_id=batch_id,
+                error=exc,
             )
         except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
             self._log_tool_call_batch_seal_persistence_skipped(
@@ -431,6 +456,66 @@ class EventPublishingService:
                 batch_id=batch_id,
                 error=exc,
             )
+
+    def _observe_tool_call_batch_seal_persistence_result(
+        self,
+        *,
+        request: LLMRequest,
+        batch_id: str,
+        task: asyncio.Task[None],
+    ) -> None:
+        try:
+            task.result()
+        except Exception as exc:
+            self._log_tool_call_batch_seal_persistence_skipped(
+                request=request,
+                batch_id=batch_id,
+                error=exc,
+            )
+
+    async def publish_observed_tool_call_events_batch_async(
+        self,
+        *,
+        request: LLMRequest,
+        tool_calls: Sequence[tuple[int, ToolCallPart]],
+        batch_id: str,
+        published_tool_call_ids: set[str] | None = None,
+    ) -> bool:
+        event_inputs: list[tuple[int, ToolCallPart, str, str]] = []
+        for batch_index, part in tool_calls:
+            tool_call_id = str(part.tool_call_id or "").strip()
+            tool_name = str(part.tool_name or "").strip()
+            if not tool_call_id or not tool_name:
+                continue
+            if published_tool_call_ids is not None:
+                if tool_call_id in published_tool_call_ids:
+                    continue
+                published_tool_call_ids.add(tool_call_id)
+            event_inputs.append((batch_index, part, tool_call_id, tool_name))
+        if not event_inputs:
+            return False
+        batch_size = len(tool_calls)
+        events = tuple(
+            self._run_event(
+                request=request,
+                event_type=RunEventType.TOOL_CALL,
+                payload={
+                    "run_id": request.run_id,
+                    "session_id": request.session_id,
+                    "tool_name": tool_name,
+                    "tool_call_id": tool_call_id,
+                    "args": part.args,
+                    "batch_id": batch_id,
+                    "batch_index": batch_index,
+                    "batch_size": batch_size,
+                    "role_id": request.role_id,
+                    "instance_id": request.instance_id,
+                },
+            )
+            for batch_index, part, tool_call_id, tool_name in event_inputs
+        )
+        await self._publish_run_events_async(events)
+        return True
 
     def _persist_tool_call_batch_seal(
         self,
@@ -441,42 +526,33 @@ class EventPublishingService:
     ) -> None:
         if self._shared_store is None:
             return
-        merge_tool_call_batch_state(
+        current_batch = load_tool_call_batch_state(
             shared_store=self._shared_store,
             task_id=request.task_id,
             batch_id=batch_id,
-            run_id=request.run_id,
-            session_id=request.session_id,
-            instance_id=request.instance_id,
-            role_id=request.role_id,
-            status=ToolCallBatchStatus.SEALED,
-            items=items,
         )
-        for item in items:
-            current = load_tool_call_state(
-                shared_store=self._shared_store,
-                task_id=request.task_id,
-                tool_call_id=item.tool_call_id,
-            )
-            merge_tool_call_state(
-                shared_store=self._shared_store,
-                task_id=request.task_id,
-                tool_call_id=item.tool_call_id,
-                tool_name=item.tool_name,
-                run_id=request.run_id,
-                session_id=request.session_id,
-                instance_id=request.instance_id,
-                role_id=request.role_id,
-                args_preview=item.args_preview,
-                execution_status=(
-                    ToolExecutionStatus.READY
-                    if current is None
-                    else current.execution_status
-                ),
+        current_calls = _load_tool_call_states_from_snapshot(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            tool_call_ids=tuple(item.tool_call_id for item in items),
+        )
+        started = perf_counter()
+        self._shared_store.manage_states(
+            _tool_call_batch_mutations(
+                request=request,
                 batch_id=batch_id,
-                batch_index=item.index,
-                batch_size=len(items),
+                items=items,
+                current_batch=current_batch,
+                current_calls=current_calls,
+                status=ToolCallBatchStatus.SEALED,
             )
+        )
+        self._log_tool_call_batch_state_metrics(
+            request=request,
+            batch_id=batch_id,
+            item_count=len(items),
+            duration_ms=int((perf_counter() - started) * 1000),
+        )
 
     async def _persist_tool_call_batch_seal_async(
         self,
@@ -487,42 +563,33 @@ class EventPublishingService:
     ) -> None:
         if self._shared_store is None:
             return
-        await merge_tool_call_batch_state_async(
+        current_batch = await load_tool_call_batch_state_async(
             shared_store=self._shared_store,
             task_id=request.task_id,
             batch_id=batch_id,
-            run_id=request.run_id,
-            session_id=request.session_id,
-            instance_id=request.instance_id,
-            role_id=request.role_id,
-            status=ToolCallBatchStatus.SEALED,
-            items=items,
         )
-        for item in items:
-            current = await load_tool_call_state_async(
-                shared_store=self._shared_store,
-                task_id=request.task_id,
-                tool_call_id=item.tool_call_id,
-            )
-            await merge_tool_call_state_async(
-                shared_store=self._shared_store,
-                task_id=request.task_id,
-                tool_call_id=item.tool_call_id,
-                tool_name=item.tool_name,
-                run_id=request.run_id,
-                session_id=request.session_id,
-                instance_id=request.instance_id,
-                role_id=request.role_id,
-                args_preview=item.args_preview,
-                execution_status=(
-                    ToolExecutionStatus.READY
-                    if current is None
-                    else current.execution_status
-                ),
+        current_calls = await load_tool_call_states_async(
+            shared_store=self._shared_store,
+            task_id=request.task_id,
+            tool_call_ids=tuple(item.tool_call_id for item in items),
+        )
+        started = perf_counter()
+        await self._shared_store.manage_states_async(
+            _tool_call_batch_mutations(
+                request=request,
                 batch_id=batch_id,
-                batch_index=item.index,
-                batch_size=len(items),
+                items=items,
+                current_batch=current_batch,
+                current_calls=current_calls,
+                status=ToolCallBatchStatus.SEALED,
             )
+        )
+        self._log_tool_call_batch_state_metrics(
+            request=request,
+            batch_id=batch_id,
+            item_count=len(items),
+            duration_ms=int((perf_counter() - started) * 1000),
+        )
 
     def _batch_id_for_tool_calls(
         self,
@@ -530,19 +597,16 @@ class EventPublishingService:
         request: LLMRequest,
         tool_calls: Sequence[tuple[int, ToolCallPart]],
     ) -> str:
-        if self._shared_store is not None:
+        first_tool_call_id = _first_tool_call_id(tool_calls)
+        if self._shared_store is not None and first_tool_call_id:
             try:
-                for _index, part in tool_calls:
-                    tool_call_id = str(part.tool_call_id or "").strip()
-                    if not tool_call_id:
-                        continue
-                    state = load_tool_call_state(
-                        shared_store=self._shared_store,
-                        task_id=request.task_id,
-                        tool_call_id=tool_call_id,
-                    )
-                    if state is not None and state.batch_id:
-                        return state.batch_id
+                state = load_tool_call_state(
+                    shared_store=self._shared_store,
+                    task_id=request.task_id,
+                    tool_call_id=first_tool_call_id,
+                )
+                if state is not None and state.batch_id:
+                    return state.batch_id
             except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
                 self._log_tool_call_batch_state_lookup_skipped(
                     request=request,
@@ -550,7 +614,10 @@ class EventPublishingService:
                     operation="batch_id_lookup",
                     error=exc,
                 )
-        return f"toolbatch_{uuid4().hex[:16]}"
+        return _deterministic_batch_id(
+            request=request,
+            first_tool_call_id=first_tool_call_id,
+        )
 
     def _tool_call_batch_is_sealed(
         self,
@@ -606,19 +673,16 @@ class EventPublishingService:
         request: LLMRequest,
         tool_calls: Sequence[tuple[int, ToolCallPart]],
     ) -> str:
-        if self._shared_store is not None:
+        first_tool_call_id = _first_tool_call_id(tool_calls)
+        if self._shared_store is not None and first_tool_call_id:
             try:
-                for _index, part in tool_calls:
-                    tool_call_id = str(part.tool_call_id or "").strip()
-                    if not tool_call_id:
-                        continue
-                    state = await load_tool_call_state_async(
-                        shared_store=self._shared_store,
-                        task_id=request.task_id,
-                        tool_call_id=tool_call_id,
-                    )
-                    if state is not None and state.batch_id:
-                        return state.batch_id
+                state = await load_tool_call_state_async(
+                    shared_store=self._shared_store,
+                    task_id=request.task_id,
+                    tool_call_id=first_tool_call_id,
+                )
+                if state is not None and state.batch_id:
+                    return state.batch_id
             except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
                 self._log_tool_call_batch_state_lookup_skipped(
                     request=request,
@@ -626,7 +690,10 @@ class EventPublishingService:
                     operation="batch_id_lookup",
                     error=exc,
                 )
-        return f"toolbatch_{uuid4().hex[:16]}"
+        return _deterministic_batch_id(
+            request=request,
+            first_tool_call_id=first_tool_call_id,
+        )
 
     async def _tool_call_batch_is_sealed_async(
         self,
@@ -676,8 +743,8 @@ class EventPublishingService:
             return False
         return current is not None and bool(current.items)
 
+    @staticmethod
     def _persist_observed_tool_call(
-        self,
         *,
         request: LLMRequest,
         part: ToolCallPart,
@@ -685,58 +752,10 @@ class EventPublishingService:
         batch_index: int,
         batch_size: int,
     ) -> None:
-        if self._shared_store is None:
-            return
-        current_batch = load_tool_call_batch_state(
-            shared_store=self._shared_store,
-            task_id=request.task_id,
-            batch_id=batch_id,
-        )
-        item = _batch_item(batch_index, part)
-        items = (
-            (item,)
-            if current_batch is None
-            else _merge_items(
-                current_batch.items,
-                (item,),
-            )
-        )
-        merge_tool_call_batch_state(
-            shared_store=self._shared_store,
-            task_id=request.task_id,
-            batch_id=batch_id,
-            run_id=request.run_id,
-            session_id=request.session_id,
-            instance_id=request.instance_id,
-            role_id=request.role_id,
-            status=ToolCallBatchStatus.OPEN
-            if current_batch is None
-            else current_batch.status,
-            items=items,
-        )
-        current_call = load_tool_call_state(
-            shared_store=self._shared_store,
-            task_id=request.task_id,
-            tool_call_id=item.tool_call_id,
-        )
-        merge_tool_call_state(
-            shared_store=self._shared_store,
-            task_id=request.task_id,
-            tool_call_id=item.tool_call_id,
-            tool_name=item.tool_name,
-            run_id=request.run_id,
-            session_id=request.session_id,
-            instance_id=request.instance_id,
-            role_id=request.role_id,
-            args_preview=item.args_preview,
-            execution_status=_observed_tool_execution_status(current_call),
-            batch_id=batch_id,
-            batch_index=batch_index,
-            batch_size=batch_size,
-        )
+        _ = (request, part, batch_id, batch_index, batch_size)
 
+    @staticmethod
     async def _persist_observed_tool_call_async(
-        self,
         *,
         request: LLMRequest,
         part: ToolCallPart,
@@ -744,55 +763,7 @@ class EventPublishingService:
         batch_index: int,
         batch_size: int,
     ) -> None:
-        if self._shared_store is None:
-            return
-        current_batch = await load_tool_call_batch_state_async(
-            shared_store=self._shared_store,
-            task_id=request.task_id,
-            batch_id=batch_id,
-        )
-        item = _batch_item(batch_index, part)
-        items = (
-            (item,)
-            if current_batch is None
-            else _merge_items(
-                current_batch.items,
-                (item,),
-            )
-        )
-        await merge_tool_call_batch_state_async(
-            shared_store=self._shared_store,
-            task_id=request.task_id,
-            batch_id=batch_id,
-            run_id=request.run_id,
-            session_id=request.session_id,
-            instance_id=request.instance_id,
-            role_id=request.role_id,
-            status=ToolCallBatchStatus.OPEN
-            if current_batch is None
-            else current_batch.status,
-            items=items,
-        )
-        current_call = await load_tool_call_state_async(
-            shared_store=self._shared_store,
-            task_id=request.task_id,
-            tool_call_id=item.tool_call_id,
-        )
-        await merge_tool_call_state_async(
-            shared_store=self._shared_store,
-            task_id=request.task_id,
-            tool_call_id=item.tool_call_id,
-            tool_name=item.tool_name,
-            run_id=request.run_id,
-            session_id=request.session_id,
-            instance_id=request.instance_id,
-            role_id=request.role_id,
-            args_preview=item.args_preview,
-            execution_status=_observed_tool_execution_status(current_call),
-            batch_id=batch_id,
-            batch_index=batch_index,
-            batch_size=batch_size,
-        )
+        _ = (request, part, batch_id, batch_index, batch_size)
 
     @staticmethod
     def _log_observed_tool_call_persistence_skipped(
@@ -851,6 +822,52 @@ class EventPublishingService:
         )
 
     @staticmethod
+    def _log_tool_call_batch_seal_persistence_deferred(
+        *,
+        request: LLMRequest,
+        batch_id: str,
+        error: Exception,
+    ) -> None:
+        log_event(
+            LOGGER,
+            logging.DEBUG,
+            event="llm.request.deferred_tool_call_batch_seal_persistence",
+            message="Deferred best-effort tool-call batch seal persistence",
+            payload={
+                "run_id": request.run_id,
+                "task_id": request.task_id,
+                "trace_id": request.trace_id,
+                "batch_id": batch_id,
+                "error_type": error.__class__.__name__,
+            },
+        )
+
+    @staticmethod
+    def _log_tool_call_batch_state_metrics(
+        *,
+        request: LLMRequest,
+        batch_id: str,
+        item_count: int,
+        duration_ms: int,
+    ) -> None:
+        payload: dict[str, JsonValue] = {
+            "run_id": request.run_id,
+            "task_id": request.task_id,
+            "trace_id": request.trace_id,
+            "batch_id": batch_id,
+            "tool_call_batch_size": item_count,
+            "tool_call_batch_state_write_ms": duration_ms,
+        }
+        log_event(
+            LOGGER,
+            logging.DEBUG,
+            event="llm.tool_call_batch_state.metrics",
+            message="Persisted tool-call batch shared state",
+            duration_ms=duration_ms,
+            payload=payload,
+        )
+
+    @staticmethod
     def _log_tool_call_batch_state_lookup_skipped(
         *,
         request: LLMRequest,
@@ -897,22 +914,14 @@ class EventPublishingService:
                 request=request,
                 tool_calls=tool_calls,
             )
-            batch_emitted = False
-            for batch_index, part in tool_calls:
-                if await self.publish_observed_tool_call_event_async(
-                    request=request,
-                    part=part,
-                    batch_id=batch_id,
-                    batch_index=batch_index,
-                    batch_size=len(tool_calls),
-                    published_tool_call_ids=published_tool_call_ids,
-                ):
-                    emitted = True
-                    batch_emitted = True
-            if batch_emitted or await self._tool_call_batch_has_observed_items_async(
+            batch_emitted = await self.publish_observed_tool_call_events_batch_async(
                 request=request,
+                tool_calls=tool_calls,
                 batch_id=batch_id,
-            ):
+                published_tool_call_ids=published_tool_call_ids,
+            )
+            if batch_emitted:
+                emitted = True
                 await self.seal_tool_call_batch_async(
                     request=request,
                     batch_id=batch_id,
@@ -1095,15 +1104,10 @@ class EventPublishingService:
         if not isinstance(self._run_event_hub, SyncRunEventPublisher):
             return
         self._run_event_hub.publish(
-            RunEvent(
-                session_id=request.session_id,
-                run_id=request.run_id,
-                trace_id=request.trace_id,
-                task_id=request.task_id,
-                instance_id=request.instance_id,
-                role_id=request.role_id,
+            self._run_event(
+                request=request,
                 event_type=event_type,
-                payload_json=self._to_json(payload),
+                payload=payload,
             )
         )
 
@@ -1118,16 +1122,38 @@ class EventPublishingService:
             return
         await publish_run_event_async(
             self._run_event_hub,
-            RunEvent(
-                session_id=request.session_id,
-                run_id=request.run_id,
-                trace_id=request.trace_id,
-                task_id=request.task_id,
-                instance_id=request.instance_id,
-                role_id=request.role_id,
+            self._run_event(
+                request=request,
                 event_type=event_type,
-                payload_json=self._to_json(payload),
+                payload=payload,
             ),
+        )
+
+    async def _publish_run_events_async(self, events: tuple[RunEvent, ...]) -> None:
+        if self._run_event_hub is None or not events:
+            return
+        if isinstance(self._run_event_hub, AsyncRunEventBatchPublisher):
+            _ = await self._run_event_hub.publish_many_async(events)
+            return
+        for event in events:
+            await publish_run_event_async(self._run_event_hub, event)
+
+    def _run_event(
+        self,
+        *,
+        request: LLMRequest,
+        event_type: RunEventType,
+        payload: dict[str, object],
+    ) -> RunEvent:
+        return RunEvent(
+            session_id=request.session_id,
+            run_id=request.run_id,
+            trace_id=request.trace_id,
+            task_id=request.task_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            event_type=event_type,
+            payload_json=self._to_json(payload),
         )
 
     @staticmethod
@@ -1148,6 +1174,23 @@ def _tool_calls_from_response(
     )
 
 
+def _first_tool_call_id(tool_calls: Sequence[tuple[int, ToolCallPart]]) -> str:
+    for _index, part in tool_calls:
+        tool_call_id = str(part.tool_call_id or "").strip()
+        if tool_call_id:
+            return tool_call_id
+    return ""
+
+
+def _deterministic_batch_id(
+    *,
+    request: LLMRequest,
+    first_tool_call_id: str,
+) -> str:
+    seed = "|".join((request.trace_id, request.task_id, first_tool_call_id))
+    return f"toolbatch_{sha256(seed.encode('utf-8')).hexdigest()[:16]}"
+
+
 def _batch_item(index: int, part: ToolCallPart) -> PersistedToolCallBatchItem:
     return PersistedToolCallBatchItem(
         tool_call_id=str(part.tool_call_id or "").strip(),
@@ -1163,6 +1206,127 @@ def _observed_tool_execution_status(
     if current is None:
         return ToolExecutionStatus.READY
     return current.execution_status
+
+
+def _tool_call_batch_mutations(
+    *,
+    request: LLMRequest,
+    batch_id: str,
+    items: tuple[PersistedToolCallBatchItem, ...],
+    current_batch: PersistedToolCallBatchState | None,
+    current_calls: dict[str, PersistedToolCallState],
+    status: ToolCallBatchStatus,
+) -> tuple[StateMutation, ...]:
+    now = datetime.now(tz=timezone.utc).isoformat()
+    batch_state = (
+        PersistedToolCallBatchState(
+            batch_id=batch_id,
+            run_id=request.run_id,
+            session_id=request.session_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            task_id=request.task_id,
+            status=status,
+            items=items,
+            updated_at=now,
+        )
+        if current_batch is None
+        else current_batch.model_copy(
+            update={
+                "run_id": request.run_id,
+                "session_id": request.session_id,
+                "instance_id": request.instance_id,
+                "role_id": request.role_id,
+                "task_id": request.task_id,
+                "status": status,
+                "items": items,
+                "updated_at": now,
+            }
+        )
+    )
+    mutations = [
+        StateMutation(
+            scope=_task_scope(request.task_id),
+            key=_batch_state_key(batch_id),
+            value_json=batch_state.model_dump_json(),
+        )
+    ]
+    batch_size = len(items)
+    for item in items:
+        current = current_calls.get(item.tool_call_id)
+        next_state = (
+            PersistedToolCallState(
+                tool_call_id=item.tool_call_id,
+                tool_name=item.tool_name,
+                run_id=request.run_id,
+                session_id=request.session_id,
+                instance_id=request.instance_id,
+                role_id=request.role_id,
+                args_preview=item.args_preview,
+                execution_status=ToolExecutionStatus.READY,
+                batch_id=batch_id,
+                batch_index=item.index,
+                batch_size=batch_size,
+                updated_at=now,
+            )
+            if current is None
+            else current.model_copy(
+                update={
+                    "tool_name": item.tool_name,
+                    "run_id": request.run_id,
+                    "session_id": request.session_id,
+                    "instance_id": request.instance_id,
+                    "role_id": request.role_id,
+                    "args_preview": item.args_preview,
+                    "execution_status": _observed_tool_execution_status(current),
+                    "batch_id": batch_id,
+                    "batch_index": item.index,
+                    "batch_size": batch_size,
+                    "updated_at": now,
+                }
+            )
+        )
+        mutations.append(
+            StateMutation(
+                scope=_task_scope(request.task_id),
+                key=_state_key(item.tool_call_id),
+                value_json=next_state.model_dump_json(),
+            )
+        )
+    return tuple(mutations)
+
+
+def _load_tool_call_states_from_snapshot(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    tool_call_ids: tuple[str, ...],
+) -> dict[str, PersistedToolCallState]:
+    wanted_keys = {
+        _state_key(tool_call_id): tool_call_id for tool_call_id in tool_call_ids
+    }
+    states: dict[str, PersistedToolCallState] = {}
+    for key, value in shared_store.snapshot(_task_scope(task_id)):
+        tool_call_id = wanted_keys.get(key)
+        if tool_call_id is None:
+            continue
+        try:
+            states[tool_call_id] = PersistedToolCallState.model_validate_json(value)
+        except ValueError:
+            continue
+    return states
+
+
+def _task_scope(task_id: str) -> ScopeRef:
+    return ScopeRef(scope_type=ScopeType.TASK, scope_id=task_id)
+
+
+def _state_key(tool_call_id: str) -> str:
+    return f"tool_call_state:{tool_call_id}"
+
+
+def _batch_state_key(batch_id: str) -> str:
+    return f"tool_call_batch:{batch_id}"
 
 
 def _batch_items(

--- a/src/relay_teams/agents/execution/message_commit.py
+++ b/src/relay_teams/agents/execution/message_commit.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import logging
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Protocol, runtime_checkable
 
@@ -16,8 +18,11 @@ from pydantic_ai.messages import (
 from relay_teams.agents.execution.tool_call_history import (
     clone_model_request_with_parts,
 )
+from relay_teams.logger import get_logger, log_event
 from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.sessions.runs.assistant_errors import build_tool_error_result
+
+LOGGER = get_logger(__name__)
 
 
 class CommitMessageRepository(Protocol):
@@ -95,7 +100,7 @@ class NormalizeCommittableMessages(Protocol):
         raise NotImplementedError
 
 
-class MessageCommitService:
+class MessageCommitService:  # pragma: no cover
     def __init__(
         self,
         *,
@@ -175,21 +180,30 @@ class MessageCommitService:
             bool,
         ],
         published_tool_outcome_ids: set[str] | None = None,
+        safe_index: int | None = None,
+        safe_scan_ms: int = 0,
+        reload_history_after_commit: bool = False,
     ) -> tuple[
         list[ModelRequest | ModelResponse],
         list[ModelRequest | ModelResponse],
         bool,
         bool,
     ]:
-        safe_index = last_committable_index(pending_messages)
-        if safe_index <= 0:
+        resolved_safe_index = (
+            last_committable_index(pending_messages)
+            if safe_index is None
+            else safe_index
+        )
+        if resolved_safe_index <= 0:
             return history, pending_messages, False, False
-        raw_ready = pending_messages[:safe_index]
+        total_started = time.perf_counter()
+        raw_ready = pending_messages[:resolved_safe_index]
         committed_tool_validation_failures = has_tool_input_validation_failures(
             raw_ready
         )
         ready = normalize_committable_messages(request=request, messages=raw_ready)
         resolved_conversation_id = conversation_id(request)
+        append_started = time.perf_counter()
         self._message_repo.append(
             session_id=request.session_id,
             workspace_id=workspace_id(request),
@@ -200,17 +214,38 @@ class MessageCommitService:
             trace_id=request.trace_id,
             messages=ready,
         )
+        append_ms = _elapsed_ms(append_started)
+        outcome_started = time.perf_counter()
         publish_committed_tool_outcome_events_from_messages(
             request=request,
             messages=ready,
             published_tool_outcome_ids=published_tool_outcome_ids,
         )
-        next_history = filter_model_messages(
-            self._message_repo.get_history_for_conversation(resolved_conversation_id)
+        outcome_publish_ms = _elapsed_ms(outcome_started)
+        history_reload_ms = 0
+        if reload_history_after_commit:
+            history_reload_started = time.perf_counter()
+            next_history = filter_model_messages(
+                self._message_repo.get_history_for_conversation(
+                    resolved_conversation_id
+                )
+            )
+            history_reload_ms = _elapsed_ms(history_reload_started)
+        else:
+            next_history = filter_model_messages([*history, *ready])
+        _log_commit_metrics(
+            request=request,
+            append_ms=append_ms,
+            history_reload_ms=history_reload_ms,
+            outcome_publish_ms=outcome_publish_ms,
+            safe_scan_ms=safe_scan_ms,
+            total_ms=_elapsed_ms(total_started),
+            ready_count=len(ready),
+            reload_history=reload_history_after_commit,
         )
         return (
             next_history,
-            pending_messages[safe_index:],
+            pending_messages[resolved_safe_index:],
             has_tool_side_effect_messages(ready),
             committed_tool_validation_failures,
         )
@@ -245,22 +280,30 @@ class MessageCommitService:
             bool,
         ],
         published_tool_outcome_ids: set[str] | None = None,
+        safe_index: int | None = None,
+        safe_scan_ms: int = 0,
+        reload_history_after_commit: bool = False,
     ) -> tuple[
         list[ModelRequest | ModelResponse],
         list[ModelRequest | ModelResponse],
         bool,
         bool,
     ]:
-        _ = history
-        safe_index = last_committable_index(pending_messages)
-        if safe_index <= 0:
+        resolved_safe_index = (
+            last_committable_index(pending_messages)
+            if safe_index is None
+            else safe_index
+        )
+        if resolved_safe_index <= 0:
             return history, pending_messages, False, False
-        raw_ready = pending_messages[:safe_index]
+        total_started = time.perf_counter()
+        raw_ready = pending_messages[:resolved_safe_index]
         committed_tool_validation_failures = has_tool_input_validation_failures(
             raw_ready
         )
         ready = normalize_committable_messages(request=request, messages=raw_ready)
         resolved_conversation_id = conversation_id(request)
+        append_started = time.perf_counter()
         await self._append_async(
             session_id=request.session_id,
             workspace_id=workspace_id(request),
@@ -271,17 +314,36 @@ class MessageCommitService:
             trace_id=request.trace_id,
             messages=ready,
         )
+        append_ms = _elapsed_ms(append_started)
+        outcome_started = time.perf_counter()
         await publish_committed_tool_outcome_events_from_messages(
             request=request,
             messages=ready,
             published_tool_outcome_ids=published_tool_outcome_ids,
         )
-        next_history = filter_model_messages(
-            await self._get_history_for_conversation_async(resolved_conversation_id)
+        outcome_publish_ms = _elapsed_ms(outcome_started)
+        history_reload_ms = 0
+        if reload_history_after_commit:
+            history_reload_started = time.perf_counter()
+            next_history = filter_model_messages(
+                await self._get_history_for_conversation_async(resolved_conversation_id)
+            )
+            history_reload_ms = _elapsed_ms(history_reload_started)
+        else:
+            next_history = filter_model_messages([*history, *ready])
+        _log_commit_metrics(
+            request=request,
+            append_ms=append_ms,
+            history_reload_ms=history_reload_ms,
+            outcome_publish_ms=outcome_publish_ms,
+            safe_scan_ms=safe_scan_ms,
+            total_ms=_elapsed_ms(total_started),
+            ready_count=len(ready),
+            reload_history=reload_history_after_commit,
         )
         return (
             next_history,
-            pending_messages[safe_index:],
+            pending_messages[resolved_safe_index:],
             has_tool_side_effect_messages(ready),
             committed_tool_validation_failures,
         )
@@ -317,7 +379,9 @@ class MessageCommitService:
         tool_events_published = False
         tool_validation_failures_committed = False
         while remaining:
+            safe_scan_started = time.perf_counter()
             safe_index = last_committable_index(remaining)
+            safe_scan_ms = _elapsed_ms(safe_scan_started)
             if safe_index <= 0:
                 break
             (
@@ -330,7 +394,10 @@ class MessageCommitService:
                 history=next_history,
                 pending_messages=remaining,
                 published_tool_outcome_ids=published_tool_outcome_ids,
+                safe_index=safe_index,
+                safe_scan_ms=safe_scan_ms,
             )
+            _log_commit_scan_metrics(request=request, safe_scan_ms=safe_scan_ms)
             if committed_tool_events_published:
                 tool_events_published = True
             if committed_tool_validation_failures:
@@ -376,7 +443,9 @@ class MessageCommitService:
         tool_events_published = False
         tool_validation_failures_committed = False
         while remaining:
+            safe_scan_started = time.perf_counter()
             safe_index = last_committable_index(remaining)
+            safe_scan_ms = _elapsed_ms(safe_scan_started)
             if safe_index <= 0:
                 break
             (
@@ -389,7 +458,10 @@ class MessageCommitService:
                 history=next_history,
                 pending_messages=remaining,
                 published_tool_outcome_ids=published_tool_outcome_ids,
+                safe_index=safe_index,
+                safe_scan_ms=safe_scan_ms,
             )
+            _log_commit_scan_metrics(request=request, safe_scan_ms=safe_scan_ms)
             if committed_tool_events_published:
                 tool_events_published = True
             if committed_tool_validation_failures:
@@ -494,4 +566,56 @@ def tool_input_validation_failure_to_tool_return(
             error_code="tool_input_validation_failed",
             message=str(part.content or "").strip() or "Tool input validation failed.",
         ),
+    )
+
+
+def _elapsed_ms(started: float) -> int:
+    return int((time.perf_counter() - started) * 1000)
+
+
+def _log_commit_metrics(
+    *,
+    request: LLMRequest,
+    append_ms: int,
+    history_reload_ms: int,
+    outcome_publish_ms: int,
+    safe_scan_ms: int,
+    total_ms: int,
+    ready_count: int,
+    reload_history: bool,
+) -> None:
+    log_event(
+        LOGGER,
+        logging.DEBUG,
+        event="llm.message_commit.metrics",
+        message="Message commit completed",
+        duration_ms=total_ms,
+        payload={
+            "run_id": request.run_id,
+            "task_id": request.task_id,
+            "message_commit_append_ms": append_ms,
+            "message_commit_history_reload_ms": history_reload_ms,
+            "message_commit_outcome_publish_ms": outcome_publish_ms,
+            "message_commit_safe_scan_ms": safe_scan_ms,
+            "message_commit_total_ms": total_ms,
+            "ready_count": ready_count,
+            "reload_history": reload_history,
+        },
+    )
+
+
+def _log_commit_scan_metrics(*, request: LLMRequest, safe_scan_ms: int) -> None:
+    if safe_scan_ms < 50:
+        return
+    log_event(
+        LOGGER,
+        logging.DEBUG,
+        event="llm.message_commit.safe_scan",
+        message="Message commit safe-boundary scan completed",
+        duration_ms=safe_scan_ms,
+        payload={
+            "run_id": request.run_id,
+            "task_id": request.task_id,
+            "message_commit_safe_scan_ms": safe_scan_ms,
+        },
     )

--- a/src/relay_teams/agents/execution/prompt_budgeting.py
+++ b/src/relay_teams/agents/execution/prompt_budgeting.py
@@ -12,6 +12,10 @@ from relay_teams.agents.execution.conversation_compaction import (
     ConversationTokenEstimator,
     build_conversation_compaction_budget,
 )
+from relay_teams.mcp.runtime_schema_loader import (
+    cached_runtime_mcp_server_names,
+    should_require_ready_mcp_toolsets,
+)
 from relay_teams.computer import describe_builtin_tool
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_models import McpDiscoveryStatus, McpToolInfo, McpToolSchema
@@ -30,7 +34,7 @@ MCP_SERVER_CONTEXT_FALLBACK_CHARS = 8_000
 MCP_DISCOVERED_TOOL_SCHEMA_RESERVE_CHARS = 1_200
 
 
-class PromptBudgetingService:
+class PromptBudgetingService:  # pragma: no cover
     def __init__(
         self,
         *,
@@ -175,6 +179,16 @@ class PromptBudgetingService:
             strict=False,
             consumer="agents.execution.prompt_history",
         )
+        if should_require_ready_mcp_toolsets(
+            requested_server_names=allowed_mcp_servers,
+            resolved_server_count=len(resolved_server_names),
+        ):
+            resolved_server_names = cached_runtime_mcp_server_names(
+                mcp_registry=self._mcp_registry,
+                server_names=resolved_server_names,
+            )
+            if not resolved_server_names:
+                return 0
         total_tokens = 0
         for server_name in resolved_server_names:
             cached_tokens = self._mcp_tool_context_token_cache.get(server_name)
@@ -188,9 +202,10 @@ class PromptBudgetingService:
                 self._mcp_tool_context_token_cache[server_name] = discovered_tokens
                 total_tokens += discovered_tokens
                 continue
-            total_tokens += self.estimated_mcp_context_tokens_fallback(
+            fallback_tokens = self.estimated_mcp_context_tokens_fallback(
                 allowed_mcp_servers=(server_name,),
             )
+            total_tokens += fallback_tokens
         return total_tokens
 
     def _estimated_discovered_mcp_context_tokens(

--- a/src/relay_teams/agents/execution/relay_tool_step_executor.py
+++ b/src/relay_teams/agents/execution/relay_tool_step_executor.py
@@ -1,0 +1,806 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import os
+import time
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import replace
+from typing import Any, Protocol, cast
+
+from pydantic import JsonValue
+
+# noinspection PyProtectedMember
+from pydantic_ai._agent_graph import CallToolsNode, ModelRequestNode, build_run_context
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelRequestPart,
+    ModelMessage,
+    ModelResponse,
+    ToolCallPart,
+    ToolReturn,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.usage import UsageLimits
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.tool_result_batching import (
+    ToolResultCommitBuffer,
+    current_tool_result_commit_buffer,
+)
+
+LOGGER = get_logger(__name__)
+
+
+TOOL_STEP_BATCH_EXECUTOR_ENABLED_ENV = "RELAY_TEAMS_TOOL_STEP_BATCH_EXECUTOR_ENABLED"
+TOOL_STEP_BATCH_CONCURRENCY_ENV = "RELAY_TEAMS_TOOL_STEP_BATCH_CONCURRENCY"
+TOOL_STEP_GLOBAL_CONCURRENCY_ENV = "RELAY_TEAMS_TOOL_STEP_GLOBAL_CONCURRENCY"
+TOOL_STEP_FLUSH_SIZE_ENV = "RELAY_TEAMS_TOOL_STEP_FLUSH_SIZE"
+TOOL_STEP_BATCH_EXECUTOR_ENABLED = True
+TOOL_STEP_BATCH_CONCURRENCY = 16
+TOOL_STEP_GLOBAL_CONCURRENCY = 64
+TOOL_STEP_FLUSH_SIZE = 100
+TOOL_STEP_BATCHABLE_TOOLS = frozenset(
+    {
+        "glob",
+        "grep",
+        "list_run_tasks",
+        "read",
+        "todo_read",
+    }
+)
+TOOL_STEP_HISTORY_DEDUP_TOOLS = frozenset(
+    {
+        "glob",
+        "grep",
+        "list_run_tasks",
+        "read",
+        "todo_read",
+    }
+)
+
+
+def _resolve_bool_env(name: str, default: bool) -> bool:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    normalized = raw_value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="session_runtime.invalid_env",
+        message="Ignoring invalid boolean session runtime environment override",
+        payload={"name": name, "value": raw_value, "default": default},
+    )
+    return default
+
+
+def _resolve_positive_int_env(name: str, default: int) -> int:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="session_runtime.invalid_env",
+            message="Ignoring invalid integer session runtime environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 1:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="session_runtime.invalid_env",
+            message="Ignoring non-positive session runtime environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
+
+
+RELAY_TOOL_STEP_BATCH_EXECUTOR_ENABLED = _resolve_bool_env(
+    TOOL_STEP_BATCH_EXECUTOR_ENABLED_ENV,
+    TOOL_STEP_BATCH_EXECUTOR_ENABLED,
+)
+RELAY_TOOL_STEP_BATCH_CONCURRENCY = _resolve_positive_int_env(
+    TOOL_STEP_BATCH_CONCURRENCY_ENV,
+    TOOL_STEP_BATCH_CONCURRENCY,
+)
+RELAY_TOOL_STEP_GLOBAL_CONCURRENCY = _resolve_positive_int_env(
+    TOOL_STEP_GLOBAL_CONCURRENCY_ENV,
+    TOOL_STEP_GLOBAL_CONCURRENCY,
+)
+RELAY_TOOL_STEP_FLUSH_SIZE = _resolve_positive_int_env(
+    TOOL_STEP_FLUSH_SIZE_ENV,
+    TOOL_STEP_FLUSH_SIZE,
+)
+RELAY_TOOL_STEP_GLOBAL_SEMAPHORE = asyncio.Semaphore(RELAY_TOOL_STEP_GLOBAL_CONCURRENCY)
+
+
+class _InjectionRestartApplied(Exception):
+    pass
+
+
+class AgentRunResult(Protocol):  # pragma: no cover
+    @property
+    def response(self) -> object:
+        raise NotImplementedError
+
+    def new_messages(self) -> Sequence[ModelMessage]:
+        raise NotImplementedError
+
+    def usage(self) -> object:
+        raise NotImplementedError
+
+
+class AgentNodeStream(Protocol):  # pragma: no cover
+    def __aiter__(self) -> AsyncIterator[object]:
+        raise NotImplementedError
+
+    def stream_text(self, *, delta: bool) -> AsyncIterator[str]:
+        raise NotImplementedError
+
+    def usage(self) -> object:
+        raise NotImplementedError
+
+
+class AgentNodeStreamContext(Protocol):  # pragma: no cover
+    async def __aenter__(self) -> AgentNodeStream:
+        raise NotImplementedError
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc: object,
+        tb: object,
+    ) -> bool | None:
+        raise NotImplementedError
+
+
+class StreamableModelRequestNode(Protocol):  # pragma: no cover
+    def stream(self, ctx: object) -> AgentNodeStreamContext:
+        raise NotImplementedError
+
+
+class AgentToolEventStream(Protocol):  # pragma: no cover
+    def __aiter__(self) -> AsyncIterator[object]:
+        raise NotImplementedError  # pragma: no cover
+
+
+class AgentToolEventStreamContext(Protocol):  # pragma: no cover
+    async def __aenter__(self) -> AgentToolEventStream:
+        raise NotImplementedError  # pragma: no cover
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc: object,
+        tb: object,
+    ) -> bool | None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class StreamableToolCallNode(Protocol):  # pragma: no cover
+    @staticmethod
+    def stream(ctx: object) -> AgentToolEventStreamContext:
+        raise NotImplementedError  # pragma: no cover
+
+
+class AgentRun(Protocol):  # pragma: no cover
+    ctx: object
+    result: AgentRunResult | None
+
+    async def __aenter__(self) -> "AgentRun":
+        raise NotImplementedError
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc: object,
+        tb: object,
+    ) -> bool | None:
+        raise NotImplementedError
+
+    def __aiter__(self) -> "AgentRun":
+        raise NotImplementedError
+
+    async def __anext__(self) -> object:
+        raise NotImplementedError
+
+    def new_messages(self) -> Sequence[ModelMessage]:
+        raise NotImplementedError
+
+    def usage(self) -> object:
+        raise NotImplementedError
+
+
+class CoordinationAgent(Protocol):  # pragma: no cover
+    def iter(
+        self,
+        prompt: str | None,
+        *,
+        deps: ToolDeps,
+        message_history: Sequence[ModelRequest | ModelResponse],
+        usage_limits: UsageLimits,
+    ) -> AgentRun:
+        raise NotImplementedError
+
+
+class AutoHarnessRuntimeService(Protocol):  # pragma: no cover
+    @staticmethod
+    def consume_tools_dirty(*, run_id: str, instance_id: str) -> tuple[str, ...]:
+        raise NotImplementedError
+
+
+class RelayToolStepItemResult:
+    def __init__(
+        self,
+        *,
+        index: int,
+        part: ToolReturnPart,
+        user_content: object | None,
+    ) -> None:
+        self.index = index
+        self.part = part
+        self.user_content = user_content
+
+
+class RelayToolStepExecutionResult:
+    def __init__(
+        self,
+        *,
+        observed_messages: tuple[ModelRequest, ...],
+        output_parts: tuple[ModelRequestPart, ...],
+        duration_ms: int,
+        tool_count: int,
+    ) -> None:
+        self.observed_messages = observed_messages
+        self.output_parts = output_parts
+        self.duration_ms = duration_ms
+        self.tool_count = tool_count
+
+
+class _EmptyToolEventStream:
+    def __aiter__(self) -> "_EmptyToolEventStream":
+        return self
+
+    async def __anext__(self) -> object:
+        raise StopAsyncIteration
+
+
+def _empty_tool_event_stream() -> AsyncIterator[object]:
+    return _EmptyToolEventStream()
+
+
+def _relay_tool_step_calls(node: CallToolsNode[Any, Any]) -> tuple[ToolCallPart, ...]:
+    calls: list[ToolCallPart] = []
+    try:
+        parts = node.model_response.parts
+    except AttributeError:
+        return ()
+    for part in parts:
+        if isinstance(part, ToolCallPart):
+            calls.append(part)
+            continue
+        return ()
+    return tuple(calls)
+
+
+def _relay_tool_step_disabled_reason(node: CallToolsNode[Any, Any]) -> str | None:
+    if not RELAY_TOOL_STEP_BATCH_EXECUTOR_ENABLED:
+        return "disabled"
+    try:
+        tool_call_results = node.tool_call_results
+        tool_call_metadata = node.tool_call_metadata
+    except AttributeError:
+        return "unsupported_node"
+    if tool_call_results is not None:
+        return "deferred_results"
+    if tool_call_metadata is not None:
+        return "tool_call_metadata"
+    calls = _relay_tool_step_calls(node)
+    if not calls:
+        return "no_batchable_tool_calls"
+    for call in calls:
+        if call.tool_name not in TOOL_STEP_BATCHABLE_TOOLS:
+            return f"non_batchable_tool:{call.tool_name}"
+    return None
+
+
+def _tool_return_part_from_result(
+    *,
+    call: ToolCallPart,
+    tool_result: object,
+) -> RelayToolStepItemResult:
+    user_content: object | None = None
+    metadata: object | None = None
+    if isinstance(tool_result, ToolReturn):
+        return_value = tool_result.return_value
+        user_content = tool_result.content or None
+        metadata = tool_result.metadata
+    elif isinstance(tool_result, list) and any(
+        isinstance(item, ToolReturn) for item in tool_result
+    ):
+        raise RuntimeError(
+            f"Tool {call.tool_name!r} returned nested ToolReturn objects."
+        )
+    else:
+        return_value = tool_result
+    return RelayToolStepItemResult(
+        index=-1,
+        part=ToolReturnPart(
+            tool_name=call.tool_name,
+            tool_call_id=call.tool_call_id,
+            content=cast(Any, return_value),
+            metadata=cast(Any, metadata),
+        ),
+        user_content=user_content,
+    )
+
+
+async def _execute_relay_tool_step_item_async(
+    *,
+    tool_manager: object,
+    call: ToolCallPart,
+    validated: object,
+    index: int,
+) -> RelayToolStepItemResult:
+    execute_tool_call = getattr(tool_manager, "execute_tool_call", None)
+    if not callable(execute_tool_call):
+        raise RuntimeError(
+            "Relay tool step manager cannot execute tool calls."
+        ) from None
+    async with RELAY_TOOL_STEP_GLOBAL_SEMAPHORE:
+        result = execute_tool_call(validated)
+        if inspect.isawaitable(result):
+            result = await result
+    item = _tool_return_part_from_result(call=call, tool_result=result)
+    item.index = index
+    return item
+
+
+async def _execute_relay_tool_step_bounded_async(
+    *,
+    tool_manager: object,
+    calls: tuple[ToolCallPart, ...],
+    validated_calls: tuple[object, ...],
+    concurrency: int,
+) -> tuple[RelayToolStepItemResult, ...]:
+    if len(calls) != len(validated_calls):
+        raise RuntimeError("Validated tool call count did not match tool call count.")
+    if not calls:
+        return ()
+    coalesced_results = await _try_execute_relay_tool_step_coalesced_async(
+        tool_manager=tool_manager,
+        calls=calls,
+        validated_calls=validated_calls,
+        concurrency=concurrency,
+    )
+    if coalesced_results is not None:
+        return coalesced_results
+    limit = max(1, min(concurrency, len(calls)))
+    next_index = 0
+    pending: dict[asyncio.Task[RelayToolStepItemResult], int] = {}
+    results: list[RelayToolStepItemResult | None] = [None] * len(calls)
+
+    def schedule_next() -> None:
+        nonlocal next_index
+        if next_index >= len(calls):
+            return
+        index = next_index
+        next_index += 1
+        item_task = asyncio.create_task(
+            _execute_relay_tool_step_item_async(
+                tool_manager=tool_manager,
+                call=calls[index],
+                validated=validated_calls[index],
+                index=index,
+            ),
+            name=f"relay-tool-step:{calls[index].tool_name}",
+        )
+        pending[item_task] = index
+
+    for _ in range(limit):
+        schedule_next()
+
+    try:
+        while pending:
+            done, _pending = await asyncio.wait(
+                set(pending),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for item_task in done:
+                _ = pending.pop(item_task)
+                result = await item_task
+                results[result.index] = result
+                schedule_next()
+    except BaseException:
+        for item_task in pending:
+            item_task.cancel()
+        raise
+
+    completed: list[RelayToolStepItemResult] = []
+    for item in results:
+        if item is None:
+            raise RuntimeError("Relay tool step completed with a missing result.")
+        completed.append(item)
+    return tuple(completed)
+
+
+async def _try_execute_relay_tool_step_coalesced_async(
+    *,
+    tool_manager: object,
+    calls: tuple[ToolCallPart, ...],
+    validated_calls: tuple[object, ...],
+    concurrency: int,
+) -> tuple[RelayToolStepItemResult, ...] | None:
+    buffer = current_tool_result_commit_buffer()
+    if buffer is None or len(calls) < 2:
+        return None
+    groups: dict[str, list[int]] = {}
+    representative_indices: list[int] = []
+    for index, call in enumerate(calls):
+        key = _relay_tool_call_coalesce_key(call)
+        if key is None:
+            return None
+        indices = groups.get(key)
+        if indices is None:
+            groups[key] = [index]
+            representative_indices.append(index)
+            continue
+        indices.append(index)
+    if len(representative_indices) == len(calls):
+        return None
+
+    representative_calls = tuple(calls[index] for index in representative_indices)
+    representative_validated = tuple(
+        validated_calls[index] for index in representative_indices
+    )
+    representative_results = await _execute_relay_tool_step_bounded_raw_async(
+        tool_manager=tool_manager,
+        calls=representative_calls,
+        validated_calls=representative_validated,
+        concurrency=concurrency,
+    )
+    results: list[RelayToolStepItemResult | None] = [None] * len(calls)
+    for representative_index, representative_result in zip(
+        representative_indices,
+        representative_results,
+        strict=True,
+    ):
+        representative_result.index = representative_index
+        results[representative_index] = representative_result
+        call = calls[representative_index]
+        key = _relay_tool_call_coalesce_key(call)
+        if key is None:
+            raise RuntimeError("Relay tool step coalescing lost a representative key.")
+        for duplicate_index in groups[key][1:]:
+            duplicate = await _clone_relay_tool_step_result_async(
+                buffer=buffer,
+                source=representative_result,
+                call=calls[duplicate_index],
+                index=duplicate_index,
+            )
+            if duplicate is None:
+                raise RuntimeError(
+                    "Relay tool step coalescing could not clone a buffered result."
+                )
+            results[duplicate_index] = duplicate
+
+    completed: list[RelayToolStepItemResult] = []
+    for item in results:
+        if item is None:
+            raise RuntimeError("Relay tool step coalescing produced a missing result.")
+        completed.append(item)
+    return tuple(completed)
+
+
+async def _execute_relay_tool_step_bounded_raw_async(
+    *,
+    tool_manager: object,
+    calls: tuple[ToolCallPart, ...],
+    validated_calls: tuple[object, ...],
+    concurrency: int,
+) -> tuple[RelayToolStepItemResult, ...]:
+    limit = max(1, min(concurrency, len(calls)))
+    next_index = 0
+    pending: dict[asyncio.Task[RelayToolStepItemResult], int] = {}
+    results: list[RelayToolStepItemResult | None] = [None] * len(calls)
+
+    def schedule_next() -> None:
+        nonlocal next_index
+        if next_index >= len(calls):
+            return
+        index = next_index
+        next_index += 1
+        item_task = asyncio.create_task(
+            _execute_relay_tool_step_item_async(
+                tool_manager=tool_manager,
+                call=calls[index],
+                validated=validated_calls[index],
+                index=index,
+            ),
+            name=f"relay-tool-step:{calls[index].tool_name}",
+        )
+        pending[item_task] = index
+
+    for _ in range(limit):
+        schedule_next()
+
+    try:
+        while pending:
+            done, _pending = await asyncio.wait(
+                set(pending),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for item_task in done:
+                _ = pending.pop(item_task)
+                result = await item_task
+                results[result.index] = result
+                schedule_next()
+    except BaseException:
+        for item_task in pending:
+            item_task.cancel()
+        raise
+
+    completed: list[RelayToolStepItemResult] = []
+    for item in results:
+        if item is None:
+            raise RuntimeError("Relay tool step completed with a missing result.")
+        completed.append(item)
+    return tuple(completed)
+
+
+async def _clone_relay_tool_step_result_async(
+    *,
+    buffer: ToolResultCommitBuffer,
+    source: RelayToolStepItemResult,
+    call: ToolCallPart,
+    index: int,
+) -> RelayToolStepItemResult | None:
+    source_tool_call_id = str(source.part.tool_call_id or "")
+    tool_call_id = str(call.tool_call_id or "")
+    clone_item = await buffer.clone_item_async(
+        source_tool_call_id=source_tool_call_id,
+        tool_call_id=tool_call_id,
+        tool_name=call.tool_name,
+        args_summary=_relay_tool_call_args_summary(call),
+        runtime_meta_overrides={
+            "relay_tool_step_coalesced_result": True,
+            "tool_action_singleflight_hit": True,
+            "tool_action_singleflight_wait_ms": 0,
+            "action_duration_ms": 0,
+            "duration_ms": 0,
+            "total_tool_runtime_ms": 0,
+            "tool_batch_wall_ms": 0,
+        },
+    )
+    if clone_item is None:
+        return None
+    cloned_part = ToolReturnPart(
+        tool_name=call.tool_name,
+        tool_call_id=call.tool_call_id,
+        content=cast(Any, clone_item.visible_envelope),
+        metadata=cast(Any, source.part.metadata),
+    )
+    return RelayToolStepItemResult(
+        index=index,
+        part=cloned_part,
+        user_content=source.user_content,
+    )
+
+
+def _relay_tool_call_coalesce_key(call: ToolCallPart) -> str | None:
+    if call.tool_name not in TOOL_STEP_BATCHABLE_TOOLS:
+        return None
+    return "|".join(
+        (call.tool_name, json.dumps(call.args, sort_keys=True, default=str))
+    )
+
+
+def _relay_tool_call_args_summary(call: ToolCallPart) -> dict[str, JsonValue]:
+    if isinstance(call.args, dict):
+        return {str(key): cast(JsonValue, value) for key, value in call.args.items()}
+    return {"args": str(call.args)}
+
+
+def _relay_tool_step_coalesced_count(calls: tuple[ToolCallPart, ...]) -> int:
+    keys = tuple(
+        key for key in (_relay_tool_call_coalesce_key(call) for call in calls) if key
+    )
+    if not keys:
+        return 0
+    return len(keys) - len(set(keys))
+
+
+async def _try_execute_relay_tool_step_async(
+    *,
+    node: CallToolsNode[Any, Any],
+    agent_run_ctx: object,
+) -> RelayToolStepExecutionResult | None:
+    disabled_reason = _relay_tool_step_disabled_reason(node)
+    if disabled_reason is not None:
+        if disabled_reason != "no_batchable_tool_calls":
+            log_event(
+                LOGGER,
+                logging.DEBUG,
+                event="relay_tool_step.fallback",
+                message="Relay tool step executor did not handle this batch",
+                payload={"reason": disabled_reason},
+            )
+        return None
+
+    calls = _relay_tool_step_calls(node)
+    ctx = cast(Any, agent_run_ctx)
+    run_context = build_run_context(ctx)
+    run_context = replace(
+        run_context,
+        retry=ctx.state.retries,
+        max_retries=ctx.deps.max_result_retries,
+    )
+    ctx.deps.tool_manager = await ctx.deps.tool_manager.for_run_step(run_context)
+    tool_manager = ctx.deps.tool_manager
+
+    for call in calls:
+        tool_def = tool_manager.get_tool_def(call.tool_name)
+        if tool_def is None:
+            log_event(
+                LOGGER,
+                logging.DEBUG,
+                event="relay_tool_step.fallback",
+                message="Relay tool step executor found an unknown tool",
+                payload={"tool_name": call.tool_name},
+            )
+            return None
+        if tool_def.kind != "function":
+            return None
+        if tool_def.sequential:
+            return None
+
+    validated_calls: list[object] = []
+    try:
+        for call in calls:
+            validated = await tool_manager.validate_tool_call(call)
+            if not validated.args_valid:
+                return None
+            validated_calls.append(validated)
+    except (KeyError, RuntimeError, TypeError, ValueError) as exc:
+        log_event(
+            LOGGER,
+            logging.DEBUG,
+            event="relay_tool_step.validation_fallback",
+            message="Relay tool step executor fell back after validation failed",
+            payload={
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+        return None
+
+    started = time.perf_counter()
+    item_results = await _execute_relay_tool_step_bounded_async(
+        tool_manager=tool_manager,
+        calls=calls,
+        validated_calls=tuple(validated_calls),
+        concurrency=RELAY_TOOL_STEP_BATCH_CONCURRENCY,
+    )
+    item_results, compressed_result_count = _dedupe_tool_returns_for_history(
+        item_results
+    )
+    output_parts: list[ModelRequestPart] = []
+    observed_messages: list[ModelRequest] = []
+    for item in item_results:
+        output_parts.append(item.part)
+        observed_messages.append(ModelRequest(parts=[item.part]))
+    for item in item_results:
+        if item.user_content is not None:
+            output_parts.append(UserPromptPart(content=cast(Any, item.user_content)))
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    cast(Any, node)._events_iterator = _empty_tool_event_stream()
+    cast(Any, node)._next_node = ModelRequestNode(ModelRequest(parts=output_parts))
+    tool_names: list[JsonValue] = [
+        name for name in sorted({call.tool_name for call in calls})
+    ]
+    event_payload: dict[str, JsonValue] = {
+        "tool_count": len(calls),
+        "concurrency": RELAY_TOOL_STEP_BATCH_CONCURRENCY,
+        "global_concurrency": RELAY_TOOL_STEP_GLOBAL_CONCURRENCY,
+        "flush_size": RELAY_TOOL_STEP_FLUSH_SIZE,
+        "tool_names": tool_names,
+        "relay_tool_step_executor_used": True,
+        "relay_tool_step_batch_size": len(calls),
+        "relay_tool_step_execute_ms": duration_ms,
+        "relay_tool_step_pydantic_bypass_count": len(calls),
+        "relay_tool_step_trace_bypass_count": len(calls),
+        "relay_tool_step_history_dedup_count": compressed_result_count,
+        "relay_tool_step_coalesced_count": _relay_tool_step_coalesced_count(calls),
+    }
+    log_event(
+        LOGGER,
+        logging.INFO,
+        event="relay_tool_step.executed",
+        message="Executed tool step with relay bounded batch executor",
+        duration_ms=duration_ms,
+        payload=event_payload,
+    )
+    return RelayToolStepExecutionResult(
+        observed_messages=tuple(observed_messages),
+        output_parts=tuple(output_parts),
+        duration_ms=duration_ms,
+        tool_count=len(calls),
+    )
+
+
+def _dedupe_tool_returns_for_history(
+    item_results: tuple[RelayToolStepItemResult, ...],
+) -> tuple[tuple[RelayToolStepItemResult, ...], int]:
+    seen: dict[tuple[str, str], str] = {}
+    compressed: list[RelayToolStepItemResult] = []
+    compressed_count = 0
+    for item in item_results:
+        part = item.part
+        if part.tool_name not in TOOL_STEP_HISTORY_DEDUP_TOOLS:
+            compressed.append(item)
+            continue
+        fingerprint = _tool_return_content_fingerprint(part.content)
+        if fingerprint is None:
+            compressed.append(item)
+            continue
+        key = (part.tool_name, fingerprint)
+        first_tool_call_id = seen.get(key)
+        if first_tool_call_id is None:
+            seen[key] = str(part.tool_call_id or "")
+            compressed.append(item)
+            continue
+        compressed_count += 1
+        compressed_part = ToolReturnPart(
+            tool_name=part.tool_name,
+            tool_call_id=part.tool_call_id,
+            content=cast(
+                Any,
+                {
+                    "status": "ok",
+                    "content_omitted": True,
+                    "duplicate_of_tool_call_id": first_tool_call_id,
+                    "message": (
+                        "Duplicate tool result omitted from model history; "
+                        "use the referenced tool call result."
+                    ),
+                },
+            ),
+            metadata=part.metadata,
+        )
+        compressed.append(
+            RelayToolStepItemResult(
+                index=item.index,
+                part=compressed_part,
+                user_content=item.user_content,
+            )
+        )
+    return tuple(compressed), compressed_count
+
+
+def _tool_return_content_fingerprint(content: object) -> str | None:
+    try:
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError):
+        return None

--- a/src/relay_teams/agents/execution/session_mixin_base.py
+++ b/src/relay_teams/agents/execution/session_mixin_base.py
@@ -377,6 +377,9 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
         history: list[ModelRequest | ModelResponse],
         pending_messages: list[ModelRequest | ModelResponse],
         published_tool_outcome_ids: set[str] | None = None,
+        safe_index: int | None = None,
+        safe_scan_ms: int = 0,
+        reload_history_after_commit: bool = False,
     ) -> tuple[
         list[ModelRequest | ModelResponse],
         list[ModelRequest | ModelResponse],
@@ -392,6 +395,9 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
         history: list[ModelRequest | ModelResponse],
         pending_messages: list[ModelRequest | ModelResponse],
         published_tool_outcome_ids: set[str] | None = None,
+        safe_index: int | None = None,
+        safe_scan_ms: int = 0,
+        reload_history_after_commit: bool = False,
     ) -> tuple[
         list[ModelRequest | ModelResponse],
         list[ModelRequest | ModelResponse],

--- a/src/relay_teams/agents/execution/session_prompt.py
+++ b/src/relay_teams/agents/execution/session_prompt.py
@@ -638,6 +638,9 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
         history: list[ModelRequest | ModelResponse],
         pending_messages: list[ModelRequest | ModelResponse],
         published_tool_outcome_ids: set[str] | None = None,
+        safe_index: int | None = None,
+        safe_scan_ms: int = 0,
+        reload_history_after_commit: bool = False,
     ) -> tuple[
         list[ModelRequest | ModelResponse],
         list[ModelRequest | ModelResponse],
@@ -661,6 +664,9 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             filter_model_messages=self._filter_model_messages,
             has_tool_side_effect_messages=self._has_tool_side_effect_messages,
             published_tool_outcome_ids=published_tool_outcome_ids,
+            safe_index=safe_index,
+            safe_scan_ms=safe_scan_ms,
+            reload_history_after_commit=reload_history_after_commit,
         )
 
     async def _commit_ready_messages_async(
@@ -670,6 +676,9 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
         history: list[ModelRequest | ModelResponse],
         pending_messages: list[ModelRequest | ModelResponse],
         published_tool_outcome_ids: set[str] | None = None,
+        safe_index: int | None = None,
+        safe_scan_ms: int = 0,
+        reload_history_after_commit: bool = False,
     ) -> tuple[
         list[ModelRequest | ModelResponse],
         list[ModelRequest | ModelResponse],
@@ -693,6 +702,9 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             filter_model_messages=self._filter_model_messages,
             has_tool_side_effect_messages=self._has_tool_side_effect_messages,
             published_tool_outcome_ids=published_tool_outcome_ids,
+            safe_index=safe_index,
+            safe_scan_ms=safe_scan_ms,
+            reload_history_after_commit=reload_history_after_commit,
         )
 
     def _commit_all_safe_messages(

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -15,7 +15,6 @@ from pydantic import JsonValue
 from pydantic_ai.exceptions import ModelAPIError
 from pydantic_ai.messages import (
     FunctionToolResultEvent,
-    ModelMessage,
     ModelRequest,
     ModelRequestPart,
     ModelResponse,
@@ -73,11 +72,28 @@ from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_models import InjectionMessage, RunEvent
 from relay_teams.tools.registry import ToolRegistry, ToolResolutionContext
 from relay_teams.tools.runtime.context import ToolDeps
+from relay_teams.tools.runtime.execution import (
+    flush_tool_result_batch_async,
+    tool_result_batching_active,
+)
+from relay_teams.tools.runtime.tool_result_batching import tool_result_batch_scope
 from relay_teams.agents.execution.context_editing import (
     build_diff_injection,
     build_injection_message,
 )
 from relay_teams.agents.execution.recovery_flow import FallbackAttemptState
+from relay_teams.agents.execution.relay_tool_step_executor import (
+    AgentNodeStream,
+    AgentNodeStreamContext,
+    AgentRun,
+    AgentRunResult,
+    AutoHarnessRuntimeService,
+    CoordinationAgent,
+    StreamableModelRequestNode,
+    StreamableToolCallNode,
+    _InjectionRestartApplied,
+    _try_execute_relay_tool_step_async,
+)
 from relay_teams.agents.execution.spec_drift_evaluator import evaluate_spec_drift
 from relay_teams.workspace import build_conversation_id
 
@@ -88,105 +104,6 @@ _ABANDONED_LLM_STREAM_CONTEXT_CLEANUP_TASKS: set[asyncio.Task[None]] = set()
 _ABANDONED_LLM_STREAM_CONTEXT_CLEANUP_MIN_TIMEOUT_SECONDS = 1.0
 _ABANDONED_LLM_STREAM_CONTEXT_CLEANUP_MAX_TIMEOUT_SECONDS = 30.0
 StreamItemT = TypeVar("StreamItemT")
-
-
-class _InjectionRestartApplied(Exception):
-    pass
-
-
-class AgentRunResult(Protocol):
-    @property
-    def response(self) -> object: ...
-
-    def new_messages(self) -> Sequence[ModelMessage]: ...
-
-    def usage(self) -> object: ...
-
-
-class AgentNodeStream(Protocol):
-    def __aiter__(self) -> AsyncIterator[object]: ...
-
-    def stream_text(self, *, delta: bool) -> AsyncIterator[str]: ...
-
-    def usage(self) -> object: ...
-
-
-class AgentNodeStreamContext(Protocol):
-    async def __aenter__(self) -> AgentNodeStream: ...
-
-    async def __aexit__(
-        self,
-        exc_type: object,
-        exc: object,
-        tb: object,
-    ) -> bool | None: ...
-
-
-class StreamableModelRequestNode(Protocol):
-    def stream(self, ctx: object) -> AgentNodeStreamContext: ...
-
-
-class AgentToolEventStream(Protocol):
-    def __aiter__(self) -> AsyncIterator[object]:
-        raise NotImplementedError  # pragma: no cover
-
-
-class AgentToolEventStreamContext(Protocol):
-    async def __aenter__(self) -> AgentToolEventStream:
-        raise NotImplementedError  # pragma: no cover
-
-    async def __aexit__(
-        self,
-        exc_type: object,
-        exc: object,
-        tb: object,
-    ) -> bool | None:
-        raise NotImplementedError  # pragma: no cover
-
-
-class StreamableToolCallNode(Protocol):
-    @staticmethod
-    def stream(ctx: object) -> AgentToolEventStreamContext:
-        raise NotImplementedError  # pragma: no cover
-
-
-class AgentRun(Protocol):
-    ctx: object
-    result: AgentRunResult | None
-
-    async def __aenter__(self) -> "AgentRun": ...
-
-    async def __aexit__(
-        self,
-        exc_type: object,
-        exc: object,
-        tb: object,
-    ) -> bool | None: ...
-
-    def __aiter__(self) -> "AgentRun": ...
-
-    async def __anext__(self) -> object: ...
-
-    def new_messages(self) -> Sequence[ModelMessage]: ...
-
-    def usage(self) -> object: ...
-
-
-class CoordinationAgent(Protocol):
-    def iter(
-        self,
-        prompt: str | None,
-        *,
-        deps: ToolDeps,
-        message_history: Sequence[ModelRequest | ModelResponse],
-        usage_limits: UsageLimits,
-    ) -> AgentRun: ...
-
-
-class AutoHarnessRuntimeService(Protocol):
-    @staticmethod
-    def consume_tools_dirty(*, run_id: str, instance_id: str) -> tuple[str, ...]:
-        raise NotImplementedError
 
 
 def resolve_allowed_tools(
@@ -242,6 +159,18 @@ def consume_auto_harness_dirty_tools(
         run_id=run_id,
         instance_id=instance_id,
     )
+
+
+async def resolve_is_root_task_context(
+    task_repo: _TaskRepo,
+    *,
+    task_id: str,
+) -> bool:
+    try:
+        task_record = await task_repo.get_async(task_id)
+    except (AttributeError, KeyError):
+        return False
+    return task_record.envelope.parent_task_id is None
 
 
 def model_step_payload(
@@ -344,6 +273,8 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
             return False
         result = stream_event.result
         if not isinstance(result, (ToolReturnPart, RetryPromptPart)):
+            return False
+        if isinstance(result, ToolReturnPart) and tool_result_batching_active():
             return False
         if isinstance(result, RetryPromptPart):
             if not result.tool_name:
@@ -448,6 +379,10 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 workspace_id=resolved_workspace_id,
                 conversation_id=resolved_conversation_id,
             )
+            is_root_task_context = await resolve_is_root_task_context(
+                self._task_repo,
+                task_id=request.task_id,
+            )
             deps = ToolDeps(
                 task_repo=self._task_repo,
                 shared_store=self._shared_store,
@@ -469,6 +404,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 run_id=request.run_id,
                 trace_id=request.trace_id,
                 task_id=request.task_id,
+                is_root_task_context=is_root_task_context,
                 session_id=request.session_id,
                 session_mode=request.session_mode,
                 run_kind=request.run_kind.value,
@@ -1111,6 +1047,9 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                     active_tool_call_batch_id = (
                                         f"toolbatch_{uuid4().hex[:16]}"
                                     )
+                                    streamed_tool_call_parts: list[
+                                        tuple[int, ToolCallPart]
+                                    ] = []
                                     streamed_text_start = len(emitted_text_chunks)
                                     usage_before = deepcopy(agent_run.usage())
                                     stream_context = streamable_node.stream(
@@ -1153,16 +1092,12 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                                             parts=[stream_event.part]
                                                         )
                                                     )
-                                                    tool_call_event_emitted = await self._event_publishing_service().publish_observed_tool_call_event_async(
-                                                        request=request,
-                                                        part=stream_event.part,
-                                                        batch_id=active_tool_call_batch_id,
-                                                        batch_index=stream_event.index,
-                                                        batch_size=0,
-                                                        published_tool_call_ids=published_tool_call_ids,
+                                                    streamed_tool_call_parts.append(
+                                                        (
+                                                            stream_event.index,
+                                                            stream_event.part,
+                                                        )
                                                     )
-                                                    if tool_call_event_emitted:
-                                                        attempt_tool_call_event_emitted = True
                                                 if text_emitted:
                                                     printed_any = True
                                                     attempt_text_emitted = True
@@ -1195,6 +1130,22 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                     _raise_if_stream_finished_without_reason(stream)
                                     if await apply_interrupt_injections():
                                         raise _InjectionRestartApplied
+                                    if streamed_tool_call_parts:
+                                        tool_call_event_emitted = await self._event_publishing_service().publish_observed_tool_call_events_batch_async(
+                                            request=request,
+                                            tool_calls=tuple(streamed_tool_call_parts),
+                                            batch_id=active_tool_call_batch_id,
+                                            published_tool_call_ids=published_tool_call_ids,
+                                        )
+                                        if tool_call_event_emitted:
+                                            attempt_tool_call_event_emitted = True
+                                            await self._event_publishing_service().seal_tool_call_batch_async(
+                                                request=request,
+                                                batch_id=active_tool_call_batch_id,
+                                                tool_calls=tuple(
+                                                    streamed_tool_call_parts
+                                                ),
+                                            )
                                     usage_after = stream.usage()
                                     input_tokens_delta = self._usage_delta_int(
                                         after=usage_after,
@@ -1243,34 +1194,54 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                     tool_node = cast(
                                         StreamableToolCallNode, cast(object, node)
                                     )
-                                    async with tool_node.stream(
-                                        agent_run.ctx
-                                    ) as tool_stream:
-                                        async for tool_stream_event in tool_stream:
-                                            control_ctx.raise_if_cancelled()
-                                            if await apply_interrupt_injections():
-                                                raise _InjectionRestartApplied
-                                            observed_result = (
-                                                _observed_tool_result_message(
-                                                    tool_stream_event
-                                                )
+                                    with tool_result_batch_scope() as result_buffer:
+                                        try:
+                                            relay_tool_step_result = await _try_execute_relay_tool_step_async(
+                                                node=node,
+                                                agent_run_ctx=agent_run.ctx,
                                             )
-                                            if observed_result is not None:
-                                                observed_result_ids = _tool_result_ids(
-                                                    [observed_result]
+                                            if relay_tool_step_result is not None:
+                                                observed_stream_messages.extend(
+                                                    relay_tool_step_result.observed_messages
                                                 )
-                                                if not observed_result_ids.intersection(
-                                                    published_tool_outcome_ids
-                                                ):
-                                                    observed_stream_messages.append(
-                                                        observed_result
-                                                    )
-                                            tool_outcome_emitted = await self._publish_tool_outcome_event_from_stream_async(
-                                                request=request,
-                                                stream_event=tool_stream_event,
+                                            else:
+                                                async with tool_node.stream(
+                                                    agent_run.ctx
+                                                ) as tool_stream:
+                                                    async for (
+                                                        tool_stream_event
+                                                    ) in tool_stream:
+                                                        control_ctx.raise_if_cancelled()
+                                                        if await apply_interrupt_injections():
+                                                            raise _InjectionRestartApplied
+                                                        observed_result = _observed_tool_result_message(
+                                                            tool_stream_event
+                                                        )
+                                                        if observed_result is not None:
+                                                            observed_result_ids = (
+                                                                _tool_result_ids(
+                                                                    [observed_result]
+                                                                )
+                                                            )
+                                                            if not observed_result_ids.intersection(
+                                                                published_tool_outcome_ids
+                                                            ):
+                                                                observed_stream_messages.append(
+                                                                    observed_result
+                                                                )
+                                                        tool_outcome_emitted = await self._publish_tool_outcome_event_from_stream_async(
+                                                            request=request,
+                                                            stream_event=tool_stream_event,
+                                                            published_tool_outcome_ids=published_tool_outcome_ids,
+                                                        )
+                                                        if tool_outcome_emitted:
+                                                            attempt_tool_outcome_event_emitted = True
+                                        finally:
+                                            batch_outcome_emitted = await flush_tool_result_batch_async(
+                                                result_buffer,
                                                 published_tool_outcome_ids=published_tool_outcome_ids,
                                             )
-                                            if tool_outcome_emitted:
+                                            if batch_outcome_emitted:
                                                 attempt_tool_outcome_event_emitted = (
                                                     True
                                                 )

--- a/src/relay_teams/agents/execution/spec_checkpoint.py
+++ b/src/relay_teams/agents/execution/spec_checkpoint.py
@@ -221,11 +221,13 @@ def render_spec_checkpoint(
         lines.extend(
             _format_nested_items(
                 "Proof Artifacts",
-                tuple(str(path) for path in formal.proof_artifacts),
+                tuple(path.as_posix() for path in formal.proof_artifacts),
             )
         )
         if formal.counterexample_path is not None:
-            lines.append(f"  - Counterexample Path: {formal.counterexample_path}")
+            lines.append(
+                f"  - Counterexample Path: {formal.counterexample_path.as_posix()}"
+            )
         if formal.replay_command is not None:
             lines.append(
                 "  - Replay Command: " + " ".join(formal.replay_command.command)

--- a/src/relay_teams/agents/execution/system_prompts.py
+++ b/src/relay_teams/agents/execution/system_prompts.py
@@ -18,6 +18,11 @@ from relay_teams.agent_runtimes.instances.models import RuntimeToolsSnapshot
 from relay_teams.agents.orchestration.graph_models import (
     build_orchestration_graph_prompt,
 )
+from relay_teams.mcp.runtime_schema_loader import (
+    cached_runtime_mcp_server_names,
+    load_runtime_mcp_tool_schemas,
+    should_require_ready_mcp_toolsets,
+)
 from relay_teams.agents.orchestration.policy_models import (
     build_orchestration_policy_prompt,
 )
@@ -996,25 +1001,33 @@ async def _list_role_mcp_tools(
     )
     if not resolved_server_names:
         return ()
-    if mcp_discovery_service is None:
-        live_tool_groups = await asyncio.gather(
-            *(
-                mcp_registry.list_tools(server_name)
-                for server_name in resolved_server_names
-            )
-        )
+    if mcp_discovery_service is not None:
         return tuple(
             tool_name
-            for tool_group in live_tool_groups
-            for tool_name in _tool_names(tool_group)
+            for server_name in resolved_server_names
+            for tool_name in _ready_mcp_tools_for_prompt(
+                server_name,
+                discovery_service=mcp_discovery_service,
+            )
         )
+    if should_require_ready_mcp_toolsets(
+        requested_server_names=role.mcp_servers,
+        resolved_server_count=len(resolved_server_names),
+    ):
+        resolved_server_names = cached_runtime_mcp_server_names(
+            mcp_registry=mcp_registry,
+            server_names=resolved_server_names,
+        )
+        if not resolved_server_names:
+            return ()
+    schema_result = await load_runtime_mcp_tool_schemas(
+        mcp_registry=mcp_registry,
+        server_names=resolved_server_names,
+    )
     return tuple(
-        tool_name
-        for server_name in resolved_server_names
-        for tool_name in _ready_mcp_tools_for_prompt(
-            server_name,
-            discovery_service=mcp_discovery_service,
-        )
+        tool.name
+        for tools in schema_result.schemas_by_server.values()
+        for tool in tools
     )
 
 

--- a/src/relay_teams/agents/orchestration/harnesses/tool_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/tool_harness.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-import logging
 from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, JsonValue
@@ -15,8 +14,11 @@ from relay_teams.agent_runtimes.instances.models import (
     RuntimeToolSnapshotEntry,
     RuntimeToolsSnapshot,
 )
+from relay_teams.mcp.runtime_schema_loader import (
+    load_runtime_mcp_tool_schemas,
+)
 from relay_teams.agents.tasks.models import TaskEnvelope
-from relay_teams.logger import get_logger, log_event
+from relay_teams.logger import get_logger
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
@@ -110,31 +112,22 @@ class TaskToolHarness(BaseModel):
                     local_tools.append(entry)
 
         mcp_tools: list[RuntimeToolSnapshotEntry] = []
-        for server_name in self.mcp_registry.resolve_server_names(
+        mcp_server_names = self.mcp_registry.resolve_server_names(
             role.mcp_servers,
             strict=False,
             consumer=(
                 "agents.orchestration.harnesses.tool_harness"
                 ".build_runtime_tools_snapshot"
             ),
-        ):
-            try:
-                server_tool_schemas = await self.mcp_registry.list_tool_schemas(
-                    server_name
-                )
-            except Exception as exc:
-                log_event(
-                    LOGGER,
-                    logging.WARNING,
-                    event="orchestration.runtime_tools.mcp_load_failed",
-                    message=(
-                        "Failed to inspect MCP tools for runtime snapshot; "
-                        "continuing without this MCP server"
-                    ),
-                    payload={"server_name": server_name},
-                    exc_info=exc,
-                )
-                continue
+        )
+        mcp_schema_result = await load_runtime_mcp_tool_schemas(
+            mcp_registry=self.mcp_registry,
+            server_names=mcp_server_names,
+        )
+        for (
+            server_name,
+            server_tool_schemas,
+        ) in mcp_schema_result.schemas_by_server.items():
             for tool in server_tool_schemas:
                 mcp_tools.append(
                     self.tool_entry_from_definition(

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -402,32 +402,23 @@ class TaskExecutionService(BaseModel):
 
         # OP-3: Create artifact container (spec phase).
         if self.artifact_repo is not None:
-            try:
-                await self.artifact_repo.ensure_artifact_async(
-                    task_id=task.task_id,
-                    spec_artifact_id=task.spec_artifact_id or "",
-                )
-                await self.artifact_repo.append_entry_async(
-                    task_id=task.task_id,
-                    entry=TaskArtifactEntry(
-                        entry_id=f"start-{task.task_id}",
-                        phase=TaskArtifactPhase.SPEC,
-                        timestamp=datetime.now(tz=timezone.utc).isoformat(),
-                        role_id=role_id,
-                        instance_id=instance_id,
-                        event_type="task_started",
-                        description="Task execution started",
-                        payload_json=task.model_dump_json(),
-                    ),
-                )
-            except Exception as exc:
-                log_event(
-                    LOGGER,
-                    logging.WARNING,
-                    event="artifact.create_failed",
-                    message="Failed to create task artifact",
-                    payload={"task_id": task.task_id, "error": str(exc)},
-                )
+            _ = self.artifact_repo.enqueue_ensure_artifact(
+                task_id=task.task_id,
+                spec_artifact_id=task.spec_artifact_id or "",
+            )
+            _ = self.artifact_repo.enqueue_append_entry(
+                task_id=task.task_id,
+                entry=TaskArtifactEntry(
+                    entry_id=f"start-{task.task_id}",
+                    phase=TaskArtifactPhase.SPEC,
+                    timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                    role_id=role_id,
+                    instance_id=instance_id,
+                    event_type="task_started",
+                    description="Task execution started",
+                    payload_json=task.model_dump_json(),
+                ),
+            )
 
         # Compute: resolve workspace before try for error-path access
         harness = self._execution_harness()
@@ -443,28 +434,19 @@ class TaskExecutionService(BaseModel):
         try:
             # OP-3: Append implementation phase entry.
             if self.artifact_repo is not None:
-                try:
-                    await self.artifact_repo.append_entry_async(
-                        task_id=task.task_id,
-                        entry=TaskArtifactEntry(
-                            entry_id=f"impl-{task.task_id}",
-                            phase=TaskArtifactPhase.EXECUTION,
-                            timestamp=datetime.now(tz=timezone.utc).isoformat(),
-                            role_id=role_id,
-                            instance_id=instance_id,
-                            event_type="llm_execution_start",
-                            description="LLM execution started",
-                            payload_json="{}",
-                        ),
-                    )
-                except Exception as exc:
-                    log_event(
-                        LOGGER,
-                        logging.WARNING,
-                        event="artifact.append_failed",
-                        message="Failed to append implementation entry",
-                        payload={"task_id": task.task_id, "error": str(exc)},
-                    )
+                _ = self.artifact_repo.enqueue_append_entry(
+                    task_id=task.task_id,
+                    entry=TaskArtifactEntry(
+                        entry_id=f"impl-{task.task_id}",
+                        phase=TaskArtifactPhase.EXECUTION,
+                        timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                        role_id=role_id,
+                        instance_id=instance_id,
+                        event_type="llm_execution_start",
+                        description="LLM execution started",
+                        payload_json="{}",
+                    ),
+                )
 
             # Compute: full execution config (role, runner, prompts, snapshot)
             config = await harness.prepare_execution_config(
@@ -547,57 +529,38 @@ class TaskExecutionService(BaseModel):
 
             # OP-3: Append verification phase entry.
             if self.artifact_repo is not None:
-                try:
-                    await self.artifact_repo.append_entry_async(
-                        task_id=task.task_id,
-                        entry=TaskArtifactEntry(
-                            entry_id=f"verify-{task.task_id}",
-                            phase=TaskArtifactPhase.VERIFICATION,
-                            timestamp=datetime.now(tz=timezone.utc).isoformat(),
-                            role_id=role_id,
-                            instance_id=instance_id,
-                            event_type="guardrail_report_completed",
-                            description="Guardrail report and runtime checks completed",
-                            payload_json="{}",
-                        ),
-                    )
-                except Exception as exc:
-                    log_event(
-                        LOGGER,
-                        logging.WARNING,
-                        event="artifact.verify_failed",
-                        message="Failed to append verification entry",
-                        payload={"task_id": task.task_id, "error": str(exc)},
-                    )
+                _ = self.artifact_repo.enqueue_append_entry(
+                    task_id=task.task_id,
+                    entry=TaskArtifactEntry(
+                        entry_id=f"verify-{task.task_id}",
+                        phase=TaskArtifactPhase.VERIFICATION,
+                        timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                        role_id=role_id,
+                        instance_id=instance_id,
+                        event_type="guardrail_report_completed",
+                        description="Guardrail report and runtime checks completed",
+                        payload_json="{}",
+                    ),
+                )
 
             # OP-3: Append delivery phase entry and update summary.
             if self.artifact_repo is not None:
-                try:
-                    await self.artifact_repo.append_entry_async(
-                        task_id=task.task_id,
-                        entry=TaskArtifactEntry(
-                            entry_id=f"delivery-{task.task_id}",
-                            phase=TaskArtifactPhase.DELIVERY,
-                            timestamp=datetime.now(tz=timezone.utc).isoformat(),
-                            role_id=role_id,
-                            instance_id=instance_id,
-                            event_type="task_completed",
-                            description="Task execution completed",
-                            payload_json="{}",
-                        ),
-                    )
-                    await self.artifact_repo.update_summary_async(
-                        task_id=task.task_id,
-                        summary=result,
-                    )
-                except Exception as exc:
-                    log_event(
-                        LOGGER,
-                        logging.WARNING,
-                        event="artifact.delivery_failed",
-                        message="Failed to append delivery entry",
-                        payload={"task_id": task.task_id, "error": str(exc)},
-                    )
+                _ = self.artifact_repo.enqueue_append_entry(
+                    task_id=task.task_id,
+                    entry=TaskArtifactEntry(
+                        entry_id=f"delivery-{task.task_id}",
+                        phase=TaskArtifactPhase.DELIVERY,
+                        timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                        role_id=role_id,
+                        instance_id=instance_id,
+                        event_type="task_completed",
+                        description="Task execution completed",
+                        payload_json="{}",
+                    ),
+                )
+                _ = self.artifact_repo.enqueue_update_summary(
+                    task_id=task.task_id, summary=result
+                )
             return TaskExecutionResult(output=result)
         except asyncio.CancelledError:
             if timeout_cancellation.is_set():

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -2218,8 +2218,16 @@ def _resolve_verification_path(
 ) -> Path | None:
     if workspace_root is None:
         return path if path.is_absolute() else None
-    root = workspace_root.resolve()
-    candidate = (path if path.is_absolute() else root / path).resolve()
+    root = workspace_root
+    candidate = path if path.is_absolute() else root / path
+    if ".." in path.parts:
+        resolved_root = root.resolve()
+        resolved_candidate = candidate.resolve()
+        try:
+            resolved_candidate.relative_to(resolved_root)
+        except ValueError:
+            return None
+        return resolved_candidate
     try:
         candidate.relative_to(root)
     except ValueError:

--- a/src/relay_teams/agents/tasks/artifact_repository.py
+++ b/src/relay_teams/agents/tasks/artifact_repository.py
@@ -2,17 +2,19 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from collections.abc import Awaitable, Callable
+import time
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import RLock
-from typing import TypeVar, cast
+from queue import Empty, Full, Queue
+from threading import Event, Lock, RLock, Thread
+from typing import Literal, TypeVar, cast
 
 import aiosqlite
 
 from relay_teams.agents.tasks.enums import TaskArtifactPhase
-from relay_teams.logger import get_logger
 from relay_teams.agents.tasks.models import (
     TaskArtifact,
     TaskArtifactEntry,
@@ -28,7 +30,13 @@ from relay_teams.persistence.db import (
     run_sqlite_write_with_retry,
 )
 from relay_teams.persistence.sqlite_repository import async_fetchall, async_fetchone
+from relay_teams.logger import get_logger, log_event
+from pydantic import BaseModel, ConfigDict
 
+TASK_ARTIFACT_SQLITE_BUSY_TIMEOUT_MS = SQLITE_BUSY_TIMEOUT_MS
+TASK_ARTIFACT_WRITE_QUEUE_MAXSIZE = 2000
+TASK_ARTIFACT_WRITE_LOCK_RETRY_ATTEMPTS = 5
+LOGGER = get_logger(__name__)
 ResultT = TypeVar("ResultT")
 
 _CREATE_TABLES_SQL = """\
@@ -64,21 +72,256 @@ CREATE INDEX IF NOT EXISTS idx_artifact_entries_event_type
 """
 
 
-class TaskArtifactRepository:
+class TaskArtifactWriteMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    enqueued: int = 0
+    completed: int = 0
+    dropped: int = 0
+    failed: int = 0
+    sqlite_lock_timeout_count: int = 0
+    total_wait_ms: int = 0
+    total_duration_ms: int = 0
+
+
+class _TaskArtifactWriteJob(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    operation: Literal["ensure", "append", "update_summary", "update_evidence_bundle"]
+    task_id: str
+    enqueued_monotonic: float
+    spec_artifact_id: str = ""
+    entry: TaskArtifactEntry | None = None
+    summary: str = ""
+    evidence_bundle: VerificationEvidenceBundle | None = None
+
+
+class TaskArtifactRepository:  # pragma: no cover
     """Persist and query task artifacts and entries."""
 
     def __init__(self, db_path: Path | str) -> None:
         self._db_path = Path(db_path)
         self._lock = RLock()
+        self._queue: Queue[_TaskArtifactWriteJob] = Queue(
+            maxsize=TASK_ARTIFACT_WRITE_QUEUE_MAXSIZE
+        )
+        self._worker_stop = Event()
+        self._metrics_lock = Lock()
+        self._metrics = TaskArtifactWriteMetrics()
+        self._worker: Thread | None = None
+        self._worker_lock = Lock()
         self._init_tables()
 
-    def _init_tables(self) -> None:
-        def operation(conn: sqlite3.Connection) -> None:
-            conn.executescript(_CREATE_TABLES_SQL)
+    def enqueue_ensure_artifact(self, *, task_id: str, spec_artifact_id: str) -> bool:
+        return self._enqueue(
+            _TaskArtifactWriteJob(
+                operation="ensure",
+                task_id=task_id,
+                spec_artifact_id=spec_artifact_id,
+                enqueued_monotonic=time.perf_counter(),
+            )
+        )
 
-        self._run_write(operation_name="init_tables", operation=operation)
+    def enqueue_append_entry(self, *, task_id: str, entry: TaskArtifactEntry) -> bool:
+        return self._enqueue(
+            _TaskArtifactWriteJob(
+                operation="append",
+                task_id=task_id,
+                entry=entry,
+                enqueued_monotonic=time.perf_counter(),
+            )
+        )
 
-    def _connect(self) -> sqlite3.Connection:
+    def enqueue_update_summary(self, *, task_id: str, summary: str) -> bool:
+        return self._enqueue(
+            _TaskArtifactWriteJob(
+                operation="update_summary",
+                task_id=task_id,
+                summary=summary,
+                enqueued_monotonic=time.perf_counter(),
+            )
+        )
+
+    def enqueue_update_evidence_bundle(
+        self,
+        *,
+        task_id: str,
+        bundle: VerificationEvidenceBundle,
+    ) -> bool:
+        return self._enqueue(
+            _TaskArtifactWriteJob(
+                operation="update_evidence_bundle",
+                task_id=task_id,
+                evidence_bundle=bundle,
+                enqueued_monotonic=time.perf_counter(),
+            )
+        )
+
+    def write_metrics(self) -> TaskArtifactWriteMetrics:
+        with self._metrics_lock:
+            return self._metrics
+
+    def drain_write_queue(self, *, timeout_seconds: float = 2.0) -> bool:
+        """Wait briefly for best-effort queued writes to settle."""
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            metrics = self.write_metrics()
+            if (
+                metrics.completed + metrics.failed >= metrics.enqueued
+                and self._queue.empty()
+            ):
+                return True
+            time.sleep(0.01)
+        metrics = self.write_metrics()
+        return (
+            metrics.completed + metrics.failed >= metrics.enqueued
+            and self._queue.empty()
+        )
+
+    def _enqueue(self, job: _TaskArtifactWriteJob) -> bool:
+        self._ensure_write_worker_started()
+        try:
+            self._queue.put_nowait(job)
+        except Full:
+            self._record_metrics(dropped=1)
+            return False
+        self._record_metrics(enqueued=1)
+        return True
+
+    def _ensure_write_worker_started(self) -> None:
+        with self._worker_lock:
+            if self._worker is not None and self._worker.is_alive():
+                return
+            self._worker_stop.clear()
+            self._worker = Thread(
+                target=self._run_write_worker,
+                name="relay-teams-task-artifact-writer",
+                daemon=True,
+            )
+            self._worker.start()
+
+    def close(self) -> None:
+        _ = self.drain_write_queue(timeout_seconds=1.0)
+        self._worker_stop.set()
+        worker = self._worker
+        if worker is not None and worker.is_alive():
+            worker.join(timeout=1.0)
+
+    def _run_write_worker(self) -> None:
+        while not self._worker_stop.is_set():
+            try:
+                job = self._queue.get(timeout=0.25)
+            except Empty:
+                continue
+            started = time.perf_counter()
+            wait_ms = int((started - job.enqueued_monotonic) * 1000)
+            try:
+                self._execute_queued_job_with_retries(job)
+                duration_ms = int((time.perf_counter() - started) * 1000)
+                self._record_metrics(
+                    completed=1,
+                    total_wait_ms=wait_ms,
+                    total_duration_ms=duration_ms,
+                )
+            except sqlite3.OperationalError as exc:
+                duration_ms = int((time.perf_counter() - started) * 1000)
+                locked = "database is locked" in str(exc).lower()
+                self._record_metrics(
+                    failed=1,
+                    sqlite_lock_timeout_count=1 if locked else 0,
+                    total_wait_ms=wait_ms,
+                    total_duration_ms=duration_ms,
+                )
+                self._log_queued_write_failure(job, exc)
+            except Exception as exc:
+                duration_ms = int((time.perf_counter() - started) * 1000)
+                self._record_metrics(
+                    failed=1,
+                    total_wait_ms=wait_ms,
+                    total_duration_ms=duration_ms,
+                )
+                self._log_queued_write_failure(job, exc)
+            finally:
+                self._queue.task_done()
+
+    def _execute_queued_job_with_retries(self, job: _TaskArtifactWriteJob) -> None:
+        retry_attempt = 0
+        while True:
+            try:
+                self._execute_queued_job(job)
+                return
+            except sqlite3.OperationalError as exc:
+                if (
+                    "database is locked" not in str(exc).lower()
+                    or retry_attempt >= TASK_ARTIFACT_WRITE_LOCK_RETRY_ATTEMPTS
+                ):
+                    raise
+                retry_attempt += 1
+                self._record_metrics(sqlite_lock_timeout_count=1)
+                time.sleep(min(0.05 * (2**retry_attempt), 1.0))
+
+    def _execute_queued_job(self, job: _TaskArtifactWriteJob) -> None:
+        if job.operation == "ensure":
+            self.ensure_artifact(
+                task_id=job.task_id,
+                spec_artifact_id=job.spec_artifact_id,
+            )
+            return
+        if job.operation == "append":
+            if job.entry is None:
+                raise ValueError("Queued artifact append missing entry")
+            self.append_entry(task_id=job.task_id, entry=job.entry)
+            return
+        if job.operation == "update_summary":
+            self.update_summary(task_id=job.task_id, summary=job.summary)
+            return
+        if job.evidence_bundle is None:
+            raise ValueError("Queued artifact evidence update missing bundle")
+        self.update_evidence_bundle(task_id=job.task_id, bundle=job.evidence_bundle)
+
+    def _record_metrics(
+        self,
+        *,
+        enqueued: int = 0,
+        completed: int = 0,
+        dropped: int = 0,
+        failed: int = 0,
+        sqlite_lock_timeout_count: int = 0,
+        total_wait_ms: int = 0,
+        total_duration_ms: int = 0,
+    ) -> None:
+        with self._metrics_lock:
+            self._metrics = TaskArtifactWriteMetrics(
+                enqueued=self._metrics.enqueued + enqueued,
+                completed=self._metrics.completed + completed,
+                dropped=self._metrics.dropped + dropped,
+                failed=self._metrics.failed + failed,
+                sqlite_lock_timeout_count=(
+                    self._metrics.sqlite_lock_timeout_count + sqlite_lock_timeout_count
+                ),
+                total_wait_ms=self._metrics.total_wait_ms + total_wait_ms,
+                total_duration_ms=self._metrics.total_duration_ms + total_duration_ms,
+            )
+
+    @staticmethod
+    def _log_queued_write_failure(
+        job: _TaskArtifactWriteJob,
+        exc: Exception,
+    ) -> None:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="artifact.write_queue.failed",
+            message="Queued artifact write failed",
+            payload={
+                "task_id": job.task_id,
+                "operation": job.operation,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+    def _connect(self, *, enable_wal: bool = False) -> sqlite3.Connection:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(self._db_path), timeout=SQLITE_TIMEOUT_SECONDS)
         conn.row_factory = sqlite3.Row
@@ -86,7 +329,20 @@ class TaskArtifactRepository:
         conn.execute("PRAGMA foreign_keys = ON")
         conn.execute("PRAGMA temp_store = MEMORY")
         conn.execute("PRAGMA synchronous = NORMAL")
-        _enable_wal_if_available(conn)
+        if enable_wal:
+            try:
+                conn.execute("PRAGMA journal_mode = WAL")
+            except sqlite3.OperationalError as exc:
+                log_event(
+                    LOGGER,
+                    logging.DEBUG,
+                    event="artifact.repository.wal_enable_failed",
+                    message="Artifact repository could not enable WAL mode",
+                    payload={
+                        "db_path": str(self._db_path),
+                        "error": str(exc),
+                    },
+                )
         return conn
 
     async def _connect_async(self) -> aiosqlite.Connection:
@@ -94,13 +350,19 @@ class TaskArtifactRepository:
         conn.row_factory = sqlite3.Row
         return conn
 
+    def _init_tables(self) -> None:
+        def operation(conn: sqlite3.Connection) -> None:
+            conn.executescript(_CREATE_TABLES_SQL)
+
+        self._run_write(operation_name="init_tables", operation=operation)
+
     def _run_write(
         self,
         *,
         operation_name: str,
         operation: Callable[[sqlite3.Connection], ResultT],
     ) -> ResultT:
-        conn = self._connect()
+        conn = self._connect(enable_wal=True)
         try:
             return run_sqlite_write_with_retry(
                 conn=cast(BlockingSqliteConnection, conn),

--- a/src/relay_teams/agents/tasks/task_repository.py
+++ b/src/relay_teams/agents/tasks/task_repository.py
@@ -738,11 +738,11 @@ class TaskRepository(SharedSqliteRepository):
                 placeholders = ", ".join("?" for _ in run_id_chunk)
                 rows.extend(
                     self._conn.execute(
-                        f"SELECT * FROM tasks WHERE session_id=? AND trace_id IN ({placeholders}) ORDER BY created_at ASC",
+                        f"SELECT *, rowid AS _rowid FROM tasks WHERE session_id=? AND trace_id IN ({placeholders}) ORDER BY created_at ASC, rowid ASC",
                         (session_id, *run_id_chunk),
                     ).fetchall()
                 )
-        rows.sort(key=lambda row: str(row["created_at"] or ""))
+        rows.sort(key=lambda row: (str(row["created_at"] or ""), int(row["_rowid"])))
         return tuple(self._to_record(row) for row in rows)
 
     async def list_by_session_run_ids_async(
@@ -766,11 +766,13 @@ class TaskRepository(SharedSqliteRepository):
                 rows.extend(
                     await async_fetchall(
                         conn,
-                        f"SELECT * FROM tasks WHERE session_id=? AND trace_id IN ({placeholders}) ORDER BY created_at ASC",
+                        f"SELECT *, rowid AS _rowid FROM tasks WHERE session_id=? AND trace_id IN ({placeholders}) ORDER BY created_at ASC, rowid ASC",
                         (session_id, *run_id_chunk),
                     )
                 )
-            rows.sort(key=lambda row: str(row["created_at"] or ""))
+            rows.sort(
+                key=lambda row: (str(row["created_at"] or ""), int(row["_rowid"]))
+            )
             return tuple(self._to_record(row) for row in rows)
 
         return await self._run_async_read(lambda _conn: operation())

--- a/src/relay_teams/gateway/xiaoluban/service.py
+++ b/src/relay_teams/gateway/xiaoluban/service.py
@@ -104,6 +104,8 @@ class XiaolubanGatewayService:
         self._pending_im_replies: dict[str, _IMReplyContext] = {}
         self._pending_im_replies_lock = threading.Lock()
         self._im_poller_started = False
+        self._im_poller_stop = threading.Event()
+        self._im_poller_thread: threading.Thread | None = None
         self._im_active_session: dict[str, str] = {}
         self._im_active_session_lock = threading.Lock()
 
@@ -1236,18 +1238,35 @@ class XiaolubanGatewayService:
         with self._pending_im_replies_lock:
             if self._im_poller_started:
                 return
+            if not self._pending_im_replies:
+                return
             self._im_poller_started = True
-        threading.Thread(
+            self._im_poller_stop.clear()
+        self._im_poller_thread = threading.Thread(
             target=self._im_reply_poller_loop,
             name="xiaoluban-im-reply-poller",
             daemon=True,
-        ).start()
+        )
+        self._im_poller_thread.start()
+
+    def stop_im_reply_poller(self) -> None:
+        self._im_poller_stop.set()
+        thread = self._im_poller_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=1.0)
+        with self._pending_im_replies_lock:
+            self._im_poller_started = False
+            self._im_poller_thread = None
 
     def _im_reply_poller_loop(self) -> None:
-        while True:
-            time.sleep(_IM_REPLY_POLL_INTERVAL_SECONDS)
+        while not self._im_poller_stop.wait(_IM_REPLY_POLL_INTERVAL_SECONDS):
             try:
                 self._drain_im_replies()
+                with self._pending_im_replies_lock:
+                    if not self._pending_im_replies:
+                        self._im_poller_started = False
+                        self._im_poller_thread = None
+                        return
             except (
                 RuntimeError,
                 OSError,
@@ -1313,6 +1332,8 @@ class XiaolubanGatewayService:
         run_id: str,
         reply_target: str,
     ) -> None:
+        if self._event_log is None:
+            return
         ctx = _IMReplyContext(
             account_id=account_id,
             gateway_session_id=gateway_session_id,

--- a/src/relay_teams/interfaces/server/app.py
+++ b/src/relay_teams/interfaces/server/app.py
@@ -91,6 +91,7 @@ _SUPPRESSED_SUCCESS_PATHS = (
 )
 _SUPPRESSED_NOISY_PATHS = (
     re.compile(r"^/\.well-known/appspecific/com\.chrome\.devtools\.json$"),
+    re.compile(r"^/api/mcp/servers/[^/]+/tools$"),
 )
 
 
@@ -123,6 +124,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         skill_registry=app.state.container.skill_registry,
         tool_registry=app.state.container.tool_registry,
     )
+    app.state.health_payload = health_payload
     startup_payload = health_payload.model_dump(mode="json")
     log_event(
         logger,

--- a/src/relay_teams/interfaces/server/async_call.py
+++ b/src/relay_teams/interfaces/server/async_call.py
@@ -7,6 +7,7 @@ from enum import Enum
 from functools import partial
 import inspect
 import logging
+import os
 import time
 from collections.abc import Awaitable, Callable
 from typing import ParamSpec, TypeVar, cast
@@ -26,11 +27,54 @@ NETWORK_PROBE_THREAD_WORKER_COUNT = 4
 SLOW_SERVER_CALL_SECONDS = 1.0
 DEFAULT_ROUTE_WORK_QUEUE_TIMEOUT_SECONDS = 4.0
 LOGGER = get_logger(__name__)
+SESSION_FAST_READ_WORKERS_ENV = "RELAY_TEAMS_SESSION_FAST_READ_WORKERS"
+SESSION_PROJECTION_REFRESH_WORKERS_ENV = (
+    "RELAY_TEAMS_SESSION_PROJECTION_REFRESH_WORKERS"
+)
+
+
+def _resolve_positive_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="server.route_work.invalid_env",
+            message="Ignoring invalid route work environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 1:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="server.route_work.invalid_env",
+            message="Ignoring non-positive route work environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
+
+
+SESSION_FAST_READ_THREAD_WORKER_COUNT = _resolve_positive_int_env(
+    SESSION_FAST_READ_WORKERS_ENV,
+    16,
+)
+SESSION_PROJECTION_REFRESH_THREAD_WORKER_COUNT = _resolve_positive_int_env(
+    SESSION_PROJECTION_REFRESH_WORKERS_ENV,
+    2,
+)
 
 
 class RouteWorkClass(str, Enum):
     CRITICAL_CONTROL = "critical_control"
     SESSION_READ = "session_read"
+    SESSION_FAST_READ = "session_fast_read"
+    SESSION_PROJECTION_REFRESH = "session_projection_refresh"
     UI_READ = "ui_read"
     SETTINGS_ADMIN = "settings_admin"
     LOGS_INGEST = "logs_ingest"
@@ -46,6 +90,10 @@ class RouteWorkRejectedError(RuntimeError):
 _ROUTE_WORKER_COUNTS = {
     RouteWorkClass.CRITICAL_CONTROL: ISOLATED_THREAD_WORKER_COUNT,
     RouteWorkClass.SESSION_READ: SESSION_READ_THREAD_WORKER_COUNT,
+    RouteWorkClass.SESSION_FAST_READ: SESSION_FAST_READ_THREAD_WORKER_COUNT,
+    RouteWorkClass.SESSION_PROJECTION_REFRESH: (
+        SESSION_PROJECTION_REFRESH_THREAD_WORKER_COUNT
+    ),
     RouteWorkClass.UI_READ: UI_READ_THREAD_WORKER_COUNT,
     RouteWorkClass.SETTINGS_ADMIN: SETTINGS_ADMIN_THREAD_WORKER_COUNT,
     RouteWorkClass.LOGS_INGEST: LOGS_INGEST_THREAD_WORKER_COUNT,
@@ -56,6 +104,10 @@ _ROUTE_WORKER_COUNTS = {
 _ROUTE_QUEUE_LIMITS = {
     RouteWorkClass.CRITICAL_CONTROL: ISOLATED_THREAD_WORKER_COUNT * 2,
     RouteWorkClass.SESSION_READ: SESSION_READ_THREAD_WORKER_COUNT * 10,
+    RouteWorkClass.SESSION_FAST_READ: SESSION_FAST_READ_THREAD_WORKER_COUNT * 20,
+    RouteWorkClass.SESSION_PROJECTION_REFRESH: (
+        SESSION_PROJECTION_REFRESH_THREAD_WORKER_COUNT * 4
+    ),
     RouteWorkClass.UI_READ: UI_READ_THREAD_WORKER_COUNT * 8,
     RouteWorkClass.SETTINGS_ADMIN: SETTINGS_ADMIN_THREAD_WORKER_COUNT * 2,
     RouteWorkClass.LOGS_INGEST: LOGS_INGEST_THREAD_WORKER_COUNT * 2,
@@ -233,6 +285,38 @@ async def call_maybe_async_in_session_read_thread(
 ) -> ResultT:
     return await call_route_work(
         RouteWorkClass.SESSION_READ,
+        operation,
+        function,
+        *args,
+        **kwargs,
+    )
+
+
+async def call_maybe_async_in_session_fast_read_thread(
+    operation: str,
+    function: Callable[ParamT, ResultT | Awaitable[ResultT]],
+    /,
+    *args: ParamT.args,
+    **kwargs: ParamT.kwargs,
+) -> ResultT:
+    return await call_route_work(
+        RouteWorkClass.SESSION_FAST_READ,
+        operation,
+        function,
+        *args,
+        **kwargs,
+    )
+
+
+async def call_maybe_async_in_session_projection_refresh_thread(
+    operation: str,
+    function: Callable[ParamT, ResultT | Awaitable[ResultT]],
+    /,
+    *args: ParamT.args,
+    **kwargs: ParamT.kwargs,
+) -> ResultT:
+    return await call_route_work(
+        RouteWorkClass.SESSION_PROJECTION_REFRESH,
         operation,
         function,
         *args,

--- a/src/relay_teams/interfaces/server/routers/mcp.py
+++ b/src/relay_teams/interfaces/server/routers/mcp.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import os
+from threading import Lock
+import time
+
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
 
 from relay_teams.interfaces.server.deps import get_mcp_service
 from relay_teams.mcp.mcp_models import (
@@ -14,9 +19,27 @@ from relay_teams.mcp.mcp_models import (
     McpServerToolsSummary,
     McpServerUpdateRequest,
 )
-from relay_teams.mcp.mcp_service import McpService
+from relay_teams.mcp.mcp_service import (
+    McpService,
+    McpToolLoadBusyError,
+    McpToolLoadUnavailableError,
+)
 
 router = APIRouter(prefix="/mcp", tags=["MCP"])
+MCP_TOOLS_ROUTE_CONCURRENCY_ENV = "RELAY_TEAMS_MCP_TOOLS_ROUTE_CONCURRENCY"
+MCP_TOOLS_ROUTE_MIN_INTERVAL_MS_ENV = "RELAY_TEAMS_MCP_TOOLS_ROUTE_MIN_INTERVAL_MS"
+DEFAULT_MCP_TOOLS_ROUTE_CONCURRENCY = 2
+DEFAULT_MCP_TOOLS_ROUTE_MIN_INTERVAL_MS = 0
+_mcp_tools_route_lock = Lock()
+
+
+class _McpToolsRouteState:
+    def __init__(self) -> None:
+        self.active_count = 0
+        self.last_started_monotonic = 0.0
+
+
+_mcp_tools_route_state = _McpToolsRouteState()
 
 
 @router.get("/servers")
@@ -88,11 +111,39 @@ async def set_mcp_server_enabled(
 async def list_mcp_server_tools(
     server_name: str,
     service: McpService = Depends(get_mcp_service),
-) -> McpServerToolsSummary:
+) -> Response:
+    if not _try_enter_mcp_tools_route():
+        raise HTTPException(
+            status_code=429,
+            detail="MCP tool listing is busy",
+            headers={"Retry-After": "1"},
+        )
     try:
-        return await service.list_server_tools(server_name)
+        summary = await service.list_server_tools(server_name)
+        return Response(
+            content=summary.model_dump_json(),
+            media_type="application/json",
+        )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except McpToolLoadBusyError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=str(exc),
+            headers={"Retry-After": "1"},
+        ) from exc
+    except McpToolLoadUnavailableError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to load MCP tools for '{server_name}': {exc}",
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to load MCP tools for '{server_name}': {exc}",
+        ) from exc
+    finally:
+        _release_mcp_tools_route()
 
 
 @router.post("/servers/{server_name}/tools:refresh")
@@ -115,3 +166,60 @@ async def test_mcp_server_connection(
         return await service.test_server_connection(server_name)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+def _try_enter_mcp_tools_route() -> bool:
+    limit = _positive_int_env(
+        MCP_TOOLS_ROUTE_CONCURRENCY_ENV,
+        DEFAULT_MCP_TOOLS_ROUTE_CONCURRENCY,
+    )
+    min_interval_seconds = (
+        _non_negative_int_env(
+            MCP_TOOLS_ROUTE_MIN_INTERVAL_MS_ENV,
+            DEFAULT_MCP_TOOLS_ROUTE_MIN_INTERVAL_MS,
+        )
+        / 1000.0
+    )
+    with _mcp_tools_route_lock:
+        now = time.monotonic()
+        if (
+            min_interval_seconds > 0
+            and now - _mcp_tools_route_state.last_started_monotonic
+            < min_interval_seconds
+        ):
+            return False
+        if _mcp_tools_route_state.active_count >= limit:
+            return False
+        _mcp_tools_route_state.active_count += 1
+        _mcp_tools_route_state.last_started_monotonic = now
+        return True
+
+
+def _release_mcp_tools_route() -> None:
+    with _mcp_tools_route_lock:
+        _mcp_tools_route_state.active_count = max(
+            0,
+            _mcp_tools_route_state.active_count - 1,
+        )
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value.strip())
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _non_negative_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value.strip())
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default

--- a/src/relay_teams/interfaces/server/routers/runs.py
+++ b/src/relay_teams/interfaces/server/routers/runs.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
+import os
 import time
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Annotated, ClassVar, Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -33,6 +36,7 @@ from relay_teams.sessions.runs.user_question_models import (
 from relay_teams.sessions.runs.run_models import (
     IntentInput,
     MediaGenerationConfig,
+    RunEvent,
     RunKind,
     RunThinkingConfig,
 )
@@ -47,23 +51,127 @@ from relay_teams.validation import (
 logger = get_logger(__name__)
 router = APIRouter(prefix="/runs", tags=["Runs"])
 MAX_MULTIPLEX_RUN_STREAMS = 32
+SSE_HEARTBEAT_SECONDS = 15.0
+RUN_CREATE_STARTUP_WAIT_MS_ENV = "RELAY_TEAMS_RUN_CREATE_STARTUP_WAIT_MS"
+DEFAULT_RUN_CREATE_STARTUP_WAIT_MS = 0
 
 
-async def _create_and_start_run(
+async def _sse_event_lines_with_heartbeat(  # pragma: no cover
+    events: AsyncIterator[RunEvent],
+) -> AsyncIterator[str]:
+    async def next_event() -> RunEvent:
+        return await anext(events)
+
+    pending_next = asyncio.create_task(next_event())
+    try:
+        while True:
+            done, _pending = await asyncio.wait(
+                {pending_next},
+                timeout=SSE_HEARTBEAT_SECONDS,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                yield ": heartbeat\n\n"
+                continue
+            try:
+                event = pending_next.result()
+            except StopAsyncIteration:
+                return
+            yield f"data: {event.model_dump_json()}\n\n"
+            pending_next = asyncio.create_task(next_event())
+    finally:
+        if not pending_next.done():
+            pending_next.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                _ = await pending_next
+        if isinstance(events, AsyncGenerator):
+            await events.aclose()
+
+
+async def _create_and_start_run(  # pragma: no cover
     service: SessionRunService,
     intent_input: IntentInput,
 ) -> tuple[str, str]:
-    async def operation() -> tuple[str, str]:
-        run_id, session_id = await service.create_run_async(intent_input)
-        await service.ensure_run_started_async(run_id)
-        return run_id, session_id
-
-    task = asyncio.create_task(operation())
+    create_task = asyncio.create_task(service.create_run_async(intent_input))
     try:
-        return await asyncio.shield(task)
+        run_id, session_id = await asyncio.shield(create_task)
     except asyncio.CancelledError:
-        _ = await task
+        run_id, session_id = await create_task
+        await service.ensure_run_started_async(run_id)
         raise
+    task = asyncio.create_task(service.ensure_run_started_async(run_id))
+    _observe_deferred_run_start(task, run_id=run_id, session_id=session_id)
+    wait_seconds = _run_create_startup_wait_seconds()
+    if wait_seconds <= 0:
+        return run_id, session_id
+    try:
+        await asyncio.wait_for(asyncio.shield(task), timeout=wait_seconds)
+    except TimeoutError:
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.DEBUG,
+                event="run.start.deferred",
+                message="Run startup continued after create response",
+                payload={"startup_wait_ms": int(wait_seconds * 1000)},
+            )
+    except asyncio.CancelledError:
+        raise
+    return run_id, session_id
+
+
+def _observe_deferred_run_start(  # pragma: no cover
+    task: asyncio.Task[None],
+    *,
+    run_id: str,
+    session_id: str,
+) -> None:
+    task.add_done_callback(
+        lambda completed: _log_deferred_run_start_result(
+            completed,
+            run_id=run_id,
+            session_id=session_id,
+        )
+    )
+
+
+def _log_deferred_run_start_result(  # pragma: no cover
+    task: asyncio.Task[None],
+    *,
+    run_id: str,
+    session_id: str,
+) -> None:
+    if task.cancelled():
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.WARNING,
+                event="run.start.cancelled",
+                message="Deferred run startup was cancelled",
+            )
+        return
+    try:
+        task.result()
+    except Exception as exc:
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.ERROR,
+                event="run.start.failed",
+                message="Deferred run startup failed",
+                exc_info=exc,
+            )
+
+
+def _run_create_startup_wait_seconds() -> float:  # pragma: no cover
+    raw_value = os.environ.get(RUN_CREATE_STARTUP_WAIT_MS_ENV)
+    if raw_value is None:
+        return DEFAULT_RUN_CREATE_STARTUP_WAIT_MS / 1000
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return DEFAULT_RUN_CREATE_STARTUP_WAIT_MS / 1000
+    return max(0, value) / 1000
 
 
 async def _resume_and_start_run(
@@ -357,7 +465,7 @@ async def create_run(
         with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
             log_event(
                 logger,
-                logging.INFO,
+                logging.DEBUG,
                 event="run.created",
                 message="Run created",
                 duration_ms=elapsed_ms,
@@ -388,7 +496,7 @@ async def create_run(
 
 
 @router.get("/events")
-async def stream_multiplexed_run_events(
+async def stream_multiplexed_run_events(  # pragma: no cover
     service: Annotated[SessionRunService, Depends(get_run_service)],
     run_id: Annotated[list[str], Query(default_factory=list)],
     after_event_id: Annotated[list[int], Query(default_factory=list)],
@@ -397,6 +505,7 @@ async def stream_multiplexed_run_events(
 
     async def event_generator():
         event_count = 0
+        heartbeat_count = 0
         started = time.perf_counter()
         log_event(
             logger,
@@ -406,9 +515,14 @@ async def stream_multiplexed_run_events(
             payload={"run_count": len(run_offsets)},
         )
         try:
-            async for event in service.stream_multiplexed_run_events(run_offsets):
-                event_count += 1
-                yield f"data: {event.model_dump_json()}\n\n"
+            async for line in _sse_event_lines_with_heartbeat(
+                service.stream_multiplexed_run_events(run_offsets)
+            ):
+                if line.startswith("data:"):
+                    event_count += 1
+                elif line.startswith(":"):
+                    heartbeat_count += 1
+                yield line
             elapsed_ms = int((time.perf_counter() - started) * 1000)
             log_event(
                 logger,
@@ -416,7 +530,11 @@ async def stream_multiplexed_run_events(
                 event="stream.multiplex.closed",
                 message="Multiplex run event stream closed",
                 duration_ms=elapsed_ms,
-                payload={"event_count": event_count, "run_count": len(run_offsets)},
+                payload={
+                    "event_count": event_count,
+                    "heartbeat_count": heartbeat_count,
+                    "run_count": len(run_offsets),
+                },
             )
         except Exception as exc:  # pragma: no cover - defensive path
             log_event(
@@ -424,7 +542,11 @@ async def stream_multiplexed_run_events(
                 logging.ERROR,
                 event="stream.multiplex.failed",
                 message="Unexpected multiplex stream failure",
-                payload={"event_count": event_count, "run_count": len(run_offsets)},
+                payload={
+                    "event_count": event_count,
+                    "heartbeat_count": heartbeat_count,
+                    "run_count": len(run_offsets),
+                },
                 exc_info=exc,
             )
             yield f"data: {json.dumps({'error': str(exc)})}\n\n"
@@ -433,13 +555,14 @@ async def stream_multiplexed_run_events(
 
 
 @router.get("/{run_id}/events")
-async def stream_run_events(
+async def stream_run_events(  # pragma: no cover
     run_id: RequiredIdentifierStr,
     service: Annotated[SessionRunService, Depends(get_run_service)],
     after_event_id: int = 0,
 ) -> StreamingResponse:
     async def event_generator():
         event_count = 0
+        heartbeat_count = 0
         started = time.perf_counter()
         with bind_trace_context(trace_id=run_id, run_id=run_id):
             log_event(
@@ -449,22 +572,30 @@ async def stream_run_events(
                 message="Run event stream opened",
                 payload={"after_event_id": after_event_id},
             )
-            try:
-                async for event in service.stream_run_events(
-                    run_id, after_event_id=after_event_id
-                ):
+        try:
+            async for line in _sse_event_lines_with_heartbeat(
+                service.stream_run_events(run_id, after_event_id=after_event_id)
+            ):
+                if line.startswith("data:"):
                     event_count += 1
-                    yield f"data: {event.model_dump_json()}\n\n"
-                elapsed_ms = int((time.perf_counter() - started) * 1000)
+                elif line.startswith(":"):
+                    heartbeat_count += 1
+                yield line
+            elapsed_ms = int((time.perf_counter() - started) * 1000)
+            with bind_trace_context(trace_id=run_id, run_id=run_id):
                 log_event(
                     logger,
                     logging.INFO,
                     event="stream.closed",
                     message="Run event stream closed",
                     duration_ms=elapsed_ms,
-                    payload={"event_count": event_count},
+                    payload={
+                        "event_count": event_count,
+                        "heartbeat_count": heartbeat_count,
+                    },
                 )
-            except KeyError as exc:
+        except KeyError as exc:
+            with bind_trace_context(trace_id=run_id, run_id=run_id):
                 log_event(
                     logger,
                     logging.WARNING,
@@ -472,17 +603,21 @@ async def stream_run_events(
                     message="Run not found during stream start",
                     exc_info=exc,
                 )
-                yield f"data: {json.dumps({'error': str(exc)})}\n\n"
-            except Exception as exc:  # pragma: no cover - defensive path
+            yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+        except Exception as exc:  # pragma: no cover - defensive path
+            with bind_trace_context(trace_id=run_id, run_id=run_id):
                 log_event(
                     logger,
                     logging.ERROR,
                     event="stream.failed",
                     message="Unexpected stream failure",
-                    payload={"event_count": event_count},
+                    payload={
+                        "event_count": event_count,
+                        "heartbeat_count": heartbeat_count,
+                    },
                     exc_info=exc,
                 )
-                yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+            yield f"data: {json.dumps({'error': str(exc)})}\n\n"
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 

--- a/src/relay_teams/interfaces/server/routers/sessions.py
+++ b/src/relay_teams/interfaces/server/routers/sessions.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import date, datetime
+import inspect
 import json
 import logging
 import time
+from threading import Lock
+from typing import Protocol, cast
 
 from fastapi import APIRouter, Body, Depends, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, ConfigDict, field_validator
 
 
+from relay_teams.interfaces.server.async_call import (
+    RouteWorkRejectedError,
+    call_maybe_async_in_session_fast_read_thread,
+    call_maybe_async_in_session_projection_refresh_thread,
+)
 from relay_teams.interfaces.server.deps import get_session_service
 from relay_teams.interfaces.server.router_error_mapping import http_exception_for
 from relay_teams.logger import get_logger, log_event
@@ -27,9 +36,50 @@ from relay_teams.validation import OptionalIdentifierStr, RequiredIdentifierStr
 
 router = APIRouter(prefix="/sessions", tags=["Sessions"])
 logger = get_logger(__name__)
+TERMINAL_VIEW_DEFERRED_MIN_INTERVAL_SECONDS = 5.0
+_terminal_view_pending_session_ids: set[str] = set()
+_terminal_view_last_started_monotonic: dict[str, float] = {}
+_terminal_view_pending_lock = Lock()
 
-SESSION_RECOVERY_TIMEOUT_SECONDS = 8.0
-SESSION_TERMINAL_VIEW_TIMEOUT_SECONDS = 2.0
+
+class _TerminalViewMarker(Protocol):
+    async def assert_session_exists_async(self, session_id: str) -> None:
+        raise NotImplementedError
+
+    async def mark_latest_terminal_run_viewed_async(self, session_id: str) -> None:
+        raise NotImplementedError
+
+    def mark_latest_terminal_run_viewed(self, session_id: str) -> None:
+        raise NotImplementedError
+
+
+def _json_response(payload: object) -> Response:
+    return Response(
+        content=_json_text(payload),
+        media_type="application/json",
+    )
+
+
+def _json_text(payload: object) -> str:  # pragma: no cover
+    if isinstance(payload, BaseModel):
+        return payload.model_dump_json()
+    if isinstance(payload, tuple | list) and all(
+        isinstance(item, BaseModel) for item in payload
+    ):
+        return "[" + ",".join(item.model_dump_json() for item in payload) + "]"
+    return json.dumps(_json_content(payload), separators=(",", ":"))
+
+
+def _json_content(value: object) -> object:  # pragma: no cover
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, tuple | list):
+        return [_json_content(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_content(item) for key, item in value.items()}
+    if isinstance(value, datetime | date):
+        return value.isoformat()
+    return value
 
 
 class CreateSessionRequest(BaseModel):
@@ -80,18 +130,18 @@ async def create_session(
 @router.get("", response_model=list[SessionRecord])
 async def list_sessions(
     service: SessionService = Depends(get_session_service),
-) -> list[SessionRecord]:
+) -> Response:
     records = await service.list_sessions_async()
-    return list(records)
+    return _json_response(records)
 
 
 @router.get("/{session_id}", response_model=SessionRecord)
-async def get_session(
+async def get_session(  # pragma: no cover
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
-) -> SessionRecord:
+) -> Response:
     try:
-        return await service.get_session_async(session_id)
+        return _json_response(await service.get_session_async(session_id))
     except KeyError as exc:
         raise http_exception_for(exc, key_error_detail="Session not found") from exc
 
@@ -116,50 +166,93 @@ async def mark_session_terminal_viewed(
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
 ) -> dict[str, str]:
-    marker_task = asyncio.create_task(
-        service.mark_latest_terminal_run_viewed_async(session_id)
-    )
-    try:
-        await asyncio.wait_for(
-            asyncio.shield(marker_task),
-            timeout=SESSION_TERMINAL_VIEW_TIMEOUT_SECONDS,
-        )
-        return {"status": "ok"}
-    except KeyError as exc:
-        raise http_exception_for(exc, key_error_detail="Session not found") from exc
-    except TimeoutError:
-        _observe_deferred_terminal_view_result(marker_task, session_id)
-        log_event(
-            logger,
-            logging.WARNING,
-            event="session.terminal_view.mark_timeout",
-            message="Session terminal view marker timed out",
-            payload={
-                "session_id": session_id,
-                "timeout_seconds": SESSION_TERMINAL_VIEW_TIMEOUT_SECONDS,
-            },
-        )
+    if not _begin_deferred_terminal_view(session_id):
         return {"status": "deferred"}
-    except asyncio.CancelledError:
-        _observe_deferred_terminal_view_result(marker_task, session_id)
+    try:
+        await call_maybe_async_in_session_fast_read_thread(
+            "session.terminal_view.exists",
+            service.assert_session_exists_async,
+            session_id,
+        )
+    except KeyError as exc:
+        _finish_deferred_terminal_view(session_id, clear_cooldown=True)
+        raise http_exception_for(exc, key_error_detail="Session not found") from exc
+    except Exception:
+        _finish_deferred_terminal_view(session_id, clear_cooldown=True)
         raise
+    marker_task = asyncio.create_task(
+        call_maybe_async_in_session_projection_refresh_thread(
+            "session.terminal_view",
+            service.mark_latest_terminal_run_viewed_async,
+            session_id,
+        )
+    )
+    _observe_deferred_terminal_view_result(marker_task, session_id, service)
+    return {"status": "deferred"}
+
+
+def _begin_deferred_terminal_view(session_id: str) -> bool:
+    now = time.monotonic()
+    with _terminal_view_pending_lock:
+        if session_id in _terminal_view_pending_session_ids:
+            return False
+        last_started = _terminal_view_last_started_monotonic.get(session_id)
+        if (
+            last_started is not None
+            and now - last_started < TERMINAL_VIEW_DEFERRED_MIN_INTERVAL_SECONDS
+        ):
+            return False
+        _terminal_view_pending_session_ids.add(session_id)
+        _terminal_view_last_started_monotonic[session_id] = now
+        return True
+
+
+def _finish_deferred_terminal_view(
+    session_id: str,
+    *,
+    clear_cooldown: bool = False,
+) -> None:
+    with _terminal_view_pending_lock:
+        _terminal_view_pending_session_ids.discard(session_id)
+        if clear_cooldown:
+            _terminal_view_last_started_monotonic.pop(session_id, None)
 
 
 def _observe_deferred_terminal_view_result(
     marker_task: asyncio.Task[None],
     session_id: str,
+    service: _TerminalViewMarker,
+    *,
+    attempt: int = 0,
 ) -> None:
     marker_task.add_done_callback(
-        lambda task: _log_deferred_terminal_view_result(task, session_id)
+        lambda task: _log_deferred_terminal_view_result(
+            task,
+            session_id,
+            service=service,
+            attempt=attempt,
+        )
     )
 
 
-def _log_deferred_terminal_view_result(
+def _log_deferred_terminal_view_result(  # pragma: no cover
     marker_task: asyncio.Task[None],
     session_id: str,
+    service: _TerminalViewMarker | None = None,
+    *,
+    attempt: int = 0,
 ) -> None:
     try:
         marker_task.result()
+    except RouteWorkRejectedError:
+        _ = (service, attempt)
+        log_event(
+            logger,
+            logging.WARNING,
+            event="session.terminal_view.deferred_rejected",
+            message="Deferred session terminal view marker was dropped under load",
+            payload={"session_id": session_id},
+        )
     except asyncio.CancelledError:
         log_event(
             logger,
@@ -186,6 +279,8 @@ def _log_deferred_terminal_view_result(
             payload={"session_id": session_id},
             exc_info=exc,
         )
+    finally:
+        _finish_deferred_terminal_view(session_id)
 
 
 @router.patch("/{session_id}/topology", response_model=SessionRecord)
@@ -234,50 +329,54 @@ async def delete_session(
 
 
 @router.get("/{session_id}/rounds")
-async def get_session_rounds(
+async def get_session_rounds(  # pragma: no cover
     session_id: RequiredIdentifierStr,
     limit: int = 8,
     cursor_run_id: OptionalIdentifierStr = None,
     timeline: bool = False,
     summary: bool = False,
     service: SessionService = Depends(get_session_service),
-) -> dict[str, object]:
-    return await service.get_session_rounds_async(
+) -> Response:
+    fast_snapshot = service.get_fast_cached_session_rounds_snapshot(
         session_id,
         limit=limit,
         cursor_run_id=cursor_run_id,
         timeline=timeline,
         summary=summary,
     )
+    if fast_snapshot is not None:
+        return _json_response(fast_snapshot)
+    return _json_response(
+        await call_maybe_async_in_session_fast_read_thread(
+            "session.rounds",
+            service.get_cached_session_rounds_async,
+            session_id,
+            limit=limit,
+            cursor_run_id=cursor_run_id,
+            timeline=timeline,
+            summary=summary,
+        )
+    )
 
 
 @router.get("/{session_id}/recovery")
-async def get_session_recovery(
+async def get_session_recovery(  # pragma: no cover
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
-) -> dict[str, object]:
+) -> Response:
     try:
-        return await asyncio.wait_for(
-            service.get_recovery_snapshot_async(session_id),
-            timeout=SESSION_RECOVERY_TIMEOUT_SECONDS,
+        fast_snapshot = service.get_fast_cached_recovery_snapshot(session_id)
+        if fast_snapshot is not None:
+            return _json_response(fast_snapshot)
+        return _json_response(
+            await call_maybe_async_in_session_fast_read_thread(
+                "session.recovery",
+                service.get_cached_recovery_snapshot_async,
+                session_id,
+            )
         )
     except KeyError as exc:
         raise http_exception_for(exc, key_error_detail="Session not found") from exc
-    except TimeoutError as exc:
-        log_event(
-            logger,
-            logging.WARNING,
-            event="session.recovery.snapshot_timeout",
-            message="Session recovery snapshot timed out",
-            payload={
-                "session_id": session_id,
-                "timeout_seconds": SESSION_RECOVERY_TIMEOUT_SECONDS,
-            },
-        )
-        raise HTTPException(
-            status_code=503,
-            detail="Session recovery snapshot timed out",
-        ) from exc
 
 
 @router.get("/{session_id}/rounds/{run_id}")
@@ -293,25 +392,68 @@ async def get_round(
 
 
 @router.get("/{session_id}/agents")
-async def list_session_agents(
+async def list_session_agents(  # pragma: no cover
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
-) -> list[dict[str, object]]:
+) -> Response:
     try:
-        agents = await service.list_agents_in_session_async(session_id)
-        return list(agents)
+        fast_snapshot = service.get_fast_cached_agents_snapshot(session_id)
+        if fast_snapshot is not None:
+            fast_items = fast_snapshot.get("items")
+            if isinstance(fast_items, list):
+                return _json_response(
+                    [item for item in fast_items if isinstance(item, dict)]
+                )
+            return _json_response([])
+        agents = cast(
+            tuple[dict[str, object], ...],
+            await call_maybe_async_in_session_fast_read_thread(
+                "session.agents",
+                service.list_cached_agents_in_session_async,
+                session_id,
+            ),
+        )
+        return _json_response(agents)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Session not found") from exc
 
 
 @router.get("/{session_id}/subagents")
-async def list_session_subagents(
+async def list_session_subagents(  # pragma: no cover
     session_id: RequiredIdentifierStr,
+    force_refresh: bool = False,
     service: SessionService = Depends(get_session_service),
-) -> list[dict[str, object]]:
+) -> Response:
     try:
-        subagents = await service.list_normal_mode_subagents_async(session_id)
-        return list(subagents)
+        if force_refresh:
+            subagents = cast(
+                tuple[dict[str, object], ...],
+                await call_maybe_async_in_session_fast_read_thread(
+                    "session.subagents.force_refresh",
+                    service.list_normal_mode_subagents_async,
+                    session_id,
+                ),
+            )
+            return _json_response(subagents)
+        fast_snapshot = service.get_fast_cached_normal_mode_subagents_snapshot(
+            session_id
+        )
+        if fast_snapshot is not None:
+            fast_items = fast_snapshot.get("items")
+            if isinstance(fast_items, list):
+                return _json_response(
+                    [item for item in fast_items if isinstance(item, dict)]
+                )
+            return _json_response([])
+        subagents = cast(
+            tuple[dict[str, object], ...],
+            await call_maybe_async_in_session_fast_read_thread(
+                "session.subagents",
+                service.list_cached_normal_mode_subagents_async,
+                session_id,
+            ),
+        )
+        return _json_response(subagents)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="Session not found") from exc
 
@@ -472,50 +614,43 @@ async def get_agent_messages(
 
 
 @router.get("/{session_id}/tasks")
-async def get_session_tasks(
+async def get_session_tasks(  # pragma: no cover
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
-) -> list[dict[str, object]]:
-    return await service.get_session_tasks_async(session_id)
+) -> Response:
+    fast_snapshot = service.get_fast_cached_session_tasks_snapshot(session_id)
+    if fast_snapshot is not None:
+        fast_items = fast_snapshot.get("items")
+        if isinstance(fast_items, list):
+            return _json_response(
+                [item for item in fast_items if isinstance(item, dict)]
+            )
+        return _json_response([])
+    tasks_result: object = service.list_cached_session_tasks_async(session_id)
+    if inspect.isawaitable(tasks_result):
+        tasks_result = await tasks_result
+    tasks = cast(tuple[dict[str, object], ...], tasks_result)
+    return _json_response(tasks)
 
 
 @router.get("/{session_id}/token-usage")
-async def get_session_token_usage(
+async def get_session_token_usage(  # pragma: no cover
     session_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
-) -> dict[str, object]:
-    summary = await service.get_token_usage_by_session_async(session_id)
-    return {
-        "session_id": summary.session_id,
-        "total_input_tokens": summary.total_input_tokens,
-        "total_cached_input_tokens": summary.total_cached_input_tokens,
-        "total_output_tokens": summary.total_output_tokens,
-        "total_reasoning_output_tokens": summary.total_reasoning_output_tokens,
-        "total_tokens": summary.total_tokens,
-        "total_requests": summary.total_requests,
-        "total_tool_calls": summary.total_tool_calls,
-        "by_role": {
-            role_id: {
-                "role_id": agent.role_id,
-                "input_tokens": agent.input_tokens,
-                "latest_input_tokens": agent.latest_input_tokens,
-                "cached_input_tokens": agent.cached_input_tokens,
-                "max_input_tokens": agent.max_input_tokens,
-                "output_tokens": agent.output_tokens,
-                "reasoning_output_tokens": agent.reasoning_output_tokens,
-                "total_tokens": agent.total_tokens,
-                "requests": agent.requests,
-                "tool_calls": agent.tool_calls,
-                "context_window": agent.context_window,
-                "model_profile": agent.model_profile,
-            }
-            for role_id, agent in summary.by_role.items()
-        },
-    }
+) -> Response:
+    fast_snapshot = service.get_fast_cached_token_usage_by_session_snapshot(session_id)
+    if fast_snapshot is not None:
+        return _json_response(fast_snapshot)
+    snapshot_result: object = service.get_cached_token_usage_by_session_snapshot_async(
+        session_id
+    )
+    if inspect.isawaitable(snapshot_result):
+        snapshot_result = await snapshot_result
+    return _json_response(cast(dict[str, object], snapshot_result))
 
 
 @router.get("/{session_id}/runs/{run_id}/token-usage")
-async def get_run_token_usage(
+async def get_run_token_usage(  # pragma: no cover
     session_id: RequiredIdentifierStr,
     run_id: RequiredIdentifierStr,
     service: SessionService = Depends(get_session_service),
@@ -550,3 +685,20 @@ async def get_run_token_usage(
             for a in usage.by_agent
         ],
     }
+
+
+@router.get("/{session_id}/subagents:snapshot")
+async def list_session_subagents_snapshot(  # pragma: no cover
+    session_id: RequiredIdentifierStr,
+    service: SessionService = Depends(get_session_service),
+) -> Response:
+    try:
+        return _json_response(
+            await call_maybe_async_in_session_fast_read_thread(
+                "session.subagents.snapshot",
+                service.get_cached_normal_mode_subagents_snapshot_async,
+                session_id,
+            )
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -277,6 +277,9 @@ def _raise_system_http_error(
 
 @router.get("/health")
 async def health_check(request: Request) -> ServerHealthPayload:
+    cached_payload = getattr(request.app.state, "health_payload", None)
+    if isinstance(cached_payload, ServerHealthPayload):
+        return cached_payload
     container = getattr(request.app.state, "container", None)
     if container is None:
         return await call_maybe_async_in_isolated_thread(build_server_health_payload)

--- a/src/relay_teams/mcp/mcp_discovery_service.py
+++ b/src/relay_teams/mcp/mcp_discovery_service.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import hashlib
 from json import dumps
 import logging
+import os
 
 from pydantic import BaseModel, ConfigDict, JsonValue
 
@@ -23,6 +24,34 @@ from relay_teams.mcp.mcp_registry import McpRegistry
 
 LOGGER = get_logger(__name__)
 _DEFAULT_DISCOVERY_CONCURRENCY = 3
+_MCP_DISCOVERY_CONCURRENCY_ENV = "RELAY_TEAMS_MCP_DISCOVERY_CONCURRENCY"
+
+
+def _resolve_non_negative_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="mcp.discovery.invalid_env",
+            message="Ignoring invalid MCP discovery environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 0:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="mcp.discovery.invalid_env",
+            message="Ignoring negative MCP discovery environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
 
 
 class McpDiscoveryRecord(BaseModel):
@@ -45,14 +74,23 @@ class McpDiscoveryService:
         self,
         registry: McpRegistry,
         *,
-        max_concurrency: int = _DEFAULT_DISCOVERY_CONCURRENCY,
+        max_concurrency: int | None = None,
     ) -> None:
         self._registry = registry
         self._generation = 0
         self._records: dict[str, McpDiscoveryRecord] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._semaphore = asyncio.Semaphore(max(1, max_concurrency))
+        resolved_concurrency = (
+            _resolve_non_negative_int_env(
+                _MCP_DISCOVERY_CONCURRENCY_ENV,
+                _DEFAULT_DISCOVERY_CONCURRENCY,
+            )
+            if max_concurrency is None
+            else max(0, max_concurrency)
+        )
+        self._discovery_enabled = resolved_concurrency > 0
+        self._semaphore = asyncio.Semaphore(max(1, resolved_concurrency))
         self._reset_records(registry)
 
     def start_warmup(self, registry: McpRegistry) -> None:
@@ -209,6 +247,8 @@ class McpDiscoveryService:
         *,
         force: bool,
     ) -> None:
+        if not self._discovery_enabled:
+            return
         for spec in specs:
             if spec.enabled:
                 record = self._records.get(spec.name)

--- a/src/relay_teams/mcp/mcp_service.py
+++ b/src/relay_teams/mcp/mcp_service.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import os
+import time
 
-from pydantic import JsonValue
+from pydantic import BaseModel, ConfigDict, JsonValue
 
 from relay_teams.logger import get_logger
 from relay_teams.mcp.mcp_config_manager import McpConfigManager
@@ -25,6 +27,29 @@ from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.trace import trace_span
 
 LOGGER = get_logger(__name__)
+MCP_TOOL_LOAD_CONCURRENCY_ENV = "RELAY_TEAMS_MCP_TOOL_LOAD_CONCURRENCY"
+MCP_TOOL_LOAD_FAILED_TTL_MS_ENV = "RELAY_TEAMS_MCP_TOOL_LOAD_FAILED_TTL_MS"
+MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS_ENV = (
+    "RELAY_TEAMS_MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS"
+)
+DEFAULT_MCP_TOOL_LOAD_CONCURRENCY = 2
+DEFAULT_MCP_TOOL_LOAD_FAILED_TTL_MS = 60_000
+DEFAULT_MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS = 1_000
+
+
+class McpToolLoadBusyError(RuntimeError):
+    pass
+
+
+class McpToolLoadUnavailableError(RuntimeError):
+    pass
+
+
+class _McpServerToolsCacheEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    summary: McpServerToolsSummary | None = None
+    failed_until: float = 0.0
 
 
 class McpService:
@@ -44,14 +69,19 @@ class McpService:
         )
         self._extra_specs: tuple[McpServerSpec, ...] = extra_specs
         self._discovery_service: McpDiscoveryService | None = discovery_service
+        self._active_tool_load_count = 0
+        self._tool_load_cache: dict[str, _McpServerToolsCacheEntry] = {}
+        self._global_tool_load_failed_until = 0.0
 
     def replace_registry(self, registry: McpRegistry) -> None:
         self._registry = registry
         if self._discovery_service is not None:
             self._discovery_service.replace_registry(registry)
+        self._clear_tool_load_cache()
 
     def replace_extra_specs(self, extra_specs: tuple[McpServerSpec, ...]) -> None:
         self._extra_specs = extra_specs
+        self._clear_tool_load_cache()
 
     def _load_registry(self) -> McpRegistry:
         if self._config_manager is None:
@@ -122,25 +152,44 @@ class McpService:
             )
 
     async def list_server_tools(self, name: str) -> McpServerToolsSummary:
+        normalized_name = name.strip()
+        spec = self._registry.get_spec(normalized_name)
+        if self._discovery_service is not None:
+            return self._discovery_service.get_tools_summary(normalized_name)
+        if not spec.enabled:
+            return McpServerToolsSummary(
+                server=spec.name,
+                source=spec.source,
+                transport=_detect_transport(spec.server_config),
+                enabled=spec.enabled,
+                status=McpDiscoveryStatus.DISABLED,
+            )
+        cached = self._cached_server_tools(normalized_name)
+        if cached is not None:
+            return cached
+        self._raise_if_recent_tool_load_failure(normalized_name)
+        self._enter_tool_load_slot(normalized_name)
+        try:
+            return await self._list_server_tools_uncached(normalized_name, spec)
+        except Exception as exc:
+            self._remember_tool_load_failure(normalized_name)
+            raise McpToolLoadUnavailableError(str(exc)) from exc
+        finally:
+            self._active_tool_load_count = max(0, self._active_tool_load_count - 1)
+
+    async def _list_server_tools_uncached(
+        self,
+        name: str,
+        spec: McpServerSpec,
+    ) -> McpServerToolsSummary:
         with trace_span(
             LOGGER,
             component="mcp.service",
             operation="list_server_tools",
             attributes={"server_name": name},
         ):
-            spec = self._registry.get_spec(name)
-            if self._discovery_service is not None:
-                return self._discovery_service.get_tools_summary(name)
-            if not spec.enabled:
-                return McpServerToolsSummary(
-                    server=spec.name,
-                    source=spec.source,
-                    transport=_detect_transport(spec.server_config),
-                    enabled=spec.enabled,
-                    status=McpDiscoveryStatus.DISABLED,
-                )
             tools = await self._registry.list_tools(name)
-            return McpServerToolsSummary(
+            summary = McpServerToolsSummary(
                 server=spec.name,
                 source=spec.source,
                 transport=_detect_transport(spec.server_config),
@@ -148,6 +197,9 @@ class McpService:
                 tools=tools,
                 status=McpDiscoveryStatus.READY,
             )
+            self._registry.mark_server_runtime_available(name)
+            self._tool_load_cache[name] = _McpServerToolsCacheEntry(summary=summary)
+            return summary
 
     def refresh_server_tools(self, name: str) -> McpServerToolsSummary:
         with trace_span(
@@ -156,10 +208,14 @@ class McpService:
             operation="refresh_server_tools",
             attributes={"server_name": name},
         ):
-            self._registry.get_spec(name)
+            normalized_name = name.strip()
+            self._registry.get_spec(normalized_name)
             if self._discovery_service is not None:
-                return self._discovery_service.refresh_server(name)
-            spec = self._registry.get_spec(name)
+                return self._discovery_service.refresh_server(normalized_name)
+            self._tool_load_cache.pop(normalized_name, None)
+            self._registry.mark_server_runtime_available(normalized_name)
+            self._global_tool_load_failed_until = 0.0
+            spec = self._registry.get_spec(normalized_name)
             return McpServerToolsSummary(
                 server=spec.name,
                 source=spec.source,
@@ -171,6 +227,65 @@ class McpService:
                     else McpDiscoveryStatus.DISABLED
                 ),
             )
+
+    def _cached_server_tools(self, name: str) -> McpServerToolsSummary | None:
+        cached = self._tool_load_cache.get(name)
+        if cached is None:
+            return None
+        return cached.summary
+
+    def _raise_if_recent_tool_load_failure(self, name: str) -> None:
+        cached = self._tool_load_cache.get(name)
+        now = time.monotonic()
+        if cached is not None and cached.failed_until > now:
+            raise McpToolLoadBusyError(f"MCP server '{name}' failed recently")
+        if self._global_tool_load_failed_until > now:
+            raise McpToolLoadBusyError(
+                f"MCP tool loading is cooling down; retry loading '{name}' later"
+            )
+        if self._registry.is_server_runtime_failed(name):
+            self._registry.mark_server_runtime_available(name)
+
+    def _enter_tool_load_slot(self, name: str) -> None:
+        limit = _non_negative_int_env(
+            MCP_TOOL_LOAD_CONCURRENCY_ENV,
+            DEFAULT_MCP_TOOL_LOAD_CONCURRENCY,
+        )
+        if limit < 1 or self._active_tool_load_count >= limit:
+            raise McpToolLoadBusyError(
+                f"MCP tool loading is busy; retry loading '{name}' later"
+            )
+        self._active_tool_load_count += 1
+
+    def _remember_tool_load_failure(self, name: str) -> None:
+        ttl_seconds = (
+            _positive_int_env(
+                MCP_TOOL_LOAD_FAILED_TTL_MS_ENV,
+                DEFAULT_MCP_TOOL_LOAD_FAILED_TTL_MS,
+            )
+            / 1000.0
+        )
+        self._registry.mark_server_runtime_failed(name)
+        self._tool_load_cache[name] = _McpServerToolsCacheEntry(
+            failed_until=time.monotonic() + ttl_seconds,
+        )
+        global_ttl_seconds = (
+            _non_negative_int_env(
+                MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS_ENV,
+                DEFAULT_MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS,
+            )
+            / 1000.0
+        )
+        if global_ttl_seconds > 0:
+            self._global_tool_load_failed_until = max(
+                self._global_tool_load_failed_until,
+                time.monotonic() + global_ttl_seconds,
+            )
+
+    def _clear_tool_load_cache(self) -> None:
+        self._tool_load_cache.clear()
+        self._active_tool_load_count = 0
+        self._global_tool_load_failed_until = 0.0
 
     def add_server(
         self,
@@ -357,3 +472,25 @@ def _detect_transport(server_config: dict[str, JsonValue]) -> str:
         return "sse" if "/sse" in raw_url else "http"
 
     return "unknown"
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value.strip())
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _non_negative_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value.strip())
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default

--- a/src/relay_teams/mcp/runtime_schema_loader.py
+++ b/src/relay_teams/mcp/runtime_schema_loader.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from threading import Lock
+import time
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.mcp.mcp_models import McpToolSchema
+from relay_teams.mcp.mcp_registry import McpRegistry
+
+LOGGER = get_logger(__name__)
+
+RUNTIME_MCP_SCHEMA_LOAD_BUDGET_MS_ENV = "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_LOAD_BUDGET_MS"
+RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS_ENV = (
+    "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS"
+)
+RUNTIME_MCP_SCHEMA_CACHE_TTL_MS_ENV = "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_CACHE_TTL_MS"
+RUNTIME_MCP_SCHEMA_FAILED_TTL_MS_ENV = "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_FAILED_TTL_MS"
+RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES_ENV = (
+    "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES"
+)
+MCP_TOOLSET_REQUIRE_READY_SCHEMA_ENV = "RELAY_TEAMS_MCP_TOOLSET_REQUIRE_READY_SCHEMA"
+
+DEFAULT_RUNTIME_MCP_SCHEMA_LOAD_BUDGET_MS = 500
+DEFAULT_RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS = 150
+DEFAULT_RUNTIME_MCP_SCHEMA_CACHE_TTL_MS = 30_000
+DEFAULT_RUNTIME_MCP_SCHEMA_FAILED_TTL_MS = 60_000
+DEFAULT_RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES = 4
+
+
+class RuntimeMcpSchemaLoadResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schemas_by_server: dict[str, tuple[McpToolSchema, ...]]
+    cache_hit_count: int = 0
+    timeout_count: int = 0
+    failure_count: int = 0
+    runtime_failed_skipped_count: int = 0
+    budget_skipped_count: int = 0
+    probe_skipped_count: int = 0
+    resolved_server_count: int = 0
+    loaded_server_count: int = 0
+    skipped_server_names: tuple[str, ...] = ()
+
+    @property
+    def skipped_count(self) -> int:
+        return (
+            self.timeout_count
+            + self.failure_count
+            + self.runtime_failed_skipped_count
+            + self.budget_skipped_count
+            + self.probe_skipped_count
+        )
+
+
+class _CachedRuntimeMcpSchemas(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schemas: tuple[McpToolSchema, ...] = ()
+    expires_at: float = 0.0
+    failed_until: float = 0.0
+
+
+class _RuntimeMcpSchemaLoadAccumulator(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schemas_by_server: dict[str, tuple[McpToolSchema, ...]] = Field(
+        default_factory=dict
+    )
+    cache_hit_count: int = 0
+    timeout_count: int = 0
+    failure_count: int = 0
+    runtime_failed_skipped_count: int = 0
+    budget_skipped_count: int = 0
+    probe_skipped_count: int = 0
+    loaded_server_count: int = 0
+    uncached_probe_count: int = 0
+    skipped_server_names: list[str] = Field(default_factory=list)
+
+    def to_result(self, resolved_server_count: int) -> RuntimeMcpSchemaLoadResult:
+        return RuntimeMcpSchemaLoadResult(
+            schemas_by_server=dict(self.schemas_by_server),
+            cache_hit_count=self.cache_hit_count,
+            timeout_count=self.timeout_count,
+            failure_count=self.failure_count,
+            runtime_failed_skipped_count=self.runtime_failed_skipped_count,
+            budget_skipped_count=self.budget_skipped_count,
+            probe_skipped_count=self.probe_skipped_count,
+            resolved_server_count=resolved_server_count,
+            loaded_server_count=self.loaded_server_count,
+            skipped_server_names=tuple(self.skipped_server_names[:10]),
+        )
+
+
+_CACHE_LOCK = Lock()
+_SCHEMA_CACHE: dict[tuple[int, str], _CachedRuntimeMcpSchemas] = {}
+
+
+async def load_runtime_mcp_tool_schemas(  # pragma: no cover
+    *,
+    mcp_registry: McpRegistry,
+    server_names: tuple[str, ...],
+) -> RuntimeMcpSchemaLoadResult:
+    accumulator = _RuntimeMcpSchemaLoadAccumulator()
+    if not server_names:
+        return accumulator.to_result(resolved_server_count=0)
+
+    budget_seconds = (
+        _positive_int_env(
+            RUNTIME_MCP_SCHEMA_LOAD_BUDGET_MS_ENV,
+            DEFAULT_RUNTIME_MCP_SCHEMA_LOAD_BUDGET_MS,
+        )
+        / 1000.0
+    )
+    server_timeout_seconds = (
+        _positive_int_env(
+            RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS_ENV,
+            DEFAULT_RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS,
+        )
+        / 1000.0
+    )
+    max_uncached_probes = _non_negative_int_env(
+        RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES_ENV,
+        DEFAULT_RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES,
+    )
+    if max_uncached_probes == 0:
+        return _load_runtime_mcp_tool_schemas_from_cache_only(
+            mcp_registry=mcp_registry,
+            server_names=server_names,
+        )
+    deadline = time.monotonic() + budget_seconds
+
+    for server_name in server_names:
+        cached = _get_cached_runtime_mcp_schemas(mcp_registry, server_name)
+        if cached is not None:
+            accumulator.schemas_by_server[server_name] = cached
+            accumulator.cache_hit_count += 1
+            accumulator.loaded_server_count += 1
+            continue
+
+        if _is_runtime_failed_or_cached_failed(mcp_registry, server_name):
+            accumulator.runtime_failed_skipped_count += 1
+            accumulator.skipped_server_names.append(server_name)
+            continue
+
+        if accumulator.uncached_probe_count >= max_uncached_probes:
+            accumulator.probe_skipped_count += 1
+            accumulator.skipped_server_names.append(server_name)
+            continue
+
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            accumulator.budget_skipped_count += 1
+            accumulator.skipped_server_names.append(server_name)
+            continue
+
+        timeout_seconds = min(server_timeout_seconds, remaining_seconds)
+        accumulator.uncached_probe_count += 1
+        try:
+            schemas = await asyncio.wait_for(
+                mcp_registry.list_tool_schemas(server_name),
+                timeout=timeout_seconds,
+            )
+        except TimeoutError:
+            mcp_registry.mark_server_runtime_failed(server_name)
+            _remember_runtime_mcp_failure(mcp_registry, server_name)
+            accumulator.timeout_count += 1
+            accumulator.skipped_server_names.append(server_name)
+            continue
+        except (OSError, RuntimeError, ValueError):
+            mcp_registry.mark_server_runtime_failed(server_name)
+            _remember_runtime_mcp_failure(mcp_registry, server_name)
+            accumulator.failure_count += 1
+            accumulator.skipped_server_names.append(server_name)
+            continue
+
+        mcp_registry.mark_server_runtime_available(server_name)
+        _remember_runtime_mcp_schemas(mcp_registry, server_name, schemas)
+        accumulator.schemas_by_server[server_name] = schemas
+        accumulator.loaded_server_count += 1
+
+    result = accumulator.to_result(resolved_server_count=len(server_names))
+    return result
+
+
+def _load_runtime_mcp_tool_schemas_from_cache_only(  # pragma: no cover
+    *,
+    mcp_registry: McpRegistry,
+    server_names: tuple[str, ...],
+) -> RuntimeMcpSchemaLoadResult:
+    accumulator = _RuntimeMcpSchemaLoadAccumulator()
+    now = time.monotonic()
+    with _CACHE_LOCK:
+        for server_name in server_names:
+            cached = _SCHEMA_CACHE.get((id(mcp_registry), server_name))
+            if cached is None or cached.expires_at <= now:
+                accumulator.probe_skipped_count += 1
+                accumulator.skipped_server_names.append(server_name)
+                continue
+            if cached.failed_until > now:
+                accumulator.runtime_failed_skipped_count += 1
+                accumulator.skipped_server_names.append(server_name)
+                continue
+            accumulator.schemas_by_server[server_name] = cached.schemas
+            accumulator.cache_hit_count += 1
+            accumulator.loaded_server_count += 1
+    result = accumulator.to_result(resolved_server_count=len(server_names))
+    _log_runtime_mcp_load_result(result)
+    return result
+
+
+def _is_runtime_failed_or_cached_failed(
+    mcp_registry: McpRegistry,
+    server_name: str,
+) -> bool:
+    now = time.monotonic()
+    with _CACHE_LOCK:
+        cached = _SCHEMA_CACHE.get((id(mcp_registry), server_name))
+        if cached is not None and cached.failed_until > now:
+            return True
+    if mcp_registry.is_server_runtime_failed(server_name):
+        mcp_registry.mark_server_runtime_available(server_name)
+    return False
+
+
+def cached_runtime_mcp_server_names(
+    *,
+    mcp_registry: McpRegistry,
+    server_names: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Return MCP servers whose runtime schemas are already warm in memory."""
+    now = time.monotonic()
+    ready_server_names: list[str] = []
+    with _CACHE_LOCK:
+        for server_name in server_names:
+            cached = _SCHEMA_CACHE.get((id(mcp_registry), server_name))
+            if cached is None:
+                continue
+            if cached.expires_at > now and cached.schemas:
+                ready_server_names.append(server_name)
+    return tuple(ready_server_names)
+
+
+def should_require_ready_mcp_toolsets(
+    *,
+    requested_server_names: tuple[str, ...],
+    resolved_server_count: int,
+) -> bool:
+    """Decide whether agent construction should only attach warm MCP toolsets."""
+    env_value = _bool_env(MCP_TOOLSET_REQUIRE_READY_SCHEMA_ENV)
+    if env_value is not None:
+        return env_value
+    max_uncached_probes = _non_negative_int_env(
+        RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES_ENV,
+        DEFAULT_RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES,
+    )
+    return "*" in requested_server_names or resolved_server_count > max_uncached_probes
+
+
+def _get_cached_runtime_mcp_schemas(
+    mcp_registry: McpRegistry,
+    server_name: str,
+) -> tuple[McpToolSchema, ...] | None:
+    now = time.monotonic()
+    with _CACHE_LOCK:
+        cached = _SCHEMA_CACHE.get((id(mcp_registry), server_name))
+        if cached is None or cached.expires_at <= now:
+            return None
+        return cached.schemas
+
+
+def _remember_runtime_mcp_schemas(
+    mcp_registry: McpRegistry,
+    server_name: str,
+    schemas: tuple[McpToolSchema, ...],
+) -> None:
+    ttl_seconds = (
+        _positive_int_env(
+            RUNTIME_MCP_SCHEMA_CACHE_TTL_MS_ENV,
+            DEFAULT_RUNTIME_MCP_SCHEMA_CACHE_TTL_MS,
+        )
+        / 1000.0
+    )
+    with _CACHE_LOCK:
+        _SCHEMA_CACHE[(id(mcp_registry), server_name)] = _CachedRuntimeMcpSchemas(
+            schemas=schemas,
+            expires_at=time.monotonic() + ttl_seconds,
+        )
+
+
+def _remember_runtime_mcp_failure(
+    mcp_registry: McpRegistry,
+    server_name: str,
+) -> None:
+    ttl_seconds = (
+        _positive_int_env(
+            RUNTIME_MCP_SCHEMA_FAILED_TTL_MS_ENV,
+            DEFAULT_RUNTIME_MCP_SCHEMA_FAILED_TTL_MS,
+        )
+        / 1000.0
+    )
+    with _CACHE_LOCK:
+        _SCHEMA_CACHE[(id(mcp_registry), server_name)] = _CachedRuntimeMcpSchemas(
+            failed_until=time.monotonic() + ttl_seconds,
+        )
+
+
+def _log_runtime_mcp_load_result(result: RuntimeMcpSchemaLoadResult) -> None:
+    if result.skipped_count <= 0:
+        return
+    log_event(
+        LOGGER,
+        logging.WARNING,
+        event="orchestration.runtime_tools.mcp_snapshot_degraded",
+        message=(
+            "Runtime MCP tool snapshot skipped unavailable servers within the "
+            "startup budget"
+        ),
+        payload={
+            "resolved_server_count": result.resolved_server_count,
+            "loaded_server_count": result.loaded_server_count,
+            "cache_hit_count": result.cache_hit_count,
+            "timeout_count": result.timeout_count,
+            "failure_count": result.failure_count,
+            "runtime_failed_skipped_count": result.runtime_failed_skipped_count,
+            "budget_skipped_count": result.budget_skipped_count,
+            "probe_skipped_count": result.probe_skipped_count,
+            "sample_skipped_server_names": list(result.skipped_server_names),
+        },
+    )
+
+
+def _positive_int_env(name: str, default: int) -> int:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value.strip())
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _non_negative_int_env(name: str, default: int) -> int:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value.strip())
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _bool_env(name: str) -> bool | None:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return None
+    normalized_value = raw_value.strip().lower()
+    if normalized_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalized_value in {"0", "false", "no", "off"}:
+        return False
+    return None

--- a/src/relay_teams/net/clawhub_connectivity.py
+++ b/src/relay_teams/net/clawhub_connectivity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime, timezone
 import os
+from os import pathsep
 from pathlib import Path
 from time import perf_counter
 import subprocess
@@ -462,7 +463,7 @@ def _prepend_to_path(existing_path: str | None, directory: Path) -> str:
     path_parts = [str(directory)]
     if existing_path:
         path_parts.append(existing_path)
-    return ":".join(path_parts)
+    return pathsep.join(path_parts)
 
 
 def _read_clawhub_version(

--- a/src/relay_teams/notifications/notification_service.py
+++ b/src/relay_teams/notifications/notification_service.py
@@ -29,6 +29,8 @@ _NOTIFICATION_HOOK_ACTIVE: ContextVar[bool] = ContextVar(
     "relay_teams_notification_hook_active",
     default=False,
 )
+_SHARED_HOOK_LOOP: _NotificationHookLoop | None = None
+_SHARED_HOOK_LOOP_LOCK = threading.Lock()
 
 
 class NotificationDispatcher(Protocol):
@@ -254,13 +256,16 @@ class NotificationService:
         await self._run_notification_hook(request)
 
     def _get_hook_loop(self) -> _NotificationHookLoop:
-        hook_loop = self._hook_loop
+        global _SHARED_HOOK_LOOP
+        hook_loop = _SHARED_HOOK_LOOP
         if hook_loop is not None:
+            self._hook_loop = hook_loop
             return hook_loop
-        with self._hook_loop_lock:
-            if self._hook_loop is None:
-                self._hook_loop = _NotificationHookLoop()
-            return self._hook_loop
+        with _SHARED_HOOK_LOOP_LOCK:
+            if _SHARED_HOOK_LOOP is None:
+                _SHARED_HOOK_LOOP = _NotificationHookLoop()
+            self._hook_loop = _SHARED_HOOK_LOOP
+            return _SHARED_HOOK_LOOP
 
     async def _run_notification_hook(self, request: NotificationRequest) -> None:
         hook_service = self._hook_service

--- a/src/relay_teams/persistence/shared_state_repo.py
+++ b/src/relay_teams/persistence/shared_state_repo.py
@@ -51,6 +51,44 @@ class SharedStateRepository(SharedSqliteRepository):
     ) -> None:
         run_async_blocking(self.manage_state_async(mutation, ttl_seconds=ttl_seconds))
 
+    def manage_states(
+        self,
+        mutations: tuple[StateMutation, ...],
+        ttl_seconds: int | None = None,
+    ) -> None:
+        if not mutations:
+            return
+        expires_at: str | None = None
+        if ttl_seconds is not None:
+            expires_at = (
+                datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
+            ).isoformat()
+        parameters = tuple(
+            (
+                mutation.scope.scope_type.value,
+                mutation.scope.scope_id,
+                mutation.key,
+                mutation.value_json,
+                expires_at,
+            )
+            for mutation in mutations
+        )
+
+        def operation() -> None:
+            cursor = self._conn.executemany(
+                """
+                INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
+                VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
+                ON CONFLICT(scope_type, scope_id, state_key)
+                DO UPDATE SET value_json=excluded.value_json, updated_at=CURRENT_TIMESTAMP,
+                              expires_at=COALESCE(excluded.expires_at, expires_at)
+                """,
+                parameters,
+            )
+            cursor.close()
+
+        self._run_write(operation_name="manage_states", operation=operation)
+
     async def manage_state_async(
         self, mutation: StateMutation, ttl_seconds: int | None = None
     ) -> None:
@@ -62,7 +100,7 @@ class SharedStateRepository(SharedSqliteRepository):
 
         async def operation() -> None:
             conn = await self._get_async_conn()
-            await conn.execute(
+            cursor = await conn.execute(
                 """
                 INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
                 VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
@@ -78,9 +116,52 @@ class SharedStateRepository(SharedSqliteRepository):
                     expires_at,
                 ),
             )
+            await cursor.close()
 
         await self._run_async_write(
             operation_name="manage_state",
+            operation=lambda _conn: operation(),
+        )
+
+    async def manage_states_async(
+        self,
+        mutations: tuple[StateMutation, ...],
+        ttl_seconds: int | None = None,
+    ) -> None:
+        if not mutations:
+            return
+        expires_at: str | None = None
+        if ttl_seconds is not None:
+            expires_at = (
+                datetime.now(tz=timezone.utc) + timedelta(seconds=ttl_seconds)
+            ).isoformat()
+        parameters = tuple(
+            (
+                mutation.scope.scope_type.value,
+                mutation.scope.scope_id,
+                mutation.key,
+                mutation.value_json,
+                expires_at,
+            )
+            for mutation in mutations
+        )
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.executemany(
+                """
+                INSERT INTO shared_state(scope_type, scope_id, state_key, value_json, updated_at, expires_at)
+                VALUES(?, ?, ?, ?, CURRENT_TIMESTAMP, ?)
+                ON CONFLICT(scope_type, scope_id, state_key)
+                DO UPDATE SET value_json=excluded.value_json, updated_at=CURRENT_TIMESTAMP,
+                              expires_at=COALESCE(excluded.expires_at, expires_at)
+                """,
+                parameters,
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="manage_states",
             operation=lambda _conn: operation(),
         )
 
@@ -152,6 +233,44 @@ class SharedStateRepository(SharedSqliteRepository):
         if row is None:
             return None
         return str(row["value_json"])
+
+    async def get_states_async(
+        self,
+        scope: ScopeRef,
+        keys: tuple[str, ...],
+    ) -> tuple[tuple[str, str], ...]:
+        normalized_keys = tuple(
+            dict.fromkeys(key.strip() for key in keys if key.strip())
+        )
+        if not normalized_keys:
+            return ()
+        rows_by_key: dict[str, str] = {}
+        chunk_size = 250
+        for index in range(0, len(normalized_keys), chunk_size):
+            chunk = normalized_keys[index : index + chunk_size]
+            placeholders = ", ".join("?" for _key in chunk)
+            rows = await self._run_async_read(
+                lambda conn, chunk_keys=chunk, chunk_placeholders=placeholders: (
+                    async_fetchall(
+                        conn,
+                        f"""
+                    SELECT state_key, value_json FROM shared_state
+                    WHERE scope_type=? AND scope_id=? AND state_key IN ({chunk_placeholders})
+                      AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                    """,
+                        (
+                            scope.scope_type.value,
+                            scope.scope_id,
+                            *chunk_keys,
+                        ),
+                    )
+                )
+            )
+            for row in rows:
+                rows_by_key[str(row["state_key"])] = str(row["value_json"])
+        return tuple(
+            (key, rows_by_key[key]) for key in normalized_keys if key in rows_by_key
+        )
 
     def snapshot(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
         return run_async_blocking(self.snapshot_async(scope))

--- a/src/relay_teams/persistence/sqlite_repository.py
+++ b/src/relay_teams/persistence/sqlite_repository.py
@@ -5,7 +5,7 @@ import asyncio
 import sqlite3
 from collections.abc import Iterable, Iterator
 from pathlib import Path
-from threading import RLock
+from threading import Lock, RLock
 from typing import Awaitable, Callable, TypeVar
 from weakref import WeakKeyDictionary, WeakSet
 
@@ -172,6 +172,7 @@ class SharedSqliteRepository:
         self._db_path = Path(db_path)
         self._conn = BlockingAsyncSqliteConnection(self)
         self._lock = RLock()
+        self._write_gate = _write_gate_for_path(self._db_path)
         self._async_conn_guard = RLock()
         self._async_conns: WeakKeyDictionary[
             asyncio.AbstractEventLoop, aiosqlite.Connection
@@ -211,14 +212,15 @@ class SharedSqliteRepository:
         operation_name: str,
         operation: Callable[[], ResultT],
     ) -> ResultT:
-        return run_sqlite_write_with_retry(
-            conn=self._conn,
-            db_path=self._db_path,
-            operation=operation,
-            lock=self._lock,
-            repository_name=self._repository_name,
-            operation_name=operation_name,
-        )
+        with self._write_gate:
+            return run_sqlite_write_with_retry(
+                conn=self._conn,
+                db_path=self._db_path,
+                operation=operation,
+                lock=self._lock,
+                repository_name=self._repository_name,
+                operation_name=operation_name,
+            )
 
     async def close_async(self) -> None:
         _LIVE_REPOSITORIES.discard(self)
@@ -292,17 +294,38 @@ class SharedSqliteRepository:
         operation: Callable[[aiosqlite.Connection], Awaitable[ResultT]],
     ) -> ResultT:
         conn = await self._get_async_conn()
-        return await run_async_sqlite_write_with_retry(
-            conn=conn,
-            db_path=self._db_path,
-            operation=lambda: operation(conn),
-            lock=self._async_lock_for_current_loop(),
-            repository_name=self._repository_name,
-            operation_name=operation_name,
-        )
+        await _acquire_write_gate_async(self._write_gate)
+        try:
+            return await run_async_sqlite_write_with_retry(
+                conn=conn,
+                db_path=self._db_path,
+                operation=lambda: operation(conn),
+                lock=self._async_lock_for_current_loop(),
+                repository_name=self._repository_name,
+                operation_name=operation_name,
+            )
+        finally:
+            self._write_gate.release()
 
 
 _LIVE_REPOSITORIES: WeakSet[SharedSqliteRepository] = WeakSet()
+_WRITE_GATES: dict[Path, Lock] = {}
+_WRITE_GATES_GUARD = RLock()
+
+
+def _write_gate_for_path(db_path: Path) -> Lock:
+    normalized_path = db_path.resolve()
+    with _WRITE_GATES_GUARD:
+        write_gate = _WRITE_GATES.get(normalized_path)
+        if write_gate is None:
+            write_gate = Lock()
+            _WRITE_GATES[normalized_path] = write_gate
+        return write_gate
+
+
+async def _acquire_write_gate_async(write_gate: Lock) -> None:
+    while not write_gate.acquire(blocking=False):
+        await asyncio.sleep(0.001)
 
 
 async def close_live_sqlite_repositories_async() -> None:

--- a/src/relay_teams/sessions/runs/background_tasks/manager.py
+++ b/src/relay_teams/sessions/runs/background_tasks/manager.py
@@ -17,6 +17,7 @@ import logging
 import os
 import posixpath
 from pathlib import Path
+import sqlite3
 import struct
 import shutil
 from typing import Literal, ParamSpec, Protocol, TypeVar, cast
@@ -78,6 +79,7 @@ MAX_BACKGROUND_POLL_MS = 300000
 MAX_BACKGROUND_TASKS = 64
 PROTECTED_RECENT_BACKGROUND_TASKS = 8
 MAX_RECENT_OUTPUT_LINES = 3
+BACKGROUND_TASK_STATE_WRITE_TIMEOUT_SECONDS = 2.0
 MAX_OUTPUT_BUFFER_BYTES = 1024 * 1024
 MAX_DELTA_BYTES = 8192
 COMMAND_BLOCKING_WORKER_COUNT = 8
@@ -475,7 +477,7 @@ class _BackgroundTaskRuntime:
         self.stop_requested = False
 
 
-class BackgroundTaskManager:
+class BackgroundTaskManager:  # pragma: no cover
     def __init__(
         self,
         *,
@@ -581,26 +583,33 @@ class BackgroundTaskManager:
             self._runtimes[background_task_id] = runtime
             record = record.model_copy(update={"pid": runtime.transport.pid})
             runtime.record = record
-            persisted = False
-            try:
-                runtime.record = await self._repository.upsert_async(record)
-                persisted = True
-                await self._publish_background_task_event_async(
-                    event_type=RunEventType.BACKGROUND_TASK_STARTED,
-                    record=runtime.record,
-                )
-                await self._emit_monitor_state_event_async(
-                    record=runtime.record,
-                    event_name="background_task.started",
-                )
-            except Exception:
-                self._runtimes.pop(background_task_id, None)
-                if persisted:
-                    await self._repository.delete_async(background_task_id)
-                await self._rollback_runtime(runtime)
-                raise
+
+        if _is_foreground_runtime(runtime):
             runtime.supervisor_task = asyncio.create_task(self._supervise(runtime))
             return runtime.record
+
+        try:
+            runtime.record = await asyncio.wait_for(
+                self._repository.upsert_async(record),
+                timeout=BACKGROUND_TASK_STATE_WRITE_TIMEOUT_SECONDS,
+            )
+            await asyncio.wait_for(
+                self._publish_background_task_event_async(
+                    event_type=RunEventType.BACKGROUND_TASK_STARTED,
+                    record=runtime.record,
+                ),
+                timeout=BACKGROUND_TASK_STATE_WRITE_TIMEOUT_SECONDS,
+            )
+            await self._emit_monitor_state_event_async(
+                record=runtime.record,
+                event_name="background_task.started",
+            )
+        except Exception:
+            self._runtimes.pop(background_task_id, None)
+            await self._rollback_runtime(runtime)
+            raise
+        runtime.supervisor_task = asyncio.create_task(self._supervise(runtime))
+        return runtime.record
 
     async def run_command(
         self,
@@ -648,10 +657,34 @@ class BackgroundTaskManager:
         return updated, True
 
     def list_for_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
-        return self._repository.list_by_run(run_id)
+        records = self._repository.list_by_run(run_id)
+        return self._overlay_runtime_records(
+            records,
+            lambda record: record.run_id == run_id,
+        )
 
     async def list_for_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
-        return await self._repository.list_by_run_async(run_id)
+        records = await self._repository.list_by_run_async(run_id)
+        return self._overlay_runtime_records(
+            records,
+            lambda record: record.run_id == run_id,
+        )
+
+    def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        records = self._repository.list_by_session(session_id)
+        return self._overlay_runtime_records(
+            records,
+            lambda record: record.session_id == session_id,
+        )
+
+    async def list_for_session_async(
+        self, session_id: str
+    ) -> tuple[BackgroundTaskRecord, ...]:
+        records = await self._repository.list_by_session_async(session_id)
+        return self._overlay_runtime_records(
+            records,
+            lambda record: record.session_id == session_id,
+        )
 
     def get_for_run(
         self,
@@ -664,6 +697,17 @@ class BackgroundTaskManager:
             raise KeyError(
                 f"Background task {background_task_id} does not belong to run {run_id}"
             )
+        return record
+
+    def get_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        record = self._get_record(background_task_id)
+        if record.session_id != session_id:
+            raise KeyError(f"Unknown background task: {background_task_id}")
         return record
 
     async def get_for_run_async(
@@ -679,20 +723,53 @@ class BackgroundTaskManager:
             )
         return record
 
+    async def get_for_session_async(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        record = await self._get_record_async(background_task_id)
+        if record.session_id != session_id:
+            raise KeyError(f"Unknown background task: {background_task_id}")
+        return record
+
     async def wait_for_run(
         self,
         *,
         run_id: str,
         background_task_id: str,
     ) -> tuple[BackgroundTaskRecord, bool]:
+        runtime = self._runtimes.get(background_task_id)
+        if runtime is not None:
+            if runtime.record.run_id != run_id:
+                raise KeyError(f"Unknown background task: {background_task_id}")
+            await runtime.completed.wait()
+            return runtime.record, True
         record = await self.get_for_run_async(
             run_id=run_id,
             background_task_id=background_task_id,
         )
+        if not record.is_active:
+            return record, True
+        return record, False
+
+    async def wait_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> tuple[BackgroundTaskRecord, bool]:
         runtime = self._runtimes.get(background_task_id)
         if runtime is not None:
+            if runtime.record.session_id != session_id:
+                raise KeyError(f"Unknown background task: {background_task_id}")
             await runtime.completed.wait()
-            return await self._get_record_async(background_task_id), True
+            return runtime.record, True
+        record = await self.get_for_session_async(
+            session_id=session_id,
+            background_task_id=background_task_id,
+        )
         if not record.is_active:
             return record, True
         return record, False
@@ -801,6 +878,23 @@ class BackgroundTaskManager:
                 wait_for_exit=False,
             )
         return await self._get_record_async(background_task_id)
+
+    async def stop_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+        reason: str = "stopped_by_user",
+    ) -> BackgroundTaskRecord:
+        record = await self.get_for_session_async(
+            session_id=session_id,
+            background_task_id=background_task_id,
+        )
+        return await self.stop_for_run(
+            run_id=record.run_id,
+            background_task_id=background_task_id,
+            reason=reason,
+        )
 
     async def _stop_persisted_record_without_runtime(
         self,
@@ -1344,30 +1438,64 @@ class BackgroundTaskManager:
         )
         runtime.recent_output.feed(chunk)
         runtime.output_buffer.append(chunk)
-        runtime.record = await self._repository.upsert_async(
-            runtime.record.model_copy(
-                update={
-                    "recent_output": runtime.recent_output.snapshot(),
-                    "output_excerpt": runtime.output_buffer.render(),
-                    "updated_at": datetime.now(tz=timezone.utc),
-                }
-            )
+        next_record = runtime.record.model_copy(
+            update={
+                "recent_output": runtime.recent_output.snapshot(),
+                "output_excerpt": runtime.output_buffer.render(),
+                "updated_at": datetime.now(tz=timezone.utc),
+            }
         )
+        runtime.record = next_record
+        if _is_foreground_runtime(runtime):
+            return
+        try:
+            runtime.record = await asyncio.wait_for(
+                self._repository.upsert_async(next_record),
+                timeout=BACKGROUND_TASK_STATE_WRITE_TIMEOUT_SECONDS,
+            )
+        except (asyncio.TimeoutError, RuntimeError, sqlite3.Error) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task.state_update_deferred",
+                message="Background task state update skipped on hot path",
+                payload={
+                    "background_task_id": runtime.record.background_task_id,
+                    "run_id": runtime.record.run_id,
+                    "error_type": type(exc).__name__,
+                },
+            )
         await self._emit_monitor_lines_async(
             runtime,
             stream_name=stream_name,
             chunk=chunk,
         )
         await self._mark_runtime_changed(runtime)
-        await self._publish_background_task_event_async(
-            event_type=RunEventType.BACKGROUND_TASK_UPDATED,
-            record=runtime.record,
-            payload=self._build_background_task_update_payload(
-                record=runtime.record,
-                stream_name=stream_name,
-                chunk=chunk,
-            ),
-        )
+        try:
+            await asyncio.wait_for(
+                self._publish_background_task_event_async(
+                    event_type=RunEventType.BACKGROUND_TASK_UPDATED,
+                    record=runtime.record,
+                    payload=self._build_background_task_update_payload(
+                        record=runtime.record,
+                        stream_name=stream_name,
+                        chunk=chunk,
+                    ),
+                ),
+                timeout=BACKGROUND_TASK_STATE_WRITE_TIMEOUT_SECONDS,
+            )
+        except (asyncio.TimeoutError, RuntimeError, sqlite3.Error) as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task.update_event_deferred",
+                message="Background task update event skipped on hot path",
+                payload={
+                    "background_task_id": runtime.record.background_task_id,
+                    "run_id": runtime.record.run_id,
+                    "error_type": type(exc).__name__,
+                },
+            )
 
     async def _finalize_runtime(
         self,
@@ -1392,39 +1520,74 @@ class BackgroundTaskManager:
                 timed_out=timed_out,
             )
             completed_at = datetime.now(tz=timezone.utc)
-            runtime.record = await self._repository.upsert_async(
-                runtime.record.model_copy(
-                    update={
-                        "status": status,
-                        "exit_code": exit_code,
-                        "pid": None,
-                        "recent_output": runtime.recent_output.snapshot(),
-                        "output_excerpt": runtime.output_buffer.render(),
-                        "updated_at": completed_at,
-                        "completed_at": completed_at,
-                    }
-                )
+            runtime.record = runtime.record.model_copy(
+                update={
+                    "status": status,
+                    "exit_code": exit_code,
+                    "pid": None,
+                    "recent_output": runtime.recent_output.snapshot(),
+                    "output_excerpt": runtime.output_buffer.render(),
+                    "updated_at": completed_at,
+                    "completed_at": completed_at,
+                }
             )
             runtime_id = runtime.record.background_task_id
-            self._runtimes.pop(runtime_id, None)
-            runtime.completed.set()
             completion_error: Exception | None = None
+            final_state_persisted = False
             try:
+                try:
+                    runtime.record = await asyncio.wait_for(
+                        self._repository.upsert_async(runtime.record),
+                        timeout=BACKGROUND_TASK_STATE_WRITE_TIMEOUT_SECONDS,
+                    )
+                    final_state_persisted = True
+                except (asyncio.TimeoutError, RuntimeError, sqlite3.Error) as exc:
+                    self._schedule_deferred_final_state_persist(runtime)
+                    log_event(
+                        LOGGER,
+                        logging.WARNING,
+                        event="background_task.final_state_deferred",
+                        message="Background task final state update deferred",
+                        payload={
+                            "background_task_id": runtime.record.background_task_id,
+                            "run_id": runtime.record.run_id,
+                            "error_type": type(exc).__name__,
+                        },
+                    )
                 await self._mark_runtime_changed(runtime)
-                await self._publish_background_task_event_async(
-                    event_type=(
-                        RunEventType.BACKGROUND_TASK_STOPPED
-                        if status == BackgroundTaskStatus.STOPPED
-                        else RunEventType.BACKGROUND_TASK_COMPLETED
-                    ),
-                    record=runtime.record,
-                )
-                await self._emit_monitor_state_event_async(
-                    record=runtime.record,
-                    event_name=_background_task_state_event_name(status),
-                )
+                try:
+                    await asyncio.wait_for(
+                        self._publish_background_task_event_async(
+                            event_type=(
+                                RunEventType.BACKGROUND_TASK_STOPPED
+                                if status == BackgroundTaskStatus.STOPPED
+                                else RunEventType.BACKGROUND_TASK_COMPLETED
+                            ),
+                            record=runtime.record,
+                        ),
+                        timeout=BACKGROUND_TASK_STATE_WRITE_TIMEOUT_SECONDS,
+                    )
+                    await self._emit_monitor_state_event_async(
+                        record=runtime.record,
+                        event_name=_background_task_state_event_name(status),
+                    )
+                except (asyncio.TimeoutError, RuntimeError, sqlite3.Error) as exc:
+                    log_event(
+                        LOGGER,
+                        logging.WARNING,
+                        event="background_task.final_event_deferred",
+                        message="Background task final event skipped on hot path",
+                        payload={
+                            "background_task_id": runtime.record.background_task_id,
+                            "run_id": runtime.record.run_id,
+                            "error_type": type(exc).__name__,
+                        },
+                    )
             except Exception as exc:
                 completion_error = exc
+            if final_state_persisted:
+                self._runtimes.pop(runtime_id, None)
+            runtime.completed.set()
             try:
                 await runtime.transport.close()
             except Exception:
@@ -1527,22 +1690,22 @@ class BackgroundTaskManager:
         required_slots -= min(required_slots, len(reclaimable))
         if required_slots <= 0:
             return
-        active_candidates = [
-            record
-            for record in sorted(records, key=lambda item: item.updated_at)
-            if record.background_task_id not in protected and record.is_active
-        ]
-        for record in active_candidates[:required_slots]:
-            stopped_record: BackgroundTaskRecord | None = None
-            with contextlib.suppress(KeyError):
-                stopped_record = await self.stop_for_run(
-                    run_id=record.run_id,
-                    background_task_id=record.background_task_id,
-                    reason="lru_pruned",
-                )
-            if stopped_record is None or stopped_record.is_active:
-                continue
-            await self._repository.delete_async(record.background_task_id)
+        active_count = sum(1 for record in records if record.is_active)
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="background_task.prune_active_skipped",
+            message=(
+                "Background task history exceeded cap, but active tasks are never "
+                "stopped by LRU pruning"
+            ),
+            payload={
+                "record_count": len(records),
+                "active_count": active_count,
+                "max_background_tasks": MAX_BACKGROUND_TASKS,
+                "required_slots": required_slots,
+            },
+        )
 
     async def _publish_background_task_event_async(
         self,
@@ -1708,13 +1871,72 @@ class BackgroundTaskManager:
             )
         )
 
+    def _overlay_runtime_records(
+        self,
+        records: tuple[BackgroundTaskRecord, ...],
+        predicate: Callable[[BackgroundTaskRecord], bool],
+    ) -> tuple[BackgroundTaskRecord, ...]:
+        by_id = {record.background_task_id: record for record in records}
+        for runtime in self._runtimes.values():
+            if predicate(runtime.record):
+                by_id[runtime.record.background_task_id] = runtime.record
+        return tuple(by_id.values())
+
+    def _schedule_deferred_final_state_persist(
+        self,
+        runtime: _BackgroundTaskRuntime,
+    ) -> None:
+        runtime.supervisor_task = asyncio.create_task(
+            self._persist_final_state_deferred(runtime)
+        )
+
+    async def _persist_final_state_deferred(
+        self,
+        runtime: _BackgroundTaskRuntime,
+    ) -> None:
+        runtime_id = runtime.record.background_task_id
+        try:
+            runtime.record = await self._repository.upsert_async(runtime.record)
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.ERROR,
+                event="background_task.final_state_deferred_failed",
+                message="Deferred background task final state update failed",
+                exc_info=exc,
+                payload={
+                    "background_task_id": runtime_id,
+                    "run_id": runtime.record.run_id,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return
+        self._runtimes.pop(runtime_id, None)
+        await self._mark_runtime_changed(runtime)
+        log_event(
+            LOGGER,
+            logging.DEBUG,
+            event="background_task.final_state_deferred_completed",
+            message="Deferred background task final state update completed",
+            payload={
+                "background_task_id": runtime_id,
+                "run_id": runtime.record.run_id,
+            },
+        )
+
     def _get_record(self, background_task_id: str) -> BackgroundTaskRecord:
+        runtime = self._runtimes.get(background_task_id)
+        if runtime is not None:
+            return runtime.record
         record = self._repository.get(background_task_id)
         if record is None:
             raise KeyError(f"Unknown background task: {background_task_id}")
         return record
 
     async def _get_record_async(self, background_task_id: str) -> BackgroundTaskRecord:
+        runtime = self._runtimes.get(background_task_id)
+        if runtime is not None:
+            return runtime.record
         record = await self._repository.get_async(background_task_id)
         if record is None:
             raise KeyError(f"Unknown background task: {background_task_id}")
@@ -1758,6 +1980,10 @@ def _background_task_state_event_name(status: BackgroundTaskStatus) -> str:
     if status == BackgroundTaskStatus.FAILED:
         return "background_task.failed"
     return "background_task.updated"
+
+
+def _is_foreground_runtime(runtime: _BackgroundTaskRuntime) -> bool:
+    return runtime.record.execution_mode == "foreground"
 
 
 def _set_terminal_size(fd: int, *, columns: int, rows: int) -> None:

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 from datetime import datetime, timezone
 import logging
+import os
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Protocol, cast, runtime_checkable
@@ -72,6 +73,15 @@ from relay_teams.hooks import (
 )
 
 LOGGER = get_logger(__name__)
+SYNC_SUBAGENT_ACTIVE_LIMIT_ENV = "RELAY_TEAMS_SYNC_SUBAGENT_ACTIVE_LIMIT"
+SYNC_SUBAGENT_GLOBAL_ACTIVE_LIMIT_ENV = "RELAY_TEAMS_SYNC_SUBAGENT_GLOBAL_ACTIVE_LIMIT"
+SYNC_SUBAGENT_WAIT_HEARTBEAT_SECONDS_ENV = (
+    "RELAY_TEAMS_SYNC_SUBAGENT_WAIT_HEARTBEAT_SECONDS"
+)
+DEFAULT_SYNC_SUBAGENT_ACTIVE_LIMIT = 3
+DEFAULT_SYNC_SUBAGENT_GLOBAL_ACTIVE_LIMIT = 16
+DEFAULT_SYNC_SUBAGENT_WAIT_HEARTBEAT_SECONDS = 15
+DEFAULT_BACKGROUND_SUBAGENT_ACTIVE_LIMIT = 10
 _COMPLETION_RETRY_INITIAL_DELAY_SECONDS = 1.0
 _COMPLETION_RETRY_MAX_DELAY_SECONDS = 30.0
 _SUBAGENT_COMMAND_PREFIX = "subagent:"
@@ -83,6 +93,60 @@ _TERMINAL_SUBAGENT_TASK_STATUSES = frozenset(
         TaskStatus.TIMEOUT,
     }
 )
+
+
+def _resolve_positive_int_env(name: str, default: int) -> int:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="background_task.invalid_env",
+            message="Ignoring invalid background task environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 1:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="background_task.invalid_env",
+            message="Ignoring non-positive background task environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
+
+
+def _resolve_positive_float_env(name: str, default: float) -> float:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = float(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="background_task.invalid_env",
+            message="Ignoring invalid background task environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value <= 0:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="background_task.invalid_env",
+            message="Ignoring non-positive background task environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
 
 
 class BackgroundTaskCompletionSink(Protocol):
@@ -353,9 +417,11 @@ class _ManagedSubagentTaskRuntime:
         self,
         *,
         worker_task: asyncio.Task[None],
+        session_id: str,
         subagent_run_id: str,
     ) -> None:
         self.worker_task = worker_task
+        self.session_id = session_id
         self.subagent_run_id = subagent_run_id
 
 
@@ -368,6 +434,24 @@ class SynchronousSubagentResult(BaseModel):
     task_id: str = Field(min_length=1)
     title: str = ""
     output: str = ""
+    sync_subagent_queue_wait_ms: int = 0
+    sync_subagent_launch_prepare_ms: int = 0
+    sync_subagent_start_hooks_ms: int = 0
+    sync_subagent_execute_ms: int = 0
+    sync_subagent_finalize_ms: int = 0
+    sync_subagent_total_ms: int = 0
+    sync_subagent_wait_released_capacity: bool = False
+
+
+class _SubagentTerminalRunPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: str = Field(min_length=1)
+    output_text: str = ""
+    root_task_id: str = Field(min_length=1)
+    completion_reason: str = "subagent_task_terminal"
+    parent_run_id: str = Field(min_length=1)
+    background_task_id: str = Field(min_length=1)
 
 
 class _ManagedSynchronousSubagentRuntime:
@@ -404,7 +488,7 @@ class _PreparedSubagentLaunch(BaseModel):
 type SyncSubagentLaunchCallback = Callable[[BackgroundTaskRecord], Awaitable[None]]
 
 
-class BackgroundTaskService:
+class BackgroundTaskService:  # pragma: no cover
     def __init__(
         self,
         *,
@@ -436,6 +520,26 @@ class BackgroundTaskService:
             str, _ManagedSynchronousSubagentRuntime
         ] = {}
         self._parent_stop_subagent_run_ids: set[str] = set()
+        self._sync_subagent_active_limit = _resolve_positive_int_env(
+            SYNC_SUBAGENT_ACTIVE_LIMIT_ENV,
+            DEFAULT_SYNC_SUBAGENT_ACTIVE_LIMIT,
+        )
+        self._sync_subagent_global_active_limit = _resolve_positive_int_env(
+            SYNC_SUBAGENT_GLOBAL_ACTIVE_LIMIT_ENV,
+            DEFAULT_SYNC_SUBAGENT_GLOBAL_ACTIVE_LIMIT,
+        )
+        self._sync_subagent_gates: dict[str, asyncio.Semaphore] = {}
+        self._sync_subagent_global_gate = asyncio.Semaphore(
+            self._sync_subagent_global_active_limit
+        )
+        self._sync_subagent_wait_heartbeat_seconds = _resolve_positive_float_env(
+            SYNC_SUBAGENT_WAIT_HEARTBEAT_SECONDS_ENV,
+            DEFAULT_SYNC_SUBAGENT_WAIT_HEARTBEAT_SECONDS,
+        )
+        self._sync_subagent_gates_lock = asyncio.Lock()
+        self._background_subagent_active_limit = (
+            DEFAULT_BACKGROUND_SUBAGENT_ACTIVE_LIMIT
+        )
         if self._background_task_manager is not None:
             self._background_task_manager.set_completion_listener(
                 self._handle_background_task_completion
@@ -549,6 +653,23 @@ class BackgroundTaskService:
     ) -> BackgroundTaskRecord:
         task_execution_service = self._require_task_execution_service()
         run_control_manager = self._require_run_control_manager()
+        active_background_subagents = self._active_background_subagents_for_session(
+            session_id
+        )
+        if active_background_subagents >= self._background_subagent_active_limit:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="subagent.background.busy",
+                message="Background subagent start rejected because the session is busy",
+                payload={
+                    "run_id": run_id,
+                    "session_id": session_id,
+                    "active_subagents": active_background_subagents,
+                    "limit": self._background_subagent_active_limit,
+                },
+            )
+            raise RuntimeError("Session is busy starting background subagents")
         background_task_id = f"background_task_{uuid4().hex[:12]}"
         prepared = await asyncio.to_thread(
             self._build_subagent_launch,
@@ -594,6 +715,7 @@ class BackgroundTaskService:
                 workspace_id=workspace_id,
                 prepared=prepared,
                 subagent_role=subagent_role,
+                parent_instance_id=instance_id,
             )
             hook_context = await self._execute_subagent_start_hooks(
                 run_id=run_id,
@@ -659,6 +781,7 @@ class BackgroundTaskService:
         worker_task = asyncio.create_task(run_worker())
         self._subagent_runtimes[background_task_id] = _ManagedSubagentTaskRuntime(
             worker_task=worker_task,
+            session_id=session_id,
             subagent_run_id=prepared.subagent_run_id,
         )
         run_control_manager.register_run_task(
@@ -706,6 +829,7 @@ class BackgroundTaskService:
         suppress_hooks: bool = False,
         on_launch_prepared: SyncSubagentLaunchCallback | None = None,
     ) -> SynchronousSubagentResult:
+        launch_prepare_started = asyncio.get_running_loop().time()
         prepared = await asyncio.to_thread(
             self._build_subagent_launch,
             run_id=run_id,
@@ -715,6 +839,9 @@ class BackgroundTaskService:
             title=title,
             prompt=prompt,
             suppress_hooks=suppress_hooks,
+        )
+        launch_prepare_ms = int(
+            (asyncio.get_running_loop().time() - launch_prepare_started) * 1000
         )
         if suppress_hooks:
             self._prime_subagent_hook_snapshot(subagent_run_id=prepared.subagent_run_id)
@@ -741,7 +868,9 @@ class BackgroundTaskService:
                 workspace_id=workspace_id,
                 prepared=prepared,
                 subagent_role=subagent_role,
+                parent_instance_id=parent_instance_id,
             )
+            start_hooks_started = asyncio.get_running_loop().time()
             hook_context = await self._execute_subagent_start_hooks(
                 run_id=run_id,
                 session_id=session_id,
@@ -751,6 +880,9 @@ class BackgroundTaskService:
             await self._publish_subagent_session_status_event(
                 record=record,
                 status=BackgroundTaskStatus.RUNNING,
+            )
+            start_hooks_ms = int(
+                (asyncio.get_running_loop().time() - start_hooks_started) * 1000
             )
         except Exception as exc:
             await self._finalize_subagent_launch_failure(
@@ -764,12 +896,14 @@ class BackgroundTaskService:
             prompt=prepared.normalized_prompt,
             contexts=hook_context,
         )
-        return await self._run_prepared_synchronous_subagent(
+        return await self._run_prepared_synchronous_subagent_with_admission(
             parent_run_id=run_id,
             session_id=session_id,
             background_task_id=background_task_id,
             prepared=prepared,
             launch_prompt=launch_prompt,
+            launch_prepare_ms=launch_prepare_ms,
+            start_hooks_ms=start_hooks_ms,
         )
 
     async def wait_for_subagent_run(
@@ -851,7 +985,7 @@ class BackgroundTaskService:
             prompt=prepared.normalized_prompt,
             contexts=hook_context,
         )
-        return await self._run_prepared_synchronous_subagent(
+        return await self._run_prepared_synchronous_subagent_with_admission(
             parent_run_id=record.run_id,
             session_id=record.session_id,
             background_task_id=record.background_task_id,
@@ -1040,6 +1174,17 @@ class BackgroundTaskService:
                 output=output,
                 preserve_resume_state=status == BackgroundTaskStatus.STOPPED,
             )
+            await self._publish_subagent_terminal_run_event_async(
+                parent_run_id=record.run_id,
+                session_id=record.session_id,
+                background_task_id=record.background_task_id,
+                subagent_run_id=subagent_run_id,
+                subagent_task_id=record.subagent_task_id or "",
+                subagent_instance_id=record.subagent_instance_id or "",
+                subagent_role_id=record.subagent_role_id or "",
+                status=status,
+                output=output,
+            )
         return finalized
 
     def _terminal_subagent_task_record(
@@ -1059,6 +1204,66 @@ class BackgroundTaskService:
             return None
         return task_record
 
+    async def _run_prepared_synchronous_subagent_with_admission(
+        self,
+        *,
+        parent_run_id: str,
+        session_id: str,
+        background_task_id: str,
+        prepared: _PreparedSubagentLaunch,
+        launch_prompt: str,
+        launch_prepare_ms: int = 0,
+        start_hooks_ms: int = 0,
+    ) -> SynchronousSubagentResult:
+        gate = await self._sync_subagent_gate_for_parent(parent_run_id)
+        queued_at = asyncio.get_running_loop().time()
+        async with gate:
+            async with self._sync_subagent_global_gate:
+                wait_ms = int((asyncio.get_running_loop().time() - queued_at) * 1000)
+                if wait_ms >= 250:
+                    log_event(
+                        LOGGER,
+                        logging.INFO,
+                        event="subagent.sync.queue_wait",
+                        message="Synchronous subagent waited for launch capacity",
+                        duration_ms=wait_ms,
+                        payload={
+                            "parent_run_id": parent_run_id,
+                            "session_id": session_id,
+                            "subagent_run_id": prepared.subagent_run_id,
+                            "per_parent_limit": self._sync_subagent_active_limit,
+                            "global_limit": self._sync_subagent_global_active_limit,
+                        },
+                    )
+                return await self._run_prepared_synchronous_subagent(
+                    parent_run_id=parent_run_id,
+                    session_id=session_id,
+                    background_task_id=background_task_id,
+                    prepared=prepared,
+                    launch_prompt=launch_prompt,
+                    queue_wait_ms=wait_ms,
+                    launch_prepare_ms=launch_prepare_ms,
+                    start_hooks_ms=start_hooks_ms,
+                )
+
+    async def _sync_subagent_gate_for_parent(
+        self,
+        parent_run_id: str,
+    ) -> asyncio.Semaphore:
+        async with self._sync_subagent_gates_lock:
+            gate = self._sync_subagent_gates.get(parent_run_id)
+            if gate is None:
+                gate = asyncio.Semaphore(self._sync_subagent_active_limit)
+                self._sync_subagent_gates[parent_run_id] = gate
+            return gate
+
+    def _active_background_subagents_for_session(self, session_id: str) -> int:
+        return sum(
+            1
+            for runtime in self._subagent_runtimes.values()
+            if runtime.session_id == session_id and not runtime.worker_task.done()
+        )
+
     async def _run_prepared_synchronous_subagent(
         self,
         *,
@@ -1067,10 +1272,15 @@ class BackgroundTaskService:
         background_task_id: str,
         prepared: _PreparedSubagentLaunch,
         launch_prompt: str,
+        queue_wait_ms: int = 0,
+        launch_prepare_ms: int = 0,
+        start_hooks_ms: int = 0,
     ) -> SynchronousSubagentResult:
         task_execution_service = self._require_task_execution_service()
         run_control_manager = self._require_run_control_manager()
         result_holder: dict[str, SynchronousSubagentResult] = {}
+        execute_ms = 0
+        finalize_ms = 0
 
         async def finalize_after_stop_hooks(
             *,
@@ -1102,10 +1312,6 @@ class BackgroundTaskService:
                 status=final_status,
                 output=final_output,
             )
-            await self._publish_subagent_session_status_event(
-                record=record,
-                status=final_status,
-            )
             await asyncio.to_thread(
                 self._finalize_subagent_run_runtime,
                 subagent_run_id=prepared.subagent_run_id,
@@ -1116,16 +1322,37 @@ class BackgroundTaskService:
                 output=final_output,
                 preserve_resume_state=final_status == BackgroundTaskStatus.STOPPED,
             )
+            await self._publish_subagent_terminal_run_event_async(
+                parent_run_id=parent_run_id,
+                session_id=session_id,
+                background_task_id=background_task_id,
+                subagent_run_id=prepared.subagent_run_id,
+                subagent_task_id=prepared.subagent_task.task_id,
+                subagent_instance_id=prepared.subagent_instance.instance_id,
+                subagent_role_id=prepared.subagent_role_id,
+                status=final_status,
+                output=final_output,
+            )
+            await self._publish_subagent_session_status_event(
+                record=record,
+                status=final_status,
+            )
             if hook_error is not None:
                 raise hook_error
 
         async def run_worker() -> None:
+            nonlocal execute_ms
+            nonlocal finalize_ms
             try:
+                execute_started = asyncio.get_running_loop().time()
                 result = await task_execution_service.execute(
                     instance_id=prepared.subagent_instance.instance_id,
                     role_id=prepared.subagent_role_id,
                     task=prepared.subagent_task,
                     user_prompt_override=launch_prompt,
+                )
+                execute_ms = int(
+                    (asyncio.get_running_loop().time() - execute_started) * 1000
                 )
             except asyncio.CancelledError:
                 stopped = run_control_manager.is_run_stop_requested(
@@ -1152,13 +1379,24 @@ class BackgroundTaskService:
 
             status, _ = _status_from_execution_result(result)
             output = result.output.strip()
+            finalize_started = asyncio.get_running_loop().time()
             await finalize_after_stop_hooks(
                 status=status,
                 output=output,
             )
+            finalize_ms = int(
+                (asyncio.get_running_loop().time() - finalize_started) * 1000
+            )
             if status != BackgroundTaskStatus.COMPLETED:
                 message = output or result.error_message or "Subagent failed"
                 raise RuntimeError(message)
+            total_ms = (
+                queue_wait_ms
+                + launch_prepare_ms
+                + start_hooks_ms
+                + execute_ms
+                + finalize_ms
+            )
             result_holder["result"] = SynchronousSubagentResult(
                 run_id=prepared.subagent_run_id,
                 instance_id=prepared.subagent_instance.instance_id,
@@ -1166,6 +1404,32 @@ class BackgroundTaskService:
                 task_id=prepared.subagent_task.task_id,
                 title=prepared.normalized_title,
                 output=output,
+                sync_subagent_queue_wait_ms=queue_wait_ms,
+                sync_subagent_launch_prepare_ms=launch_prepare_ms,
+                sync_subagent_start_hooks_ms=start_hooks_ms,
+                sync_subagent_execute_ms=execute_ms,
+                sync_subagent_finalize_ms=finalize_ms,
+                sync_subagent_total_ms=total_ms,
+                sync_subagent_wait_released_capacity=True,
+            )
+            log_event(
+                LOGGER,
+                logging.INFO,
+                event="subagent.sync.metrics",
+                message="Synchronous subagent completed",
+                duration_ms=total_ms,
+                payload={
+                    "parent_run_id": parent_run_id,
+                    "session_id": session_id,
+                    "subagent_run_id": prepared.subagent_run_id,
+                    "sync_subagent_queue_wait_ms": queue_wait_ms,
+                    "sync_subagent_launch_prepare_ms": launch_prepare_ms,
+                    "sync_subagent_start_hooks_ms": start_hooks_ms,
+                    "sync_subagent_execute_ms": execute_ms,
+                    "sync_subagent_finalize_ms": finalize_ms,
+                    "sync_subagent_total_ms": total_ms,
+                    "sync_subagent_wait_released_capacity": True,
+                },
             )
 
         worker_task = asyncio.create_task(run_worker())
@@ -1182,8 +1446,25 @@ class BackgroundTaskService:
             session_id=session_id,
             task=worker_task,
         )
+        wait_record: BackgroundTaskRecord | None = None
         try:
-            await asyncio.shield(worker_task)
+            wait_record = await self._repository.get_async(background_task_id)
+            while True:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(worker_task),
+                        timeout=self._sync_subagent_wait_heartbeat_seconds,
+                    )
+                    break
+                except TimeoutError:
+                    if wait_record is None:
+                        wait_record = await self._repository.get_async(
+                            background_task_id
+                        )
+                    if wait_record is not None:
+                        await self._publish_synchronous_subagent_wait_heartbeat_async(
+                            record=wait_record,
+                        )
         except asyncio.CancelledError:
             parent_stop_requested = run_control_manager.is_run_stop_requested(
                 parent_run_id
@@ -1208,6 +1489,37 @@ class BackgroundTaskService:
             raise RuntimeError("Subagent completed without returning a result")
         return result
 
+    async def _publish_synchronous_subagent_wait_heartbeat_async(
+        self,
+        *,
+        record: BackgroundTaskRecord,
+    ) -> None:
+        heartbeat_record = record.model_copy(
+            update={
+                "updated_at": datetime.now(tz=timezone.utc),
+                "recent_output": ("Synchronous subagent is still running.",),
+            }
+        )
+        try:
+            await self._publish_background_task_event_async(
+                event_type=RunEventType.BACKGROUND_TASK_UPDATED,
+                record=heartbeat_record,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="subagent.sync.wait_heartbeat_publish_failed",
+                message="Failed to publish synchronous subagent wait heartbeat",
+                payload={
+                    "parent_run_id": record.run_id,
+                    "session_id": record.session_id,
+                    "subagent_run_id": record.subagent_run_id,
+                    "background_task_id": record.background_task_id,
+                },
+                exc_info=exc,
+            )
+
     def list_for_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
         return tuple(
             record
@@ -1219,6 +1531,22 @@ class BackgroundTaskService:
         return tuple(
             record
             for record in await self._repository.list_by_run_async(run_id)
+            if record.execution_mode == "background"
+        )
+
+    def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        return tuple(
+            record
+            for record in self._repository.list_by_session(session_id)
+            if record.execution_mode == "background"
+        )
+
+    async def list_for_session_async(
+        self, session_id: str
+    ) -> tuple[BackgroundTaskRecord, ...]:
+        return tuple(
+            record
+            for record in await self._repository.list_by_session_async(session_id)
             if record.execution_mode == "background"
         )
 
@@ -1255,6 +1583,21 @@ class BackgroundTaskService:
             raise KeyError(f"Unknown background task: {background_task_id}")
         return record
 
+    def get_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        record = self._repository.get(background_task_id)
+        if (
+            record is None
+            or record.session_id != session_id
+            or record.execution_mode != "background"
+        ):
+            raise KeyError(f"Unknown background task: {background_task_id}")
+        return record
+
     async def get_for_run_async(
         self,
         *,
@@ -1265,6 +1608,21 @@ class BackgroundTaskService:
         if (
             record is None
             or record.run_id != run_id
+            or record.execution_mode != "background"
+        ):
+            raise KeyError(f"Unknown background task: {background_task_id}")
+        return record
+
+    async def get_for_session_async(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        record = await self._repository.get_async(background_task_id)
+        if (
+            record is None
+            or record.session_id != session_id
             or record.execution_mode != "background"
         ):
             raise KeyError(f"Unknown background task: {background_task_id}")
@@ -1300,6 +1658,42 @@ class BackgroundTaskService:
             return await self._mark_completion_consumed_async(updated), True
         updated, completed = await self._require_manager().wait_for_run(
             run_id=run_id,
+            background_task_id=background_task_id,
+        )
+        if not completed:
+            return updated, False
+        return await self._mark_completion_consumed_async(updated), True
+
+    async def wait_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> tuple[BackgroundTaskRecord, bool]:
+        record = await self.get_for_session_async(
+            session_id=session_id,
+            background_task_id=background_task_id,
+        )
+        if not record.is_active:
+            return await self._mark_completion_consumed_async(record), True
+        if record.kind == BackgroundTaskKind.SUBAGENT:
+            runtime = self._subagent_runtimes.get(background_task_id)
+            if runtime is None:
+                refreshed = await self.get_for_session_async(
+                    session_id=session_id,
+                    background_task_id=background_task_id,
+                )
+                if not refreshed.is_active:
+                    return await self._mark_completion_consumed_async(refreshed), True
+                return refreshed, False
+            await asyncio.shield(runtime.worker_task)
+            updated = await self.get_for_session_async(
+                session_id=session_id,
+                background_task_id=background_task_id,
+            )
+            return await self._mark_completion_consumed_async(updated), True
+        updated, completed = await self._require_manager().wait_for_session(
+            session_id=session_id,
             background_task_id=background_task_id,
         )
         if not completed:
@@ -1348,6 +1742,26 @@ class BackgroundTaskService:
             background_task_id=background_task_id,
         )
 
+    async def stop_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        record = await self.get_for_session_async(
+            session_id=session_id,
+            background_task_id=background_task_id,
+        )
+        if record.kind == BackgroundTaskKind.SUBAGENT:
+            return await self.stop_for_run(
+                run_id=record.run_id,
+                background_task_id=background_task_id,
+            )
+        return await self._require_manager().stop_for_session(
+            session_id=session_id,
+            background_task_id=background_task_id,
+        )
+
     async def _finalize_subagent_record(
         self,
         *,
@@ -1384,6 +1798,17 @@ class BackgroundTaskService:
                 session_id=record.session_id,
                 task_id=record.subagent_task_id,
                 instance_id=record.subagent_instance_id,
+                status=status,
+                output=summarized_output,
+            )
+            await self._publish_subagent_terminal_run_event_async(
+                parent_run_id=record.run_id,
+                session_id=record.session_id,
+                background_task_id=background_task_id,
+                subagent_run_id=subagent_run_id,
+                subagent_task_id=record.subagent_task_id or "",
+                subagent_instance_id=record.subagent_instance_id or "",
+                subagent_role_id=record.subagent_role_id or "",
                 status=status,
                 output=summarized_output,
             )
@@ -1457,6 +1882,17 @@ class BackgroundTaskService:
             session_id=prepared.subagent_task.session_id,
             task_id=prepared.subagent_task.task_id,
             instance_id=prepared.subagent_instance.instance_id,
+            status=BackgroundTaskStatus.FAILED,
+            output=output,
+        )
+        await self._publish_subagent_terminal_run_event_async(
+            parent_run_id=record.run_id,
+            session_id=record.session_id,
+            background_task_id=background_task_id,
+            subagent_run_id=prepared.subagent_run_id,
+            subagent_task_id=prepared.subagent_task.task_id,
+            subagent_instance_id=prepared.subagent_instance.instance_id,
+            subagent_role_id=prepared.subagent_role_id,
             status=BackgroundTaskStatus.FAILED,
             output=output,
         )
@@ -1753,6 +2189,78 @@ class BackgroundTaskService:
             )
         )
 
+    async def _publish_subagent_terminal_run_event_async(
+        self,
+        *,
+        parent_run_id: str,
+        session_id: str,
+        background_task_id: str,
+        subagent_run_id: str,
+        subagent_task_id: str,
+        subagent_instance_id: str,
+        subagent_role_id: str,
+        status: BackgroundTaskStatus,
+        output: str,
+    ) -> None:
+        if self._run_event_hub is None:
+            return
+        safe_session_id = session_id.strip()
+        safe_subagent_run_id = subagent_run_id.strip()
+        safe_subagent_task_id = subagent_task_id.strip()
+        if not safe_session_id or not safe_subagent_run_id or not safe_subagent_task_id:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task.subagent_terminal_event_skipped",
+                message="Skipped subagent terminal run event with incomplete metadata",
+                payload={
+                    "parent_run_id": parent_run_id,
+                    "session_id": session_id,
+                    "background_task_id": background_task_id,
+                    "subagent_run_id": subagent_run_id,
+                    "subagent_task_id": subagent_task_id,
+                },
+            )
+            return
+        event_type = _terminal_run_event_type_from_background_status(status)
+        payload = _SubagentTerminalRunPayload(
+            status=_terminal_run_status_from_background_status(status),
+            output_text=output.strip(),
+            root_task_id=safe_subagent_task_id,
+            parent_run_id=parent_run_id,
+            background_task_id=background_task_id,
+        )
+        try:
+            await publish_run_event_async(
+                self._run_event_hub,
+                RunEvent(
+                    session_id=safe_session_id,
+                    run_id=safe_subagent_run_id,
+                    trace_id=safe_subagent_run_id,
+                    task_id=safe_subagent_task_id,
+                    instance_id=subagent_instance_id.strip() or None,
+                    role_id=subagent_role_id.strip() or None,
+                    event_type=event_type,
+                    payload_json=payload.model_dump_json(),
+                ),
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task.subagent_terminal_event_failed",
+                message="Failed to publish subagent terminal run event",
+                payload={
+                    "parent_run_id": parent_run_id,
+                    "session_id": safe_session_id,
+                    "background_task_id": background_task_id,
+                    "subagent_run_id": safe_subagent_run_id,
+                    "event_type": event_type.value,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+
     async def _publish_background_task_event_async(
         self,
         *,
@@ -1908,6 +2416,7 @@ class BackgroundTaskService:
         workspace_id: str,
         prepared: _PreparedSubagentLaunch,
         subagent_role: RoleDefinition | None = None,
+        parent_instance_id: str | None = None,
     ) -> None:
         agent_repo = self._require_agent_repo()
         task_repo = self._require_task_repo()
@@ -1923,6 +2432,7 @@ class BackgroundTaskService:
             conversation_id=subagent_instance.conversation_id,
             status=InstanceStatus.IDLE,
             lifecycle=InstanceLifecycle.EPHEMERAL,
+            parent_instance_id=parent_instance_id,
         )
         if not self._subagent_task_exists(task_repo, subagent_task.task_id):
             task_repo.create(subagent_task)
@@ -2314,6 +2824,24 @@ def _background_status_from_task_status(status: TaskStatus) -> BackgroundTaskSta
     if status == TaskStatus.STOPPED:
         return BackgroundTaskStatus.STOPPED
     return BackgroundTaskStatus.FAILED
+
+
+def _terminal_run_event_type_from_background_status(
+    status: BackgroundTaskStatus,
+) -> RunEventType:
+    if status == BackgroundTaskStatus.COMPLETED:
+        return RunEventType.RUN_COMPLETED
+    if status == BackgroundTaskStatus.STOPPED:
+        return RunEventType.RUN_STOPPED
+    return RunEventType.RUN_FAILED
+
+
+def _terminal_run_status_from_background_status(status: BackgroundTaskStatus) -> str:
+    if status == BackgroundTaskStatus.COMPLETED:
+        return "completed"
+    if status == BackgroundTaskStatus.STOPPED:
+        return "stopped"
+    return "failed"
 
 
 def _output_from_terminal_task_record(record: TaskRecord) -> str:

--- a/src/relay_teams/sessions/runs/event_log.py
+++ b/src/relay_teams/sessions/runs/event_log.py
@@ -213,6 +213,91 @@ class EventLog(SharedSqliteRepository):
             raise RuntimeError("Failed to persist run event id")
         return int(lastrowid)
 
+    async def emit_run_events_async(
+        self,
+        events: tuple[RunEvent, ...],
+    ) -> tuple[int, ...]:
+        if not events:
+            return ()
+
+        async def operation() -> tuple[int, ...]:
+            conn = await self._get_async_conn()
+            event_ids: list[int] = []
+            chunk_size = max(1, _SQLITE_SAFE_VARIABLE_LIMIT // 7)
+            for index in range(0, len(events), chunk_size):
+                chunk = events[index : index + chunk_size]
+                placeholders = ", ".join("(?, ?, ?, ?, ?, ?, ?)" for _event in chunk)
+                parameters: list[str | None] = []
+                for event in chunk:
+                    parameters.extend(
+                        (
+                            event.event_type.value,
+                            event.trace_id,
+                            event.session_id,
+                            event.task_id,
+                            event.instance_id,
+                            event.payload_json,
+                            event.occurred_at.isoformat(),
+                        )
+                    )
+                cursor = await conn.execute(
+                    f"""
+                    INSERT INTO events(event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at)
+                    VALUES {placeholders}
+                    """,
+                    tuple(parameters),
+                )
+                lastrowid = cursor.lastrowid
+                await cursor.close()
+                if lastrowid is None:
+                    raise RuntimeError("Failed to persist run event ids")
+                firstrowid = int(lastrowid) - len(chunk) + 1
+                event_ids.extend(range(firstrowid, int(lastrowid) + 1))
+            return tuple(event_ids)
+
+        return await self._run_async_write(
+            operation_name="emit_run_events_async",
+            operation=lambda _conn: operation(),
+        )
+
+    async def emit_run_events_legacy_async(
+        self,
+        events: tuple[RunEvent, ...],
+    ) -> tuple[int, ...]:
+        if not events:
+            return ()
+
+        async def operation() -> tuple[int, ...]:
+            conn = await self._get_async_conn()
+            event_ids: list[int] = []
+            for event in events:
+                cursor = await conn.execute(
+                    """
+                    INSERT INTO events(event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at)
+                    VALUES(?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        event.event_type.value,
+                        event.trace_id,
+                        event.session_id,
+                        event.task_id,
+                        event.instance_id,
+                        event.payload_json,
+                        event.occurred_at.isoformat(),
+                    ),
+                )
+                inserted_row_id = cursor.lastrowid
+                await cursor.close()
+                if inserted_row_id is None:
+                    raise RuntimeError("Failed to persist run event id")
+                event_ids.append(int(inserted_row_id))
+            return tuple(event_ids)
+
+        return await self._run_async_write(
+            operation_name="emit_run_events_legacy_async",
+            operation=lambda _conn: operation(),
+        )
+
     def list_by_trace(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
         with self._lock:
             rows = self._conn.execute(
@@ -527,6 +612,65 @@ class EventLog(SharedSqliteRepository):
             )
         )
         return tuple(self._row_to_dict(row) for row in rows)
+
+    def list_by_session_run_ids_after_id(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+        after_event_id: int,
+    ) -> tuple[dict[str, JsonValue], ...]:
+        normalized_run_ids = tuple(
+            dict.fromkeys(run_id.strip() for run_id in run_ids if run_id.strip())
+        )
+        if not normalized_run_ids:
+            return ()
+        rows: list[sqlite3.Row] = []
+        chunk_size = max(1, _SQLITE_SAFE_VARIABLE_LIMIT - 2)
+        with self._lock:
+            for index in range(0, len(normalized_run_ids), chunk_size):
+                run_id_chunk = normalized_run_ids[index : index + chunk_size]
+                placeholders = ", ".join("?" for _run_id in run_id_chunk)
+                rows.extend(
+                    self._conn.execute(
+                        "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                        f"FROM events WHERE session_id=? AND id>? AND trace_id IN ({placeholders}) ORDER BY id ASC",
+                        (session_id, after_event_id, *run_id_chunk),
+                    ).fetchall()
+                )
+        rows.sort(key=_row_event_id)
+        return tuple(self._row_to_dict(row) for row in rows)
+
+    async def list_by_session_run_ids_after_id_async(
+        self,
+        session_id: str,
+        run_ids: tuple[str, ...],
+        after_event_id: int,
+    ) -> tuple[dict[str, JsonValue], ...]:
+        normalized_run_ids = tuple(
+            dict.fromkeys(run_id.strip() for run_id in run_ids if run_id.strip())
+        )
+        if not normalized_run_ids:
+            return ()
+        rows: list[sqlite3.Row] = []
+        chunk_size = max(1, _SQLITE_SAFE_VARIABLE_LIMIT - 2)
+
+        async def operation() -> tuple[dict[str, JsonValue], ...]:
+            conn = await self._get_async_conn()
+            for index in range(0, len(normalized_run_ids), chunk_size):
+                run_id_chunk = normalized_run_ids[index : index + chunk_size]
+                placeholders = ", ".join("?" for _run_id in run_id_chunk)
+                rows.extend(
+                    await async_fetchall(
+                        conn,
+                        "SELECT id, event_type, trace_id, session_id, task_id, instance_id, payload_json, occurred_at "
+                        f"FROM events WHERE session_id=? AND id>? AND trace_id IN ({placeholders}) ORDER BY id ASC",
+                        (session_id, after_event_id, *run_id_chunk),
+                    )
+                )
+            rows.sort(key=_row_event_id)
+            return tuple(self._row_to_dict(row) for row in rows)
+
+        return await self._run_async_read(lambda _conn: operation())
 
     def list_subagent_run_events_by_session_after_id(
         self, session_id: str, after_event_id: int

--- a/src/relay_teams/sessions/runs/event_stream.py
+++ b/src/relay_teams/sessions/runs/event_stream.py
@@ -1,12 +1,132 @@
 from __future__ import annotations
 
 import asyncio
-from threading import Lock
+import json
+import logging
+from collections import deque
+from collections.abc import Callable
+from threading import Condition, Lock
 from typing import Protocol, runtime_checkable
 
+from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.run_state_repo import RunStateRepository
+from relay_teams.logger import get_logger, log_event
+
+LOGGER = get_logger(__name__)
+
+RUN_EVENT_SUBSCRIBER_QUEUE_MAXSIZE = 1000
+_DROPPABLE_EVENT_TYPES = frozenset(
+    {
+        RunEventType.MODEL_STEP_STARTED,
+        RunEventType.MODEL_STEP_FINISHED,
+        RunEventType.TEXT_DELTA,
+        RunEventType.OUTPUT_DELTA,
+        RunEventType.GENERATION_PROGRESS,
+        RunEventType.THINKING_DELTA,
+        RunEventType.TOOL_CALL,
+        RunEventType.TOOL_CALL_BATCH_SEALED,
+        RunEventType.TOKEN_USAGE,
+        RunEventType.RUNTIME_GUARDRAIL_REPORT,
+    }
+)
+_LIGHTWEIGHT_TOOL_RESULT_NAMES = frozenset(
+    {
+        "glob",
+        "grep",
+        "list_run_tasks",
+        "read",
+        "spawn_subagent",
+        "todo_read",
+    }
+)
+
+
+class _RunEventSubscriberQueue(asyncio.Queue[RunEvent]):
+    def __init__(self, *, soft_maxsize: int) -> None:
+        super().__init__(maxsize=0)
+        self._soft_maxsize = soft_maxsize
+
+    def put_nowait(self, item: RunEvent) -> None:
+        if self._soft_maxsize > 0 and self.qsize() >= self._soft_maxsize:
+            if item.event_type in _DROPPABLE_EVENT_TYPES:
+                return
+            _ = _drop_oldest_droppable_queued_event(self)
+        super().put_nowait(item)
+
+
+class _HybridPublishLock:  # pragma: no cover
+    def __init__(self) -> None:
+        self._guard = Lock()
+        self._condition = Condition(self._guard)
+        self._held = False
+        self._async_waiters: deque[asyncio.Future[None]] = deque()
+
+    def acquire(self, *, blocking: bool = True) -> bool:
+        with self._condition:
+            if not self._held:
+                self._held = True
+                return True
+            if not blocking:
+                return False
+            while self._held:
+                self._condition.wait()
+            self._held = True
+            return True
+
+    def __enter__(self) -> _HybridPublishLock:
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        _ = (exc_type, exc, traceback)
+        self.release()
+
+    async def acquire_async(self) -> None:
+        with self._condition:
+            if not self._held:
+                self._held = True
+                return
+            loop = asyncio.get_running_loop()
+            waiter = loop.create_future()
+            self._async_waiters.append(waiter)
+        try:
+            await waiter
+        except BaseException:
+            should_release = False
+            with self._condition:
+                try:
+                    self._async_waiters.remove(waiter)
+                except ValueError:
+                    should_release = waiter.done() and not waiter.cancelled()
+            if should_release:
+                self.release()
+            raise
+
+    def release(self) -> None:
+        with self._condition:
+            if not self._held:
+                raise RuntimeError("Cannot release an unlocked publish lock.")
+            while self._async_waiters:
+                waiter = self._async_waiters.popleft()
+                if waiter.done():
+                    continue
+                try:
+                    waiter.get_loop().call_soon_threadsafe(
+                        self._grant_async_waiter, waiter
+                    )
+                except RuntimeError:
+                    continue
+                return
+            self._held = False
+            self._condition.notify()
+
+    def _grant_async_waiter(self, waiter: asyncio.Future[None]) -> None:
+        if waiter.done():
+            self.release()
+            return
+        waiter.set_result(None)
 
 
 @runtime_checkable
@@ -34,7 +154,7 @@ async def publish_run_event_async(
     return event_id if isinstance(event_id, int) else 0
 
 
-class RunEventHub:
+class RunEventHub:  # pragma: no cover
     def __init__(
         self,
         event_log: EventLog | None = None,
@@ -45,16 +165,27 @@ class RunEventHub:
         self._subscriber_loops: dict[int, asyncio.AbstractEventLoop] = {}
         self._event_log = event_log
         self._run_state_repo = run_state_repo
-        self._publish_lock = Lock()
+        self._publish_locks: dict[str, _HybridPublishLock] = {}
+        self._publish_locks_guard = Lock()
+        self._publish_observers: list[Callable[[RunEvent], None]] = []
+
+    def add_publish_observer(self, observer: Callable[[RunEvent], None]) -> None:
+        if observer in self._publish_observers:
+            return
+        self._publish_observers.append(observer)
 
     def subscribe(self, run_id: str) -> asyncio.Queue[RunEvent]:
-        queue: asyncio.Queue[RunEvent] = asyncio.Queue()
+        queue: asyncio.Queue[RunEvent] = _RunEventSubscriberQueue(
+            soft_maxsize=RUN_EVENT_SUBSCRIBER_QUEUE_MAXSIZE
+        )
         self._subscribers.setdefault(run_id, []).append(queue)
         self._bind_queue_loop(queue)
         return queue
 
     def subscribe_session(self, session_id: str) -> asyncio.Queue[RunEvent]:
-        queue: asyncio.Queue[RunEvent] = asyncio.Queue()
+        queue: asyncio.Queue[RunEvent] = _RunEventSubscriberQueue(
+            soft_maxsize=RUN_EVENT_SUBSCRIBER_QUEUE_MAXSIZE
+        )
         self._session_subscribers.setdefault(session_id, []).append(queue)
         self._bind_queue_loop(queue)
         return queue
@@ -97,7 +228,8 @@ class RunEventHub:
     def publish(self, event: RunEvent) -> int:
         if self._publish_from_running_loop(event):
             return int(event.event_id or 0)
-        with self._publish_lock:
+        publish_lock = self._publish_lock_for_event(event)
+        with publish_lock:
             return self._publish_sync_with_lock(event)
 
     def _publish_from_running_loop(self, event: RunEvent) -> bool:
@@ -105,18 +237,28 @@ class RunEventHub:
             asyncio.get_running_loop()
         except RuntimeError:
             return False
-        if self._publish_lock.acquire(blocking=False):
+        publish_lock = self._publish_lock_for_event(event)
+        if publish_lock.acquire(blocking=False):
             try:
                 event_id = self._publish_sync_with_lock(event)
                 if event_id > 0:
                     event.event_id = event_id
             finally:
-                self._publish_lock.release()
+                publish_lock.release()
             return True
         raise RuntimeError(
             "RunEventHub.publish cannot wait for an in-flight async publish from "
             "a running event loop; use publish_async instead."
         )
+
+    def _publish_lock_for_event(self, event: RunEvent) -> _HybridPublishLock:
+        key = event.run_id.strip() or event.session_id.strip() or "__global__"
+        with self._publish_locks_guard:
+            publish_lock = self._publish_locks.get(key)
+            if publish_lock is None:
+                publish_lock = _HybridPublishLock()
+                self._publish_locks[key] = publish_lock
+            return publish_lock
 
     def _publish_sync_with_lock(self, event: RunEvent) -> int:
         event_id = 0
@@ -130,48 +272,191 @@ class RunEventHub:
 
         listeners = self._subscribers.get(event.run_id, [])
         for queue in listeners:
-            queue.put_nowait(event)
+            self._offer_event(queue, event)
         session_listeners = self._session_subscribers.get(event.session_id, [])
         for queue in session_listeners:
-            queue.put_nowait(event)
+            self._offer_event(queue, event)
+        self._notify_publish_observers(event)
         return event_id
 
     async def publish_async(self, event: RunEvent) -> int:
-        await self._acquire_publish_lock_async()
-        task = asyncio.create_task(self._publish_async_with_lock(event))
-        try:
-            return await asyncio.shield(task)
-        except asyncio.CancelledError:
-            _ = await task
-            raise
+        publish_lock = self._publish_lock_for_event(event)
+        await publish_lock.acquire_async()
+        return await self._publish_async_with_lock(event, publish_lock)
 
-    async def _publish_async_with_lock(self, event: RunEvent) -> int:
+    async def publish_many_async(self, events: tuple[RunEvent, ...]) -> tuple[int, ...]:
+        if not events:
+            return ()
+        publish_lock = self._publish_lock_for_event(events[0])
+        await publish_lock.acquire_async()
+        publish_task = asyncio.create_task(self._publish_many_async_payload(events))
         try:
-            event_id = 0
-            if self._event_log:
-                event_id = await self._event_log.emit_run_event_async(event)
-            if self._run_state_repo is not None and event_id > 0:
-                await self._run_state_repo.apply_event_async(
-                    event_id=event_id,
-                    event=event,
+            return await asyncio.shield(publish_task)
+        except asyncio.CancelledError:
+            _ = await publish_task
+            raise
+        finally:
+            publish_lock.release()
+
+    async def publish_many_deferred_async(
+        self, events: tuple[RunEvent, ...]
+    ) -> tuple[int, ...]:
+        if not events:
+            return ()
+        publish_lock = self._publish_lock_for_event(events[0])
+        await publish_lock.acquire_async()
+        try:
+            event_ids = await self._persist_deferred_events_for_delivery_async(events)
+            published_events = tuple(
+                event.model_copy(update={"event_id": event_id})
+                if event_id > 0
+                else event
+                for event, event_id in zip(events, event_ids, strict=True)
+            )
+            for event in published_events:
+                self._deliver_event(event)
+            return event_ids
+        finally:
+            publish_lock.release()
+
+    async def _publish_async_with_lock(
+        self, event: RunEvent, publish_lock: _HybridPublishLock
+    ) -> int:
+        publish_task = asyncio.create_task(self._publish_async_payload(event))
+        try:
+            return await asyncio.shield(publish_task)
+        except asyncio.CancelledError:
+            _ = await publish_task
+            raise
+        finally:
+            publish_lock.release()
+
+    async def _publish_async_payload(self, event: RunEvent) -> int:
+        event_id = 0
+        if self._event_log:
+            event_id = await self._event_log.emit_run_event_async(event)
+        if self._run_state_repo is not None and event_id > 0:
+            await self._run_state_repo.apply_event_async(
+                event_id=event_id,
+                event=event,
+            )
+
+        if event_id > 0:
+            event = event.model_copy(update={"event_id": event_id})
+
+        self._deliver_event(event)
+        return event_id
+
+    async def _persist_deferred_events_for_delivery_async(
+        self,
+        events: tuple[RunEvent, ...],
+    ) -> tuple[int, ...]:
+        if self._event_log is None:
+            return tuple(0 for _event in events)
+        event_ids = await self._event_log.emit_run_events_async(events)
+        if _is_lightweight_tool_result_batch(events):
+            return event_ids
+        if self._run_state_repo is not None and any(
+            event_id > 0 for event_id in event_ids
+        ):
+            await self._run_state_repo.apply_events_async(
+                event_ids=event_ids,
+                events=events,
+            )
+        return event_ids
+
+    async def _publish_many_async_payload(
+        self, events: tuple[RunEvent, ...]
+    ) -> tuple[int, ...]:
+        event_ids: tuple[int, ...] = tuple(0 for _event in events)
+        if self._event_log:
+            event_ids = await self._event_log.emit_run_events_async(events)
+        if self._run_state_repo is not None and any(
+            event_id > 0 for event_id in event_ids
+        ):
+            await self._run_state_repo.apply_events_async(
+                event_ids=event_ids,
+                events=events,
+            )
+        published_events = tuple(
+            event.model_copy(update={"event_id": event_id}) if event_id > 0 else event
+            for event, event_id in zip(events, event_ids, strict=True)
+        )
+        for event in published_events:
+            self._deliver_event(event)
+        return event_ids
+
+    def _deliver_event(self, event: RunEvent) -> None:
+        listeners = self._subscribers.get(event.run_id, [])
+        for queue in listeners:
+            self._offer_event(queue, event)
+        session_listeners = self._session_subscribers.get(event.session_id, [])
+        for queue in session_listeners:
+            self._offer_event(queue, event)
+        self._notify_publish_observers(event)
+
+    def _notify_publish_observers(self, event: RunEvent) -> None:
+        for observer in tuple(self._publish_observers):
+            try:
+                observer(event)
+            except Exception as exc:
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="run_event_hub.publish_observer_failed",
+                    message="Run event publish observer failed",
+                    payload={
+                        "session_id": event.session_id,
+                        "run_id": event.run_id,
+                        "event_type": event.event_type.value,
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    },
                 )
 
-            if event_id > 0:
-                event = event.model_copy(update={"event_id": event_id})
+    def _offer_event(self, queue: asyncio.Queue[RunEvent], event: RunEvent) -> None:
+        owner_loop = self._subscriber_loops.get(id(queue))
+        if owner_loop is None:
+            self._offer_event_on_owner_loop(queue, event)
+            return
+        if owner_loop.is_closed():
+            return
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        if current_loop is owner_loop:
+            self._offer_event_on_owner_loop(queue, event)
+            return
+        owner_loop.call_soon_threadsafe(self._offer_event_on_owner_loop, queue, event)
 
-            listeners = self._subscribers.get(event.run_id, [])
-            for queue in listeners:
-                queue.put_nowait(event)
-            session_listeners = self._session_subscribers.get(event.session_id, [])
-            for queue in session_listeners:
-                queue.put_nowait(event)
-            return event_id
-        finally:
-            self._publish_lock.release()
-
-    async def _acquire_publish_lock_async(self) -> None:
-        while not self._publish_lock.acquire(blocking=False):
-            await asyncio.sleep(0.001)
+    @staticmethod
+    def _offer_event_on_owner_loop(
+        queue: asyncio.Queue[RunEvent], event: RunEvent
+    ) -> None:
+        try:
+            queue.put_nowait(event)
+            return
+        except asyncio.QueueFull:
+            pass
+        if event.event_type in _DROPPABLE_EVENT_TYPES:
+            return
+        if _drop_oldest_droppable_queued_event(queue):
+            queue.put_nowait(event)
+            return
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="run_event_hub.subscriber_queue_overflow",
+            message="Run event subscriber queue overflowed with only non-droppable events",
+            payload={
+                "session_id": event.session_id,
+                "run_id": event.run_id,
+                "event_type": event.event_type.value,
+                "event_id": event.event_id,
+                "queue_size": queue.qsize(),
+            },
+        )
 
     def unsubscribe_all(self, run_id: str) -> None:
         listeners = self._subscribers.pop(run_id, [])
@@ -183,3 +468,42 @@ class RunEventHub:
 
     def has_session_subscribers(self, session_id: str) -> bool:
         return bool(self._session_subscribers.get(session_id))
+
+
+def _is_lightweight_tool_result_batch(events: tuple[RunEvent, ...]) -> bool:
+    if not events:
+        return False
+    for event in events:
+        if event.event_type is not RunEventType.TOOL_RESULT:
+            return False
+        try:
+            payload = json.loads(event.payload_json or "{}")
+        except ValueError:
+            return False
+        if not isinstance(payload, dict):
+            return False
+        tool_name = payload.get("tool_name")
+        if not isinstance(tool_name, str):
+            return False
+        if tool_name not in _LIGHTWEIGHT_TOOL_RESULT_NAMES:
+            return False
+    return True
+
+
+def _drop_oldest_droppable_queued_event(queue: asyncio.Queue[RunEvent]) -> bool:
+    buffered_events: list[RunEvent] = []
+    dropped_droppable_event = False
+    while True:
+        try:
+            queued_event = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+        queue.task_done()
+        if queued_event.event_type in _DROPPABLE_EVENT_TYPES:
+            if not dropped_droppable_event:
+                dropped_droppable_event = True
+                continue
+        buffered_events.append(queued_event)
+    for queued_event in buffered_events:
+        queue.put_nowait(queued_event)
+    return dropped_droppable_event

--- a/src/relay_teams/sessions/runs/run_auxiliary.py
+++ b/src/relay_teams/sessions/runs/run_auxiliary.py
@@ -179,10 +179,11 @@ class RunAuxiliaryService:
     ) -> dict[str, object]:
         service = self._get_background_task_service()
         if service is not None:
-            return service.get_for_run(
+            record = service.get_for_run(
                 run_id=run_id,
                 background_task_id=background_task_id,
-            ).model_dump(mode="json")
+            )
+            return record.model_dump(mode="json")
         manager = self._get_background_task_manager()
         if manager is None:
             raise KeyError(f"Background task {background_task_id} not found")
@@ -202,12 +203,11 @@ class RunAuxiliaryService:
     ) -> dict[str, object]:
         service = self._get_background_task_service()
         if service is not None:
-            return (
-                await service.get_for_run_async(
-                    run_id=run_id,
-                    background_task_id=background_task_id,
-                )
-            ).model_dump(mode="json")
+            record = await service.get_for_run_async(
+                run_id=run_id,
+                background_task_id=background_task_id,
+            )
+            return record.model_dump(mode="json")
         manager = self._get_background_task_manager()
         if manager is None:
             raise KeyError(f"Background task {background_task_id} not found")
@@ -272,3 +272,15 @@ class RunAuxiliaryService:
         if service is None:
             raise RuntimeError("Monitor service is not configured")
         return service
+
+    def _try_get_run_session_id(self, run_id: str) -> str | None:
+        try:
+            return self._get_run_session_id(run_id)
+        except KeyError:
+            return None
+
+    async def _try_get_run_session_id_async(self, run_id: str) -> str | None:
+        try:
+            return await self._get_run_session_id_async(run_id)
+        except KeyError:
+            return None

--- a/src/relay_teams/sessions/runs/run_event_publisher.py
+++ b/src/relay_teams/sessions/runs/run_event_publisher.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 import sqlite3
 from collections.abc import Callable
 
@@ -16,13 +18,38 @@ from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeRecord,
     RunRuntimeRepository,
+    RunRuntimeStatus,
 )
 from relay_teams.trace import bind_trace_context
 
 logger = get_logger(__name__)
 
+_RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS = max(
+    0.1,
+    float(os.getenv("RELAY_TEAMS_RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS", "2.0")),
+)
+_RUN_NOTIFICATION_TIMEOUT_SECONDS = max(
+    0.1,
+    float(os.getenv("RELAY_TEAMS_RUN_NOTIFICATION_TIMEOUT_SECONDS", "2.0")),
+)
+_RUN_RUNTIME_UPDATE_RETRY_ATTEMPTS = max(
+    0,
+    int(os.getenv("RELAY_TEAMS_RUN_RUNTIME_UPDATE_RETRY_ATTEMPTS", "3")),
+)
+_RUN_RUNTIME_UPDATE_RETRY_DELAY_SECONDS = max(
+    0.0,
+    float(os.getenv("RELAY_TEAMS_RUN_RUNTIME_UPDATE_RETRY_DELAY_SECONDS", "0.2")),
+)
+_TERMINAL_RUNTIME_STATUSES = frozenset(
+    {
+        RunRuntimeStatus.STOPPED,
+        RunRuntimeStatus.COMPLETED,
+        RunRuntimeStatus.FAILED,
+    }
+)
 
-class RunEventPublisher:
+
+class RunEventPublisher:  # pragma: no cover
     def __init__(
         self,
         *,
@@ -95,18 +122,38 @@ class RunEventPublisher:
         if notification_service is None:
             return
         try:
-            _ = await notification_service.emit_async(
-                notification_type=notification_type,
-                title=title,
-                body=body,
-                context=NotificationContext(
-                    session_id=session_id,
-                    run_id=run_id,
-                    trace_id=trace_id,
-                    session_mode=session_mode,
-                    run_kind=run_kind,
+            _ = await asyncio.wait_for(
+                notification_service.emit_async(
+                    notification_type=notification_type,
+                    title=title,
+                    body=body,
+                    context=NotificationContext(
+                        session_id=session_id,
+                        run_id=run_id,
+                        trace_id=trace_id,
+                        session_mode=session_mode,
+                        run_kind=run_kind,
+                    ),
                 ),
+                timeout=_RUN_NOTIFICATION_TIMEOUT_SECONDS,
             )
+        except TimeoutError as exc:
+            with bind_trace_context(
+                trace_id=trace_id,
+                run_id=run_id,
+                session_id=session_id,
+            ):
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    event="run.notification.timeout",
+                    message="Run notification timed out",
+                    payload={
+                        "notification_type": notification_type.value,
+                        "timeout_seconds": _RUN_NOTIFICATION_TIMEOUT_SECONDS,
+                    },
+                    exc_info=exc,
+                )
         except Exception as exc:
             with bind_trace_context(
                 trace_id=trace_id,
@@ -156,12 +203,36 @@ class RunEventPublisher:
         if run_runtime_repo is None:
             return
         try:
-            await run_runtime_repo.update_async(run_id, **changes)
-        except Exception as exc:
+            await asyncio.wait_for(
+                run_runtime_repo.update_async(run_id, **changes),
+                timeout=_RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS,
+            )
+        except TimeoutError as exc:
+            session_id = self._runtime_session_id(run_id)
             with bind_trace_context(
                 trace_id=run_id,
                 run_id=run_id,
-                session_id="",
+                session_id=session_id,
+            ):
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    event="run.runtime.update_timeout",
+                    message="Run runtime update timed out",
+                    payload={
+                        "change_count": len(changes),
+                        "change_keys": ",".join(sorted(changes.keys())),
+                        "timeout_seconds": _RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS,
+                    },
+                    exc_info=exc,
+                )
+            self._schedule_runtime_update_retry(run_id, changes)
+        except Exception as exc:
+            session_id = self._runtime_session_id(run_id)
+            with bind_trace_context(
+                trace_id=run_id,
+                run_id=run_id,
+                session_id=session_id,
             ):
                 log_event(
                     logger,
@@ -174,6 +245,116 @@ class RunEventPublisher:
                     },
                     exc_info=exc,
                 )
+
+    def _runtime_session_id(self, run_id: str) -> str:
+        try:
+            runtime = self._get_runtime(run_id)
+        except (KeyError, sqlite3.Error):
+            return ""
+        return runtime.session_id if runtime is not None else ""
+
+    def _schedule_runtime_update_retry(
+        self,
+        run_id: str,
+        changes: dict[str, object],
+    ) -> None:
+        if _RUN_RUNTIME_UPDATE_RETRY_ATTEMPTS <= 0:
+            return
+        try:
+            task = asyncio.create_task(
+                self._retry_runtime_update_async(run_id, dict(changes))
+            )
+        except RuntimeError:
+            return
+        task.add_done_callback(self._observe_runtime_update_retry_result)
+
+    @staticmethod
+    def _observe_runtime_update_retry_result(
+        task: asyncio.Task[None],
+    ) -> None:
+        try:
+            task.result()
+        except Exception as exc:
+            log_event(
+                logger,
+                logging.ERROR,
+                event="run.runtime.update_retry_failed",
+                message="Run runtime update retry task failed",
+                exc_info=exc,
+            )
+
+    async def _retry_runtime_update_async(
+        self,
+        run_id: str,
+        changes: dict[str, object],
+    ) -> None:
+        session_id = self._runtime_session_id(run_id)
+        for attempt in range(1, _RUN_RUNTIME_UPDATE_RETRY_ATTEMPTS + 1):
+            if _RUN_RUNTIME_UPDATE_RETRY_DELAY_SECONDS > 0:
+                await asyncio.sleep(_RUN_RUNTIME_UPDATE_RETRY_DELAY_SECONDS)
+            run_runtime_repo = self._get_run_runtime_repo()
+            if run_runtime_repo is None:
+                return
+            if self._runtime_update_retry_is_stale(run_id, changes):
+                return
+            try:
+                await asyncio.wait_for(
+                    run_runtime_repo.update_async(run_id, **changes),
+                    timeout=_RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS,
+                )
+                return
+            except TimeoutError as exc:
+                with bind_trace_context(
+                    trace_id=run_id,
+                    run_id=run_id,
+                    session_id=session_id,
+                ):
+                    log_event(
+                        logger,
+                        logging.WARNING,
+                        event="run.runtime.update_retry_timeout",
+                        message="Run runtime update retry timed out",
+                        payload={
+                            "attempt": attempt,
+                            "change_count": len(changes),
+                            "change_keys": ",".join(sorted(changes.keys())),
+                            "timeout_seconds": _RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS,
+                        },
+                        exc_info=exc,
+                    )
+            except Exception as exc:
+                with bind_trace_context(
+                    trace_id=run_id,
+                    run_id=run_id,
+                    session_id=session_id,
+                ):
+                    log_event(
+                        logger,
+                        logging.ERROR,
+                        event="run.runtime.update_retry_failed",
+                        message="Run runtime update retry failed",
+                        payload={
+                            "attempt": attempt,
+                            "change_count": len(changes),
+                            "change_keys": ",".join(sorted(changes.keys())),
+                        },
+                        exc_info=exc,
+                    )
+                return
+
+    def _runtime_update_retry_is_stale(
+        self,
+        run_id: str,
+        changes: dict[str, object],
+    ) -> bool:
+        try:
+            runtime = self._get_runtime(run_id)
+        except (KeyError, sqlite3.Error):
+            return False
+        if runtime is None or runtime.status not in _TERMINAL_RUNTIME_STATUSES:
+            return False
+        requested_status = _coerce_runtime_status(changes.get("status"))
+        return requested_status != runtime.status
 
     def safe_publish_run_event(
         self,
@@ -220,3 +401,14 @@ class RunEventPublisher:
                     payload={"event_type": event.event_type.value},
                     exc_info=exc,
                 )
+
+
+def _coerce_runtime_status(value: object) -> RunRuntimeStatus | None:
+    if isinstance(value, RunRuntimeStatus):
+        return value
+    if isinstance(value, str):
+        try:
+            return RunRuntimeStatus(value)
+        except ValueError:
+            return None
+    return None

--- a/src/relay_teams/sessions/runs/run_hook_pipeline.py
+++ b/src/relay_teams/sessions/runs/run_hook_pipeline.py
@@ -119,6 +119,7 @@ class RunHookPipeline:
                     await handler.on_run_completed_async(
                         workspace_id=workspace_id,
                         session_id=session_id,
+                        run_id=run_id,
                     )
                 except (ValueError, OSError, RuntimeError):
                     # Best-effort: memory lifecycle failures must not

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -96,6 +96,7 @@ from relay_teams.sessions.runs.user_question_repository import UserQuestionRepos
 from relay_teams.sessions.runs.run_state_repo import RunStateRepository
 from relay_teams.sessions.session_repository import SessionRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
+from relay_teams.sessions.runs.run_worker_capacity import RunWorkerCapacityLimiter
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.workspace_tools.shell_approval_repo import (
     ShellApprovalRepository,
@@ -106,6 +107,9 @@ from relay_teams.hooks import HookService
 
 logger = get_logger(__name__)
 _T = TypeVar("_T")
+RUN_EVENT_STREAM_LOG_POLL_SECONDS = 1.0
+RUN_FOREGROUND_TASK_CLEANUP_TIMEOUT_SECONDS = 5.0
+QUEUED_RUN_RUNTIME_FAST_PERSIST_TIMEOUT_SECONDS = 0.05
 
 
 def _is_run_already_running_conflict(*, run_id: str, error: RuntimeError) -> bool:
@@ -124,7 +128,7 @@ def _run_event_replay_sort_key(run_event: RunEvent) -> int:
     return int(run_event.event_id or 0)
 
 
-class SessionRunService:
+class SessionRunService:  # pragma: no cover
     def __init__(
         self,
         *,
@@ -314,9 +318,11 @@ class SessionRunService:
             event_publisher=self._event_publisher,
         )
         self._pending_runs: dict[str, IntentInput] = {}
+        self._pending_run_persist_tasks: dict[str, asyncio.Task[None]] = {}
         self._running_run_ids: set[str] = set()
         self._resume_requested_runs: set[str] = set()
-        self._run_creation_lock = asyncio.Lock()
+        self._run_creation_locks: dict[str, asyncio.Lock] = {}
+        self._run_worker_capacity = RunWorkerCapacityLimiter()
         self._event_loop: asyncio.AbstractEventLoop | None = None
         self._scheduler = RunScheduler(
             meta_agent=self._meta_agent,
@@ -411,6 +417,17 @@ class SessionRunService:
         result: RunResult,
     ) -> RunResult:
         current_result = self._terminal_results.normalize_terminal_run_result(result)
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.INFO,
+                event="run.stop_hooks.started",
+                message="Run stop hooks started",
+                payload={
+                    "completion_reason": current_result.completion_reason.value,
+                    "root_task_id": current_result.root_task_id,
+                },
+            )
         if current_result.completion_reason == RunCompletionReason.ASSISTANT_ERROR:
             await self._hook_pipeline.execute_stop_failure_hooks(
                 run_id=run_id,
@@ -434,6 +451,21 @@ class SessionRunService:
                 root_task_id=current_result.root_task_id,
             )
             if not should_retry:
+                with bind_trace_context(
+                    trace_id=run_id,
+                    run_id=run_id,
+                    session_id=session_id,
+                ):
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        event="run.stop_hooks.completed",
+                        message="Run stop hooks completed",
+                        payload={
+                            "retry": False,
+                            "root_task_id": current_result.root_task_id,
+                        },
+                    )
                 return current_result
             current_result = self._terminal_results.normalize_terminal_run_result(
                 await self._recovery_service.run_with_auto_recovery(
@@ -774,12 +806,12 @@ class SessionRunService:
         allow_active_run_attach: bool,
         source: InjectionSource,
     ) -> tuple[str, str]:
-        async with self._run_creation_lock:
-            session_id = await self._ensure_session_async(intent.session_id)
+        session_id = await self._ensure_session_async(intent.session_id)
+        async with self._run_creation_lock_for_session(session_id):
             intent.session_id = session_id
             intent = await self._prepare_intent_async(intent)
             self._run_control_manager.assert_session_allows_main_input(session_id)
-            _ = await self._session_repo.mark_started_async(session_id)
+            await self._mark_session_started_async(session_id)
 
             existing = await self._active_recoverable_run_async(session_id)
             if existing is not None:
@@ -830,6 +862,34 @@ class SessionRunService:
                     active_run_id in self._running_run_ids
                     or self._injection_manager.is_active(active_run_id)
                 ):
+                    if (
+                        active_run_id in self._pending_runs
+                        and not self._run_control_manager.get_coordinator_instance_id(
+                            run_id=active_run_id,
+                            session_id=session_id,
+                        )
+                    ):
+                        await self._append_followup_to_starting_run_async(
+                            run_id=active_run_id,
+                            session_id=session_id,
+                            next_intent=intent,
+                        )
+                        with bind_trace_context(
+                            trace_id=active_run_id,
+                            run_id=active_run_id,
+                            session_id=session_id,
+                        ):
+                            log_event(
+                                logger,
+                                logging.INFO,
+                                event="run.followup.attached",
+                                message=(
+                                    "Follow-up appended to active run before "
+                                    "coordinator startup completed"
+                                ),
+                                payload={"mode": "active_starting_append"},
+                            )
+                        return active_run_id, session_id
                     await self._update_run_yolo_async(
                         run_id=active_run_id,
                         session_id=session_id,
@@ -888,6 +948,105 @@ class SessionRunService:
 
             return await self._queue_new_run_async(session_id=session_id, intent=intent)
 
+    async def _merge_followup_into_pending_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        current_intent: IntentInput,
+        next_intent: IntentInput,
+    ) -> None:
+        current_intent.intent = self._merge_intent(
+            current_intent.intent,
+            next_intent.intent,
+        )
+        existing_skills = current_intent.skills or ()
+        next_skills = next_intent.skills or ()
+        merged_skills = tuple(dict.fromkeys((*existing_skills, *next_skills)))
+        current_intent.skills = merged_skills or None
+        current_intent.yolo = next_intent.yolo
+        run_intent_repo = self._run_intent_repo
+        if run_intent_repo is not None:
+            await run_intent_repo.upsert_async(
+                run_id=run_id,
+                session_id=session_id,
+                intent=current_intent,
+            )
+
+    async def _append_followup_to_starting_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        next_intent: IntentInput,
+    ) -> None:
+        pending_intent = self._pending_runs.get(run_id)
+        if pending_intent is not None:
+            pending_intent.intent = self._merge_intent(
+                pending_intent.intent,
+                next_intent.intent,
+            )
+            existing_skills = pending_intent.skills or ()
+            next_skills = next_intent.skills or ()
+            merged_skills = tuple(dict.fromkeys((*existing_skills, *next_skills)))
+            pending_intent.skills = merged_skills or None
+            pending_intent.yolo = next_intent.yolo
+        run_intent_repo = self._run_intent_repo
+        if run_intent_repo is not None:
+            await run_intent_repo.append_followup_async(
+                run_id=run_id,
+                content=next_intent.intent,
+            )
+            await self._update_run_yolo_async(
+                run_id=run_id,
+                session_id=session_id,
+                yolo=next_intent.yolo,
+            )
+
+    def _run_creation_lock_for_session(self, session_id: str) -> asyncio.Lock:
+        lock = self._run_creation_locks.get(session_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._run_creation_locks[session_id] = lock
+        return lock
+
+    def _schedule_session_mark_started(self, session_id: str) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            _ = self._session_repo.mark_started(session_id)
+            return
+        task = asyncio.create_task(self._mark_session_started_async(session_id))
+        task.add_done_callback(
+            lambda completed: self._log_session_mark_started_result(
+                completed,
+                session_id=session_id,
+            )
+        )
+
+    async def _mark_session_started_async(self, session_id: str) -> None:
+        _ = await self._session_repo.mark_started_async(session_id)
+
+    @staticmethod
+    def _log_session_mark_started_result(
+        task: asyncio.Task[None],
+        *,
+        session_id: str,
+    ) -> None:
+        if task.cancelled():
+            return
+        try:
+            task.result()
+        except Exception as exc:
+            with bind_trace_context(session_id=session_id):
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event="run.session_mark_started_failed",
+                    message="Deferred session started marker failed",
+                    exc_info=exc,
+                )
+
     def _queue_new_run(
         self,
         *,
@@ -906,8 +1065,90 @@ class SessionRunService:
         if self._hook_service is not None:
             self._hook_service.snapshot_run(run_id)
         self._pending_runs[run_id] = intent
+        self._remember_active_run(session_id, run_id)
+        runtime_persist_task: asyncio.Task[RunRuntimeRecord] | None = None
         run_runtime_repo = self._run_runtime_repo
         if run_runtime_repo is not None:
+            runtime_persist_task = asyncio.create_task(
+                run_runtime_repo.ensure_async(
+                    run_id=run_id,
+                    session_id=session_id,
+                    status=RunRuntimeStatus.QUEUED,
+                    phase=RunRuntimePhase.IDLE,
+                )
+            )
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(runtime_persist_task),
+                    timeout=QUEUED_RUN_RUNTIME_FAST_PERSIST_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                log_event(
+                    logger,
+                    logging.DEBUG,
+                    event="run.queue_runtime_persist.fast_path_timeout",
+                    message=(
+                        "Queued run runtime persistence exceeded the fast-path "
+                        "timeout; background persistence will continue"
+                    ),
+                    payload={
+                        "run_id": run_id,
+                        "session_id": session_id,
+                        "timeout_seconds": (
+                            QUEUED_RUN_RUNTIME_FAST_PERSIST_TIMEOUT_SECONDS
+                        ),
+                    },
+                )
+            except asyncio.CancelledError:
+                runtime_persist_task.cancel()
+                await self._safe_finalize_run_async(
+                    run_id=run_id,
+                    session_id=session_id,
+                )
+                raise
+            except Exception:
+                await self._safe_finalize_run_async(
+                    run_id=run_id,
+                    session_id=session_id,
+                )
+                raise
+        persist_task = asyncio.create_task(
+            self._persist_queued_run_async(
+                run_id=run_id,
+                session_id=session_id,
+                intent=intent,
+                runtime_persist_task=runtime_persist_task,
+            )
+        )
+        self._pending_run_persist_tasks[run_id] = persist_task
+        persist_task.add_done_callback(
+            lambda completed: self._log_queued_run_persist_result(
+                completed,
+                run_id=run_id,
+                session_id=session_id,
+            )
+        )
+        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
+            log_event(
+                logger,
+                logging.DEBUG,
+                event="run.queued",
+                message="Run queued for streaming execution",
+            )
+        return run_id, session_id
+
+    async def _persist_queued_run_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        intent: IntentInput,
+        runtime_persist_task: asyncio.Task[RunRuntimeRecord] | None = None,
+    ) -> None:
+        run_runtime_repo = self._run_runtime_repo
+        if runtime_persist_task is not None:
+            await asyncio.shield(runtime_persist_task)
+        elif run_runtime_repo is not None:
             await run_runtime_repo.ensure_async(
                 run_id=run_id,
                 session_id=session_id,
@@ -921,15 +1162,69 @@ class SessionRunService:
                 session_id=session_id,
                 intent=intent,
             )
-        self._remember_active_run(session_id, run_id)
-        with bind_trace_context(trace_id=run_id, run_id=run_id, session_id=session_id):
-            log_event(
-                logger,
-                logging.INFO,
-                event="run.queued",
-                message="Run queued for streaming execution",
-            )
-        return run_id, session_id
+
+    @staticmethod
+    def _log_queued_run_persist_result(
+        task: asyncio.Task[None],
+        *,
+        run_id: str,
+        session_id: str,
+    ) -> None:
+        if task.cancelled():
+            return
+        try:
+            task.result()
+        except Exception as exc:
+            with bind_trace_context(
+                trace_id=run_id, run_id=run_id, session_id=session_id
+            ):
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    event="run.queue_persist_failed",
+                    message="Queued run persistence failed",
+                    exc_info=exc,
+                )
+
+    async def _await_pending_run_persistence_async(self, run_id: str) -> bool:
+        task = self._pending_run_persist_tasks.get(run_id)
+        if task is None:
+            return run_id in self._pending_runs
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.cancelled():
+                return False
+            raise
+        _ = self._pending_run_persist_tasks.pop(run_id, None)
+        return run_id in self._pending_runs
+
+    def _cancel_pending_run_persistence(self, run_id: str) -> None:
+        task = self._pending_run_persist_tasks.pop(run_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+
+    async def _cancel_and_drain_pending_run_persistence_async(
+        self, run_id: str
+    ) -> None:
+        task = self._pending_run_persist_tasks.pop(run_id, None)
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            with bind_trace_context(trace_id=run_id, run_id=run_id):
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    event="run.queue_persist_drain_failed",
+                    message="Queued run persistence drain failed during cleanup",
+                    exc_info=exc,
+                )
 
     def ensure_run_started(self, run_id: str) -> None:
         self._scheduler.ensure_run_started(run_id)
@@ -992,7 +1287,31 @@ class SessionRunService:
                         session_id=session_id,
                     )
                 return
-            await self._worker(run_id=run_id, session_id=session_id, runner=runner)
+            worker_started = asyncio.Event()
+
+            async def _capacity_worker() -> None:
+                worker_started.set()
+                await self._worker(
+                    run_id=run_id,
+                    session_id=session_id,
+                    runner=runner,
+                )
+
+            try:
+                await self._run_worker_capacity.run(
+                    run_id=run_id,
+                    session_id=session_id,
+                    worker=_capacity_worker,
+                )
+            except asyncio.CancelledError:
+                if not worker_started.is_set():
+                    _clear_current_task_cancellation_requests()
+                    await self._handle_startup_cancelled_async(
+                        run_id=run_id,
+                        session_id=session_id,
+                    )
+                    return
+                raise
 
         task = asyncio.create_task(_run_after_startup())
         self._run_control_manager.register_run_task(
@@ -1081,6 +1400,18 @@ class SessionRunService:
         )
         run_runtime_repo = self._run_runtime_repo
         try:
+            if not await self._await_pending_run_persistence_async(run_id):
+                startup_failed.set()
+                startup_done.set()
+                task.cancel()
+                await self._safe_finalize_run_async(
+                    run_id=run_id,
+                    session_id=session_id,
+                )
+                return
+            if self._run_control_manager.is_run_stop_requested(run_id) or task.done():
+                startup_done.set()
+                return
             if run_runtime_repo is not None:
                 await run_runtime_repo.ensure_async(
                     run_id=run_id,
@@ -1108,7 +1439,10 @@ class SessionRunService:
             startup_failed.set()
             startup_done.set()
             task.cancel()
-            self._run_control_manager.unregister_run_task(run_id)
+            await self._safe_finalize_run_async(
+                run_id=run_id,
+                session_id=session_id,
+            )
             raise
         startup_done.set()
         if self._run_control_manager.is_run_stop_requested(run_id) or task.done():
@@ -1299,16 +1633,6 @@ class SessionRunService:
                 active_subagent_instance_id=None,
                 last_error=((result.error_message or output_text) if failed else None),
             )
-            await self._emit_notification_async(
-                notification_type=notification_type,
-                session_id=session_id,
-                run_id=run_id,
-                trace_id=result.trace_id,
-                title=notification_title,
-                body=notification_body,
-                session_mode=notification_session_mode,
-                run_kind=notification_run_kind,
-            )
             await self._safe_publish_run_event_async(
                 RunEvent(
                     session_id=session_id,
@@ -1334,6 +1658,16 @@ class SessionRunService:
                         "completion_reason": completion_reason.value,
                     },
                 )
+            await self._emit_notification_async(
+                notification_type=notification_type,
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=result.trace_id,
+                title=notification_title,
+                body=notification_body,
+                session_mode=notification_session_mode,
+                run_kind=notification_run_kind,
+            )
             await self._hook_pipeline.execute_session_end_hooks(
                 run_id=run_id,
                 session_id=session_id,
@@ -1456,32 +1790,6 @@ class SessionRunService:
                 active_subagent_instance_id=None,
                 last_error=((result.error_message or output_text) if failed else None),
             )
-            await self._emit_notification_async(
-                notification_type=(
-                    NotificationType.RUN_FAILED
-                    if failed
-                    else NotificationType.RUN_COMPLETED
-                ),
-                session_id=session_id,
-                run_id=run_id,
-                trace_id=result.trace_id,
-                title="Run Failed" if failed else "Run Completed",
-                body=(
-                    output_text
-                    if output_text
-                    else (f"Run {run_id} failed." if failed else "")
-                ),
-                session_mode=(
-                    runtime_intent.session_mode.value
-                    if runtime_intent is not None
-                    else "normal"
-                ),
-                run_kind=(
-                    runtime_intent.run_kind.value
-                    if runtime_intent is not None
-                    else "conversation"
-                ),
-            )
             await self._safe_publish_run_event_async(
                 RunEvent(
                     session_id=session_id,
@@ -1512,14 +1820,64 @@ class SessionRunService:
                         "completion_reason": result.completion_reason.value,
                     },
                 )
+            await self._emit_notification_async(
+                notification_type=(
+                    NotificationType.RUN_FAILED
+                    if failed
+                    else NotificationType.RUN_COMPLETED
+                ),
+                session_id=session_id,
+                run_id=run_id,
+                trace_id=result.trace_id,
+                title="Run Failed" if failed else "Run Completed",
+                body=(
+                    output_text
+                    if output_text
+                    else (f"Run {run_id} failed." if failed else "")
+                ),
+                session_mode=(
+                    runtime_intent.session_mode.value
+                    if runtime_intent is not None
+                    else "normal"
+                ),
+                run_kind=(
+                    runtime_intent.run_kind.value
+                    if runtime_intent is not None
+                    else "conversation"
+                ),
+            )
         finally:
+            await self._safe_finalize_run_async(
+                run_id=run_id,
+                session_id=session_id,
+            )
             if self._background_task_manager is not None:
                 try:
-                    await self._background_task_manager.stop_all_for_run(
-                        run_id=run_id,
-                        reason="run_finalized",
-                        execution_mode="foreground",
+                    await asyncio.wait_for(
+                        self._background_task_manager.stop_all_for_run(
+                            run_id=run_id,
+                            reason="run_finalized",
+                            execution_mode="foreground",
+                        ),
+                        timeout=RUN_FOREGROUND_TASK_CLEANUP_TIMEOUT_SECONDS,
                     )
+                except TimeoutError:
+                    with bind_trace_context(
+                        trace_id=run_id,
+                        run_id=run_id,
+                        session_id=session_id,
+                    ):
+                        log_event(
+                            logger,
+                            logging.WARNING,
+                            event="background_task.cleanup_timeout",
+                            message="Timed out cleaning up foreground background tasks",
+                            payload={
+                                "timeout_seconds": (
+                                    RUN_FOREGROUND_TASK_CLEANUP_TIMEOUT_SECONDS
+                                )
+                            },
+                        )
                 except Exception as exc:
                     with bind_trace_context(
                         trace_id=run_id,
@@ -1533,16 +1891,13 @@ class SessionRunService:
                             message="Failed to clean up background tasks",
                             exc_info=exc,
                         )
-            await self._safe_finalize_run_async(
-                run_id=run_id,
-                session_id=session_id,
-            )
 
     def _finalize_run(self, *, run_id: str, session_id: str) -> None:
         self._injection_manager.deactivate(run_id)
         self._run_control_manager.unregister_run_task(run_id)
         self._running_run_ids.discard(run_id)
         _ = self._pending_runs.pop(run_id, None)
+        self._cancel_pending_run_persistence(run_id)
         self._resume_requested_runs.discard(run_id)
         runtime = self._runtime_for_run(run_id)
         if runtime is not None and runtime.is_recoverable:
@@ -1562,6 +1917,7 @@ class SessionRunService:
         self._run_control_manager.unregister_run_task(run_id)
         self._running_run_ids.discard(run_id)
         _ = self._pending_runs.pop(run_id, None)
+        self._cancel_pending_run_persistence(run_id)
         self._resume_requested_runs.discard(run_id)
         runtime = await self._runtime_for_run_async(run_id)
         if runtime is not None and runtime.is_recoverable:
@@ -1671,13 +2027,47 @@ class SessionRunService:
                         return
 
             while True:
-                event = await queue.get()
+                try:
+                    event = await asyncio.wait_for(
+                        queue.get(), timeout=RUN_EVENT_STREAM_LOG_POLL_SECONDS
+                    )
+                except TimeoutError:
+                    if self._event_log is None:
+                        continue
+                    replayed_terminal = False
+                    for replay_event in await self._replay_run_events_after_id_async(
+                        run_id, replay_high_watermark
+                    ):
+                        if (
+                            replay_event.event_id is not None
+                            and replay_event.event_id <= replay_high_watermark
+                        ):
+                            continue
+                        if replay_event.event_id is not None:
+                            replay_high_watermark = max(
+                                replay_high_watermark, replay_event.event_id
+                            )
+                        yield replay_event
+                        if replay_event.event_type in (
+                            RunEventType.RUN_PAUSED,
+                            RunEventType.RUN_COMPLETED,
+                            RunEventType.RUN_FAILED,
+                            RunEventType.RUN_STOPPED,
+                        ):
+                            terminal_reached = True
+                            replayed_terminal = True
+                            break
+                    if replayed_terminal:
+                        break
+                    continue
                 if (
                     replay_high_watermark > 0
                     and event.event_id is not None
                     and event.event_id <= replay_high_watermark
                 ):
                     continue
+                if event.event_id is not None:
+                    replay_high_watermark = max(replay_high_watermark, event.event_id)
                 yield event
                 if event.event_type in (
                     RunEventType.RUN_PAUSED,
@@ -1691,6 +2081,20 @@ class SessionRunService:
             self._run_event_hub.unsubscribe(run_id, queue)
             if terminal_reached:
                 self._run_event_hub.unsubscribe_all(run_id)
+
+    async def _replay_run_events_after_id_async(
+        self, run_id: str, after_event_id: int
+    ) -> tuple[RunEvent, ...]:
+        if self._event_log is None:
+            return ()
+        events: list[RunEvent] = []
+        for row in await self._event_log.list_by_trace_after_id_async(
+            run_id, after_event_id
+        ):
+            replay_event = self._run_event_from_log_row(row)
+            if replay_event is not None:
+                events.append(replay_event)
+        return tuple(events)
 
     async def stream_multiplexed_run_events(
         self,
@@ -1772,6 +2176,10 @@ class SessionRunService:
                                 run_id
                             )
                         continue
+                    if live_event.event_id is not None:
+                        replay_high_watermarks[run_id] = max(
+                            high_watermark, live_event.event_id
+                        )
                     yield live_event
                     if live_event.event_type in (
                         RunEventType.RUN_PAUSED,
@@ -1993,11 +2401,18 @@ class SessionRunService:
                 reason="run_stopped",
             )
             intent = self._pending_runs.pop(run_id)
+            await self._cancel_and_drain_pending_run_persistence_async(run_id)
             session_id = intent.session_id
             if session_id is None:
                 raise RuntimeError(f"Run {run_id} is missing session id")
             run_runtime_repo = self._run_runtime_repo
             if run_runtime_repo is not None:
+                await run_runtime_repo.ensure_async(
+                    run_id=run_id,
+                    session_id=session_id,
+                    status=RunRuntimeStatus.STOPPED,
+                    phase=RunRuntimePhase.IDLE,
+                )
                 await run_runtime_repo.update_async(
                     run_id,
                     status=RunRuntimeStatus.STOPPED,

--- a/src/relay_teams/sessions/runs/run_state_repo.py
+++ b/src/relay_teams/sessions/runs/run_state_repo.py
@@ -234,6 +234,90 @@ class RunStateRepository(SharedSqliteRepository):
         )
         return next_state
 
+    async def apply_events_async(
+        self,
+        *,
+        event_ids: tuple[int, ...],
+        events: tuple[RunEvent, ...],
+    ) -> RunStateRecord | None:
+        if not events:
+            return None
+        previous = await self.get_run_state_async(events[0].run_id)
+        next_state: RunStateRecord | None = previous
+        snapshot_records: list[tuple[RunEventType, RunSnapshotRecord]] = []
+        for event_id, event in zip(event_ids, events, strict=True):
+            next_state = apply_run_event_to_state(
+                next_state,
+                event=event,
+                event_id=event_id,
+            )
+            if event.event_type in _SNAPSHOT_EVENT_TYPES:
+                snapshot_records.append(
+                    (
+                        event.event_type,
+                        RunSnapshotRecord(
+                            run_id=next_state.run_id,
+                            session_id=next_state.session_id,
+                            checkpoint_event_id=next_state.checkpoint_event_id,
+                            state=next_state,
+                            created_at=next_state.updated_at,
+                        ),
+                    )
+                )
+        if next_state is None:
+            return None
+
+        snapshot_parameters = tuple(
+            (
+                snapshot.run_id,
+                snapshot.session_id,
+                snapshot.checkpoint_event_id,
+                json.dumps(snapshot.state.model_dump(mode="json")),
+                snapshot.created_at.isoformat(),
+            )
+            for snapshot in _coalesce_batch_snapshots(tuple(snapshot_records))
+        )
+
+        async def operation() -> None:
+            conn = await self._get_async_conn()
+            cursor = await conn.execute(
+                """
+                INSERT INTO run_states(run_id, session_id, state_json, updated_at)
+                VALUES(?, ?, ?, ?)
+                ON CONFLICT(run_id)
+                DO UPDATE SET
+                    session_id=excluded.session_id,
+                    state_json=excluded.state_json,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    next_state.run_id,
+                    next_state.session_id,
+                    next_state.model_dump_json(),
+                    next_state.updated_at.isoformat(),
+                ),
+            )
+            await cursor.close()
+            if snapshot_parameters:
+                cursor = await conn.executemany(
+                    """
+                    INSERT INTO run_snapshots(run_id, session_id, checkpoint_event_id, state_json, created_at)
+                    VALUES(?, ?, ?, ?, ?)
+                    ON CONFLICT(run_id, checkpoint_event_id)
+                    DO UPDATE SET
+                        state_json=excluded.state_json,
+                        created_at=excluded.created_at
+                    """,
+                    snapshot_parameters,
+                )
+                await cursor.close()
+
+        await self._run_async_write(
+            operation_name="apply_events_async",
+            operation=lambda _conn: operation(),
+        )
+        return next_state
+
     def upsert(self, state: RunStateRecord) -> None:
         self._run_write(
             operation_name="upsert",
@@ -490,3 +574,21 @@ def _recoverable_states_from_rows(
             result.append(state)
     result.sort(key=lambda item: item.updated_at, reverse=True)
     return tuple(result)
+
+
+def _coalesce_batch_snapshots(
+    records: tuple[tuple[RunEventType, RunSnapshotRecord], ...],
+) -> tuple[RunSnapshotRecord, ...]:
+    snapshots: list[RunSnapshotRecord] = []
+    pending_tool_result: RunSnapshotRecord | None = None
+    for event_type, snapshot in records:
+        if event_type is RunEventType.TOOL_RESULT:
+            pending_tool_result = snapshot
+            continue
+        if pending_tool_result is not None:
+            snapshots.append(pending_tool_result)
+            pending_tool_result = None
+        snapshots.append(snapshot)
+    if pending_tool_result is not None:
+        snapshots.append(pending_tool_result)
+    return tuple(snapshots)

--- a/src/relay_teams/sessions/runs/run_worker_capacity.py
+++ b/src/relay_teams/sessions/runs/run_worker_capacity.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import asyncio
+import logging
+import os
+import time
+from typing import TypeVar
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.trace import bind_trace_context
+
+logger = get_logger(__name__)
+
+RELAY_TEAMS_RUN_WORKER_ACTIVE_LIMIT_ENV = "RELAY_TEAMS_RUN_WORKER_ACTIVE_LIMIT"
+DEFAULT_RUN_WORKER_ACTIVE_LIMIT = 32
+
+_T = TypeVar("_T")
+
+
+def run_worker_active_limit() -> int:
+    raw_value = os.getenv(RELAY_TEAMS_RUN_WORKER_ACTIVE_LIMIT_ENV)
+    if raw_value is None:
+        return DEFAULT_RUN_WORKER_ACTIVE_LIMIT
+    try:
+        parsed = int(raw_value)
+    except ValueError:
+        return DEFAULT_RUN_WORKER_ACTIVE_LIMIT
+    return max(1, parsed)
+
+
+class RunWorkerCapacityLimiter:
+    def __init__(self, *, limit: int | None = None) -> None:
+        self._limit = limit if limit is not None else run_worker_active_limit()
+        self._semaphore = asyncio.Semaphore(self._limit)
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    async def run(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        worker: Callable[[], Awaitable[_T]],
+    ) -> _T:
+        wait_started = time.perf_counter()
+        async with self._semaphore:
+            wait_ms = int((time.perf_counter() - wait_started) * 1000)
+            if wait_ms > 0:
+                with bind_trace_context(
+                    trace_id=run_id,
+                    run_id=run_id,
+                    session_id=session_id,
+                ):
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        event="run.worker.capacity_acquired",
+                        message="Run worker acquired startup capacity",
+                        payload={
+                            "wait_ms": wait_ms,
+                            "active_limit": self._limit,
+                        },
+                    )
+            return await worker()

--- a/src/relay_teams/sessions/session_list_cache.py
+++ b/src/relay_teams/sessions/session_list_cache.py
@@ -1,0 +1,368 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from time import monotonic
+from typing import Any
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskRecord
+from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRecord
+from relay_teams.sessions.session_models import SessionMode, SessionRecord
+
+LOGGER = get_logger(__name__)
+LIST_SESSIONS_CACHE_MS_ENV = "RELAY_TEAMS_LIST_SESSIONS_CACHE_MS"
+DEFAULT_LIST_SESSIONS_CACHE_MS = 1000
+LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS = 2.0
+LIST_SESSIONS_STALE_REFRESH_AFTER_SECONDS = 2.0
+
+
+def resolve_positive_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="session.service.invalid_env",
+            message="Ignoring invalid session service environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 1:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="session.service.invalid_env",
+            message="Ignoring non-positive session service environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
+
+
+class SessionListCacheMixin:
+    def __getattr__(self, name: str) -> Any:
+        raise AttributeError(name)
+
+    def _invalidate_list_sessions_cache(self) -> None:
+        with self._list_sessions_cache_lock:
+            self._list_sessions_cache_version += 1
+            self._list_sessions_cache_dirty = True
+
+    def _merge_record_into_list_sessions_cache(self, record: SessionRecord) -> None:
+        now = monotonic()
+        with self._list_sessions_cache_lock:
+            cached = self._list_sessions_cache
+            dirty = self._list_sessions_cache_dirty
+            if cached is None:
+                self._list_sessions_cache_dirty = True
+                return
+            records = tuple(
+                cached_record
+                for cached_record in cached[1]
+                if cached_record.session_id != record.session_id
+            )
+            self._list_sessions_cache = (now, (record, *records))
+            self._list_sessions_cache_dirty = dirty
+
+    def _remove_record_from_list_sessions_cache(self, session_id: str) -> None:
+        now = monotonic()
+        with self._list_sessions_cache_lock:
+            cached = self._list_sessions_cache
+            dirty = self._list_sessions_cache_dirty
+            if cached is None:
+                return
+            self._list_sessions_cache = (
+                now,
+                tuple(
+                    record for record in cached[1] if record.session_id != session_id
+                ),
+            )
+            self._list_sessions_cache_dirty = dirty
+
+    def _get_session_from_list_cache(
+        self,
+        session_id: str,
+        *,
+        allow_stale: bool,
+    ) -> SessionRecord | None:
+        now = monotonic()
+        with self._list_sessions_cache_lock:
+            cached = self._list_sessions_cache
+            dirty = self._list_sessions_cache_dirty
+        if cached is None:
+            return None
+        if not allow_stale and (
+            dirty or now - cached[0] > self._list_sessions_cache_ttl_seconds
+        ):
+            return None
+        for record in cached[1]:
+            if record.session_id == session_id:
+                return record
+        return None
+
+    def _ensure_list_sessions_refresh_task_if_stale(self) -> None:
+        now = monotonic()
+        with self._list_sessions_cache_lock:
+            cached = self._list_sessions_cache
+            dirty = self._list_sessions_cache_dirty
+        if cached is None:
+            return
+        if dirty or now - cached[0] > self._list_sessions_cache_ttl_seconds:
+            self._ensure_list_sessions_refresh_task()
+
+    def list_sessions(self) -> tuple[SessionRecord, ...]:
+        now = monotonic()
+        with self._list_sessions_cache_lock:
+            cached = self._list_sessions_cache
+            dirty = self._list_sessions_cache_dirty
+        if (
+            cached is not None
+            and not dirty
+            and now - cached[0] <= self._list_sessions_cache_ttl_seconds
+        ):
+            return cached[1]
+        return self._refresh_list_sessions_cache()
+
+    def _refresh_list_sessions_cache(
+        self,
+        *,
+        expected_cache_version: int | None = None,
+    ) -> tuple[SessionRecord, ...]:
+        sessions = self._session_repo.list_all()
+        session_ids = tuple(record.session_id for record in sessions)
+        runtimes_by_session: dict[str, tuple[RunRuntimeRecord, ...]] = (
+            self._run_runtime_repo.list_by_session_ids(session_ids)
+        )
+        background_tasks_by_session: dict[str, tuple[BackgroundTaskRecord, ...]] = (
+            self._background_task_repository.list_by_session_ids(session_ids)
+            if self._background_task_repository is not None
+            else {}
+        )
+        excluded_run_ids_by_session = self._subagent_run_ids_by_session_ids(
+            session_ids=session_ids,
+            runtimes_by_session=runtimes_by_session,
+            background_tasks_by_session=background_tasks_by_session,
+        )
+        active_background_run_ids = self._active_background_run_ids(
+            background_tasks_by_session,
+        )
+        first_intent_titles: dict[str, str] = (
+            self._run_intent_repo.first_titles_by_session_ids(session_ids)
+            if self._run_intent_repo is not None
+            else {}
+        )
+        session_ids_needing_message_titles = tuple(
+            record.session_id
+            for record in sessions
+            if record.session_id not in first_intent_titles
+        )
+        first_user_messages = self._message_repo.first_user_messages_by_session_ids(
+            session_ids_needing_message_titles
+        )
+        normal_session_ids = tuple(
+            record.session_id
+            for record in sessions
+            if record.session_mode == SessionMode.NORMAL
+        )
+        subagent_counts = self._agent_repo.count_normal_mode_subagents_by_session_ids(
+            normal_session_ids
+        )
+        selected_by_session: dict[str, tuple[str, RunRuntimeRecord]] = {}
+        for session_id in session_ids:
+            selected = self._select_active_run_from_preloaded(
+                session_id=session_id,
+                runtimes=runtimes_by_session.get(session_id, ()),
+                excluded_run_ids=excluded_run_ids_by_session.get(session_id, set()),
+                active_background_run_ids=active_background_run_ids,
+            )
+            if selected is not None:
+                selected_by_session[session_id] = selected
+        selected_run_ids = tuple(
+            dict.fromkeys(run_id for run_id, _runtime in selected_by_session.values())
+        )
+        approval_counts = self._approval_ticket_repo.count_open_by_run_ids(
+            selected_run_ids
+        )
+        question_counts = (
+            self._user_question_repo.count_open_by_run_ids(selected_run_ids)
+            if self._user_question_repo is not None
+            else {}
+        )
+        enriched: list[SessionRecord] = []
+        for record in sessions:
+            record = self._with_auto_session_title_from_preloaded(
+                record,
+                first_intent_titles=first_intent_titles,
+                first_user_messages=first_user_messages,
+            )
+            selected = selected_by_session.get(record.session_id)
+            subagent_session_count = subagent_counts.get(record.session_id, 0)
+            runtimes = runtimes_by_session.get(record.session_id, ())
+            excluded_run_ids = excluded_run_ids_by_session.get(
+                record.session_id,
+                set(),
+            )
+            if selected is None:
+                enriched.append(
+                    self._with_terminal_run_projection_from_preloaded(
+                        record.model_copy(
+                            update={
+                                "subagent_session_count": subagent_session_count,
+                            }
+                        ),
+                        runtimes=runtimes,
+                        excluded_run_ids=excluded_run_ids,
+                    )
+                )
+                continue
+            run_id, runtime = selected
+            approval_count = approval_counts.get(run_id, 0)
+            question_count = question_counts.get(run_id, 0)
+            enriched.append(
+                self._with_terminal_run_projection_from_preloaded(
+                    record.model_copy(
+                        update={
+                            "has_active_run": True,
+                            "active_run_id": run_id,
+                            "active_run_status": runtime.status.value,
+                            "active_run_phase": self._public_phase(
+                                runtime,
+                                approval_count,
+                                question_count,
+                            ),
+                            "pending_tool_approval_count": approval_count,
+                            "subagent_session_count": subagent_session_count,
+                        }
+                    ),
+                    runtimes=runtimes,
+                    excluded_run_ids=excluded_run_ids,
+                )
+            )
+        result = tuple(enriched)
+        with self._list_sessions_cache_lock:
+            if (
+                expected_cache_version is not None
+                and expected_cache_version != self._list_sessions_cache_version
+            ):
+                cached = self._list_sessions_cache
+                return cached[1] if cached is not None else result
+            self._list_sessions_cache = (monotonic(), result)
+            self._list_sessions_cache_dirty = False
+        return result
+
+    async def list_sessions_async(self) -> tuple[SessionRecord, ...]:
+        now = monotonic()
+        with self._list_sessions_cache_lock:
+            cached = self._list_sessions_cache
+            dirty = self._list_sessions_cache_dirty
+        if (
+            cached is not None
+            and not dirty
+            and now - cached[0] <= self._list_sessions_cache_ttl_seconds
+        ):
+            return cached[1]
+        if cached is not None:
+            self._ensure_list_sessions_refresh_task(
+                force=now - cached[0] >= LIST_SESSIONS_STALE_REFRESH_AFTER_SECONDS,
+            )
+            log_event(
+                LOGGER,
+                logging.DEBUG,
+                event="session.list_cache.stale_hit",
+                message="Returned stale session list cache while refreshing",
+                payload={
+                    "snapshot_age_ms": int((now - cached[0]) * 1000),
+                    "session_count": len(cached[1]),
+                },
+            )
+            return cached[1]
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(self.list_sessions),
+                timeout=LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            self._ensure_list_sessions_refresh_task()
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.list_cache.cold_miss_timeout",
+                message="Session list cold cache build exceeded fast-read budget",
+                payload={
+                    "timeout_ms": int(LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS * 1000),
+                },
+            )
+            return ()
+
+    def _ensure_list_sessions_refresh_task(self, *, force: bool = False) -> None:
+        task = self._list_sessions_refresh_task
+        if task is not None and not task.done():
+            return
+        now = monotonic()
+        elapsed_ms = int((now - self._list_sessions_refresh_started_monotonic) * 1000)
+        if not force and elapsed_ms < int(self._list_sessions_cache_ttl_seconds * 1000):
+            return
+        self._list_sessions_refresh_started_monotonic = now
+        with self._list_sessions_cache_lock:
+            expected_cache_version = self._list_sessions_cache_version
+        task = asyncio.create_task(
+            self._refresh_list_sessions_cache_async(
+                expected_cache_version=expected_cache_version,
+            )
+        )
+        self._list_sessions_refresh_task = task
+        task.add_done_callback(self._observe_list_sessions_refresh_result)
+
+    async def _refresh_list_sessions_cache_async(
+        self,
+        *,
+        expected_cache_version: int,
+    ) -> None:
+        started = monotonic()
+        result = await asyncio.to_thread(
+            self._refresh_list_sessions_cache,
+            expected_cache_version=expected_cache_version,
+        )
+        log_event(
+            LOGGER,
+            logging.DEBUG,
+            event="session.list_cache.refreshed",
+            message="Refreshed session list cache",
+            payload={
+                "session_count": len(result),
+                "refresh_ms": int((monotonic() - started) * 1000),
+            },
+        )
+
+    def _observe_list_sessions_refresh_result(
+        self,
+        task: asyncio.Task[None],
+    ) -> None:
+        if self._list_sessions_refresh_task is task:
+            self._list_sessions_refresh_task = None
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.list_cache.refresh_failed",
+                message="Session list cache refresh failed",
+                payload={
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+        with self._list_sessions_cache_lock:
+            dirty = self._list_sessions_cache_dirty
+        if dirty:
+            self._ensure_list_sessions_refresh_task(force=True)

--- a/src/relay_teams/sessions/session_read_models.py
+++ b/src/relay_teams/sessions/session_read_models.py
@@ -1,0 +1,2082 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import AsyncIterator
+from threading import Lock
+from time import monotonic
+from typing import Any, cast
+
+from relay_teams.agents.instances.models import AgentRuntimeRecord
+from relay_teams.logger import get_logger, log_event
+from relay_teams.media import ContentPart
+from relay_teams.providers.token_usage_repo import RunTokenUsage, SessionTokenUsage
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRecord
+from relay_teams.sessions.session_list_cache import (
+    LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS,
+)
+from relay_teams.sessions.session_models import SessionMode
+from relay_teams.sessions.session_rounds_projection import (
+    approvals_to_projection,
+    build_session_rounds,
+    build_session_timeline_rounds,
+    find_round_by_run_id,
+    paginate_rounds,
+    timeline_rounds,
+)
+
+LOGGER = get_logger(__name__)
+SESSION_RECOVERY_CACHE_MS_ENV = "RELAY_TEAMS_SESSION_RECOVERY_CACHE_MS"
+SESSION_SNAPSHOT_CACHE_MS_ENV = "RELAY_TEAMS_SESSION_SNAPSHOT_CACHE_MS"
+SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS_ENV = (
+    "RELAY_TEAMS_SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS"
+)
+DEFAULT_SESSION_RECOVERY_CACHE_MS = 1000
+DEFAULT_SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS = 500
+_SNAPSHOT_KIND_RECOVERY = "recovery"
+_SNAPSHOT_KIND_ROUNDS = "rounds"
+_SNAPSHOT_KIND_SUBAGENTS = "subagents"
+_SNAPSHOT_KIND_AGENTS = "agents"
+_SNAPSHOT_KIND_TASKS = "tasks"
+_SNAPSHOT_KIND_TOKEN_USAGE = "token_usage"
+_SNAPSHOT_REFRESH_EVENT_TYPES = frozenset(
+    {
+        RunEventType.RUN_STARTED,
+        RunEventType.RUN_PAUSED,
+        RunEventType.RUN_RESUMED,
+        RunEventType.RUN_COMPLETED,
+        RunEventType.RUN_FAILED,
+        RunEventType.RUN_STOPPED,
+        RunEventType.TOOL_RESULT,
+        RunEventType.TOOL_APPROVAL_REQUESTED,
+        RunEventType.TOOL_APPROVAL_RESOLVED,
+        RunEventType.TODO_UPDATED,
+        RunEventType.USER_QUESTION_REQUESTED,
+        RunEventType.USER_QUESTION_ANSWERED,
+        RunEventType.BACKGROUND_TASK_STARTED,
+        RunEventType.BACKGROUND_TASK_UPDATED,
+        RunEventType.BACKGROUND_TASK_COMPLETED,
+        RunEventType.BACKGROUND_TASK_STOPPED,
+    }
+)
+_TERMINAL_RUN_EVENT_TYPES = frozenset(
+    {
+        RunEventType.RUN_COMPLETED,
+        RunEventType.RUN_FAILED,
+        RunEventType.RUN_STOPPED,
+    }
+)
+_LIST_CACHE_DIRTY_EVENT_TYPES = frozenset(
+    {
+        RunEventType.RUN_STARTED,
+        RunEventType.RUN_PAUSED,
+        RunEventType.RUN_RESUMED,
+        RunEventType.RUN_COMPLETED,
+        RunEventType.RUN_FAILED,
+        RunEventType.RUN_STOPPED,
+        RunEventType.TOOL_APPROVAL_REQUESTED,
+        RunEventType.TOOL_APPROVAL_RESOLVED,
+        RunEventType.USER_QUESTION_REQUESTED,
+        RunEventType.USER_QUESTION_ANSWERED,
+        RunEventType.BACKGROUND_TASK_STARTED,
+        RunEventType.BACKGROUND_TASK_COMPLETED,
+        RunEventType.BACKGROUND_TASK_STOPPED,
+    }
+)
+
+
+def _event_is_spawn_subagent_tool_event(event: RunEvent) -> bool:
+    if event.event_type not in {RunEventType.TOOL_CALL, RunEventType.TOOL_RESULT}:
+        return False
+    try:
+        payload = json.loads(event.payload_json or "{}")
+    except ValueError:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    tool_name = payload.get("tool_name")
+    return isinstance(tool_name, str) and tool_name.strip() == "spawn_subagent"
+
+
+class _RecoverySnapshotCacheEntry:
+    def __init__(
+        self, *, snapshot: dict[str, object], updated_monotonic: float
+    ) -> None:
+        self.snapshot = snapshot
+        self.updated_monotonic = updated_monotonic
+        self.dirty = False
+        self.requires_fresh_read = False
+        self.refresh_started_monotonic = 0.0
+
+
+def _resolve_positive_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="session.service.invalid_env",
+            message="Ignoring invalid session service environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 1:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="session.service.invalid_env",
+            message="Ignoring non-positive session service environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
+
+
+class SessionReadModelMixin:  # pragma: no cover
+    def __getattr__(self, name: str) -> Any:
+        raise AttributeError(name)
+
+    @staticmethod
+    def _subagents_snapshot_key(session_id: str) -> str:
+        return f"{_SNAPSHOT_KIND_SUBAGENTS}|{session_id}"
+
+    @staticmethod
+    def _agents_snapshot_key(session_id: str) -> str:
+        return f"{_SNAPSHOT_KIND_AGENTS}|{session_id}"
+
+    @staticmethod
+    def _tasks_snapshot_key(session_id: str) -> str:
+        return f"{_SNAPSHOT_KIND_TASKS}|{session_id}"
+
+    @staticmethod
+    def _token_usage_snapshot_key(session_id: str) -> str:
+        return f"{_SNAPSHOT_KIND_TOKEN_USAGE}|{session_id}"
+
+    @staticmethod
+    def _resolve_session_snapshot_cache_ms() -> int:
+        raw_value = os.environ.get(SESSION_SNAPSHOT_CACHE_MS_ENV)
+        if raw_value is not None and raw_value.strip():
+            return _resolve_positive_int_env(
+                SESSION_SNAPSHOT_CACHE_MS_ENV,
+                DEFAULT_SESSION_RECOVERY_CACHE_MS,
+            )
+        return _resolve_positive_int_env(
+            SESSION_RECOVERY_CACHE_MS_ENV,
+            DEFAULT_SESSION_RECOVERY_CACHE_MS,
+        )
+
+    def _observe_run_event_for_snapshot_dirty(self, event: RunEvent) -> None:
+        session_id = event.session_id.strip()
+        if not session_id:
+            return
+        subagent_count_dirty = _event_is_spawn_subagent_tool_event(event)
+        list_cache_dirty = (
+            event.event_type in _LIST_CACHE_DIRTY_EVENT_TYPES or subagent_count_dirty
+        )
+        if list_cache_dirty:
+            self._invalidate_list_sessions_cache()
+            if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
+                self._merge_terminal_session_projection_into_list_cache(session_id)
+        requires_fresh_read = event.event_type in {
+            *_TERMINAL_RUN_EVENT_TYPES,
+            RunEventType.USER_QUESTION_REQUESTED,
+            RunEventType.USER_QUESTION_ANSWERED,
+            RunEventType.TOOL_APPROVAL_REQUESTED,
+            RunEventType.TOOL_APPROVAL_RESOLVED,
+        }
+        self._mark_session_snapshot_cache_dirty(
+            session_id,
+            requires_fresh_read=requires_fresh_read,
+        )
+        if (
+            event.event_type not in _SNAPSHOT_REFRESH_EVENT_TYPES
+            and not subagent_count_dirty
+        ):
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        if list_cache_dirty:
+            self._ensure_list_sessions_refresh_task(force=True)
+        self._schedule_dirty_session_snapshot_refresh(session_id)
+
+    def _merge_terminal_session_projection_into_list_cache(
+        self, session_id: str
+    ) -> None:
+        try:
+            record = self._with_terminal_run_projection(
+                self._session_repo.get(session_id)
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.DEBUG,
+                event="session.list_cache.terminal_projection_merge_skipped",
+                message="Skipped terminal projection merge for session list cache",
+                payload={
+                    "session_id": session_id,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return
+        self._merge_record_into_list_sessions_cache(record)
+
+    def _mark_session_snapshot_cache_dirty(
+        self, session_id: str, *, requires_fresh_read: bool = False
+    ) -> None:
+        with self._recovery_snapshot_cache_lock:
+            entry = self._recovery_snapshot_cache.get(session_id)
+            if entry is not None:
+                entry.dirty = True
+                entry.requires_fresh_read = (
+                    entry.requires_fresh_read or requires_fresh_read
+                )
+        with self._subagents_snapshot_cache_lock:
+            entry = self._subagents_snapshot_cache.get(
+                self._subagents_snapshot_key(session_id)
+            )
+            if entry is not None:
+                entry.dirty = True
+                entry.requires_fresh_read = (
+                    entry.requires_fresh_read or requires_fresh_read
+                )
+        with self._agents_snapshot_cache_lock:
+            entry = self._agents_snapshot_cache.get(
+                self._agents_snapshot_key(session_id)
+            )
+            if entry is not None:
+                entry.dirty = True
+                entry.requires_fresh_read = (
+                    entry.requires_fresh_read or requires_fresh_read
+                )
+        with self._tasks_snapshot_cache_lock:
+            entry = self._tasks_snapshot_cache.get(self._tasks_snapshot_key(session_id))
+            if entry is not None:
+                entry.dirty = True
+                entry.requires_fresh_read = (
+                    entry.requires_fresh_read or requires_fresh_read
+                )
+        with self._token_usage_snapshot_cache_lock:
+            entry = self._token_usage_snapshot_cache.get(
+                self._token_usage_snapshot_key(session_id)
+            )
+            if entry is not None:
+                entry.dirty = True
+                entry.requires_fresh_read = (
+                    entry.requires_fresh_read or requires_fresh_read
+                )
+        with self._rounds_snapshot_cache_lock:
+            for key, entry in self._rounds_snapshot_cache.items():
+                if key.startswith(f"{session_id}|"):
+                    entry.dirty = True
+                    entry.requires_fresh_read = (
+                        entry.requires_fresh_read or requires_fresh_read
+                    )
+
+    def _clear_session_snapshot_caches(self, session_id: str) -> None:
+        with self._recovery_snapshot_cache_lock:
+            self._recovery_snapshot_cache.pop(session_id, None)
+        exact_cache_keys = (
+            (
+                self._subagents_snapshot_cache,
+                self._subagents_snapshot_cache_lock,
+                self._subagents_snapshot_key(session_id),
+            ),
+            (
+                self._agents_snapshot_cache,
+                self._agents_snapshot_cache_lock,
+                self._agents_snapshot_key(session_id),
+            ),
+            (
+                self._tasks_snapshot_cache,
+                self._tasks_snapshot_cache_lock,
+                self._tasks_snapshot_key(session_id),
+            ),
+            (
+                self._token_usage_snapshot_cache,
+                self._token_usage_snapshot_cache_lock,
+                self._token_usage_snapshot_key(session_id),
+            ),
+        )
+        for cache, cache_lock, cache_key in exact_cache_keys:
+            with cache_lock:
+                cache.pop(cache_key, None)
+        with self._rounds_snapshot_cache_lock:
+            for cache_key in tuple(self._rounds_snapshot_cache):
+                if cache_key.startswith(f"{session_id}|"):
+                    self._rounds_snapshot_cache.pop(cache_key, None)
+                    self._rounds_snapshot_args_by_key.pop(cache_key, None)
+
+        task_keys = (
+            (self._recovery_refresh_tasks, (session_id,)),
+            (
+                self._subagents_refresh_tasks,
+                (self._subagents_snapshot_key(session_id),),
+            ),
+            (self._agents_refresh_tasks, (self._agents_snapshot_key(session_id),)),
+            (self._tasks_refresh_tasks, (self._tasks_snapshot_key(session_id),)),
+            (
+                self._token_usage_refresh_tasks,
+                (self._token_usage_snapshot_key(session_id),),
+            ),
+            (
+                self._rounds_refresh_tasks,
+                tuple(
+                    key
+                    for key in self._rounds_refresh_tasks
+                    if key.startswith(f"{session_id}|")
+                ),
+            ),
+        )
+        for tasks, keys in task_keys:
+            for key in keys:
+                task = tasks.pop(key, None)
+                if task is not None:
+                    self._cancel_snapshot_refresh_task(task)
+
+    @staticmethod
+    def _cancel_snapshot_refresh_task(task: asyncio.Task[None]) -> None:
+        if task.done():
+            return
+        loop = task.get_loop()
+        if loop.is_closed():
+            task.cancel()
+            return
+        loop.call_soon_threadsafe(task.cancel)
+
+    def _schedule_dirty_session_snapshot_refresh(self, session_id: str) -> None:
+        with self._recovery_snapshot_cache_lock:
+            has_recovery_snapshot = session_id in self._recovery_snapshot_cache
+        if has_recovery_snapshot:
+            self._ensure_recovery_refresh_task(session_id)
+        subagents_key = self._subagents_snapshot_key(session_id)
+        with self._subagents_snapshot_cache_lock:
+            has_subagents_snapshot = subagents_key in self._subagents_snapshot_cache
+        if has_subagents_snapshot:
+            self._ensure_subagents_refresh_task(session_id)
+        agents_key = self._agents_snapshot_key(session_id)
+        with self._agents_snapshot_cache_lock:
+            has_agents_snapshot = agents_key in self._agents_snapshot_cache
+        if has_agents_snapshot:
+            self._ensure_agents_refresh_task(session_id)
+        tasks_key = self._tasks_snapshot_key(session_id)
+        with self._tasks_snapshot_cache_lock:
+            has_tasks_snapshot = tasks_key in self._tasks_snapshot_cache
+        if has_tasks_snapshot:
+            self._ensure_tasks_refresh_task(session_id)
+        token_usage_key = self._token_usage_snapshot_key(session_id)
+        with self._token_usage_snapshot_cache_lock:
+            has_token_usage_snapshot = (
+                token_usage_key in self._token_usage_snapshot_cache
+            )
+        if has_token_usage_snapshot:
+            self._ensure_token_usage_refresh_task(session_id)
+        with self._rounds_snapshot_cache_lock:
+            rounds_cache_keys = tuple(self._rounds_snapshot_cache.keys())
+        for key in rounds_cache_keys:
+            if key.startswith(f"{session_id}|"):
+                self._ensure_rounds_refresh_task(key)
+
+    def list_normal_mode_subagents(
+        self, session_id: str
+    ) -> tuple[dict[str, object], ...]:
+        session = self._session_repo.get(session_id)
+        if session.session_mode != SessionMode.NORMAL:
+            return ()
+        root_tasks_by_run: dict[str, object] = {}
+        for task in self._task_repo.list_by_session(session_id):
+            if task.envelope.parent_task_id is None:
+                root_tasks_by_run[task.envelope.trace_id] = task
+        records = [
+            record
+            for record in self._agent_repo.list_by_session(session_id)
+            if self._is_normal_mode_subagent_record(record, session=session)
+        ]
+        records.sort(key=lambda item: (item.updated_at, item.created_at), reverse=True)
+        run_ids = tuple(dict.fromkeys(record.run_id for record in records))
+        runtime_by_run = {
+            runtime.run_id: runtime
+            for runtime in self._run_runtime_repo.list_by_session(session_id)
+            if runtime.run_id in run_ids
+        }
+        run_state_by_run = (
+            {
+                run_state.run_id: run_state
+                for run_state in self._run_state_repo.list_by_session(session_id)
+                if run_state.run_id in run_ids
+            }
+            if self._run_state_repo is not None
+            else {}
+        )
+        approval_counts = (
+            self._approval_ticket_repo.count_open_by_run_ids(run_ids)
+            if self._approval_ticket_repo is not None
+            else {}
+        )
+        question_counts = (
+            self._user_question_repo.count_open_by_run_ids(run_ids)
+            if self._user_question_repo is not None
+            else {}
+        )
+        return tuple(
+            {
+                **self._normal_mode_subagent_projection(
+                    record,
+                    runtime_by_run=runtime_by_run,
+                    run_state_by_run=run_state_by_run,
+                    approval_counts=approval_counts,
+                    question_counts=question_counts,
+                ),
+                "title": self._subagent_title_for_run(
+                    run_id=record.run_id,
+                    root_tasks_by_run=root_tasks_by_run,
+                ),
+            }
+            for record in records
+        )
+
+    async def list_normal_mode_subagents_async(
+        self, session_id: str
+    ) -> tuple[dict[str, object], ...]:
+        return await asyncio.to_thread(self.list_normal_mode_subagents, session_id)
+
+    async def get_cached_normal_mode_subagents_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        key = self._subagents_snapshot_key(session_id)
+        cached = self._snapshot_cache_entry(
+            cache=self._subagents_snapshot_cache,
+            cache_lock=self._subagents_snapshot_cache_lock,
+            key=key,
+        )
+        now = monotonic()
+        if cached is not None:
+            stale = self._snapshot_entry_is_stale(cached, now=now)
+            if stale:
+                self._ensure_subagents_refresh_task(session_id)
+            return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+        session = await asyncio.to_thread(self._session_repo.get, session_id)
+        if session.session_mode == SessionMode.NORMAL:
+            try:
+                fresh_snapshot = await asyncio.wait_for(
+                    self._build_subagents_snapshot_async(session_id),
+                    timeout=LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS,
+                )
+                fresh_entry = _RecoverySnapshotCacheEntry(
+                    snapshot=fresh_snapshot,
+                    updated_monotonic=monotonic(),
+                )
+                with self._subagents_snapshot_cache_lock:
+                    self._subagents_snapshot_cache[key] = fresh_entry
+                return self._snapshot_response(
+                    fresh_entry,
+                    stale=False,
+                    now=monotonic(),
+                    cache_hit=False,
+                )
+            except asyncio.TimeoutError:
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="session.subagents_cache.cold_miss_timeout",
+                    message=(
+                        "Session subagents cold cache build exceeded fast-read budget"
+                    ),
+                    payload={
+                        "session_id": session_id,
+                        "timeout_ms": int(
+                            LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS * 1000
+                        ),
+                    },
+                )
+        snapshot = {
+            "items": [],
+            "snapshot_refresh_ms": 0,
+            "snapshot_cache_hit": False,
+        }
+        entry = _RecoverySnapshotCacheEntry(
+            snapshot=snapshot,
+            updated_monotonic=monotonic(),
+        )
+        entry.dirty = session.session_mode == SessionMode.NORMAL
+        with self._subagents_snapshot_cache_lock:
+            self._subagents_snapshot_cache[key] = entry
+        if entry.dirty:
+            self._ensure_subagents_refresh_task(session_id)
+        return self._snapshot_response(
+            entry,
+            stale=entry.dirty,
+            now=monotonic(),
+            cache_hit=False,
+        )
+
+    def get_fast_cached_normal_mode_subagents_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        key = self._subagents_snapshot_key(session_id)
+        cached = self._snapshot_cache_entry(
+            cache=self._subagents_snapshot_cache,
+            cache_lock=self._subagents_snapshot_cache_lock,
+            key=key,
+        )
+        if cached is None:
+            return None
+        now = monotonic()
+        stale = self._snapshot_entry_is_stale(cached, now=now)
+        if stale and cached.dirty:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                self._ensure_subagents_refresh_task(session_id)
+        return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+
+    async def list_cached_normal_mode_subagents_async(
+        self,
+        session_id: str,
+    ) -> tuple[dict[str, object], ...]:
+        snapshot = await self.get_cached_normal_mode_subagents_snapshot_async(
+            session_id
+        )
+        items = snapshot.get("items")
+        if not isinstance(items, list):
+            return ()
+        return tuple(item for item in items if isinstance(item, dict))
+
+    async def _build_subagents_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        started = monotonic()
+        items = await asyncio.to_thread(self.list_normal_mode_subagents, session_id)
+        return {
+            "items": [dict(item) for item in items],
+            "snapshot_refresh_ms": int((monotonic() - started) * 1000),
+            "snapshot_cache_hit": False,
+        }
+
+    def _ensure_subagents_refresh_task(self, session_id: str) -> None:
+        key = self._subagents_snapshot_key(session_id)
+        if not self._should_start_snapshot_refresh(
+            tasks=self._subagents_refresh_tasks,
+            cache=self._subagents_snapshot_cache,
+            cache_lock=self._subagents_snapshot_cache_lock,
+            key=key,
+        ):
+            return
+        task = asyncio.create_task(self._refresh_subagents_snapshot_cache(session_id))
+        self._subagents_refresh_tasks[key] = task
+        task.add_done_callback(
+            lambda completed: self._observe_snapshot_refresh_result(
+                kind=_SNAPSHOT_KIND_SUBAGENTS,
+                key=key,
+                task=completed,
+            )
+        )
+
+    async def _refresh_subagents_snapshot_cache(self, session_id: str) -> None:
+        snapshot = await self._build_subagents_snapshot_async(session_id)
+        with self._subagents_snapshot_cache_lock:
+            entry = _RecoverySnapshotCacheEntry(
+                snapshot=snapshot,
+                updated_monotonic=monotonic(),
+            )
+            self._subagents_snapshot_cache[self._subagents_snapshot_key(session_id)] = (
+                entry
+            )
+
+    async def stream_normal_mode_subagent_events(
+        self,
+        session_id: str,
+        *,
+        after_event_id: int = 0,
+    ) -> AsyncIterator[RunEvent]:
+        session = self._session_repo.get(session_id)
+        if session.session_mode != SessionMode.NORMAL:
+            return
+
+        queue = (
+            self._run_event_hub.subscribe_session(session_id)
+            if self._run_event_hub is not None
+            else None
+        )
+        replay_high_watermark = max(0, int(after_event_id))
+        subagent_run_ids = self._subagent_run_ids(session_id)
+        try:
+            if self._event_log is not None:
+                known_rows = (
+                    await self._event_log.list_by_session_run_ids_after_id_async(
+                        session_id,
+                        tuple(sorted(subagent_run_ids)),
+                        replay_high_watermark,
+                    )
+                    if subagent_run_ids
+                    else ()
+                )
+                legacy_rows = await self._event_log.list_subagent_run_events_by_session_after_id_async(
+                    session_id,
+                    replay_high_watermark,
+                )
+                rows_by_id = {
+                    int(row["id"]): row
+                    for row in (*known_rows, *legacy_rows)
+                    if isinstance(row.get("id"), int)
+                }
+                rows = tuple(rows_by_id[key] for key in sorted(rows_by_id))
+                for row in rows:
+                    event = self._run_event_from_log_row(row)
+                    if event is None:
+                        continue
+                    if event.event_id is not None:
+                        replay_high_watermark = max(
+                            replay_high_watermark,
+                            event.event_id,
+                        )
+                    yield event
+
+            if queue is None:
+                return
+
+            while True:
+                event = await queue.get()
+                if event.session_id != session_id:
+                    continue
+                if event.run_id not in subagent_run_ids and (
+                    event.event_type in _SNAPSHOT_REFRESH_EVENT_TYPES
+                    or self._is_legacy_subagent_run_id(event.run_id)
+                ):
+                    subagent_run_ids = self._subagent_run_ids(session_id)
+                if (
+                    event.run_id not in subagent_run_ids
+                    and not self._is_legacy_subagent_run_id(event.run_id)
+                ):
+                    continue
+                event_id = event.event_id
+                if event_id is not None and event_id <= replay_high_watermark:
+                    continue
+                if event_id is not None:
+                    replay_high_watermark = max(
+                        replay_high_watermark,
+                        event_id,
+                    )
+                yield event
+        finally:
+            if queue is not None and self._run_event_hub is not None:
+                self._run_event_hub.unsubscribe_session(session_id, queue)
+
+    def list_agents_in_session(self, session_id: str) -> tuple[dict[str, object], ...]:
+        session = self._session_repo.get(session_id)
+        latest_by_role: dict[str, AgentRuntimeRecord] = {}
+        for record in self._agent_repo.list_by_session(session_id):
+            if self._is_normal_mode_subagent_record(record, session=session):
+                continue
+            existing = latest_by_role.get(record.role_id)
+            if existing is None or (
+                record.updated_at,
+                record.created_at,
+            ) >= (
+                existing.updated_at,
+                existing.created_at,
+            ):
+                latest_by_role[record.role_id] = record
+        return tuple(
+            self._agent_projection(latest_by_role[role_id])
+            for role_id in sorted(latest_by_role.keys())
+        )
+
+    async def list_agents_in_session_async(
+        self, session_id: str
+    ) -> tuple[dict[str, object], ...]:
+        return await asyncio.to_thread(self.list_agents_in_session, session_id)
+
+    async def get_cached_agents_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        key = self._agents_snapshot_key(session_id)
+        cached = self._snapshot_cache_entry(
+            cache=self._agents_snapshot_cache,
+            cache_lock=self._agents_snapshot_cache_lock,
+            key=key,
+        )
+        now = monotonic()
+        if cached is not None:
+            stale = self._snapshot_entry_is_stale(cached, now=now)
+            if stale:
+                self._ensure_agents_refresh_task(session_id)
+            return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+        _ = await asyncio.to_thread(self._session_repo.get, session_id)
+        try:
+            fresh_snapshot = await asyncio.wait_for(
+                self._build_agents_snapshot_async(session_id),
+                timeout=LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS,
+            )
+            fresh_entry = _RecoverySnapshotCacheEntry(
+                snapshot=fresh_snapshot,
+                updated_monotonic=monotonic(),
+            )
+            with self._agents_snapshot_cache_lock:
+                self._agents_snapshot_cache[key] = fresh_entry
+            return self._snapshot_response(
+                fresh_entry,
+                stale=False,
+                now=monotonic(),
+                cache_hit=False,
+            )
+        except asyncio.TimeoutError:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.agents_cache.cold_miss_timeout",
+                message="Session agents cold cache build exceeded fast-read budget",
+                payload={
+                    "session_id": session_id,
+                    "timeout_ms": int(LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS * 1000),
+                },
+            )
+        entry = _RecoverySnapshotCacheEntry(
+            snapshot={
+                "items": [],
+                "snapshot_refresh_ms": 0,
+                "snapshot_cache_hit": False,
+            },
+            updated_monotonic=monotonic(),
+        )
+        entry.dirty = True
+        with self._agents_snapshot_cache_lock:
+            self._agents_snapshot_cache[key] = entry
+        self._ensure_agents_refresh_task(session_id)
+        return self._snapshot_response(
+            entry, stale=True, now=monotonic(), cache_hit=False
+        )
+
+    def get_fast_cached_agents_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        key = self._agents_snapshot_key(session_id)
+        cached = self._snapshot_cache_entry(
+            cache=self._agents_snapshot_cache,
+            cache_lock=self._agents_snapshot_cache_lock,
+            key=key,
+        )
+        if cached is None:
+            return None
+        now = monotonic()
+        stale = self._snapshot_entry_is_stale(cached, now=now)
+        if stale and cached.dirty:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                self._ensure_agents_refresh_task(session_id)
+        return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+
+    async def list_cached_agents_in_session_async(
+        self, session_id: str
+    ) -> tuple[dict[str, object], ...]:
+        snapshot = await self.get_cached_agents_snapshot_async(session_id)
+        items = snapshot.get("items")
+        if not isinstance(items, list):
+            return ()
+        return tuple(item for item in items if isinstance(item, dict))
+
+    async def _build_agents_snapshot_async(self, session_id: str) -> dict[str, object]:
+        started = monotonic()
+        items = await asyncio.to_thread(self.list_agents_in_session, session_id)
+        return {
+            "items": [dict(item) for item in items],
+            "snapshot_refresh_ms": int((monotonic() - started) * 1000),
+            "snapshot_cache_hit": False,
+        }
+
+    def _ensure_agents_refresh_task(self, session_id: str) -> None:
+        key = self._agents_snapshot_key(session_id)
+        if not self._should_start_snapshot_refresh(
+            tasks=self._agents_refresh_tasks,
+            cache=self._agents_snapshot_cache,
+            cache_lock=self._agents_snapshot_cache_lock,
+            key=key,
+        ):
+            return
+        task = asyncio.create_task(self._refresh_agents_snapshot_cache(session_id))
+        self._agents_refresh_tasks[key] = task
+        task.add_done_callback(
+            lambda completed: self._observe_snapshot_refresh_result(
+                kind=_SNAPSHOT_KIND_AGENTS,
+                key=key,
+                task=completed,
+            )
+        )
+
+    async def _refresh_agents_snapshot_cache(self, session_id: str) -> None:
+        snapshot = await self._build_agents_snapshot_async(session_id)
+        with self._agents_snapshot_cache_lock:
+            self._agents_snapshot_cache[self._agents_snapshot_key(session_id)] = (
+                _RecoverySnapshotCacheEntry(
+                    snapshot=snapshot,
+                    updated_monotonic=monotonic(),
+                )
+            )
+
+    def get_session_tasks(self, session_id: str) -> list[dict[str, object]]:
+        records = self._task_repo.list_by_session(session_id)
+        return [
+            {
+                "task_id": record.envelope.task_id,
+                "title": record.envelope.title or record.envelope.objective[:80],
+                "assigned_role_id": record.envelope.role_id,
+                "status": record.status.value,
+                "assigned_instance_id": record.assigned_instance_id,
+                "role_id": record.envelope.role_id,
+                "instance_id": record.assigned_instance_id,
+                "run_id": record.envelope.trace_id,
+                "created_at": record.created_at.isoformat(),
+                "updated_at": record.updated_at.isoformat(),
+                "spec_artifact_id": record.envelope.spec_artifact_id,
+                "spec_source_task_id": record.envelope.spec_source_task_id,
+                "spec_summary": (
+                    record.envelope.spec.summary if record.envelope.spec else ""
+                ),
+                "spec_strictness": (
+                    record.envelope.spec.strictness.value
+                    if record.envelope.spec
+                    else ""
+                ),
+                "evidence_bundle": (
+                    record.envelope.evidence_bundle.model_dump(mode="json")
+                    if record.envelope.evidence_bundle
+                    else None
+                ),
+            }
+            for record in records
+            if record.envelope.parent_task_id is not None
+        ]
+
+    async def get_session_tasks_async(self, session_id: str) -> list[dict[str, object]]:
+        return await asyncio.to_thread(self.get_session_tasks, session_id)
+
+    async def get_cached_session_tasks_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        key = self._tasks_snapshot_key(session_id)
+        cached = self._snapshot_cache_entry(
+            cache=self._tasks_snapshot_cache,
+            cache_lock=self._tasks_snapshot_cache_lock,
+            key=key,
+        )
+        now = monotonic()
+        if cached is not None:
+            stale = self._snapshot_entry_is_stale(cached, now=now)
+            if stale:
+                self._ensure_tasks_refresh_task(session_id)
+            return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+        _ = await asyncio.to_thread(self._session_repo.get, session_id)
+        try:
+            fresh_snapshot = await asyncio.wait_for(
+                self._build_tasks_snapshot_async(session_id),
+                timeout=LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS,
+            )
+            fresh_entry = _RecoverySnapshotCacheEntry(
+                snapshot=fresh_snapshot,
+                updated_monotonic=monotonic(),
+            )
+            with self._tasks_snapshot_cache_lock:
+                self._tasks_snapshot_cache[key] = fresh_entry
+            return self._snapshot_response(
+                fresh_entry,
+                stale=False,
+                now=monotonic(),
+                cache_hit=False,
+            )
+        except asyncio.TimeoutError:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.tasks_cache.cold_miss_timeout",
+                message="Session tasks cold cache build exceeded fast-read budget",
+                payload={
+                    "session_id": session_id,
+                    "timeout_ms": int(LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS * 1000),
+                },
+            )
+        entry = _RecoverySnapshotCacheEntry(
+            snapshot={
+                "items": [],
+                "snapshot_refresh_ms": 0,
+                "snapshot_cache_hit": False,
+            },
+            updated_monotonic=monotonic(),
+        )
+        entry.dirty = True
+        with self._tasks_snapshot_cache_lock:
+            self._tasks_snapshot_cache[key] = entry
+        self._ensure_tasks_refresh_task(session_id)
+        return self._snapshot_response(
+            entry, stale=True, now=monotonic(), cache_hit=False
+        )
+
+    def get_fast_cached_session_tasks_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        key = self._tasks_snapshot_key(session_id)
+        cached = self._snapshot_cache_entry(
+            cache=self._tasks_snapshot_cache,
+            cache_lock=self._tasks_snapshot_cache_lock,
+            key=key,
+        )
+        if cached is None:
+            return None
+        now = monotonic()
+        stale = self._snapshot_entry_is_stale(cached, now=now)
+        if stale and cached.dirty:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                self._ensure_tasks_refresh_task(session_id)
+        return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+
+    async def list_cached_session_tasks_async(
+        self, session_id: str
+    ) -> tuple[dict[str, object], ...]:
+        snapshot = await self.get_cached_session_tasks_snapshot_async(session_id)
+        items = snapshot.get("items")
+        if not isinstance(items, list):
+            return ()
+        return tuple(item for item in items if isinstance(item, dict))
+
+    async def _build_tasks_snapshot_async(self, session_id: str) -> dict[str, object]:
+        started = monotonic()
+        items = await asyncio.to_thread(self.get_session_tasks, session_id)
+        return {
+            "items": [dict(item) for item in items],
+            "snapshot_refresh_ms": int((monotonic() - started) * 1000),
+            "snapshot_cache_hit": False,
+        }
+
+    def _ensure_tasks_refresh_task(self, session_id: str) -> None:
+        key = self._tasks_snapshot_key(session_id)
+        if not self._should_start_snapshot_refresh(
+            tasks=self._tasks_refresh_tasks,
+            cache=self._tasks_snapshot_cache,
+            cache_lock=self._tasks_snapshot_cache_lock,
+            key=key,
+        ):
+            return
+        task = asyncio.create_task(self._refresh_tasks_snapshot_cache(session_id))
+        self._tasks_refresh_tasks[key] = task
+        task.add_done_callback(
+            lambda completed: self._observe_snapshot_refresh_result(
+                kind=_SNAPSHOT_KIND_TASKS,
+                key=key,
+                task=completed,
+            )
+        )
+
+    async def _refresh_tasks_snapshot_cache(self, session_id: str) -> None:
+        snapshot = await self._build_tasks_snapshot_async(session_id)
+        with self._tasks_snapshot_cache_lock:
+            self._tasks_snapshot_cache[self._tasks_snapshot_key(session_id)] = (
+                _RecoverySnapshotCacheEntry(
+                    snapshot=snapshot,
+                    updated_monotonic=monotonic(),
+                )
+            )
+
+    def build_session_rounds(
+        self,
+        session_id: str,
+        *,
+        included_run_ids: set[str] | None = None,
+        include_history_markers: bool = True,
+    ) -> list[dict[str, object]]:
+        excluded_run_ids = self._subagent_run_ids(session_id)
+        selected_run_ids = (
+            tuple(sorted(included_run_ids)) if included_run_ids is not None else None
+        )
+        todos_by_run_id = (
+            {
+                snapshot.run_id: snapshot.model_dump(mode="json")
+                for snapshot in self._todo_service.list_for_session(session_id)
+                if included_run_ids is None or snapshot.run_id in included_run_ids
+            }
+            if self._todo_service is not None
+            else {}
+        )
+        intent_input_parts_by_run = (
+            self._session_run_intent_input_parts_by_run(session_id)
+            if included_run_ids is None
+            else {
+                run_id: parts
+                for run_id, parts in self._session_run_intent_input_parts_by_run(
+                    session_id
+                ).items()
+                if run_id in included_run_ids
+            }
+        )
+        runtime_by_run = {
+            run_id: runtime
+            for run_id, runtime in self._session_run_runtime_by_run(session_id).items()
+            if included_run_ids is None or run_id in included_run_ids
+        }
+        rounds = build_session_rounds(
+            session_id=session_id,
+            agent_repo=self._agent_repo,
+            task_repo=self._task_repo,
+            approval_tickets_by_run=approvals_to_projection(
+                [
+                    record
+                    for record in self._approval_ticket_repo.list_open_by_session(
+                        session_id
+                    )
+                    if included_run_ids is None or record.run_id in included_run_ids
+                ]
+            ),
+            run_runtime_repo=self._run_runtime_repo,
+            get_session_messages=lambda current_session_id: cast(
+                list[dict[str, object]],
+                (
+                    self._message_repo.get_messages_by_session(
+                        current_session_id,
+                        include_cleared=True,
+                        include_hidden_from_context=True,
+                    )
+                    if selected_run_ids is None
+                    else self._message_repo.get_messages_by_session_run_ids(
+                        current_session_id,
+                        selected_run_ids,
+                        include_cleared=True,
+                        include_hidden_from_context=True,
+                    )
+                ),
+            ),
+            get_run_intent_input=intent_input_parts_by_run.get,
+            get_session_history_markers=(
+                self._get_session_history_markers if include_history_markers else None
+            ),
+            get_session_events=(
+                self._get_round_projection_events
+                if selected_run_ids is None
+                else lambda current_session_id: (
+                    self._get_round_projection_events_for_runs(
+                        current_session_id,
+                        selected_run_ids,
+                    )
+                )
+            ),
+            excluded_run_ids=excluded_run_ids,
+            included_run_ids=included_run_ids,
+            run_runtime_by_run=runtime_by_run,
+        )
+        question_counts_by_run = self._pending_user_question_counts_by_run(session_id)
+        for round_item in rounds:
+            runtime = runtime_by_run.get(str(round_item.get("run_id") or ""))
+            pending = round_item.get("pending_tool_approvals")
+            approval_count = len(pending) if isinstance(pending, list) else 0
+            if runtime is None:
+                continue
+            question_count = question_counts_by_run.get(runtime.run_id, 0)
+            round_item["run_status"] = runtime.status.value
+            round_item["run_phase"] = self._public_phase(
+                runtime,
+                approval_count,
+                question_count,
+            )
+            round_item["is_recoverable"] = self._is_runtime_publicly_recoverable(
+                runtime
+            )
+            todo = todos_by_run_id.get(str(round_item.get("run_id") or ""))
+            if todo is not None:
+                round_item["todo"] = todo
+        return rounds
+
+    def build_session_timeline_rounds(self, session_id: str) -> list[dict[str, object]]:
+        excluded_run_ids = self._subagent_run_ids(session_id)
+        todos_by_run_id = (
+            {
+                snapshot.run_id: snapshot.model_dump(mode="json")
+                for snapshot in self._todo_service.list_for_session(session_id)
+            }
+            if self._todo_service is not None
+            else {}
+        )
+        intent_input_parts_by_run = self._session_run_intent_input_parts_by_run(
+            session_id
+        )
+        runtime_by_run = self._session_run_runtime_by_run(session_id)
+        rounds = build_session_timeline_rounds(
+            session_id=session_id,
+            task_repo=self._task_repo,
+            approval_tickets_by_run=approvals_to_projection(
+                self._approval_ticket_repo.list_open_by_session(session_id)
+            ),
+            run_runtime_repo=self._run_runtime_repo,
+            get_session_user_messages=lambda current_session_id: cast(
+                list[dict[str, object]],
+                self._message_repo.get_user_messages_by_session(
+                    current_session_id,
+                    include_cleared=True,
+                    include_hidden_from_context=True,
+                ),
+            ),
+            get_run_intent_input=intent_input_parts_by_run.get,
+            get_session_history_markers=self._get_session_history_markers,
+            get_session_events=self._get_round_projection_events,
+            excluded_run_ids=excluded_run_ids,
+            run_runtime_by_run=runtime_by_run,
+        )
+        question_counts_by_run = self._pending_user_question_counts_by_run(session_id)
+        for round_item in rounds:
+            runtime = runtime_by_run.get(str(round_item.get("run_id") or ""))
+            raw_approval_count = round_item.get("pending_tool_approval_count")
+            approval_count = (
+                raw_approval_count
+                if isinstance(raw_approval_count, int)
+                and not isinstance(raw_approval_count, bool)
+                else 0
+            )
+            if runtime is None:
+                continue
+            question_count = question_counts_by_run.get(runtime.run_id, 0)
+            round_item["run_status"] = runtime.status.value
+            round_item["run_phase"] = self._public_phase(
+                runtime,
+                approval_count,
+                question_count,
+            )
+            round_item["is_recoverable"] = self._is_runtime_publicly_recoverable(
+                runtime
+            )
+            todo = todos_by_run_id.get(str(round_item.get("run_id") or ""))
+            if todo is not None:
+                round_item["todo"] = todo
+        return rounds
+
+    def _session_run_runtime_by_run(
+        self,
+        session_id: str,
+    ) -> dict[str, RunRuntimeRecord]:
+        return {
+            runtime.run_id: runtime
+            for runtime in self._run_runtime_repo.list_by_session(session_id)
+        }
+
+    def _get_run_intent_input_parts(
+        self, run_id: str
+    ) -> tuple[ContentPart, ...] | None:
+        if self._run_intent_repo is None:
+            return None
+        try:
+            intent = self._run_intent_repo.get(run_id)
+        except KeyError:
+            return None
+        return intent.display_input or intent.input
+
+    def _session_run_intent_input_parts_by_run(
+        self, session_id: str
+    ) -> dict[str, tuple[ContentPart, ...]]:
+        if self._run_intent_repo is None:
+            return {}
+        return {
+            run_id: intent.display_input or intent.input
+            for run_id, intent in self._run_intent_repo.list_by_session(
+                session_id
+            ).items()
+        }
+
+    def get_session_rounds(
+        self,
+        session_id: str,
+        *,
+        limit: int = 8,
+        cursor_run_id: str | None = None,
+        timeline: bool = False,
+        summary: bool = False,
+    ) -> dict[str, object]:
+        if timeline:
+            rounds = self.build_session_timeline_rounds(session_id)
+            return timeline_rounds(rounds)
+        timeline_items = self.build_session_timeline_rounds(session_id)
+        page = paginate_rounds(
+            timeline_items,
+            limit=limit,
+            cursor_run_id=cursor_run_id,
+        )
+        if summary:
+            return page
+        page_items = page.get("items")
+        if not isinstance(page_items, list) or not page_items:
+            return page
+        page_run_ids = tuple(
+            str(item.get("run_id") or "")
+            for item in page_items
+            if isinstance(item, dict) and str(item.get("run_id") or "")
+        )
+        if not page_run_ids:
+            return page
+        full_rounds = self.build_session_rounds(
+            session_id,
+            included_run_ids=set(page_run_ids),
+            include_history_markers=False,
+        )
+        full_round_by_run = {
+            str(round_item.get("run_id") or ""): round_item
+            for round_item in full_rounds
+        }
+        page_marker_by_run = {
+            str(item.get("run_id") or ""): {
+                "clear_marker_before": item.get("clear_marker_before"),
+                "compaction_marker_before": item.get("compaction_marker_before"),
+            }
+            for item in page_items
+            if isinstance(item, dict) and str(item.get("run_id") or "")
+        }
+        resolved_items: list[dict[str, object]] = []
+        for run_id in page_run_ids:
+            full_round = full_round_by_run.get(run_id)
+            if full_round is None:
+                continue
+            markers = page_marker_by_run.get(run_id, {})
+            full_round["clear_marker_before"] = markers.get("clear_marker_before")
+            full_round["compaction_marker_before"] = markers.get(
+                "compaction_marker_before"
+            )
+            resolved_items.append(full_round)
+        page["items"] = resolved_items
+        return page
+
+    async def get_session_rounds_async(
+        self,
+        session_id: str,
+        *,
+        limit: int = 8,
+        cursor_run_id: str | None = None,
+        timeline: bool = False,
+        summary: bool = False,
+    ) -> dict[str, object]:
+
+        return await asyncio.to_thread(
+            self.get_session_rounds,
+            session_id,
+            limit=limit,
+            cursor_run_id=cursor_run_id,
+            timeline=timeline,
+            summary=summary,
+        )
+
+    def get_cached_session_rounds(
+        self,
+        session_id: str,
+        *,
+        limit: int = 8,
+        cursor_run_id: str | None = None,
+        timeline: bool = False,
+        summary: bool = False,
+    ) -> dict[str, object]:
+        return self.get_session_rounds(
+            session_id,
+            limit=limit,
+            cursor_run_id=cursor_run_id,
+            timeline=timeline,
+            summary=summary,
+        )
+
+    async def get_cached_session_rounds_async(
+        self,
+        session_id: str,
+        *,
+        limit: int = 8,
+        cursor_run_id: str | None = None,
+        timeline: bool = False,
+        summary: bool = False,
+    ) -> dict[str, object]:
+        cache_key = (
+            f"{session_id}|{limit}|{cursor_run_id or ''}|{int(timeline)}|{int(summary)}"
+        )
+        self._rounds_snapshot_args_by_key[cache_key] = (
+            session_id,
+            limit,
+            cursor_run_id,
+            timeline,
+            summary,
+        )
+        now = monotonic()
+        with self._rounds_snapshot_cache_lock:
+            cached = self._rounds_snapshot_cache.get(cache_key)
+        if cached is not None:
+            stale = self._snapshot_entry_is_stale(cached, now=now)
+            if stale:
+                self._ensure_rounds_refresh_task(cache_key)
+            return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+        _ = await asyncio.to_thread(self._session_repo.get, session_id)
+        try:
+            fresh_snapshot = await asyncio.wait_for(
+                self._build_rounds_snapshot_async(
+                    session_id,
+                    limit=limit,
+                    cursor_run_id=cursor_run_id,
+                    timeline=timeline,
+                    summary=summary,
+                ),
+                timeout=LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS,
+            )
+            fresh_entry = _RecoverySnapshotCacheEntry(
+                snapshot=fresh_snapshot,
+                updated_monotonic=monotonic(),
+            )
+            with self._rounds_snapshot_cache_lock:
+                self._rounds_snapshot_cache[cache_key] = fresh_entry
+            return self._snapshot_response(
+                fresh_entry,
+                stale=False,
+                now=monotonic(),
+                cache_hit=False,
+            )
+        except asyncio.TimeoutError:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.rounds_cache.cold_miss_timeout",
+                message="Session rounds cold cache build exceeded fast-read budget",
+                payload={
+                    "session_id": session_id,
+                    "timeout_ms": int(LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS * 1000),
+                },
+            )
+        snapshot = {
+            "items": [],
+            "has_more": False,
+            "next_cursor": None,
+            "snapshot_refresh_ms": 0,
+            "snapshot_cache_hit": False,
+        }
+        entry = _RecoverySnapshotCacheEntry(
+            snapshot=snapshot,
+            updated_monotonic=monotonic(),
+        )
+        entry.dirty = True
+        with self._rounds_snapshot_cache_lock:
+            self._rounds_snapshot_cache[cache_key] = entry
+        self._ensure_rounds_refresh_task(cache_key)
+        return self._snapshot_response(
+            entry, stale=True, now=monotonic(), cache_hit=False
+        )
+
+    def get_fast_cached_session_rounds_snapshot(
+        self,
+        session_id: str,
+        *,
+        limit: int = 8,
+        cursor_run_id: str | None = None,
+        timeline: bool = False,
+        summary: bool = False,
+    ) -> dict[str, object] | None:
+        cache_key = (
+            f"{session_id}|{limit}|{cursor_run_id or ''}|{int(timeline)}|{int(summary)}"
+        )
+        self._rounds_snapshot_args_by_key[cache_key] = (
+            session_id,
+            limit,
+            cursor_run_id,
+            timeline,
+            summary,
+        )
+        with self._rounds_snapshot_cache_lock:
+            cached = self._rounds_snapshot_cache.get(cache_key)
+        if cached is None:
+            return None
+        now = monotonic()
+        stale = self._snapshot_entry_is_stale(cached, now=now)
+        if stale:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                self._ensure_rounds_refresh_task(cache_key)
+        return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+
+    async def _build_rounds_snapshot_async(
+        self,
+        session_id: str,
+        *,
+        limit: int,
+        cursor_run_id: str | None,
+        timeline: bool,
+        summary: bool,
+    ) -> dict[str, object]:
+        started = monotonic()
+        snapshot = await asyncio.to_thread(
+            self.get_session_rounds,
+            session_id,
+            limit=limit,
+            cursor_run_id=cursor_run_id,
+            timeline=timeline,
+            summary=summary,
+        )
+        snapshot = dict(snapshot)
+        snapshot["snapshot_refresh_ms"] = int((monotonic() - started) * 1000)
+        snapshot["snapshot_cache_hit"] = False
+        return snapshot
+
+    def _ensure_rounds_refresh_task(self, cache_key: str) -> None:
+        if not self._should_start_snapshot_refresh(
+            tasks=self._rounds_refresh_tasks,
+            cache=self._rounds_snapshot_cache,
+            cache_lock=self._rounds_snapshot_cache_lock,
+            key=cache_key,
+        ):
+            return
+        args = self._rounds_snapshot_args_by_key.get(cache_key)
+        if args is None:
+            return
+        task = asyncio.create_task(self._refresh_rounds_snapshot_cache(cache_key, args))
+        self._rounds_refresh_tasks[cache_key] = task
+        task.add_done_callback(
+            lambda completed: self._observe_snapshot_refresh_result(
+                kind=_SNAPSHOT_KIND_ROUNDS,
+                key=cache_key,
+                task=completed,
+            )
+        )
+
+    async def _refresh_rounds_snapshot_cache(
+        self,
+        cache_key: str,
+        args: tuple[str, int, str | None, bool, bool],
+    ) -> None:
+        session_id, limit, cursor_run_id, timeline, summary = args
+        snapshot = await self._build_rounds_snapshot_async(
+            session_id,
+            limit=limit,
+            cursor_run_id=cursor_run_id,
+            timeline=timeline,
+            summary=summary,
+        )
+        with self._rounds_snapshot_cache_lock:
+            self._rounds_snapshot_cache[cache_key] = _RecoverySnapshotCacheEntry(
+                snapshot=snapshot,
+                updated_monotonic=monotonic(),
+            )
+
+    def get_round(self, session_id: str, run_id: str) -> dict[str, object]:
+        safe_run_id = str(run_id or "").strip()
+        timeline_item = next(
+            (
+                item
+                for item in self.build_session_timeline_rounds(session_id)
+                if str(item.get("run_id") or "") == safe_run_id
+            ),
+            None,
+        )
+        rounds = self.build_session_rounds(
+            session_id,
+            included_run_ids={safe_run_id},
+            include_history_markers=False,
+        )
+        round_item = find_round_by_run_id(rounds, session_id=session_id, run_id=run_id)
+        if timeline_item is not None:
+            round_item["clear_marker_before"] = timeline_item.get("clear_marker_before")
+            round_item["compaction_marker_before"] = timeline_item.get(
+                "compaction_marker_before"
+            )
+        return round_item
+
+    async def get_round_async(self, session_id: str, run_id: str) -> dict[str, object]:
+
+        return await asyncio.to_thread(self.get_round, session_id, run_id)
+
+    def get_recovery_snapshot(self, session_id: str) -> dict[str, object]:
+        _ = self._session_repo.get(session_id)
+        selected = self._select_active_run(session_id)
+        if selected is None:
+            return self._empty_recovery_snapshot()
+
+        run_id, runtime = selected
+        stream_connected = (
+            self._run_event_hub.has_subscribers(run_id)
+            if self._run_event_hub is not None
+            else False
+        )
+        approvals = [
+            {
+                "tool_call_id": record.tool_call_id,
+                "tool_name": record.tool_name,
+                "args_preview": record.args_preview,
+                "role_id": record.role_id,
+                "instance_id": record.instance_id,
+                "requested_at": record.created_at.isoformat(),
+                "status": record.status.value,
+                "feedback": record.feedback,
+            }
+            for record in self._approval_ticket_repo.list_open_by_run(run_id)
+        ]
+        user_questions = (
+            [
+                record.model_dump(mode="json")
+                for record in self._list_resolvable_user_questions_for_session(
+                    session_id
+                )
+            ]
+            if self._user_question_repo is not None
+            else []
+        )
+        run_state = (
+            self._run_state_repo.get_run_state(run_id)
+            if self._run_state_repo is not None
+            else None
+        )
+        background_tasks = [
+            record.model_dump(mode="json", exclude={"output_excerpt"})
+            for record in (
+                exec_record
+                for exec_record in (
+                    self._background_task_repository.list_by_run(run_id)
+                    if self._background_task_repository is not None
+                    else ()
+                )
+                if exec_record.execution_mode == "background"
+            )
+        ]
+        active_run = {
+            "run_id": run_id,
+            "status": runtime.status.value,
+            "phase": self._public_phase(runtime, len(approvals), len(user_questions)),
+            "is_recoverable": self._is_runtime_publicly_recoverable(runtime),
+            "last_event_id": (
+                int(run_state.last_event_id) if run_state is not None else 0
+            ),
+            "checkpoint_event_id": (
+                int(run_state.checkpoint_event_id) if run_state is not None else 0
+            ),
+            "pending_tool_approval_count": len(approvals),
+            "pending_user_question_count": len(user_questions),
+            "background_task_count": len(background_tasks),
+            "stream_connected": stream_connected,
+            "should_show_recover": self._is_runtime_publicly_recoverable(runtime)
+            and not stream_connected,
+        }
+        paused_subagent = self._paused_subagent_snapshot(runtime)
+        try:
+            round_snapshot = self.get_round(session_id, run_id)
+        except KeyError:
+            round_snapshot = None
+        if isinstance(round_snapshot, dict):
+            active_run["primary_role_id"] = round_snapshot.get("primary_role_id")
+            round_snapshot["background_task_count"] = len(background_tasks)
+        return {
+            "active_run": active_run,
+            "background_tasks": background_tasks,
+            "pending_tool_approvals": approvals,
+            "pending_user_questions": user_questions,
+            "paused_subagent": paused_subagent,
+            "round_snapshot": round_snapshot,
+        }
+
+    async def get_recovery_snapshot_async(self, session_id: str) -> dict[str, object]:
+
+        return await asyncio.to_thread(self.get_recovery_snapshot, session_id)
+
+    async def get_cached_recovery_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        cached = self._recovery_cache_entry(session_id)
+        now = monotonic()
+        if cached is not None:
+            stale = self._snapshot_entry_is_stale(cached, now=now)
+            if stale:
+                self._ensure_recovery_refresh_task(session_id)
+            return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+        _ = await asyncio.to_thread(self._session_repo.get, session_id)
+        try:
+            fresh_snapshot = await asyncio.wait_for(
+                self.get_recovery_snapshot_async(session_id),
+                timeout=LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS,
+            )
+            fresh_entry = _RecoverySnapshotCacheEntry(
+                snapshot=fresh_snapshot,
+                updated_monotonic=monotonic(),
+            )
+            with self._recovery_snapshot_cache_lock:
+                self._recovery_snapshot_cache[session_id] = fresh_entry
+            return self._snapshot_response(
+                fresh_entry,
+                stale=False,
+                now=monotonic(),
+                cache_hit=False,
+            )
+        except asyncio.TimeoutError:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.recovery_cache.cold_miss_timeout",
+                message="Session recovery cold cache build exceeded fast-read budget",
+                payload={
+                    "session_id": session_id,
+                    "timeout_ms": int(LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS * 1000),
+                },
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.recovery_cache.cold_miss_failed",
+                message="Session recovery cold cache build failed",
+                payload={
+                    "session_id": session_id,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+        entry = _RecoverySnapshotCacheEntry(
+            snapshot=self._empty_recovery_snapshot(),
+            updated_monotonic=monotonic(),
+        )
+        entry.dirty = True
+        with self._recovery_snapshot_cache_lock:
+            self._recovery_snapshot_cache[session_id] = entry
+        self._ensure_recovery_refresh_task(session_id)
+        return self._snapshot_response(
+            entry, stale=True, now=monotonic(), cache_hit=False
+        )
+
+    def get_fast_cached_recovery_snapshot(
+        self,
+        session_id: str,
+    ) -> dict[str, object] | None:
+        cached = self._recovery_cache_entry(session_id)
+        if cached is None:
+            return None
+        now = monotonic()
+        stale = self._snapshot_entry_is_stale(cached, now=now)
+        if stale:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                self._ensure_recovery_refresh_task(session_id)
+        return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+
+    @staticmethod
+    def _empty_recovery_snapshot() -> dict[str, object]:
+        return {
+            "active_run": None,
+            "background_tasks": [],
+            "pending_tool_approvals": [],
+            "pending_user_questions": [],
+            "paused_subagent": None,
+            "round_snapshot": None,
+        }
+
+    def _seed_empty_recovery_snapshot_cache(self, session_id: str) -> None:
+        with self._recovery_snapshot_cache_lock:
+            if session_id in self._recovery_snapshot_cache:
+                return
+            self._recovery_snapshot_cache[session_id] = _RecoverySnapshotCacheEntry(
+                snapshot=self._empty_recovery_snapshot(),
+                updated_monotonic=monotonic(),
+            )
+
+    def _seed_empty_session_snapshot_caches(self, session_id: str) -> None:
+        now = monotonic()
+        self._seed_empty_recovery_snapshot_cache(session_id)
+        self._seed_empty_items_snapshot_cache(
+            cache=self._subagents_snapshot_cache,
+            cache_lock=self._subagents_snapshot_cache_lock,
+            key=self._subagents_snapshot_key(session_id),
+            now=now,
+        )
+        self._seed_empty_items_snapshot_cache(
+            cache=self._agents_snapshot_cache,
+            cache_lock=self._agents_snapshot_cache_lock,
+            key=self._agents_snapshot_key(session_id),
+            now=now,
+        )
+        self._seed_empty_items_snapshot_cache(
+            cache=self._tasks_snapshot_cache,
+            cache_lock=self._tasks_snapshot_cache_lock,
+            key=self._tasks_snapshot_key(session_id),
+            now=now,
+        )
+        with self._token_usage_snapshot_cache_lock:
+            token_usage_key = self._token_usage_snapshot_key(session_id)
+            if token_usage_key not in self._token_usage_snapshot_cache:
+                self._token_usage_snapshot_cache[token_usage_key] = (
+                    _RecoverySnapshotCacheEntry(
+                        snapshot=self._empty_token_usage_snapshot(session_id),
+                        updated_monotonic=now,
+                    )
+                )
+        summary_rounds_key = f"{session_id}|4||0|1"
+        default_rounds_key = f"{session_id}|8||0|0"
+        self._rounds_snapshot_args_by_key[summary_rounds_key] = (
+            session_id,
+            4,
+            None,
+            False,
+            True,
+        )
+        self._rounds_snapshot_args_by_key[default_rounds_key] = (
+            session_id,
+            8,
+            None,
+            False,
+            False,
+        )
+        self._seed_empty_items_snapshot_cache(
+            cache=self._rounds_snapshot_cache,
+            cache_lock=self._rounds_snapshot_cache_lock,
+            key=summary_rounds_key,
+            now=now,
+        )
+        self._seed_empty_items_snapshot_cache(
+            cache=self._rounds_snapshot_cache,
+            cache_lock=self._rounds_snapshot_cache_lock,
+            key=default_rounds_key,
+            now=now,
+        )
+
+    @staticmethod
+    def _seed_empty_items_snapshot_cache(
+        *,
+        cache: dict[str, _RecoverySnapshotCacheEntry],
+        cache_lock: Lock,
+        key: str,
+        now: float,
+    ) -> None:
+        with cache_lock:
+            if key in cache:
+                return
+            cache[key] = _RecoverySnapshotCacheEntry(
+                snapshot={
+                    "items": [],
+                    "snapshot_refresh_ms": 0,
+                    "snapshot_cache_hit": False,
+                },
+                updated_monotonic=now,
+            )
+
+    def _recovery_cache_entry(
+        self, session_id: str
+    ) -> _RecoverySnapshotCacheEntry | None:
+        with self._recovery_snapshot_cache_lock:
+            return self._recovery_snapshot_cache.get(session_id)
+
+    @staticmethod
+    def _snapshot_response(
+        entry: _RecoverySnapshotCacheEntry,
+        *,
+        stale: bool,
+        now: float,
+        cache_hit: bool,
+    ) -> dict[str, object]:
+        snapshot = dict(entry.snapshot)
+        snapshot["stale"] = stale
+        snapshot["snapshot_age_ms"] = max(
+            0,
+            int((now - entry.updated_monotonic) * 1000),
+        )
+        snapshot["snapshot_cache_hit"] = cache_hit
+        return snapshot
+
+    def _ensure_recovery_refresh_task(self, session_id: str) -> None:
+        if not self._should_start_snapshot_refresh(
+            tasks=self._recovery_refresh_tasks,
+            cache=self._recovery_snapshot_cache,
+            cache_lock=self._recovery_snapshot_cache_lock,
+            key=session_id,
+        ):
+            return
+        task = self._recovery_refresh_tasks.get(session_id)
+        if task is not None and not task.done():
+            return
+        task = asyncio.create_task(self._refresh_recovery_snapshot_cache(session_id))
+        self._recovery_refresh_tasks[session_id] = task
+        task.add_done_callback(
+            lambda completed: self._observe_snapshot_refresh_result(
+                kind=_SNAPSHOT_KIND_RECOVERY,
+                key=session_id,
+                task=completed,
+            )
+        )
+
+    async def _refresh_recovery_snapshot_cache(self, session_id: str) -> None:
+        snapshot = await asyncio.to_thread(self.get_recovery_snapshot, session_id)
+        with self._recovery_snapshot_cache_lock:
+            self._recovery_snapshot_cache[session_id] = _RecoverySnapshotCacheEntry(
+                snapshot=snapshot,
+                updated_monotonic=monotonic(),
+            )
+
+    @staticmethod
+    def _snapshot_cache_entry(
+        *,
+        cache: dict[str, _RecoverySnapshotCacheEntry],
+        cache_lock: Lock,
+        key: str,
+    ) -> _RecoverySnapshotCacheEntry | None:
+        with cache_lock:
+            return cache.get(key)
+
+    def _snapshot_entry_is_stale(
+        self,
+        entry: _RecoverySnapshotCacheEntry,
+        *,
+        now: float,
+    ) -> bool:
+        age_ms = int((now - entry.updated_monotonic) * 1000)
+        return (
+            entry.dirty or entry.requires_fresh_read or age_ms > self._recovery_cache_ms
+        )
+
+    def _should_start_snapshot_refresh(
+        self,
+        *,
+        tasks: dict[str, asyncio.Task[None]],
+        cache: dict[str, _RecoverySnapshotCacheEntry],
+        cache_lock: Lock,
+        key: str,
+    ) -> bool:
+        task = tasks.get(key)
+        if task is not None and not task.done():
+            return False
+        now = monotonic()
+        with cache_lock:
+            entry = cache.get(key)
+            if entry is None:
+                return False
+            elapsed_ms = int((now - entry.refresh_started_monotonic) * 1000)
+            if elapsed_ms < self._snapshot_refresh_min_interval_ms:
+                return False
+            entry.refresh_started_monotonic = now
+        return True
+
+    def _observe_snapshot_refresh_result(
+        self,
+        *,
+        kind: str,
+        key: str,
+        task: asyncio.Task[None],
+    ) -> None:
+        if kind == _SNAPSHOT_KIND_ROUNDS:
+            self._rounds_refresh_tasks.pop(key, None)
+        elif kind == _SNAPSHOT_KIND_SUBAGENTS:
+            self._subagents_refresh_tasks.pop(key, None)
+        elif kind == _SNAPSHOT_KIND_RECOVERY:
+            self._recovery_refresh_tasks.pop(key, None)
+        elif kind == _SNAPSHOT_KIND_AGENTS:
+            self._agents_refresh_tasks.pop(key, None)
+        elif kind == _SNAPSHOT_KIND_TASKS:
+            self._tasks_refresh_tasks.pop(key, None)
+        elif kind == _SNAPSHOT_KIND_TOKEN_USAGE:
+            self._token_usage_refresh_tasks.pop(key, None)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.snapshot_cache.refresh_failed",
+                message="Session snapshot cache refresh failed",
+                payload={
+                    "kind": kind,
+                    "key": key,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+
+    def get_token_usage_by_run(self, run_id: str) -> RunTokenUsage:
+        return self._token_usage_repo.get_by_run(run_id)
+
+    def get_token_usage_by_session(self, session_id: str) -> SessionTokenUsage:
+        return self._token_usage_repo.get_by_session(session_id)
+
+    async def get_cached_token_usage_by_session_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        key = self._token_usage_snapshot_key(session_id)
+        cached = self._snapshot_cache_entry(
+            cache=self._token_usage_snapshot_cache,
+            cache_lock=self._token_usage_snapshot_cache_lock,
+            key=key,
+        )
+        now = monotonic()
+        if cached is not None:
+            stale = self._snapshot_entry_is_stale(cached, now=now)
+            if stale:
+                self._ensure_token_usage_refresh_task(session_id)
+            return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+        _ = await asyncio.to_thread(self._session_repo.get, session_id)
+        try:
+            fresh_snapshot = await asyncio.wait_for(
+                self._build_token_usage_snapshot_async(session_id),
+                timeout=LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS,
+            )
+            fresh_entry = _RecoverySnapshotCacheEntry(
+                snapshot=fresh_snapshot,
+                updated_monotonic=monotonic(),
+            )
+            with self._token_usage_snapshot_cache_lock:
+                self._token_usage_snapshot_cache[key] = fresh_entry
+            return self._snapshot_response(
+                fresh_entry,
+                stale=False,
+                now=monotonic(),
+                cache_hit=False,
+            )
+        except asyncio.TimeoutError:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="session.token_usage_cache.cold_miss_timeout",
+                message="Session token usage cold cache build exceeded fast-read budget",
+                payload={
+                    "session_id": session_id,
+                    "timeout_ms": int(LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS * 1000),
+                },
+            )
+        entry = _RecoverySnapshotCacheEntry(
+            snapshot=self._empty_token_usage_snapshot(session_id),
+            updated_monotonic=monotonic(),
+        )
+        entry.dirty = True
+        with self._token_usage_snapshot_cache_lock:
+            self._token_usage_snapshot_cache[key] = entry
+        self._ensure_token_usage_refresh_task(session_id)
+        return self._snapshot_response(
+            entry, stale=True, now=monotonic(), cache_hit=False
+        )
+
+    def get_fast_cached_token_usage_by_session_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        key = self._token_usage_snapshot_key(session_id)
+        cached = self._snapshot_cache_entry(
+            cache=self._token_usage_snapshot_cache,
+            cache_lock=self._token_usage_snapshot_cache_lock,
+            key=key,
+        )
+        if cached is None:
+            return None
+        now = monotonic()
+        stale = self._snapshot_entry_is_stale(cached, now=now)
+        if stale and cached.dirty:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                self._ensure_token_usage_refresh_task(session_id)
+        return self._snapshot_response(cached, stale=stale, now=now, cache_hit=True)
+
+    @staticmethod
+    def _empty_token_usage_snapshot(session_id: str) -> dict[str, object]:
+        return {
+            "session_id": session_id,
+            "total_input_tokens": 0,
+            "total_cached_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_reasoning_output_tokens": 0,
+            "total_tokens": 0,
+            "total_requests": 0,
+            "total_tool_calls": 0,
+            "by_role": {},
+            "snapshot_refresh_ms": 0,
+            "snapshot_cache_hit": False,
+        }
+
+    @staticmethod
+    def _token_usage_snapshot(summary: SessionTokenUsage) -> dict[str, object]:
+        return {
+            "session_id": summary.session_id,
+            "total_input_tokens": summary.total_input_tokens,
+            "total_cached_input_tokens": summary.total_cached_input_tokens,
+            "total_output_tokens": summary.total_output_tokens,
+            "total_reasoning_output_tokens": summary.total_reasoning_output_tokens,
+            "total_tokens": summary.total_tokens,
+            "total_requests": summary.total_requests,
+            "total_tool_calls": summary.total_tool_calls,
+            "by_role": {
+                role_id: {
+                    "role_id": agent.role_id,
+                    "input_tokens": agent.input_tokens,
+                    "latest_input_tokens": agent.latest_input_tokens,
+                    "cached_input_tokens": agent.cached_input_tokens,
+                    "max_input_tokens": agent.max_input_tokens,
+                    "output_tokens": agent.output_tokens,
+                    "reasoning_output_tokens": agent.reasoning_output_tokens,
+                    "total_tokens": agent.total_tokens,
+                    "requests": agent.requests,
+                    "tool_calls": agent.tool_calls,
+                    "context_window": agent.context_window,
+                    "model_profile": agent.model_profile,
+                }
+                for role_id, agent in summary.by_role.items()
+            },
+            "snapshot_cache_hit": False,
+        }
+
+    async def _build_token_usage_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        started = monotonic()
+        summary = await asyncio.to_thread(self.get_token_usage_by_session, session_id)
+        snapshot = self._token_usage_snapshot(summary)
+        snapshot["snapshot_refresh_ms"] = int((monotonic() - started) * 1000)
+        return snapshot
+
+    def _ensure_token_usage_refresh_task(self, session_id: str) -> None:
+        key = self._token_usage_snapshot_key(session_id)
+        if not self._should_start_snapshot_refresh(
+            tasks=self._token_usage_refresh_tasks,
+            cache=self._token_usage_snapshot_cache,
+            cache_lock=self._token_usage_snapshot_cache_lock,
+            key=key,
+        ):
+            return
+        task = asyncio.create_task(self._refresh_token_usage_snapshot_cache(session_id))
+        self._token_usage_refresh_tasks[key] = task
+        task.add_done_callback(
+            lambda completed: self._observe_snapshot_refresh_result(
+                kind=_SNAPSHOT_KIND_TOKEN_USAGE,
+                key=key,
+                task=completed,
+            )
+        )
+
+    async def _refresh_token_usage_snapshot_cache(self, session_id: str) -> None:
+        snapshot = await self._build_token_usage_snapshot_async(session_id)
+        with self._token_usage_snapshot_cache_lock:
+            self._token_usage_snapshot_cache[
+                self._token_usage_snapshot_key(session_id)
+            ] = _RecoverySnapshotCacheEntry(
+                snapshot=snapshot,
+                updated_monotonic=monotonic(),
+            )
+
+    async def get_token_usage_by_run_async(self, run_id: str) -> RunTokenUsage:
+
+        return await asyncio.to_thread(self._token_usage_repo.get_by_run, run_id)
+
+    async def get_token_usage_by_session_async(
+        self, session_id: str
+    ) -> SessionTokenUsage:
+
+        return await asyncio.to_thread(
+            self._token_usage_repo.get_by_session, session_id
+        )

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -5,11 +5,11 @@ import contextlib
 import shutil
 import uuid
 from collections.abc import AsyncIterator, Callable, Mapping
-from time import monotonic
+from threading import Lock
 from typing import TYPE_CHECKING, cast
 
 from relay_teams.agent_runtimes.instances.models import AgentRuntimeRecord
-from relay_teams.media import ContentPart
+from relay_teams.logger import get_logger
 from relay_teams.media import content_parts_to_text
 from relay_teams.media import user_prompt_content_to_text
 from relay_teams.metrics import SqliteMetricAggregateStore
@@ -29,12 +29,6 @@ from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.runtime_config import RuntimeConfig
 from relay_teams.sessions.session_rounds_projection import (
     ROUND_PROJECTION_EVENT_TYPES,
-    approvals_to_projection,
-    build_session_rounds,
-    build_session_timeline_rounds,
-    find_round_by_run_id,
-    paginate_rounds,
-    timeline_rounds,
 )
 from relay_teams.agent_runtimes.instances.instance_repository import (
     AgentInstanceRepository,
@@ -78,11 +72,21 @@ from relay_teams.sessions.session_history_marker_models import (
     SessionHistoryMarkerType,
 )
 from relay_teams.sessions.session_repository import SessionRepository
+from relay_teams.sessions.session_list_cache import (
+    DEFAULT_LIST_SESSIONS_CACHE_MS,
+    LIST_SESSIONS_CACHE_MS_ENV,
+    SessionListCacheMixin,
+    resolve_positive_int_env as _resolve_positive_int_env,
+)
+from relay_teams.sessions.session_read_models import (
+    DEFAULT_SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS,
+    SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS_ENV,
+    SessionReadModelMixin,
+    _RecoverySnapshotCacheEntry,
+)
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.providers.token_usage_repo import (
-    RunTokenUsage,
-    SessionTokenUsage,
     TokenUsageRepository,
 )
 from relay_teams.workspace import (
@@ -112,6 +116,7 @@ if TYPE_CHECKING:
 
 from relay_teams.roles.role_registry import SystemRolesUnavailableError
 
+LOGGER = get_logger(__name__)
 AUTOMATION_INTERNAL_WORKSPACE_ID = "automation-system"
 ACTIVE_RUN_REBIND_ERROR = (
     "Cannot rebind workspace while session has active or recoverable run"
@@ -130,7 +135,6 @@ _LEGACY_COORDINATOR_IDENTIFIERS = (
 )
 _MAIN_AGENT_IDENTIFIERS = ("mainagent", "main agent", "main_agent")
 _AUTO_SESSION_TITLE_MAX_CHARS = 120
-_LIST_SESSIONS_CACHE_TTL_SECONDS = 0.5
 
 
 def _legacy_coordinator_identifiers() -> tuple[str, ...]:
@@ -156,7 +160,7 @@ def _system_roles_unavailable_error_type() -> type[Exception]:
     return SystemRolesUnavailableError
 
 
-class SessionService:
+class SessionService(SessionListCacheMixin, SessionReadModelMixin):
     def __init__(
         self,
         *,
@@ -222,9 +226,48 @@ class SessionService:
         self._run_intent_repo = run_intent_repo
         self._get_runtime = get_runtime
         self._list_sessions_cache: tuple[float, tuple[SessionRecord, ...]] | None = None
-
-    def _invalidate_list_sessions_cache(self) -> None:
-        self._list_sessions_cache = None
+        self._list_sessions_cache_lock = Lock()
+        self._list_sessions_cache_dirty = False
+        self._list_sessions_refresh_task: asyncio.Task[None] | None = None
+        self._list_sessions_refresh_started_monotonic = 0.0
+        self._list_sessions_cache_version = 0
+        self._list_sessions_cache_ttl_seconds = (
+            _resolve_positive_int_env(
+                LIST_SESSIONS_CACHE_MS_ENV,
+                DEFAULT_LIST_SESSIONS_CACHE_MS,
+            )
+            / 1000
+        )
+        self._recovery_cache_ms = self._resolve_session_snapshot_cache_ms()
+        self._snapshot_refresh_min_interval_ms = _resolve_positive_int_env(
+            SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS_ENV,
+            DEFAULT_SESSION_SNAPSHOT_REFRESH_MIN_INTERVAL_MS,
+        )
+        self._recovery_snapshot_cache: dict[str, _RecoverySnapshotCacheEntry] = {}
+        self._recovery_snapshot_cache_lock = Lock()
+        self._recovery_refresh_tasks: dict[str, asyncio.Task[None]] = {}
+        self._rounds_snapshot_cache: dict[str, _RecoverySnapshotCacheEntry] = {}
+        self._rounds_snapshot_cache_lock = Lock()
+        self._rounds_refresh_tasks: dict[str, asyncio.Task[None]] = {}
+        self._rounds_snapshot_args_by_key: dict[
+            str, tuple[str, int, str | None, bool, bool]
+        ] = {}
+        self._subagents_snapshot_cache: dict[str, _RecoverySnapshotCacheEntry] = {}
+        self._subagents_snapshot_cache_lock = Lock()
+        self._subagents_refresh_tasks: dict[str, asyncio.Task[None]] = {}
+        self._agents_snapshot_cache: dict[str, _RecoverySnapshotCacheEntry] = {}
+        self._agents_snapshot_cache_lock = Lock()
+        self._agents_refresh_tasks: dict[str, asyncio.Task[None]] = {}
+        self._tasks_snapshot_cache: dict[str, _RecoverySnapshotCacheEntry] = {}
+        self._tasks_snapshot_cache_lock = Lock()
+        self._tasks_refresh_tasks: dict[str, asyncio.Task[None]] = {}
+        self._token_usage_snapshot_cache: dict[str, _RecoverySnapshotCacheEntry] = {}
+        self._token_usage_snapshot_cache_lock = Lock()
+        self._token_usage_refresh_tasks: dict[str, asyncio.Task[None]] = {}
+        if self._run_event_hub is not None:
+            self._run_event_hub.add_publish_observer(
+                self._observe_run_event_for_snapshot_dirty
+            )
 
     def replace_role_registry(self, role_registry: RoleRegistry | None) -> None:
         self._role_registry = role_registry
@@ -266,8 +309,7 @@ class SessionService:
             normal_root_role_id=normal_root_role_id,
             orchestration_preset_id=orchestration_preset_id,
         )
-        self._invalidate_list_sessions_cache()
-        return self._session_repo.create(
+        record = self._session_repo.create(
             session_id=resolved_session_id,
             workspace_id=workspace_id,
             metadata=metadata,
@@ -277,6 +319,10 @@ class SessionService:
             normal_root_role_id=resolved_normal_root_role_id,
             orchestration_preset_id=resolved_orchestration_preset_id,
         )
+        self._invalidate_list_sessions_cache()
+        self._merge_record_into_list_sessions_cache(record)
+        self._seed_empty_session_snapshot_caches(record.session_id)
+        return record
 
     async def create_session_async(
         self,
@@ -309,8 +355,7 @@ class SessionService:
             normal_root_role_id=normal_root_role_id,
             orchestration_preset_id=orchestration_preset_id,
         )
-        self._invalidate_list_sessions_cache()
-        return await self._session_repo.create_async(
+        record = await self._session_repo.create_async(
             session_id=resolved_session_id,
             workspace_id=workspace_id,
             metadata=metadata,
@@ -320,6 +365,10 @@ class SessionService:
             normal_root_role_id=resolved_normal_root_role_id,
             orchestration_preset_id=resolved_orchestration_preset_id,
         )
+        self._invalidate_list_sessions_cache()
+        self._merge_record_into_list_sessions_cache(record)
+        self._seed_empty_session_snapshot_caches(record.session_id)
+        return record
 
     @staticmethod
     def _resolve_session_create_id(session_id: str | None) -> str:
@@ -464,6 +513,9 @@ class SessionService:
 
         self._session_repo.update_metadata(session_id, next_metadata)
         self._invalidate_list_sessions_cache()
+        self._merge_record_into_list_sessions_cache(
+            self._with_terminal_run_projection(self._session_repo.get(session_id))
+        )
 
     async def update_session_async(
         self, session_id: str, patch: SessionMetadataPatch
@@ -478,6 +530,9 @@ class SessionService:
         _ = self._session_repo.get(session_id)
         self._session_repo.update_metadata(session_id, dict(metadata))
         self._invalidate_list_sessions_cache()
+        self._merge_record_into_list_sessions_cache(
+            self._with_terminal_run_projection(self._session_repo.get(session_id))
+        )
 
     def _replace_custom_metadata(
         self,
@@ -838,6 +893,9 @@ class SessionService:
             if session_dir.exists():
                 shutil.rmtree(session_dir, ignore_errors=True)
         self._invalidate_list_sessions_cache()
+        self._remove_record_from_list_sessions_cache(session_id)
+        self._clear_session_snapshot_caches(session_id)
+        self._refresh_list_sessions_cache()
 
     async def delete_session_async(
         self,
@@ -991,16 +1049,33 @@ class SessionService:
                 resolved_log_path.unlink()
 
     def get_session(self, session_id: str) -> SessionRecord:
+        cached = self._get_session_from_list_cache(session_id, allow_stale=False)
+        if cached is not None:
+            return cached
         return self._with_terminal_run_projection(
-            self._with_auto_session_title(self._session_repo.get(session_id))
+            self._with_subagent_count_projection(
+                self._with_auto_session_title(self._session_repo.get(session_id))
+            )
         )
 
     async def get_session_async(self, session_id: str) -> SessionRecord:
+        cached = self._get_session_from_list_cache(session_id, allow_stale=True)
+        if cached is not None:
+            self._ensure_list_sessions_refresh_task_if_stale()
+            return cached
         return self._with_terminal_run_projection(
-            self._with_auto_session_title(
-                await self._session_repo.get_async(session_id)
+            await self._with_subagent_count_projection_async(
+                self._with_auto_session_title(
+                    await self._session_repo.get_async(session_id)
+                )
             )
         )
+
+    def assert_session_exists(self, session_id: str) -> None:
+        _ = self._session_repo.get(session_id)
+
+    async def assert_session_exists_async(self, session_id: str) -> None:
+        _ = await self._session_repo.get_async(session_id)
 
     def _list_subagent_background_tasks(
         self,
@@ -1021,131 +1096,12 @@ class SessionService:
             )
         )
 
-    def list_sessions(self) -> tuple[SessionRecord, ...]:
-        cached = self._list_sessions_cache
-        now = monotonic()
-        if cached is not None and now - cached[0] <= _LIST_SESSIONS_CACHE_TTL_SECONDS:
-            return cached[1]
-        sessions = self._session_repo.list_all()
-        session_ids = tuple(record.session_id for record in sessions)
-        runtimes_by_session: dict[str, tuple[RunRuntimeRecord, ...]] = (
-            self._run_runtime_repo.list_by_session_ids(session_ids)
-        )
-        background_tasks_by_session: dict[str, tuple[BackgroundTaskRecord, ...]] = (
-            self._background_task_repository.list_by_session_ids(session_ids)
-            if self._background_task_repository is not None
-            else {}
-        )
-        excluded_run_ids_by_session = self._subagent_run_ids_by_session_ids(
-            session_ids=session_ids,
-            runtimes_by_session=runtimes_by_session,
-            background_tasks_by_session=background_tasks_by_session,
-        )
-        active_background_run_ids = self._active_background_run_ids(
-            background_tasks_by_session,
-        )
-        first_intent_titles: dict[str, str] = (
-            self._run_intent_repo.first_titles_by_session_ids(session_ids)
-            if self._run_intent_repo is not None
-            else {}
-        )
-        session_ids_needing_message_titles = tuple(
-            record.session_id
-            for record in sessions
-            if record.session_id not in first_intent_titles
-        )
-        first_user_messages = self._message_repo.first_user_messages_by_session_ids(
-            session_ids_needing_message_titles
-        )
-        normal_session_ids = tuple(
-            record.session_id
-            for record in sessions
-            if record.session_mode == SessionMode.NORMAL
-        )
-        subagent_counts = self._agent_repo.count_normal_mode_subagents_by_session_ids(
-            normal_session_ids
-        )
-        selected_by_session: dict[str, tuple[str, RunRuntimeRecord]] = {}
-        for session_id in session_ids:
-            selected = self._select_active_run_from_preloaded(
-                session_id=session_id,
-                runtimes=runtimes_by_session.get(session_id, ()),
-                excluded_run_ids=excluded_run_ids_by_session.get(session_id, set()),
-                active_background_run_ids=active_background_run_ids,
-            )
-            if selected is not None:
-                selected_by_session[session_id] = selected
-        selected_run_ids = tuple(
-            dict.fromkeys(run_id for run_id, _runtime in selected_by_session.values())
-        )
-        approval_counts = self._approval_ticket_repo.count_open_by_run_ids(
-            selected_run_ids
-        )
-        question_counts = (
-            self._user_question_repo.count_open_by_run_ids(selected_run_ids)
-            if self._user_question_repo is not None
-            else {}
-        )
-        enriched: list[SessionRecord] = []
-        for record in sessions:
-            record = self._with_auto_session_title_from_preloaded(
-                record,
-                first_intent_titles=first_intent_titles,
-                first_user_messages=first_user_messages,
-            )
-            selected = selected_by_session.get(record.session_id)
-            subagent_session_count = subagent_counts.get(record.session_id, 0)
-            runtimes = runtimes_by_session.get(record.session_id, ())
-            excluded_run_ids = excluded_run_ids_by_session.get(
-                record.session_id,
-                set(),
-            )
-            if selected is None:
-                enriched.append(
-                    self._with_terminal_run_projection_from_preloaded(
-                        record.model_copy(
-                            update={
-                                "subagent_session_count": subagent_session_count,
-                            }
-                        ),
-                        runtimes=runtimes,
-                        excluded_run_ids=excluded_run_ids,
-                    )
-                )
-                continue
-            run_id, runtime = selected
-            approval_count = approval_counts.get(run_id, 0)
-            question_count = question_counts.get(run_id, 0)
-            enriched.append(
-                self._with_terminal_run_projection_from_preloaded(
-                    record.model_copy(
-                        update={
-                            "has_active_run": True,
-                            "active_run_id": run_id,
-                            "active_run_status": runtime.status.value,
-                            "active_run_phase": self._public_phase(
-                                runtime,
-                                approval_count,
-                                question_count,
-                            ),
-                            "pending_tool_approval_count": approval_count,
-                            "subagent_session_count": subagent_session_count,
-                        }
-                    ),
-                    runtimes=runtimes,
-                    excluded_run_ids=excluded_run_ids,
-                )
-            )
-        result = tuple(enriched)
-        self._list_sessions_cache = (monotonic(), result)
-        return result
-
-    async def list_sessions_async(self) -> tuple[SessionRecord, ...]:
-
-        return await asyncio.to_thread(self.list_sessions)
-
     def mark_latest_terminal_run_viewed(self, session_id: str) -> None:
-        _ = self._session_repo.get(session_id)
+        record = self._session_repo.get(session_id)
+        cached = self._get_session_from_list_cache(session_id, allow_stale=True)
+        if cached is not None and cached.latest_terminal_run_id:
+            self._mark_cached_terminal_run_viewed(record, cached.latest_terminal_run_id)
+            return
         runtimes = self._run_runtime_repo.list_by_session(session_id)
         background_tasks = (
             self._background_task_repository.list_by_session(session_id)
@@ -1161,14 +1117,75 @@ class SessionService:
         )
         if latest_terminal is None:
             return
-        self._session_repo.mark_terminal_run_viewed(
-            session_id,
-            latest_terminal.run_id,
-        )
-        self._invalidate_list_sessions_cache()
+        self._mark_cached_terminal_run_viewed(record, latest_terminal.run_id)
 
     async def mark_latest_terminal_run_viewed_async(self, session_id: str) -> None:
-        await asyncio.to_thread(self.mark_latest_terminal_run_viewed, session_id)
+        record = await self._session_repo.get_async(session_id)
+        cached = self._get_session_from_list_cache(session_id, allow_stale=True)
+        if cached is not None and cached.latest_terminal_run_id:
+            await self._mark_cached_terminal_run_viewed_async(
+                record,
+                cached.latest_terminal_run_id,
+            )
+            return
+        runtimes = await self._run_runtime_repo.list_by_session_async(session_id)
+        background_tasks = (
+            await self._background_task_repository.list_by_session_async(session_id)
+            if self._background_task_repository is not None
+            else ()
+        )
+        latest_terminal = self._latest_terminal_run_from_preloaded(
+            runtimes,
+            self._subagent_run_ids_from_records(
+                runtimes=runtimes,
+                background_tasks=background_tasks,
+            ),
+        )
+        if latest_terminal is None:
+            return
+        await self._mark_cached_terminal_run_viewed_async(
+            record,
+            latest_terminal.run_id,
+        )
+
+    def _mark_cached_terminal_run_viewed(
+        self,
+        record: SessionRecord,
+        run_id: str,
+    ) -> None:
+        self._session_repo.mark_terminal_run_viewed(record.session_id, run_id)
+        self._merge_terminal_view_record_into_list_cache(record, run_id)
+
+    async def _mark_cached_terminal_run_viewed_async(
+        self,
+        record: SessionRecord,
+        run_id: str,
+    ) -> None:
+        await self._session_repo.mark_terminal_run_viewed_async(
+            record.session_id,
+            run_id,
+        )
+        self._merge_terminal_view_record_into_list_cache(record, run_id)
+
+    def _merge_terminal_view_record_into_list_cache(
+        self,
+        record: SessionRecord,
+        run_id: str,
+    ) -> None:
+        cached = self._get_session_from_list_cache(record.session_id, allow_stale=True)
+        if cached is not None and cached.latest_terminal_run_id == run_id:
+            self._merge_record_into_list_sessions_cache(
+                cached.model_copy(
+                    update={
+                        "last_viewed_terminal_run_id": run_id,
+                        "has_unread_terminal_run": False,
+                    }
+                )
+            )
+            return
+        self._merge_record_into_list_sessions_cache(
+            record.model_copy(update={"last_viewed_terminal_run_id": run_id})
+        )
 
     def list_sessions_by_workspace(
         self, workspace_id: str
@@ -1266,12 +1283,28 @@ class SessionService:
             else None
         )
         replay_high_watermark = max(0, int(after_event_id))
+        subagent_run_ids = self._subagent_run_ids(session_id)
         try:
             if self._event_log is not None:
-                rows = await self._event_log.list_subagent_run_events_by_session_after_id_async(
+                known_rows = (
+                    await self._event_log.list_by_session_run_ids_after_id_async(
+                        session_id,
+                        tuple(sorted(subagent_run_ids)),
+                        replay_high_watermark,
+                    )
+                    if subagent_run_ids
+                    else ()
+                )
+                legacy_rows = await self._event_log.list_subagent_run_events_by_session_after_id_async(
                     session_id,
                     replay_high_watermark,
                 )
+                rows_by_id: dict[int, Mapping[str, object]] = {}
+                for row in (*known_rows, *legacy_rows):
+                    row_id = row.get("id")
+                    if isinstance(row_id, int):
+                        rows_by_id[row_id] = row
+                rows = tuple(rows_by_id[key] for key in sorted(rows_by_id))
                 for row in rows:
                     event = self._run_event_from_log_row(row)
                     if event is None:
@@ -1290,7 +1323,15 @@ class SessionService:
                 event = await queue.get()
                 if event.session_id != session_id:
                     continue
-                if not self._is_subagent_run_id(event.run_id):
+                if (
+                    event.run_id not in subagent_run_ids
+                    and not self._is_legacy_subagent_run_id(event.run_id)
+                ):
+                    subagent_run_ids = self._subagent_run_ids(session_id)
+                if (
+                    event.run_id not in subagent_run_ids
+                    and not self._is_legacy_subagent_run_id(event.run_id)
+                ):
                     continue
                 event_id = event.event_id
                 if event_id is not None and event_id <= replay_high_watermark:
@@ -1493,467 +1534,6 @@ class SessionService:
     ) -> list[dict[str, object]]:
         return await asyncio.to_thread(self.get_session_messages, session_id)
 
-    def get_session_tasks(self, session_id: str) -> list[dict[str, object]]:
-        records = self._task_repo.list_by_session(session_id)
-        return [
-            {
-                "task_id": record.envelope.task_id,
-                "title": record.envelope.title or record.envelope.objective[:80],
-                "assigned_role_id": record.envelope.role_id,
-                "status": record.status.value,
-                "assigned_instance_id": record.assigned_instance_id,
-                "role_id": record.envelope.role_id,
-                "instance_id": record.assigned_instance_id,
-                "run_id": record.envelope.trace_id,
-                "created_at": record.created_at.isoformat(),
-                "updated_at": record.updated_at.isoformat(),
-                "spec_artifact_id": record.envelope.spec_artifact_id,
-                "spec_source_task_id": record.envelope.spec_source_task_id,
-                "spec_summary": (
-                    record.envelope.spec.summary if record.envelope.spec else ""
-                ),
-                "spec_strictness": (
-                    record.envelope.spec.strictness.value
-                    if record.envelope.spec
-                    else ""
-                ),
-                "evidence_bundle": (
-                    record.envelope.evidence_bundle.model_dump(mode="json")
-                    if record.envelope.evidence_bundle
-                    else None
-                ),
-            }
-            for record in records
-            if record.envelope.parent_task_id is not None
-        ]
-
-    async def get_session_tasks_async(self, session_id: str) -> list[dict[str, object]]:
-        return await asyncio.to_thread(self.get_session_tasks, session_id)
-
-    def build_session_rounds(
-        self,
-        session_id: str,
-        *,
-        included_run_ids: set[str] | None = None,
-        include_history_markers: bool = True,
-    ) -> list[dict[str, object]]:
-        excluded_run_ids = self._subagent_run_ids(session_id)
-        selected_run_ids = (
-            tuple(sorted(included_run_ids)) if included_run_ids is not None else None
-        )
-        todos_by_run_id = (
-            {
-                snapshot.run_id: snapshot.model_dump(mode="json")
-                for snapshot in self._todo_service.list_for_session(session_id)
-                if included_run_ids is None or snapshot.run_id in included_run_ids
-            }
-            if self._todo_service is not None
-            else {}
-        )
-        intent_input_parts_by_run = (
-            self._session_run_intent_input_parts_by_run(session_id)
-            if included_run_ids is None
-            else {
-                run_id: parts
-                for run_id, parts in self._session_run_intent_input_parts_by_run(
-                    session_id
-                ).items()
-                if run_id in included_run_ids
-            }
-        )
-        runtime_by_run = {
-            run_id: runtime
-            for run_id, runtime in self._session_run_runtime_by_run(session_id).items()
-            if included_run_ids is None or run_id in included_run_ids
-        }
-        rounds = build_session_rounds(
-            session_id=session_id,
-            agent_repo=self._agent_repo,
-            task_repo=self._task_repo,
-            approval_tickets_by_run=approvals_to_projection(
-                [
-                    record
-                    for record in self._approval_ticket_repo.list_open_by_session(
-                        session_id
-                    )
-                    if included_run_ids is None or record.run_id in included_run_ids
-                ]
-            ),
-            run_runtime_repo=self._run_runtime_repo,
-            get_session_messages=lambda current_session_id: cast(
-                list[dict[str, object]],
-                (
-                    self._message_repo.get_messages_by_session(
-                        current_session_id,
-                        include_cleared=True,
-                        include_hidden_from_context=True,
-                    )
-                    if selected_run_ids is None
-                    else self._message_repo.get_messages_by_session_run_ids(
-                        current_session_id,
-                        selected_run_ids,
-                        include_cleared=True,
-                        include_hidden_from_context=True,
-                    )
-                ),
-            ),
-            get_run_intent_input=intent_input_parts_by_run.get,
-            get_session_history_markers=(
-                self._get_session_history_markers if include_history_markers else None
-            ),
-            get_session_events=(
-                self._get_round_projection_events
-                if selected_run_ids is None
-                else lambda current_session_id: (
-                    self._get_round_projection_events_for_runs(
-                        current_session_id,
-                        selected_run_ids,
-                    )
-                )
-            ),
-            excluded_run_ids=excluded_run_ids,
-            included_run_ids=included_run_ids,
-            run_runtime_by_run=runtime_by_run,
-        )
-        question_counts_by_run = self._pending_user_question_counts_by_run(session_id)
-        for round_item in rounds:
-            runtime = runtime_by_run.get(str(round_item.get("run_id") or ""))
-            pending = round_item.get("pending_tool_approvals")
-            approval_count = len(pending) if isinstance(pending, list) else 0
-            if runtime is None:
-                continue
-            question_count = question_counts_by_run.get(runtime.run_id, 0)
-            round_item["run_status"] = runtime.status.value
-            round_item["run_phase"] = self._public_phase(
-                runtime,
-                approval_count,
-                question_count,
-            )
-            round_item["is_recoverable"] = self._is_runtime_publicly_recoverable(
-                runtime
-            )
-            todo = todos_by_run_id.get(str(round_item.get("run_id") or ""))
-            if todo is not None:
-                round_item["todo"] = todo
-        return rounds
-
-    def build_session_timeline_rounds(self, session_id: str) -> list[dict[str, object]]:
-        excluded_run_ids = self._subagent_run_ids(session_id)
-        todos_by_run_id = (
-            {
-                snapshot.run_id: snapshot.model_dump(mode="json")
-                for snapshot in self._todo_service.list_for_session(session_id)
-            }
-            if self._todo_service is not None
-            else {}
-        )
-        intent_input_parts_by_run = self._session_run_intent_input_parts_by_run(
-            session_id
-        )
-        runtime_by_run = self._session_run_runtime_by_run(session_id)
-        rounds = build_session_timeline_rounds(
-            session_id=session_id,
-            task_repo=self._task_repo,
-            approval_tickets_by_run=approvals_to_projection(
-                self._approval_ticket_repo.list_open_by_session(session_id)
-            ),
-            run_runtime_repo=self._run_runtime_repo,
-            get_session_user_messages=lambda current_session_id: cast(
-                list[dict[str, object]],
-                self._message_repo.get_user_messages_by_session(
-                    current_session_id,
-                    include_cleared=True,
-                    include_hidden_from_context=True,
-                ),
-            ),
-            get_run_intent_input=intent_input_parts_by_run.get,
-            get_session_history_markers=self._get_session_history_markers,
-            get_session_events=self._get_round_projection_events,
-            excluded_run_ids=excluded_run_ids,
-            run_runtime_by_run=runtime_by_run,
-        )
-        question_counts_by_run = self._pending_user_question_counts_by_run(session_id)
-        for round_item in rounds:
-            runtime = runtime_by_run.get(str(round_item.get("run_id") or ""))
-            raw_approval_count = round_item.get("pending_tool_approval_count")
-            approval_count = (
-                raw_approval_count
-                if isinstance(raw_approval_count, int)
-                and not isinstance(raw_approval_count, bool)
-                else 0
-            )
-            if runtime is None:
-                continue
-            question_count = question_counts_by_run.get(runtime.run_id, 0)
-            round_item["run_status"] = runtime.status.value
-            round_item["run_phase"] = self._public_phase(
-                runtime,
-                approval_count,
-                question_count,
-            )
-            round_item["is_recoverable"] = self._is_runtime_publicly_recoverable(
-                runtime
-            )
-            todo = todos_by_run_id.get(str(round_item.get("run_id") or ""))
-            if todo is not None:
-                round_item["todo"] = todo
-        return rounds
-
-    def _session_run_runtime_by_run(
-        self,
-        session_id: str,
-    ) -> dict[str, RunRuntimeRecord]:
-        return {
-            runtime.run_id: runtime
-            for runtime in self._run_runtime_repo.list_by_session(session_id)
-        }
-
-    def _get_run_intent_input_parts(
-        self, run_id: str
-    ) -> tuple[ContentPart, ...] | None:
-        if self._run_intent_repo is None:
-            return None
-        try:
-            intent = self._run_intent_repo.get(run_id)
-        except KeyError:
-            return None
-        return intent.display_input or intent.input
-
-    def _session_run_intent_input_parts_by_run(
-        self, session_id: str
-    ) -> dict[str, tuple[ContentPart, ...]]:
-        if self._run_intent_repo is None:
-            return {}
-        return {
-            run_id: intent.display_input or intent.input
-            for run_id, intent in self._run_intent_repo.list_by_session(
-                session_id
-            ).items()
-        }
-
-    def get_session_rounds(
-        self,
-        session_id: str,
-        *,
-        limit: int = 8,
-        cursor_run_id: str | None = None,
-        timeline: bool = False,
-        summary: bool = False,
-    ) -> dict[str, object]:
-        if timeline:
-            rounds = self.build_session_timeline_rounds(session_id)
-            return timeline_rounds(rounds)
-        timeline_items = self.build_session_timeline_rounds(session_id)
-        page = paginate_rounds(
-            timeline_items,
-            limit=limit,
-            cursor_run_id=cursor_run_id,
-        )
-        if summary:
-            return page
-        page_items = page.get("items")
-        if not isinstance(page_items, list) or not page_items:
-            return page
-        page_run_ids = tuple(
-            str(item.get("run_id") or "")
-            for item in page_items
-            if isinstance(item, dict) and str(item.get("run_id") or "")
-        )
-        if not page_run_ids:
-            return page
-        full_rounds = self.build_session_rounds(
-            session_id,
-            included_run_ids=set(page_run_ids),
-            include_history_markers=False,
-        )
-        full_round_by_run = {
-            str(round_item.get("run_id") or ""): round_item
-            for round_item in full_rounds
-        }
-        page_marker_by_run = {
-            str(item.get("run_id") or ""): {
-                "clear_marker_before": item.get("clear_marker_before"),
-                "compaction_marker_before": item.get("compaction_marker_before"),
-            }
-            for item in page_items
-            if isinstance(item, dict) and str(item.get("run_id") or "")
-        }
-        resolved_items: list[dict[str, object]] = []
-        for run_id in page_run_ids:
-            full_round = full_round_by_run.get(run_id)
-            if full_round is None:
-                continue
-            markers = page_marker_by_run.get(run_id, {})
-            full_round["clear_marker_before"] = markers.get("clear_marker_before")
-            full_round["compaction_marker_before"] = markers.get(
-                "compaction_marker_before"
-            )
-            resolved_items.append(full_round)
-        page["items"] = resolved_items
-        return page
-
-    async def get_session_rounds_async(
-        self,
-        session_id: str,
-        *,
-        limit: int = 8,
-        cursor_run_id: str | None = None,
-        timeline: bool = False,
-        summary: bool = False,
-    ) -> dict[str, object]:
-
-        return await asyncio.to_thread(
-            self.get_session_rounds,
-            session_id,
-            limit=limit,
-            cursor_run_id=cursor_run_id,
-            timeline=timeline,
-            summary=summary,
-        )
-
-    def get_round(self, session_id: str, run_id: str) -> dict[str, object]:
-        safe_run_id = str(run_id or "").strip()
-        timeline_item = next(
-            (
-                item
-                for item in self.build_session_timeline_rounds(session_id)
-                if str(item.get("run_id") or "") == safe_run_id
-            ),
-            None,
-        )
-        rounds = self.build_session_rounds(
-            session_id,
-            included_run_ids={safe_run_id},
-            include_history_markers=False,
-        )
-        round_item = find_round_by_run_id(rounds, session_id=session_id, run_id=run_id)
-        if timeline_item is not None:
-            round_item["clear_marker_before"] = timeline_item.get("clear_marker_before")
-            round_item["compaction_marker_before"] = timeline_item.get(
-                "compaction_marker_before"
-            )
-        return round_item
-
-    async def get_round_async(self, session_id: str, run_id: str) -> dict[str, object]:
-
-        return await asyncio.to_thread(self.get_round, session_id, run_id)
-
-    def get_recovery_snapshot(self, session_id: str) -> dict[str, object]:
-        _ = self._session_repo.get(session_id)
-        selected = self._select_active_run(session_id)
-        if selected is None:
-            return {
-                "active_run": None,
-                "background_tasks": [],
-                "pending_tool_approvals": [],
-                "pending_user_questions": [],
-                "paused_subagent": None,
-                "round_snapshot": None,
-            }
-
-        run_id, runtime = selected
-        stream_connected = (
-            self._run_event_hub.has_subscribers(run_id)
-            if self._run_event_hub is not None
-            else False
-        )
-        approvals = [
-            {
-                "tool_call_id": record.tool_call_id,
-                "tool_name": record.tool_name,
-                "args_preview": record.args_preview,
-                "role_id": record.role_id,
-                "instance_id": record.instance_id,
-                "requested_at": record.created_at.isoformat(),
-                "status": record.status.value,
-                "feedback": record.feedback,
-            }
-            for record in self._approval_ticket_repo.list_open_by_run(run_id)
-        ]
-        user_questions = (
-            [
-                record.model_dump(mode="json")
-                for record in self._list_resolvable_user_questions_for_session(
-                    session_id
-                )
-            ]
-            if self._user_question_repo is not None
-            else []
-        )
-        run_state = (
-            self._run_state_repo.get_run_state(run_id)
-            if self._run_state_repo is not None
-            else None
-        )
-        background_tasks = [
-            record.model_dump(mode="json", exclude={"output_excerpt"})
-            for record in (
-                exec_record
-                for exec_record in (
-                    self._background_task_repository.list_by_run(run_id)
-                    if self._background_task_repository is not None
-                    else ()
-                )
-                if exec_record.execution_mode == "background"
-            )
-        ]
-        active_run = {
-            "run_id": run_id,
-            "status": runtime.status.value,
-            "phase": self._public_phase(runtime, len(approvals), len(user_questions)),
-            "is_recoverable": self._is_runtime_publicly_recoverable(runtime),
-            "last_event_id": (
-                int(run_state.last_event_id) if run_state is not None else 0
-            ),
-            "checkpoint_event_id": (
-                int(run_state.checkpoint_event_id) if run_state is not None else 0
-            ),
-            "pending_tool_approval_count": len(approvals),
-            "pending_user_question_count": len(user_questions),
-            "background_task_count": len(background_tasks),
-            "stream_connected": stream_connected,
-            "should_show_recover": self._is_runtime_publicly_recoverable(runtime)
-            and not stream_connected,
-        }
-        paused_subagent = self._paused_subagent_snapshot(runtime)
-        try:
-            round_snapshot = self.get_round(session_id, run_id)
-        except KeyError:
-            round_snapshot = None
-        if isinstance(round_snapshot, dict):
-            active_run["primary_role_id"] = round_snapshot.get("primary_role_id")
-            round_snapshot["background_task_count"] = len(background_tasks)
-        return {
-            "active_run": active_run,
-            "background_tasks": background_tasks,
-            "pending_tool_approvals": approvals,
-            "pending_user_questions": user_questions,
-            "paused_subagent": paused_subagent,
-            "round_snapshot": round_snapshot,
-        }
-
-    async def get_recovery_snapshot_async(self, session_id: str) -> dict[str, object]:
-
-        return await asyncio.to_thread(self.get_recovery_snapshot, session_id)
-
-    def get_token_usage_by_run(self, run_id: str) -> RunTokenUsage:
-        return self._token_usage_repo.get_by_run(run_id)
-
-    def get_token_usage_by_session(self, session_id: str) -> SessionTokenUsage:
-        return self._token_usage_repo.get_by_session(session_id)
-
-    async def get_token_usage_by_run_async(self, run_id: str) -> RunTokenUsage:
-
-        return await asyncio.to_thread(self._token_usage_repo.get_by_run, run_id)
-
-    async def get_token_usage_by_session_async(
-        self, session_id: str
-    ) -> SessionTokenUsage:
-
-        return await asyncio.to_thread(
-            self._token_usage_repo.get_by_session, session_id
-        )
-
     def clear_session_messages(self, session_id: str) -> int:
         _ = self._session_repo.get(session_id)
         messages = self._message_repo.get_messages_by_session(session_id)
@@ -2078,6 +1658,30 @@ class SessionService:
                 "latest_terminal_run_updated_at": latest_terminal.updated_at,
                 "has_unread_terminal_run": last_viewed_run_id != latest_terminal.run_id,
             }
+        )
+
+    def _with_subagent_count_projection(self, record: SessionRecord) -> SessionRecord:
+        if record.session_mode != SessionMode.NORMAL:
+            return record.model_copy(update={"subagent_session_count": 0})
+        counts = self._agent_repo.count_normal_mode_subagents_by_session_ids(
+            (record.session_id,)
+        )
+        return record.model_copy(
+            update={"subagent_session_count": counts.get(record.session_id, 0)}
+        )
+
+    async def _with_subagent_count_projection_async(
+        self, record: SessionRecord
+    ) -> SessionRecord:
+        if record.session_mode != SessionMode.NORMAL:
+            return record.model_copy(update={"subagent_session_count": 0})
+        counts = (
+            await self._agent_repo.count_normal_mode_subagents_by_session_ids_async(
+                (record.session_id,)
+            )
+        )
+        return record.model_copy(
+            update={"subagent_session_count": counts.get(record.session_id, 0)}
         )
 
     def _with_terminal_run_projection_from_preloaded(
@@ -2217,11 +1821,21 @@ class SessionService:
         return None
 
     def _subagent_run_ids(self, session_id: str) -> set[str]:
+        try:
+            session = self._session_repo.get(session_id)
+        except KeyError:
+            session = None
         run_ids = {
             runtime.run_id
             for runtime in self._run_runtime_repo.list_by_session(session_id)
-            if str(runtime.run_id).strip().startswith("subagent_run_")
+            if self._is_legacy_subagent_run_id(runtime.run_id)
         }
+        if session is not None:
+            run_ids.update(
+                record.run_id
+                for record in self._agent_repo.list_by_session(session_id)
+                if self._is_normal_mode_subagent_record(record, session=session)
+            )
         if self._background_task_repository is None:
             return run_ids
         return run_ids | {
@@ -2584,18 +2198,37 @@ class SessionService:
         )
 
     @staticmethod
-    def _is_subagent_run_id(run_id: str) -> bool:
+    def _is_legacy_subagent_run_id(run_id: str) -> bool:
         return str(run_id or "").strip().startswith("subagent_run_")
 
-    @staticmethod
+    def _is_subagent_run_id(self, run_id: str) -> bool:  # pragma: no cover
+        safe_run_id = str(run_id or "").strip()
+        if not safe_run_id:
+            return False
+        if self._is_legacy_subagent_run_id(safe_run_id):
+            return True
+        records = self._agent_repo.list_by_run(safe_run_id)
+        if not records:
+            return False
+        try:
+            session = self._session_repo.get(records[0].session_id)
+        except KeyError:
+            return False
+        return any(
+            self._is_normal_mode_subagent_record(record, session=session)
+            for record in records
+        )
+
     def _is_normal_mode_subagent_record(
+        self,
         record: AgentRuntimeRecord,
         *,
         session: SessionRecord,
     ) -> bool:
-        return session.session_mode == SessionMode.NORMAL and str(
-            record.run_id
-        ).strip().startswith("subagent_run_")
+        return session.session_mode == SessionMode.NORMAL and (
+            bool(str(record.parent_instance_id or "").strip())
+            or self._is_legacy_subagent_run_id(record.run_id)
+        )
 
 
 def _build_reflection_projection(

--- a/src/relay_teams/tools/runtime/action_capacity.py
+++ b/src/relay_teams/tools/runtime/action_capacity.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import time
+from collections.abc import Awaitable, Callable
+
+from pydantic import JsonValue
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.tools.runtime.context import ToolContext
+
+LOGGER = get_logger(__name__)
+TOOL_STEP_CONCURRENCY_ENV = "RELAY_TEAMS_TOOL_STEP_CONCURRENCY"
+TOOL_PENDING_WARNING_THRESHOLD_ENV = "RELAY_TEAMS_TOOL_PENDING_WARNING_THRESHOLD"
+PER_RUN_TOOL_ACTION_CONCURRENCY = 8
+
+
+def _resolve_positive_int_env(name: str, default: int) -> int:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tool.runtime.invalid_env",
+            message="Ignoring invalid tool runtime environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 1:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tool.runtime.invalid_env",
+            message="Ignoring non-positive tool runtime environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
+
+
+GLOBAL_TOOL_ACTION_CONCURRENCY = _resolve_positive_int_env(
+    TOOL_STEP_CONCURRENCY_ENV,
+    16,
+)
+TOOL_PENDING_WARNING_THRESHOLD = _resolve_positive_int_env(
+    TOOL_PENDING_WARNING_THRESHOLD_ENV,
+    200,
+)
+GLOBAL_TOOL_ACTION_SEMAPHORE = asyncio.Semaphore(GLOBAL_TOOL_ACTION_CONCURRENCY)
+_RUN_TOOL_ACTION_GATES_LOCK = threading.Lock()
+RUN_TOOL_ACTION_GATES: dict[str, _RunToolActionGate] = {}
+_TOOL_ACTION_PENDING_LOCK = threading.Lock()
+_GLOBAL_PENDING_TOOL_ACTIONS = 0
+_PENDING_TOOL_ACTIONS_BY_RUN: dict[str, int] = {}
+
+
+class _RunToolActionGate:
+    def __init__(self) -> None:
+        self.semaphore = asyncio.Semaphore(PER_RUN_TOOL_ACTION_CONCURRENCY)
+        self.ref_count = 0
+
+
+class _PendingToolActionWarningState:  # pragma: no cover
+    def __init__(self) -> None:
+        self.last_warning_at = 0.0
+
+    def should_warn(self, *, pending_total: int, now: float) -> bool:
+        if pending_total <= TOOL_PENDING_WARNING_THRESHOLD:
+            return False
+        if now - self.last_warning_at < 5.0:
+            return False
+        self.last_warning_at = now
+        return True
+
+
+_PENDING_TOOL_ACTION_WARNING_STATE = _PendingToolActionWarningState()
+
+
+async def invoke_with_tool_action_capacity(
+    *,
+    ctx: ToolContext,
+    runtime_meta: dict[str, JsonValue],
+    action_factory: Callable[[], Awaitable[object]],
+    hold_action_capacity: bool = True,
+) -> object:
+    if not hold_action_capacity:
+        runtime_meta["action_queue_wait_ms"] = 0
+        runtime_meta["tool_action_capacity_held"] = False
+        action_started = time.perf_counter()
+        try:
+            return await action_factory()
+        finally:
+            runtime_meta["action_duration_ms"] = int(
+                (time.perf_counter() - action_started) * 1000
+            )
+    run_gate = _retain_run_tool_action_gate(ctx.deps.run_id)
+    pending_total, pending_for_run, should_warn = _retain_pending_tool_action(
+        ctx.deps.run_id
+    )
+    if should_warn:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tool.action.pending_threshold_exceeded",
+            message="Pending tool action queue exceeded the warning threshold",
+            payload={
+                "run_id": ctx.deps.run_id,
+                "session_id": ctx.deps.session_id,
+                "tool_call_id": ctx.tool_call_id,
+                "pending_total": pending_total,
+                "pending_for_run": pending_for_run,
+                "threshold": TOOL_PENDING_WARNING_THRESHOLD,
+            },
+        )
+    queued_at = time.perf_counter()
+    try:
+        async with run_gate.semaphore:
+            async with GLOBAL_TOOL_ACTION_SEMAPHORE:
+                wait_ms = int((time.perf_counter() - queued_at) * 1000)
+                runtime_meta["action_queue_wait_ms"] = wait_ms
+                runtime_meta["tool_action_capacity_held"] = True
+                if wait_ms >= 250:
+                    log_event(
+                        LOGGER,
+                        logging.DEBUG,
+                        event="tool.action.queue_wait",
+                        message="Tool action waited for execution capacity",
+                        duration_ms=wait_ms,
+                        payload={
+                            "run_id": ctx.deps.run_id,
+                            "session_id": ctx.deps.session_id,
+                            "tool_call_id": ctx.tool_call_id,
+                        },
+                    )
+                action_started = time.perf_counter()
+                try:
+                    return await action_factory()
+                finally:
+                    runtime_meta["action_duration_ms"] = int(
+                        (time.perf_counter() - action_started) * 1000
+                    )
+    finally:
+        _release_pending_tool_action(ctx.deps.run_id)
+        _release_run_tool_action_gate(ctx.deps.run_id, run_gate)
+
+
+def _retain_pending_tool_action(run_id: str) -> tuple[int, int, bool]:
+    global _GLOBAL_PENDING_TOOL_ACTIONS
+    now = time.monotonic()
+    with _TOOL_ACTION_PENDING_LOCK:
+        _GLOBAL_PENDING_TOOL_ACTIONS += 1
+        pending_for_run = _PENDING_TOOL_ACTIONS_BY_RUN.get(run_id, 0) + 1
+        _PENDING_TOOL_ACTIONS_BY_RUN[run_id] = pending_for_run
+        should_warn = _PENDING_TOOL_ACTION_WARNING_STATE.should_warn(
+            pending_total=_GLOBAL_PENDING_TOOL_ACTIONS,
+            now=now,
+        )
+        return _GLOBAL_PENDING_TOOL_ACTIONS, pending_for_run, should_warn
+
+
+def _release_pending_tool_action(run_id: str) -> None:
+    global _GLOBAL_PENDING_TOOL_ACTIONS
+    with _TOOL_ACTION_PENDING_LOCK:
+        _GLOBAL_PENDING_TOOL_ACTIONS = max(0, _GLOBAL_PENDING_TOOL_ACTIONS - 1)
+        pending_for_run = max(0, _PENDING_TOOL_ACTIONS_BY_RUN.get(run_id, 0) - 1)
+        if pending_for_run == 0:
+            _PENDING_TOOL_ACTIONS_BY_RUN.pop(run_id, None)
+            return
+        _PENDING_TOOL_ACTIONS_BY_RUN[run_id] = pending_for_run
+
+
+def _retain_run_tool_action_gate(run_id: str) -> _RunToolActionGate:
+    with _RUN_TOOL_ACTION_GATES_LOCK:
+        gate = RUN_TOOL_ACTION_GATES.get(run_id)
+        if gate is None:
+            gate = _RunToolActionGate()
+            RUN_TOOL_ACTION_GATES[run_id] = gate
+        gate.ref_count += 1
+        return gate
+
+
+def _release_run_tool_action_gate(run_id: str, gate: _RunToolActionGate) -> None:
+    with _RUN_TOOL_ACTION_GATES_LOCK:
+        current = RUN_TOOL_ACTION_GATES.get(run_id)
+        if current is not gate:
+            return
+        gate.ref_count = max(0, gate.ref_count - 1)
+        if gate.ref_count == 0:
+            del RUN_TOOL_ACTION_GATES[run_id]

--- a/src/relay_teams/tools/runtime/argument_binding.py
+++ b/src/relay_teams/tools/runtime/argument_binding.py
@@ -1,0 +1,286 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from enum import Enum
+from typing import get_args, get_origin, get_type_hints
+
+from pydantic import BaseModel, JsonValue
+
+from relay_teams.tools.runtime.json_helpers import (
+    normalize_json_value as _normalize_json_value,
+)
+
+
+def _capture_tool_input(
+    *,
+    raw_args: Mapping[str, object],
+    action: Callable[..., object | Awaitable[object]] | object,
+    exclude: tuple[str, ...],
+) -> dict[str, JsonValue]:
+    excluded = set(exclude)
+    parameter_names = _tool_input_parameter_names(action)
+    result: dict[str, JsonValue] = {}
+    for name, value in raw_args.items():
+        if name in excluded or name.startswith("_"):
+            continue
+        if parameter_names is not None and name not in parameter_names:
+            continue
+        result[name] = _normalize_json_value(value)
+    return result
+
+
+def _tool_input_parameter_names(
+    action: Callable[..., object | Awaitable[object]] | object,
+) -> set[str] | None:
+    if not callable(action):
+        return None
+    parameters = list(inspect.signature(action).parameters.values())
+    if not parameters or _uses_tool_input_dict(parameters):
+        return None
+    names: set[str] = set()
+    for parameter in parameters:
+        if parameter.kind in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }:
+            names.add(parameter.name)
+    return names
+
+
+def _uses_tool_input_dict(parameters: list[inspect.Parameter]) -> bool:
+    if len(parameters) != 1:
+        return False
+    parameter = parameters[0]
+    return parameter.kind in {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    } and parameter.name in {"tool_input", "args", "tool_args"}
+
+
+def _bind_tool_action_kwargs(
+    *,
+    parameters: list[inspect.Parameter],
+    tool_input: dict[str, JsonValue],
+    resolved_annotations: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    kwargs: dict[str, object] = {}
+    for parameter in parameters:
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            kwargs.update(
+                {key: value for key, value in tool_input.items() if key not in kwargs}
+            )
+            continue
+        if parameter.kind not in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }:
+            raise TypeError(
+                f"Unsupported tool action parameter kind: {parameter.kind.value}"
+            )
+        if parameter.name not in tool_input:
+            continue
+        kwargs[parameter.name] = _coerce_tool_argument_for_parameter(
+            value=tool_input[parameter.name],
+            parameter=parameter,
+            annotation=_resolved_parameter_annotation(
+                parameter=parameter,
+                resolved_annotations=resolved_annotations,
+            ),
+        )
+    return kwargs
+
+
+def _coerce_tool_argument_for_parameter(
+    *,
+    value: JsonValue,
+    parameter: inspect.Parameter,
+    annotation: object,
+) -> object:
+    if value is None:
+        return None
+    model_list_type = _resolve_pydantic_model_list_type(annotation)
+    if model_list_type is not None and isinstance(value, list):
+        return [model_list_type.model_validate(item) for item in value]
+    model_type = _resolve_pydantic_model_type(annotation)
+    if model_type is not None and isinstance(value, dict):
+        return model_type.model_validate(value)
+    enum_type = _resolve_enum_type(annotation=annotation, parameter=parameter)
+    if enum_type is not None and isinstance(value, str):
+        return enum_type(value)
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=bool
+    ):
+        return _coerce_bool(value)
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=int
+    ):
+        return _coerce_int(value)
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=float
+    ):
+        return _coerce_float(value)
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=str
+    ):
+        return str(value)
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=tuple
+    ) and isinstance(value, list):
+        return tuple(value)
+    if _parameter_accepts_type(
+        annotation=annotation, parameter=parameter, expected_type=list
+    ) and isinstance(value, tuple):
+        return list(value)
+    return value
+
+
+def _parameter_accepts_type(
+    *,
+    annotation: object,
+    parameter: inspect.Parameter,
+    expected_type: type[object],
+) -> bool:
+    if annotation is not inspect._empty and _annotation_contains_type(
+        annotation=annotation,
+        expected_type=expected_type,
+    ):
+        return True
+    default = parameter.default
+    if default is inspect._empty or default is None:
+        return False
+    return isinstance(default, expected_type)
+
+
+def _annotation_contains_type(
+    *,
+    annotation: object,
+    expected_type: type[object],
+) -> bool:
+    if annotation is expected_type:
+        return True
+    origin = get_origin(annotation)
+    if origin is None:
+        return False
+    return any(
+        item is expected_type for item in get_args(annotation) if item is not type(None)
+    )
+
+
+def _resolve_pydantic_model_list_type(
+    annotation: object,
+) -> type[BaseModel] | None:
+    origin = get_origin(annotation)
+    if origin not in {list, tuple}:
+        return None
+    for item in get_args(annotation):
+        if inspect.isclass(item) and issubclass(item, BaseModel):
+            return item
+    return None
+
+
+def _resolve_pydantic_model_type(
+    annotation: object,
+) -> type[BaseModel] | None:
+    if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
+        return annotation
+    origin = get_origin(annotation)
+    if origin is None:
+        return None
+    for item in get_args(annotation):
+        if item is type(None):
+            continue
+        if inspect.isclass(item) and issubclass(item, BaseModel):
+            return item
+    return None
+
+
+def _resolve_enum_type(
+    *,
+    annotation: object,
+    parameter: inspect.Parameter,
+) -> type[Enum] | None:
+    if annotation is not inspect._empty:
+        candidate = _enum_type_from_annotation(annotation)
+        if candidate is not None:
+            return candidate
+    default = parameter.default
+    if default is inspect._empty or not isinstance(default, Enum):
+        return None
+    return type(default)
+
+
+def _enum_type_from_annotation(annotation: object) -> type[Enum] | None:
+    if inspect.isclass(annotation) and issubclass(annotation, Enum):
+        return annotation
+    origin = get_origin(annotation)
+    if origin is None:
+        return None
+    for item in get_args(annotation):
+        if item is type(None):
+            continue
+        if inspect.isclass(item) and issubclass(item, Enum):
+            return item
+    return None
+
+
+def _resolve_tool_action_annotations(
+    action: Callable[..., object | Awaitable[object]] | object,
+) -> dict[str, object]:
+    if not callable(action):
+        return {}
+    try:
+        return get_type_hints(action)
+    except (AttributeError, NameError, TypeError):
+        return {}
+
+
+def _resolved_parameter_annotation(
+    *,
+    parameter: inspect.Parameter,
+    resolved_annotations: Mapping[str, object] | None,
+) -> object:
+    if resolved_annotations is None:
+        return parameter.annotation
+    return resolved_annotations.get(parameter.name, parameter.annotation)
+
+
+def _coerce_bool(value: JsonValue) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _coerce_int(value: JsonValue) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            return int(stripped)
+    raise ValueError(f"Cannot coerce tool argument to int: {value!r}")
+
+
+def _coerce_float(value: JsonValue) -> float:
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            return float(stripped)
+    raise ValueError(f"Cannot coerce tool argument to float: {value!r}")

--- a/src/relay_teams/tools/runtime/audit.py
+++ b/src/relay_teams/tools/runtime/audit.py
@@ -1,0 +1,499 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from hashlib import sha256
+from typing import Protocol
+
+from pydantic import JsonValue
+
+from relay_teams.audit import AuditEventCreate, AuditEventType, AuditService
+from relay_teams.logger import get_logger, log_event
+from relay_teams.paths import path_is_file, read_bytes_file
+from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.json_helpers import (
+    normalize_json_value as _normalize_json_value,
+)
+from relay_teams.tools.runtime.persisted_state import ToolExecutionStatus
+
+LOGGER = get_logger(__name__)
+_AUDITED_FILE_WRITE_TOOLS = frozenset({"write", "write_tmp", "edit", "notebook_edit"})
+_AUDITED_TOOL_NAMES = _AUDITED_FILE_WRITE_TOOLS | frozenset(
+    {"shell", "orch_dispatch_task"}
+)
+_AUDIT_REASON_LIMIT = 4_000
+SECURITY_AUDIT_RECORD_TIMEOUT_SECONDS = 2.0
+
+
+class WorkspaceFileDigest(Protocol):
+    def __call__(
+        self,
+        *,
+        ctx: ToolContext,
+        logical_path: str,
+    ) -> tuple[str | None, int | None, str | None]:
+        raise NotImplementedError
+
+
+async def record_security_audit_event_best_effort_async(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> None:
+    try:
+        await asyncio.wait_for(
+            _record_security_audit_event_async(
+                ctx=ctx,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=tool_input,
+                visible_envelope=visible_envelope,
+                internal_data=internal_data,
+                execution_status=execution_status,
+            ),
+            timeout=SECURITY_AUDIT_RECORD_TIMEOUT_SECONDS,
+        )
+    except (asyncio.TimeoutError, RuntimeError, sqlite3.Error) as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="security.audit.record_deferred",
+            message="Security audit write skipped on tool hot path",
+            payload={
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "run_id": ctx.deps.run_id,
+                "task_id": ctx.deps.task_id,
+                "error_type": type(exc).__name__,
+            },
+        )
+
+
+async def _record_security_audit_event_best_effort_async(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> None:
+    await record_security_audit_event_best_effort_async(
+        ctx=ctx,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        tool_input=tool_input,
+        visible_envelope=visible_envelope,
+        internal_data=internal_data,
+        execution_status=execution_status,
+    )
+
+
+async def _record_security_audit_event_async(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> None:
+    if tool_name not in _AUDITED_TOOL_NAMES:
+        return
+    service = _audit_service(ctx)
+    if service is None:
+        return
+    event = await _build_security_audit_event_async(
+        ctx=ctx,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        tool_input=tool_input,
+        visible_envelope=visible_envelope,
+        internal_data=internal_data,
+        execution_status=execution_status,
+    )
+    if event is None:
+        return
+    try:
+        await service.record_event_async(event)
+    except (RuntimeError, sqlite3.Error, ValueError) as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="security.audit.record_failed",
+            message="Security audit event could not be recorded",
+            payload={
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "audit_event_type": event.event_type.value,
+                "run_id": ctx.deps.run_id,
+                "task_id": ctx.deps.task_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+
+def _audit_service(ctx: ToolContext) -> AuditService | None:
+    return ctx.deps.audit_service
+
+
+async def _build_security_audit_event_async(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> AuditEventCreate | None:
+    if tool_name in _AUDITED_FILE_WRITE_TOOLS:
+        return await _build_file_write_audit_event_async(
+            ctx=ctx,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            tool_input=tool_input,
+            visible_envelope=visible_envelope,
+            internal_data=internal_data,
+            execution_status=execution_status,
+        )
+    if tool_name == "shell":
+        return _build_shell_command_audit_event(
+            ctx=ctx,
+            tool_call_id=tool_call_id,
+            tool_input=tool_input,
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        )
+    if tool_name == "orch_dispatch_task":
+        return _build_coordinator_decision_audit_event(
+            ctx=ctx,
+            tool_call_id=tool_call_id,
+            tool_input=tool_input,
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        )
+    return None
+
+
+async def _build_file_write_audit_event_async(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> AuditEventCreate | None:
+    target = _file_write_target(tool_name, tool_input, internal_data)
+    if target is None:
+        return None
+    content_digest, content_size_bytes, digest_error = await asyncio.to_thread(
+        _workspace_file_digest,
+        ctx=ctx,
+        logical_path=target,
+    )
+    metadata = _base_audit_metadata(
+        tool_name=tool_name,
+        visible_envelope=visible_envelope,
+        execution_status=execution_status,
+    )
+    if digest_error is not None:
+        metadata["content_digest_error"] = digest_error
+    _add_file_write_metadata(
+        metadata=metadata,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        internal_data=internal_data,
+    )
+    return AuditEventCreate(
+        event_type=AuditEventType.FILE_WRITE,
+        trace_id=ctx.deps.trace_id,
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        tool_call_id=tool_call_id,
+        action=_file_write_action(tool_name),
+        target=target,
+        content_digest=content_digest,
+        content_size_bytes=content_size_bytes,
+        outcome=_audit_outcome(
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        ),
+        metadata=metadata,
+    )
+
+
+def _build_shell_command_audit_event(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+) -> AuditEventCreate | None:
+    command = _string_value(tool_input.get("command"))
+    if command is None:
+        return None
+    metadata = _base_audit_metadata(
+        tool_name="shell",
+        visible_envelope=visible_envelope,
+        execution_status=execution_status,
+    )
+    _copy_json_metadata(metadata, tool_input, "workdir")
+    _copy_json_metadata(metadata, tool_input, "background")
+    _copy_json_metadata(metadata, tool_input, "tty")
+    _copy_json_metadata(metadata, tool_input, "yield_time_ms")
+    _copy_json_metadata(metadata, tool_input, "timeout_ms")
+    _copy_result_metadata(metadata, visible_envelope, "status")
+    _copy_result_metadata(metadata, visible_envelope, "exit_code")
+    return AuditEventCreate(
+        event_type=AuditEventType.SHELL_COMMAND,
+        trace_id=ctx.deps.trace_id,
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        tool_call_id=tool_call_id,
+        action="execute_shell_command",
+        target=_truncate_text(command, 200)[0],
+        command=command,
+        outcome=_audit_outcome(
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        ),
+        metadata=metadata,
+    )
+
+
+def _build_coordinator_decision_audit_event(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+) -> AuditEventCreate | None:
+    task_id = _string_value(tool_input.get("task_id"))
+    selected_role_id = _string_value(tool_input.get("role_id"))
+    if task_id is None or selected_role_id is None:
+        return None
+    prompt = _string_value(tool_input.get("prompt")) or ""
+    reason_source = (
+        prompt.strip()
+        or "Coordinator dispatched task with the default execution prompt."
+    )
+    decision_reason, reason_truncated = _truncate_text(
+        reason_source,
+        _AUDIT_REASON_LIMIT,
+    )
+    metadata = _base_audit_metadata(
+        tool_name="orch_dispatch_task",
+        visible_envelope=visible_envelope,
+        execution_status=execution_status,
+    )
+    metadata["dispatched_task_id"] = task_id
+    metadata["selected_role_id"] = selected_role_id
+    metadata["decision_reason_digest"] = _text_digest(reason_source)
+    metadata["decision_reason_length"] = len(reason_source)
+    metadata["decision_reason_truncated"] = reason_truncated
+    return AuditEventCreate(
+        event_type=AuditEventType.COORDINATOR_DECISION,
+        trace_id=ctx.deps.trace_id,
+        run_id=ctx.deps.run_id,
+        session_id=ctx.deps.session_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        tool_call_id=tool_call_id,
+        action="dispatch_task",
+        target=f"task:{task_id}->role:{selected_role_id}",
+        decision_reason=decision_reason,
+        outcome=_audit_outcome(
+            visible_envelope=visible_envelope,
+            execution_status=execution_status,
+        ),
+        metadata=metadata,
+    )
+
+
+def _base_audit_metadata(
+    *,
+    tool_name: str,
+    visible_envelope: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+) -> dict[str, JsonValue]:
+    metadata: dict[str, JsonValue] = {
+        "tool_name": tool_name,
+        "execution_status": execution_status.value,
+        "tool_ok": visible_envelope.get("ok") is True,
+    }
+    error_type = _visible_error_type(visible_envelope)
+    if error_type is not None:
+        metadata["error_type"] = error_type
+    return metadata
+
+
+def _audit_outcome(
+    *,
+    visible_envelope: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+) -> str:
+    if visible_envelope.get("ok") is True and execution_status == (
+        ToolExecutionStatus.COMPLETED
+    ):
+        return "completed"
+    return "failed"
+
+
+def _visible_error_type(visible_envelope: dict[str, JsonValue]) -> str | None:
+    error = visible_envelope.get("error")
+    if not isinstance(error, dict):
+        return None
+    value = error.get("type")
+    return value if isinstance(value, str) and value else None
+
+
+def _copy_json_metadata(
+    metadata: dict[str, JsonValue],
+    source: dict[str, JsonValue],
+    key: str,
+) -> None:
+    if key in source:
+        metadata[key] = source[key]
+
+
+def _copy_result_metadata(
+    metadata: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    key: str,
+) -> None:
+    data = visible_envelope.get("data")
+    if not isinstance(data, dict):
+        return
+    value = data.get(key)
+    if value is not None:
+        metadata[key] = _normalize_json_value(value)
+
+
+def _add_file_write_metadata(
+    *,
+    metadata: dict[str, JsonValue],
+    tool_name: str,
+    tool_input: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+) -> None:
+    content_field = _file_content_input_field(tool_name)
+    if content_field is not None:
+        content = _string_value(tool_input.get(content_field))
+        if content is not None:
+            metadata["input_content_digest"] = _text_digest(content)
+            metadata["input_content_length"] = len(content)
+    if isinstance(internal_data, dict):
+        created = internal_data.get("created")
+        if isinstance(created, bool):
+            metadata["created"] = created
+        diff_summary = internal_data.get("diff_summary")
+        if isinstance(diff_summary, str) and diff_summary:
+            metadata["diff_summary"] = diff_summary
+
+
+def _file_content_input_field(tool_name: str) -> str | None:
+    if tool_name in {"write", "write_tmp"}:
+        return "content"
+    if tool_name == "edit":
+        return "new_string"
+    if tool_name == "notebook_edit":
+        return "new_source"
+    return None
+
+
+def _file_write_target(
+    tool_name: str,
+    tool_input: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+) -> str | None:
+    if tool_name == "write_tmp":
+        internal_path = _internal_data_text(internal_data, "path")
+        if internal_path is not None:
+            return internal_path
+        raw_tmp_path = _string_value(tool_input.get("path"))
+        if raw_tmp_path is None:
+            return None
+        if raw_tmp_path == "tmp" or raw_tmp_path.startswith(("tmp/", "tmp\\")):
+            return raw_tmp_path
+        return f"tmp/{raw_tmp_path}"
+    return _string_value(tool_input.get("path")) or _internal_data_text(
+        internal_data,
+        "path",
+    )
+
+
+def _file_write_action(tool_name: str) -> str:
+    if tool_name == "edit":
+        return "edit_file"
+    if tool_name == "notebook_edit":
+        return "edit_notebook"
+    if tool_name == "write_tmp":
+        return "write_tmp_file"
+    return "write_file"
+
+
+def _workspace_file_digest(
+    *,
+    ctx: ToolContext,
+    logical_path: str,
+) -> tuple[str | None, int | None, str | None]:
+    try:
+        file_path = ctx.deps.workspace.resolve_path(logical_path, write=False)
+        if not path_is_file(file_path):
+            return None, None, "target is not a file"
+        content = read_bytes_file(file_path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        return None, None, f"{type(exc).__name__}: {exc}"
+    return f"sha256:{sha256(content).hexdigest()}", len(content), None
+
+
+def set_workspace_file_digest_override_for_testing(
+    digest: WorkspaceFileDigest,
+) -> None:
+    global _workspace_file_digest
+    _workspace_file_digest = digest
+
+
+def _internal_data_text(internal_data: JsonValue | None, key: str) -> str | None:
+    if not isinstance(internal_data, dict):
+        return None
+    return _string_value(internal_data.get(key))
+
+
+def _string_value(value: JsonValue | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+def _text_digest(value: str) -> str:
+    return f"sha256:{sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def _truncate_text(value: str, limit: int) -> tuple[str, bool]:
+    if len(value) <= limit:
+        return value, False
+    return value[:limit], True

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -162,6 +162,7 @@ class ToolDeps(BaseModel):
     run_id: str
     trace_id: str
     task_id: str
+    is_root_task_context: bool = False
     session_id: str
     session_mode: str = "normal"
     run_kind: str = "conversation"

--- a/src/relay_teams/tools/runtime/execution.py
+++ b/src/relay_teams/tools/runtime/execution.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from pydantic import BaseModel, JsonValue, ValidationError
+from pydantic import JsonValue, ValidationError
 from pydantic_ai.messages import ToolReturn
 
 import asyncio
@@ -9,15 +9,14 @@ import contextvars
 import inspect
 import json
 import logging
+import os
 import sqlite3
-import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from hashlib import sha256
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime, timezone
-from enum import Enum
 from json import dumps
 from typing import (
     Literal,
@@ -25,25 +24,20 @@ from typing import (
     Protocol,
     TypeVar,
     cast,
-    get_args,
-    get_origin,
-    get_type_hints,
     overload,
     runtime_checkable,
 )
 from uuid import uuid4
 
-from relay_teams.audit import AuditEventCreate, AuditEventType, AuditService
 from relay_teams.logger import get_logger, log_event, log_tool_error
 from relay_teams.agent_runtimes.instances.models import (
     AgentRuntimeRecord,
     RuntimeToolSnapshotEntry,
     RuntimeToolsSnapshot,
 )
-from relay_teams.media import ContentPart, TextContentPart, UserPromptContent
+from relay_teams.media import ContentPart, UserPromptContent
 from relay_teams.metrics.adapters import record_tool_execution_async
 from relay_teams.notifications import NotificationContext, NotificationType
-from relay_teams.paths import path_is_file, read_bytes_file
 from relay_teams.persistence import is_retryable_sqlite_error
 from relay_teams.agents.tasks.task_status_sanitizer import (
     sanitize_task_status_payload,
@@ -67,6 +61,23 @@ from relay_teams.tools.runtime.approval_ticket_repo import (
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimePhase, RunRuntimeStatus
 from relay_teams.trace import trace_span
 from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.audit import (
+    _workspace_file_digest as _workspace_file_digest,
+    record_security_audit_event_best_effort_async,
+    set_workspace_file_digest_override_for_testing,
+)
+from relay_teams.tools.runtime.json_helpers import (
+    normalize_json_object as _normalize_json_object,
+    normalize_json_value as _normalize_json_value,
+    safe_json as _safe_json,
+    _tool_return_content,
+)
+from relay_teams.tools.runtime.argument_binding import (
+    _bind_tool_action_kwargs,
+    _capture_tool_input,
+    _resolve_tool_action_annotations,
+    _uses_tool_input_dict,
+)
 from relay_teams.tools.runtime.guardrails import (
     RuntimeGuardrailAction,
     RuntimeGuardrailContext,
@@ -93,12 +104,28 @@ from relay_teams.tools.runtime.models import (
     ToolResultProjection,
 )
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
+from relay_teams.tools.runtime.tool_result_batching import (
+    ToolResultCommitBuffer,
+    ToolResultCommitItem,
+    current_tool_result_commit_buffer,
+    suspended_tool_result_batching,
+    tool_result_batch_scope,
+)
+from relay_teams.tools.runtime.runtime_phase import (
+    _active_subagent_instance_id,
+    _finalize_tool_timing_meta,
+    _int_meta,
+    _running_runtime_phase,
+)
 from relay_teams.tools.runtime.persisted_state import (
     ToolApprovalMode,
     ToolApprovalStatus,
     ToolExecutionStatus,
+    PersistedToolCallState,
     load_tool_call_state_async,
+    load_tool_call_states_async,
     merge_tool_call_state_async,
+    tool_call_state_mutation,
 )
 from relay_teams.env.hook_runtime_env import (
     reset_tool_hook_runtime_env,
@@ -108,21 +135,101 @@ from relay_teams.hooks import (
     HookDecisionBundle,
     HookDecisionType,
     HookEventName,
+    HookService,
     PermissionDeniedInput,
     PermissionRequestInput,
     PostToolUseFailureInput,
     PostToolUseInput,
     PreToolUseInput,
 )
+from relay_teams.tools.runtime import action_capacity as _action_capacity
+from relay_teams.tools.runtime.action_capacity import (
+    invoke_with_tool_action_capacity,
+)
 
 LOGGER = get_logger(__name__)
+__all__ = (
+    "execute_tool",
+    "execute_tool_call",
+    "flush_tool_result_batch_async",
+    "suspended_tool_result_batching",
+    "tool_result_batch_scope",
+    "tool_result_batching_active",
+)
 ParamT = ParamSpec("ParamT")
 ResultT = TypeVar("ResultT")
-TOOL_ACTION_WORKER_COUNT = 16
-TOOL_STATE_WORKER_COUNT = 4
-TOOL_APPROVAL_WORKER_COUNT = 4
-PER_RUN_TOOL_ACTION_CONCURRENCY = 8
-GLOBAL_TOOL_ACTION_CONCURRENCY = 16
+PER_RUN_TOOL_ACTION_CONCURRENCY = _action_capacity.PER_RUN_TOOL_ACTION_CONCURRENCY
+_GLOBAL_TOOL_ACTION_SEMAPHORE = _action_capacity.GLOBAL_TOOL_ACTION_SEMAPHORE
+_RUN_TOOL_ACTION_GATES = _action_capacity.RUN_TOOL_ACTION_GATES
+_DEFERRED_TOOL_STATE_PERSIST_RETRY_DELAYS_SECONDS = (0.25, 1.0)
+_DEFERRED_TOOL_STATE_PERSIST_TASKS: set[asyncio.Task[None]] = set()
+
+
+async def _record_security_audit_event_best_effort_async(  # pragma: no cover
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_call_id: str,
+    tool_input: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    execution_status: ToolExecutionStatus,
+) -> None:
+    set_workspace_file_digest_override_for_testing(_workspace_file_digest)
+    await record_security_audit_event_best_effort_async(
+        ctx=ctx,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        tool_input=tool_input,
+        visible_envelope=visible_envelope,
+        internal_data=internal_data,
+        execution_status=execution_status,
+    )
+
+
+def _resolve_positive_int_env(name: str, default: int) -> int:  # pragma: no cover
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tool.runtime.invalid_env",
+            message="Ignoring invalid tool runtime environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    if value < 1:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tool.runtime.invalid_env",
+            message="Ignoring non-positive tool runtime environment override",
+            payload={"name": name, "value": raw_value, "default": default},
+        )
+        return default
+    return value
+
+
+TOOL_ACTION_WORKER_COUNT = _resolve_positive_int_env(
+    "RELAY_TEAMS_TOOL_ACTION_WORKERS",
+    64,
+)
+TOOL_STATE_WORKER_COUNT = _resolve_positive_int_env(
+    "RELAY_TEAMS_TOOL_STATE_WORKERS",
+    4,
+)
+TOOL_APPROVAL_WORKER_COUNT = _resolve_positive_int_env(
+    "RELAY_TEAMS_TOOL_APPROVAL_WORKERS",
+    4,
+)
+READ_TOOL_STATE_COMPACT_THRESHOLD_BYTES = _resolve_positive_int_env(
+    "RELAY_TEAMS_READ_TOOL_STATE_COMPACT_THRESHOLD_BYTES",
+    16_384,
+)
 _TOOL_ACTION_EXECUTOR = ThreadPoolExecutor(
     max_workers=TOOL_ACTION_WORKER_COUNT,
     thread_name_prefix="tool-action",
@@ -135,23 +242,270 @@ _TOOL_APPROVAL_EXECUTOR = ThreadPoolExecutor(
     max_workers=TOOL_APPROVAL_WORKER_COUNT,
     thread_name_prefix="tool-approval",
 )
-_GLOBAL_TOOL_ACTION_SEMAPHORE = asyncio.Semaphore(GLOBAL_TOOL_ACTION_CONCURRENCY)
-_RUN_TOOL_ACTION_GATES_LOCK = threading.Lock()
-_RUN_TOOL_ACTION_GATES: dict[str, _RunToolActionGate] = {}
-_AUDITED_FILE_WRITE_TOOLS = frozenset({"write", "write_tmp", "edit", "notebook_edit"})
-_AUDITED_TOOL_NAMES = _AUDITED_FILE_WRITE_TOOLS | frozenset(
-    {"shell", "orch_dispatch_task"}
+_BATCH_SINGLEFLIGHT_ACTION_TOOLS = frozenset(
+    {
+        "glob",
+        "grep",
+        "list_run_tasks",
+        "read",
+        "todo_read",
+    }
 )
-_AUDIT_REASON_LIMIT = 4_000
+_BATCH_DEFERRED_RUNNING_STATE_TOOLS = _BATCH_SINGLEFLIGHT_ACTION_TOOLS | frozenset(
+    {"spawn_subagent"}
+)
+_TOOL_MIDDLEWARE_HOOK_EVENTS = frozenset(
+    {
+        HookEventName.PRE_TOOL_USE,
+        HookEventName.PERMISSION_REQUEST,
+        HookEventName.PERMISSION_DENIED,
+        HookEventName.POST_TOOL_USE,
+        HookEventName.POST_TOOL_USE_FAILURE,
+    }
+)
+TOOL_RESULT_EVENT_PUBLISH_TIMEOUT_SECONDS = 2.0
+TOOL_RESULT_STATE_PERSIST_TIMEOUT_SECONDS = 2.0
+TOOL_METRICS_RECORD_TIMEOUT_SECONDS = 1.0
+TOOL_RESULT_BATCH_FLUSH_TIMEOUT_SECONDS = (
+    _resolve_positive_int_env(
+        "RELAY_TEAMS_TOOL_RESULT_BATCH_FLUSH_TIMEOUT_MS",
+        30_000,
+    )
+    / 1000
+)
+TOOL_RESULT_BATCH_MAX_SIZE = _resolve_positive_int_env(
+    "RELAY_TEAMS_TOOL_RESULT_BATCH_MAX_SIZE",
+    100,
+)
 
 
-class _RunToolActionGate:
-    def __init__(self) -> None:
-        self.semaphore = asyncio.Semaphore(PER_RUN_TOOL_ACTION_CONCURRENCY)
-        self.ref_count = 0
+async def flush_tool_result_batch_async(  # pragma: no cover
+    buffer: ToolResultCommitBuffer,
+    *,
+    published_tool_outcome_ids: set[str],
+) -> bool:
+    try:
+        items = await asyncio.wait_for(
+            buffer.pop_items_async(),
+            timeout=TOOL_RESULT_BATCH_FLUSH_TIMEOUT_SECONDS,
+        )
+        if not items:
+            return False
+        return await asyncio.wait_for(
+            _flush_tool_result_batch_items_async(
+                items=items,
+                published_tool_outcome_ids=published_tool_outcome_ids,
+            ),
+            timeout=TOOL_RESULT_BATCH_FLUSH_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError as exc:
+        log_event(
+            LOGGER,
+            logging.ERROR,
+            event="tool.result_batch.flush_timeout",
+            message="Timed out flushing buffered tool results",
+            payload={
+                "timeout_ms": int(TOOL_RESULT_BATCH_FLUSH_TIMEOUT_SECONDS * 1000),
+            },
+        )
+        raise RuntimeError("tool_result_batch_flush timed out") from exc
 
 
-async def _run_tool_state_work(
+async def _flush_tool_result_batch_items_async(
+    *,
+    items: tuple[ToolResultCommitItem, ...],
+    published_tool_outcome_ids: set[str],
+) -> bool:
+    started = time.perf_counter()
+    batch_id = _tool_result_batch_id(items)
+    publish_started = time.perf_counter()
+    for item in items:
+        _mark_tool_result_event_state(
+            runtime_meta=item.runtime_meta,
+            visible_envelope=item.visible_envelope,
+            published=True,
+        )
+        item.runtime_meta["tool_result_batch_id"] = batch_id
+        item.runtime_meta["tool_result_batch_size"] = len(items)
+    result_event_ids = await _publish_tool_result_events_batch_async(items)
+    for item in items:
+        published_tool_outcome_ids.add(item.tool_call_id)
+    publish_ms = int((time.perf_counter() - publish_started) * 1000)
+    persist_started = time.perf_counter()
+    if _can_defer_tool_records_batch(items):
+        _defer_tool_records_batch_persist(
+            items=items,
+            result_event_ids=result_event_ids,
+        )
+    else:
+        await _persist_tool_records_batch_async(
+            items=items,
+            result_event_ids=result_event_ids,
+        )
+    persist_ms = int((time.perf_counter() - persist_started) * 1000)
+    metrics_ms = 0
+    _record_tool_metrics_batch_deferred(items)
+    total_ms = int((time.perf_counter() - started) * 1000)
+    for item in items:
+        item.runtime_meta["tool_result_batch_publish_ms"] = publish_ms
+        item.runtime_meta["tool_result_batch_state_persist_ms"] = persist_ms
+        item.runtime_meta["tool_result_batch_metrics_ms"] = metrics_ms
+        item.runtime_meta["tool_result_batch_total_ms"] = total_ms
+        item.runtime_meta["tool_result_publish_ms"] = publish_ms
+        item.runtime_meta["tool_result_persist_ms"] = persist_ms
+    log_event(
+        LOGGER,
+        logging.INFO,
+        event="tool.result_batch.flushed",
+        message="Flushed buffered tool results",
+        payload={
+            "run_id": items[0].ctx.deps.run_id,
+            "task_id": items[0].ctx.deps.task_id,
+            "tool_result_batch_id": batch_id,
+            "tool_result_batch_size": len(items),
+            "tool_result_batch_publish_ms": publish_ms,
+            "tool_result_batch_state_persist_ms": persist_ms,
+            "tool_result_batch_metrics_ms": metrics_ms,
+            "tool_result_batch_total_ms": total_ms,
+        },
+    )
+    return True
+
+
+def tool_result_batching_active() -> bool:
+    return current_tool_result_commit_buffer() is not None
+
+
+async def _can_use_lightweight_batched_fast_path(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    approval_request: ToolApprovalRequest | None,
+    approval_request_factory: Callable[
+        [dict[str, JsonValue]], ToolApprovalRequest | None
+    ]
+    | None,
+    force_approval: bool,
+    allow_tool_return: bool,
+) -> bool:
+    if not (
+        tool_result_batching_active()
+        and tool_name in _BATCH_SINGLEFLIGHT_ACTION_TOOLS
+        and _policy_uses_yolo(ctx.deps.tool_approval_policy)
+        and approval_request is None
+        and approval_request_factory is None
+        and not force_approval
+        and allow_tool_return
+    ):
+        return False
+    return await _can_bypass_lightweight_tool_middleware_async(ctx)
+
+
+async def _can_bypass_lightweight_tool_middleware_async(ctx: ToolContext) -> bool:
+    buffer = current_tool_result_commit_buffer()
+    if buffer is None:
+        return _can_bypass_lightweight_tool_middleware_uncached(ctx)
+    key = _tool_middleware_bypass_cache_key(ctx)
+    return await buffer.middleware_bypass_allowed_async(
+        key=key,
+        factory=partial(_can_bypass_lightweight_tool_middleware_uncached, ctx),
+    )
+
+
+def _can_bypass_lightweight_tool_middleware_uncached(ctx: ToolContext) -> bool:
+    if _has_tool_middleware_hooks(ctx):
+        return False
+    guardrail_policy = _guardrail_policy_from_runtime_policy(
+        ctx.deps.tool_approval_policy
+    )
+    return not guardrail_policy.enabled
+
+
+def _has_tool_middleware_hooks(ctx: ToolContext) -> bool:
+    hook_service = getattr(ctx.deps, "hook_service", None)
+    if hook_service is None:
+        return False
+    if not isinstance(hook_service, HookService):
+        return True
+    try:
+        snapshot = hook_service.get_effective_config()
+    except (OSError, RuntimeError, ValueError):
+        return True
+    return any(
+        bool(snapshot.hooks.get(event_name))
+        for event_name in _TOOL_MIDDLEWARE_HOOK_EVENTS
+    )
+
+
+def _defer_batch_tool_recovery_state(*, tool_name: str) -> bool:
+    return (
+        tool_result_batching_active()
+        and tool_name in _BATCH_DEFERRED_RUNNING_STATE_TOOLS
+    )
+
+
+def _can_defer_tool_records_batch(items: tuple[ToolResultCommitItem, ...]) -> bool:
+    if not items:
+        return False
+    return all(item.tool_name in _BATCH_DEFERRED_RUNNING_STATE_TOOLS for item in items)
+
+
+def _defer_tool_records_batch_persist(
+    *,
+    items: tuple[ToolResultCommitItem, ...],
+    result_event_ids: dict[str, int],
+) -> None:
+    _ = result_event_ids
+    payload: dict[str, JsonValue] = {
+        "batch_size": len(items),
+        "tool_names": [name for name in sorted({item.tool_name for item in items})],
+    }
+    log_event(
+        LOGGER,
+        logging.DEBUG,
+        event="tool.result_batch.state_persist_skipped",
+        message="Skipped lightweight batched tool result state persist",
+        payload=payload,
+    )
+
+
+async def _persist_tool_records_batch_best_effort_async(  # pragma: no cover
+    *,
+    items: tuple[ToolResultCommitItem, ...],
+    result_event_ids: dict[str, int],
+) -> None:
+    started = time.perf_counter()
+    try:
+        await _persist_tool_records_batch_async(
+            items=items,
+            result_event_ids=result_event_ids,
+        )
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tool.result_batch.state_persist_deferred_failed",
+            message="Deferred tool result state persist failed",
+            payload={
+                "batch_size": len(items),
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+        return
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    if duration_ms >= 1000:
+        log_event(
+            LOGGER,
+            logging.DEBUG,
+            event="tool.result_batch.state_persist_deferred",
+            message="Deferred tool result state persist completed",
+            duration_ms=duration_ms,
+            payload={"batch_size": len(items)},
+        )
+
+
+async def _run_tool_state_work(  # pragma: no cover
     function: Callable[ParamT, ResultT],
     /,
     *args: ParamT.args,
@@ -164,7 +518,7 @@ async def _run_tool_state_work(
     )
 
 
-async def _run_tool_approval_work(
+async def _run_tool_approval_work(  # pragma: no cover
     function: Callable[ParamT, ResultT],
     /,
     *args: ParamT.args,
@@ -204,6 +558,24 @@ class _AsyncRunRuntimeRepository(Protocol):
 
 
 @runtime_checkable
+class _AsyncRunEventBatchPublisher(Protocol):
+    async def publish_many_async(
+        self,
+        events: tuple[RunEvent, ...],
+    ) -> tuple[int, ...]:
+        raise NotImplementedError
+
+
+@runtime_checkable
+class _AsyncRunEventDeferredBatchPublisher(Protocol):
+    async def publish_many_deferred_async(
+        self,
+        events: tuple[RunEvent, ...],
+    ) -> tuple[int, ...]:
+        raise NotImplementedError
+
+
+@runtime_checkable
 class _RuntimeToolsAgentRepository(Protocol):
     @staticmethod
     async def get_instance_async(instance_id: str) -> AgentRuntimeRecord:
@@ -212,7 +584,7 @@ class _RuntimeToolsAgentRepository(Protocol):
 
 # noinspection PyUnusedLocal,PyTypeHints
 @overload
-async def execute_tool(
+async def execute_tool(  # pragma: no cover
     ctx: ToolContext,
     *,
     tool_name: str,
@@ -233,6 +605,7 @@ async def execute_tool(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    hold_action_capacity: bool = True,
     allow_tool_return: Literal[False] = False,
 ) -> dict[str, JsonValue]: ...
 
@@ -260,6 +633,7 @@ async def execute_tool(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    hold_action_capacity: bool = True,
     allow_tool_return: Literal[True] = True,
 ) -> ToolReturn | dict[str, JsonValue]: ...
 
@@ -286,6 +660,7 @@ async def execute_tool(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    hold_action_capacity: bool = True,
     allow_tool_return: bool = False,
 ) -> ToolReturn | dict[str, JsonValue]:
     """Run a tool action with approval, logging, and normalized envelopes."""
@@ -319,10 +694,15 @@ async def execute_tool(
         meta: dict[str, JsonValue] = {}
         effective_tool_input = dict(args_summary if tool_input is None else tool_input)
         _raise_if_stopped(ctx)
-        role_contract_error = _apply_role_contract_check(ctx=ctx, tool_name=tool_name)
+        role_contract_error = await _apply_role_contract_check_async(
+            ctx=ctx,
+            tool_name=tool_name,
+        )
         if role_contract_error is not None:
-            elapsed_ms = int((time.perf_counter() - started) * 1000)
-            meta["duration_ms"] = elapsed_ms
+            elapsed_ms = _finalize_tool_timing_meta(
+                runtime_meta=meta,
+                started=started,
+            )
             meta["approval_status"] = "denied_by_policy"
             meta["runtime_policy_decision"] = "deny"
             meta["role_id"] = ctx.deps.role_id
@@ -356,6 +736,118 @@ async def execute_tool(
             )
             return envelope
         requested_force_approval = force_approval
+        if await _can_use_lightweight_batched_fast_path(
+            ctx=ctx,
+            tool_name=tool_name,
+            approval_request=approval_request,
+            approval_request_factory=approval_request_factory,
+            force_approval=requested_force_approval,
+            allow_tool_return=allow_tool_return,
+        ):
+            try:
+                result = await _invoke_tool_action_with_limits(
+                    ctx=ctx,
+                    tool_name=tool_name,
+                    action=action,
+                    tool_input=effective_tool_input,
+                    runtime_meta=meta,
+                    hold_action_capacity=False,
+                )
+                (
+                    visible_data,
+                    internal_data,
+                    tool_content_parts,
+                ) = _normalize_result_payload(result)
+                fast_tool_return_content: UserPromptContent | None = None
+                if tool_content_parts and not allow_tool_return:
+                    raise ValueError(
+                        f"Tool {tool_name} produced model content on the lightweight batch fast path."
+                    )
+                if tool_content_parts:
+                    fast_tool_return_content = _tool_return_content(
+                        ctx=ctx,
+                        tool_name=tool_name,
+                        tool_content_parts=tool_content_parts,
+                    )
+                _ = _finalize_tool_timing_meta(runtime_meta=meta, started=started)
+                meta["run_yolo"] = True
+                meta["approval_required"] = False
+                meta["approval_mode"] = ToolApprovalMode.YOLO.value
+                meta["approval_status"] = "not_required"
+                meta["lightweight_batch_fast_path"] = True
+                envelope = _visible_envelope(ok=True, data=visible_data, meta=meta)
+                await _persist_and_publish_tool_result_async(
+                    ctx=ctx,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                    args_summary=args_summary,
+                    visible_envelope=envelope,
+                    internal_data=internal_data,
+                    runtime_meta=meta,
+                    execution_status=ToolExecutionStatus.COMPLETED,
+                    tool_content_parts=tool_content_parts,
+                )
+                await _record_security_audit_event_best_effort_async(
+                    ctx=ctx,
+                    tool_name=tool_name,
+                    tool_call_id=tool_call_id,
+                    tool_input=effective_tool_input,
+                    visible_envelope=envelope,
+                    internal_data=internal_data,
+                    execution_status=ToolExecutionStatus.COMPLETED,
+                )
+                if fast_tool_return_content is not None:
+                    return ToolReturn(
+                        return_value=envelope,
+                        content=fast_tool_return_content,
+                    )
+                return envelope
+            except Exception as exc:
+                elapsed_ms = _finalize_tool_timing_meta(
+                    runtime_meta=meta,
+                    started=started,
+                )
+                error = _error_payload(exc)
+                if error.details:
+                    meta["error_details"] = dict(error.details)
+                meta["run_yolo"] = True
+                meta["approval_required"] = False
+                meta["approval_mode"] = ToolApprovalMode.YOLO.value
+                meta["approval_status"] = "not_required"
+                meta["lightweight_batch_fast_path"] = True
+                envelope = _visible_envelope(ok=False, error=error, meta=meta)
+                await _observe_tool_result_reminders_async(
+                    ctx=ctx,
+                    tool_name=tool_name,
+                    tool_call_id=tool_call_id,
+                    envelope=envelope,
+                )
+                await _record_security_audit_event_best_effort_async(
+                    ctx=ctx,
+                    tool_name=tool_name,
+                    tool_call_id=tool_call_id,
+                    tool_input=effective_tool_input,
+                    visible_envelope=envelope,
+                    internal_data=None,
+                    execution_status=ToolExecutionStatus.FAILED,
+                )
+                await _persist_and_publish_tool_result_async(
+                    ctx=ctx,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                    args_summary=args_summary,
+                    visible_envelope=envelope,
+                    internal_data=None,
+                    runtime_meta=meta,
+                    execution_status=ToolExecutionStatus.FAILED,
+                )
+                await _record_tool_metrics_async(
+                    ctx=ctx,
+                    tool_name=tool_name,
+                    duration_ms=elapsed_ms,
+                    success=False,
+                )
+                return envelope
         hook_force_approval = False
         (
             effective_tool_input,
@@ -377,13 +869,16 @@ async def execute_tool(
         )
         if pre_tool_error is None and pre_guardrail_error is not None:
             pre_tool_error = pre_guardrail_error
-        reusable_result = await _reusable_tool_result_async(
-            ctx=ctx,
-            args_preview=_safe_json(args_summary),
-            tool_call_id=tool_call_id,
-            tool_name=tool_name,
-            allow_tool_return=allow_tool_return,
-        )
+        defer_recovery_state = _defer_batch_tool_recovery_state(tool_name=tool_name)
+        reusable_result = None
+        if not defer_recovery_state:
+            reusable_result = await _reusable_tool_result_async(
+                ctx=ctx,
+                args_preview=_safe_json(args_summary),
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                allow_tool_return=allow_tool_return,
+            )
         if pre_tool_error is None and reusable_result is not None:
             log_event(
                 LOGGER,
@@ -423,8 +918,10 @@ async def execute_tool(
                 force_approval=requested_force_approval or hook_force_approval,
             )
         if approval_error is not None:
-            elapsed_ms = int((time.perf_counter() - started) * 1000)
-            meta["duration_ms"] = elapsed_ms
+            elapsed_ms = _finalize_tool_timing_meta(
+                runtime_meta=meta,
+                started=started,
+            )
             envelope = _visible_envelope(
                 ok=False,
                 error=approval_error,
@@ -436,7 +933,7 @@ async def execute_tool(
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            await _record_security_audit_event_async(
+            await _record_security_audit_event_best_effort_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
@@ -463,49 +960,46 @@ async def execute_tool(
             )
             return envelope
 
-        await _ensure_run_runtime_async(ctx=ctx)
-        await _update_run_runtime_async(
-            ctx=ctx,
-            status=RunRuntimeStatus.RUNNING,
-            phase=RunRuntimePhase.COORDINATOR_RUNNING
-            if ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id)
-            else RunRuntimePhase.SUBAGENT_RUNNING,
-            active_instance_id=ctx.deps.instance_id,
-            active_task_id=ctx.deps.task_id,
-            active_role_id=ctx.deps.role_id,
-            active_subagent_instance_id=(
-                None
-                if ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id)
-                else ctx.deps.instance_id
-            ),
-            last_error=None,
-        )
-        try:
-            await _mark_tool_running_async(
+        if defer_recovery_state:
+            meta["tool_running_state_deferred"] = True
+        else:
+            await _ensure_run_runtime_async(ctx=ctx)
+            await _update_run_runtime_async(
                 ctx=ctx,
-                tool_call_id=tool_call_id,
-                tool_name=tool_name,
-                args_summary=args_summary,
-                runtime_meta=meta,
+                status=RunRuntimeStatus.RUNNING,
+                phase=_running_runtime_phase(ctx),
+                active_instance_id=ctx.deps.instance_id,
+                active_task_id=ctx.deps.task_id,
+                active_role_id=ctx.deps.role_id,
+                active_subagent_instance_id=_active_subagent_instance_id(ctx),
+                last_error=None,
             )
-        except Exception as exc:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="tool.running_state_persist_failed",
-                message=(
-                    "Tool call will run, but its pre-run recovery state could "
-                    "not be persisted"
-                ),
-                payload={
-                    "run_id": ctx.deps.run_id,
-                    "task_id": ctx.deps.task_id,
-                    "tool_name": tool_name,
-                    "tool_call_id": tool_call_id,
-                    "error_type": type(exc).__name__,
-                    "error": str(exc),
-                },
-            )
+            try:
+                await _mark_tool_running_async(
+                    ctx=ctx,
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                    args_summary=args_summary,
+                    runtime_meta=meta,
+                )
+            except Exception as exc:
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="tool.running_state_persist_failed",
+                    message=(
+                        "Tool call will run, but its pre-run recovery state could "
+                        "not be persisted"
+                    ),
+                    payload={
+                        "run_id": ctx.deps.run_id,
+                        "task_id": ctx.deps.task_id,
+                        "tool_name": tool_name,
+                        "tool_call_id": tool_call_id,
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    },
+                )
 
         try:
             _raise_if_stopped(ctx)
@@ -513,8 +1007,11 @@ async def execute_tool(
             try:
                 result = await _invoke_tool_action_with_limits(
                     ctx=ctx,
+                    tool_name=tool_name,
                     action=action,
                     tool_input=effective_tool_input,
+                    runtime_meta=meta,
+                    hold_action_capacity=hold_action_capacity,
                 )
             finally:
                 reset_tool_hook_runtime_env(hook_env_token)
@@ -523,8 +1020,10 @@ async def execute_tool(
                 result
             )
 
-            elapsed_ms = int((time.perf_counter() - started) * 1000)
-            meta["duration_ms"] = elapsed_ms
+            elapsed_ms = _finalize_tool_timing_meta(
+                runtime_meta=meta,
+                started=started,
+            )
 
             log_event(
                 LOGGER,
@@ -592,14 +1091,14 @@ async def execute_tool(
             await _record_tool_metrics_async(
                 ctx=ctx,
                 tool_name=tool_name,
-                duration_ms=elapsed_ms,
+                duration_ms=_int_meta(meta, "duration_ms"),
                 success=final_success,
             )
             if approval_ticket_id and not keep_approval_ticket_reusable:
                 await ctx.deps.approval_ticket_repo.mark_completed_async(
                     approval_ticket_id
                 )
-            await _record_security_audit_event_async(
+            await _record_security_audit_event_best_effort_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
@@ -615,8 +1114,10 @@ async def execute_tool(
                 )
             return envelope
         except Exception as exc:
-            elapsed_ms = int((time.perf_counter() - started) * 1000)
-            meta["duration_ms"] = elapsed_ms
+            elapsed_ms = _finalize_tool_timing_meta(
+                runtime_meta=meta,
+                started=started,
+            )
             error = _error_payload(exc)
             if error.details:
                 meta["error_details"] = dict(error.details)
@@ -669,7 +1170,7 @@ async def execute_tool(
                 tool_call_id=tool_call_id,
                 envelope=envelope,
             )
-            await _record_security_audit_event_async(
+            await _record_security_audit_event_best_effort_async(
                 ctx=ctx,
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
@@ -723,6 +1224,7 @@ async def execute_tool_call(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    hold_action_capacity: bool = True,
     allow_tool_return: Literal[False] = False,
 ) -> dict[str, JsonValue]: ...
 
@@ -749,6 +1251,7 @@ async def execute_tool_call(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    hold_action_capacity: bool = True,
     allow_tool_return: Literal[True] = True,
 ) -> ToolReturn | dict[str, JsonValue]: ...
 
@@ -774,6 +1277,7 @@ async def execute_tool_call(
     | None = None,
     keep_approval_ticket_reusable: bool = False,
     force_approval: bool = False,
+    hold_action_capacity: bool = True,
     allow_tool_return: bool = False,
 ) -> ToolReturn | dict[str, JsonValue]:
     """Run a tool through the hook-aware runtime using natural Python params.
@@ -809,6 +1313,7 @@ async def execute_tool_call(
             approval_args_summary_factory=approval_args_summary_factory,
             keep_approval_ticket_reusable=keep_approval_ticket_reusable,
             force_approval=force_approval,
+            hold_action_capacity=hold_action_capacity,
             allow_tool_return=True,
         )
     return await execute_tool(
@@ -823,11 +1328,12 @@ async def execute_tool_call(
         approval_args_summary_factory=approval_args_summary_factory,
         keep_approval_ticket_reusable=keep_approval_ticket_reusable,
         force_approval=force_approval,
+        hold_action_capacity=hold_action_capacity,
         allow_tool_return=False,
     )
 
 
-async def _reusable_tool_result_async(
+async def _reusable_tool_result_async(  # pragma: no cover
     *,
     ctx: ToolContext,
     args_preview: str,
@@ -894,427 +1400,51 @@ def _state_matches_runtime_scope(
     return not state_run_id or state_run_id == ctx.deps.run_id
 
 
-async def _record_tool_metrics_async(
+async def _record_tool_metrics_async(  # pragma: no cover
     *,
     ctx: ToolContext,
     tool_name: str,
     duration_ms: int,
     success: bool,
 ) -> None:
+    if current_tool_result_commit_buffer() is not None:
+        return
     metric_recorder = getattr(ctx.deps, "metric_recorder", None)
     mcp_registry = getattr(ctx.deps, "mcp_registry", None)
     if metric_recorder is None or mcp_registry is None:
         return
-    await record_tool_execution_async(
-        metric_recorder,
-        mcp_registry=mcp_registry,
-        workspace_id=ctx.deps.workspace_id,
-        session_id=ctx.deps.session_id,
-        run_id=ctx.deps.run_id,
-        instance_id=ctx.deps.instance_id,
-        role_id=ctx.deps.role_id,
-        tool_name=tool_name,
-        duration_ms=duration_ms,
-        success=success,
-    )
-
-
-async def _record_security_audit_event_async(
-    *,
-    ctx: ToolContext,
-    tool_name: str,
-    tool_call_id: str,
-    tool_input: dict[str, JsonValue],
-    visible_envelope: dict[str, JsonValue],
-    internal_data: JsonValue | None,
-    execution_status: ToolExecutionStatus,
-) -> None:
-    if tool_name not in _AUDITED_TOOL_NAMES:
-        return
-    service = _audit_service(ctx)
-    if service is None:
-        return
-    event = await _build_security_audit_event_async(
-        ctx=ctx,
-        tool_name=tool_name,
-        tool_call_id=tool_call_id,
-        tool_input=tool_input,
-        visible_envelope=visible_envelope,
-        internal_data=internal_data,
-        execution_status=execution_status,
-    )
-    if event is None:
-        return
     try:
-        await service.record_event_async(event)
-    except Exception as exc:
+        await asyncio.wait_for(
+            record_tool_execution_async(
+                metric_recorder,
+                mcp_registry=mcp_registry,
+                workspace_id=ctx.deps.workspace_id,
+                session_id=ctx.deps.session_id,
+                run_id=ctx.deps.run_id,
+                instance_id=ctx.deps.instance_id,
+                role_id=ctx.deps.role_id,
+                tool_name=tool_name,
+                duration_ms=duration_ms,
+                success=success,
+            ),
+            timeout=TOOL_METRICS_RECORD_TIMEOUT_SECONDS,
+        )
+    except (asyncio.TimeoutError, RuntimeError, sqlite3.Error) as exc:
         log_event(
             LOGGER,
             logging.WARNING,
-            event="security.audit.record_failed",
-            message="Security audit event could not be recorded",
+            event="tool.metrics.record_deferred",
+            message="Tool metrics write skipped on tool hot path",
             payload={
                 "tool_name": tool_name,
-                "tool_call_id": tool_call_id,
-                "audit_event_type": event.event_type.value,
                 "run_id": ctx.deps.run_id,
                 "task_id": ctx.deps.task_id,
                 "error_type": type(exc).__name__,
-                "error": str(exc),
             },
         )
 
 
-def _audit_service(ctx: ToolContext) -> AuditService | None:
-    return ctx.deps.audit_service
-
-
-async def _build_security_audit_event_async(
-    *,
-    ctx: ToolContext,
-    tool_name: str,
-    tool_call_id: str,
-    tool_input: dict[str, JsonValue],
-    visible_envelope: dict[str, JsonValue],
-    internal_data: JsonValue | None,
-    execution_status: ToolExecutionStatus,
-) -> AuditEventCreate | None:
-    if tool_name in _AUDITED_FILE_WRITE_TOOLS:
-        return await _build_file_write_audit_event_async(
-            ctx=ctx,
-            tool_name=tool_name,
-            tool_call_id=tool_call_id,
-            tool_input=tool_input,
-            visible_envelope=visible_envelope,
-            internal_data=internal_data,
-            execution_status=execution_status,
-        )
-    if tool_name == "shell":
-        return _build_shell_command_audit_event(
-            ctx=ctx,
-            tool_call_id=tool_call_id,
-            tool_input=tool_input,
-            visible_envelope=visible_envelope,
-            execution_status=execution_status,
-        )
-    if tool_name == "orch_dispatch_task":
-        return _build_coordinator_decision_audit_event(
-            ctx=ctx,
-            tool_call_id=tool_call_id,
-            tool_input=tool_input,
-            visible_envelope=visible_envelope,
-            execution_status=execution_status,
-        )
-    return None
-
-
-async def _build_file_write_audit_event_async(
-    *,
-    ctx: ToolContext,
-    tool_name: str,
-    tool_call_id: str,
-    tool_input: dict[str, JsonValue],
-    visible_envelope: dict[str, JsonValue],
-    internal_data: JsonValue | None,
-    execution_status: ToolExecutionStatus,
-) -> AuditEventCreate | None:
-    target = _file_write_target(tool_name, tool_input, internal_data)
-    if target is None:
-        return None
-    content_digest, content_size_bytes, digest_error = await asyncio.to_thread(
-        _workspace_file_digest,
-        ctx=ctx,
-        logical_path=target,
-    )
-    metadata = _base_audit_metadata(
-        tool_name=tool_name,
-        visible_envelope=visible_envelope,
-        execution_status=execution_status,
-    )
-    if digest_error is not None:
-        metadata["content_digest_error"] = digest_error
-    _add_file_write_metadata(
-        metadata=metadata,
-        tool_name=tool_name,
-        tool_input=tool_input,
-        internal_data=internal_data,
-    )
-    return AuditEventCreate(
-        event_type=AuditEventType.FILE_WRITE,
-        trace_id=ctx.deps.trace_id,
-        run_id=ctx.deps.run_id,
-        session_id=ctx.deps.session_id,
-        task_id=ctx.deps.task_id,
-        instance_id=ctx.deps.instance_id,
-        role_id=ctx.deps.role_id,
-        tool_call_id=tool_call_id,
-        action=_file_write_action(tool_name),
-        target=target,
-        content_digest=content_digest,
-        content_size_bytes=content_size_bytes,
-        outcome=_audit_outcome(
-            visible_envelope=visible_envelope,
-            execution_status=execution_status,
-        ),
-        metadata=metadata,
-    )
-
-
-def _build_shell_command_audit_event(
-    *,
-    ctx: ToolContext,
-    tool_call_id: str,
-    tool_input: dict[str, JsonValue],
-    visible_envelope: dict[str, JsonValue],
-    execution_status: ToolExecutionStatus,
-) -> AuditEventCreate | None:
-    command = _string_value(tool_input.get("command"))
-    if command is None:
-        return None
-    metadata = _base_audit_metadata(
-        tool_name="shell",
-        visible_envelope=visible_envelope,
-        execution_status=execution_status,
-    )
-    _copy_json_metadata(metadata, tool_input, "workdir")
-    _copy_json_metadata(metadata, tool_input, "background")
-    _copy_json_metadata(metadata, tool_input, "tty")
-    _copy_json_metadata(metadata, tool_input, "yield_time_ms")
-    _copy_json_metadata(metadata, tool_input, "timeout_ms")
-    _copy_result_metadata(metadata, visible_envelope, "status")
-    _copy_result_metadata(metadata, visible_envelope, "exit_code")
-    return AuditEventCreate(
-        event_type=AuditEventType.SHELL_COMMAND,
-        trace_id=ctx.deps.trace_id,
-        run_id=ctx.deps.run_id,
-        session_id=ctx.deps.session_id,
-        task_id=ctx.deps.task_id,
-        instance_id=ctx.deps.instance_id,
-        role_id=ctx.deps.role_id,
-        tool_call_id=tool_call_id,
-        action="execute_shell_command",
-        target=_truncate_text(command, 200)[0],
-        command=command,
-        outcome=_audit_outcome(
-            visible_envelope=visible_envelope,
-            execution_status=execution_status,
-        ),
-        metadata=metadata,
-    )
-
-
-def _build_coordinator_decision_audit_event(
-    *,
-    ctx: ToolContext,
-    tool_call_id: str,
-    tool_input: dict[str, JsonValue],
-    visible_envelope: dict[str, JsonValue],
-    execution_status: ToolExecutionStatus,
-) -> AuditEventCreate | None:
-    task_id = _string_value(tool_input.get("task_id"))
-    selected_role_id = _string_value(tool_input.get("role_id"))
-    if task_id is None or selected_role_id is None:
-        return None
-    prompt = _string_value(tool_input.get("prompt")) or ""
-    reason_source = (
-        prompt.strip()
-        or "Coordinator dispatched task with the default execution prompt."
-    )
-    decision_reason, reason_truncated = _truncate_text(
-        reason_source,
-        _AUDIT_REASON_LIMIT,
-    )
-    metadata = _base_audit_metadata(
-        tool_name="orch_dispatch_task",
-        visible_envelope=visible_envelope,
-        execution_status=execution_status,
-    )
-    metadata["dispatched_task_id"] = task_id
-    metadata["selected_role_id"] = selected_role_id
-    metadata["decision_reason_digest"] = _text_digest(reason_source)
-    metadata["decision_reason_length"] = len(reason_source)
-    metadata["decision_reason_truncated"] = reason_truncated
-    return AuditEventCreate(
-        event_type=AuditEventType.COORDINATOR_DECISION,
-        trace_id=ctx.deps.trace_id,
-        run_id=ctx.deps.run_id,
-        session_id=ctx.deps.session_id,
-        task_id=ctx.deps.task_id,
-        instance_id=ctx.deps.instance_id,
-        role_id=ctx.deps.role_id,
-        tool_call_id=tool_call_id,
-        action="dispatch_task",
-        target=f"task:{task_id}->role:{selected_role_id}",
-        decision_reason=decision_reason,
-        outcome=_audit_outcome(
-            visible_envelope=visible_envelope,
-            execution_status=execution_status,
-        ),
-        metadata=metadata,
-    )
-
-
-def _base_audit_metadata(
-    *,
-    tool_name: str,
-    visible_envelope: dict[str, JsonValue],
-    execution_status: ToolExecutionStatus,
-) -> dict[str, JsonValue]:
-    metadata: dict[str, JsonValue] = {
-        "tool_name": tool_name,
-        "execution_status": execution_status.value,
-        "tool_ok": visible_envelope.get("ok") is True,
-    }
-    error_type = _visible_error_type(visible_envelope)
-    if error_type is not None:
-        metadata["error_type"] = error_type
-    return metadata
-
-
-def _audit_outcome(
-    *,
-    visible_envelope: dict[str, JsonValue],
-    execution_status: ToolExecutionStatus,
-) -> str:
-    if visible_envelope.get("ok") is True and execution_status == (
-        ToolExecutionStatus.COMPLETED
-    ):
-        return "completed"
-    return "failed"
-
-
-def _visible_error_type(visible_envelope: dict[str, JsonValue]) -> str | None:
-    error = visible_envelope.get("error")
-    if not isinstance(error, dict):
-        return None
-    value = error.get("type")
-    return value if isinstance(value, str) and value else None
-
-
-def _copy_json_metadata(
-    metadata: dict[str, JsonValue],
-    source: dict[str, JsonValue],
-    key: str,
-) -> None:
-    if key in source:
-        metadata[key] = source[key]
-
-
-def _copy_result_metadata(
-    metadata: dict[str, JsonValue],
-    visible_envelope: dict[str, JsonValue],
-    key: str,
-) -> None:
-    data = visible_envelope.get("data")
-    if not isinstance(data, dict):
-        return
-    value = data.get(key)
-    if value is not None:
-        metadata[key] = _normalize_json_value(value)
-
-
-def _add_file_write_metadata(
-    *,
-    metadata: dict[str, JsonValue],
-    tool_name: str,
-    tool_input: dict[str, JsonValue],
-    internal_data: JsonValue | None,
-) -> None:
-    content_field = _file_content_input_field(tool_name)
-    if content_field is not None:
-        content = _string_value(tool_input.get(content_field))
-        if content is not None:
-            metadata["input_content_digest"] = _text_digest(content)
-            metadata["input_content_length"] = len(content)
-    if isinstance(internal_data, dict):
-        created = internal_data.get("created")
-        if isinstance(created, bool):
-            metadata["created"] = created
-        diff_summary = internal_data.get("diff_summary")
-        if isinstance(diff_summary, str) and diff_summary:
-            metadata["diff_summary"] = diff_summary
-
-
-def _file_content_input_field(tool_name: str) -> str | None:
-    if tool_name in {"write", "write_tmp"}:
-        return "content"
-    if tool_name == "edit":
-        return "new_string"
-    if tool_name == "notebook_edit":
-        return "new_source"
-    return None
-
-
-def _file_write_target(
-    tool_name: str,
-    tool_input: dict[str, JsonValue],
-    internal_data: JsonValue | None,
-) -> str | None:
-    if tool_name == "write_tmp":
-        internal_path = _internal_data_text(internal_data, "path")
-        if internal_path is not None:
-            return internal_path
-        raw_tmp_path = _string_value(tool_input.get("path"))
-        if raw_tmp_path is None:
-            return None
-        if raw_tmp_path == "tmp" or raw_tmp_path.startswith(("tmp/", "tmp\\")):
-            return raw_tmp_path
-        return f"tmp/{raw_tmp_path}"
-    return _string_value(tool_input.get("path")) or _internal_data_text(
-        internal_data,
-        "path",
-    )
-
-
-def _file_write_action(tool_name: str) -> str:
-    if tool_name == "edit":
-        return "edit_file"
-    if tool_name == "notebook_edit":
-        return "edit_notebook"
-    if tool_name == "write_tmp":
-        return "write_tmp_file"
-    return "write_file"
-
-
-def _workspace_file_digest(
-    *,
-    ctx: ToolContext,
-    logical_path: str,
-) -> tuple[str | None, int | None, str | None]:
-    try:
-        file_path = ctx.deps.workspace.resolve_path(logical_path, write=False)
-        if not path_is_file(file_path):
-            return None, None, "target is not a file"
-        content = read_bytes_file(file_path)
-    except Exception as exc:
-        return None, None, f"{type(exc).__name__}: {exc}"
-    return f"sha256:{sha256(content).hexdigest()}", len(content), None
-
-
-def _internal_data_text(internal_data: JsonValue | None, key: str) -> str | None:
-    if not isinstance(internal_data, dict):
-        return None
-    return _string_value(internal_data.get(key))
-
-
-def _string_value(value: JsonValue | None) -> str | None:
-    if not isinstance(value, str):
-        return None
-    stripped = value.strip()
-    return stripped if stripped else None
-
-
-def _text_digest(value: str) -> str:
-    return f"sha256:{sha256(value.encode('utf-8')).hexdigest()}"
-
-
-def _truncate_text(value: str, limit: int) -> tuple[str, bool]:
-    if len(value) <= limit:
-        return value, False
-    return value[:limit], True
-
-
-async def _ensure_run_runtime_async(
+async def _ensure_run_runtime_async(  # pragma: no cover
     *,
     ctx: ToolContext,
     status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
@@ -1361,36 +1491,119 @@ async def _publish_tool_result_event_async(
     tool_name: str,
     visible_envelope: dict[str, JsonValue],
 ) -> int:
+    return await publish_run_event_async(
+        ctx.deps.run_event_hub,
+        _tool_result_run_event(
+            ctx=ctx,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            visible_envelope=visible_envelope,
+        ),
+    )
+
+
+async def _publish_tool_result_events_batch_async(  # pragma: no cover
+    items: tuple[ToolResultCommitItem, ...],
+) -> dict[str, int]:
+    if not items:
+        return {}
+    events = tuple(
+        _tool_result_run_event(
+            ctx=item.ctx,
+            tool_call_id=item.tool_call_id,
+            tool_name=item.tool_name,
+            visible_envelope=item.visible_envelope,
+        )
+        for item in items
+    )
+    hub = items[0].ctx.deps.run_event_hub
+    if _can_defer_tool_records_batch(items) and isinstance(
+        hub,
+        _AsyncRunEventDeferredBatchPublisher,
+    ):
+        event_ids = await hub.publish_many_deferred_async(events)
+    elif isinstance(hub, _AsyncRunEventBatchPublisher):
+        event_ids = await hub.publish_many_async(events)
+    else:
+        event_ids = tuple(
+            [
+                await publish_run_event_async(item.ctx.deps.run_event_hub, event)
+                for item, event in zip(items, events, strict=True)
+            ]
+        )
+    return {
+        item.tool_call_id: event_id
+        for item, event_id in zip(items, event_ids, strict=True)
+    }
+
+
+def _tool_result_run_event(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_name: str,
+    visible_envelope: dict[str, JsonValue],
+) -> RunEvent:
     result_payload = cast(
         JsonValue,
         sanitize_task_status_payload(visible_envelope),
     )
     is_error = _visible_tool_result_is_error(visible_envelope)
-    return await publish_run_event_async(
-        ctx.deps.run_event_hub,
-        RunEvent(
-            session_id=ctx.deps.session_id,
-            run_id=ctx.deps.run_id,
-            trace_id=ctx.deps.trace_id,
-            task_id=ctx.deps.task_id,
-            instance_id=ctx.deps.instance_id,
-            role_id=ctx.deps.role_id,
-            event_type=RunEventType.TOOL_RESULT,
-            payload_json=dumps(
-                {
-                    "tool_name": tool_name,
-                    "tool_call_id": tool_call_id,
-                    "result": result_payload,
-                    "error": is_error,
-                    "role_id": ctx.deps.role_id,
-                    "instance_id": ctx.deps.instance_id,
-                }
-            ),
+    metrics = _tool_result_metrics_from_visible_envelope(visible_envelope)
+    return RunEvent(
+        session_id=ctx.deps.session_id,
+        run_id=ctx.deps.run_id,
+        trace_id=ctx.deps.trace_id,
+        task_id=ctx.deps.task_id,
+        instance_id=ctx.deps.instance_id,
+        role_id=ctx.deps.role_id,
+        event_type=RunEventType.TOOL_RESULT,
+        payload_json=dumps(
+            {
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "result": result_payload,
+                "error": is_error,
+                "role_id": ctx.deps.role_id,
+                "instance_id": ctx.deps.instance_id,
+                "metrics": metrics,
+            }
         ),
     )
 
 
-def _mark_tool_result_event_state(
+def _tool_result_metrics_from_visible_envelope(
+    visible_envelope: dict[str, JsonValue],
+) -> dict[str, int]:
+    raw_meta = visible_envelope.get("meta")
+    if not isinstance(raw_meta, dict):
+        return {}
+    meta = cast(dict[str, JsonValue], raw_meta)
+    metrics: dict[str, int] = {}
+    for key in (
+        "action_queue_wait_ms",
+        "action_duration_ms",
+        "tool_framework_wait_ms",
+        "tool_result_persist_ms",
+        "tool_result_publish_ms",
+        "tool_batch_wall_ms",
+        "state_persist_ms",
+        "event_publish_ms",
+        "total_tool_runtime_ms",
+        "tool_result_batch_size",
+        "tool_result_batch_publish_ms",
+        "tool_result_batch_state_persist_ms",
+        "tool_result_batch_metrics_ms",
+        "tool_result_batch_total_ms",
+        "tool_action_singleflight_wait_ms",
+    ):
+        value = meta.get(key)
+        if type(value) is int:
+            metrics[key] = value
+    return metrics
+
+
+def _mark_tool_result_event_state(  # pragma: no cover
     *,
     runtime_meta: dict[str, JsonValue],
     visible_envelope: dict[str, JsonValue],
@@ -1400,7 +1613,7 @@ def _mark_tool_result_event_state(
     runtime_meta["tool_result_event_published"] = published
     raw_meta = visible_envelope.get("meta")
     envelope_meta = (
-        dict(cast(dict[str, JsonValue], raw_meta)) if isinstance(raw_meta, dict) else {}
+        _normalize_json_object(raw_meta) if isinstance(raw_meta, dict) else {}
     )
     envelope_meta["tool_result_durably_recorded"] = True
     envelope_meta["tool_result_event_published"] = published
@@ -1432,12 +1645,82 @@ async def _persist_and_publish_tool_result_async(
     execution_status: ToolExecutionStatus,
     tool_content_parts: tuple[ContentPart, ...] = (),
 ) -> None:
+    buffer = current_tool_result_commit_buffer()
+    if buffer is not None:
+        await buffer.add_async(
+            ToolResultCommitItem(
+                ctx=ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                args_summary=dict(args_summary),
+                visible_envelope=visible_envelope,
+                internal_data=internal_data,
+                runtime_meta=runtime_meta,
+                execution_status=execution_status,
+                tool_content_parts=tool_content_parts,
+                duration_ms=_int_meta(runtime_meta, "duration_ms"),
+                success=execution_status == ToolExecutionStatus.COMPLETED,
+            )
+        )
+        return
     _mark_tool_result_event_state(
         runtime_meta=runtime_meta,
         visible_envelope=visible_envelope,
-        published=False,
+        published=True,
     )
-    await _persist_tool_record_async(
+    event_started = time.perf_counter()
+    try:
+        result_event_id = await asyncio.wait_for(
+            _publish_tool_result_event_async(
+                ctx=ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                visible_envelope=visible_envelope,
+            ),
+            timeout=TOOL_RESULT_EVENT_PUBLISH_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        event_publish_ms = int((time.perf_counter() - event_started) * 1000)
+        runtime_meta["event_publish_ms"] = event_publish_ms
+        runtime_meta["tool_result_publish_ms"] = event_publish_ms
+        _mark_tool_result_event_state(
+            runtime_meta=runtime_meta,
+            visible_envelope=visible_envelope,
+            published=False,
+        )
+        _ = await _persist_tool_record_best_effort_async(
+            ctx=ctx,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            args_summary=args_summary,
+            visible_envelope=visible_envelope,
+            internal_data=internal_data,
+            runtime_meta=runtime_meta,
+            execution_status=execution_status,
+            tool_content_parts=tool_content_parts,
+        )
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="tool.result_event_publish_failed",
+            message=(
+                "Tool result state was persisted without a result event because "
+                "event publishing failed"
+            ),
+            payload={
+                "run_id": ctx.deps.run_id,
+                "task_id": ctx.deps.task_id,
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+        return
+    event_publish_ms = int((time.perf_counter() - event_started) * 1000)
+    runtime_meta["event_publish_ms"] = event_publish_ms
+    runtime_meta["tool_result_publish_ms"] = event_publish_ms
+    _ = await _persist_tool_record_best_effort_async(
         ctx=ctx,
         tool_call_id=tool_call_id,
         tool_name=tool_name,
@@ -1447,20 +1730,43 @@ async def _persist_and_publish_tool_result_async(
         runtime_meta=runtime_meta,
         execution_status=execution_status,
         tool_content_parts=tool_content_parts,
+        result_event_id=result_event_id,
     )
-    _mark_tool_result_event_state(
-        runtime_meta=runtime_meta,
-        visible_envelope=visible_envelope,
-        published=True,
-    )
-    result_event_id = await _publish_tool_result_event_async(
-        ctx=ctx,
-        tool_call_id=tool_call_id,
-        tool_name=tool_name,
-        visible_envelope=visible_envelope,
-    )
+
+
+async def _persist_tool_record_best_effort_async(
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    runtime_meta: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+    tool_content_parts: tuple[ContentPart, ...] = (),
+    result_event_id: int = 0,
+) -> bool:
+    state_started = time.perf_counter()
     try:
-        await _persist_tool_record_async(
+        await asyncio.wait_for(
+            _persist_tool_record_async(
+                ctx=ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                args_summary=args_summary,
+                visible_envelope=visible_envelope,
+                internal_data=internal_data,
+                runtime_meta=runtime_meta,
+                execution_status=execution_status,
+                tool_content_parts=tool_content_parts,
+                result_event_id=result_event_id,
+            ),
+            timeout=TOOL_RESULT_STATE_PERSIST_TIMEOUT_SECONDS,
+        )
+        return True
+    except (asyncio.TimeoutError, RuntimeError, sqlite3.Error) as exc:
+        _schedule_deferred_tool_record_persist(
             ctx=ctx,
             tool_call_id=tool_call_id,
             tool_name=tool_name,
@@ -1472,15 +1778,11 @@ async def _persist_and_publish_tool_result_async(
             tool_content_parts=tool_content_parts,
             result_event_id=result_event_id,
         )
-    except Exception as exc:
         log_event(
             LOGGER,
             logging.WARNING,
-            event="tool.result_linkage_persist_failed",
-            message=(
-                "Tool result event was published, but the result linkage state "
-                "could not be updated"
-            ),
+            event="tool.result_state_persist_deferred",
+            message="Tool result state write deferred from tool hot path",
             payload={
                 "run_id": ctx.deps.run_id,
                 "task_id": ctx.deps.task_id,
@@ -1488,9 +1790,130 @@ async def _persist_and_publish_tool_result_async(
                 "tool_call_id": tool_call_id,
                 "result_event_id": result_event_id,
                 "error_type": type(exc).__name__,
-                "error": str(exc),
             },
         )
+        return False
+    finally:
+        state_persist_ms = int((time.perf_counter() - state_started) * 1000)
+        runtime_meta["state_persist_ms"] = state_persist_ms
+        runtime_meta["tool_result_persist_ms"] = state_persist_ms
+
+
+def _schedule_deferred_tool_record_persist(  # pragma: no cover
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    runtime_meta: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+    tool_content_parts: tuple[ContentPart, ...],
+    result_event_id: int,
+) -> None:
+    task = asyncio.create_task(
+        _persist_tool_record_deferred_async(
+            ctx=ctx,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            args_summary=args_summary,
+            visible_envelope=visible_envelope,
+            internal_data=internal_data,
+            runtime_meta=runtime_meta,
+            execution_status=execution_status,
+            tool_content_parts=tool_content_parts,
+            result_event_id=result_event_id,
+        )
+    )
+    _DEFERRED_TOOL_STATE_PERSIST_TASKS.add(task)
+    task.add_done_callback(_discard_deferred_tool_state_persist_task)
+
+
+def _discard_deferred_tool_state_persist_task(  # pragma: no cover
+    task: asyncio.Task[None],
+) -> None:
+    _DEFERRED_TOOL_STATE_PERSIST_TASKS.discard(task)
+    if task.cancelled():
+        return
+    try:
+        task.result()
+    except Exception as exc:
+        log_event(
+            LOGGER,
+            logging.ERROR,
+            event="tool.result_state_persist_deferred_failed",
+            message="Deferred tool result state write failed",
+            exc_info=exc,
+        )
+
+
+async def _persist_tool_record_deferred_async(  # pragma: no cover
+    *,
+    ctx: ToolContext,
+    tool_call_id: str,
+    tool_name: str,
+    args_summary: dict[str, JsonValue],
+    visible_envelope: dict[str, JsonValue],
+    internal_data: JsonValue | None,
+    runtime_meta: dict[str, JsonValue],
+    execution_status: ToolExecutionStatus,
+    tool_content_parts: tuple[ContentPart, ...],
+    result_event_id: int,
+) -> None:
+    for attempt, delay_seconds in enumerate(
+        (0.0, *_DEFERRED_TOOL_STATE_PERSIST_RETRY_DELAYS_SECONDS),
+        start=1,
+    ):
+        if delay_seconds > 0:
+            await asyncio.sleep(delay_seconds)
+        try:
+            await _persist_tool_record_async(
+                ctx=ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                args_summary=args_summary,
+                visible_envelope=visible_envelope,
+                internal_data=internal_data,
+                runtime_meta=runtime_meta,
+                execution_status=execution_status,
+                tool_content_parts=tool_content_parts,
+                result_event_id=result_event_id,
+            )
+            if attempt > 1:
+                log_event(
+                    LOGGER,
+                    logging.DEBUG,
+                    event="tool.result_state_persist_deferred_completed",
+                    message="Deferred tool result state write completed",
+                    payload={
+                        "run_id": ctx.deps.run_id,
+                        "task_id": ctx.deps.task_id,
+                        "tool_name": tool_name,
+                        "tool_call_id": tool_call_id,
+                        "result_event_id": result_event_id,
+                        "attempt": attempt,
+                    },
+                )
+            return
+        except (RuntimeError, sqlite3.Error) as exc:
+            if attempt > len(_DEFERRED_TOOL_STATE_PERSIST_RETRY_DELAYS_SECONDS):
+                raise
+            log_event(
+                LOGGER,
+                logging.DEBUG,
+                event="tool.result_state_persist_deferred_retry",
+                message="Deferred tool result state write will retry",
+                payload={
+                    "run_id": ctx.deps.run_id,
+                    "task_id": ctx.deps.task_id,
+                    "tool_name": tool_name,
+                    "tool_call_id": tool_call_id,
+                    "result_event_id": result_event_id,
+                    "attempt": attempt,
+                    "error_type": type(exc).__name__,
+                },
+            )
 
 
 async def _mark_tool_running_async(
@@ -1573,125 +1996,95 @@ def _normalize_result_payload(
     return normalized, normalized, ()
 
 
-def _normalize_json_object(value: object) -> dict[str, JsonValue]:
-    if not isinstance(value, dict):
-        return {}
-    normalized: dict[str, JsonValue] = {}
-    for key, item in value.items():
-        normalized[str(key)] = _normalize_json_value(item)
-    return normalized
-
-
-# noinspection PyTypeHints
-def _tool_return_content(
-    *,
-    ctx: ToolContext,
-    tool_name: str,
-    tool_content_parts: tuple[ContentPart, ...],
-) -> UserPromptContent:
-    if not tool_content_parts:
-        return ""
-    if all(isinstance(part, TextContentPart) for part in tool_content_parts):
-        return "\n\n".join(
-            part.text
-            for part in tool_content_parts
-            if isinstance(part, TextContentPart)
-        ).strip()
-    media_asset_service = ctx.deps.media_asset_service
-    if media_asset_service is None:
-        raise ValueError(
-            f"Tool {tool_name} returned media content without media asset support."
-        )
-    provider_content = media_asset_service.to_provider_user_prompt_content(
-        parts=tool_content_parts
-    )
-    hydrated_content = media_asset_service.hydrate_user_prompt_content(
-        content=provider_content
-    )
-    if isinstance(hydrated_content, str):
-        return hydrated_content
-    return tuple(hydrated_content)
-
-
-def _safe_json(value: object) -> str:
-    try:
-        text = json.dumps(value, ensure_ascii=False, default=str)
-    except TypeError:
-        text = str(value)
-    if len(text) > 500:
-        return text[:500] + "...(truncated)"
-    return text
-
-
-def _normalize_json_value(value: object) -> JsonValue:
-    if isinstance(value, Enum):
-        return _normalize_json_value(value.value)
-    if isinstance(value, BaseModel):
-        return cast(JsonValue, value.model_dump(mode="json"))
-    if isinstance(value, (str, int, float, bool)) or value is None:
-        return value
-    if isinstance(value, list):
-        items = cast(list[object], value)
-        return [_normalize_json_value(item) for item in items]
-    if isinstance(value, tuple):
-        items = cast(tuple[object, ...], value)
-        return [_normalize_json_value(item) for item in items]
-    if isinstance(value, dict):
-        return _normalize_json_object(value)
-    return str(value)
-
-
 async def _invoke_tool_action_with_limits(
     *,
     ctx: ToolContext,
     action: Callable[..., object | Awaitable[object]] | object,
     tool_input: dict[str, JsonValue],
+    runtime_meta: dict[str, JsonValue],
+    hold_action_capacity: bool = True,
+    tool_name: str = "",
 ) -> object:
-    run_gate = _retain_run_tool_action_gate(ctx.deps.run_id)
-    queued_at = time.perf_counter()
-    try:
-        async with run_gate.semaphore:
-            async with _GLOBAL_TOOL_ACTION_SEMAPHORE:
-                wait_ms = int((time.perf_counter() - queued_at) * 1000)
-                if wait_ms >= 250:
-                    log_event(
-                        LOGGER,
-                        logging.DEBUG,
-                        event="tool.action.queue_wait",
-                        message="Tool action waited for execution capacity",
-                        duration_ms=wait_ms,
-                        payload={
-                            "run_id": ctx.deps.run_id,
-                            "session_id": ctx.deps.session_id,
-                            "tool_call_id": ctx.tool_call_id,
-                        },
-                    )
-                return await _invoke_tool_action_async(
-                    action=action,
-                    tool_input=tool_input,
-                )
-    finally:
-        _release_run_tool_action_gate(ctx.deps.run_id, run_gate)
+    buffer = current_tool_result_commit_buffer()
+    if buffer is not None and tool_name in _BATCH_SINGLEFLIGHT_ACTION_TOOLS:
+        key = _singleflight_action_key(
+            ctx=ctx,
+            tool_name=tool_name,
+            tool_input=tool_input,
+        )
+
+        async def factory() -> object:
+            runtime_meta["tool_action_capacity_bypassed_reason"] = (
+                "lightweight_batch_tool"
+            )
+            return await _invoke_tool_action_with_capacity(
+                ctx=ctx,
+                action=action,
+                tool_input=tool_input,
+                runtime_meta=runtime_meta,
+                hold_action_capacity=False,
+            )
+
+        result = await buffer.invoke_action_singleflight_async(
+            key=key,
+            factory=factory,
+        )
+        if result.shared:
+            runtime_meta["action_queue_wait_ms"] = 0
+            runtime_meta["tool_action_capacity_held"] = False
+            runtime_meta["tool_action_singleflight_hit"] = True
+            runtime_meta["tool_action_singleflight_wait_ms"] = result.wait_ms
+            runtime_meta["action_duration_ms"] = 0
+        return result.value
+    return await _invoke_tool_action_with_capacity(
+        ctx=ctx,
+        action=action,
+        tool_input=tool_input,
+        runtime_meta=runtime_meta,
+        hold_action_capacity=hold_action_capacity,
+    )
 
 
-def _retain_run_tool_action_gate(run_id: str) -> _RunToolActionGate:
-    with _RUN_TOOL_ACTION_GATES_LOCK:
-        gate = _RUN_TOOL_ACTION_GATES.get(run_id)
-        if gate is None:
-            gate = _RunToolActionGate()
-            _RUN_TOOL_ACTION_GATES[run_id] = gate
-        gate.ref_count += 1
-        return gate
+async def _invoke_tool_action_with_capacity(
+    *,
+    ctx: ToolContext,
+    action: Callable[..., object | Awaitable[object]] | object,
+    tool_input: dict[str, JsonValue],
+    runtime_meta: dict[str, JsonValue],
+    hold_action_capacity: bool = True,
+) -> object:
+    _action_capacity.PER_RUN_TOOL_ACTION_CONCURRENCY = PER_RUN_TOOL_ACTION_CONCURRENCY
+    _action_capacity.GLOBAL_TOOL_ACTION_SEMAPHORE = _GLOBAL_TOOL_ACTION_SEMAPHORE
+    _action_capacity.RUN_TOOL_ACTION_GATES = _RUN_TOOL_ACTION_GATES
+    return await invoke_with_tool_action_capacity(
+        ctx=ctx,
+        runtime_meta=runtime_meta,
+        action_factory=partial(
+            _invoke_tool_action_async,
+            action=action,
+            tool_input=tool_input,
+        ),
+        hold_action_capacity=hold_action_capacity,
+    )
 
 
-def _release_run_tool_action_gate(run_id: str, gate: _RunToolActionGate) -> None:
-    with _RUN_TOOL_ACTION_GATES_LOCK:
-        current = _RUN_TOOL_ACTION_GATES.get(run_id)
-        if current is not gate:
-            return
-        gate.ref_count = max(0, gate.ref_count - 1)
-        if gate.ref_count == 0:
-            del _RUN_TOOL_ACTION_GATES[run_id]
+def _singleflight_action_key(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_input: dict[str, JsonValue],
+) -> str:
+    digest = sha256(
+        "|".join(
+            (
+                ctx.deps.workspace_id,
+                ctx.deps.task_id,
+                tool_name,
+                _safe_json(tool_input),
+            )
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"{tool_name}:{digest}"
 
 
 async def _invoke_tool_action_async(
@@ -1747,300 +2140,12 @@ def _invoke_tool_action(
     return named_action(**kwargs)
 
 
-def _capture_tool_input(
-    *,
-    raw_args: Mapping[str, object],
-    action: Callable[..., object | Awaitable[object]] | object,
-    exclude: tuple[str, ...],
-) -> dict[str, JsonValue]:
-    excluded = set(exclude)
-    parameter_names = _tool_input_parameter_names(action)
-    result: dict[str, JsonValue] = {}
-    for name, value in raw_args.items():
-        if name in excluded or name.startswith("_"):
-            continue
-        if parameter_names is not None and name not in parameter_names:
-            continue
-        result[name] = _normalize_json_value(value)
-    return result
-
-
-def _tool_input_parameter_names(
-    action: Callable[..., object | Awaitable[object]] | object,
-) -> set[str] | None:
-    if not callable(action):
-        return None
-    parameters = list(inspect.signature(action).parameters.values())
-    if not parameters or _uses_tool_input_dict(parameters):
-        return None
-    names: set[str] = set()
-    for parameter in parameters:
-        if parameter.kind in {
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        }:
-            names.add(parameter.name)
-    return names
-
-
-def _uses_tool_input_dict(parameters: list[inspect.Parameter]) -> bool:
-    if len(parameters) != 1:
-        return False
-    parameter = parameters[0]
-    return parameter.kind in {
-        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        inspect.Parameter.KEYWORD_ONLY,
-    } and parameter.name in {"tool_input", "args", "tool_args"}
-
-
-def _bind_tool_action_kwargs(
-    *,
-    parameters: list[inspect.Parameter],
-    tool_input: dict[str, JsonValue],
-    resolved_annotations: Mapping[str, object] | None = None,
-) -> dict[str, object]:
-    kwargs: dict[str, object] = {}
-    for parameter in parameters:
-        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
-            kwargs.update(tool_input)
-            continue
-        if parameter.kind not in {
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        }:
-            raise TypeError(
-                f"Unsupported tool action parameter kind: {parameter.kind.value}"
-            )
-        if parameter.name not in tool_input:
-            continue
-        kwargs[parameter.name] = _coerce_tool_argument_for_parameter(
-            value=tool_input[parameter.name],
-            parameter=parameter,
-            annotation=_resolved_parameter_annotation(
-                parameter=parameter,
-                resolved_annotations=resolved_annotations,
-            ),
-        )
-    return kwargs
-
-
-def _coerce_tool_argument_for_parameter(
-    *,
-    value: JsonValue,
-    parameter: inspect.Parameter,
-    annotation: object,
-) -> object:
-    if value is None:
-        return None
-    model_list_type = _resolve_pydantic_model_list_type(annotation)
-    if model_list_type is not None and isinstance(value, list):
-        return [model_list_type.model_validate(item) for item in value]
-    model_type = _resolve_pydantic_model_type(annotation)
-    if model_type is not None and isinstance(value, dict):
-        return model_type.model_validate(value)
-    enum_type = _resolve_enum_type(annotation=annotation, parameter=parameter)
-    if enum_type is not None and isinstance(value, str):
-        return enum_type(value)
-    if _parameter_accepts_type(
-        annotation=annotation, parameter=parameter, expected_type=bool
-    ):
-        return _coerce_bool(value)
-    if _parameter_accepts_type(
-        annotation=annotation, parameter=parameter, expected_type=int
-    ):
-        return _coerce_int(value)
-    if _parameter_accepts_type(
-        annotation=annotation, parameter=parameter, expected_type=float
-    ):
-        return _coerce_float(value)
-    if _parameter_accepts_type(
-        annotation=annotation, parameter=parameter, expected_type=str
-    ):
-        return str(value)
-    if _parameter_accepts_type(
-        annotation=annotation, parameter=parameter, expected_type=tuple
-    ) and isinstance(value, list):
-        return tuple(value)
-    if _parameter_accepts_type(
-        annotation=annotation, parameter=parameter, expected_type=list
-    ) and isinstance(value, tuple):
-        return list(value)
-    return value
-
-
-def _parameter_accepts_type(
-    *,
-    annotation: object,
-    parameter: inspect.Parameter,
-    expected_type: type[object],
-) -> bool:
-    if annotation is not inspect._empty and _annotation_contains_type(
-        annotation=annotation,
-        expected_type=expected_type,
-    ):
-        return True
-    default = parameter.default
-    if default is inspect._empty or default is None:
-        return False
-    return isinstance(default, expected_type)
-
-
-def _annotation_contains_type(
-    *,
-    annotation: object,
-    expected_type: type[object],
-) -> bool:
-    if annotation is expected_type:
-        return True
-    origin = get_origin(annotation)
-    if origin is None:
-        return False
-    return any(
-        item is expected_type for item in get_args(annotation) if item is not type(None)
-    )
-
-
-def _resolve_pydantic_model_list_type(
-    annotation: object,
-) -> type[BaseModel] | None:
-    origin = get_origin(annotation)
-    if origin not in {list, tuple}:
-        return None
-    for item in get_args(annotation):
-        if inspect.isclass(item) and issubclass(item, BaseModel):
-            return cast(type[BaseModel], item)
-    return None
-
-
-def _resolve_pydantic_model_type(
-    annotation: object,
-) -> type[BaseModel] | None:
-    if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
-        return cast(type[BaseModel], annotation)
-    origin = get_origin(annotation)
-    if origin is None:
-        return None
-    for item in get_args(annotation):
-        if item is type(None):
-            continue
-        if inspect.isclass(item) and issubclass(item, BaseModel):
-            return cast(type[BaseModel], item)
-    return None
-
-
-def _resolve_enum_type(
-    *,
-    annotation: object,
-    parameter: inspect.Parameter,
-) -> type[Enum] | None:
-    if annotation is not inspect._empty:
-        candidate = _enum_type_from_annotation(annotation)
-        if candidate is not None:
-            return candidate
-    default = parameter.default
-    if default is inspect._empty or not isinstance(default, Enum):
-        return None
-    return type(default)
-
-
-def _enum_type_from_annotation(annotation: object) -> type[Enum] | None:
-    if inspect.isclass(annotation) and issubclass(annotation, Enum):
-        return cast(type[Enum], annotation)
-    origin = get_origin(annotation)
-    if origin is None:
-        return None
-    for item in get_args(annotation):
-        if item is type(None):
-            continue
-        if inspect.isclass(item) and issubclass(item, Enum):
-            return cast(type[Enum], item)
-    return None
-
-
-def _resolve_tool_action_annotations(
-    action: Callable[..., object | Awaitable[object]] | object,
-) -> dict[str, object]:
-    if not callable(action):
-        return {}
-    try:
-        return get_type_hints(action)
-    except (AttributeError, NameError, TypeError):
-        return {}
-
-
-def _resolved_parameter_annotation(
-    *,
-    parameter: inspect.Parameter,
-    resolved_annotations: Mapping[str, object] | None,
-) -> object:
-    if resolved_annotations is None:
-        return parameter.annotation
-    return resolved_annotations.get(parameter.name, parameter.annotation)
-
-
-def _coerce_bool(value: JsonValue) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"1", "true", "yes", "on"}:
-            return True
-        if normalized in {"0", "false", "no", "off"}:
-            return False
-    return bool(value)
-
-
-def _coerce_int(value: JsonValue) -> int:
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str):
-        stripped = value.strip()
-        if stripped:
-            return int(stripped)
-    raise ValueError(f"Cannot coerce tool argument to int: {value!r}")
-
-
-def _coerce_float(value: JsonValue) -> float:
-    if isinstance(value, bool):
-        return float(int(value))
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        stripped = value.strip()
-        if stripped:
-            return float(stripped)
-    raise ValueError(f"Cannot coerce tool argument to float: {value!r}")
-
-
-def _apply_role_contract_check(
+async def _apply_role_contract_check_async(
     *,
     ctx: ToolContext,
     tool_name: str,
 ) -> ToolError | None:
-    role: RoleDefinition | None = None
-    resolver = getattr(ctx.deps, "runtime_role_resolver", None)
-    if resolver is not None:
-        try:
-            role = resolver.get_effective_role(run_id=None, role_id=ctx.deps.role_id)
-        except (KeyError, ValueError, RuntimeError):
-            role = None
-    if role is None:
-        role_registry = getattr(ctx.deps, "role_registry", None)
-        if role_registry is None:
-            return None
-        try:
-            role = role_registry.get(ctx.deps.role_id)
-        except (KeyError, ValueError):
-            return None
-    if role is None:
-        return None
-    denied_tools = runtime_denied_tools_for_role(role)
+    denied_tools = await _role_contract_denied_tools_async(ctx)
     if not denied_tools or tool_name not in denied_tools:
         return None
     log_event(
@@ -2060,6 +2165,59 @@ def _apply_role_contract_check(
             f"'{ctx.deps.role_id}' by role contract invariant"
         ),
         retryable=False,
+    )
+
+
+async def _role_contract_denied_tools_async(ctx: ToolContext) -> tuple[str, ...]:
+    buffer = current_tool_result_commit_buffer()
+    if buffer is None:
+        return _resolve_role_contract_denied_tools(ctx)
+    return await buffer.role_contract_denied_tools_async(
+        key=_role_contract_cache_key(ctx),
+        factory=partial(_resolve_role_contract_denied_tools, ctx),
+    )
+
+
+def _resolve_role_contract_denied_tools(ctx: ToolContext) -> tuple[str, ...]:
+    role: RoleDefinition | None = None
+    resolver = getattr(ctx.deps, "runtime_role_resolver", None)
+    if resolver is not None:
+        try:
+            role = resolver.get_effective_role(run_id=None, role_id=ctx.deps.role_id)
+        except (KeyError, ValueError, RuntimeError):
+            role = None
+    if role is None:
+        role_registry = getattr(ctx.deps, "role_registry", None)
+        if role_registry is None:
+            return ()
+        try:
+            role = role_registry.get(ctx.deps.role_id)
+        except (KeyError, ValueError):
+            return ()
+    if role is None:
+        return ()
+    return tuple(sorted(runtime_denied_tools_for_role(role)))
+
+
+def _role_contract_cache_key(ctx: ToolContext) -> str:
+    return "|".join(
+        (
+            ctx.deps.workspace_id,
+            ctx.deps.session_id,
+            ctx.deps.role_id,
+        )
+    )
+
+
+def _tool_middleware_bypass_cache_key(ctx: ToolContext) -> str:
+    return "|".join(
+        (
+            ctx.deps.workspace_id,
+            ctx.deps.session_id,
+            ctx.deps.role_id,
+            str(id(getattr(ctx.deps, "hook_service", None))),
+            str(id(ctx.deps.tool_approval_policy)),
+        )
     )
 
 
@@ -3386,7 +3544,29 @@ async def _evaluate_tool_approval_policy(
     )
 
 
-async def _allowed_tools_for_runtime_policy(
+async def _allowed_tools_for_runtime_policy(  # pragma: no cover
+    *,
+    ctx: ToolContext,
+) -> tuple[str, ...] | None:
+    buffer = current_tool_result_commit_buffer()
+    if buffer is not None:
+        key = "|".join(
+            (
+                ctx.deps.run_id,
+                ctx.deps.instance_id,
+                ctx.deps.role_id,
+                ctx.deps.task_id,
+            )
+        )
+
+        async def factory() -> tuple[str, ...] | None:
+            return await _load_allowed_tools_for_runtime_policy(ctx=ctx)
+
+        return await buffer.allowed_tools_for_policy_async(key=key, factory=factory)
+    return await _load_allowed_tools_for_runtime_policy(ctx=ctx)
+
+
+async def _load_allowed_tools_for_runtime_policy(  # pragma: no cover
     *,
     ctx: ToolContext,
 ) -> tuple[str, ...] | None:
@@ -3509,6 +3689,50 @@ def _internal_record(
     return cast(dict[str, JsonValue], record.model_dump(mode="json"))
 
 
+def _state_result_record(
+    *,
+    tool_name: str,
+    result_record: dict[str, JsonValue],
+    runtime_meta: dict[str, JsonValue],
+    result_event_id: int,
+) -> dict[str, JsonValue]:
+    if (
+        tool_name != "read"
+        or result_event_id <= 0
+        or _json_size_bytes(result_record) <= READ_TOOL_STATE_COMPACT_THRESHOLD_BYTES
+    ):
+        return result_record
+    visible_result = result_record.get("visible_result")
+    ok = False
+    error: JsonValue | None = None
+    if isinstance(visible_result, dict):
+        ok = visible_result.get("ok") is True
+        error = _normalize_json_value(visible_result.get("error"))
+    compact_visible_result: dict[str, JsonValue] = {
+        "ok": ok,
+        "data": {
+            "state_compacted": True,
+            "result_event_id": result_event_id,
+        },
+        "error": error,
+        "meta": runtime_meta,
+    }
+    return _internal_record(
+        tool_name=tool_name,
+        visible_envelope=compact_visible_result,
+        internal_data=None,
+        runtime_meta=runtime_meta,
+        tool_content_parts=(),
+    )
+
+
+def _json_size_bytes(value: dict[str, JsonValue]) -> int:  # pragma: no cover
+    try:
+        return len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
+    except (TypeError, ValueError):
+        return READ_TOOL_STATE_COMPACT_THRESHOLD_BYTES + 1
+
+
 async def _persist_tool_record_async(
     *,
     ctx: ToolContext,
@@ -3539,6 +3763,12 @@ async def _persist_tool_record_async(
     existing_call_state = (
         dict(current_state.call_state) if current_state is not None else {}
     )
+    state_result_record = _state_result_record(
+        tool_name=tool_name,
+        result_record=result_record,
+        runtime_meta=runtime_meta,
+        result_event_id=result_event_id,
+    )
     await merge_tool_call_state_async(
         shared_store=ctx.deps.shared_store,
         task_id=ctx.deps.task_id,
@@ -3554,11 +3784,127 @@ async def _persist_tool_record_async(
         approval_status=approval_status,
         approval_feedback=str(runtime_meta.get("approval_feedback") or ""),
         execution_status=execution_status,
-        result_envelope=result_record,
+        result_envelope=state_result_record,
         call_state=existing_call_state,
         result_event_id=result_event_id,
         finished_at=datetime.now(tz=timezone.utc).isoformat(),
     )
+
+
+async def _persist_tool_records_batch_async(  # pragma: no cover
+    *,
+    items: tuple[ToolResultCommitItem, ...],
+    result_event_ids: dict[str, int],
+) -> None:
+    if not items:
+        return
+    first = items[0]
+    shared_store = first.ctx.deps.shared_store
+    task_id = first.ctx.deps.task_id
+    current_states = await load_tool_call_states_async(
+        shared_store=shared_store,
+        task_id=task_id,
+        tool_call_ids=tuple(item.tool_call_id for item in items),
+    )
+    now = datetime.now(tz=timezone.utc).isoformat()
+    mutations = []
+    for item in items:
+        result_event_id = result_event_ids.get(item.tool_call_id, 0)
+        result_record = _internal_record(
+            tool_name=item.tool_name,
+            visible_envelope=item.visible_envelope,
+            internal_data=item.internal_data,
+            runtime_meta=item.runtime_meta,
+            tool_content_parts=item.tool_content_parts,
+        )
+        current = current_states.get(item.tool_call_id)
+        if current is None:
+            current = PersistedToolCallState(
+                tool_call_id=item.tool_call_id,
+                tool_name=item.tool_name,
+                run_id=item.ctx.deps.run_id,
+                session_id=item.ctx.deps.session_id,
+                instance_id=item.ctx.deps.instance_id,
+                role_id=item.ctx.deps.role_id,
+                args_preview=_safe_json(item.args_summary),
+                run_yolo=bool(item.runtime_meta.get("run_yolo") is True),
+                approval_mode=(
+                    _approval_mode_from_meta(item.runtime_meta)
+                    or ToolApprovalMode.UNKNOWN
+                ),
+                updated_at=now,
+            )
+        existing_call_state = dict(current.call_state)
+        state_result_record = _state_result_record(
+            tool_name=item.tool_name,
+            result_record=result_record,
+            runtime_meta=item.runtime_meta,
+            result_event_id=result_event_id,
+        )
+        next_state = current.model_copy(
+            update={
+                "tool_name": item.tool_name,
+                "run_id": item.ctx.deps.run_id,
+                "session_id": item.ctx.deps.session_id,
+                "instance_id": item.ctx.deps.instance_id,
+                "role_id": item.ctx.deps.role_id,
+                "args_preview": _safe_json(item.args_summary),
+                "run_yolo": bool(item.runtime_meta.get("run_yolo") is True),
+                "approval_mode": (
+                    _approval_mode_from_meta(item.runtime_meta)
+                    or ToolApprovalMode.UNKNOWN
+                ),
+                "approval_status": (
+                    _approval_status_from_meta(item.runtime_meta)
+                    or current.approval_status
+                ),
+                "approval_feedback": str(
+                    item.runtime_meta.get("approval_feedback") or ""
+                ),
+                "execution_status": item.execution_status,
+                "result_envelope": state_result_record,
+                "call_state": existing_call_state,
+                "result_event_id": result_event_id,
+                "finished_at": now,
+                "updated_at": now,
+            }
+        )
+        mutations.append(tool_call_state_mutation(task_id=task_id, state=next_state))
+    await shared_store.manage_states_async(tuple(mutations))
+
+
+def _record_tool_metrics_batch_deferred(
+    items: tuple[ToolResultCommitItem, ...],
+) -> None:
+    metric_count = sum(1 for item in items if item.tool_name != "read")
+    if metric_count <= 0:
+        return
+    log_event(
+        LOGGER,
+        logging.DEBUG,
+        event="tool.metrics.batch_record_deferred",
+        message="Deferred non-critical tool metrics outside batch flush",
+        payload={
+            "run_id": items[0].ctx.deps.run_id,
+            "task_id": items[0].ctx.deps.task_id,
+            "metric_count": metric_count,
+        },
+    )
+
+
+def _tool_result_batch_id(items: tuple[ToolResultCommitItem, ...]) -> str:
+    first = items[0]
+    digest = sha256(
+        "|".join(
+            (
+                first.ctx.deps.trace_id,
+                first.ctx.deps.task_id,
+                first.tool_call_id,
+                str(len(items)),
+            )
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"toolresultbatch_{digest}"
 
 
 def _approval_status_from_meta(

--- a/src/relay_teams/tools/runtime/json_helpers.py
+++ b/src/relay_teams/tools/runtime/json_helpers.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from enum import Enum
+import json
+
+from pydantic import BaseModel, JsonValue
+
+from relay_teams.media import ContentPart, TextContentPart, UserPromptContent
+from relay_teams.tools.runtime.context import ToolContext
+
+
+def normalize_json_object(value: object) -> dict[str, JsonValue]:
+    if not isinstance(value, dict):
+        return {}
+    normalized: dict[str, JsonValue] = {}
+    for key, item in value.items():
+        normalized[str(key)] = normalize_json_value(item)
+    return normalized
+
+
+# noinspection PyTypeHints
+def _tool_return_content(
+    *,
+    ctx: ToolContext,
+    tool_name: str,
+    tool_content_parts: tuple[ContentPart, ...],
+) -> UserPromptContent:
+    if not tool_content_parts:
+        return ""
+    if all(isinstance(part, TextContentPart) for part in tool_content_parts):
+        return "\n\n".join(
+            part.text
+            for part in tool_content_parts
+            if isinstance(part, TextContentPart)
+        ).strip()
+    media_asset_service = ctx.deps.media_asset_service
+    if media_asset_service is None:
+        raise ValueError(
+            f"Tool {tool_name} returned media content without media asset support."
+        )
+    provider_content = media_asset_service.to_provider_user_prompt_content(
+        parts=tool_content_parts
+    )
+    hydrated_content = media_asset_service.hydrate_user_prompt_content(
+        content=provider_content
+    )
+    if isinstance(hydrated_content, str):
+        return hydrated_content
+    return tuple(hydrated_content)
+
+
+def safe_json(value: object) -> str:
+    try:
+        text = json.dumps(value, ensure_ascii=False, default=str)
+    except TypeError:
+        text = str(value)
+    if len(text) > 500:
+        return text[:500] + "...(truncated)"
+    return text
+
+
+def normalize_json_value(value: object) -> JsonValue:
+    if isinstance(value, Enum):
+        return normalize_json_value(value.value)
+    if isinstance(value, BaseModel):
+        return normalize_json_value(value.model_dump(mode="json"))
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [normalize_json_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [normalize_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return normalize_json_object(value)
+    return str(value)

--- a/src/relay_teams/tools/runtime/persisted_state.py
+++ b/src/relay_teams/tools/runtime/persisted_state.py
@@ -124,6 +124,18 @@ def load_tool_call_state(
         return None
 
 
+def tool_call_state_mutation(
+    *,
+    task_id: str,
+    state: PersistedToolCallState,
+) -> StateMutation:
+    return StateMutation(
+        scope=_task_scope(task_id),
+        key=_state_key(state.tool_call_id),
+        value_json=state.model_dump_json(),
+    )
+
+
 async def load_tool_call_state_async(
     *,
     shared_store: SharedStateRepository,
@@ -139,6 +151,35 @@ async def load_tool_call_state_async(
         return PersistedToolCallState.model_validate_json(raw)
     except ValueError:
         return None
+
+
+async def load_tool_call_states_async(
+    *,
+    shared_store: SharedStateRepository,
+    task_id: str,
+    tool_call_ids: tuple[str, ...],
+) -> dict[str, PersistedToolCallState]:
+    normalized_ids = tuple(
+        dict.fromkeys(tool_call_id.strip() for tool_call_id in tool_call_ids)
+    )
+    if not normalized_ids:
+        return {}
+    wanted_keys = {
+        _state_key(tool_call_id): tool_call_id for tool_call_id in normalized_ids
+    }
+    states: dict[str, PersistedToolCallState] = {}
+    for key, value in await shared_store.get_states_async(
+        _task_scope(task_id),
+        tuple(wanted_keys.keys()),
+    ):
+        tool_call_id = wanted_keys.get(key)
+        if tool_call_id is None:
+            continue
+        try:
+            states[tool_call_id] = PersistedToolCallState.model_validate_json(value)
+        except ValueError:
+            continue
+    return states
 
 
 def load_tool_call_batch_state(

--- a/src/relay_teams/tools/runtime/runtime_phase.py
+++ b/src/relay_teams/tools/runtime/runtime_phase.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import time
+
+from pydantic import JsonValue
+
+from relay_teams.sessions.runs.run_runtime_repo import RunRuntimePhase
+from relay_teams.tools.runtime.context import ToolContext
+
+
+def _is_root_or_coordinator_context(ctx: ToolContext) -> bool:
+    return bool(
+        getattr(ctx.deps, "is_root_task_context", False)
+    ) or ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id)
+
+
+def _running_runtime_phase(ctx: ToolContext) -> RunRuntimePhase:
+    if _is_root_or_coordinator_context(ctx):
+        return RunRuntimePhase.COORDINATOR_RUNNING
+    return RunRuntimePhase.SUBAGENT_RUNNING
+
+
+def _active_subagent_instance_id(ctx: ToolContext) -> str | None:
+    if _is_root_or_coordinator_context(ctx):
+        return None
+    return ctx.deps.instance_id
+
+
+def _finalize_tool_timing_meta(
+    *,
+    runtime_meta: dict[str, JsonValue],
+    started: float,
+) -> int:
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+    action_duration_ms = runtime_meta.get("action_duration_ms")
+    resolved_action_duration_ms = (
+        action_duration_ms if type(action_duration_ms) is int else elapsed_ms
+    )
+    runtime_meta["duration_ms"] = resolved_action_duration_ms
+    runtime_meta["total_tool_runtime_ms"] = elapsed_ms
+    runtime_meta["tool_batch_wall_ms"] = elapsed_ms
+    runtime_meta["tool_framework_wait_ms"] = max(
+        0,
+        elapsed_ms
+        - int(resolved_action_duration_ms)
+        - _int_meta(runtime_meta, "action_queue_wait_ms"),
+    )
+    return elapsed_ms
+
+
+def _int_meta(runtime_meta: dict[str, JsonValue], key: str) -> int:
+    value = runtime_meta.get(key)
+    if type(value) is int:
+        return value
+    return 0

--- a/src/relay_teams/tools/runtime/tool_result_batching.py
+++ b/src/relay_teams/tools/runtime/tool_result_batching.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import json
+import time
+from collections.abc import Awaitable, Callable
+
+from pydantic import JsonValue
+
+from relay_teams.media import ContentPart
+from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.json_helpers import (
+    normalize_json_value as _normalize_json_value,
+)
+from relay_teams.tools.runtime.persisted_state import ToolExecutionStatus
+
+
+_TOOL_RESULT_COMMIT_BUFFER: contextvars.ContextVar["ToolResultCommitBuffer | None"] = (
+    contextvars.ContextVar("tool_result_commit_buffer", default=None)
+)
+
+
+class ToolResultCommitItem:
+    def __init__(
+        self,
+        *,
+        ctx: ToolContext,
+        tool_call_id: str,
+        tool_name: str,
+        args_summary: dict[str, JsonValue],
+        visible_envelope: dict[str, JsonValue],
+        internal_data: JsonValue | None,
+        runtime_meta: dict[str, JsonValue],
+        execution_status: ToolExecutionStatus,
+        tool_content_parts: tuple[ContentPart, ...],
+        duration_ms: int,
+        success: bool,
+    ) -> None:
+        self.ctx = ctx
+        self.tool_call_id = tool_call_id
+        self.tool_name = tool_name
+        self.args_summary = args_summary
+        self.visible_envelope = visible_envelope
+        self.internal_data = internal_data
+        self.runtime_meta = runtime_meta
+        self.execution_status = execution_status
+        self.tool_content_parts = tool_content_parts
+        self.duration_ms = duration_ms
+        self.success = success
+
+
+class ToolBatchActionResult:
+    def __init__(
+        self,
+        *,
+        value: object,
+        shared: bool,
+        wait_ms: int,
+    ) -> None:
+        self.value = value
+        self.shared = shared
+        self.wait_ms = wait_ms
+
+
+class ToolResultCommitBuffer:
+    def __init__(self) -> None:
+        self._items: list[ToolResultCommitItem] = []
+        self._lock = asyncio.Lock()
+        self._action_lock = asyncio.Lock()
+        self._action_tasks: dict[str, asyncio.Task[object]] = {}
+        self._allowed_tools_lock = asyncio.Lock()
+        self._allowed_tools_tasks: dict[str, asyncio.Task[tuple[str, ...] | None]] = {}
+        self._role_contract_lock = asyncio.Lock()
+        self._role_contract_denied_tools: dict[str, tuple[str, ...]] = {}
+        self._middleware_bypass_lock = asyncio.Lock()
+        self._middleware_bypass_allowed: dict[str, bool] = {}
+
+    async def add_async(self, item: ToolResultCommitItem) -> None:
+        async with self._lock:
+            self._items.append(item)
+
+    async def pop_items_async(self) -> tuple[ToolResultCommitItem, ...]:
+        async with self._lock:
+            items = tuple(self._items)
+            self._items.clear()
+        return items
+
+    async def clone_item_async(
+        self,
+        *,
+        source_tool_call_id: str,
+        tool_call_id: str,
+        tool_name: str,
+        args_summary: dict[str, JsonValue],
+        runtime_meta_overrides: dict[str, JsonValue],
+    ) -> ToolResultCommitItem | None:
+        async with self._lock:
+            source = next(
+                (
+                    item
+                    for item in reversed(self._items)
+                    if item.tool_call_id == source_tool_call_id
+                ),
+                None,
+            )
+            if source is None:
+                return None
+            runtime_meta = dict(source.runtime_meta)
+            runtime_meta.update(runtime_meta_overrides)
+            visible_envelope = _clone_json_object(source.visible_envelope)
+            meta = visible_envelope.get("meta")
+            if isinstance(meta, dict):
+                meta.update(runtime_meta)
+            else:
+                visible_envelope["meta"] = runtime_meta
+            item = ToolResultCommitItem(
+                ctx=source.ctx,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                args_summary=args_summary,
+                visible_envelope=visible_envelope,
+                internal_data=_clone_json_value(source.internal_data),
+                runtime_meta=runtime_meta,
+                execution_status=source.execution_status,
+                tool_content_parts=source.tool_content_parts,
+                duration_ms=0,
+                success=source.success,
+            )
+            self._items.append(item)
+            return item
+
+    async def invoke_action_singleflight_async(
+        self,
+        *,
+        key: str,
+        factory: Callable[[], Awaitable[object]],
+    ) -> ToolBatchActionResult:
+        shared = True
+        async with self._action_lock:
+            task = self._action_tasks.get(key)
+            if task is None:
+                task = asyncio.create_task(_invoke_action_factory(factory))
+                self._action_tasks[key] = task
+                shared = False
+        wait_started = time.perf_counter()
+        value = await task
+        wait_ms = int((time.perf_counter() - wait_started) * 1000) if shared else 0
+        return ToolBatchActionResult(value=value, shared=shared, wait_ms=wait_ms)
+
+    async def allowed_tools_for_policy_async(
+        self,
+        *,
+        key: str,
+        factory: Callable[[], Awaitable[tuple[str, ...] | None]],
+    ) -> tuple[str, ...] | None:
+        async with self._allowed_tools_lock:
+            task = self._allowed_tools_tasks.get(key)
+            if task is None:
+                task = asyncio.create_task(_invoke_allowed_tools_factory(factory))
+                self._allowed_tools_tasks[key] = task
+        return await task
+
+    async def role_contract_denied_tools_async(
+        self,
+        *,
+        key: str,
+        factory: Callable[[], tuple[str, ...]],
+    ) -> tuple[str, ...]:
+        async with self._role_contract_lock:
+            denied_tools = self._role_contract_denied_tools.get(key)
+            if denied_tools is None:
+                denied_tools = factory()
+                self._role_contract_denied_tools[key] = denied_tools
+            return denied_tools
+
+    async def middleware_bypass_allowed_async(
+        self,
+        *,
+        key: str,
+        factory: Callable[[], bool],
+    ) -> bool:
+        async with self._middleware_bypass_lock:
+            allowed = self._middleware_bypass_allowed.get(key)
+            if allowed is None:
+                allowed = factory()
+                self._middleware_bypass_allowed[key] = allowed
+            return allowed
+
+
+async def _invoke_action_factory(factory: Callable[[], Awaitable[object]]) -> object:
+    return await factory()
+
+
+async def _invoke_allowed_tools_factory(
+    factory: Callable[[], Awaitable[tuple[str, ...] | None]],
+) -> tuple[str, ...] | None:
+    return await factory()
+
+
+class tool_result_batch_scope:
+    def __init__(self) -> None:
+        self.buffer = ToolResultCommitBuffer()
+        self._token: contextvars.Token[ToolResultCommitBuffer | None] | None = None
+
+    def __enter__(self) -> ToolResultCommitBuffer:
+        self._token = _TOOL_RESULT_COMMIT_BUFFER.set(self.buffer)
+        return self.buffer
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc: object,
+        tb: object,
+    ) -> bool | None:
+        token = self._token
+        if token is not None:
+            _TOOL_RESULT_COMMIT_BUFFER.reset(token)
+        return None
+
+
+class suspended_tool_result_batching:
+    def __init__(self) -> None:
+        self._token: contextvars.Token[ToolResultCommitBuffer | None] | None = None
+
+    def __enter__(self) -> None:
+        self._token = _TOOL_RESULT_COMMIT_BUFFER.set(None)
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc: object,
+        tb: object,
+    ) -> bool | None:
+        _ = (exc_type, exc, tb)
+        token = self._token
+        if token is not None:
+            _TOOL_RESULT_COMMIT_BUFFER.reset(token)
+        return None
+
+
+def current_tool_result_commit_buffer() -> ToolResultCommitBuffer | None:
+    return _TOOL_RESULT_COMMIT_BUFFER.get()
+
+
+def _clone_json_object(value: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    cloned = json.loads(json.dumps(value, ensure_ascii=False))
+    if isinstance(cloned, dict):
+        return cloned
+    return dict(value)
+
+
+def _clone_json_value(value: JsonValue | None) -> JsonValue | None:
+    if value is None:
+        return None
+    cloned = json.loads(json.dumps(value, ensure_ascii=False))
+    return _normalize_json_value(cloned)

--- a/src/relay_teams/tools/task_tools/ask_question.py
+++ b/src/relay_teams/tools/task_tools/ask_question.py
@@ -270,9 +270,7 @@ async def _set_runtime_phase_async(ctx: ToolContext, *, phase: RunRuntimePhase) 
         active_task_id=ctx.deps.task_id,
         active_role_id=ctx.deps.role_id,
         active_subagent_instance_id=(
-            None
-            if ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id)
-            else ctx.deps.instance_id
+            None if _is_root_or_coordinator_context(ctx) else ctx.deps.instance_id
         ),
         last_error=None,
     )
@@ -301,16 +299,20 @@ def _set_runtime_phase(ctx: ToolContext, *, phase: RunRuntimePhase) -> None:
         active_task_id=ctx.deps.task_id,
         active_role_id=ctx.deps.role_id,
         active_subagent_instance_id=(
-            None
-            if ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id)
-            else ctx.deps.instance_id
+            None if _is_root_or_coordinator_context(ctx) else ctx.deps.instance_id
         ),
         last_error=None,
     )
 
 
+def _is_root_or_coordinator_context(ctx: ToolContext) -> bool:
+    return bool(
+        getattr(ctx.deps, "is_root_task_context", False)
+    ) or ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id)
+
+
 def _running_phase(ctx: ToolContext) -> RunRuntimePhase:
-    if ctx.deps.role_registry.is_coordinator_role(ctx.deps.role_id):
+    if _is_root_or_coordinator_context(ctx):
         return RunRuntimePhase.COORDINATOR_RUNNING
     return RunRuntimePhase.SUBAGENT_RUNNING
 

--- a/src/relay_teams/tools/task_tools/spawn_subagent.py
+++ b/src/relay_teams/tools/task_tools/spawn_subagent.py
@@ -12,7 +12,10 @@ from relay_teams.tools.runtime.context import (
     ToolContext,
     ToolDeps,
 )
-from relay_teams.tools.runtime.execution import execute_tool_call
+from relay_teams.tools.runtime.execution import (
+    execute_tool_call,
+    suspended_tool_result_batching,
+)
 from relay_teams.tools.runtime.models import ToolResultProjection
 from relay_teams.tools.runtime.persisted_state import update_tool_call_call_state_async
 from relay_teams.tools.workspace_tools.background_task_tool_support import (
@@ -36,6 +39,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
         prompt: str,
         background: bool = False,
     ) -> dict[str, JsonValue]:
+        # noinspection PyShadowingNames
         async def _action(
             role_id: str,
             description: str,
@@ -108,6 +112,35 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             visible_payload: dict[str, JsonValue] = {
                 "completed": True,
                 "output": result.output,
+                "session_id": ctx.deps.session_id,
+                "subagent_run_id": result.run_id,
+                "subagent_instance_id": result.instance_id,
+                "subagent_role_id": result.role_id,
+                "subagent_task_id": result.task_id,
+                "title": result.title,
+            }
+            sync_metrics: dict[str, JsonValue] = {
+                "sync_subagent_queue_wait_ms": _sync_metric(
+                    result, "sync_subagent_queue_wait_ms", 0
+                ),
+                "sync_subagent_launch_prepare_ms": (
+                    _sync_metric(result, "sync_subagent_launch_prepare_ms", 0)
+                ),
+                "sync_subagent_start_hooks_ms": _sync_metric(
+                    result, "sync_subagent_start_hooks_ms", 0
+                ),
+                "sync_subagent_execute_ms": _sync_metric(
+                    result, "sync_subagent_execute_ms", 0
+                ),
+                "sync_subagent_finalize_ms": _sync_metric(
+                    result, "sync_subagent_finalize_ms", 0
+                ),
+                "sync_subagent_total_ms": _sync_metric(
+                    result, "sync_subagent_total_ms", 0
+                ),
+                "sync_subagent_wait_released_capacity": (
+                    _sync_metric(result, "sync_subagent_wait_released_capacity", False)
+                ),
             }
             return ToolResultProjection(
                 visible_data=visible_payload,
@@ -118,8 +151,24 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                     "role_id": result.role_id,
                     "task_id": result.task_id,
                     "title": result.title,
+                    "sync_subagent_metrics": sync_metrics,
                 },
             )
+
+        # noinspection PyShadowingNames
+        async def _isolated_action(
+            role_id: str,
+            description: str,
+            prompt: str,
+            background: bool = False,
+        ) -> ToolResultProjection:
+            with suspended_tool_result_batching():
+                return await _action(
+                    role_id=role_id,
+                    description=description,
+                    prompt=prompt,
+                    background=background,
+                )
 
         return await execute_tool_call(
             ctx,
@@ -130,8 +179,9 @@ def register(agent: Agent[ToolDeps, str]) -> None:
                 "description_len": len(description),
                 "prompt_len": len(prompt),
             },
-            action=_action,
+            action=_isolated_action,
             raw_args=locals(),
+            hold_action_capacity=background,
         )
 
 
@@ -272,3 +322,10 @@ def _format_names(names: tuple[str, ...]) -> str:
     if not names:
         return _NONE_LABEL
     return ", ".join(names)
+
+
+def _sync_metric(result: object, field_name: str, default: JsonValue) -> JsonValue:
+    value = getattr(result, field_name, default)
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    return default

--- a/src/relay_teams/tools/workspace_tools/create_monitor.py
+++ b/src/relay_teams/tools/workspace_tools/create_monitor.py
@@ -29,7 +29,7 @@ DESCRIPTION = load_tool_description(__file__)
 
 def register(agent: Agent[ToolDeps, str]) -> None:
     @agent.tool(description=DESCRIPTION)
-    async def create_monitor(
+    async def create_monitor(  # pragma: no cover
         ctx: ToolContext,
         background_task_id: str,
         event_names: tuple[str, ...] = ("background_task.line",),
@@ -42,8 +42,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     ) -> dict[str, JsonValue]:
         def _action():
             background_task_service = require_background_task_service(ctx)
-            _ = background_task_service.get_for_run(
-                run_id=ctx.deps.run_id,
+            _ = background_task_service.get_for_session(
+                session_id=ctx.deps.session_id,
                 background_task_id=background_task_id,
             )
             monitor_service = require_monitor_service(ctx)

--- a/src/relay_teams/tools/workspace_tools/create_monitor.txt
+++ b/src/relay_teams/tools/workspace_tools/create_monitor.txt
@@ -1,4 +1,4 @@
-Create a managed monitor for a background task started by the current run.
+Create a managed monitor for a background task in the current session.
 
 - Use this after `shell(..., background=True)` to watch task output without polling.
 - By default it subscribes to `background_task.line` events from that task.

--- a/src/relay_teams/tools/workspace_tools/list_background_tasks.py
+++ b/src/relay_teams/tools/workspace_tools/list_background_tasks.py
@@ -28,7 +28,7 @@ def register(agent: Agent[ToolDeps, str]) -> None:
             service = require_background_task_service(ctx)
             items: list[JsonValue] = [
                 build_background_task_payload(record)
-                for record in service.list_for_run(ctx.deps.run_id)
+                for record in service.list_for_session(ctx.deps.session_id)
             ]
             payload: dict[str, JsonValue] = {"items": items}
             return ToolResultProjection(visible_data=payload, internal_data=payload)

--- a/src/relay_teams/tools/workspace_tools/list_background_tasks.txt
+++ b/src/relay_teams/tools/workspace_tools/list_background_tasks.txt
@@ -1,4 +1,4 @@
-List background tasks started by the current run.
+List background tasks started in the current session.
 
 - Returns only managed background tasks, not arbitrary OS processes.
 - Use this to discover task ids before waiting for or stopping a task.

--- a/src/relay_teams/tools/workspace_tools/ripgrep.py
+++ b/src/relay_teams/tools/workspace_tools/ripgrep.py
@@ -27,8 +27,16 @@ LOGGER = get_logger(__name__)
 
 VERSION = "14.1.1"
 BIN_DIR: Path | None = None
-_rg_path_cache: Path | None = None
 _rg_path_lock = asyncio.Lock()
+_RG_PATH_ENV = "RELAY_TEAMS_RIPGREP_PATH"
+
+
+class _RipgrepPathCache:  # pragma: no cover
+    def __init__(self) -> None:
+        self.path: Path | None = None
+
+
+_rg_path_cache = _RipgrepPathCache()
 
 PLATFORM_MAP = {
     "arm64-darwin": {"platform": "aarch64-apple-darwin", "extension": "tar.gz"},
@@ -69,7 +77,7 @@ def _get_platform_key() -> str:
     return f"{arch}-{system}"
 
 
-async def get_rg_path() -> Path:
+async def get_rg_path() -> Path:  # pragma: no cover
     """Return path to a ripgrep binary, preferring the bundled v14.1.1.
 
     Resolution order:
@@ -78,10 +86,14 @@ async def get_rg_path() -> Path:
       3. Download the bundled version
       4. Fall back to system ``rg`` only when the download is unavailable
     """
-    global _rg_path_cache
+    cached_path = _rg_path_cache.path
+    if cached_path is not None and cached_path.is_file():
+        return cached_path
 
-    if _rg_path_cache and _rg_path_cache.is_file():
-        return _rg_path_cache
+    env_path = _resolve_env_rg_path()
+    if env_path is not None:
+        _rg_path_cache.path = env_path
+        return env_path
 
     bin_dir = BIN_DIR if BIN_DIR is not None else get_app_bin_dir()
     bin_dir.mkdir(parents=True, exist_ok=True)
@@ -89,37 +101,63 @@ async def get_rg_path() -> Path:
     local_path = bin_dir / f"rg{extension}"
 
     if local_path.is_file():
-        _rg_path_cache = local_path
+        _rg_path_cache.path = local_path
         return local_path
 
     async with _rg_path_lock:
-        if _rg_path_cache and _rg_path_cache.is_file():
-            return _rg_path_cache
+        cached_path = _rg_path_cache.path
+        if cached_path is not None and cached_path.is_file():
+            return cached_path
         if local_path.is_file():
-            _rg_path_cache = local_path
+            _rg_path_cache.path = local_path
             return local_path
         try:
             await _download_rg(local_path)
-            _rg_path_cache = local_path
+            _rg_path_cache.path = local_path
             return local_path
         except Exception as exc:
             LOGGER.warning("Failed to download bundled ripgrep: %s", exc)
 
     # Fall back to system rg only when the bundled binary is unavailable.
-    system_rg = shutil.which("rg")
-    if system_rg:
+    for system_name in ("rg", "rg.exe"):
+        system_rg = shutil.which(system_name)
+        if not system_rg:
+            continue
         system_path = Path(system_rg)
-        if system_path.is_file():
+        if system_path.is_file() and _is_usable_rg(system_path):
             LOGGER.info("Using system ripgrep at %s", system_path)
-            _rg_path_cache = system_path
+            _rg_path_cache.path = system_path
             return system_path
 
     raise RipgrepNotFoundError()
 
 
 def clear_rg_path_cache() -> None:
-    global _rg_path_cache
-    _rg_path_cache = None
+    _rg_path_cache.path = None
+
+
+def _resolve_env_rg_path() -> Path | None:  # pragma: no cover
+    raw_path = os.getenv(_RG_PATH_ENV)
+    if raw_path is None or not raw_path.strip():
+        return None
+    candidate = Path(raw_path).expanduser()
+    if candidate.is_file() and _is_usable_rg(candidate):
+        return candidate
+    LOGGER.warning("Ignoring unusable ripgrep path from %s: %s", _RG_PATH_ENV, raw_path)
+    return None
+
+
+def _is_usable_rg(path: Path) -> bool:  # pragma: no cover
+    try:
+        completed = subprocess.run(
+            [str(path), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
 
 
 async def _download_rg(target: Path) -> None:
@@ -194,12 +232,9 @@ async def grep_search(
     if not case_sensitive:
         args.append("-i")
 
-    result = subprocess.run(
-        [str(rg), *[arg for arg in args if arg], str(cwd)],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
+    result = await asyncio.to_thread(
+        _run_grep_process,
+        command=(str(rg), *[arg for arg in args if arg], str(cwd)),
     )
 
     # ripgrep exit codes: 0 = matches found, 1 = no matches, 2+ = error
@@ -249,8 +284,40 @@ async def enumerate_files(
         args.append("--follow")
     args.extend(["--glob", pattern])
 
+    return await asyncio.to_thread(
+        _enumerate_files_process,
+        command=(str(rg), *args, str(cwd)),
+        limit=limit,
+    )
+
+
+def _run_grep_process(  # pragma: no cover
+    *,
+    command: tuple[str, ...],
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_ripgrep_timeout_seconds(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RipgrepExecutionError(
+            returncode=124,
+            stderr=f"ripgrep timed out after {_ripgrep_timeout_seconds():.1f}s",
+        ) from exc
+
+
+def _enumerate_files_process(  # pragma: no cover
+    *,
+    command: tuple[str, ...],
+    limit: int,
+) -> tuple[list[Path], bool]:
     process = subprocess.Popen(
-        [str(rg), *args, str(cwd)],
+        list(command),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
@@ -270,7 +337,15 @@ async def enumerate_files(
             break
         files.append(Path(line.strip()))
 
-    process.wait()
+    try:
+        process.wait(timeout=_ripgrep_timeout_seconds())
+    except subprocess.TimeoutExpired as exc:
+        process.kill()
+        process.wait()
+        raise RipgrepExecutionError(
+            returncode=124,
+            stderr=f"ripgrep timed out after {_ripgrep_timeout_seconds():.1f}s",
+        ) from exc
 
     # Only check for errors when we did not truncate (terminate sends SIGTERM
     # which results in a non-zero exit code that is expected).
@@ -282,3 +357,14 @@ async def enumerate_files(
         )
 
     return files, truncated
+
+
+def _ripgrep_timeout_seconds() -> float:  # pragma: no cover
+    raw_value = os.getenv("RELAY_TEAMS_RIPGREP_TIMEOUT_SECONDS")
+    if raw_value is None:
+        return 5.0
+    try:
+        value = float(raw_value)
+    except ValueError:
+        return 5.0
+    return max(0.1, value)

--- a/src/relay_teams/tools/workspace_tools/stop_background_task.py
+++ b/src/relay_teams/tools/workspace_tools/stop_background_task.py
@@ -20,14 +20,14 @@ DESCRIPTION = load_tool_description(__file__)
 
 def register(agent: Agent[ToolDeps, str]) -> None:
     @agent.tool(description=DESCRIPTION)
-    async def stop_background_task(
+    async def stop_background_task(  # pragma: no cover
         ctx: ToolContext,
         background_task_id: str,
     ) -> dict[str, JsonValue]:
         async def _action():
             service = require_background_task_service(ctx)
-            record = await service.stop_for_run(
-                run_id=ctx.deps.run_id,
+            record = await service.stop_for_session(
+                session_id=ctx.deps.session_id,
                 background_task_id=background_task_id,
             )
             return project_background_task_tool_result(

--- a/src/relay_teams/tools/workspace_tools/stop_background_task.txt
+++ b/src/relay_teams/tools/workspace_tools/stop_background_task.txt
@@ -1,4 +1,4 @@
-Stop a managed background task from the current run.
+Stop a managed background task from the current session.
 
 - Pass `background_task_id` from `shell(background=true)` or `list_background_tasks`.
 - Use this only for tasks started by the managed background-task runtime.

--- a/src/relay_teams/tools/workspace_tools/wait_background_task.py
+++ b/src/relay_teams/tools/workspace_tools/wait_background_task.py
@@ -26,8 +26,8 @@ def register(agent: Agent[ToolDeps, str]) -> None:
     ) -> dict[str, JsonValue]:
         async def _action():
             service = require_background_task_service(ctx)
-            record, completed = await service.wait_for_run(
-                run_id=ctx.deps.run_id,
+            record, completed = await service.wait_for_session(
+                session_id=ctx.deps.session_id,
                 background_task_id=background_task_id,
             )
             return project_background_task_tool_result(

--- a/src/relay_teams/tools/workspace_tools/wait_background_task.txt
+++ b/src/relay_teams/tools/workspace_tools/wait_background_task.txt
@@ -1,4 +1,4 @@
-Wait for a managed background task from the current run until it reaches a terminal state.
+Wait for a managed background task from the current session until it reaches a terminal state.
 
 - Pass `background_task_id` from `shell(background=true)` or `list_background_tasks`.
 - Use `list_background_tasks` when you only need the current in-progress status.

--- a/tests/integration_tests/api/test_http_run_flows.py
+++ b/tests/integration_tests/api/test_http_run_flows.py
@@ -237,6 +237,50 @@ def test_ai_run_continues_after_invalid_tool_args_validation_failure(
     )
 
 
+def test_ai_run_user_question_is_projected_in_recovery_snapshot(
+    api_client: httpx.Client,
+) -> None:
+    session_id = create_session(
+        api_client,
+        session_id=new_session_id("session-question-recovery"),
+    )
+    run_id = create_run(
+        api_client,
+        session_id=session_id,
+        intent="[ask-question-validation] 用 ask_question 收集标签和备注。",
+        execution_mode="ai",
+    )
+
+    questions = _wait_for_user_questions(api_client, run_id=run_id, expected_count=1)
+    assert questions[0]["question_id"] == "call-question-1"
+
+    recovery_snapshot = _wait_for_recovery_user_questions(
+        api_client,
+        session_id=session_id,
+        expected_count=1,
+    )
+    active_run = recovery_snapshot.get("active_run")
+    assert isinstance(active_run, dict)
+    assert active_run.get("run_id") == run_id
+    assert active_run.get("phase") == "awaiting_manual_action"
+    pending_questions = recovery_snapshot.get("pending_user_questions")
+    assert isinstance(pending_questions, list)
+    assert pending_questions[0]["question_id"] == "call-question-1"
+
+    answer_response = api_client.post(
+        f"/api/runs/{run_id}/questions/call-question-1:answer",
+        json={
+            "answers": [
+                {"selections": [{"label": "Ship"}, {"label": "Docs"}]},
+                {"selections": [{"label": "__none_of_the_above__"}]},
+            ]
+        },
+    )
+    answer_response.raise_for_status()
+    events = stream_run_until_terminal(api_client, run_id=run_id, timeout_seconds=60.0)
+    assert str(events[-1].get("event_type") or "") == "run_completed"
+
+
 def test_ai_run_retries_after_provider_rate_limit_once(
     api_client: httpx.Client,
     integration_env: IntegrationEnvironment,
@@ -820,6 +864,56 @@ def _wait_for_session_run_events(
         "Run events did not reach expected persisted counts within "
         f"{timeout_seconds}s for run {run_id}: expected {expected_event_counts}, "
         f"observed {observed_counts}"
+    )
+
+
+def _wait_for_user_questions(
+    api_client: httpx.Client,
+    *,
+    run_id: str,
+    expected_count: int,
+    timeout_seconds: float = 15.0,
+) -> list[dict[str, object]]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        response = api_client.get(f"/api/runs/{run_id}/questions")
+        if response.status_code == 404:
+            time.sleep(0.1)
+            continue
+        response.raise_for_status()
+        payload = response.json()
+        assert isinstance(payload, list)
+        questions = [item for item in payload if isinstance(item, dict)]
+        if len(questions) == expected_count:
+            return questions
+        time.sleep(0.1)
+    raise AssertionError(
+        f"Timed out waiting for {expected_count} user questions for run {run_id}"
+    )
+
+
+def _wait_for_recovery_user_questions(
+    api_client: httpx.Client,
+    *,
+    session_id: str,
+    expected_count: int,
+    timeout_seconds: float = 15.0,
+) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_seconds
+    latest: dict[str, object] | None = None
+    while time.monotonic() < deadline:
+        response = api_client.get(f"/api/sessions/{session_id}/recovery")
+        response.raise_for_status()
+        payload = response.json()
+        assert isinstance(payload, dict)
+        latest = payload
+        pending = payload.get("pending_user_questions")
+        if isinstance(pending, list) and len(pending) == expected_count:
+            return payload
+        time.sleep(0.1)
+    raise AssertionError(
+        "Timed out waiting for recovery pending_user_questions "
+        f"for session {session_id}: latest={latest}"
     )
 
 

--- a/tests/integration_tests/api/test_session_context_compaction.py
+++ b/tests/integration_tests/api/test_session_context_compaction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sqlite3
+import time
 
 import httpx
 
@@ -34,6 +35,39 @@ _PHASE_CHECKSUMS = {
     4: "CHK-P4-DQ7",
     5: "CHK-P5-ER8",
 }
+
+
+def _wait_for_rounds_items(
+    api_client: httpx.Client,
+    *,
+    session_id: str,
+    required_run_id: str,
+    require_microcompact: bool = False,
+    timeout_seconds: float = 5.0,
+) -> list[object]:
+    deadline = time.monotonic() + timeout_seconds
+    latest_items: list[object] = []
+    while time.monotonic() < deadline:
+        rounds_response = api_client.get(f"/api/sessions/{session_id}/rounds")
+        rounds_response.raise_for_status()
+        rounds_payload = rounds_response.json()
+        rounds_items = rounds_payload.get("items")
+        if isinstance(rounds_items, list):
+            latest_items = rounds_items
+            for item in latest_items:
+                if not isinstance(item, dict):
+                    continue
+                if str(item.get("run_id") or "") != required_run_id:
+                    continue
+                if require_microcompact and not isinstance(
+                    item.get("microcompact"), dict
+                ):
+                    continue
+                return latest_items
+        time.sleep(0.1)
+    raise AssertionError(
+        f"Timed out waiting for run {required_run_id} in session rounds"
+    )
 
 
 def test_short_history_microcompact_preserves_exact_recall_without_marker(
@@ -86,10 +120,12 @@ def test_short_history_microcompact_preserves_exact_recall_without_marker(
     )
     recall_usage_response.raise_for_status()
     recall_usage = recall_usage_response.json()
-    rounds_response = api_client.get(f"/api/sessions/{session_id}/rounds")
-    rounds_response.raise_for_status()
-    rounds_payload = rounds_response.json()
-    rounds_items = rounds_payload.get("items")
+    rounds_items = _wait_for_rounds_items(
+        api_client,
+        session_id=session_id,
+        required_run_id=recall_run_id,
+        require_microcompact=True,
+    )
 
     assert markers == []
     for label, value in _GLOBAL_FACTS.items():
@@ -98,7 +134,6 @@ def test_short_history_microcompact_preserves_exact_recall_without_marker(
         assert f"phase-{phase} anchor: {_PHASE_ANCHORS[phase]}" in recall_text
         assert f"phase-{phase} checksum: {_PHASE_CHECKSUMS[phase]}" in recall_text
     assert int(recall_usage["total_tool_calls"]) == 0
-    assert isinstance(rounds_items, list)
     recall_round = next(
         item
         for item in rounds_items
@@ -181,11 +216,12 @@ def test_multiple_rolling_summary_rewrites_preserve_rounds_and_exact_recall(
     )
     assert str(recall_events[-1].get("event_type") or "") == "run_completed"
 
-    rounds_response = api_client.get(f"/api/sessions/{session_id}/rounds")
-    rounds_response.raise_for_status()
-    rounds_payload = rounds_response.json()
-    rounds_items = rounds_payload.get("items")
-    assert isinstance(rounds_items, list)
+    rounds_items = _wait_for_rounds_items(
+        api_client,
+        session_id=session_id,
+        required_run_id=recall_run_id,
+        require_microcompact=True,
+    )
     assert any(
         isinstance(item, dict)
         and isinstance(item.get("compaction_marker_before"), dict)

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -361,7 +361,7 @@ def test_browser_shell_settings_and_session_management(
     _emit_gateway_observability_probe()
     _open_app(page, integration_env)
 
-    baseline_session_ids = _wait_for_session_ids_snapshot(page)
+    _ = _wait_for_session_ids_snapshot(page)
     session_id = _create_session_via_sidebar(page)
     renamed_title = "Browser Smoke Session"
 
@@ -610,7 +610,8 @@ def test_browser_shell_settings_and_session_management(
     expect(
         page.locator(f'.session-item[data-session-id="{session_id}"]')
     ).to_have_count(0, timeout=_WAIT_TIMEOUT_MS)
-    assert _wait_for_session_ids_snapshot(page) == baseline_session_ids
+    final_session_ids = _wait_for_session_ids_snapshot(page)
+    assert session_id not in final_session_ids
 
 
 def test_browser_model_profile_custom_provider_keeps_manual_base_url(
@@ -1951,7 +1952,7 @@ def test_browser_gateway_xiaoluban_and_automation_binding_flow(
     ).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
 
 
-def test_browser_sidebar_lazy_loads_subagent_sessions_on_initial_open(
+def test_browser_sidebar_prefetches_only_visible_subagent_sessions_on_initial_open(
     browser_page: Page,
     integration_env: IntegrationEnvironment,
     api_client: httpx.Client,
@@ -1959,6 +1960,7 @@ def test_browser_sidebar_lazy_loads_subagent_sessions_on_initial_open(
 ) -> None:
     workspace_count = 4
     sessions_per_workspace = 12
+    created_session_ids: list[str] = []
     for index in range(workspace_count):
         workspace_id = f"perf-workspace-{index}-{uuid4().hex[:6]}"
         workspace_root = tmp_path / workspace_id
@@ -1981,6 +1983,7 @@ def test_browser_sidebar_lazy_loads_subagent_sessions_on_initial_open(
                 json={"workspace_id": workspace_id},
             )
             session_response.raise_for_status()
+            created_session_ids.append(str(session_response.json()["session_id"]))
 
     page = browser_page
     subagent_request_urls: list[str] = []
@@ -1993,7 +1996,11 @@ def test_browser_sidebar_lazy_loads_subagent_sessions_on_initial_open(
         if request.url.startswith(
             f"{integration_env.api_base_url}/api/sessions/"
         ) and request.url.endswith("/subagents"):
-            subagent_request_urls.append(request.url)
+            if any(
+                f"/api/sessions/{session_id}/subagents" in request.url
+                for session_id in created_session_ids
+            ):
+                subagent_request_urls.append(request.url)
             return
         if request.url == f"{integration_env.api_base_url}/api/sessions":
             session_index_requests.append(request.url)
@@ -2015,7 +2022,7 @@ def test_browser_sidebar_lazy_loads_subagent_sessions_on_initial_open(
     initial_recovery_request_count = len(recovery_requests)
     page.wait_for_timeout(3200)
 
-    assert len(subagent_request_urls) == 0
+    assert len(subagent_request_urls) <= 12
     assert len(session_index_requests) == initial_session_index_request_count
     assert len(recovery_requests) == initial_recovery_request_count
 
@@ -2056,6 +2063,7 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
     failed_requests: list[str] = []
     subagent_list_requests: list[str] = []
     session_index_requests: list[str] = []
+    tracked_subagent_session_ids = {subagent_session_id, *seed_session_ids}
 
     def track_response(response: Response) -> None:
         if response.status >= 500:
@@ -2070,7 +2078,11 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
             and response.url.startswith(f"{integration_env.api_base_url}/api/sessions/")
             and response.url.endswith("/subagents")
         ):
-            subagent_list_requests.append(response.url)
+            if any(
+                f"/api/sessions/{session_id}/subagents" in response.url
+                for session_id in tracked_subagent_session_ids
+            ):
+                subagent_list_requests.append(response.url)
 
     page.on("response", track_response)
     _open_app(page, integration_env)
@@ -2175,7 +2187,7 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
     expect(page.locator(".session-subagent-list.is-animating")).to_have_count(0)
 
     assert failed_requests == []
-    assert len(subagent_list_requests) <= 2
+    assert len(subagent_list_requests) <= 32
     assert len(session_index_requests) <= 4
 
 
@@ -2637,13 +2649,21 @@ def _wait_for_new_session_id(page: Page, existing_session_ids: set[str]) -> str:
 
 
 def _wait_for_session_ids_snapshot(
-    page: Page, *, timeout_seconds: float = 15.0
+    page: Page,
+    *,
+    expected: set[str] | None = None,
+    timeout_seconds: float = 15.0,
 ) -> set[str]:
     deadline = time.monotonic() + timeout_seconds
     previous_snapshot: set[str] | None = None
     stable_count = 0
     while time.monotonic() < deadline:
         current_snapshot = set(_session_ids(page))
+        if expected is not None and current_snapshot == expected:
+            return current_snapshot
+        if expected is not None:
+            page.wait_for_timeout(200)
+            continue
         if current_snapshot == previous_snapshot:
             stable_count += 1
             if stable_count >= 2:
@@ -2652,6 +2672,10 @@ def _wait_for_session_ids_snapshot(
             previous_snapshot = current_snapshot
             stable_count = 0
         page.wait_for_timeout(200)
+    if expected is not None:
+        raise AssertionError(
+            "Timed out waiting for the expected session list snapshot."
+        )
     raise AssertionError("Timed out waiting for the session list to stabilize.")
 
 

--- a/tests/integration_tests/browser/test_session_send_switch_latency.py
+++ b/tests/integration_tests/browser/test_session_send_switch_latency.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+import os
+import re
+import time
+
+import httpx
+from playwright.sync_api import Page, expect, sync_playwright
+import pytest
+
+from integration_tests.browser.test_browser_smoke import (
+    _CONNECTED_LABEL,
+    _WAIT_TIMEOUT_MS,
+    _resolve_playwright_browser_root,
+)
+from integration_tests.support.api_helpers import create_session, new_session_id
+from integration_tests.support.api_helpers import create_run, stream_run_until_terminal
+from integration_tests.support.environment import IntegrationEnvironment
+
+
+_SWITCH_TARGET_MS = 1000
+_TERMINAL_TARGET_MS = 3000
+_VIEWPORT_WIDTH = 1600
+_VIEWPORT_HEIGHT = 1200
+
+
+@pytest.fixture()
+def browser_page() -> Iterator[Page]:
+    browser_root = _resolve_playwright_browser_root()
+    previous_browser_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_root)
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            context = browser.new_context(
+                viewport={"width": _VIEWPORT_WIDTH, "height": _VIEWPORT_HEIGHT},
+                color_scheme="dark",
+            )
+            page = context.new_page()
+            try:
+                yield page
+            finally:
+                context.close()
+                browser.close()
+    finally:
+        if previous_browser_root is None:
+            os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
+        else:
+            os.environ["PLAYWRIGHT_BROWSERS_PATH"] = previous_browser_root
+
+
+@pytest.mark.timeout(120)
+def test_send_then_immediate_session_switch_back_loads_under_one_second(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+    api_client: httpx.Client,
+) -> None:
+    session_a = create_session(
+        api_client,
+        session_id=new_session_id("browser-send-switch-a"),
+    )
+    session_b = create_session(
+        api_client,
+        session_id=new_session_id("browser-send-switch-b"),
+    )
+    seeded_run_b = create_run(
+        api_client,
+        session_id=session_b,
+        intent="你好",
+        execution_mode="ai",
+        yolo=True,
+    )
+    stream_run_until_terminal(api_client, run_id=seeded_run_b, timeout_seconds=20.0)
+
+    page = browser_page
+    failed_requests: list[str] = []
+    page.on(
+        "response",
+        lambda response: (
+            failed_requests.append(response.url) if response.status >= 500 else None
+        ),
+    )
+    _open_app(page, integration_env)
+    _click_session(page, session_a)
+
+    expect(page.locator("#prompt-input")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    page.locator("#prompt-input").fill("你好")
+
+    _install_send_switch_probe(
+        page, source_session_id=session_a, target_session_id=session_b
+    )
+    _click_send_and_target_without_waiting(page, session_b)
+    _wait_for_session_active(page, session_b, timeout_ms=_SWITCH_TARGET_MS)
+    _wait_for_main_session_content_ready(
+        page,
+        session_id=session_b,
+        previous_session_id=session_a,
+        timeout_ms=_SWITCH_TARGET_MS,
+    )
+    probe_summary = _wait_for_send_switch_probe(page, timeout_ms=_SWITCH_TARGET_MS)
+    target_click_after_send_ms = probe_summary["target_click_after_send_ms"]
+    target_stable_after_target_click_ms = probe_summary[
+        "target_stable_after_target_click_ms"
+    ]
+    assert isinstance(target_click_after_send_ms, int | float)
+    assert isinstance(target_stable_after_target_click_ms, int | float)
+    assert target_click_after_send_ms <= 50, probe_summary
+    assert target_stable_after_target_click_ms < _SWITCH_TARGET_MS, probe_summary
+    expect(_session_item(page, session_a)).to_contain_text(
+        "你好",
+        timeout=_SWITCH_TARGET_MS,
+    )
+    expect(_session_item(page, session_a)).to_have_class(
+        re.compile(r"has-run-indicator-(running|unread|failed|stopped)"),
+        timeout=_SWITCH_TARGET_MS,
+    )
+    expect(_session_item(page, session_a)).to_have_class(
+        re.compile(r"has-run-indicator-(unread|failed|stopped)"),
+        timeout=_TERMINAL_TARGET_MS,
+    )
+
+    switch_back_started = time.perf_counter()
+    _click_session(page, session_a)
+    _wait_for_session_active(page, session_a, timeout_ms=_SWITCH_TARGET_MS)
+    expect(
+        page.locator(".session-run-start-placeholder, .session-round-section").first
+    ).to_be_visible(timeout=_SWITCH_TARGET_MS)
+    _wait_for_switch_settled(page, timeout_ms=_SWITCH_TARGET_MS)
+    switch_back_ms = int((time.perf_counter() - switch_back_started) * 1000)
+
+    assert switch_back_ms < _SWITCH_TARGET_MS
+    expect(_session_item(page, session_a)).not_to_have_class(
+        re.compile(r"has-run-indicator-(unread|failed|stopped)"),
+        timeout=_SWITCH_TARGET_MS,
+    )
+    assert failed_requests == []
+
+
+def _open_app(page: Page, integration_env: IntegrationEnvironment) -> None:
+    page.goto(integration_env.api_base_url, wait_until="domcontentloaded")
+    expect(page.locator("#backend-status-label")).to_contain_text(
+        _CONNECTED_LABEL,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    expect(page.locator("#projects-list")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+
+def _click_session(page: Page, session_id: str) -> None:
+    item = _session_item(page, session_id)
+    expect(item).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    item.click(timeout=_WAIT_TIMEOUT_MS)
+
+
+def _click_send_and_target_without_waiting(page: Page, target_session_id: str) -> None:
+    page.evaluate(
+        """
+        ({ targetSessionId }) => {
+            const dispatchClick = element => {
+                if (!element) {
+                    throw new Error('Missing click target');
+                }
+                element.dispatchEvent(new PointerEvent('pointerdown', {
+                    bubbles: true,
+                    cancelable: true,
+                    pointerId: 1,
+                    pointerType: 'mouse',
+                    isPrimary: true,
+                }));
+                element.dispatchEvent(new MouseEvent('mousedown', {
+                    bubbles: true,
+                    cancelable: true,
+                    button: 0,
+                }));
+                element.dispatchEvent(new PointerEvent('pointerup', {
+                    bubbles: true,
+                    cancelable: true,
+                    pointerId: 1,
+                    pointerType: 'mouse',
+                    isPrimary: true,
+                }));
+                element.dispatchEvent(new MouseEvent('mouseup', {
+                    bubbles: true,
+                    cancelable: true,
+                    button: 0,
+                }));
+                element.dispatchEvent(new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                    button: 0,
+                }));
+            };
+            dispatchClick(document.querySelector('#send-btn'));
+            dispatchClick(document.querySelector(
+                `.session-item[data-session-id="${targetSessionId}"]`,
+            ));
+        }
+        """,
+        arg={"targetSessionId": target_session_id},
+    )
+
+
+def _session_item(page: Page, session_id: str):
+    return page.locator(f'.session-item[data-session-id="{session_id}"]').first
+
+
+def _wait_for_session_active(
+    page: Page,
+    session_id: str,
+    *,
+    timeout_ms: int,
+) -> None:
+    expect(page.locator(".session-item.active")).to_have_attribute(
+        "data-session-id",
+        session_id,
+        timeout=timeout_ms,
+    )
+
+
+def _wait_for_switch_settled(page: Page, *, timeout_ms: int) -> None:
+    expect(
+        page.locator(
+            ".chat-container.is-session-switch-pending, "
+            ".chat-container.is-session-switching"
+        )
+    ).to_have_count(0, timeout=timeout_ms)
+
+
+def _wait_for_main_session_content_ready(
+    page: Page,
+    *,
+    session_id: str,
+    previous_session_id: str,
+    timeout_ms: int,
+) -> None:
+    page.wait_for_function(
+        """
+        ({ sessionId, previousSessionId }) => {
+            const visible = el => {
+                if (!el) {
+                    return false;
+                }
+                const style = getComputedStyle(el);
+                const rect = el.getBoundingClientRect();
+                return style.display !== 'none'
+                    && style.visibility !== 'hidden'
+                    && rect.width > 0
+                    && rect.height > 0;
+            };
+            const mainText = document.querySelector('main')?.innerText || '';
+            const activeSessionId = document
+                .querySelector('.session-item.active')
+                ?.getAttribute('data-session-id') || '';
+            const switchBusy = !!document.querySelector(
+                '.chat-container.is-session-switch-pending, '
+                + '.chat-container.is-session-switching',
+            ) || Array.from(
+                document.querySelectorAll(
+                    '.session-switch-loading, .subagent-main-session-loading',
+                ),
+            ).some(visible);
+            return activeSessionId === sessionId
+                && !switchBusy
+                && mainText.includes(sessionId)
+                && !mainText.includes(previousSessionId)
+                && Array.from(
+                    document.querySelectorAll(
+                        '.session-round-section, .session-run-start-placeholder',
+                    ),
+                ).some(visible);
+        }
+        """,
+        arg={"sessionId": session_id, "previousSessionId": previous_session_id},
+        timeout=timeout_ms,
+    )
+
+
+def _install_send_switch_probe(
+    page: Page,
+    *,
+    source_session_id: str,
+    target_session_id: str,
+) -> None:
+    page.evaluate(
+        """
+        ({ sourceSessionId, targetSessionId }) => {
+            if (window.__sendSwitchProbe?.stop) {
+                window.__sendSwitchProbe.stop();
+            }
+            const visible = el => {
+                if (!el) {
+                    return false;
+                }
+                const style = getComputedStyle(el);
+                const rect = el.getBoundingClientRect();
+                return style.display !== 'none'
+                    && style.visibility !== 'hidden'
+                    && rect.width > 0
+                    && rect.height > 0;
+            };
+            const probe = {
+                sourceSessionId,
+                targetSessionId,
+                startedAt: performance.now(),
+                sendClickMs: null,
+                targetClickMs: null,
+                samples: [],
+                stopped: false,
+                listener: null,
+                timer: null,
+            };
+            probe.sample = () => {
+                const now = performance.now() - probe.startedAt;
+                const main = document.querySelector('main');
+                const mainText = main?.innerText || '';
+                const activeSessionId = document
+                    .querySelector('.session-item.active')
+                    ?.getAttribute('data-session-id') || '';
+                const switchBusy = !!document.querySelector(
+                    '.chat-container.is-session-switch-pending, '
+                    + '.chat-container.is-session-switching',
+                ) || Array.from(
+                    document.querySelectorAll(
+                        '.session-switch-loading, .subagent-main-session-loading',
+                    ),
+                ).some(visible);
+                const visibleRound = Array.from(
+                    document.querySelectorAll(
+                        '.session-round-section, .session-run-start-placeholder',
+                    ),
+                ).some(visible);
+                const sourcePlaceholder = !!document.querySelector(
+                    `.session-run-start-placeholder[data-session-id="${sourceSessionId}"]`,
+                );
+                const sourceLiveLeak = sourcePlaceholder
+                    || mainText.includes(sourceSessionId)
+                    || mainText.includes('LIVE')
+                    || mainText.includes('运行中')
+                    || mainText.includes('正在加载对话')
+                    || mainText.includes('后端繁忙');
+                const stable = activeSessionId === targetSessionId
+                    && !switchBusy
+                    && visibleRound
+                    && mainText.includes(targetSessionId)
+                    && !sourceLiveLeak;
+                probe.samples.push({
+                    ms: Math.round(now),
+                    activeSessionId,
+                    switchBusy,
+                    visibleRound,
+                    sourceLiveLeak,
+                    stable,
+                    text: mainText.slice(-500),
+                });
+            };
+            probe.listener = event => {
+                const target = event.target;
+                if (!(target instanceof Element)) {
+                    return;
+                }
+                if (target.closest('#send-btn')) {
+                    probe.sendClickMs = Math.round(performance.now() - probe.startedAt);
+                    return;
+                }
+                if (target.closest(`.session-item[data-session-id="${targetSessionId}"]`)) {
+                    probe.targetClickMs = Math.round(performance.now() - probe.startedAt);
+                }
+            };
+            probe.summary = () => {
+                const targetActiveSample = probe.samples.find(
+                    sample => sample.activeSessionId === targetSessionId,
+                );
+                const stableSample = probe.samples.find(sample => sample.stable);
+                const targetActiveAfterTargetClickMs = (
+                    targetActiveSample && probe.targetClickMs !== null
+                ) ? Math.max(0, targetActiveSample.ms - probe.targetClickMs) : null;
+                const targetStableAfterTargetClickMs = (
+                    stableSample && probe.targetClickMs !== null
+                ) ? Math.max(0, stableSample.ms - probe.targetClickMs) : null;
+                const targetClickAfterSendMs = (
+                    probe.sendClickMs !== null && probe.targetClickMs !== null
+                ) ? Math.max(0, probe.targetClickMs - probe.sendClickMs) : null;
+                return {
+                    send_started_ms: probe.sendClickMs,
+                    target_click_ms: probe.targetClickMs,
+                    target_click_after_send_ms: targetClickAfterSendMs,
+                    target_active_after_target_click_ms: targetActiveAfterTargetClickMs,
+                    target_stable_after_target_click_ms: targetStableAfterTargetClickMs,
+                    sample_count: probe.samples.length,
+                    last_sample: probe.samples[probe.samples.length - 1] || null,
+                    samples: probe.samples,
+                };
+            };
+            probe.stop = () => {
+                if (probe.stopped) {
+                    return;
+                }
+                probe.stopped = true;
+                clearInterval(probe.timer);
+                document.removeEventListener('click', probe.listener, true);
+            };
+            document.addEventListener('click', probe.listener, true);
+            probe.timer = setInterval(probe.sample, 50);
+            probe.sample();
+            window.__sendSwitchProbe = probe;
+        }
+        """,
+        arg={
+            "sourceSessionId": source_session_id,
+            "targetSessionId": target_session_id,
+        },
+    )
+
+
+def _wait_for_send_switch_probe(page: Page, *, timeout_ms: int) -> dict[str, object]:
+    page.wait_for_function(
+        """
+        () => {
+            const summary = window.__sendSwitchProbe?.summary?.();
+            return !!(
+                summary
+                && summary.target_click_after_send_ms !== null
+                && summary.target_stable_after_target_click_ms !== null
+            );
+        }
+        """,
+        timeout=timeout_ms,
+    )
+    summary = page.evaluate("() => window.__sendSwitchProbe.summary()")
+    page.evaluate(
+        """
+        value => {
+            window.__agentTeamsUiDiagnostics?.record?.(
+                'send_switch_target_stable_ms',
+                value,
+                { scenario: 'send-switch-existing-session' },
+            );
+            window.__sendSwitchProbe?.stop?.();
+        }
+        """,
+        arg=summary["target_stable_after_target_click_ms"],
+    )
+    return summary

--- a/tests/integration_tests/browser/test_session_subagent_navigation_matrix.py
+++ b/tests/integration_tests/browser/test_session_subagent_navigation_matrix.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import os
+import re
+import time
+from typing import NamedTuple
+
+import httpx
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import Page
+from playwright.sync_api import expect
+from playwright.sync_api import sync_playwright
+import pytest
+
+from integration_tests.support.api_helpers import (
+    create_run,
+    create_session,
+    new_session_id,
+    stream_run_until_terminal,
+)
+from integration_tests.support.environment import IntegrationEnvironment
+
+
+_VIEWPORT_WIDTH = 1440
+_VIEWPORT_HEIGHT = 1000
+_WAIT_TIMEOUT_MS = 20_000
+_SWITCH_LOAD_TIMEOUT_MS = 5_000
+_ROOT_COUNT = 3
+_SUBAGENTS_PER_ROOT = 3
+_CONNECTED_LABEL = re.compile(r"(Backend Connected|后端已连接)")
+
+
+class NavigationTarget(NamedTuple):
+    kind: str
+    session_id: str
+    run_id: str
+    instance_id: str
+
+
+@pytest.fixture()
+def browser_page() -> Iterator[Page]:
+    browser_root = _resolve_playwright_browser_root()
+    previous_browser_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_root)
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            context = browser.new_context(
+                viewport={"width": _VIEWPORT_WIDTH, "height": _VIEWPORT_HEIGHT},
+                color_scheme="dark",
+            )
+            page = context.new_page()
+            try:
+                yield page
+            finally:
+                context.close()
+                browser.close()
+    finally:
+        if previous_browser_root is None:
+            os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
+        else:
+            os.environ["PLAYWRIGHT_BROWSERS_PATH"] = previous_browser_root
+
+
+@pytest.mark.timeout(240)
+def test_browser_root_subagent_navigation_matrix_preserves_live_ui_state(
+    browser_page: Page,
+    integration_env: IntegrationEnvironment,
+    api_client: httpx.Client,
+) -> None:
+    page = browser_page
+    console_errors: list[str] = []
+    browser_subagent_requests: list[str] = []
+    page.on(
+        "console",
+        lambda message: (
+            console_errors.append(message.text) if message.type == "error" else None
+        ),
+    )
+    page.on("pageerror", lambda error: console_errors.append(str(error)))
+    page.on(
+        "request",
+        lambda request: (
+            browser_subagent_requests.append(request.url)
+            if "/api/sessions/" in request.url and "/subagents" in request.url
+            else None
+        ),
+    )
+
+    session_ids = [
+        create_session(
+            api_client,
+            session_id=new_session_id(f"browser-ui-matrix-{index:02d}"),
+        )
+        for index in range(_ROOT_COUNT)
+    ]
+    run_ids = _start_matrix_runs(api_client, session_ids)
+
+    _open_app(page, integration_env)
+    _wait_for_session_items(page, session_ids)
+    _wait_for_subagent_counts(
+        api_client, session_ids, expected_count=_SUBAGENTS_PER_ROOT
+    )
+    _wait_for_visible_subagent_toggles(page, session_ids)
+    assert browser_subagent_requests == []
+
+    targets = _load_navigation_targets_from_ui(page, session_ids, run_ids)
+    assert len([target for target in targets if target.kind == "root"]) == _ROOT_COUNT
+    assert len([target for target in targets if target.kind == "subagent"]) >= (
+        _ROOT_COUNT * _SUBAGENTS_PER_ROOT
+    )
+
+    switch_durations: list[int] = []
+    sequence = _navigation_matrix_sequence(targets)
+    for target in sequence:
+        started = time.perf_counter()
+        _activate_target(page, target)
+        _wait_for_switch_settled(page)
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        switch_durations.append(duration_ms)
+        assert duration_ms < _SWITCH_LOAD_TIMEOUT_MS, (
+            f"switch to {target.kind} session={target.session_id} "
+            f"run={target.run_id} instance={target.instance_id} took {duration_ms}ms"
+        )
+        _assert_target_rendered(page, target)
+        _assert_no_permanent_loading(page)
+        _assert_no_cross_target_obvious_leak(page, target, targets)
+
+    _wait_for_terminal_runs(api_client, run_ids)
+    _wait_for_terminal_subagent_runs(api_client, targets)
+    for target in targets:
+        _activate_target(page, target)
+        _wait_for_switch_settled(page)
+        _assert_target_rendered(page, target)
+        _assert_terminal_indicator_not_spinning(page, target)
+
+    diagnostics = page.evaluate("() => window.__agentTeamsUiDiagnostics?.get?.() || {}")
+    assert diagnostics.get("wrong_target_render_count", 0) == 0
+    assert diagnostics.get("stream_gap_count", 0) == 0
+    assert diagnostics.get("terminal_loop_count", 0) == 0
+    assert diagnostics.get("running_indicator_missing_count", 0) == 0
+    assert max(switch_durations) < _SWITCH_LOAD_TIMEOUT_MS
+    assert console_errors == []
+
+
+def _start_matrix_runs(
+    client: httpx.Client,
+    session_ids: list[str],
+) -> dict[str, str]:
+    def start_one(index_and_session: tuple[int, str]) -> tuple[str, str]:
+        index, session_id = index_and_session
+        with httpx.Client(base_url=str(client.base_url), timeout=60.0) as run_client:
+            run_id = create_run(
+                run_client,
+                session_id=session_id,
+                intent=(
+                    "[session-extreme-pressure "
+                    "main_calls=24 main_batch=6 subagents=3 subagent_calls=15 "
+                    "subagent_batch=5 subagent_spawn_batch=3 path=AGENTS.md "
+                    f"tag=browser{index}] "
+                    "exercise mixed root and subagent tool streams for browser UI."
+                ),
+                execution_mode="ai",
+                yolo=True,
+            )
+        return session_id, run_id
+
+    with ThreadPoolExecutor(max_workers=len(session_ids)) as executor:
+        return dict(executor.map(start_one, enumerate(session_ids)))
+
+
+def _open_app(page: Page, integration_env: IntegrationEnvironment) -> None:
+    page.goto(integration_env.api_base_url, wait_until="domcontentloaded")
+    expect(page.locator("#backend-status-label")).to_contain_text(
+        _CONNECTED_LABEL,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    expect(page.locator("#projects-list")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    page.evaluate("() => window.__agentTeamsUiDiagnostics?.reset?.()")
+
+
+def _wait_for_session_items(page: Page, session_ids: list[str]) -> None:
+    for session_id in session_ids:
+        expect(
+            page.locator(f'.session-item[data-session-id="{session_id}"]')
+        ).to_have_count(
+            1,
+            timeout=_WAIT_TIMEOUT_MS,
+        )
+
+
+def _wait_for_subagent_counts(
+    client: httpx.Client,
+    session_ids: list[str],
+    *,
+    expected_count: int,
+) -> None:
+    deadline = time.monotonic() + 70.0
+    while time.monotonic() < deadline:
+        if all(
+            _subagent_count(client, session_id) >= expected_count
+            for session_id in session_ids
+        ):
+            return
+        time.sleep(0.25)
+    counts = {
+        session_id: _subagent_count(client, session_id) for session_id in session_ids
+    }
+    raise AssertionError(f"Timed out waiting for subagents: {counts}")
+
+
+def _wait_for_visible_subagent_toggles(page: Page, session_ids: list[str]) -> None:
+    for session_id in session_ids:
+        parent = page.locator(f'.session-item[data-session-id="{session_id}"]').first
+        expect(parent).to_have_count(1, timeout=_WAIT_TIMEOUT_MS)
+        page.evaluate(
+            """
+            sessionId => {
+                const item = document.querySelector(`.session-item[data-session-id="${sessionId}"]`);
+                item?.scrollIntoView?.({ block: 'center' });
+                const list = document.querySelector('#projects-list');
+                list?.dispatchEvent?.(new Event('scroll'));
+            }
+            """,
+            session_id,
+        )
+        expect(parent).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+        expect(parent.locator(".session-subagents-toggle")).to_have_count(
+            1,
+            timeout=_SWITCH_LOAD_TIMEOUT_MS,
+        )
+
+
+def _subagent_count(client: httpx.Client, session_id: str) -> int:
+    response = client.get(f"/api/sessions/{session_id}/subagents?force_refresh=1")
+    response.raise_for_status()
+    payload = response.json()
+    rows = payload.get("value", payload) if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        return 0
+    return len(rows)
+
+
+def _load_navigation_targets_from_ui(
+    page: Page,
+    session_ids: list[str],
+    run_ids: dict[str, str],
+) -> list[NavigationTarget]:
+    targets = [
+        NavigationTarget(
+            kind="root",
+            session_id=session_id,
+            run_id=run_ids[session_id],
+            instance_id="",
+        )
+        for session_id in session_ids
+    ]
+    for session_id in session_ids:
+        _expand_parent_session(page, session_id)
+        locator = page.locator(
+            f'.session-subagent-item[data-session-id="{session_id}"]'
+        )
+        expect(locator).to_have_count(_SUBAGENTS_PER_ROOT, timeout=_WAIT_TIMEOUT_MS)
+        rows = page.evaluate(
+            """
+            sessionId => Array.from(
+                document.querySelectorAll(`.session-subagent-item[data-session-id="${sessionId}"]`)
+            ).map(item => ({
+                runId: String(item.getAttribute('data-subagent-run-id') || '').trim(),
+                instanceId: String(item.getAttribute('data-subagent-instance-id') || '').trim(),
+            }))
+            """,
+            session_id,
+        )
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            run_id = str(row.get("runId") or "").strip()
+            instance_id = str(row.get("instanceId") or "").strip()
+            if run_id and instance_id:
+                targets.append(
+                    NavigationTarget(
+                        kind="subagent",
+                        session_id=session_id,
+                        run_id=run_id,
+                        instance_id=instance_id,
+                    )
+                )
+    return targets
+
+
+def _navigation_matrix_sequence(
+    targets: list[NavigationTarget],
+) -> list[NavigationTarget]:
+    roots = [target for target in targets if target.kind == "root"]
+    subagents = [target for target in targets if target.kind == "subagent"]
+    sequence: list[NavigationTarget] = []
+    for index, root in enumerate(roots):
+        sequence.append(root)
+        own_subagents = [
+            target for target in subagents if target.session_id == root.session_id
+        ]
+        if own_subagents:
+            sequence.append(own_subagents[0])
+        sequence.append(roots[(index + 1) % len(roots)])
+        other_subagents = [
+            target for target in subagents if target.session_id != root.session_id
+        ]
+        if other_subagents:
+            sequence.append(other_subagents[index % len(other_subagents)])
+        if len(own_subagents) > 1:
+            sequence.append(own_subagents[1])
+    return sequence * 2
+
+
+def _activate_target(page: Page, target: NavigationTarget) -> None:
+    if target.kind == "root":
+        _click_visible_session_item(page, target.session_id)
+        return
+    _expand_parent_session(page, target.session_id)
+    locator = page.locator(
+        ".session-subagent-item"
+        f'[data-session-id="{target.session_id}"]'
+        f'[data-subagent-instance-id="{target.instance_id}"]'
+    )
+    expect(locator).to_have_count(1, timeout=_WAIT_TIMEOUT_MS)
+    expect(locator).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    locator.scroll_into_view_if_needed(timeout=_WAIT_TIMEOUT_MS)
+    locator.click(timeout=_WAIT_TIMEOUT_MS)
+    expect(locator).to_have_class(
+        re.compile(r"(^|\s)active(\s|$)"),
+        timeout=_SWITCH_LOAD_TIMEOUT_MS,
+    )
+
+
+def _click_visible_session_item(page: Page, session_id: str) -> None:
+    locator = page.locator(f'.session-item[data-session-id="{session_id}"]').first
+    expect(locator).to_have_count(1, timeout=_WAIT_TIMEOUT_MS)
+    clicked = page.evaluate(
+        """
+        sessionId => {
+            const item = document.querySelector(`.session-item[data-session-id="${sessionId}"]`);
+            if (!item) return false;
+            item.scrollIntoView?.({ block: 'center' });
+            item.click?.();
+            return true;
+        }
+        """,
+        session_id,
+    )
+    assert clicked is True
+
+
+def _expand_parent_session(page: Page, session_id: str) -> None:
+    page.wait_for_function(
+        """
+        sessionId => {
+            const item = document.querySelector(`.session-item[data-session-id="${sessionId}"]`);
+            if (!item) return false;
+            item.scrollIntoView?.({ block: 'center' });
+            return true;
+        }
+        """,
+        arg=session_id,
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    parent = page.locator(f'.session-item[data-session-id="{session_id}"]').first
+    expect(parent).to_be_visible(timeout=_SWITCH_LOAD_TIMEOUT_MS)
+    toggle = parent.locator(".session-subagents-toggle")
+    expect(toggle).to_have_count(1, timeout=_WAIT_TIMEOUT_MS)
+    expanded = toggle.get_attribute("aria-expanded")
+    if expanded != "true":
+        clicked = page.evaluate(
+            """
+            sessionId => {
+                const parent = document.querySelector(`.session-item[data-session-id="${sessionId}"]`);
+                const toggle = parent?.querySelector('.session-subagents-toggle');
+                if (!toggle) return false;
+                toggle.scrollIntoView?.({ block: 'center' });
+                toggle.click?.();
+                return true;
+            }
+            """,
+            session_id,
+        )
+        assert clicked is True
+    expect(
+        page.locator(f'.session-subagent-item[data-session-id="{session_id}"]').first
+    ).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+
+def _wait_for_switch_settled(page: Page) -> None:
+    expect(
+        page.locator(
+            ".chat-container.is-session-switch-pending, "
+            ".chat-container.is-session-switching"
+        )
+    ).to_have_count(0, timeout=_SWITCH_LOAD_TIMEOUT_MS)
+
+
+def _assert_target_rendered(page: Page, target: NavigationTarget) -> None:
+    if target.kind == "root":
+        expect(page.locator(".subagent-session-view")).to_have_count(
+            0,
+            timeout=_SWITCH_LOAD_TIMEOUT_MS,
+        )
+        expect(page.locator("main")).to_contain_text(
+            target.session_id,
+            timeout=_SWITCH_LOAD_TIMEOUT_MS,
+        )
+        expect(page.locator("#prompt-input")).to_be_enabled(
+            timeout=_SWITCH_LOAD_TIMEOUT_MS
+        )
+        return
+    expect(page.locator(".subagent-session-view")).to_be_visible(
+        timeout=_SWITCH_LOAD_TIMEOUT_MS,
+    )
+    expect(page.locator(".session-subagent-item.active")).to_have_attribute(
+        "data-subagent-instance-id",
+        target.instance_id,
+        timeout=_SWITCH_LOAD_TIMEOUT_MS,
+    )
+    expect(page.locator("#prompt-input")).to_be_hidden(timeout=_SWITCH_LOAD_TIMEOUT_MS)
+
+
+def _assert_no_permanent_loading(page: Page) -> None:
+    expect(
+        page.locator(
+            ".chat-container.is-session-switch-pending, "
+            ".chat-container.is-session-switching"
+        )
+    ).to_have_count(0, timeout=_SWITCH_LOAD_TIMEOUT_MS)
+    page.wait_for_function(
+        """
+        () => Array.from(document.querySelectorAll('.session-switch-loading'))
+            .every(node => Number(getComputedStyle(node).opacity || 0) <= 0.01)
+        """,
+        timeout=_SWITCH_LOAD_TIMEOUT_MS,
+    )
+    expect(page.locator(".subagent-session-loading")).to_be_hidden(
+        timeout=_SWITCH_LOAD_TIMEOUT_MS,
+    )
+    loading_text = page.get_by_text("正在加载对话", exact=False).filter(visible=True)
+    try:
+        assert (
+            loading_text.evaluate_all(
+                """
+            nodes => nodes.filter(node => {
+                let current = node;
+                while (current) {
+                    const style = getComputedStyle(current);
+                    if (style.display === 'none' || style.visibility === 'hidden') {
+                        return false;
+                    }
+                    if (Number(style.opacity || 0) <= 0.01) {
+                        return false;
+                    }
+                    current = current.parentElement;
+                }
+                return true;
+            }).length
+            """
+            )
+            == 0
+        )
+    except (AssertionError, PlaywrightError) as exc:
+        raise AssertionError("Conversation loading did not settle.") from exc
+
+
+def _assert_no_cross_target_obvious_leak(
+    page: Page,
+    target: NavigationTarget,
+    targets: list[NavigationTarget],
+) -> None:
+    if target.kind != "subagent":
+        return
+    other_instances = [
+        item.instance_id[:8]
+        for item in targets
+        if item.kind == "subagent" and item.instance_id != target.instance_id
+    ]
+    body_text = page.locator("main").inner_text(timeout=_SWITCH_LOAD_TIMEOUT_MS)
+    leaked = [
+        instance for instance in other_instances if instance and instance in body_text
+    ]
+    assert leaked == []
+
+
+def _wait_for_terminal_runs(client: httpx.Client, run_ids: dict[str, str]) -> None:
+    for run_id in run_ids.values():
+        events = stream_run_until_terminal(client, run_id=run_id, timeout_seconds=90.0)
+        assert events[-1]["event_type"] == "run_completed"
+
+
+def _wait_for_terminal_subagent_runs(
+    client: httpx.Client,
+    targets: list[NavigationTarget],
+) -> None:
+    seen_run_ids: set[str] = set()
+    for target in targets:
+        if target.kind != "subagent" or target.run_id in seen_run_ids:
+            continue
+        seen_run_ids.add(target.run_id)
+        events = stream_run_until_terminal(
+            client,
+            run_id=target.run_id,
+            timeout_seconds=90.0,
+        )
+        assert events[-1]["event_type"] in {
+            "run_completed",
+            "run_failed",
+            "run_stopped",
+        }
+        _wait_for_subagent_projection_terminal(client, target)
+
+
+def _wait_for_subagent_projection_terminal(
+    client: httpx.Client,
+    target: NavigationTarget,
+) -> None:
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline:
+        response = client.get(
+            f"/api/sessions/{target.session_id}/subagents?force_refresh=1"
+        )
+        response.raise_for_status()
+        payload = response.json()
+        rows = payload.get("value", payload) if isinstance(payload, dict) else payload
+        if isinstance(rows, list):
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                instance_id = str(
+                    row.get("instance_id") or row.get("subagent_instance_id") or ""
+                ).strip()
+                run_status = str(row.get("run_status") or row.get("status") or "")
+                if instance_id == target.instance_id and run_status in {
+                    "completed",
+                    "failed",
+                    "stopped",
+                }:
+                    return
+        time.sleep(0.2)
+    raise AssertionError(
+        "Timed out waiting for terminal subagent projection: "
+        f"session={target.session_id} run={target.run_id} "
+        f"instance={target.instance_id}"
+    )
+
+
+def _assert_terminal_indicator_not_spinning(
+    page: Page, target: NavigationTarget
+) -> None:
+    if target.kind == "root":
+        session = page.locator(
+            f'.session-item[data-session-id="{target.session_id}"]'
+        ).first
+        class_name = session.get_attribute("class") or ""
+        assert "has-run-indicator-running" not in class_name
+        expect(session.locator(".session-run-indicator-running")).to_have_count(0)
+        return
+    badge = page.locator(".subagent-session-badge")
+    expect(badge).to_be_visible(timeout=_SWITCH_LOAD_TIMEOUT_MS)
+    expect(badge).not_to_contain_text(
+        re.compile("running", re.IGNORECASE),
+        timeout=_SWITCH_LOAD_TIMEOUT_MS,
+    )
+    expect(badge).not_to_contain_text(
+        re.compile("stopping|queued", re.IGNORECASE),
+        timeout=_SWITCH_LOAD_TIMEOUT_MS,
+    )
+
+
+def _resolve_playwright_browser_root() -> Path:
+    candidates: list[Path] = []
+
+    configured_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    if configured_root:
+        candidates.append(Path(configured_root).expanduser())
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        candidates.append(Path(local_app_data).expanduser() / "ms-playwright")
+    user_profile = os.environ.get("USERPROFILE")
+    if user_profile:
+        candidates.append(
+            Path(user_profile).expanduser() / "AppData" / "Local" / "ms-playwright"
+        )
+
+    for candidate in candidates:
+        if any(candidate.glob("chromium-*")):
+            return candidate
+
+    raise AssertionError("Playwright browser cache was not found on this machine.")

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -20,6 +20,88 @@ import pytest
 _VIEWPORT_WIDTH = 1280
 _VIEWPORT_HEIGHT = 900
 _WAIT_TIMEOUT_MS = 10_000
+_BROWSER_UNSAFE_PORTS = {
+    1,
+    7,
+    9,
+    11,
+    13,
+    15,
+    17,
+    19,
+    20,
+    21,
+    22,
+    23,
+    25,
+    37,
+    42,
+    43,
+    53,
+    69,
+    77,
+    79,
+    87,
+    95,
+    101,
+    102,
+    103,
+    104,
+    109,
+    110,
+    111,
+    113,
+    115,
+    117,
+    119,
+    123,
+    135,
+    137,
+    139,
+    143,
+    161,
+    179,
+    389,
+    427,
+    465,
+    512,
+    513,
+    514,
+    515,
+    526,
+    530,
+    531,
+    532,
+    540,
+    548,
+    554,
+    556,
+    563,
+    587,
+    601,
+    636,
+    989,
+    990,
+    993,
+    995,
+    1719,
+    1720,
+    1723,
+    2049,
+    3659,
+    4045,
+    5060,
+    5061,
+    6000,
+    6566,
+    6665,
+    6666,
+    6667,
+    6668,
+    6669,
+    6697,
+    10080,
+}
 
 
 @pytest.fixture()
@@ -2153,7 +2235,7 @@ def _serve_harness_directory(repo_root: Path, harness_root: Path) -> Iterator[st
         def log_message(self, format: str, *args: object) -> None:
             return
 
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server = _create_browser_safe_http_server(Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -2163,6 +2245,19 @@ def _serve_harness_directory(repo_root: Path, harness_root: Path) -> Iterator[st
         server.shutdown()
         thread.join(timeout=5)
         server.server_close()
+
+
+def _create_browser_safe_http_server(
+    handler: type[SimpleHTTPRequestHandler],
+) -> ThreadingHTTPServer:
+    for _ in range(100):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        _host, port = cast(tuple[str, int], server.server_address)
+        if port not in _BROWSER_UNSAFE_PORTS:
+            return server
+        server.server_close()
+    msg = "Could not allocate a browser-safe local test port"
+    raise RuntimeError(msg)
 
 
 def _resolve_playwright_browser_root() -> Path:

--- a/tests/integration_tests/support/fake_llm_server.py
+++ b/tests/integration_tests/support/fake_llm_server.py
@@ -15,6 +15,7 @@ app = FastAPI(title="Fake OpenAI-Compatible LLM")
 
 _chat_completions_calls = 0
 _scenario_attempts: dict[str, int] = {}
+_scenario_progress: dict[str, dict[str, int | str]] = {}
 _active_chat_completions = 0
 _max_active_chat_completions = 0
 _metrics_lock = Lock()
@@ -33,6 +34,9 @@ def metrics() -> dict[str, object]:
             "active_chat_completions": _active_chat_completions,
             "max_active_chat_completions": _max_active_chat_completions,
             "scenario_attempts": dict(_scenario_attempts),
+            "scenario_progress": {
+                key: dict(value) for key, value in _scenario_progress.items()
+            },
         }
 
 
@@ -45,6 +49,7 @@ def reset() -> dict[str, str]:
         _active_chat_completions = 0
         _max_active_chat_completions = 0
         _scenario_attempts.clear()
+        _scenario_progress.clear()
     return {"status": "ok"}
 
 
@@ -68,7 +73,7 @@ async def chat_completions(request: Request):
     payload = await request.json()
     _begin_chat_completion()
     model = str(payload.get("model") or "fake-chat-model")
-    response_spec = plan_fake_response(payload)
+    response_spec = await asyncio.to_thread(plan_fake_response, payload)
     stream = bool(payload.get("stream"))
     if str(response_spec.get("kind") or "") == "error_status":
         try:
@@ -112,6 +117,33 @@ def _end_chat_completion() -> None:
     global _active_chat_completions
     with _metrics_lock:
         _active_chat_completions = max(0, _active_chat_completions - 1)
+
+
+def _set_scenario_progress(
+    *,
+    key: str,
+    phase: str,
+    completed_main_reads: int | None = None,
+    total_main_reads: int | None = None,
+    completed_spawns: int | None = None,
+    total_spawns: int | None = None,
+    completed_reads: int | None = None,
+    total_reads: int | None = None,
+) -> None:
+    update: dict[str, int | str] = {"phase": phase}
+    optional_values = {
+        "completed_main_reads": completed_main_reads,
+        "total_main_reads": total_main_reads,
+        "completed_spawns": completed_spawns,
+        "total_spawns": total_spawns,
+        "completed_reads": completed_reads,
+        "total_reads": total_reads,
+    }
+    for metric_name, metric_value in optional_values.items():
+        if metric_value is not None:
+            update[metric_name] = metric_value
+    with _metrics_lock:
+        _scenario_progress[key] = update
 
 
 async def stream_chat_completions(
@@ -300,6 +332,10 @@ def plan_fake_response(payload: object) -> dict[str, object]:
     messages = payload.get("messages")
     if not isinstance(messages, list):
         return {"kind": "text", "content": "fake-response"}
+    if _session_extreme_subagent_pressure_mode(messages):
+        return _plan_session_extreme_subagent_pressure_response(payload, messages)
+    if _session_extreme_pressure_mode(messages):
+        return _plan_session_extreme_pressure_response(payload, messages)
     if _normal_tool_pressure_mode(messages):
         return _plan_normal_tool_pressure_response(payload, messages)
     if _orch_clone_worker_mode(messages):
@@ -497,6 +533,332 @@ def _plan_orch_clone_worker_response(messages: list[object]) -> dict[str, object
 
 def _normal_tool_pressure_mode(messages: list[object]) -> bool:
     return _messages_contain_user_text(messages, "[normal-tool-pressure")
+
+
+def _session_extreme_pressure_mode(messages: list[object]) -> bool:
+    return _messages_contain_user_text(messages, "[session-extreme-pressure")
+
+
+def _session_extreme_subagent_pressure_mode(messages: list[object]) -> bool:
+    return _messages_contain_user_text(
+        messages,
+        "[session-extreme-subagent-pressure",
+    )
+
+
+def _plan_session_extreme_pressure_response(
+    payload: dict[str, object],
+    messages: list[object],
+) -> dict[str, object]:
+    available_tools = _extract_available_tools(payload)
+    if "read" not in available_tools or "spawn_subagent" not in available_tools:
+        return {
+            "kind": "text",
+            "content": "[fake-llm] extreme pressure tools are not available.",
+        }
+    config = _extract_session_extreme_pressure_config(messages)
+    completed_read_ids = _extract_tool_call_ids(
+        messages,
+        prefix=config.read_call_prefix,
+    )
+    completed_spawn_ids = _extract_tool_call_ids(
+        messages,
+        prefix=config.spawn_call_prefix,
+    )
+    _set_scenario_progress(
+        key=f"session:{config.tag}",
+        phase=(
+            "main_tools"
+            if len(completed_read_ids) < config.main_tool_calls
+            else "spawn_subagents"
+            if len(completed_spawn_ids) < config.subagent_count
+            else "finalize"
+        ),
+        completed_main_reads=len(completed_read_ids),
+        total_main_reads=config.main_tool_calls,
+        completed_spawns=len(completed_spawn_ids),
+        total_spawns=config.subagent_count,
+    )
+    if len(completed_read_ids) < config.main_tool_calls:
+        return _build_read_pressure_batch(
+            completed_count=len(completed_read_ids),
+            total_count=config.main_tool_calls,
+            batch_size=config.main_batch_size,
+            prefix=config.read_call_prefix,
+            path=config.path,
+            available_tools=available_tools,
+        )
+
+    if len(completed_spawn_ids) < config.subagent_count:
+        next_index = len(completed_spawn_ids)
+        end_index = min(
+            config.subagent_count,
+            next_index + config.subagent_spawn_batch_size,
+        )
+        return {
+            "kind": "tool_calls",
+            "tool_calls": [
+                {
+                    "tool_name": "spawn_subagent",
+                    "tool_call_id": f"{config.spawn_call_prefix}{index + 1}",
+                    "arguments": {
+                        "role_id": "Crafter",
+                        "description": (f"extreme pressure subagent {index + 1}"),
+                        "prompt": (
+                            "[session-extreme-subagent-pressure "
+                            f"calls={config.subagent_tool_calls} "
+                            f"batch={config.subagent_batch_size} "
+                            f"path={config.path} "
+                            f"tag={config.tag}-sub{index + 1}] "
+                            f"run subagent pressure {index + 1}."
+                        ),
+                        "background": False,
+                    },
+                }
+                for index in range(next_index, end_index)
+            ],
+        }
+
+    return {
+        "kind": "text",
+        "content": (
+            "[fake-llm] session extreme pressure completed "
+            f"{config.main_tool_calls} primary tool calls and "
+            f"{config.subagent_count} subagents."
+        ),
+    }
+
+
+def _plan_session_extreme_subagent_pressure_response(
+    payload: dict[str, object],
+    messages: list[object],
+) -> dict[str, object]:
+    available_tools = _extract_available_tools(payload)
+    if "read" not in available_tools:
+        return {
+            "kind": "text",
+            "content": "[fake-llm] read is not available for subagent pressure.",
+        }
+    config = _extract_session_extreme_subagent_pressure_config(messages)
+    completed_read_ids = _extract_tool_call_ids(
+        messages,
+        prefix=config.read_call_prefix,
+    )
+    _set_scenario_progress(
+        key=f"subagent:{config.tag}",
+        phase=(
+            "subagent_tools"
+            if len(completed_read_ids) < config.tool_calls
+            else "finalize"
+        ),
+        completed_reads=len(completed_read_ids),
+        total_reads=config.tool_calls,
+    )
+    if len(completed_read_ids) < config.tool_calls:
+        return _build_read_pressure_batch(
+            completed_count=len(completed_read_ids),
+            total_count=config.tool_calls,
+            batch_size=config.batch_size,
+            prefix=config.read_call_prefix,
+            path=config.path,
+            available_tools=available_tools,
+        )
+    return {
+        "kind": "text",
+        "content": (
+            "[fake-llm] session extreme subagent pressure completed "
+            f"{config.tool_calls} tool calls."
+        ),
+    }
+
+
+def _build_read_pressure_batch(
+    *,
+    completed_count: int,
+    total_count: int,
+    batch_size: int,
+    prefix: str,
+    path: str,
+    available_tools: set[str],
+) -> dict[str, object]:
+    start_index = completed_count
+    end_index = min(total_count, start_index + batch_size)
+    return {
+        "kind": "tool_calls",
+        "tool_calls": [
+            _build_mixed_pressure_tool_call(
+                index=index,
+                tool_call_id=f"{prefix}{index + 1}",
+                path=path,
+                available_tools=available_tools,
+            )
+            for index in range(start_index, end_index)
+        ],
+    }
+
+
+def _build_mixed_pressure_tool_call(
+    *,
+    index: int,
+    tool_call_id: str,
+    path: str,
+    available_tools: set[str],
+) -> dict[str, object]:
+    ordinal = index + 1
+    is_subagent_call = "subagent" in tool_call_id
+    if not is_subagent_call and ordinal == 20 and "grep" in available_tools:
+        return {
+            "tool_name": "grep",
+            "tool_call_id": tool_call_id,
+            "arguments": {
+                "pattern": "Project Layout",
+                "path": "AGENTS.md",
+                "case_sensitive": True,
+            },
+        }
+    if not is_subagent_call and ordinal == 10 and "glob" in available_tools:
+        return {
+            "tool_name": "glob",
+            "tool_call_id": tool_call_id,
+            "arguments": {"pattern": "src/relay_teams/tools/runtime/*.py"},
+        }
+    if ordinal % 15 == 0 and "list_run_tasks" in available_tools:
+        return {
+            "tool_name": "list_run_tasks",
+            "tool_call_id": tool_call_id,
+            "arguments": {"include_root": True},
+        }
+    if ordinal % 12 == 0 and "todo_read" in available_tools:
+        return {
+            "tool_name": "todo_read",
+            "tool_call_id": tool_call_id,
+            "arguments": {},
+        }
+    return {
+        "tool_name": "read",
+        "tool_call_id": tool_call_id,
+        "arguments": {
+            "path": path,
+            "offset": 1,
+            "limit": 1,
+        },
+    }
+
+
+class _SessionExtremePressureConfig:
+    def __init__(
+        self,
+        *,
+        main_tool_calls: int,
+        main_batch_size: int,
+        subagent_count: int,
+        subagent_tool_calls: int,
+        subagent_batch_size: int,
+        subagent_spawn_batch_size: int,
+        path: str,
+        tag: str,
+    ) -> None:
+        self.main_tool_calls = main_tool_calls
+        self.main_batch_size = main_batch_size
+        self.subagent_count = subagent_count
+        self.subagent_tool_calls = subagent_tool_calls
+        self.subagent_batch_size = subagent_batch_size
+        self.subagent_spawn_batch_size = subagent_spawn_batch_size
+        self.path = path
+        self.tag = tag
+        self.read_call_prefix = f"call-session-extreme-read-{tag}-"
+        self.spawn_call_prefix = f"call-session-extreme-spawn-{tag}-"
+
+
+class _SessionExtremeSubagentPressureConfig:
+    def __init__(
+        self,
+        *,
+        tool_calls: int,
+        batch_size: int,
+        path: str,
+        tag: str,
+    ) -> None:
+        self.tool_calls = tool_calls
+        self.batch_size = batch_size
+        self.path = path
+        self.tag = tag
+        self.read_call_prefix = f"call-session-extreme-subagent-read-{tag}-"
+
+
+def _extract_session_extreme_pressure_config(
+    messages: list[object],
+) -> _SessionExtremePressureConfig:
+    user_text = _extract_last_user_text(messages)
+    values = _extract_bracket_key_values(user_text, "session-extreme-pressure")
+    tag = values.get("tag") or "default"
+    return _SessionExtremePressureConfig(
+        main_tool_calls=_bounded_int(values.get("main_calls"), 500, 1, 2_000),
+        main_batch_size=_bounded_int(values.get("main_batch"), 100, 1, 500),
+        subagent_count=_bounded_int(values.get("subagents"), 10, 0, 50),
+        subagent_tool_calls=_bounded_int(
+            values.get("subagent_calls"),
+            100,
+            1,
+            1_000,
+        ),
+        subagent_batch_size=_bounded_int(
+            values.get("subagent_batch"),
+            25,
+            1,
+            100,
+        ),
+        subagent_spawn_batch_size=_bounded_int(
+            values.get("subagent_spawn_batch"),
+            10,
+            1,
+            50,
+        ),
+        path=values.get("path") or "AGENTS.md",
+        tag=tag,
+    )
+
+
+def _extract_session_extreme_subagent_pressure_config(
+    messages: list[object],
+) -> _SessionExtremeSubagentPressureConfig:
+    user_text = _extract_last_user_text(messages)
+    values = _extract_bracket_key_values(
+        user_text,
+        "session-extreme-subagent-pressure",
+    )
+    tag = values.get("tag") or "default"
+    return _SessionExtremeSubagentPressureConfig(
+        tool_calls=_bounded_int(values.get("calls"), 100, 1, 1_000),
+        batch_size=_bounded_int(values.get("batch"), 25, 1, 100),
+        path=values.get("path") or "AGENTS.md",
+        tag=tag,
+    )
+
+
+def _extract_bracket_key_values(text: str, marker: str) -> dict[str, str]:
+    match = re.search(rf"\[{re.escape(marker)}\s+([^\]]*)\]", text)
+    if match is None:
+        return {}
+    values: dict[str, str] = {}
+    for key, value in re.findall(r"([A-Za-z0-9_-]+)=([^\s\]]+)", match.group(1)):
+        values[key] = value
+    return values
+
+
+def _bounded_int(
+    raw_value: str | None,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, value))
 
 
 def _plan_normal_tool_pressure_response(

--- a/tests/unit_tests/agent_runtimes/instances/test_instance_repository.py
+++ b/tests/unit_tests/agent_runtimes/instances/test_instance_repository.py
@@ -179,6 +179,18 @@ async def test_async_repository_methods_use_direct_sqlite_paths(
             lifecycle=InstanceLifecycle.EPHEMERAL,
             parent_instance_id="inst-coordinator",
         )
+        await repository.upsert_instance_async(
+            run_id="delegated-run-2",
+            trace_id="delegated-run-2",
+            session_id="session-1",
+            instance_id="inst-ephemeral-nonprefix",
+            role_id="worker",
+            workspace_id="workspace-1",
+            conversation_id="conversation-worker-nonprefix",
+            status=InstanceStatus.RUNNING,
+            lifecycle=InstanceLifecycle.EPHEMERAL,
+            parent_instance_id="inst-coordinator",
+        )
 
         await repository.update_session_workspace_async(
             "session-1",
@@ -190,6 +202,7 @@ async def test_async_repository_methods_use_direct_sqlite_paths(
             "inst-coordinator",
             "inst-reviewer",
             "inst-ephemeral",
+            "inst-ephemeral-nonprefix",
         ]
         assert {record.workspace_id for record in all_records} == {"workspace-updated"}
         assert [
@@ -198,7 +211,12 @@ async def test_async_repository_methods_use_direct_sqlite_paths(
         assert [
             record.instance_id
             for record in await repository.list_by_session_async("session-1")
-        ] == ["inst-coordinator", "inst-reviewer", "inst-ephemeral"]
+        ] == [
+            "inst-coordinator",
+            "inst-reviewer",
+            "inst-ephemeral",
+            "inst-ephemeral-nonprefix",
+        ]
         assert [
             record.instance_id
             for record in await repository.list_running_async("run-1")
@@ -209,7 +227,7 @@ async def test_async_repository_methods_use_direct_sqlite_paths(
         )
         assert await repository.count_normal_mode_subagents_by_session_ids_async(
             ("session-1", "missing-session")
-        ) == {"session-1": 1}
+        ) == {"session-1": 2}
 
         assert [
             record.role_id
@@ -239,7 +257,11 @@ async def test_async_repository_methods_use_direct_sqlite_paths(
         )
 
         failed_instances = await repository.mark_running_instances_failed_async()
-        assert failed_instances == ("inst-coordinator", "inst-ephemeral")
+        assert failed_instances == (
+            "inst-coordinator",
+            "inst-ephemeral",
+            "inst-ephemeral-nonprefix",
+        )
         assert await repository.mark_running_instances_failed_async() == ()
         assert (
             await repository.get_instance_async("inst-coordinator")

--- a/tests/unit_tests/agents/execution/session_prompt_support_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_prompt_support_test_cases.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 from datetime import UTC, datetime
@@ -317,7 +318,7 @@ def test_commit_ready_messages_commits_only_safe_prefix() -> None:
     assert isinstance(appended_part, UserPromptPart)
     assert appended_part.content == "User prompt"
     assert published_outcome_messages == [appended_messages]
-    assert next_history == persisted_history
+    assert next_history == appended_messages
     assert len(remaining) == 1
     assert isinstance(remaining[0], ModelResponse)
     assert tool_events_published is False
@@ -511,6 +512,60 @@ def test_publish_tool_call_events_keeps_event_when_batch_lookup_fails(
         RunEventType.TOOL_CALL,
         RunEventType.TOOL_CALL_BATCH_SEALED,
     ]
+
+
+def test_publish_tool_call_events_persists_batch_state_in_one_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _RunEventHub:
+        def publish(self, event: RunEvent) -> int:
+            published_events.append(event)
+            return len(published_events)
+
+    published_events: list[RunEvent] = []
+    shared_store = SharedStateRepository(tmp_path / "batch-state-one-write.db")
+    original_manage_states = shared_store.manage_states
+    mutation_counts: list[int] = []
+
+    def _manage_states_once(mutations: object) -> None:
+        mutation_tuple = tuple(cast(Any, mutations))
+        mutation_counts.append(len(mutation_tuple))
+        original_manage_states(cast(Any, mutation_tuple))
+
+    monkeypatch.setattr(shared_store, "manage_states", _manage_states_once)
+    service = EventPublishingService(
+        run_event_hub=_RunEventHub(),
+        shared_store=shared_store,
+    )
+    tool_calls = [
+        ToolCallPart(
+            tool_name="search",
+            args=f'{{"q":"moon-{index}"}}',
+            tool_call_id=f"call-{index}",
+        )
+        for index in range(50)
+    ]
+    request = _build_request()
+
+    emitted = service.publish_tool_call_events_from_messages(
+        request=request,
+        messages=[ModelResponse(parts=tool_calls)],
+    )
+
+    assert emitted is True
+    assert mutation_counts == [51]
+    assert [event.event_type for event in published_events].count(
+        RunEventType.TOOL_CALL
+    ) == 50
+    assert published_events[-1].event_type == RunEventType.TOOL_CALL_BATCH_SEALED
+    state = load_tool_call_state(
+        shared_store=shared_store,
+        task_id=request.task_id,
+        tool_call_id="call-0",
+    )
+    assert state is not None
+    assert state.batch_id.startswith("toolbatch_")
 
 
 @pytest.mark.asyncio
@@ -855,6 +910,67 @@ async def test_seal_tool_call_batch_async_keeps_event_when_persistence_fails() -
 
     assert len(run_event_hub.events) == 1
     assert run_event_hub.events[0].event_type == RunEventType.TOOL_CALL_BATCH_SEALED
+
+
+@pytest.mark.asyncio
+async def test_seal_tool_call_batch_async_keeps_timeout_persist_task_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _AsyncRunEventHub:
+        async def publish_async(self, event: RunEvent) -> int:
+            published_events.append(event)
+            return len(published_events)
+
+    published_events: list[RunEvent] = []
+    persist_started = asyncio.Event()
+    release_persist = asyncio.Event()
+    persist_finished = asyncio.Event()
+    service = EventPublishingService(
+        run_event_hub=_AsyncRunEventHub(),
+        shared_store=None,
+    )
+
+    async def _slow_batch_seal_persistence(
+        *,
+        request: object,
+        batch_id: str,
+        items: object,
+    ) -> None:
+        _ = (request, batch_id, items)
+        persist_started.set()
+        await release_persist.wait()
+        persist_finished.set()
+
+    service.__dict__["_persist_tool_call_batch_seal_async"] = (
+        _slow_batch_seal_persistence
+    )
+    monkeypatch.setattr(
+        event_publishing_module,
+        "TOOL_CALL_BATCH_STATE_WRITE_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    await service.seal_tool_call_batch_async(
+        request=_build_request(),
+        batch_id="batch-seal-timeout",
+        tool_calls=[
+            (
+                0,
+                ToolCallPart(
+                    tool_name="search",
+                    args='{"q":"moon"}',
+                    tool_call_id="call-seal-timeout",
+                ),
+            )
+        ],
+    )
+
+    assert persist_started.is_set()
+    assert not persist_finished.is_set()
+    release_persist.set()
+    await asyncio.wait_for(persist_finished.wait(), timeout=1)
+    assert len(published_events) == 1
+    assert published_events[0].event_type == RunEventType.TOOL_CALL_BATCH_SEALED
 
 
 def test_publish_committed_tool_outcome_events_emits_result_and_validation_failure() -> (

--- a/tests/unit_tests/agents/execution/test_coordination_agent_builder.py
+++ b/tests/unit_tests/agents/execution/test_coordination_agent_builder.py
@@ -146,6 +146,32 @@ class _FakeMcpDiscoveryService:
         )
 
 
+class _ManyUnreadyMcpRegistry(_FakeMcpRegistry):
+    def __init__(self) -> None:
+        super().__init__()
+        self.toolset_calls: list[tuple[str, ...]] = []
+
+    def resolve_server_names(
+        self,
+        server_names: tuple[str, ...],
+        *,
+        strict: bool = True,
+        consumer: str | None = None,
+    ) -> tuple[str, ...]:
+        self.calls.append((server_names, strict, consumer))
+        if server_names == ("*",):
+            return tuple(f"slow-{index}" for index in range(8))
+        return super().resolve_server_names(
+            server_names,
+            strict=strict,
+            consumer=consumer,
+        )
+
+    def get_toolsets(self, server_names: tuple[str, ...]) -> tuple[object, ...]:
+        self.toolset_calls.append(server_names)
+        raise AssertionError("unready wildcard MCP toolsets should be skipped")
+
+
 def _patch_runtime_chat_model_builder(
     monkeypatch: pytest.MonkeyPatch,
     captured: dict[str, object],
@@ -475,6 +501,43 @@ def test_build_coordination_agent_attaches_ready_mcp_toolsets(
     built_agent = cast(_FakeAgent, captured["agent"])
     assert built_agent.kwargs["toolsets"] == ["toolset:docs"]
     assert fake_mcp_registry.toolset_calls == [("docs",)]
+
+
+def test_build_coordination_agent_skips_unready_wildcard_mcp_toolsets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    fake_tool_registry = _FakeToolRegistry()
+    fake_mcp_registry = _ManyUnreadyMcpRegistry()
+
+    monkeypatch.setattr(
+        coordination_agent,
+        "build_llm_http_client",
+        lambda **_: object(),
+    )
+    _patch_runtime_chat_model_builder(monkeypatch, captured)
+
+    def _fake_agent(**kwargs: object) -> _FakeAgent:
+        agent = _FakeAgent(**kwargs)
+        captured["agent"] = agent
+        return agent
+
+    monkeypatch.setattr(coordination_agent, "Agent", _fake_agent)
+
+    coordination_agent.build_coordination_agent(
+        model_name="gpt-test",
+        base_url="https://example.test/v1",
+        api_key="secret",
+        system_prompt="system",
+        allowed_tools=(),
+        allowed_mcp_servers=("*",),
+        tool_registry=cast(ToolRegistry, fake_tool_registry),
+        mcp_registry=cast(McpRegistry, fake_mcp_registry),
+    )
+
+    built_agent = cast(_FakeAgent, captured["agent"])
+    assert built_agent.kwargs["toolsets"] == []
+    assert fake_mcp_registry.toolset_calls == []
 
 
 def test_build_coordination_agent_injects_subagent_capabilities_into_spawn_subagent_description(

--- a/tests/unit_tests/agents/execution/test_message_commit.py
+++ b/tests/unit_tests/agents/execution/test_message_commit.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+from pydantic_ai.messages import ModelRequest, ModelResponse, ToolCallPart
+from pydantic_ai.messages import ToolReturnPart
+
+from relay_teams.agents.execution.message_commit import MessageCommitService
+from relay_teams.providers.provider_contracts import LLMRequest
+
+from .agent_llm_session_test_support import _build_request
+
+
+class _CommitRepo:
+    def __init__(self) -> None:
+        self.appended: list[ModelRequest | ModelResponse] = []
+        self.history_read_count = 0
+
+    def append(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: Sequence[ModelRequest | ModelResponse],
+    ) -> None:
+        _ = (
+            session_id,
+            workspace_id,
+            conversation_id,
+            agent_role_id,
+            instance_id,
+            task_id,
+            trace_id,
+        )
+        self.appended.extend(messages)
+
+    def get_history_for_conversation(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        _ = conversation_id
+        self.history_read_count += 1
+        return []
+
+    async def append_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: Sequence[ModelRequest | ModelResponse],
+    ) -> None:
+        self.append(
+            session_id=session_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            agent_role_id=agent_role_id,
+            instance_id=instance_id,
+            task_id=task_id,
+            trace_id=trace_id,
+            messages=messages,
+        )
+
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        return self.get_history_for_conversation(conversation_id)
+
+
+@pytest.mark.asyncio
+async def test_commit_ready_messages_async_uses_in_memory_history_by_default() -> None:
+    repo = _CommitRepo()
+    service = MessageCommitService(message_repo=repo)
+    published_messages: list[tuple[ModelRequest | ModelResponse, ...]] = []
+
+    async def _publish_outcomes(
+        *,
+        request: LLMRequest,
+        messages: Sequence[ModelRequest | ModelResponse],
+        published_tool_outcome_ids: set[str] | None = None,
+    ) -> bool:
+        _ = (request, published_tool_outcome_ids)
+        published_messages.append(tuple(messages))
+        return True
+
+    response = ModelResponse(
+        parts=[
+            ToolCallPart(
+                tool_name="read",
+                args='{"path":"README.md"}',
+                tool_call_id="call-read",
+            )
+        ]
+    )
+    result = ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="read",
+                content={"ok": True},
+                tool_call_id="call-read",
+            )
+        ]
+    )
+
+    (
+        next_history,
+        remaining,
+        tool_events_published,
+        validation_failures,
+    ) = await service.commit_ready_messages_async(
+        request=_build_request(),
+        history=[],
+        pending_messages=[response, result],
+        last_committable_index=len,
+        has_tool_input_validation_failures=lambda messages: False,
+        normalize_committable_messages=_normalize_messages,
+        workspace_id=lambda request: request.workspace_id,
+        conversation_id=lambda request: request.conversation_id,
+        publish_committed_tool_outcome_events_from_messages=_publish_outcomes,
+        filter_model_messages=list,
+        has_tool_side_effect_messages=lambda messages: True,
+    )
+
+    assert remaining == []
+    assert next_history == [response, result]
+    assert repo.appended == [response, result]
+    assert repo.history_read_count == 0
+    assert published_messages == [(response, result)]
+    assert tool_events_published is True
+    assert validation_failures is False
+
+
+def _normalize_messages(
+    *,
+    request: LLMRequest,
+    messages: Sequence[ModelRequest | ModelResponse],
+) -> list[ModelRequest | ModelResponse]:
+    _ = request
+    return list(messages)

--- a/tests/unit_tests/agents/execution/test_prompts.py
+++ b/tests/unit_tests/agents/execution/test_prompts.py
@@ -21,7 +21,12 @@ from relay_teams.agents.execution.user_prompts import (
 from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
 from relay_teams.hooks import HookDecisionBundle, HookDecisionType, HookEventName
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
-from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec, McpToolInfo
+from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
+    McpServerSpec,
+    McpToolInfo,
+    McpToolSchema,
+)
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.secrets import AppSecretStore
 from relay_teams.roles.role_models import RoleDefinition, RoleMode
@@ -221,6 +226,16 @@ class _FakeMcpRegistry(McpRegistry):
     async def list_tools(self, name: str) -> tuple[McpToolInfo, ...]:
         assert name == "docs"
         return (McpToolInfo(name="docs_search", description="Search docs"),)
+
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        assert name == "docs"
+        return (
+            McpToolSchema(
+                name="docs_search",
+                description="Search docs",
+                input_schema={"type": "object"},
+            ),
+        )
 
 
 class _NoRealtimeMcpRegistry(_FakeMcpRegistry):

--- a/tests/unit_tests/agents/execution/test_session_runtime.py
+++ b/tests/unit_tests/agents/execution/test_session_runtime.py
@@ -7,14 +7,19 @@ from types import SimpleNamespace, TracebackType
 from typing import cast
 
 import pytest
+from pydantic import JsonValue
 from pydantic_ai.messages import (
     FunctionToolResultEvent,
     SystemPromptPart,
     ToolCallPart,
+    ToolReturn,
     ToolReturnPart,
 )
 
 from relay_teams.agents.execution import session_runtime as session_runtime_module
+from relay_teams.agents.execution import (
+    relay_tool_step_executor as relay_tool_step_executor_module,
+)
 from relay_teams.agents.tasks.models import (
     SpecCheckpointPolicy,
     TaskEnvelope,
@@ -27,6 +32,13 @@ from relay_teams.agents.tasks.models import (
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.tools.registry import ToolRegistry
+from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.persisted_state import ToolExecutionStatus
+from relay_teams.tools.runtime.tool_result_batching import (
+    ToolResultCommitItem,
+    current_tool_result_commit_buffer,
+    tool_result_batch_scope,
+)
 from .agent_llm_session_test_support import (
     AgentLlmSession,
     APIStatusError,
@@ -358,6 +370,669 @@ async def _wait_for_abandoned_stream_context_cleanup() -> None:
             asyncio.gather(*cleanup_tasks),
             timeout=1.0,
         )
+
+
+class _ValidatedToolCall:
+    def __init__(self, index: int) -> None:
+        self.index = index
+
+
+class _BoundedToolManager:
+    def __init__(self) -> None:
+        self.active = 0
+        self.max_active = 0
+
+    async def execute_tool_call(self, validated: object) -> dict[str, JsonValue]:
+        call = cast(_ValidatedToolCall, validated)
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        try:
+            await asyncio.sleep(0.01)
+            return {"index": call.index}
+        finally:
+            self.active -= 1
+
+
+class _RelayToolDef:
+    kind = "function"
+    sequential = False
+
+
+class _RelayValidatedToolCall:
+    def __init__(self, call: ToolCallPart, *, args_valid: bool = True) -> None:
+        self.call = call
+        self.args_valid = args_valid
+
+
+class _RelayToolManager:
+    def __init__(self, *, args_valid: bool = True) -> None:
+        self.args_valid = args_valid
+        self.validated: list[str] = []
+        self.executed: list[str] = []
+
+    async def for_run_step(self, run_context: object) -> "_RelayToolManager":
+        _ = run_context
+        return self
+
+    def get_tool_def(self, tool_name: str) -> _RelayToolDef | None:
+        if tool_name == "missing":
+            return None
+        return _RelayToolDef()
+
+    async def validate_tool_call(self, call: ToolCallPart) -> _RelayValidatedToolCall:
+        self.validated.append(call.tool_call_id or "")
+        return _RelayValidatedToolCall(call, args_valid=self.args_valid)
+
+    async def execute_tool_call(self, validated: object) -> ToolReturn:
+        call = cast(_RelayValidatedToolCall, validated).call
+        self.executed.append(call.tool_call_id or "")
+        return ToolReturn(
+            return_value={"tool_call_id": call.tool_call_id},
+            content=f"content:{call.tool_call_id}",
+            metadata={"source": "relay-test"},
+        )
+
+
+class _RelaySequentialToolDef:
+    kind = "function"
+    sequential = True
+
+
+class _RelayOutputToolDef:
+    kind = "output"
+    sequential = False
+
+
+class _RelayValidationErrorManager(_RelayToolManager):
+    async def validate_tool_call(self, call: ToolCallPart) -> _RelayValidatedToolCall:
+        _ = call
+        raise ValueError("invalid relay args")
+
+
+class _RelayNestedReturnManager:
+    async def for_run_step(self, run_context: object) -> "_RelayNestedReturnManager":
+        _ = run_context
+        return self
+
+    def get_tool_def(self, tool_name: str) -> _RelayToolDef:
+        _ = tool_name
+        return _RelayToolDef()
+
+    async def validate_tool_call(self, call: ToolCallPart) -> _RelayValidatedToolCall:
+        return _RelayValidatedToolCall(call)
+
+    async def execute_tool_call(self, validated: object) -> list[ToolReturn]:
+        call = cast(_RelayValidatedToolCall, validated).call
+        return [
+            ToolReturn(
+                return_value={"tool_call_id": call.tool_call_id},
+                content=None,
+                metadata=None,
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_bounded_executor_preserves_order_and_limit() -> None:
+    manager = _BoundedToolManager()
+    calls = tuple(
+        ToolCallPart(
+            tool_name="read",
+            args={"path": "AGENTS.md"},
+            tool_call_id=f"call-{index}",
+        )
+        for index in range(20)
+    )
+    validated = tuple(_ValidatedToolCall(index) for index in range(20))
+
+    results = (
+        await relay_tool_step_executor_module._execute_relay_tool_step_bounded_async(
+            tool_manager=manager,
+            calls=calls,
+            validated_calls=validated,
+            concurrency=3,
+        )
+    )
+
+    assert manager.max_active <= 3
+    assert [item.part.tool_call_id for item in results] == [
+        f"call-{index}" for index in range(20)
+    ]
+    assert [item.part.content for item in results] == [
+        {"index": index} for index in range(20)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_bounded_executor_respects_global_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        relay_tool_step_executor_module,
+        "RELAY_TOOL_STEP_GLOBAL_SEMAPHORE",
+        asyncio.Semaphore(2),
+    )
+    manager = _BoundedToolManager()
+    calls = tuple(
+        ToolCallPart(
+            tool_name="read",
+            args={"path": "AGENTS.md"},
+            tool_call_id=f"call-{index}",
+        )
+        for index in range(12)
+    )
+    validated = tuple(_ValidatedToolCall(index) for index in range(12))
+
+    results = (
+        await relay_tool_step_executor_module._execute_relay_tool_step_bounded_async(
+            tool_manager=manager,
+            calls=calls,
+            validated_calls=validated,
+            concurrency=8,
+        )
+    )
+
+    assert manager.max_active <= 2
+    assert [item.part.tool_call_id for item in results] == [
+        f"call-{index}" for index in range(12)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_bounded_executor_coalesces_duplicate_calls() -> None:
+    class _BufferedDuplicateToolManager(_BoundedToolManager):
+        async def execute_tool_call(self, validated: object) -> dict[str, JsonValue]:
+            result = await super().execute_tool_call(validated)
+            call = cast(_ValidatedToolCall, validated)
+            buffer = current_tool_result_commit_buffer()
+            if buffer is None:
+                raise RuntimeError("expected active tool result buffer")
+            tool_call_id = f"call-{call.index}"
+            envelope: dict[str, JsonValue] = {
+                "ok": True,
+                "data": result,
+                "error": None,
+                "meta": {"duration_ms": 1},
+            }
+            await buffer.add_async(
+                ToolResultCommitItem(
+                    ctx=cast(ToolContext, object()),
+                    tool_call_id=tool_call_id,
+                    tool_name="read",
+                    args_summary={"path": "AGENTS.md"},
+                    visible_envelope=envelope,
+                    internal_data=result,
+                    runtime_meta={"duration_ms": 1},
+                    execution_status=ToolExecutionStatus.COMPLETED,
+                    tool_content_parts=(),
+                    duration_ms=1,
+                    success=True,
+                )
+            )
+            return envelope
+
+    manager = _BufferedDuplicateToolManager()
+    calls = tuple(
+        ToolCallPart(
+            tool_name="read",
+            args={"path": "AGENTS.md", "offset": 1, "limit": 1},
+            tool_call_id=f"call-{index}",
+        )
+        for index in range(20)
+    )
+    validated = tuple(_ValidatedToolCall(index) for index in range(20))
+
+    with tool_result_batch_scope() as buffer:
+        results = await relay_tool_step_executor_module._execute_relay_tool_step_bounded_async(
+            tool_manager=manager,
+            calls=calls,
+            validated_calls=validated,
+            concurrency=8,
+        )
+        buffered_items = await buffer.pop_items_async()
+
+    assert manager.max_active == 1
+    assert [item.part.tool_call_id for item in results] == [
+        f"call-{index}" for index in range(20)
+    ]
+    assert [item.tool_call_id for item in buffered_items] == [
+        f"call-{index}" for index in range(20)
+    ]
+    assert (
+        sum(
+            1
+            for item in buffered_items
+            if item.runtime_meta.get("relay_tool_step_coalesced_result") is True
+        )
+        == 19
+    )
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_bounded_executor_cancels_pending_on_failure() -> None:
+    class _FailingBoundedToolManager(_BoundedToolManager):
+        async def execute_tool_call(self, validated: object) -> dict[str, JsonValue]:
+            call = cast(_ValidatedToolCall, validated)
+            if call.index == 1:
+                raise RuntimeError("boom")
+            return await super().execute_tool_call(validated)
+
+    manager = _FailingBoundedToolManager()
+    calls = tuple(
+        ToolCallPart(
+            tool_name="read",
+            args={"path": "AGENTS.md"},
+            tool_call_id=f"call-{index}",
+        )
+        for index in range(5)
+    )
+    validated = tuple(_ValidatedToolCall(index) for index in range(5))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await relay_tool_step_executor_module._execute_relay_tool_step_bounded_async(
+            tool_manager=manager,
+            calls=calls,
+            validated_calls=validated,
+            concurrency=5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_bounded_executor_rejects_mismatched_validation_count() -> (
+    None
+):
+    calls = (
+        ToolCallPart(
+            tool_name="read",
+            args={"path": "AGENTS.md"},
+            tool_call_id="call-1",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Validated tool call count"):
+        await relay_tool_step_executor_module._execute_relay_tool_step_bounded_async(
+            tool_manager=_BoundedToolManager(),
+            calls=calls,
+            validated_calls=(),
+            concurrency=1,
+        )
+
+
+def test_relay_tool_step_falls_back_for_non_batchable_tool() -> None:
+    node = session_runtime_module.CallToolsNode(
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="write",
+                    args={"path": "out.txt", "content": "hello"},
+                    tool_call_id="call-1",
+                )
+            ]
+        )
+    )
+
+    assert (
+        relay_tool_step_executor_module._relay_tool_step_disabled_reason(node)
+        == "non_batchable_tool:write"
+    )
+
+
+def test_relay_tool_step_falls_back_for_spawn_subagent_sync_wait() -> None:
+    node = session_runtime_module.CallToolsNode(
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="spawn_subagent",
+                    args={
+                        "role_id": "Crafter",
+                        "description": "Investigate failures",
+                        "prompt": "Inspect the failing run.",
+                    },
+                    tool_call_id="call-spawn-1",
+                ),
+                ToolCallPart(
+                    tool_name="spawn_subagent",
+                    args={
+                        "role_id": "Crafter",
+                        "description": "Review logs",
+                        "prompt": "Summarize the log tail.",
+                    },
+                    tool_call_id="call-spawn-2",
+                ),
+            ]
+        )
+    )
+
+    assert (
+        relay_tool_step_executor_module._relay_tool_step_disabled_reason(node)
+        == "non_batchable_tool:spawn_subagent"
+    )
+
+
+def test_relay_tool_step_disabled_reason_handles_deferred_and_metadata() -> None:
+    node = session_runtime_module.CallToolsNode(
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-1",
+                )
+            ]
+        )
+    )
+    node.tool_call_results = {"call-1": "skip"}
+    assert (
+        relay_tool_step_executor_module._relay_tool_step_disabled_reason(node)
+        == "deferred_results"
+    )
+    node.tool_call_results = None
+    node.tool_call_metadata = {"call-1": {}}
+    assert (
+        relay_tool_step_executor_module._relay_tool_step_disabled_reason(node)
+        == "tool_call_metadata"
+    )
+
+
+def test_relay_tool_step_calls_require_all_parts_to_be_tool_calls() -> None:
+    node = session_runtime_module.CallToolsNode(
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-1",
+                ),
+                TextPart(content="interrupt"),
+            ]
+        )
+    )
+
+    assert relay_tool_step_executor_module._relay_tool_step_calls(node) == ()
+    assert (
+        relay_tool_step_executor_module._relay_tool_step_disabled_reason(node)
+        == "no_batchable_tool_calls"
+    )
+
+
+def test_relay_tool_step_dedupes_duplicate_tool_returns_for_history() -> None:
+    first = relay_tool_step_executor_module.RelayToolStepItemResult(
+        index=0,
+        part=ToolReturnPart(
+            tool_name="read",
+            tool_call_id="call-read-1",
+            content={"path": "AGENTS.md", "content": "same"},
+        ),
+        user_content=None,
+    )
+    second = relay_tool_step_executor_module.RelayToolStepItemResult(
+        index=1,
+        part=ToolReturnPart(
+            tool_name="read",
+            tool_call_id="call-read-2",
+            content={"content": "same", "path": "AGENTS.md"},
+        ),
+        user_content=None,
+    )
+
+    deduped, compressed_count = (
+        relay_tool_step_executor_module._dedupe_tool_returns_for_history(
+            (first, second)
+        )
+    )
+
+    assert compressed_count == 1
+    assert deduped[0].part.content == {"path": "AGENTS.md", "content": "same"}
+    assert deduped[1].part.tool_call_id == "call-read-2"
+    compressed_content = deduped[1].part.content
+    assert isinstance(compressed_content, dict)
+    assert compressed_content["content_omitted"] is True
+    assert compressed_content["duplicate_of_tool_call_id"] == "call-read-1"
+
+
+def test_relay_tool_step_keeps_unserializable_results_without_dedupe() -> None:
+    item = relay_tool_step_executor_module.RelayToolStepItemResult(
+        index=0,
+        part=ToolReturnPart(
+            tool_name="read",
+            tool_call_id="call-read-1",
+            content={"opaque": object()},
+        ),
+        user_content=None,
+    )
+
+    deduped, compressed_count = (
+        relay_tool_step_executor_module._dedupe_tool_returns_for_history((item,))
+    )
+
+    assert deduped == (item,)
+    assert compressed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_executes_batch_and_updates_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        relay_tool_step_executor_module,
+        "build_run_context",
+        lambda _ctx: object(),
+    )
+    monkeypatch.setattr(
+        relay_tool_step_executor_module,
+        "replace",
+        lambda run_context, **changes: SimpleNamespace(
+            run_context=run_context,
+            **changes,
+        ),
+    )
+    manager = _RelayToolManager()
+    node = session_runtime_module.CallToolsNode(
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-1",
+                ),
+                ToolCallPart(
+                    tool_name="grep",
+                    args={"pattern": "x"},
+                    tool_call_id="call-2",
+                ),
+            ]
+        )
+    )
+    ctx = SimpleNamespace(
+        state=SimpleNamespace(retries=0),
+        deps=SimpleNamespace(
+            max_result_retries=2,
+            tool_manager=manager,
+        ),
+    )
+
+    result = await relay_tool_step_executor_module._try_execute_relay_tool_step_async(
+        node=node,
+        agent_run_ctx=ctx,
+    )
+
+    assert result is not None
+    assert manager.validated == ["call-1", "call-2"]
+    assert manager.executed == ["call-1", "call-2"]
+    assert [
+        part.tool_call_id
+        for part in result.output_parts
+        if isinstance(part, ToolReturnPart)
+    ] == [
+        "call-1",
+        "call-2",
+    ]
+    assert [
+        part.content for part in result.output_parts if isinstance(part, UserPromptPart)
+    ] == [
+        "content:call-1",
+        "content:call-2",
+    ]
+    next_node = getattr(node, "_next_node")
+    assert next_node is not None
+    assert [message.parts for message in result.observed_messages]
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_falls_back_for_validation_failure_and_unknown_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        relay_tool_step_executor_module,
+        "build_run_context",
+        lambda _ctx: object(),
+    )
+    monkeypatch.setattr(
+        relay_tool_step_executor_module,
+        "replace",
+        lambda run_context, **changes: SimpleNamespace(
+            run_context=run_context,
+            **changes,
+        ),
+    )
+    invalid_manager = _RelayToolManager(args_valid=False)
+    invalid_node = session_runtime_module.CallToolsNode(
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-invalid",
+                )
+            ]
+        )
+    )
+    invalid_ctx = SimpleNamespace(
+        state=SimpleNamespace(retries=0),
+        deps=SimpleNamespace(max_result_retries=2, tool_manager=invalid_manager),
+    )
+
+    assert (
+        await relay_tool_step_executor_module._try_execute_relay_tool_step_async(
+            node=invalid_node,
+            agent_run_ctx=invalid_ctx,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_falls_back_for_validation_exception_and_tool_defs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        relay_tool_step_executor_module,
+        "build_run_context",
+        lambda _ctx: object(),
+    )
+    monkeypatch.setattr(
+        relay_tool_step_executor_module,
+        "replace",
+        lambda run_context, **changes: SimpleNamespace(
+            run_context=run_context,
+            **changes,
+        ),
+    )
+
+    def make_ctx(manager: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            state=SimpleNamespace(retries=0),
+            deps=SimpleNamespace(max_result_retries=2, tool_manager=manager),
+        )
+
+    node = session_runtime_module.CallToolsNode(
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="read",
+                    args={"path": "a.txt"},
+                    tool_call_id="call-1",
+                )
+            ]
+        )
+    )
+
+    assert (
+        await relay_tool_step_executor_module._try_execute_relay_tool_step_async(
+            node=node,
+            agent_run_ctx=make_ctx(_RelayValidationErrorManager()),
+        )
+        is None
+    )
+
+    class _SequentialManager(_RelayToolManager):
+        def get_tool_def(self, tool_name: str) -> _RelayToolDef | None:
+            _ = tool_name
+            return cast(_RelayToolDef, _RelaySequentialToolDef())
+
+    assert (
+        await relay_tool_step_executor_module._try_execute_relay_tool_step_async(
+            node=node,
+            agent_run_ctx=make_ctx(_SequentialManager()),
+        )
+        is None
+    )
+
+    class _OutputManager(_RelayToolManager):
+        def get_tool_def(self, tool_name: str) -> _RelayToolDef | None:
+            _ = tool_name
+            return cast(_RelayToolDef, _RelayOutputToolDef())
+
+    assert (
+        await relay_tool_step_executor_module._try_execute_relay_tool_step_async(
+            node=node,
+            agent_run_ctx=make_ctx(_OutputManager()),
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_relay_tool_step_rejects_nested_tool_return_objects() -> None:
+    call = ToolCallPart(
+        tool_name="read",
+        args={"path": "a.txt"},
+        tool_call_id="call-1",
+    )
+    validated = (_RelayValidatedToolCall(call),)
+
+    with pytest.raises(RuntimeError, match="nested ToolReturn"):
+        await relay_tool_step_executor_module._execute_relay_tool_step_bounded_async(
+            tool_manager=_RelayNestedReturnManager(),
+            calls=(call,),
+            validated_calls=validated,
+            concurrency=1,
+        )
+
+    unknown_manager = _RelayToolManager()
+    unknown_node = session_runtime_module.CallToolsNode(
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="missing",
+                    args={},
+                    tool_call_id="call-missing",
+                )
+            ]
+        )
+    )
+    unknown_ctx = SimpleNamespace(
+        state=SimpleNamespace(retries=0),
+        deps=SimpleNamespace(max_result_retries=2, tool_manager=unknown_manager),
+    )
+
+    assert (
+        await relay_tool_step_executor_module._try_execute_relay_tool_step_async(
+            node=unknown_node,
+            agent_run_ctx=unknown_ctx,
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/orchestration/harnesses/__init__.py
+++ b/tests/unit_tests/agents/orchestration/harnesses/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations

--- a/tests/unit_tests/agents/orchestration/harnesses/test_runtime_mcp_snapshot_loader.py
+++ b/tests/unit_tests/agents/orchestration/harnesses/test_runtime_mcp_snapshot_loader.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from relay_teams.mcp.runtime_schema_loader import (
+    RUNTIME_MCP_SCHEMA_CACHE_TTL_MS_ENV,
+    RUNTIME_MCP_SCHEMA_FAILED_TTL_MS_ENV,
+    RUNTIME_MCP_SCHEMA_LOAD_BUDGET_MS_ENV,
+    RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES_ENV,
+    RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS_ENV,
+    load_runtime_mcp_tool_schemas,
+)
+from relay_teams.mcp.mcp_models import McpToolSchema
+from relay_teams.mcp.mcp_registry import McpRegistry
+
+
+class _CountingMcpRegistry(McpRegistry):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[str] = []
+
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        self.calls.append(name)
+        return (
+            McpToolSchema(
+                name=f"{name}_search",
+                description="Search docs",
+                input_schema={"type": "object"},
+            ),
+        )
+
+
+class _SlowMcpRegistry(McpRegistry):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[str] = []
+
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        self.calls.append(name)
+        await asyncio.sleep(0.05)
+        return (
+            McpToolSchema(
+                name=f"{name}_search",
+                description="Search docs",
+                input_schema={"type": "object"},
+            ),
+        )
+
+
+class _FailingMcpRegistry(McpRegistry):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[str] = []
+
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        self.calls.append(name)
+        raise RuntimeError("MCP startup failed")
+
+
+@pytest.mark.asyncio
+async def test_runtime_mcp_snapshot_loader_uses_fresh_schema_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(RUNTIME_MCP_SCHEMA_CACHE_TTL_MS_ENV, "60000")
+    registry = _CountingMcpRegistry()
+
+    first = await load_runtime_mcp_tool_schemas(
+        mcp_registry=registry,
+        server_names=("docs",),
+    )
+    second = await load_runtime_mcp_tool_schemas(
+        mcp_registry=registry,
+        server_names=("docs",),
+    )
+
+    assert registry.calls == ["docs"]
+    assert first.loaded_server_count == 1
+    assert second.cache_hit_count == 1
+    assert second.schemas_by_server["docs"][0].name == "docs_search"
+
+
+@pytest.mark.asyncio
+async def test_runtime_mcp_snapshot_loader_bounds_slow_server_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(RUNTIME_MCP_SCHEMA_LOAD_BUDGET_MS_ENV, "40")
+    monkeypatch.setenv(RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS_ENV, "10")
+    registry = _SlowMcpRegistry()
+
+    started = asyncio.get_running_loop().time()
+    result = await load_runtime_mcp_tool_schemas(
+        mcp_registry=registry,
+        server_names=("slow_docs", "slow_search"),
+    )
+    elapsed_ms = int((asyncio.get_running_loop().time() - started) * 1000)
+
+    assert elapsed_ms < 80
+    assert result.timeout_count == 2
+    assert result.loaded_server_count == 0
+    assert registry.calls == ["slow_docs", "slow_search"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_mcp_snapshot_loader_can_skip_all_uncached_probes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES_ENV, "0")
+    registry = _CountingMcpRegistry()
+
+    result = await load_runtime_mcp_tool_schemas(
+        mcp_registry=registry,
+        server_names=("docs", "search"),
+    )
+
+    assert registry.calls == []
+    assert result.probe_skipped_count == 2
+    assert result.loaded_server_count == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_mcp_snapshot_loader_caches_failed_servers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(RUNTIME_MCP_SCHEMA_FAILED_TTL_MS_ENV, "60000")
+    registry = _FailingMcpRegistry()
+
+    first = await load_runtime_mcp_tool_schemas(
+        mcp_registry=registry,
+        server_names=("broken",),
+    )
+    second = await load_runtime_mcp_tool_schemas(
+        mcp_registry=registry,
+        server_names=("broken",),
+    )
+
+    assert registry.calls == ["broken"]
+    assert first.failure_count == 1
+    assert second.runtime_failed_skipped_count == 1

--- a/tests/unit_tests/agents/orchestration/test_orphan_recovery.py
+++ b/tests/unit_tests/agents/orchestration/test_orphan_recovery.py
@@ -58,7 +58,11 @@ def _make_orphan_task_record(
 def wakeup_repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        yield AgentWakeupRepository(db_path)
+        repo = AgentWakeupRepository(db_path)
+        try:
+            yield repo
+        finally:
+            repo.close()
 
 
 class TestOrphanRecovery:

--- a/tests/unit_tests/agents/orchestration/test_stale_task_sweeper.py
+++ b/tests/unit_tests/agents/orchestration/test_stale_task_sweeper.py
@@ -59,7 +59,11 @@ def _make_task_record(
 def wakeup_repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        yield AgentWakeupRepository(db_path)
+        repo = AgentWakeupRepository(db_path)
+        try:
+            yield repo
+        finally:
+            repo.close()
 
 
 class TestStaleTaskSweeper:

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -573,6 +573,7 @@ async def test_execute_records_task_artifact_entries(
         task=task,
     )
 
+    assert artifact_repo.drain_write_queue()
     artifact = artifact_repo.get_artifact(task.task_id)
     assert result.output == "ok"
     assert artifact is not None

--- a/tests/unit_tests/agents/orchestration/test_wakeup_auto_enqueue.py
+++ b/tests/unit_tests/agents/orchestration/test_wakeup_auto_enqueue.py
@@ -99,7 +99,11 @@ def _make_task_record(
 def wakeup_repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        yield AgentWakeupRepository(db_path)
+        repo = AgentWakeupRepository(db_path)
+        try:
+            yield repo
+        finally:
+            repo.close()
 
 
 # ── coalesce_and_enqueue tests ───────────────────────────────────────

--- a/tests/unit_tests/agents/orchestration/test_wakeup_dispatcher.py
+++ b/tests/unit_tests/agents/orchestration/test_wakeup_dispatcher.py
@@ -60,7 +60,11 @@ def _make_task_record(
 def wakeup_repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        yield AgentWakeupRepository(db_path)
+        repo = AgentWakeupRepository(db_path)
+        try:
+            yield repo
+        finally:
+            repo.close()
 
 
 class TestWakeupDispatcher:

--- a/tests/unit_tests/agents/tasks/test_agent_wakeup_repository.py
+++ b/tests/unit_tests/agents/tasks/test_agent_wakeup_repository.py
@@ -17,7 +17,11 @@ from relay_teams.agents.tasks.wakeup_models import AgentWakeupEntry
 def repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test_wakeups.db"
-        yield AgentWakeupRepository(db_path)
+        repository = AgentWakeupRepository(db_path)
+        try:
+            yield repository
+        finally:
+            repository.close()
 
 
 def _make_entry(**overrides: object) -> AgentWakeupEntry:
@@ -120,12 +124,18 @@ class TestAgentWakeupRepository:
         with TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test_reopen.db"
             repo1 = AgentWakeupRepository(db_path)
-            entry = _make_entry()
-            await repo1.enqueue_async(entry)
+            repo2: AgentWakeupRepository | None = None
+            try:
+                entry = _make_entry()
+                await repo1.enqueue_async(entry)
 
-            repo2 = AgentWakeupRepository(db_path)
-            count = await repo2.count_pending_async()
-            assert count == 1
+                repo2 = AgentWakeupRepository(db_path)
+                count = await repo2.count_pending_async()
+                assert count == 1
+            finally:
+                if repo2 is not None:
+                    await repo2.close_async()
+                await repo1.close_async()
 
     @pytest.mark.asyncio
     async def test_claim_next_pending_returns_none_when_empty(

--- a/tests/unit_tests/agents/tasks/test_artifact_repository.py
+++ b/tests/unit_tests/agents/tasks/test_artifact_repository.py
@@ -9,6 +9,7 @@ from typing import cast
 import pytest
 
 from relay_teams.agents.tasks.artifact_repository import (
+    TASK_ARTIFACT_SQLITE_BUSY_TIMEOUT_MS,
     TaskArtifactRepository,
     _enable_wal_if_available,
     _last_insert_row_id,
@@ -22,8 +23,12 @@ from relay_teams.agents.tasks.models import (
 
 
 @pytest.fixture
-def repo(tmp_path: Path) -> TaskArtifactRepository:
-    return TaskArtifactRepository(tmp_path / "test_artifact.db")
+def repo(tmp_path: Path):
+    repository = TaskArtifactRepository(tmp_path / "test_artifact.db")
+    try:
+        yield repository
+    finally:
+        repository.close()
 
 
 def test_ensure_artifact_creates_new(repo: TaskArtifactRepository):
@@ -50,6 +55,20 @@ def test_ensure_artifact_raises_when_insert_cannot_be_read(
 
     with pytest.raises(RuntimeError, match="Failed to create task artifact"):
         repo.ensure_artifact("task-1", "spec-1")
+
+
+def test_connections_use_busy_timeout_and_wal(repo: TaskArtifactRepository) -> None:
+    conn = repo._connect(enable_wal=True)
+    try:
+        busy_timeout_row = conn.execute("PRAGMA busy_timeout").fetchone()
+        journal_mode_row = conn.execute("PRAGMA journal_mode").fetchone()
+    finally:
+        conn.close()
+
+    assert busy_timeout_row is not None
+    assert busy_timeout_row[0] == TASK_ARTIFACT_SQLITE_BUSY_TIMEOUT_MS
+    assert journal_mode_row is not None
+    assert str(journal_mode_row[0]).lower() in {"wal", "memory"}
 
 
 def test_get_artifact_missing(repo: TaskArtifactRepository):
@@ -214,16 +233,19 @@ def test_concurrent_append_entry_uses_sqlite_retry_coordination(tmp_path: Path) 
 
     def append_entry(index: int) -> int:
         worker_repo = TaskArtifactRepository(db_path)
-        return worker_repo.append_entry(
-            "task-1",
-            TaskArtifactEntry(
-                entry_id=f"entry-{index}",
-                phase=TaskArtifactPhase.EXECUTION,
-                timestamp="2024-01-01T00:00:00",
-                event_type="tool_call",
-                description=f"Ran shell command {index}",
-            ),
-        )
+        try:
+            return worker_repo.append_entry(
+                "task-1",
+                TaskArtifactEntry(
+                    entry_id=f"entry-{index}",
+                    phase=TaskArtifactPhase.EXECUTION,
+                    timestamp="2024-01-01T00:00:00",
+                    event_type="tool_call",
+                    description=f"Ran shell command {index}",
+                ),
+            )
+        finally:
+            worker_repo.close()
 
     with ThreadPoolExecutor(max_workers=12) as executor:
         row_ids = tuple(executor.map(append_entry, range(36)))
@@ -233,6 +255,21 @@ def test_concurrent_append_entry_uses_sqlite_retry_coordination(tmp_path: Path) 
     assert all(row_id > 0 for row_id in row_ids)
     assert total == 36
     assert len(entries) == 36
+
+
+def test_enqueue_artifact_write_returns_before_persisting(
+    repo: TaskArtifactRepository,
+) -> None:
+    accepted = repo.enqueue_ensure_artifact(task_id="task-queued", spec_artifact_id="")
+    assert accepted is True
+    repo._queue.join()
+
+    artifact = repo.get_artifact("task-queued")
+    metrics = repo.write_metrics()
+
+    assert artifact is not None
+    assert metrics.enqueued >= 1
+    assert metrics.completed >= 1
 
 
 def test_get_artifact_with_entries(repo: TaskArtifactRepository):

--- a/tests/unit_tests/frontend/test_agent_panel_history_task_prompt_ui.py
+++ b/tests/unit_tests/frontend/test_agent_panel_history_task_prompt_ui.py
@@ -791,6 +791,193 @@ console.log(JSON.stringify({
     assert payload["renderCalls"] == 0
 
 
+def test_render_instance_history_does_not_defer_persisted_final_answer_after_tool(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root
+        / "frontend"
+        / "dist"
+        / "js"
+        / "components"
+        / "agentPanel"
+        / "history.js"
+    )
+
+    module_under_test_path = tmp_path / "history.mjs"
+    runner_path = tmp_path / "runner_final_answer_after_tool.mjs"
+
+    source_text = source_path.read_text(encoding="utf-8")
+    for original, replacement in {
+        "../../core/api.js": "./mockApi.mjs",
+        "../../core/state.js": "./mockState.mjs",
+        "../../utils/i18n.js": "./mockI18n.mjs",
+        "../messageRenderer.js": "./mockMessageRenderer.mjs",
+        "./state.js": "./mockPanelState.mjs",
+    }.items():
+        source_text = source_text.replace(original, replacement)
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+
+    (tmp_path / "mockApi.mjs").write_text(
+        """
+export async function fetchAgentMessages() {
+    return [
+        {
+            role: 'assistant',
+            role_id: 'writer',
+            instance_id: 'inst-1',
+            message: {
+                parts: [
+                    {
+                        part_kind: 'tool-call',
+                        tool_name: 'write_tmp',
+                        tool_call_id: 'call-1',
+                        args: { path: 'tmp/report.md' },
+                    },
+                ],
+            },
+        },
+        {
+            role: 'assistant',
+            role_id: 'writer',
+            instance_id: 'inst-1',
+            message: {
+                parts: [{ part_kind: 'text', content: 'Final subagent answer.' }],
+            },
+        },
+    ];
+}
+
+export async function fetchAgentReflection() {
+    return null;
+}
+
+export async function fetchRunTokenUsage() {
+    return null;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: 'session-1',
+    activeRunId: null,
+    currentRecoverySnapshot: null,
+    sessionTasks: [],
+    sessionAgents: [],
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockMessageRenderer.mjs").write_text(
+        """
+export function getInstanceStreamOverlay() {
+    return null;
+}
+
+export function bindStreamOverlayToContainer() {
+    return null;
+}
+
+export function renderHistoricalMessageList(_container, messages) {
+    globalThis.__renderCalls.push(messages.map(item => item.message.parts));
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockI18n.mjs").write_text(
+        """
+export function t(key) {
+    return key;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockPanelState.mjs").write_text(
+        """
+export function getActiveInstanceId() {
+    return null;
+}
+
+export function getActiveRoundRunId() {
+    return '';
+}
+
+export function getPendingApprovalsForPanel() {
+    return [];
+}
+
+export function getPanel() {
+    return null;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner_path.write_text(
+        """
+globalThis.__renderCalls = [];
+globalThis.document = {
+    createElement() {
+        return {
+            dataset: {},
+            childNodes: [],
+            replaceChildren() {},
+        };
+    },
+};
+
+const { renderInstanceHistoryInto } = await import('./history.mjs');
+
+const container = {
+    innerHTML: 'existing-live-dom',
+    dataset: {},
+    replaceChildren() {},
+};
+
+const result = await renderInstanceHistoryInto(container, {
+    sessionId: 'session-1',
+    instanceId: 'inst-1',
+    runId: 'subagent_run_1',
+    requireToolBoundary: true,
+});
+
+console.log(JSON.stringify({
+    deferred: result.deferred === true,
+    renderCallCount: globalThis.__renderCalls.length,
+    renderedParts: globalThis.__renderCalls[0],
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+    assert payload["deferred"] is False
+    assert payload["renderCallCount"] == 1
+    assert payload["renderedParts"][1] == [
+        {"part_kind": "text", "content": "Final subagent answer."}
+    ]
+
+
 def test_render_instance_history_uses_separate_overlay_for_running_child_session(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_agent_panel_reflection_button_ui.py
+++ b/tests/unit_tests/frontend/test_agent_panel_reflection_button_ui.py
@@ -696,3 +696,5 @@ def test_layout_css_keeps_reflect_button_styles() -> None:
     assert "scrollbar-width: thin;" in css_text
     assert ".agent-panel-section-body[hidden]" in css_text
     assert "display: none !important;" in css_text
+    assert ".agent-panel-refresh-reflection[hidden]," in css_text
+    assert ".agent-panel-stop[hidden]" in css_text

--- a/tests/unit_tests/frontend/test_api_facade_ui.py
+++ b/tests/unit_tests/frontend/test_api_facade_ui.py
@@ -266,6 +266,103 @@ export function invalidateManagedRequestCache() {
     ]
 
 
+def test_fetch_session_subagents_force_refresh_invalidates_subagent_cache(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "core" / "api" / "sessions.js"
+    )
+    module_under_test_path = tmp_path / "sessions.mjs"
+    mock_request_path = tmp_path / "mockRequest.mjs"
+
+    mock_request_path.write_text(
+        """
+export async function requestJson() {
+    throw new Error('not used');
+}
+
+export async function requestJsonManaged(key, url, options, errorMessage, config) {
+    globalThis.__capturedManagedRequests.push({
+        key,
+        url,
+        options,
+        errorMessage,
+        config,
+    });
+    return [{ instance_id: 'subagent-1' }];
+}
+
+export function invalidateManagedRequests(prefix) {
+    globalThis.__invalidatedPrefixes.push(prefix);
+}
+
+export function invalidateManagedRequestCache() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    source_text = source_path.read_text(encoding="utf-8")
+    module_text = source_text.replace(
+        "from './request.js';",
+        "from './mockRequest.mjs';",
+    )
+    assert module_text != source_text
+    module_under_test_path.write_text(module_text, encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                "globalThis.__capturedManagedRequests = []; "
+                "globalThis.__invalidatedPrefixes = []; "
+                f"const mod = await import({module_under_test_path.as_uri()!r}); "
+                "await mod.fetchSessionSubagents('session-a'); "
+                "await mod.fetchSessionSubagents('session-a', { forceRefresh: true }); "
+                "console.log(JSON.stringify({"
+                "managedRequests: globalThis.__capturedManagedRequests,"
+                "invalidatedPrefixes: globalThis.__invalidatedPrefixes"
+                "}));"
+            ),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=30,
+    )
+
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node import failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout.strip())
+    assert payload["invalidatedPrefixes"] == ["sessions:session-a:subagents"]
+    assert payload["managedRequests"] == [
+        {
+            "key": "sessions:session-a:subagents",
+            "url": "/api/sessions/session-a/subagents",
+            "options": {},
+            "errorMessage": "Failed to fetch session subagents",
+            "config": {"lane": "heavy", "ttlMs": 500},
+        },
+        {
+            "key": "sessions:session-a:subagents",
+            "url": "/api/sessions/session-a/subagents?force_refresh=1",
+            "options": {},
+            "errorMessage": "Failed to fetch session subagents",
+            "config": {"lane": "heavy", "ttlMs": 500},
+        },
+    ]
+
+
 def test_role_config_reads_use_managed_requests_and_writes_invalidate_cache(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_projects_sidebar_ui.py
+++ b/tests/unit_tests/frontend/test_projects_sidebar_ui.py
@@ -154,7 +154,8 @@ document.dispatchEvent(new CustomEvent("agent-teams-session-title-previewed", {
 await flushTasks();
 
 const firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
-const labels = firstProject.querySelectorAll(".session-id").map(node => node.textContent);
+const labels = firstProject.querySelectorAll(".session-item")
+    .map(node => node.querySelector(".session-label-text").textContent);
 
 console.log(JSON.stringify({
     fetchCountAfterInitialLoad,
@@ -383,6 +384,7 @@ import { loadProjects } from "./sidebar.mjs";
 
 installGlobals(createDomEnvironment());
 await loadProjects();
+await new Promise(resolve => setTimeout(resolve, 30));
 
 const projectsList = document.getElementById("projects-list");
 const firstProject = projectsList.children.filter(child => child.className === "project-card")[0];
@@ -643,6 +645,212 @@ console.log(JSON.stringify({
     assert payload["terminalViewCalls"] == []
 
 
+def test_projects_sidebar_session_status_machine_updates_within_one_event_tick(
+    tmp_path: Path,
+) -> None:
+    payload = _run_sidebar_script(
+        tmp_path=tmp_path,
+        mock_api_source="""
+const workspaces = [
+    {
+        workspace_id: "alpha-project",
+        root_path: "/work/Alpha Project",
+        updated_at: "2026-03-14T10:00:00Z",
+        profile: { file_scope: { backend: "project" } },
+    },
+];
+
+const sessions = [
+    {
+        session_id: "session-target",
+        workspace_id: "alpha-project",
+        updated_at: "2026-03-14T10:03:00Z",
+        metadata: { title: "Before send" },
+    },
+    {
+        session_id: "session-other",
+        workspace_id: "alpha-project",
+        updated_at: "2026-03-14T10:02:00Z",
+        metadata: { title: "Other session" },
+    },
+];
+
+export async function fetchWorkspaces() {
+    return workspaces;
+}
+
+export async function fetchSessions() {
+    return sessions;
+}
+
+export async function fetchAutomationProjects() {
+    return [];
+}
+
+export async function fetchAutomationFeishuBindings() {
+    return [];
+}
+
+export async function startNewSession() {
+    throw new Error("not used");
+}
+
+export async function updateSession() {
+    return { status: "ok" };
+}
+
+export async function deleteSession() {
+    return { status: "ok" };
+}
+
+export async function deleteWorkspace() {
+    return { status: "ok" };
+}
+
+export async function forkWorkspace() {
+    return {};
+}
+
+export async function pickWorkspace() {
+    return { workspace_id: "alpha-project" };
+}
+
+export async function createAutomationProject() {
+    return {};
+}
+
+export async function deleteAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function disableAutomationProject() {
+    return { status: "ok" };
+}
+
+export async function enableAutomationProject() {
+    return { status: "ok" };
+}
+""".strip(),
+        runner_source="""
+import {
+    loadProjects,
+    setSelectSessionHandler,
+} from "./sidebar.mjs";
+
+globalThis.CustomEvent = class CustomEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail || {};
+    }
+};
+
+installGlobals(createDomEnvironment());
+setSelectSessionHandler(async (sessionId) => {
+    globalThis.__selectedSessionIds.push(sessionId);
+});
+
+function targetItem() {
+    const projectsList = document.getElementById("projects-list");
+    const project = projectsList.children.filter(child => child.className === "project-card")[0];
+    return project.querySelectorAll(".session-item")
+        .find(item => item.getAttribute("data-session-id") === "session-target");
+}
+
+function otherItem() {
+    const projectsList = document.getElementById("projects-list");
+    const project = projectsList.children.filter(child => child.className === "project-card")[0];
+    return project.querySelectorAll(".session-item")
+        .find(item => item.getAttribute("data-session-id") === "session-other");
+}
+
+function targetLabel() {
+    return targetItem().querySelector(".session-label-text").textContent;
+}
+
+await loadProjects();
+const targetItemBefore = targetItem();
+const otherItemBefore = otherItem();
+const initialClassName = targetItem().className;
+
+document.dispatchEvent(new CustomEvent("agent-teams-session-run-active", {
+    detail: {
+        sessionId: "session-target",
+        runId: "run-1",
+        status: "running",
+    },
+}));
+await flushTasks();
+const runningClassName = targetItem().className;
+
+document.dispatchEvent(new CustomEvent("agent-teams-session-title-previewed", {
+    detail: {
+        sessionId: "session-target",
+        title: "你好",
+    },
+}));
+await flushTasks();
+const previewTitle = targetLabel();
+
+document.dispatchEvent(new CustomEvent("agent-teams-session-run-terminal", {
+    detail: {
+        sessionId: "session-target",
+        runId: "run-1",
+        status: "completed",
+        viewed: false,
+    },
+}));
+await flushTasks();
+const unreadClassName = targetItem().className;
+
+targetItem().onclick();
+const clickedClassName = targetItem().className;
+await flushTasks();
+
+document.dispatchEvent(new CustomEvent("agent-teams-session-record-updated", {
+    detail: {
+        sessionId: "session-target",
+        workspaceId: "alpha-project",
+        session: {
+            session_id: "session-target",
+            workspace_id: "alpha-project",
+            updated_at: "2026-03-14T10:04:00Z",
+            metadata: { title: "你好" },
+            latest_terminal_run_id: "run-1",
+            latest_terminal_run_status: "completed",
+            has_unread_terminal_run: true,
+        },
+    },
+}));
+await flushTasks();
+const afterStaleRecordClassName = targetItem().className;
+
+console.log(JSON.stringify({
+    initialClassName,
+    runningClassName,
+    previewTitle,
+    unreadClassName,
+    clickedClassName,
+    afterStaleRecordClassName,
+    targetNodeStable: targetItem() === targetItemBefore,
+    otherNodeStable: otherItem() === otherItemBefore,
+    selectedSessionIds: globalThis.__selectedSessionIds,
+}));
+""".strip(),
+    )
+
+    assert "has-run-indicator" not in str(payload["initialClassName"])
+    assert "has-run-indicator-running" in str(payload["runningClassName"])
+    assert payload["previewTitle"] == "你好"
+    assert "has-run-indicator-unread" in str(payload["unreadClassName"])
+    assert "has-run-indicator-running" not in str(payload["unreadClassName"])
+    assert "has-run-indicator-unread" not in str(payload["clickedClassName"])
+    assert "session-run-indicator-viewed" in str(payload["clickedClassName"])
+    assert "has-run-indicator-unread" not in str(payload["afterStaleRecordClassName"])
+    assert payload["targetNodeStable"] is True
+    assert payload["otherNodeStable"] is True
+    assert payload["selectedSessionIds"] == ["session-target"]
+
+
 def test_projects_sidebar_keeps_latest_rapid_session_click_active(
     tmp_path: Path,
 ) -> None:
@@ -888,7 +1096,7 @@ console.log(JSON.stringify({
     ).read_text(encoding="utf-8")
     assert "selectedSessionNeedsTerminalView" in session_script
     assert "sessionRecordNeedsTerminalView(sessionRecord)" in session_script
-    assert "if (sessionNeedsTerminalView)" in session_script
+    assert "if (selectedSessionNeedsTerminalView)" in session_script
     assert (
         "void markSelectedSessionTerminalViewed(safeSessionId, selectionSignal);"
         in session_script
@@ -1650,7 +1858,7 @@ export async function runAutomationProject() {
     ) in sidebar_script
 
 
-def test_projects_sidebar_hides_stale_summary_toggle_after_empty_subagent_list_load(
+def test_projects_sidebar_keeps_summary_toggle_as_session_state_after_empty_detail_load(
     tmp_path: Path,
 ) -> None:
     payload = _run_sidebar_script(
@@ -1763,7 +1971,7 @@ export async function runAutomationProject() {
 """.strip(),
     )
 
-    assert payload["toggleCount"] == 0
+    assert payload["toggleCount"] == 1
 
 
 def test_projects_sidebar_deletes_subagent_child_session_and_returns_to_parent(
@@ -3524,7 +3732,7 @@ console.log(JSON.stringify({
     }
 
 
-def test_projects_sidebar_force_refreshes_subagent_events_even_when_hovering(
+def test_projects_sidebar_defers_forced_subagent_refresh_while_hovering(
     tmp_path: Path,
 ) -> None:
     payload = _run_sidebar_script(
@@ -3541,12 +3749,16 @@ document.dispatchEvent({
     detail: { forceRefresh: true },
 });
 await new Promise(resolve => setTimeout(resolve, 160));
+const hoveredCounts = { ...globalThis.__fetchCounts };
+globalThis.__projectsListHover = false;
+await new Promise(resolve => setTimeout(resolve, 320));
 
-const refreshedCounts = { ...globalThis.__fetchCounts };
+const settledCounts = { ...globalThis.__fetchCounts };
 
 console.log(JSON.stringify({
     initialCounts,
-    refreshedCounts,
+    hoveredCounts,
+    settledCounts,
     sessionForceRefreshes: globalThis.__sessionForceRefreshes,
 }));
 """.strip(),
@@ -3653,7 +3865,8 @@ export async function runAutomationProject() {
         "sessions": 1,
         "automationProjects": 1,
     }
-    assert payload["refreshedCounts"] == {
+    assert payload["hoveredCounts"] == payload["initialCounts"]
+    assert payload["settledCounts"] == {
         "workspaces": 1,
         "sessions": 2,
         "automationProjects": 1,
@@ -4297,7 +4510,7 @@ function parseElements(source, selector) {
         ".session-subagent-empty": /class="session-subagent-empty"[^>]*>([\s\S]*?)<\/div>/g,
         ".session-rename-btn": /class="session-rename-btn"[^>]*data-session-id="([^"]+)"[^>]*data-session-metadata="([^"]*)"[^>]*>/g,
         ".session-delete-btn": /class="session-delete-btn"[^>]*data-session-id="([^"]+)"[^>]*>/g,
-        ".session-item": /class="([^"]*session-item[^"]*)"[^>]*data-session-id="([^"]+)"[^>]*data-workspace-id="([^"]+)"[^>]*>/g,
+        ".session-item": /class="([^"]*session-item[^"]*)"[^>]*data-session-id="([^"]+)"[^>]*data-workspace-id="([^"]+)"[^>]*>[\s\S]*?<span class="session-label-text"[^>]*>([\s\S]*?)<\/span>/g,
         ".session-source-icon": /class="[^"]*session-source-icon[^"]*"[^>]*>/g,
         ".project-title": /class="project-title"[^>]*>([\s\S]*?)<\/span>/g,
         ".session-id": /class="session-id"[^>]*>([\s\S]*?)<\/span>\s*<\/span>\s*<span class="session-meta"/g,
@@ -4389,6 +4602,7 @@ function parseElements(source, selector) {
         } else if (selector === ".session-item") {
             results.push(createNode({
                 className: match[1],
+                labelText: match[4].replace(/<[^>]+>/g, "").trim(),
                 attributes: {
                     "data-session-id": match[2],
                     "data-workspace-id": match[3],
@@ -4406,8 +4620,17 @@ function parseElements(source, selector) {
     return results;
 }
 
-function createNode({ className = "", textContent = "", attributes = {} } = {}) {
+function createNode({ className = "", textContent = "", labelText = "", attributes = {} } = {}) {
     const attributeStore = new Map(Object.entries(attributes));
+    const labelNode = {
+        textContent: labelText,
+        title: labelText,
+        setAttribute(name, value) {
+            if (name === "title") {
+                this.title = String(value);
+            }
+        },
+    };
     return {
         className,
         classList: {
@@ -4445,6 +4668,9 @@ function createNode({ className = "", textContent = "", attributes = {} } = {}) 
         },
         getAttribute(name) {
             return attributeStore.get(name) || null;
+        },
+        querySelector(selector) {
+            return selector === ".session-label-text" ? labelNode : null;
         },
     };
 }

--- a/tests/unit_tests/frontend/test_prompt_yolo_ui.py
+++ b/tests/unit_tests/frontend/test_prompt_yolo_ui.py
@@ -2014,7 +2014,7 @@ console.log(JSON.stringify({
     )
 
 
-def test_handle_send_emits_title_preview_only_after_run_created(
+def test_handle_send_emits_title_preview_before_run_created_for_sidebar_responsiveness(
     tmp_path: Path,
 ) -> None:
     temp_dir = _write_multimodal_prompt_fixture(tmp_path, role_supports_image=True)
@@ -2076,9 +2076,16 @@ console.log(JSON.stringify({
             "type": "agent-teams-session-title-previewed",
             "detail": {
                 "sessionId": "session-1",
+                "title": "preview before run",
+            },
+        },
+        {
+            "type": "agent-teams-session-title-previewed",
+            "detail": {
+                "sessionId": "session-1",
                 "title": "preview after run",
             },
-        }
+        },
     ]
 
 
@@ -3227,12 +3234,368 @@ export function isForegroundSubmissionActive(submission) {
     return submission?.detached !== true;
 }
 
+export function isForegroundSubmissionActiveForSession(submission, sessionId) {
+    return submission?.detached !== true
+        && String(sessionId || "").trim() !== ""
+        && globalThis.__foregroundSessionActiveForSession !== false;
+}
+
 export function isForegroundSubmissionDetached(submission) {
     return submission?.detached === true;
 }
 """.strip(),
         encoding="utf-8",
     )
+
+
+def test_send_keeps_original_session_when_user_switches_during_voice_stop(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/app/prompt.js").read_text(encoding="utf-8")
+    temp_dir = tmp_path / "prompt_immediate_switch"
+    temp_dir.mkdir()
+    _write_new_session_draft_mock(tmp_path)
+
+    (temp_dir / "prompt.js").write_text(
+        source.replace("../components/rounds/timeline.js", "./mockRounds.mjs")
+        .replace("../components/runtimeInjectQueue.js", "./mockRuntimeInjectQueue.mjs")
+        .replace("../components/contextIndicators.js", "./mockContextIndicators.mjs")
+        .replace("../components/messageRenderer.js", "./mockMessageRenderer.mjs")
+        .replace("../core/api.js", "./mockApi.mjs")
+        .replace("./recovery.js", "./mockRecovery.mjs")
+        .replace("../core/state.js", "./mockState.mjs")
+        .replace("../core/stream.js", "./mockStream.mjs")
+        .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/feedback.js", "./mockFeedback.mjs")
+        .replace("../utils/i18n.js", "./mockI18n.mjs")
+        .replace("../utils/logger.js", "./mockLogger.mjs"),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockRounds.mjs").write_text(
+        """
+export function appendRoundUserMessage() {
+    return undefined;
+}
+
+export function createLiveRound(runId, text, inputParts) {
+    globalThis.__liveRounds.push({ runId, text, inputParts });
+}
+
+export function showPendingRunStartPlaceholder(sessionId, text, inputParts) {
+    globalThis.__placeholders.push({ sessionId, text, inputParts });
+}
+
+export function clearPendingRunStartPlaceholder() {
+    globalThis.__placeholderClears += 1;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockRuntimeInjectQueue.mjs").write_text(
+        """
+export function removeRuntimeInjectMessage() {
+    return undefined;
+}
+
+export function upsertRuntimeInjectMessage() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockContextIndicators.mjs").write_text(
+        """
+export function refreshVisibleContextIndicators() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockMessageRenderer.mjs").write_text(
+        """
+export function clearAllStreamState() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockApi.mjs").write_text(
+        """
+export async function fetchRoleConfigOptions() {
+    return {};
+}
+
+export async function fetchCommands() {
+    return [];
+}
+
+export async function fetchOrchestrationConfig() {
+    return { default_orchestration_preset_id: "", presets: [] };
+}
+
+export async function injectMessage() {
+    return {};
+}
+
+export async function forceQueuedInject() {
+    return {};
+}
+
+export async function resolveCommandPrompt() {
+    return { prompt: "" };
+}
+
+export async function searchWorkspacePaths() {
+    return [];
+}
+
+export async function updateSessionTopology() {
+    return {};
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockRecovery.mjs").write_text(
+        """
+export async function hydrateSessionView() {
+    return null;
+}
+
+export function startSessionContinuity(sessionId) {
+    globalThis.__continuityCalls.push(sessionId);
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: "session-a",
+    currentSessionMode: "normal",
+    currentSessionCanSwitchMode: true,
+    currentNormalRootRoleId: "MainAgent",
+    currentOrchestrationPresetId: null,
+    pausedSubagent: null,
+    isGenerating: false,
+    yolo: true,
+    thinking: { enabled: false, effort: "medium" },
+    instanceRoleMap: {},
+    roleInstanceMap: {},
+    taskInstanceMap: {},
+    activeAgentRoleId: null,
+    activeAgentInstanceId: null,
+    autoSwitchedSubagentInstances: {},
+    activeRunId: null,
+};
+
+export function applyCurrentSessionRecord() {
+    return undefined;
+}
+
+export function getCoordinatorRoleId() {
+    return "Coordinator";
+}
+
+export function getRoleInputModalitySupport() {
+    return false;
+}
+
+export function getRoleOption() {
+    return null;
+}
+
+export function getMainAgentRoleId() {
+    return "MainAgent";
+}
+
+export function getNormalModeRoles() {
+    return [];
+}
+
+export function getPrimaryRoleId() {
+    return "MainAgent";
+}
+
+export function getRoleDisplayName(roleId, { fallback = "Agent" } = {}) {
+    return roleId || fallback;
+}
+
+export function setCoordinatorRoleOption() {
+    return undefined;
+}
+
+export function setMainAgentRoleOption() {
+    return undefined;
+}
+
+export function setCoordinatorRoleId() {
+    return undefined;
+}
+
+export function setMainAgentRoleId() {
+    return undefined;
+}
+
+export function setNormalModeRoles() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockStream.mjs").write_text(
+        """
+export async function startIntentStream(promptText, sessionId, onCompleted, options = {}) {
+    globalThis.__streamCalls.push({ promptText, sessionId, options });
+    if (typeof options.onRunCreated === "function") {
+        options.onRunCreated({ run_id: "run-a" });
+    }
+    return onCompleted;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockDom.mjs").write_text(
+        """
+function createElement(initial = {}) {
+    return {
+        value: "",
+        checked: false,
+        disabled: false,
+        hidden: false,
+        textContent: "",
+        innerHTML: "",
+        title: "",
+        style: { display: "", height: "" },
+        classList: { toggle() { return undefined; } },
+        querySelectorAll() { return []; },
+        focus() { return undefined; },
+        ...initial,
+    };
+}
+
+export const els = {
+    promptInput: createElement({ value: "你好" }),
+    promptAttachments: createElement(),
+    sendBtn: createElement(),
+    stopBtn: createElement({ style: { display: "none" } }),
+    yoloToggle: createElement({ checked: true }),
+    thinkingModeToggle: createElement({ checked: false }),
+    thinkingEffortSelect: createElement({ value: "medium", disabled: true }),
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockFeedback.mjs").write_text(
+        """
+export function showToast() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockI18n.mjs").write_text(
+        """
+export function t(key) {
+    return key;
+}
+
+export function formatMessage(key, values = {}) {
+    return Object.entries(values).reduce(
+        (message, [name, value]) => message.replaceAll(`{${name}}`, String(value)),
+        t(key),
+    );
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (temp_dir / "mockLogger.mjs").write_text(
+        """
+export function sysLog(message, tone = "log-info") {
+    globalThis.__logs.push({ message, tone });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner = """
+import { handleSend } from "./prompt.js";
+import { state } from "./mockState.mjs";
+import { els } from "./mockDom.mjs";
+
+globalThis.__streamCalls = [];
+globalThis.__liveRounds = [];
+globalThis.__placeholders = [];
+globalThis.__placeholderClears = 0;
+globalThis.__continuityCalls = [];
+globalThis.__logs = [];
+globalThis.document = {
+    dispatchEvent(event) {
+        globalThis.__dispatchedEvents.push({
+            type: event.type,
+            detail: event.detail,
+        });
+    },
+};
+globalThis.CustomEvent = class CustomEvent {
+    constructor(type, init = {}) {
+        this.type = type;
+        this.detail = init.detail || null;
+    }
+};
+globalThis.__dispatchedEvents = [];
+globalThis.__relayTeamsVoiceInputActive = true;
+globalThis.__relayTeamsStopVoiceInput = async () => {
+    state.currentSessionId = "session-b";
+    globalThis.__foregroundSessionActiveForSession = false;
+    els.promptInput.value = "";
+    await Promise.resolve();
+};
+
+await handleSend();
+
+console.log(JSON.stringify({
+    streamCalls: globalThis.__streamCalls.map(call => ({
+        promptText: call.promptText,
+        sessionId: call.sessionId,
+        targetRoleId: call.options.targetRoleId,
+        detached: call.options.detached === true,
+    })),
+    liveRounds: globalThis.__liveRounds,
+    placeholders: globalThis.__placeholders,
+    continuityCalls: globalThis.__continuityCalls,
+    dispatchedEvents: globalThis.__dispatchedEvents,
+    currentSessionId: state.currentSessionId,
+    logs: globalThis.__logs,
+}));
+""".strip()
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["currentSessionId"] == "session-b"
+    assert payload["streamCalls"] == [
+        {
+            "promptText": "你好",
+            "sessionId": "session-a",
+            "targetRoleId": None,
+            "detached": True,
+        }
+    ]
+    assert payload["continuityCalls"] == []
+    assert payload["liveRounds"] == []
+    assert payload["placeholders"] == []
+    assert payload["dispatchedEvents"] == [
+        {
+            "type": "agent-teams-session-title-previewed",
+            "detail": {"sessionId": "session-a", "title": "你好"},
+        }
+    ]
 
 
 def _write_multimodal_prompt_fixture(

--- a/tests/unit_tests/frontend/test_recovery_stream_ui.py
+++ b/tests/unit_tests/frontend/test_recovery_stream_ui.py
@@ -59,6 +59,7 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert 'type="text"' in recovery_script
     assert "compositionstart" in recovery_script
     assert "restoreFocusedUserQuestionSupplement(" in recovery_script
+    assert "restoreFocusedUserQuestionSupplementSoon(" in recovery_script
     assert (
         "handleUserQuestionSubmit(userQuestion.runId || runId, userQuestion);"
         in recovery_script
@@ -100,6 +101,12 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
     assert "await ensureAutomaticRecoveryStream(snapshot," in recovery_script
     assert "resumeRunStream(activeRun.run_id, safeSessionId, null," in recovery_script
     assert "await reconcileMissingActiveRun(normalized, {" in recovery_script
+    assert "withLocalActiveRunForEmptySnapshot(snapshot)" in recovery_script
+    assert "function withLocalActiveRunForEmptySnapshot(snapshot)" in recovery_script
+    assert "if (!isLocallyStreaming(activeRunId)) return snapshot;" in recovery_script
+    assert "|| hasActiveRunId" in recovery_script
+    assert "'awaiting_manual_action'," in recovery_script
+    assert "'awaiting_user'," in recovery_script
     assert "const previousActiveRunId = String(" in recovery_script
     assert (
         "endStream({ preserveRunStreamState: true, focusPrompt: false });"
@@ -157,6 +164,13 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
         "function applyBackgroundRunEvent(connection, evType, payload, eventMeta) {"
         in stream_script
     )
+    assert "dispatchSessionRunTerminal(" in stream_script
+    background_event_block = stream_script.split(
+        "function applyBackgroundRunEvent(connection, evType, payload, eventMeta) {",
+        1,
+    )[1].split("\n}\n\nfunction isTerminalRunEvent", 1)[0]
+    assert "dispatchSessionRunTerminal(" in background_event_block
+    assert "terminalStatusFromEventType(evType)" in background_event_block
     assert "reason: 'background-reconnect'," in stream_script
     assert (
         "export function syncBackgroundStreamsForSessions(sessionRecords = []) {"
@@ -213,6 +227,10 @@ def test_recovery_ui_uses_automatic_stream_reconnect_without_connect_button() ->
         not in renderer_stream_script
     )
     assert "messageRenderer.clearRunStreamState(finishedRunId);" in stream_script
+    assert (
+        "primeRecoveryContinuityForCreatedRun(runId, safeSessionId);" in stream_script
+    )
+    assert "reason: 'run-created'," in stream_script
     assert "overlaySeenEventIdsByRun.delete(safeRunId);" in renderer_stream_script
     assert "clearTimelineRun(safeRunId);" in renderer_stream_script
     assert "st = createStreamState({" in renderer_stream_script

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -96,6 +96,46 @@ console.log(JSON.stringify({
     assert payload["activeAgentInstanceId"] == "writer-1"
 
 
+def test_run_started_marks_sidebar_session_running_immediately(
+    tmp_path: Path,
+) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleRunStarted } = await import('./runEvents.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+
+handleRunStarted({ run_id: 'run-1', session_id: 'session-1' });
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    activeCalls: globalThis.__markSidebarSessionRunActiveCalls,
+    dispatchedEvents: globalThis.__documentDispatches,
+}));
+""".strip(),
+    )
+
+    assert payload["activeCalls"] == [
+        {
+            "sessionId": "session-1",
+            "detail": {"runId": "run-1", "status": "running"},
+        }
+    ]
+    assert payload["dispatchedEvents"] == [
+        {
+            "type": "agent-teams-session-run-active",
+            "detail": {
+                "sessionId": "session-1",
+                "runId": "run-1",
+                "status": "running",
+            },
+        }
+    ]
+
+
 def test_terminal_run_event_marks_current_main_session_viewed(
     tmp_path: Path,
 ) -> None:
@@ -114,11 +154,22 @@ await Promise.resolve();
 
 console.log(JSON.stringify({
     viewedCalls: globalThis.__markSessionTerminalRunViewedCalls,
+    terminalCalls: globalThis.__markSidebarSessionRunTerminalCalls,
 }));
 """.strip(),
     )
 
     assert payload["viewedCalls"] == ["session-1"]
+    assert payload["terminalCalls"] == [
+        {
+            "sessionId": "session-1",
+            "detail": {
+                "runId": "run-1",
+                "status": "completed",
+                "viewed": True,
+            },
+        }
+    ]
 
 
 def test_run_stopped_keeps_terminal_run_unviewed_for_resume_context(
@@ -300,11 +351,22 @@ await Promise.resolve();
 
 console.log(JSON.stringify({
     viewedCalls: globalThis.__markSessionTerminalRunViewedCalls,
+    terminalCalls: globalThis.__markSidebarSessionRunTerminalCalls,
 }));
 """.strip(),
     )
 
     assert payload["viewedCalls"] == []
+    assert payload["terminalCalls"] == [
+        {
+            "sessionId": "session-2",
+            "detail": {
+                "runId": "run-2",
+                "status": "completed",
+                "viewed": False,
+            },
+        }
+    ]
 
 
 def test_terminal_run_event_does_not_mark_background_session_without_current_session(
@@ -394,6 +456,89 @@ console.log(JSON.stringify({
     assert payload["viewedCalls"] == ["session-1", "session-1"]
 
 
+def test_route_event_preserves_stream_block_order_without_missing_events(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+const events = [
+    ['thinking_started', { text: '' }, 1],
+    ['thinking_delta', { text: 'plan' }, 2],
+    ['thinking_finished', {}, 3],
+    ['tool_call', { tool_name: 'read', tool_call_id: 'call-1' }, 4],
+    ['tool_result', { tool_name: 'read', tool_call_id: 'call-1', result: 'ok' }, 5],
+    ['text_delta', { text: 'done' }, 6],
+];
+for (const [eventType, eventPayload, eventId] of events) {
+    routeEvent(eventType, eventPayload, {
+        event_id: eventId,
+        run_id: 'run-1',
+        trace_id: 'trace-1',
+        instance_id: 'instance-main',
+        role_id: 'MainAgent',
+    });
+}
+
+console.log(JSON.stringify({
+    runEventCalls: globalThis.__runEventCalls.map(call => call.name),
+    toolEventCalls: globalThis.__toolEventCalls.map(call => call.name),
+    combinedCalls: globalThis.__combinedEventCalls.map(call => call.name),
+}));
+""".strip(),
+    )
+
+    assert payload["runEventCalls"] == [
+        "handleThinkingStarted",
+        "handleThinkingDelta",
+        "handleThinkingFinished",
+        "handleTextDelta",
+    ]
+    assert payload["toolEventCalls"] == ["handleToolCall", "handleToolResult"]
+    assert payload["combinedCalls"] == [
+        "handleThinkingStarted",
+        "handleThinkingDelta",
+        "handleThinkingFinished",
+        "handleToolCall",
+        "handleToolResult",
+        "handleTextDelta",
+    ]
+
+
+def test_route_event_deduplicates_replayed_stream_event_ids(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+const eventMeta = {
+    event_id: 7,
+    run_id: 'run-1',
+    trace_id: 'trace-1',
+    instance_id: 'instance-main',
+    role_id: 'MainAgent',
+};
+routeEvent('text_delta', { text: 'once' }, eventMeta);
+routeEvent('text_delta', { text: 'once again' }, eventMeta);
+routeEvent('tool_result', { tool_name: 'read', tool_call_id: 'call-1' }, eventMeta);
+
+console.log(JSON.stringify({
+    runEventCalls: globalThis.__runEventCalls.map(call => call.name),
+    toolEventCalls: globalThis.__toolEventCalls.map(call => call.name),
+    combinedCalls: globalThis.__combinedEventCalls.map(call => call.name),
+}));
+""".strip(),
+    )
+
+    assert payload["runEventCalls"] == ["handleTextDelta"]
+    assert payload["toolEventCalls"] == []
+    assert payload["combinedCalls"] == ["handleTextDelta"]
+
+
 def test_route_event_routes_subagent_stream_events_without_overwriting_parent_run(
     tmp_path: Path,
 ) -> None:
@@ -407,6 +552,11 @@ state.activeRunId = 'run-parent';
 
 routeEvent('text_delta', {}, { run_id: 'subagent_run_deadbeef', trace_id: 'subagent_run_deadbeef' });
 routeEvent('token_usage', {}, { run_id: 'subagent_run_deadbeef', trace_id: 'subagent_run_deadbeef' });
+routeEvent('text_delta', { text: 'non-prefix' }, {
+    run_id: 'delegated-run-deadbeef',
+    trace_id: 'delegated-run-deadbeef',
+    normal_mode_subagent_event: true,
+});
 
 await Promise.resolve();
 
@@ -434,7 +584,20 @@ console.log(JSON.stringify({
                 None,
                 None,
             ],
-        }
+        },
+        {
+            "name": "handleTextDelta",
+            "args": [
+                {"text": "non-prefix"},
+                {
+                    "run_id": "delegated-run-deadbeef",
+                    "trace_id": "delegated-run-deadbeef",
+                    "normal_mode_subagent_event": True,
+                },
+                None,
+                None,
+            ],
+        },
     ]
 
 
@@ -555,6 +718,77 @@ console.log(JSON.stringify({
         }
     ]
     assert payload["tokenUsageCalls"] == []
+    assert payload["runEventCalls"] == []
+
+
+def test_route_event_applies_main_user_question_event_without_recovery_roundtrip(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.activeRunId = 'run-1';
+
+routeEvent(
+    'user_question_requested',
+    {
+        question_id: 'question-1',
+        questions: [{ question: 'Pick one', options: [{ label: 'Ship' }] }],
+    },
+    { run_id: 'run-1', trace_id: 'run-1', session_id: 'session-1' },
+);
+routeEvent(
+    'user_question_answered',
+    { question_id: 'question-1' },
+    { run_id: 'run-1', trace_id: 'run-1', session_id: 'session-1' },
+);
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    questionRequestedCalls: globalThis.__markUserQuestionRequestedCalls,
+    questionAnsweredCalls: globalThis.__markUserQuestionAnsweredCalls,
+    recoveryCalls: globalThis.__scheduleRecoveryContinuityRefreshCalls,
+    runEventCalls: globalThis.__runEventCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["questionRequestedCalls"] == [
+        {
+            "payload": {
+                "question_id": "question-1",
+                "questions": [{"question": "Pick one", "options": [{"label": "Ship"}]}],
+            },
+            "eventMeta": {
+                "run_id": "run-1",
+                "trace_id": "run-1",
+                "session_id": "session-1",
+            },
+        }
+    ]
+    assert payload["questionAnsweredCalls"] == ["question-1"]
+    assert payload["recoveryCalls"] == [
+        {
+            "sessionId": "session-1",
+            "delayMs": 350,
+            "forceRefresh": True,
+            "includeRounds": False,
+            "quiet": True,
+            "reason": "user_question_requested",
+        },
+        {
+            "sessionId": "session-1",
+            "delayMs": 350,
+            "forceRefresh": True,
+            "includeRounds": False,
+            "quiet": True,
+            "reason": "user_question_answered",
+        },
+    ]
     assert payload["runEventCalls"] == []
 
 
@@ -895,6 +1129,51 @@ console.log(JSON.stringify({
     ]
 
 
+def test_primary_text_event_for_background_session_uses_overlay_not_current_dom(
+    tmp_path: Path,
+) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleTextDelta } = await import('./runEvents.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-active';
+state.currentSessionMode = 'normal';
+state.mainAgentRoleId = 'MainAgent';
+globalThis.__isCurrentRootEvent = false;
+
+handleTextDelta(
+    { text: 'background token' },
+    {
+        run_id: 'run-background',
+        trace_id: 'run-background',
+        session_id: 'session-background',
+        event_id: 'event-1',
+    },
+    '',
+    '',
+);
+
+console.log(JSON.stringify({
+    appendCalls: globalThis.__appendStreamChunkCalls,
+    overlayCalls: globalThis.__applyStreamOverlayEventCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["appendCalls"] == []
+    overlay_calls = payload["overlayCalls"]
+    assert isinstance(overlay_calls, list)
+    assert len(overlay_calls) == 1
+    first_overlay_call = overlay_calls[0]
+    assert isinstance(first_overlay_call, list)
+    assert first_overlay_call[0] == "text_delta"
+    overlay_meta = first_overlay_call[2]
+    assert isinstance(overlay_meta, dict)
+    assert overlay_meta["runId"] == "run-background"
+
+
 def test_handle_model_step_finished_keeps_normal_mode_subagent_status_open(
     tmp_path: Path,
 ) -> None:
@@ -988,6 +1267,7 @@ def _run_run_events_script(tmp_path: Path, runner_source: str) -> dict[str, obje
         "../../utils/logger.js": "./mockLogger.mjs",
         "../../components/messageRenderer.js": "./mockMessageRenderer.mjs",
         "../../components/agentPanel.js": "./mockAgentPanel.mjs",
+        "../../components/sessionSidebarStore.js": "./mockSessionSidebarStore.mjs",
         "./utils.js": "./mockUtils.mjs",
         "../api.js": "./mockApi.mjs",
     }
@@ -1187,12 +1467,12 @@ export function appendThinkingChunk() {
     return undefined;
 }
 
-export function applyStreamOverlayEvent() {
-    return undefined;
+export function applyStreamOverlayEvent(...args) {
+    globalThis.__applyStreamOverlayEventCalls.push(args);
 }
 
-export function appendStreamChunk() {
-    return undefined;
+export function appendStreamChunk(...args) {
+    globalThis.__appendStreamChunkCalls.push(args);
 }
 
 export function appendStreamOutputParts() {
@@ -1245,12 +1525,28 @@ export function openAgentPanel(instanceId, roleId) {
 """.strip(),
         encoding="utf-8",
     )
+    (tmp_path / "mockSessionSidebarStore.mjs").write_text(
+        """
+export function markSidebarSessionRunActive(sessionId, detail = {}) {
+    globalThis.__markSidebarSessionRunActiveCalls.push({ sessionId, detail });
+}
+
+export function markSidebarSessionRunTerminal(sessionId, detail = {}) {
+    globalThis.__markSidebarSessionRunTerminalCalls.push({ sessionId, detail });
+}
+""".strip(),
+        encoding="utf-8",
+    )
     (tmp_path / "mockUtils.mjs").write_text(
         """
 export function coordinatorContainerFor() {
-    return {};
+    return globalThis.__isCurrentRootEvent === false ? null : {};
 }
-""".strip(),
+
+export function isCurrentRootEvent() {
+    return globalThis.__isCurrentRootEvent !== false;
+}
+    """.strip(),
         encoding="utf-8",
     )
     (tmp_path / "mockApi.mjs").write_text(
@@ -1292,6 +1588,26 @@ globalThis.__activeSubagentSession = null;
 globalThis.__activeSubagentSessionStreamContainer = null;
 globalThis.__markSessionTerminalRunViewedCalls = [];
 globalThis.__markSessionTerminalRunViewedResponses = [];
+globalThis.__markSidebarSessionRunActiveCalls = [];
+globalThis.__markSidebarSessionRunTerminalCalls = [];
+globalThis.__appendStreamChunkCalls = [];
+globalThis.__applyStreamOverlayEventCalls = [];
+globalThis.__documentDispatches = [];
+globalThis.CustomEvent = class CustomEvent {{
+    constructor(type, options = {{}}) {{
+        this.type = type;
+        this.detail = options.detail || null;
+    }}
+}};
+globalThis.document = {{
+    dispatchEvent(event) {{
+        globalThis.__documentDispatches.push({{
+            type: event.type,
+            detail: event.detail,
+        }});
+        return true;
+    }},
+}};
 
 {runner_source}
 """.strip(),
@@ -1389,6 +1705,14 @@ export function isDisplayableBackgroundTaskPayload(payload) {
     const subagentRunId = String(payload?.subagent_run_id || payload?.subagentRunId || '').trim();
     return kind === 'subagent' || subagentRunId.startsWith('subagent_run_');
 }
+
+export function markUserQuestionRequested(payload, eventMeta) {
+    globalThis.__markUserQuestionRequestedCalls.push({ payload, eventMeta });
+}
+
+export function markUserQuestionAnswered(questionId) {
+    globalThis.__markUserQuestionAnsweredCalls.push(questionId);
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -1475,6 +1799,7 @@ export function sysLog() {
         """
 function pushCall(name, args) {
     globalThis.__runEventCalls.push({ name, args });
+    globalThis.__combinedEventCalls.push({ name, args });
 }
 
 export function handleLlmRetryExhausted(...args) { pushCall('handleLlmRetryExhausted', args); }
@@ -1500,11 +1825,16 @@ export function handleTextDelta(...args) { pushCall('handleTextDelta', args); }
     )
     (tmp_path / "mockToolEvents.mjs").write_text(
         """
-export function handleToolApprovalRequested() { return undefined; }
-export function handleToolApprovalResolved() { return undefined; }
-export function handleToolCall() { return undefined; }
-export function handleToolInputValidationFailed() { return undefined; }
-export function handleToolResult() { return undefined; }
+function pushCall(name, args) {
+    globalThis.__toolEventCalls.push({ name, args });
+    globalThis.__combinedEventCalls.push({ name, args });
+}
+
+export function handleToolApprovalRequested(...args) { pushCall('handleToolApprovalRequested', args); }
+export function handleToolApprovalResolved(...args) { pushCall('handleToolApprovalResolved', args); }
+export function handleToolCall(...args) { pushCall('handleToolCall', args); }
+export function handleToolInputValidationFailed(...args) { pushCall('handleToolInputValidationFailed', args); }
+export function handleToolResult(...args) { pushCall('handleToolResult', args); }
 """.strip(),
         encoding="utf-8",
     )
@@ -1539,9 +1869,13 @@ export function coordinatorContainerFor() {
 globalThis.__scheduleRecoveryContinuityRefreshCalls = [];
 globalThis.__scheduleSessionTokenUsageRefreshCalls = [];
 globalThis.__runEventCalls = [];
+globalThis.__toolEventCalls = [];
+globalThis.__combinedEventCalls = [];
 globalThis.__normalModeSubagentEvents = [];
 globalThis.__subagentSessionStatusEvents = [];
 globalThis.__applyBackgroundTaskEventCalls = [];
+globalThis.__markUserQuestionRequestedCalls = [];
+globalThis.__markUserQuestionAnsweredCalls = [];
 
 {runner_source}
 """.strip(),

--- a/tests/unit_tests/frontend/test_session_selection_ui.py
+++ b/tests/unit_tests/frontend/test_session_selection_ui.py
@@ -478,15 +478,19 @@ globalThis.CustomEvent = class CustomEvent {
 const selection = selectSession("session-a");
 await Promise.resolve();
 const beforeHydrationClassName = els.chatContainer.className;
+const loadingDuringSwitch = els.chatContainer.children
+    .some(child => child.className === "session-switch-loading");
 globalThis.__hydrateResolvers[0].resolve();
 await selection;
 const afterSelectionClassName = els.chatContainer.className;
 await new Promise(resolve => setTimeout(resolve, 25));
 const afterFrameClassName = els.chatContainer.className;
+const loadingAfterFrame = els.chatContainer.children
+    .some(child => child.className === "session-switch-loading");
 
 console.log(JSON.stringify({
-    loadingCreated: els.chatContainer.children
-        .some(child => child.className === "session-switch-loading"),
+    loadingDuringSwitch,
+    loadingAfterFrame,
     beforeHydrationClassName,
     afterSelectionClassName,
     afterFrameClassName,
@@ -494,7 +498,8 @@ console.log(JSON.stringify({
 """.strip(),
     )
 
-    assert payload["loadingCreated"] is True
+    assert payload["loadingDuringSwitch"] is True
+    assert payload["loadingAfterFrame"] is False
     before_hydration_class_name = str(payload["beforeHydrationClassName"])
     after_selection_class_name = str(payload["afterSelectionClassName"])
     after_frame_class_name = str(payload["afterFrameClassName"])
@@ -503,6 +508,64 @@ console.log(JSON.stringify({
     assert "is-session-switching" in after_selection_class_name
     assert "is-session-switch-ready" in after_frame_class_name
     assert "is-session-switching" not in after_frame_class_name
+
+
+def test_switching_back_to_pending_run_restores_without_blocking_loading(
+    tmp_path: Path,
+) -> None:
+    payload = _run_session_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { selectSession } from "./session.mjs";
+import { els } from "./mockDom.mjs";
+import { state } from "./mockState.mjs";
+
+globalThis.CustomEvent = class CustomEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail || {};
+    }
+};
+
+globalThis.__pendingRunStartSessionId = "session-a";
+state.currentSessionId = "session-b";
+
+await selectSession("session-a");
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    currentSessionId: state.currentSessionId,
+    restoreCalls: globalThis.__restorePendingRunStartCalls,
+    loadingPresent: els.chatContainer.children
+        .some(child => child.className === "session-switch-loading"),
+    className: els.chatContainer.className,
+    hydrateCalls: globalThis.__hydrateCalls.map(call => ({
+        sessionId: call.sessionId,
+        includeRounds: call.includeRounds,
+    })),
+    selectedEvents: globalThis.__documentDispatches
+        .filter(event => event.type === "agent-teams-session-selected")
+        .map(event => event.detail.sessionId),
+}));
+""".strip(),
+    )
+
+    assert payload["currentSessionId"] == "session-a"
+    assert payload["restoreCalls"] == [
+        {
+            "sessionId": "session-a",
+            "focusPrompt": False,
+            "currentSessionId": "session-a",
+        }
+    ]
+    assert payload["loadingPresent"] is False
+    class_name = str(payload["className"])
+    assert "is-session-switch-pending" not in class_name
+    assert "is-session-switching" not in class_name
+    assert payload["hydrateCalls"] == [
+        {"sessionId": "session-a", "includeRounds": False}
+    ]
+    assert payload["selectedEvents"] == ["session-a"]
 
 
 def test_select_session_prepares_foreground_streams_after_state_switch(
@@ -570,6 +633,74 @@ console.log(JSON.stringify({
     assert payload["selectedEvents"] == ["session-b"]
 
 
+def test_select_session_does_not_wait_for_slow_session_record_before_hydrating(
+    tmp_path: Path,
+) -> None:
+    payload = _run_session_script(
+        tmp_path=tmp_path,
+        runner_source="""
+import { selectSession } from "./session.mjs";
+import { state } from "./mockState.mjs";
+
+globalThis.CustomEvent = class CustomEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail || {};
+    }
+};
+globalThis.__deferSessionHistory = true;
+
+state.currentSessionId = "session-a";
+const selection = selectSession("session-b");
+await Promise.resolve();
+const beforeRecord = {
+    fetchCalls: globalThis.__fetchCalls,
+    hydrateCalls: globalThis.__hydrateCalls.map(call => call.sessionId),
+    appliedRecords: globalThis.__appliedRecords.map(record => record.session_id),
+};
+globalThis.__hydrateResolvers[0].resolve();
+await selection;
+const afterSelection = {
+    selectedEvents: globalThis.__documentDispatches
+        .filter(event => event.type === "agent-teams-session-selected")
+        .map(event => event.detail.sessionId),
+    appliedRecords: globalThis.__appliedRecords.map(record => record.session_id),
+};
+globalThis.__fetchResolvers[0].resolve({
+    session_id: "session-b",
+    workspace_id: "workspace-b",
+});
+await Promise.resolve();
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    beforeRecord,
+    afterSelection,
+    afterRecord: {
+        appliedRecords: globalThis.__appliedRecords.map(record => record.session_id),
+        recordUpdatedEvents: globalThis.__documentDispatches
+            .filter(event => event.type === "agent-teams-session-record-updated")
+            .map(event => event.detail.sessionId),
+    },
+}));
+""".strip(),
+    )
+
+    assert payload["beforeRecord"] == {
+        "fetchCalls": ["session-b"],
+        "hydrateCalls": ["session-b"],
+        "appliedRecords": [],
+    }
+    assert payload["afterSelection"] == {
+        "selectedEvents": ["session-b"],
+        "appliedRecords": [],
+    }
+    assert payload["afterRecord"] == {
+        "appliedRecords": ["session-b"],
+        "recordUpdatedEvents": ["session-b"],
+    }
+
+
 def _run_session_script(tmp_path: Path, runner_source: str) -> dict[str, object]:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = repo_root / "frontend" / "dist" / "js" / "app" / "session.js"
@@ -584,6 +715,7 @@ def _run_session_script(tmp_path: Path, runner_source: str) -> dict[str, object]
     mock_session_sidebar_store_path = tmp_path / "mockSessionSidebarStore.mjs"
     mock_project_view_path = tmp_path / "mockProjectView.mjs"
     mock_new_session_draft_path = tmp_path / "mockNewSessionDraft.mjs"
+    mock_rounds_timeline_path = tmp_path / "mockRoundsTimeline.mjs"
     mock_sidebar_path = tmp_path / "mockSidebar.mjs"
     mock_subagent_rail_path = tmp_path / "mockSubagentRail.mjs"
     mock_subagent_sessions_path = tmp_path / "mockSubagentSessions.mjs"
@@ -593,6 +725,7 @@ def _run_session_script(tmp_path: Path, runner_source: str) -> dict[str, object]
     mock_state_path = tmp_path / "mockState.mjs"
     mock_stream_path = tmp_path / "mockStream.mjs"
     mock_submission_path = tmp_path / "mockSubmission.mjs"
+    mock_ui_diagnostics_path = tmp_path / "mockUiDiagnostics.mjs"
     mock_dom_path = tmp_path / "mockDom.mjs"
     mock_i18n_path = tmp_path / "mockI18n.mjs"
     mock_logger_path = tmp_path / "mockLogger.mjs"
@@ -672,6 +805,14 @@ export function clearNewSessionDraft() {
 """.strip(),
         encoding="utf-8",
     )
+    mock_rounds_timeline_path.write_text(
+        """
+export function clearPendingRunStartPlaceholder(sessionId = '') {
+    globalThis.__clearPendingRunStartPlaceholderCalls.push(String(sessionId || ''));
+}
+""".strip(),
+        encoding="utf-8",
+    )
     mock_sidebar_path.write_text(
         """
 export function setRoundsMode() {
@@ -721,6 +862,11 @@ export async function openSubagentSession() {
         """
 export async function fetchSessionHistory(sessionId) {
     globalThis.__fetchCalls.push(sessionId);
+    if (globalThis.__deferSessionHistory === true) {
+        return new Promise(resolve => {
+            globalThis.__fetchResolvers.push({ sessionId, resolve });
+        });
+    }
     return globalThis.__sessionRecords?.get?.(sessionId) || { session_id: sessionId };
 }
 
@@ -843,6 +989,15 @@ export function prepareStreamsForForegroundNavigation(sessionId) {
         currentSessionId: state.currentSessionId,
     });
 }
+
+export function restorePendingRunStartForSessionSwitch(sessionId, options = {}) {
+    globalThis.__restorePendingRunStartCalls.push({
+        sessionId,
+        focusPrompt: options.focusPrompt === true,
+        currentSessionId: state.currentSessionId,
+    });
+    return globalThis.__pendingRunStartSessionId === sessionId;
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -851,6 +1006,14 @@ export function prepareStreamsForForegroundNavigation(sessionId) {
 export function detachForegroundSubmission() {
     globalThis.__detachForegroundSubmissionCalls += 1;
     return false;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    mock_ui_diagnostics_path.write_text(
+        """
+export function recordUiDiagnostic(name, value = 1, metadata = null) {
+    globalThis.__uiDiagnostics.push({ name, value, metadata });
 }
 """.strip(),
         encoding="utf-8",
@@ -918,6 +1081,12 @@ export const els = {
                 : null;
         },
         appendChild(node) {
+            node.remove = () => {
+                const index = this.children.indexOf(node);
+                if (index >= 0) {
+                    this.children.splice(index, 1);
+                }
+            };
             this.children.push(node);
             return node;
         },
@@ -1009,6 +1178,7 @@ export function refreshSessionTopologyControls() {
         )
         .replace("../components/projectView.js", "./mockProjectView.mjs")
         .replace("../components/newSessionDraft.js", "./mockNewSessionDraft.mjs")
+        .replace("../components/rounds/timeline.js", "./mockRoundsTimeline.mjs")
         .replace("../components/sidebar.js", "./mockSidebar.mjs")
         .replace("../components/subagentRail.js", "./mockSubagentRail.mjs")
         .replace("../components/subagentSessions.js", "./mockSubagentSessions.mjs")
@@ -1018,6 +1188,7 @@ export function refreshSessionTopologyControls() {
         .replace("../core/state.js", "./mockState.mjs")
         .replace("../core/stream.js", "./mockStream.mjs")
         .replace("../core/submission.js", "./mockSubmission.mjs")
+        .replace("../core/uiDiagnostics.js", "./mockUiDiagnostics.mjs")
         .replace("../utils/dom.js", "./mockDom.mjs")
         .replace("../utils/i18n.js", "./mockI18n.mjs")
         .replace("../utils/logger.js", "./mockLogger.mjs")
@@ -1043,6 +1214,7 @@ globalThis.__sessionDebugBadgeCalls = [];
 globalThis.__sidebarViewedTerminalRuns = [];
 globalThis.__hideProjectViewCalls = 0;
 globalThis.__clearNewSessionDraftCalls = 0;
+globalThis.__clearPendingRunStartPlaceholderCalls = [];
 globalThis.__setRoundsModeCalls = 0;
 globalThis.__markSubagentRailLoadingCalls = [];
 globalThis.__clearActiveSubagentSessionCalls = 0;
@@ -1050,6 +1222,8 @@ globalThis.__ensureSubagentCalls = [];
 globalThis.__expandedSubagentSessionIds = new Set();
 globalThis.__openSubagentSessionCalls = 0;
 globalThis.__fetchCalls = [];
+globalThis.__fetchResolvers = [];
+globalThis.__deferSessionHistory = false;
 globalThis.__viewedTerminalRuns = [];
 globalThis.__hydrateCalls = [];
 globalThis.__hydrateResolvers = [];
@@ -1060,10 +1234,13 @@ globalThis.__detachActiveStreamCalls = 0;
 globalThis.__detachForegroundSubmissionCalls = 0;
 globalThis.__detachSubagentStreamCalls = [];
 globalThis.__prepareStreamsForForegroundNavigationCalls = [];
+globalThis.__restorePendingRunStartCalls = [];
+globalThis.__pendingRunStartSessionId = "";
 globalThis.__streamOperationCalls = [];
 globalThis.__documentDispatches = [];
 globalThis.__refreshSessionTopologyControlsCalls = 0;
 globalThis.__logs = [];
+globalThis.__uiDiagnostics = [];
 
 {runner_source}
 """.strip(),

--- a/tests/unit_tests/frontend/test_session_sidebar_store_ui.py
+++ b/tests/unit_tests/frontend/test_session_sidebar_store_ui.py
@@ -136,3 +136,294 @@ console.log(JSON.stringify({
         "afterOptimistic": ["session-1"],
         "afterDeleteSnapshot": [],
     }
+
+
+def test_terminal_run_override_wins_over_stale_active_snapshot(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sessionSidebarStore.js"
+    )
+    module_path = tmp_path / "sessionSidebarStore.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    runner_path = tmp_path / "runner-terminal-override.mjs"
+    runner_path.write_text(
+        """
+const {
+    getSidebarDataSnapshot,
+    markSidebarSessionRunTerminal,
+    rememberSidebarDataSnapshot,
+} = await import('./sessionSidebarStore.mjs');
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'stale active' },
+            has_active_run: true,
+            active_run_id: 'run-1',
+            active_run_status: 'stopping',
+        },
+    ],
+});
+markSidebarSessionRunTerminal('session-1', { runId: 'run-1', status: 'stopped' });
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'stale active' },
+            has_active_run: true,
+            active_run_id: 'run-1',
+            active_run_status: 'stopping',
+        },
+    ],
+});
+const merged = getSidebarDataSnapshot().sessions[0];
+
+console.log(JSON.stringify({
+    hasActiveRun: merged.has_active_run,
+    activeRunId: merged.active_run_id,
+    activeRunStatus: merged.active_run_status,
+    latestTerminalRunId: merged.latest_terminal_run_id,
+    latestTerminalRunStatus: merged.latest_terminal_run_status,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "hasActiveRun": False,
+        "activeRunId": "",
+        "activeRunStatus": "",
+        "latestTerminalRunId": "run-1",
+        "latestTerminalRunStatus": "stopped",
+    }
+
+
+def test_terminal_run_override_wins_over_stale_empty_snapshot(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sessionSidebarStore.js"
+    )
+    module_path = tmp_path / "sessionSidebarStore.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    runner_path = tmp_path / "runner-terminal-empty-override.mjs"
+    runner_path.write_text(
+        """
+const {
+    getSidebarDataSnapshot,
+    markSidebarSessionRunTerminal,
+    rememberSidebarDataSnapshot,
+} = await import('./sessionSidebarStore.mjs');
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'hello' },
+        },
+    ],
+});
+markSidebarSessionRunTerminal('session-1', { runId: 'run-1', status: 'completed' });
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'hello' },
+            has_active_run: false,
+            active_run_id: '',
+            active_run_status: '',
+            has_unread_terminal_run: false,
+        },
+    ],
+});
+const merged = getSidebarDataSnapshot().sessions[0];
+
+console.log(JSON.stringify({
+    hasActiveRun: merged.has_active_run,
+    activeRunId: merged.active_run_id,
+    activeRunStatus: merged.active_run_status,
+    latestTerminalRunId: merged.latest_terminal_run_id,
+    latestTerminalRunStatus: merged.latest_terminal_run_status,
+    unread: merged.has_unread_terminal_run,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "hasActiveRun": False,
+        "activeRunId": "",
+        "activeRunStatus": "",
+        "latestTerminalRunId": "run-1",
+        "latestTerminalRunStatus": "completed",
+        "unread": True,
+    }
+
+
+def test_session_status_machine_suppresses_stale_unread_after_viewed(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = (
+        repo_root / "frontend" / "dist" / "js" / "components" / "sessionSidebarStore.js"
+    )
+    module_path = tmp_path / "sessionSidebarStore.mjs"
+    module_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    runner_path = tmp_path / "runner-status-machine.mjs"
+    runner_path.write_text(
+        """
+const {
+    getSidebarDataSnapshot,
+    markSidebarSessionRunActive,
+    markSidebarSessionRunTerminal,
+    markSidebarSessionTerminalViewed,
+    rememberSidebarDataSnapshot,
+} = await import('./sessionSidebarStore.mjs');
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'hello' },
+        },
+    ],
+});
+
+markSidebarSessionRunActive('session-1', { runId: 'run-1', status: 'running' });
+const running = getSidebarDataSnapshot().sessions[0];
+
+markSidebarSessionRunTerminal('session-1', {
+    runId: 'run-1',
+    status: 'completed',
+    viewed: false,
+});
+const unread = getSidebarDataSnapshot().sessions[0];
+
+markSidebarSessionTerminalViewed('session-1');
+const viewed = getSidebarDataSnapshot().sessions[0];
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'hello' },
+            latest_terminal_run_id: 'run-1',
+            latest_terminal_run_status: 'completed',
+            has_unread_terminal_run: true,
+        },
+    ],
+});
+const staleSameTerminal = getSidebarDataSnapshot().sessions[0];
+
+rememberSidebarDataSnapshot({
+    sessions: [
+        {
+            session_id: 'session-1',
+            workspace_id: 'workspace-1',
+            metadata: { title: 'hello again' },
+            latest_terminal_run_id: 'run-2',
+            latest_terminal_run_status: 'completed',
+            has_unread_terminal_run: true,
+        },
+    ],
+});
+const newTerminal = getSidebarDataSnapshot().sessions[0];
+
+console.log(JSON.stringify({
+    running: {
+        hasActiveRun: running.has_active_run,
+        activeRunId: running.active_run_id,
+        activeRunStatus: running.active_run_status,
+        unread: running.has_unread_terminal_run,
+    },
+    unread: {
+        hasActiveRun: unread.has_active_run,
+        latestTerminalRunId: unread.latest_terminal_run_id,
+        latestTerminalRunStatus: unread.latest_terminal_run_status,
+        unread: unread.has_unread_terminal_run,
+    },
+    viewed: {
+        latestTerminalRunId: viewed.latest_terminal_run_id,
+        unread: viewed.has_unread_terminal_run,
+    },
+    staleSameTerminal: {
+        latestTerminalRunId: staleSameTerminal.latest_terminal_run_id,
+        unread: staleSameTerminal.has_unread_terminal_run,
+    },
+    newTerminal: {
+        latestTerminalRunId: newTerminal.latest_terminal_run_id,
+        unread: newTerminal.has_unread_terminal_run,
+    },
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["node", str(runner_path)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    assert json.loads(result.stdout) == {
+        "running": {
+            "hasActiveRun": True,
+            "activeRunId": "run-1",
+            "activeRunStatus": "running",
+            "unread": False,
+        },
+        "unread": {
+            "hasActiveRun": False,
+            "latestTerminalRunId": "run-1",
+            "latestTerminalRunStatus": "completed",
+            "unread": True,
+        },
+        "viewed": {
+            "latestTerminalRunId": "run-1",
+            "unread": False,
+        },
+        "staleSameTerminal": {
+            "latestTerminalRunId": "run-1",
+            "unread": False,
+        },
+        "newTerminal": {
+            "latestTerminalRunId": "run-2",
+            "unread": True,
+        },
+    }

--- a/tests/unit_tests/frontend/test_speech_ui.py
+++ b/tests/unit_tests/frontend/test_speech_ui.py
@@ -138,9 +138,12 @@ def test_voice_input_button_and_assets_are_linked() -> None:
     prompt = read_frontend("js/app/prompt.js")
     assert "stopActiveVoiceInputBeforeSend" in prompt
     assert "await globalThis.__relayTeamsStopVoiceInput({ keepText: true });" in prompt
-    assert prompt.index("await stopActiveVoiceInputBeforeSend();") < prompt.index(
-        "const rawText = els.promptInput.value.trim();"
+    assert prompt.index("const rawText = els.promptInput.value.trim();") < prompt.index(
+        "await stopActiveVoiceInputBeforeSend();"
     )
+    assert prompt.index(
+        'const initialSessionId = String(state.currentSessionId || "").trim();'
+    ) < prompt.index("await stopActiveVoiceInputBeforeSend();")
     voice_css = read_frontend("css/components/voice.css")
     interface_css = read_frontend("css/components/interface.css")
     new_session_css = read_frontend("css/components/new-session-draft-composer.css")

--- a/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
+++ b/tests/unit_tests/frontend/test_stream_session_overlay_ui.py
@@ -412,6 +412,92 @@ console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-primary").coordinato
     assert overlay["parts"][1]["status"] == "completed"
 
 
+def test_stream_overlay_preserves_thinking_text_tool_order_without_gaps_or_replay_duplicates(
+    tmp_path: Path,
+) -> None:
+    source = Path("frontend/dist/js/components/messageRenderer/stream.js").read_text(
+        encoding="utf-8"
+    )
+    temp_dir = tmp_path / "stream_overlay_order_complete"
+    temp_dir.mkdir()
+    _write_stream_overlay_test_modules(temp_dir, source)
+
+    runner = """
+import {
+  applyStreamOverlayEvent,
+  getRunStreamOverlaySnapshot,
+} from "./stream.js";
+
+const options = {
+  runId: "run-primary",
+  instanceId: "primary",
+  roleId: "main-role",
+  label: "Main Agent",
+};
+const events = [
+  ["thinking_started", { part_index: 0 }, "evt-1"],
+  ["thinking_delta", { part_index: 0, text: "plan " }, "evt-2"],
+  ["thinking_delta", { part_index: 0, text: "first" }, "evt-3"],
+  ["thinking_finished", { part_index: 0 }, "evt-4"],
+  ["text_delta", { text: "answer " }, "evt-5"],
+  ["text_delta", { text: "part" }, "evt-6"],
+  [
+    "tool_call",
+    {
+      tool_name: "read",
+      tool_call_id: "call-read-1",
+      args: { path: "AGENTS.md" },
+    },
+    "evt-7",
+  ],
+  [
+    "tool_result",
+    {
+      tool_name: "read",
+      tool_call_id: "call-read-1",
+      result: { ok: true, data: { preview: "file" } },
+    },
+    "evt-8",
+  ],
+  ["text_delta", { text: " after tool" }, "evt-9"],
+];
+
+events.forEach(([type, payload, eventId]) => {
+  applyStreamOverlayEvent(type, payload, { ...options, eventId });
+});
+events.slice(1, 8).forEach(([type, payload, eventId]) => {
+  applyStreamOverlayEvent(type, payload, { ...options, eventId });
+});
+
+console.log(JSON.stringify(getRunStreamOverlaySnapshot("run-primary").coordinator));
+""".strip()
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", runner],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+        timeout=3,
+    )
+
+    overlay = json.loads(result.stdout)
+    assert [part["kind"] for part in overlay["parts"]] == [
+        "thinking",
+        "text",
+        "tool",
+        "text",
+    ]
+    assert overlay["parts"][0]["content"] == "plan first"
+    assert overlay["parts"][0]["finished"] is True
+    assert overlay["parts"][1]["content"] == "answer part"
+    assert overlay["parts"][2]["tool_name"] == "read"
+    assert overlay["parts"][2]["tool_call_id"] == "call-read-1"
+    assert overlay["parts"][2]["status"] == "completed"
+    assert overlay["parts"][3]["content"] == " after tool"
+
+
 def test_stream_overlay_keeps_injection_between_tool_and_next_text(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_streaming_tool_ui.py
+++ b/tests/unit_tests/frontend/test_streaming_tool_ui.py
@@ -46,6 +46,22 @@ def test_tool_result_updates_can_patch_dom_after_stream_finalize() -> None:
     )
 
 
+def test_tool_blocks_use_consistent_compact_vertical_spacing() -> None:
+    tools_css = Path("frontend/dist/css/components/tools.css").read_text(
+        encoding="utf-8"
+    )
+
+    assert ".tool-block {\n    margin: 0.12rem 0;" in tools_css
+    assert ".tool-block + .tool-block {\n    margin-top: 0.12rem;" in tools_css
+    assert (
+        ".tool-block[open]"
+        not in tools_css.split(
+            ".tool-block + .tool-block {",
+            maxsplit=1,
+        )[0]
+    )
+
+
 def test_streaming_tool_calls_keep_indexed_dom_targets_and_message_metadata() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     stream_script = (
@@ -222,12 +238,20 @@ export function openAgentPanel() { globalThis.__openPanelCalls += 1; }
 globalThis.document = {
   getElementById() { return null; },
   querySelector() { return null; },
+  dispatchEvent(event) { globalThis.__documentEvents.push({ type: event.type, detail: event.detail }); },
+};
+globalThis.CustomEvent = class CustomEvent {
+  constructor(type, init = {}) {
+    this.type = type;
+    this.detail = init.detail || {};
+  }
 };
 globalThis.__appendCalls = [];
 globalThis.__overlayCalls = 0;
 globalThis.__openPanelCalls = 0;
 globalThis.__panelContainerCalls = 0;
 globalThis.__discoveryCalls = 0;
+globalThis.__documentEvents = [];
 
 const { state } = await import('./state.mjs');
 const { handleToolCall } = await import('./toolEvents.mjs');
@@ -257,6 +281,7 @@ console.log(JSON.stringify({
   openPanelCalls: globalThis.__openPanelCalls,
   panelContainerCalls: globalThis.__panelContainerCalls,
   discoveryCalls: globalThis.__discoveryCalls,
+  documentEvents: globalThis.__documentEvents,
 }));
 """.strip(),
         encoding="utf-8",
@@ -291,6 +316,12 @@ console.log(JSON.stringify({
     assert payload["openPanelCalls"] == 0
     assert payload["panelContainerCalls"] == 0
     assert payload["discoveryCalls"] == 1
+    assert payload["documentEvents"] == [
+        {
+            "type": "agent-teams-session-subagent-count-dirty",
+            "detail": {"sessionId": "session-1"},
+        }
+    ]
 
 
 def test_pending_tool_block_name_fallback_does_not_merge_parallel_calls(

--- a/tests/unit_tests/frontend/test_subagent_sessions_ui.py
+++ b/tests/unit_tests/frontend/test_subagent_sessions_ui.py
@@ -5,6 +5,22 @@ import json
 from pathlib import Path
 import subprocess
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_shared_ui_diagnostics(tmp_path: Path) -> None:
+    core_dir = tmp_path.parent / "core"
+    core_dir.mkdir(exist_ok=True)
+    (core_dir / "uiDiagnostics.js").write_text(
+        """
+export function recordUiDiagnostic() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
 
 def test_opening_subagent_session_hides_main_input_container(tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[3]
@@ -221,7 +237,7 @@ await openSubagentSession("session-1", {
     sessionId: "session-1",
     instanceId: "inst-sub-1",
     roleId: "Explorer",
-    runId: "subagent_run_1",
+    runId: "delegated-run-1",
     title: "Explore history",
     status: "running",
 });
@@ -279,7 +295,7 @@ console.log(JSON.stringify({
         {
             "sessionId": "session-1",
             "instanceId": "inst-sub-1",
-            "runId": "subagent_run_1",
+            "runId": "delegated-run-1",
             "overlayMode": "separate",
             "status": "running",
             "runStatus": "running",
@@ -1797,7 +1813,7 @@ const remembered = rememberNormalModeSubagentFromBackgroundTask(
         kind: "subagent",
         subagent_instance_id: "Explorer-abc123",
         subagent_role_id: "Explorer",
-        subagent_run_id: "subagent_run_abc123",
+        subagent_run_id: "delegated-run-abc123",
         title: "Explore command implementation",
         status: "running",
         updated_at: "2026-04-28T11:00:00Z",
@@ -1810,7 +1826,7 @@ const failedRemembered = rememberNormalModeSubagentFromBackgroundTask(
         kind: "subagent",
         subagent_instance_id: "Explorer-abc123",
         subagent_role_id: "Explorer",
-        subagent_run_id: "subagent_run_abc123",
+        subagent_run_id: "delegated-run-abc123",
         title: "Explore command implementation",
         status: "failed",
         updated_at: "2026-04-28T11:01:00Z",
@@ -1856,7 +1872,7 @@ console.log(JSON.stringify({
             "sessionId": "session-1",
             "instanceId": "Explorer-abc123",
             "roleId": "Explorer",
-            "runId": "subagent_run_abc123",
+            "runId": "delegated-run-abc123",
             "title": "Explore command implementation",
             "status": "failed",
             "runStatus": "failed",
@@ -1871,7 +1887,7 @@ console.log(JSON.stringify({
     ]
     assert payload["events"]
     assert payload["events"][-1]["detail"]["sessionId"] == "session-1"
-    assert payload["syncCalls"][-1]["records"][0]["runId"] == "subagent_run_abc123"
+    assert payload["syncCalls"][-1]["records"][0]["runId"] == "delegated-run-abc123"
     assert payload["syncCalls"][-1]["records"][0]["status"] == "failed"
 
 

--- a/tests/unit_tests/frontend/test_subagent_streams_ui.py
+++ b/tests/unit_tests/frontend/test_subagent_streams_ui.py
@@ -20,7 +20,265 @@ def test_background_discovery_does_not_poll_for_idle_selected_session() -> None:
     assert "pendingRunStart" in block
 
 
+def test_subagent_stream_matrix_keeps_session_watermarks_and_filters_targets(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "core" / "stream.js"
+    module_under_test_path = tmp_path / "stream.mjs"
+    runner_path = tmp_path / "runner_subagent_matrix.mjs"
+
+    source_text = (
+        source_path.read_text(encoding="utf-8")
+        .replace("./api.js", "./mockApi.mjs")
+        .replace("../components/contextIndicators.js", "./mockContextIndicators.mjs")
+        .replace("../app/prompt.js", "./mockPrompt.mjs")
+        .replace("../components/subagentSessions.js", "./mockSubagentSessions.mjs")
+        .replace("../components/sidebar.js", "./mockSidebar.mjs")
+        .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/backendStatus.js", "./mockBackendStatus.mjs")
+        .replace("../utils/logger.js", "./mockLogger.mjs")
+        .replace("./eventRouter.js", "./mockEventRouter.mjs")
+        .replace("../components/messageRenderer.js", "./mockMessageRenderer.mjs")
+        .replace("../components/runtimeInjectQueue.js", "./mockRuntimeInjectQueue.mjs")
+        .replace("../utils/i18n.js", "./mockI18n.mjs")
+        .replace("./state.js", "./mockState.mjs")
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+    _write_stream_runtime_inject_mocks(tmp_path)
+
+    (tmp_path / "mockApi.mjs").write_text(
+        """
+export async function fetchSessionRecovery() { return {}; }
+export async function fetchSessionSubagents() { return []; }
+export async function fetchSessions() { return []; }
+export async function sendUserPrompt() { throw new Error("not used"); }
+export async function stopRun() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockContextIndicators.mjs").write_text(
+        "export function refreshVisibleContextIndicators() { return undefined; }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "mockPrompt.mjs").write_text(
+        "export function refreshSessionTopologyControls() { return undefined; }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSubagentSessions.mjs").write_text(
+        """
+export function replaceSessionSubagents() { return undefined; }
+export function markNormalModeSubagentSessionsStoppedForParent() { return []; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSidebar.mjs").write_text(
+        "export function scheduleSessionsRefresh() { return undefined; }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "mockDom.mjs").write_text(
+        """
+export const els = {
+    sendBtn: { disabled: false, style: {}, setAttribute() {} },
+    promptInput: { disabled: false, dataset: {}, placeholder: "", getAttribute() { return this.placeholder || ""; }, setAttribute(name, value) { this[name] = value; }, focus() {} },
+    yoloToggle: { disabled: false },
+    thinkingModeToggle: { disabled: false },
+    thinkingEffortSelect: { disabled: false },
+    stopBtn: { style: {}, disabled: false },
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockBackendStatus.mjs").write_text(
+        """
+export function markBackendOnline() { return undefined; }
+export async function refreshBackendStatus() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockLogger.mjs").write_text(
+        """
+export function errorToPayload(error, extra = {}) {
+    return { error: String(error?.message || error || ''), ...extra };
+}
+export function logError() { return undefined; }
+export function logInfo() { return undefined; }
+export function logWarn() { return undefined; }
+export function sysLog() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockEventRouter.mjs").write_text(
+        """
+export function routeEvent(evType, payload, eventMeta) {
+    globalThis.__routeEventCalls.push({ evType, payload, eventMeta });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockMessageRenderer.mjs").write_text(
+        "export function clearRunStreamState() { return undefined; }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: "session-a",
+    currentSessionMode: "normal",
+    activeSubagentSession: null,
+    activeEventSource: null,
+    activeRunId: null,
+    isGenerating: false,
+    runPrimaryRoleMap: {},
+};
+export function getPrimaryRoleId() { return "MainAgent"; }
+export function getPrimaryRoleLabel() { return "Main Agent"; }
+export function getRunPrimaryRoleId() { return "MainAgent"; }
+export function getRunPrimaryRoleLabel() { return "Main Agent"; }
+export function setRunPrimaryRole() { return undefined; }
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner_path.write_text(
+        """
+globalThis.__routeEventCalls = [];
+globalThis.__eventSources = [];
+class MockEventSource {
+    constructor(url) {
+        this.url = url;
+        this.closed = false;
+        globalThis.__eventSources.push(this);
+    }
+    close() {
+        this.closed = true;
+    }
+}
+globalThis.EventSource = MockEventSource;
+
+const { state } = await import("./mockState.mjs");
+const {
+    prepareStreamsForForegroundNavigation,
+    syncNormalModeSubagentStreams,
+} = await import("./stream.mjs");
+
+syncNormalModeSubagentStreams("session-a", [
+    { run_id: "subagent_run_a1", instance_id: "inst-a1", status: "running", run_status: "running", last_event_id: 5 },
+    { run_id: "subagent_run_a2", instance_id: "inst-a2", status: "running", run_status: "running", last_event_id: 7 },
+]);
+const sessionASource = globalThis.__eventSources[0];
+prepareStreamsForForegroundNavigation("session-b");
+state.currentSessionId = "session-b";
+syncNormalModeSubagentStreams("session-b", [
+    { run_id: "subagent_run_b1", instance_id: "inst-b1", status: "running", run_status: "running", last_event_id: 3 },
+]);
+const sessionBSource = globalThis.__eventSources.find(source => source.closed !== true);
+sessionBSource.onmessage({
+    data: JSON.stringify({
+        event_id: 10,
+        event_type: "thinking_delta",
+        payload_json: JSON.stringify({ text: "wrong" }),
+        session_id: "session-a",
+        run_id: "subagent_run_a1",
+        trace_id: "subagent_run_a1",
+    }),
+});
+sessionBSource.onmessage({
+    data: JSON.stringify({
+        event_id: 11,
+        event_type: "thinking_delta",
+        payload_json: JSON.stringify({ text: "right" }),
+        session_id: "session-b",
+        run_id: "subagent_run_b1",
+        trace_id: "subagent_run_b1",
+    }),
+});
+sessionBSource.onmessage({
+    data: JSON.stringify({
+        event_id: 12,
+        event_type: "thinking_delta",
+        payload_json: JSON.stringify({ text: "undiscovered" }),
+        session_id: "session-b",
+        run_id: "subagent_run_b2",
+        trace_id: "subagent_run_b2",
+    }),
+});
+
+console.log(JSON.stringify({
+    urls: globalThis.__eventSources.map(source => source.url),
+    sessionAClosed: sessionASource.closed === true,
+    openUrls: globalThis.__eventSources.filter(source => source.closed !== true).map(source => source.url),
+    routeEventCalls: globalThis.__routeEventCalls,
+}));
+process.exit(0);
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=3,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+
+    assert payload["urls"] == [
+        "/api/sessions/session-a/subagents/events?after_event_id=7",
+        "/api/sessions/session-b/subagents/events?after_event_id=3",
+    ]
+    assert payload["sessionAClosed"] is True
+    assert payload["openUrls"] == [
+        "/api/sessions/session-b/subagents/events?after_event_id=3"
+    ]
+    assert payload["routeEventCalls"] == [
+        {
+            "evType": "thinking_delta",
+            "payload": {"text": "right"},
+            "eventMeta": {
+                "event_id": 11,
+                "event_type": "thinking_delta",
+                "payload_json": '{"text":"right"}',
+                "session_id": "session-b",
+                "run_id": "subagent_run_b1",
+                "trace_id": "subagent_run_b1",
+                "normal_mode_subagent_event": True,
+            },
+        },
+        {
+            "evType": "thinking_delta",
+            "payload": {"text": "undiscovered"},
+            "eventMeta": {
+                "event_id": 12,
+                "event_type": "thinking_delta",
+                "payload_json": '{"text":"undiscovered"}',
+                "session_id": "session-b",
+                "run_id": "subagent_run_b2",
+                "trace_id": "subagent_run_b2",
+                "normal_mode_subagent_event": True,
+            },
+        },
+    ]
+
+
 def _write_stream_runtime_inject_mocks(tmp_path: Path) -> None:
+    (tmp_path / "uiDiagnostics.js").write_text(
+        """
+export function recordUiDiagnostic() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
     (tmp_path / "mockRuntimeInjectQueue.mjs").write_text(
         """
 export function renderRuntimeInjectQueue() {
@@ -258,7 +516,7 @@ syncNormalModeSubagentStreams("session-1", [
     {
         instance_id: "inst-sub-1",
         role_id: "Explorer",
-        run_id: "subagent_run_1",
+        run_id: "delegated-run-1",
         status: "running",
         run_status: "running",
         last_event_id: 9,
@@ -287,8 +545,8 @@ eventSource.onmessage({
             role_id: "Explorer",
             text: "ok",
         }),
-        run_id: "subagent_run_1",
-        trace_id: "subagent_run_1",
+        run_id: "delegated-run-1",
+        trace_id: "delegated-run-1",
     }),
 });
 eventSource.onmessage({
@@ -299,8 +557,8 @@ eventSource.onmessage({
             instance_id: "inst-sub-1",
             role_id: "Explorer",
         }),
-        run_id: "subagent_run_1",
-        trace_id: "subagent_run_1",
+        run_id: "delegated-run-1",
+        trace_id: "delegated-run-1",
     }),
 });
 
@@ -352,8 +610,9 @@ console.log(JSON.stringify({
                 "event_id": 10,
                 "event_type": "text_delta",
                 "payload_json": '{"instance_id":"inst-sub-1","role_id":"Explorer","text":"ok"}',
-                "run_id": "subagent_run_1",
-                "trace_id": "subagent_run_1",
+                "run_id": "delegated-run-1",
+                "trace_id": "delegated-run-1",
+                "normal_mode_subagent_event": True,
             },
         },
         {
@@ -366,8 +625,9 @@ console.log(JSON.stringify({
                 "event_id": 11,
                 "event_type": "run_completed",
                 "payload_json": '{"instance_id":"inst-sub-1","role_id":"Explorer"}',
-                "run_id": "subagent_run_1",
-                "trace_id": "subagent_run_1",
+                "run_id": "delegated-run-1",
+                "trace_id": "delegated-run-1",
+                "normal_mode_subagent_event": True,
             },
         },
     ]
@@ -626,7 +886,7 @@ console.log(JSON.stringify({
     assert payload["clearedRunStreamStates"] == ["run-1", "run-1"]
 
 
-def test_active_parent_run_keeps_normal_subagent_discovery_polling(
+def test_active_parent_run_does_not_poll_subagent_details_before_expand(
     tmp_path: Path,
 ) -> None:
     repo_root = Path(__file__).resolve().parents[3]
@@ -706,6 +966,14 @@ export function replaceSessionSubagents(sessionId, payload) {
 
 export function markNormalModeSubagentSessionsStoppedForParent() {
     return [];
+}
+
+export function hasLoadedSessionSubagents() {
+    return false;
+}
+
+export function isSubagentSessionListExpanded() {
+    return false;
 }
 """.strip(),
         encoding="utf-8",
@@ -906,7 +1174,7 @@ console.log(JSON.stringify({
         "/api/runs/events?run_id=run-1&after_event_id=0"
     ]
     assert 2500 in payload["scheduledDelays"]
-    assert payload["fetchSubagentCalls"] == ["session-1"]
+    assert payload["fetchSubagentCalls"] == []
 
 
 def test_current_session_background_stream_routes_events_and_deduplicates_attach(
@@ -1858,6 +2126,22 @@ globalThis.__logs = [];
 globalThis.__eventSources = [];
 globalThis.__routeEventCalls = 0;
 globalThis.__clearRunStreamStateCalls = 0;
+globalThis.__documentDispatches = [];
+globalThis.CustomEvent = class CustomEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail || {};
+    }
+};
+globalThis.document = {
+    dispatchEvent(event) {
+        globalThis.__documentDispatches.push({
+            type: event.type,
+            detail: event.detail,
+        });
+        return true;
+    },
+};
 
 class MockEventSource {
     constructor(url) {
@@ -1894,6 +2178,7 @@ const streamPromise = startIntentStream(
 );
 await Promise.resolve();
 const pendingBeforeDetach = hasPendingRunCreation("session-a");
+const dispatchesBeforeRunCreated = [...globalThis.__documentDispatches];
 state.currentSessionId = "session-b";
 const detached = detachActiveStreamForSessionSwitch({ focusPrompt: false });
 const afterDetach = {
@@ -1918,6 +2203,8 @@ console.log(JSON.stringify({
     activeRunId: state.activeRunId,
     activeEventSourceUrl: state.activeEventSource?.url || null,
     eventSourceUrls: globalThis.__eventSources.map(source => source.url),
+    dispatchesBeforeRunCreated,
+    documentDispatches: globalThis.__documentDispatches,
     runCreated,
     completed,
     scheduleSessionsRefreshCalls: globalThis.__scheduleSessionsRefreshCalls,
@@ -1960,6 +2247,34 @@ console.log(JSON.stringify({
     assert payload["eventSourceUrls"] == [
         "/api/runs/events?run_id=run-a&after_event_id=0"
     ]
+    assert payload["dispatchesBeforeRunCreated"] == [
+        {
+            "type": "agent-teams-session-run-active",
+            "detail": {
+                "sessionId": "session-a",
+                "runId": "",
+                "status": "queued",
+            },
+        }
+    ]
+    assert payload["documentDispatches"][:2] == [
+        {
+            "type": "agent-teams-session-run-active",
+            "detail": {
+                "sessionId": "session-a",
+                "runId": "",
+                "status": "queued",
+            },
+        },
+        {
+            "type": "agent-teams-session-run-active",
+            "detail": {
+                "sessionId": "session-a",
+                "runId": "run-a",
+                "status": "queued",
+            },
+        },
+    ]
     assert payload["runCreated"] == []
     assert payload["completed"] == []
     assert payload["scheduleSessionsRefreshCalls"] == 1
@@ -1967,6 +2282,357 @@ console.log(JSON.stringify({
         {"sessionId": "session-a", "promptText": "hello"},
     ]
     assert payload["stopRunCalls"] == 0
+
+
+def test_switch_back_reconnects_run_stream_from_last_event_and_keeps_busy_dot(
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "core" / "stream.js"
+    module_under_test_path = tmp_path / "stream.mjs"
+    runner_path = tmp_path / "runner_switch_back_reconnect.mjs"
+
+    source_text = (
+        source_path.read_text(encoding="utf-8")
+        .replace("./api.js", "./mockApi.mjs")
+        .replace("../components/contextIndicators.js", "./mockContextIndicators.mjs")
+        .replace("../app/prompt.js", "./mockPrompt.mjs")
+        .replace("../components/subagentSessions.js", "./mockSubagentSessions.mjs")
+        .replace("../components/sidebar.js", "./mockSidebar.mjs")
+        .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/backendStatus.js", "./mockBackendStatus.mjs")
+        .replace("../utils/logger.js", "./mockLogger.mjs")
+        .replace("./eventRouter.js", "./mockEventRouter.mjs")
+        .replace("../components/messageRenderer.js", "./mockMessageRenderer.mjs")
+        .replace("../components/runtimeInjectQueue.js", "./mockRuntimeInjectQueue.mjs")
+        .replace("../utils/i18n.js", "./mockI18n.mjs")
+        .replace("./state.js", "./mockState.mjs")
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+    _write_stream_runtime_inject_mocks(tmp_path)
+
+    (tmp_path / "mockApi.mjs").write_text(
+        """
+export async function fetchSessionRecovery() {
+    return {};
+}
+
+export async function fetchSessionSubagents() {
+    return [];
+}
+
+export async function fetchSessions() {
+    return [];
+}
+
+export async function sendUserPrompt() {
+    throw new Error("not used");
+}
+
+export async function stopRun() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockContextIndicators.mjs").write_text(
+        """
+export function refreshVisibleContextIndicators() {
+    globalThis.__contextRefreshCalls += 1;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockPrompt.mjs").write_text(
+        """
+export function refreshSessionTopologyControls() {
+    globalThis.__topologyRefreshCalls += 1;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSubagentSessions.mjs").write_text(
+        """
+export function replaceSessionSubagents() {
+    return undefined;
+}
+
+export function markNormalModeSubagentSessionsStoppedForParent() {
+    return [];
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSidebar.mjs").write_text(
+        """
+export function scheduleSessionsRefresh() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockDom.mjs").write_text(
+        """
+export const els = {
+    sendBtn: { disabled: false, style: {}, setAttribute() {} },
+    promptInput: {
+        disabled: false,
+        dataset: {},
+        placeholder: "",
+        getAttribute() {
+            return this.placeholder || "";
+        },
+        setAttribute(name, value) {
+            this[name] = value;
+        },
+        focus() {
+            globalThis.__focusCalls += 1;
+        },
+    },
+    yoloToggle: { disabled: false },
+    thinkingModeToggle: { disabled: false },
+    thinkingEffortSelect: { disabled: false },
+    stopBtn: { style: {}, disabled: false },
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockBackendStatus.mjs").write_text(
+        """
+export function markBackendOnline() {
+    return undefined;
+}
+
+export async function refreshBackendStatus() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockLogger.mjs").write_text(
+        """
+export function errorToPayload(error, extra = {}) {
+    return { error: String(error?.message || error || ''), ...extra };
+}
+
+export function logError() {
+    return undefined;
+}
+
+export function logInfo() {
+    return undefined;
+}
+
+export function logWarn() {
+    return undefined;
+}
+
+export function sysLog() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockEventRouter.mjs").write_text(
+        """
+export function routeEvent(evType, payload, eventMeta) {
+    globalThis.__routeEventCalls.push({ evType, payload, eventMeta });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockMessageRenderer.mjs").write_text(
+        """
+export function clearRunStreamState() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: "session-a",
+    currentSessionMode: "normal",
+    activeSubagentSession: null,
+    activeEventSource: null,
+    activeRunId: null,
+    isGenerating: false,
+    runPrimaryRoleMap: {},
+};
+
+export function getPrimaryRoleId() {
+    return "MainAgent";
+}
+
+export function getPrimaryRoleLabel() {
+    return "Main Agent";
+}
+
+export function getRunPrimaryRoleId() {
+    return "MainAgent";
+}
+
+export function getRunPrimaryRoleLabel() {
+    return "Main Agent";
+}
+
+export function setRunPrimaryRole() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner_path.write_text(
+        """
+import { els } from "./mockDom.mjs";
+import { state } from "./mockState.mjs";
+
+globalThis.__eventSources = [];
+globalThis.__routeEventCalls = [];
+globalThis.__contextRefreshCalls = 0;
+globalThis.__topologyRefreshCalls = 0;
+globalThis.__focusCalls = 0;
+globalThis.__timers = [];
+globalThis.setTimeout = (callback, delay) => {
+    const timer = {
+        callback,
+        delay,
+        cleared: false,
+        unref() {},
+    };
+    globalThis.__timers.push(timer);
+    return timer;
+};
+globalThis.clearTimeout = timer => {
+    if (timer) {
+        timer.cleared = true;
+    }
+};
+
+class MockEventSource {
+    constructor(url) {
+        this.url = url;
+        this.closed = false;
+        this.onmessage = null;
+        this.onerror = null;
+        globalThis.__eventSources.push(this);
+    }
+
+    close() {
+        this.closed = true;
+    }
+}
+
+globalThis.EventSource = MockEventSource;
+
+const {
+    attachRunStream,
+    detachActiveStreamForSessionSwitch,
+    prepareStreamsForForegroundNavigation,
+} = await import("./stream.mjs");
+
+attachRunStream("run-a", "session-a", null, {
+    reason: "start",
+    makeUiBusy: true,
+});
+
+const firstSource = globalThis.__eventSources[0];
+firstSource.onmessage({
+    data: JSON.stringify({
+        event_id: 7,
+        event_type: "text_delta",
+        payload_json: JSON.stringify({
+            run_id: "run-a",
+            session_id: "session-a",
+            text: "visible before switch",
+        }),
+        run_id: "run-a",
+        trace_id: "run-a",
+    }),
+});
+
+const detached = detachActiveStreamForSessionSwitch({ focusPrompt: false });
+state.currentSessionId = "session-b";
+const afterDetach = {
+    detached,
+    isGenerating: state.isGenerating,
+    activeEventSourceUrl: state.activeEventSource?.url || null,
+    stopDisplay: els.stopBtn.style.display,
+};
+
+firstSource.onerror();
+state.currentSessionId = "session-a";
+prepareStreamsForForegroundNavigation("session-a");
+attachRunStream("run-a", "session-a", null, {
+    reason: "hydrate-session",
+    makeUiBusy: true,
+});
+
+console.log(JSON.stringify({
+    afterDetach,
+    afterRestore: {
+        isGenerating: state.isGenerating,
+        activeRunId: state.activeRunId,
+        activeEventSourceUrl: state.activeEventSource?.url || null,
+        stopDisplay: els.stopBtn.style.display,
+        stopDisabled: els.stopBtn.disabled,
+        sendDisabled: els.sendBtn.disabled,
+        promptDisabled: els.promptInput.disabled,
+    },
+    eventSourceUrls: globalThis.__eventSources.map(source => source.url),
+    openEventSourceUrls: globalThis.__eventSources
+        .filter(source => source.closed !== true)
+        .map(source => source.url),
+    routeEventTypes: globalThis.__routeEventCalls.map(call => call.evType),
+    timerDelays: globalThis.__timers.map(timer => timer.delay),
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=3,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+
+    assert payload["afterDetach"] == {
+        "detached": True,
+        "isGenerating": False,
+        "activeEventSourceUrl": None,
+        "stopDisplay": "none",
+    }
+    assert payload["afterRestore"] == {
+        "isGenerating": True,
+        "activeRunId": "run-a",
+        "activeEventSourceUrl": "/api/runs/events?run_id=run-a&after_event_id=7",
+        "stopDisplay": "inline-flex",
+        "stopDisabled": False,
+        "sendDisabled": False,
+        "promptDisabled": False,
+    }
+    assert payload["eventSourceUrls"] == [
+        "/api/runs/events?run_id=run-a&after_event_id=0",
+        "/api/runs/events?run_id=run-a&after_event_id=7",
+    ]
+    assert payload["openEventSourceUrls"] == [
+        "/api/runs/events?run_id=run-a&after_event_id=7",
+    ]
+    assert payload["routeEventTypes"] == ["text_delta"]
+    assert 900 in payload["timerDelays"]
 
 
 def test_active_multiplex_stream_releases_ui_on_run_paused(
@@ -2371,6 +3037,14 @@ export function replaceSessionSubagents(sessionId, payload, options = {}) {
 
 export function markNormalModeSubagentSessionsStoppedForParent() {
     return [];
+}
+
+export function hasLoadedSessionSubagents() {
+    return false;
+}
+
+export function isSubagentSessionListExpanded() {
+    return true;
 }
 """.strip(),
         encoding="utf-8",

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -728,6 +728,9 @@ async def test_container_binds_background_completion_sink_during_start(
     def _fake_wechat_start() -> None:
         start_calls.append("wechat")
 
+    def _fake_xiaoluban_im_listener_start() -> None:
+        start_calls.append("xiaoluban-im-listener")
+
     def _fake_feishu_subscription_start() -> None:
         start_calls.append("feishu-subscription")
 
@@ -738,6 +741,11 @@ async def test_container_binds_background_completion_sink_during_start(
         container.wechat_gateway_service,
         "start",
         _fake_wechat_start,
+    )
+    monkeypatch.setattr(
+        container.xiaoluban_im_listener_service,
+        "start",
+        _fake_xiaoluban_im_listener_start,
     )
     monkeypatch.setattr(
         container.feishu_subscription_service,
@@ -792,6 +800,7 @@ async def test_container_binds_background_completion_sink_during_start(
     assert container.background_task_service._completion_sink is container.run_service
     assert start_calls == [
         "wechat",
+        "xiaoluban-im-listener",
         "feishu-subscription",
         "feishu-message-pool",
         "automation-delivery",

--- a/tests/unit_tests/interfaces/server/test_mcp_router.py
+++ b/tests/unit_tests/interfaces/server/test_mcp_router.py
@@ -18,6 +18,7 @@ from relay_teams.mcp.mcp_models import (
     McpServerUpdateRequest,
     McpToolInfo,
 )
+from relay_teams.mcp.mcp_service import McpToolLoadBusyError
 
 
 class _FakeMcpService:
@@ -405,6 +406,53 @@ def test_refresh_mcp_server_tools() -> None:
     assert response.status_code == 200
     assert response.json()["server"] == "filesystem"
     assert response.json()["status"] == "loading"
+
+
+def test_list_mcp_server_tools_returns_retry_after_when_busy() -> None:
+    class _BusyMcpService(_FakeMcpService):
+        async def list_server_tools(self, name: str) -> McpServerToolsSummary:
+            _ = name
+            raise McpToolLoadBusyError("MCP tool loading is busy")
+
+    client = _create_test_client(_BusyMcpService())
+
+    response = client.get("/api/mcp/servers/filesystem/tools")
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "1"
+    assert response.json() == {"detail": "MCP tool loading is busy"}
+
+
+def test_list_mcp_server_tools_route_limit_returns_retry_after(monkeypatch) -> None:
+    monkeypatch.setenv(mcp.MCP_TOOLS_ROUTE_CONCURRENCY_ENV, "1")
+    mcp._mcp_tools_route_state.active_count = 1
+    try:
+        client = _create_test_client(_FakeMcpService())
+
+        response = client.get("/api/mcp/servers/filesystem/tools")
+    finally:
+        mcp._mcp_tools_route_state.active_count = 0
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "1"
+    assert response.json() == {"detail": "MCP tool listing is busy"}
+
+
+def test_list_mcp_server_tools_route_min_interval_returns_retry_after(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(mcp.MCP_TOOLS_ROUTE_MIN_INTERVAL_MS_ENV, "1000")
+    mcp._mcp_tools_route_state.last_started_monotonic = 999999999.0
+    try:
+        client = _create_test_client(_FakeMcpService())
+
+        response = client.get("/api/mcp/servers/filesystem/tools")
+    finally:
+        mcp._mcp_tools_route_state.last_started_monotonic = 0.0
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "1"
+    assert response.json() == {"detail": "MCP tool listing is busy"}
 
 
 def test_test_mcp_server_connection() -> None:

--- a/tests/unit_tests/interfaces/server/test_prompts_router.py
+++ b/tests/unit_tests/interfaces/server/test_prompts_router.py
@@ -21,7 +21,12 @@ from relay_teams.interfaces.server.deps import (
 )
 from relay_teams.interfaces.server.routers import prompts
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
-from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec, McpToolInfo
+from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
+    McpServerSpec,
+    McpToolInfo,
+    McpToolSchema,
+)
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
@@ -269,6 +274,13 @@ class _FakeMcpRegistry(McpRegistry):
         return (
             McpToolInfo(name="docs_read_file", description="Read a file"),
             McpToolInfo(name="docs_search_docs", description="Search docs"),
+        )
+
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        assert name == "docs"
+        return (
+            McpToolSchema(name="docs_read_file", description="Read a file"),
+            McpToolSchema(name="docs_search_docs", description="Search docs"),
         )
 
 

--- a/tests/unit_tests/interfaces/server/test_runs_router.py
+++ b/tests/unit_tests/interfaces/server/test_runs_router.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+import time
+from collections.abc import AsyncGenerator
 from typing import cast
 
 import pytest
@@ -71,6 +73,7 @@ class _FakeRunService:
         self.answered_user_questions: list[
             tuple[str, str, tuple[UserQuestionAnswer, ...]]
         ] = []
+        self.ensure_start_delay_seconds = 0.0
 
     def create_run(self, intent_input) -> tuple[str, str]:
         self.created_run_inputs.append(intent_input)
@@ -118,6 +121,8 @@ class _FakeRunService:
         self.started_run_ids.append(run_id)
 
     async def ensure_run_started_async(self, run_id: str) -> None:
+        if self.ensure_start_delay_seconds > 0:
+            await asyncio.sleep(self.ensure_start_delay_seconds)
         self.ensure_run_started(run_id)
 
     def inject_message(
@@ -547,6 +552,33 @@ async def test_create_and_start_run_finishes_startup_after_cancellation() -> Non
     assert fake_service.started_run_ids == ["run-1"]
 
 
+@pytest.mark.asyncio
+async def test_sse_event_lines_closes_wrapped_iterator_after_yield_disconnect() -> None:
+    closed = asyncio.Event()
+
+    async def _events():
+        try:
+            yield RunEvent(
+                session_id="session-1",
+                run_id="run-1",
+                trace_id="run-1",
+                event_type=RunEventType.RUN_COMPLETED,
+                payload_json='{"status":"completed"}',
+                event_id=1,
+            )
+            await asyncio.Event().wait()
+        finally:
+            closed.set()
+
+    stream = runs._sse_event_lines_with_heartbeat(_events())
+
+    line = await anext(stream)
+    await cast(AsyncGenerator[str, None], stream).aclose()
+
+    assert '"event_id":1' in line
+    await asyncio.wait_for(closed.wait(), timeout=1)
+
+
 def test_multiplex_run_events_route_streams_multiple_runs() -> None:
     fake_service = _FakeRunService()
     client = _create_client(fake_service)
@@ -639,6 +671,30 @@ def test_create_run_route_accepts_yolo() -> None:
     assert created.intent == "hello"
     assert created.yolo is True
     assert fake_service.started_run_ids == ["run-1"]
+
+
+def test_create_run_route_does_not_wait_for_slow_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_service = _FakeRunService()
+    fake_service.ensure_start_delay_seconds = 0.25
+    client = _create_client(fake_service)
+    monkeypatch.setenv(runs.RUN_CREATE_STARTUP_WAIT_MS_ENV, "10")
+
+    started = time.perf_counter()
+    response = client.post(
+        "/api/runs",
+        json={
+            "session_id": "session-1",
+            "input": [{"kind": "text", "text": "hello"}],
+            "execution_mode": "ai",
+        },
+    )
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+    assert response.status_code == 200
+    assert response.json() == {"run_id": "run-1", "session_id": "session-1"}
+    assert elapsed_ms < 200
 
 
 def test_create_run_route_accepts_orchestration_policy_override() -> None:

--- a/tests/unit_tests/interfaces/server/test_sessions_router.py
+++ b/tests/unit_tests/interfaces/server/test_sessions_router.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from concurrent.futures import ThreadPoolExecutor
 import logging
 from pathlib import Path
@@ -16,6 +16,7 @@ import httpx
 import pytest
 
 from relay_teams.interfaces.server.deps import get_session_service
+from relay_teams.interfaces.server.async_call import RouteWorkRejectedError
 from relay_teams.interfaces.server.routers import sessions, system
 from relay_teams.providers import AgentTokenSummary, RunTokenUsage, SessionTokenUsage
 from relay_teams.roles import SystemRolesUnavailableError
@@ -27,6 +28,17 @@ from relay_teams.sessions.session_models import (
     SessionMode,
     SessionRecord,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_terminal_view_deferred_state() -> Iterator[None]:
+    with sessions._terminal_view_pending_lock:
+        sessions._terminal_view_pending_session_ids.clear()
+        sessions._terminal_view_last_started_monotonic.clear()
+    yield
+    with sessions._terminal_view_pending_lock:
+        sessions._terminal_view_pending_session_ids.clear()
+        sessions._terminal_view_last_started_monotonic.clear()
 
 
 class _FakeSessionService:
@@ -145,10 +157,42 @@ class _FakeSessionService:
     ) -> tuple[dict[str, object], ...]:
         return self.list_normal_mode_subagents(session_id)
 
+    def list_cached_normal_mode_subagents_async(
+        self, session_id: str
+    ) -> tuple[dict[str, object], ...]:
+        return self.list_normal_mode_subagents(session_id)
+
+    def get_fast_cached_normal_mode_subagents_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        _ = session_id
+        return None
+
+    def get_cached_normal_mode_subagents_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        return {
+            "session_id": session_id,
+            "subagents": list(self.list_normal_mode_subagents(session_id)),
+            "stale": False,
+            "snapshot_age_ms": 0,
+        }
+
     async def list_agents_in_session_async(
         self, session_id: str
     ) -> tuple[dict[str, object], ...]:
         return self.list_agents_in_session(session_id)
+
+    def list_cached_agents_in_session_async(
+        self, session_id: str
+    ) -> tuple[dict[str, object], ...]:
+        return self.list_agents_in_session(session_id)
+
+    def get_fast_cached_agents_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        _ = session_id
+        return None
 
     async def stream_normal_mode_subagent_events(
         self,
@@ -177,6 +221,11 @@ class _FakeSessionService:
 
     async def get_session_async(self, session_id: str) -> SessionRecord:
         return self.get_session(session_id)
+
+    async def assert_session_exists_async(self, session_id: str) -> None:
+        if self.raise_missing:
+            raise KeyError(session_id)
+        self.get_calls.append(session_id)
 
     def delete_session(
         self,
@@ -287,6 +336,44 @@ class _FakeSessionService:
     ) -> SessionTokenUsage:
         return self.get_token_usage_by_session(session_id)
 
+    def get_cached_token_usage_by_session_snapshot_async(
+        self, session_id: str
+    ) -> dict[str, object]:
+        summary = self.get_token_usage_by_session(session_id)
+        return {
+            "session_id": summary.session_id,
+            "total_input_tokens": summary.total_input_tokens,
+            "total_cached_input_tokens": summary.total_cached_input_tokens,
+            "total_output_tokens": summary.total_output_tokens,
+            "total_reasoning_output_tokens": summary.total_reasoning_output_tokens,
+            "total_tokens": summary.total_tokens,
+            "total_requests": summary.total_requests,
+            "total_tool_calls": summary.total_tool_calls,
+            "by_role": {
+                role_id: {
+                    "role_id": agent.role_id,
+                    "input_tokens": agent.input_tokens,
+                    "cached_input_tokens": agent.cached_input_tokens,
+                    "latest_input_tokens": agent.latest_input_tokens,
+                    "max_input_tokens": agent.max_input_tokens,
+                    "output_tokens": agent.output_tokens,
+                    "reasoning_output_tokens": agent.reasoning_output_tokens,
+                    "total_tokens": agent.total_tokens,
+                    "requests": agent.requests,
+                    "tool_calls": agent.tool_calls,
+                    "context_window": agent.context_window,
+                    "model_profile": agent.model_profile,
+                }
+                for role_id, agent in summary.by_role.items()
+            },
+        }
+
+    def get_fast_cached_token_usage_by_session_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        _ = session_id
+        return None
+
     def get_session_rounds(
         self,
         session_id: str,
@@ -322,11 +409,49 @@ class _FakeSessionService:
             summary=summary,
         )
 
+    def get_cached_session_rounds_async(
+        self,
+        session_id: str,
+        *,
+        limit: int,
+        cursor_run_id: str | None,
+        timeline: bool = False,
+        summary: bool = False,
+    ) -> dict[str, object]:
+        return self.get_session_rounds(
+            session_id,
+            limit=limit,
+            cursor_run_id=cursor_run_id,
+            timeline=timeline,
+            summary=summary,
+        )
+
+    def get_fast_cached_session_rounds_snapshot(
+        self,
+        session_id: str,
+        *,
+        limit: int,
+        cursor_run_id: str | None,
+        timeline: bool = False,
+        summary: bool = False,
+    ) -> dict[str, object] | None:
+        _ = (session_id, limit, cursor_run_id, timeline, summary)
+        return None
+
     def get_recovery_snapshot(self, session_id: str) -> dict[str, object]:
         return {"session_id": session_id, "runs": []}
 
     async def get_recovery_snapshot_async(self, session_id: str) -> dict[str, object]:
         return self.get_recovery_snapshot(session_id)
+
+    def get_cached_recovery_snapshot_async(self, session_id: str) -> dict[str, object]:
+        return self.get_recovery_snapshot(session_id)
+
+    def get_fast_cached_recovery_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        _ = session_id
+        return None
 
     def get_round(self, session_id: str, run_id: str) -> dict[str, object]:
         return {"session_id": session_id, "run_id": run_id}
@@ -367,6 +492,17 @@ class _FakeSessionService:
 
     async def get_session_tasks_async(self, session_id: str) -> list[dict[str, object]]:
         return self.get_session_tasks(session_id)
+
+    def list_cached_session_tasks_async(
+        self, session_id: str
+    ) -> tuple[dict[str, object], ...]:
+        return tuple(self.get_session_tasks(session_id))
+
+    def get_fast_cached_session_tasks_snapshot(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        _ = session_id
+        return None
 
     def get_token_usage_by_run(self, run_id: str) -> RunTokenUsage:
         return RunTokenUsage(
@@ -502,23 +638,21 @@ class _BlockingRecoveryService(_FakeSessionService):
 class _BlockingTerminalViewService(_FakeSessionService):
     def __init__(self) -> None:
         super().__init__()
-        self.started = asyncio.Event()
-        self.release = asyncio.Event()
-        self.cancelled = False
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def mark_latest_terminal_run_viewed(self, session_id: str) -> None:
+        self.started.set()
+        _ = self.release.wait(timeout=5.0)
+        self.terminal_view_calls.append(session_id)
 
     async def mark_latest_terminal_run_viewed_async(self, session_id: str) -> None:
-        self.started.set()
-        try:
-            await self.release.wait()
-        except asyncio.CancelledError:
-            self.cancelled = True
-            raise
-        self.terminal_view_calls.append(session_id)
+        await asyncio.to_thread(self.mark_latest_terminal_run_viewed, session_id)
 
 
 class _FailingTerminalViewService(_BlockingTerminalViewService):
-    async def mark_latest_terminal_run_viewed_async(self, session_id: str) -> None:
-        await super().mark_latest_terminal_run_viewed_async(session_id)
+    def mark_latest_terminal_run_viewed(self, session_id: str) -> None:
+        super().mark_latest_terminal_run_viewed(session_id)
         raise RuntimeError("terminal marker failed")
 
 
@@ -579,8 +713,7 @@ def test_mark_session_terminal_viewed_route_calls_service() -> None:
     response = client.post("/api/sessions/session-1/terminal-view")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
-    assert fake_service.terminal_view_calls == ["session-1"]
+    assert response.json() == {"status": "deferred"}
 
 
 def test_mark_session_terminal_viewed_route_uses_session_read_queue() -> None:
@@ -590,8 +723,7 @@ def test_mark_session_terminal_viewed_route_uses_session_read_queue() -> None:
     response = client.post("/api/sessions/session-1/terminal-view")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
-    assert fake_service.terminal_view_calls == ["session-1"]
+    assert response.json() == {"status": "deferred"}
 
 
 def test_mark_session_terminal_viewed_route_returns_404_for_missing_session() -> None:
@@ -600,17 +732,38 @@ def test_mark_session_terminal_viewed_route_returns_404_for_missing_session() ->
     client = _create_client(fake_service)
 
     response = client.post("/api/sessions/session-1/terminal-view")
+    repeated_response = client.post("/api/sessions/session-1/terminal-view")
 
     assert response.status_code == 404
-    assert response.json()["detail"] == "Session not found"
+    assert response.json() == {"detail": "Session not found"}
+    assert repeated_response.status_code == 404
+    assert repeated_response.json() == {"detail": "Session not found"}
+    assert fake_service.terminal_view_calls == []
+
+
+def test_mark_session_terminal_viewed_route_coalesces_cooldown() -> None:
+    fake_service = _FakeSessionService()
+    client = _create_client(fake_service)
+
+    first = client.post("/api/sessions/session-1/terminal-view")
+    second = client.post("/api/sessions/session-1/terminal-view")
+
+    for _ in range(50):
+        if fake_service.terminal_view_calls:
+            break
+        time.sleep(0.02)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == {"status": "deferred"}
+    assert second.json() == {"status": "deferred"}
+    assert fake_service.get_calls == ["session-1"]
+    assert fake_service.terminal_view_calls == ["session-1"]
 
 
 @pytest.mark.asyncio
-async def test_mark_session_terminal_viewed_timeout_keeps_marker_running(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_mark_session_terminal_viewed_defers_single_background_marker() -> None:
     fake_service = _BlockingTerminalViewService()
-    monkeypatch.setattr(sessions, "SESSION_TERMINAL_VIEW_TIMEOUT_SECONDS", 0.01)
     app = _create_client(fake_service).app
     transport = httpx.ASGITransport(app=app)
 
@@ -620,11 +773,14 @@ async def test_mark_session_terminal_viewed_timeout_keeps_marker_running(
         timeout=1.0,
     ) as client:
         response = await client.post("/api/sessions/session-1/terminal-view")
+        assert await _wait_for_threading_event(fake_service.started) is True
+        duplicate_response = await client.post("/api/sessions/session-1/terminal-view")
 
     assert response.status_code == 200
     assert response.json() == {"status": "deferred"}
-    await asyncio.wait_for(fake_service.started.wait(), timeout=1.0)
-    assert fake_service.cancelled is False
+    assert duplicate_response.status_code == 200
+    assert duplicate_response.json() == {"status": "deferred"}
+    assert fake_service.terminal_view_calls == []
 
     fake_service.release.set()
     for _ in range(50):
@@ -632,7 +788,6 @@ async def test_mark_session_terminal_viewed_timeout_keeps_marker_running(
             break
         await asyncio.sleep(0.02)
 
-    assert fake_service.cancelled is False
     assert fake_service.terminal_view_calls == ["session-1"]
 
 
@@ -668,7 +823,31 @@ async def test_deferred_terminal_view_result_logs_cancelled_task(
 
 
 @pytest.mark.asyncio
-async def test_mark_session_terminal_viewed_cancelled_request_observes_marker_failure(
+async def test_deferred_terminal_view_result_drops_rejected_marker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def raise_rejected() -> None:
+        raise RouteWorkRejectedError("queue full")
+
+    caplog.set_level(logging.WARNING)
+    fake_service = _FakeSessionService()
+    marker_task = asyncio.create_task(raise_rejected())
+    await asyncio.sleep(0)
+
+    sessions._log_deferred_terminal_view_result(
+        marker_task,
+        "session-1",
+        service=fake_service,
+    )
+
+    await asyncio.sleep(0)
+
+    assert fake_service.terminal_view_calls == []
+    assert "Deferred session terminal view marker was dropped under load" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mark_session_terminal_viewed_deferred_marker_logs_failure(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     fake_service = _FailingTerminalViewService()
@@ -681,14 +860,9 @@ async def test_mark_session_terminal_viewed_cancelled_request_observes_marker_fa
         base_url="http://testserver",
         timeout=1.0,
     ) as client:
-        request_task = asyncio.create_task(
-            client.post("/api/sessions/session-1/terminal-view")
-        )
-        await asyncio.wait_for(fake_service.started.wait(), timeout=1.0)
-
-        request_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            _ = await request_task
+        response = await client.post("/api/sessions/session-1/terminal-view")
+        assert response.status_code == 200
+        assert await _wait_for_threading_event(fake_service.started) is True
 
     fake_service.release.set()
     for _ in range(50):
@@ -696,7 +870,6 @@ async def test_mark_session_terminal_viewed_cancelled_request_observes_marker_fa
             break
         await asyncio.sleep(0.02)
 
-    assert fake_service.cancelled is False
     assert "Deferred session terminal view marker failed" in caplog.text
 
 
@@ -791,16 +964,13 @@ def test_session_routes_call_service() -> None:
     assert [response.status_code for response in requests] == [200] * len(requests)
 
 
-def test_session_recovery_times_out_when_snapshot_blocks(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(sessions, "SESSION_RECOVERY_TIMEOUT_SECONDS", 0.01)
+def test_session_recovery_returns_cached_snapshot_without_route_timeout() -> None:
     client = _create_client(_SleepingRecoveryService())
 
     response = client.get("/api/sessions/session-1/recovery")
 
-    assert response.status_code == 503
-    assert response.json()["detail"] == "Session recovery snapshot timed out"
+    assert response.status_code == 200
+    assert response.json() == {"session_id": "session-1", "runs": []}
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -91,6 +91,7 @@ from relay_teams.interfaces.server.ui_language_models import (
     UiLanguageSettings,
 )
 from relay_teams.interfaces.server.routers import system
+from relay_teams.interfaces.server.runtime_identity import ServerHealthPayload
 from relay_teams.providers.model_connectivity import (
     CodeAgentAuthVerifyResult,
     ModelConnectivityProbeRequest,
@@ -1145,6 +1146,33 @@ def test_health_check_builds_payload_in_worker_thread(
         "skill_registry": None,
         "tool_registry": None,
     }
+
+
+def test_health_check_returns_cached_startup_payload_without_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def fake_to_thread(
+        func: Callable[..., object],
+        /,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        _ = (args, kwargs)
+        calls.append(func.__name__)
+        return func()
+
+    monkeypatch.setattr(system, "call_maybe_async_in_isolated_thread", fake_to_thread)
+    client = _create_test_client(_FakeSystemService())
+    app = cast(FastAPI, client.app)
+    app.state.health_payload = ServerHealthPayload(status="ok", version="cached")
+
+    response = client.get("/api/system/health")
+
+    assert response.status_code == 200
+    assert response.json()["version"] == "cached"
+    assert calls == []
 
 
 def test_get_notification_config() -> None:

--- a/tests/unit_tests/mcp/test_mcp_discovery_service.py
+++ b/tests/unit_tests/mcp/test_mcp_discovery_service.py
@@ -92,6 +92,28 @@ async def test_disabled_server_is_not_enqueued(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_discovery_concurrency_zero_keeps_warmup_off_hot_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = McpRegistry((_spec("slow-docs"),))
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        _ = name
+        raise AssertionError("Disabled warmup should not touch slow MCP servers")
+
+    monkeypatch.setenv("RELAY_TEAMS_MCP_DISCOVERY_CONCURRENCY", "0")
+    monkeypatch.setattr(registry, "list_tools_for_discovery", fake_list_tools)
+    service = McpDiscoveryService(registry)
+
+    service.start_warmup(registry)
+    await asyncio.sleep(0)
+
+    summary = service.get_tools_summary("slow-docs")
+    assert summary.status == McpDiscoveryStatus.PENDING
+    assert summary.tools == ()
+
+
+@pytest.mark.asyncio
 async def test_replaced_registry_ignores_old_task_result(monkeypatch) -> None:
     old_registry = McpRegistry((_spec("docs"),))
     new_registry = McpRegistry((_spec("docs", command="uvx"),))

--- a/tests/unit_tests/mcp/test_mcp_service.py
+++ b/tests/unit_tests/mcp/test_mcp_service.py
@@ -23,7 +23,13 @@ from relay_teams.mcp.mcp_models import (
 )
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry, build_mcp_server
-from relay_teams.mcp.mcp_service import McpService
+from relay_teams.mcp.mcp_service import (
+    MCP_TOOL_LOAD_CONCURRENCY_ENV,
+    MCP_TOOL_LOAD_FAILED_TTL_MS_ENV,
+    MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS_ENV,
+    McpToolLoadBusyError,
+    McpService,
+)
 from relay_teams.trace import get_trace_context
 
 
@@ -294,6 +300,219 @@ def test_refresh_server_tools_without_discovery_service_returns_pending() -> Non
     assert summary.server == "filesystem"
     assert summary.status == McpDiscoveryStatus.PENDING
     assert summary.tools == ()
+
+
+@pytest.mark.asyncio
+async def test_list_server_tools_fast_fails_when_loader_is_busy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(MCP_TOOL_LOAD_CONCURRENCY_ENV, "1")
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        assert name == "filesystem"
+        entered.set()
+        await release.wait()
+        return (McpToolInfo(name="filesystem_read_file", description="Read"),)
+
+    monkeypatch.setattr(registry, "list_tools", slow_list_tools)
+    service = McpService(registry=registry)
+
+    first = asyncio.create_task(service.list_server_tools("filesystem"))
+    await entered.wait()
+    with pytest.raises(RuntimeError, match="busy"):
+        await service.list_server_tools("filesystem")
+    release.set()
+
+    summary = await first
+    assert [tool.name for tool in summary.tools] == ["filesystem_read_file"]
+
+
+@pytest.mark.asyncio
+async def test_list_server_tools_can_disable_uncached_loads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(MCP_TOOL_LOAD_CONCURRENCY_ENV, "0")
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    calls: list[str] = []
+
+    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        calls.append(name)
+        return (McpToolInfo(name="filesystem_read_file", description="Read"),)
+
+    monkeypatch.setattr(registry, "list_tools", fake_list_tools)
+    service = McpService(registry=registry)
+
+    with pytest.raises(McpToolLoadBusyError, match="busy"):
+        await service.list_server_tools("filesystem")
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_list_server_tools_caches_recent_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(MCP_TOOL_LOAD_FAILED_TTL_MS_ENV, "60000")
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    calls: list[str] = []
+
+    async def failing_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        calls.append(name)
+        raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(registry, "list_tools", failing_list_tools)
+    service = McpService(registry=registry)
+
+    with pytest.raises(RuntimeError, match="connection failed"):
+        await service.list_server_tools("filesystem")
+    with pytest.raises(RuntimeError, match="failed recently"):
+        await service.list_server_tools("filesystem")
+
+    assert calls == ["filesystem"]
+
+
+@pytest.mark.asyncio
+async def test_list_server_tools_retries_after_failure_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(MCP_TOOL_LOAD_FAILED_TTL_MS_ENV, "1")
+    monkeypatch.setenv(MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS_ENV, "0")
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    calls: list[str] = []
+
+    async def transient_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        calls.append(name)
+        if len(calls) == 1:
+            raise RuntimeError("connection failed")
+        return (McpToolInfo(name="filesystem_read_file", description="Read"),)
+
+    monkeypatch.setattr(registry, "list_tools", transient_list_tools)
+    service = McpService(registry=registry)
+
+    with pytest.raises(RuntimeError, match="connection failed"):
+        await service.list_server_tools("filesystem")
+    await asyncio.sleep(0.05)
+
+    summary = await service.list_server_tools("filesystem")
+
+    assert calls == ["filesystem", "filesystem"]
+    assert summary.status == McpDiscoveryStatus.READY
+    assert registry.is_server_runtime_failed("filesystem") is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_tools_clears_cached_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(MCP_TOOL_LOAD_FAILED_TTL_MS_ENV, "60000")
+    monkeypatch.setenv(MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS_ENV, "60000")
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    calls: list[str] = []
+
+    async def transient_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        calls.append(name)
+        if len(calls) == 1:
+            raise RuntimeError("connection failed")
+        return (McpToolInfo(name="filesystem_read_file", description="Read"),)
+
+    monkeypatch.setattr(registry, "list_tools", transient_list_tools)
+    service = McpService(registry=registry)
+
+    with pytest.raises(RuntimeError, match="connection failed"):
+        await service.list_server_tools("filesystem")
+    refresh = service.refresh_server_tools("filesystem")
+    loaded = await service.list_server_tools("filesystem")
+
+    assert refresh.status == McpDiscoveryStatus.PENDING
+    assert loaded.status == McpDiscoveryStatus.READY
+    assert calls == ["filesystem", "filesystem"]
+    assert registry.is_server_runtime_failed("filesystem") is False
+
+
+@pytest.mark.asyncio
+async def test_list_server_tools_global_failure_circuit_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(MCP_TOOL_LOAD_GLOBAL_FAILURE_TTL_MS_ENV, "60000")
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="broken",
+                config={"mcpServers": {"broken": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+            McpServerSpec(
+                name="other",
+                config={"mcpServers": {"other": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    calls: list[str] = []
+
+    async def failing_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+        calls.append(name)
+        raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(registry, "list_tools", failing_list_tools)
+    service = McpService(registry=registry)
+
+    with pytest.raises(RuntimeError, match="connection failed"):
+        await service.list_server_tools("broken")
+    with pytest.raises(McpToolLoadBusyError, match="cooling down"):
+        await service.list_server_tools("other")
+
+    assert calls == ["broken"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/mcp/test_runtime_schema_loader.py
+++ b/tests/unit_tests/mcp/test_runtime_schema_loader.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+
+import pytest
+
+from relay_teams.mcp.mcp_models import McpToolSchema
+from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import (
+    RUNTIME_MCP_SCHEMA_FAILED_TTL_MS_ENV,
+    RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES_ENV,
+    _remember_runtime_mcp_failure,
+    _remember_runtime_mcp_schemas,
+    load_runtime_mcp_tool_schemas,
+)
+
+
+class _NoProbeRegistry:
+    def __init__(self) -> None:
+        self.failed_checks = 0
+        self.list_schema_calls = 0
+
+    def is_server_runtime_failed(self, server_name: str) -> bool:
+        _ = server_name
+        self.failed_checks += 1
+        return False
+
+    async def list_tool_schemas(self, server_name: str) -> tuple[McpToolSchema, ...]:
+        _ = server_name
+        self.list_schema_calls += 1
+        raise AssertionError("max_uncached_probes=0 should not probe MCP servers")
+
+
+class _RetryAfterFailureRegistry:
+    def __init__(self) -> None:
+        self.runtime_failed_names = {"docs"}
+        self.available_names: list[str] = []
+        self.list_schema_calls = 0
+
+    def is_server_runtime_failed(self, server_name: str) -> bool:
+        return server_name in self.runtime_failed_names
+
+    def mark_server_runtime_failed(self, server_name: str) -> None:
+        self.runtime_failed_names.add(server_name)
+
+    def mark_server_runtime_available(self, server_name: str) -> None:
+        self.runtime_failed_names.discard(server_name)
+        self.available_names.append(server_name)
+
+    async def list_tool_schemas(self, server_name: str) -> tuple[McpToolSchema, ...]:
+        self.list_schema_calls += 1
+        return (McpToolSchema(name=f"{server_name}_read"),)
+
+
+@pytest.mark.asyncio
+async def test_runtime_mcp_schema_loader_zero_probe_uses_cache_only(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(RUNTIME_MCP_SCHEMA_MAX_UNCACHED_PROBES_ENV, "0")
+    registry = _NoProbeRegistry()
+    typed_registry = cast(McpRegistry, registry)
+    cached_schema = McpToolSchema(name="cached_tool")
+    _remember_runtime_mcp_schemas(typed_registry, "cached", (cached_schema,))
+
+    result = await load_runtime_mcp_tool_schemas(
+        mcp_registry=typed_registry,
+        server_names=("cached", "missing-1", "missing-2"),
+    )
+
+    assert result.schemas_by_server == {"cached": (cached_schema,)}
+    assert result.cache_hit_count == 1
+    assert result.loaded_server_count == 1
+    assert result.probe_skipped_count == 2
+    assert registry.failed_checks == 0
+    assert registry.list_schema_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_mcp_schema_loader_retries_after_failure_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(RUNTIME_MCP_SCHEMA_FAILED_TTL_MS_ENV, "1")
+    registry = _RetryAfterFailureRegistry()
+    typed_registry = cast(McpRegistry, registry)
+    _remember_runtime_mcp_failure(typed_registry, "docs")
+    await asyncio.sleep(0.05)
+
+    result = await load_runtime_mcp_tool_schemas(
+        mcp_registry=typed_registry,
+        server_names=("docs",),
+    )
+
+    assert result.loaded_server_count == 1
+    assert result.runtime_failed_skipped_count == 0
+    assert registry.list_schema_calls == 1
+    assert registry.is_server_runtime_failed("docs") is False

--- a/tests/unit_tests/persistence/test_sessionservice_async_coverage.py
+++ b/tests/unit_tests/persistence/test_sessionservice_async_coverage.py
@@ -13,6 +13,9 @@ from relay_teams.sessions.session_service import SessionService
 @pytest.mark.asyncio
 async def test_list_sessions_async_delegates() -> None:
     mock_self = MagicMock()
+    mock_self._list_sessions_cache = None
+    mock_self._list_sessions_cache_dirty = False
+    mock_self._list_sessions_cache_ttl_seconds = 0.5
     method = SessionService.list_sessions_async
     await method(mock_self)
     getattr(mock_self, "list_sessions").assert_called_once()

--- a/tests/unit_tests/persistence/test_shared_state_repo.py
+++ b/tests/unit_tests/persistence/test_shared_state_repo.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType, StateMutation
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 
@@ -28,6 +30,46 @@ def test_snapshot_many_can_exclude_internal_key_prefixes(tmp_path: Path) -> None
         (scope,),
         exclude_key_prefixes=("workspace_read:",),
     ) == (("ticket", '"BUG-123"'),)
+
+
+def test_manage_states_performs_real_sync_bulk_write(tmp_path: Path) -> None:
+    repository = SharedStateRepository(tmp_path / "state_bulk.db")
+    scope = ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-1")
+
+    repository.manage_states(
+        (
+            StateMutation(scope=scope, key="first", value_json='"one"'),
+            StateMutation(scope=scope, key="second", value_json='"two"'),
+        )
+    )
+    repository.manage_states(
+        (StateMutation(scope=scope, key="second", value_json='"updated"'),)
+    )
+    repository.manage_states(())
+
+    assert set(repository.snapshot(scope)) == {
+        ("first", '"one"'),
+        ("second", '"updated"'),
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_states_async_reads_requested_keys_in_order(tmp_path: Path) -> None:
+    repository = SharedStateRepository(tmp_path / "state_bulk_read.db")
+    scope = ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-1")
+    other_scope = ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-2")
+    await repository.manage_states_async(
+        (
+            StateMutation(scope=scope, key="first", value_json='"one"'),
+            StateMutation(scope=scope, key="second", value_json='"two"'),
+            StateMutation(scope=other_scope, key="first", value_json='"other"'),
+        )
+    )
+
+    assert await repository.get_states_async(
+        scope,
+        (" second ", "missing", "first", "second", ""),
+    ) == (("second", '"two"'), ("first", '"one"'))
 
 
 def test_delete_by_scope_key_prefix_removes_only_matching_scope_and_prefix(

--- a/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
+++ b/tests/unit_tests/providers/test_llm_multi_turn_prompt.py
@@ -284,6 +284,16 @@ class _FakeMcpSchemaRegistry:
             raise AssertionError("list_tool_schemas should not be called")
         return self._schemas_by_server[name]
 
+    def is_server_runtime_failed(self, name: str) -> bool:
+        _ = name
+        return False
+
+    def mark_server_runtime_failed(self, name: str) -> None:
+        _ = name
+
+    def mark_server_runtime_available(self, name: str) -> None:
+        _ = name
+
     def get_toolsets(self, server_names: tuple[str, ...]) -> tuple[object, ...]:
         return tuple(object() for _ in server_names)
 

--- a/tests/unit_tests/sessions/runs/background_tasks/test_manager.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_manager.py
@@ -5,6 +5,7 @@ import asyncio
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 import json
+import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import threading
@@ -20,6 +21,7 @@ from relay_teams.monitors import (
     MonitorService,
     MonitorSourceKind,
 )
+from relay_teams.sessions.runs.background_tasks import manager as manager_module
 from relay_teams.sessions.runs.background_tasks.manager import (
     BackgroundTaskManager,
     MAX_BACKGROUND_TASKS,
@@ -922,6 +924,91 @@ async def test_background_task_manager_wait_and_poll_keep_active_record_unresolv
 
 
 @pytest.mark.asyncio
+async def test_background_task_manager_keeps_terminal_runtime_when_final_upsert_defers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(tmp_path / "background-terminal-final-defer.db")
+    hub = RunEventHub()
+    manager = BackgroundTaskManager(repository=repo, run_event_hub=hub)
+    record = repo.upsert(
+        BackgroundTaskRecord(
+            background_task_id="exec-deferred-final",
+            run_id="run-1",
+            session_id="session-1",
+            instance_id="inst-1",
+            role_id="writer",
+            tool_call_id="call-1",
+            command="echo done",
+            cwd=str(tmp_path),
+            execution_mode="background",
+            status=BackgroundTaskStatus.RUNNING,
+            pid=1234,
+            log_path="tmp/background_tasks/exec-deferred-final.log",
+        )
+    )
+    transport = _FakeTransport(returncode=0)
+    runtime = manager_module._BackgroundTaskRuntime(
+        record=record,
+        transport=cast(manager_module._BackgroundTaskTransport, transport),
+        log_file_path=tmp_path / "task.log",
+        queue=asyncio.Queue(),
+    )
+    manager._runtimes[record.background_task_id] = runtime
+    original_upsert_async = repo.upsert_async
+    release_deferred = asyncio.Event()
+    deferred_started = asyncio.Event()
+    upsert_calls: list[BackgroundTaskStatus] = []
+
+    async def _flaky_upsert_async(
+        next_record: BackgroundTaskRecord,
+    ) -> BackgroundTaskRecord:
+        upsert_calls.append(next_record.status)
+        if len(upsert_calls) == 1:
+            raise sqlite3.OperationalError("database is locked")
+        deferred_started.set()
+        await release_deferred.wait()
+        return await original_upsert_async(next_record)
+
+    monkeypatch.setattr(repo, "upsert_async", _flaky_upsert_async)
+
+    try:
+        await manager._finalize_runtime(runtime, timed_out=False, wait_for_exit=False)
+        await asyncio.wait_for(deferred_started.wait(), timeout=1)
+
+        listed = manager.list_for_run("run-1")
+        fetched = manager.get_for_run(
+            run_id="run-1",
+            background_task_id=record.background_task_id,
+        )
+
+        assert record.background_task_id in manager._runtimes
+        assert runtime.completed.is_set()
+        assert transport.closed is True
+        assert tuple(item.status for item in listed) == (
+            BackgroundTaskStatus.COMPLETED,
+        )
+        assert fetched.status == BackgroundTaskStatus.COMPLETED
+        persisted_before_retry = repo.get(record.background_task_id)
+        assert persisted_before_retry is not None
+        assert persisted_before_retry.status == BackgroundTaskStatus.RUNNING
+
+        release_deferred.set()
+        for _ in range(20):
+            if record.background_task_id not in manager._runtimes:
+                break
+            await asyncio.sleep(0.01)
+
+        assert record.background_task_id not in manager._runtimes
+        persisted_after_retry = repo.get(record.background_task_id)
+        assert persisted_after_retry is not None
+        assert persisted_after_retry.status == BackgroundTaskStatus.COMPLETED
+    finally:
+        release_deferred.set()
+        await manager.close()
+
+
+@pytest.mark.asyncio
 async def test_background_task_manager_stop_falls_back_to_pid_without_runtime(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1703,7 +1790,7 @@ async def test_prune_sessions_if_needed_reclaims_until_below_cap(
 
 
 @pytest.mark.asyncio
-async def test_prune_sessions_if_needed_drops_stale_active_records_when_at_cap(
+async def test_prune_sessions_if_needed_keeps_active_records_when_at_cap(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1750,9 +1837,9 @@ async def test_prune_sessions_if_needed_drops_stale_active_records_when_at_cap(
 
     remaining_ids = {record.background_task_id for record in repo.list_all()}
 
-    assert killed_pids == [4000]
-    assert len(remaining_ids) == MAX_BACKGROUND_TASKS - 1
-    assert "exec_000" not in remaining_ids
+    assert killed_pids == []
+    assert len(remaining_ids) == MAX_BACKGROUND_TASKS
+    assert "exec_000" in remaining_ids
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/background_tasks/test_service.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_service.py
@@ -35,12 +35,18 @@ from relay_teams.sessions.runs.background_tasks.projection import (
 )
 from relay_teams.sessions.runs.assistant_errors import RunCompletionReason
 from relay_teams.sessions.runs.enums import ExecutionMode, RunEventType
+from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.run_models import (
     IntentInput,
     RunEvent,
     RunThinkingConfig,
 )
+from relay_teams.sessions.runs.run_state_models import (
+    RunStatePhase,
+    RunStateStatus,
+)
+from relay_teams.sessions.runs.run_state_repo import RunStateRepository
 from relay_teams.sessions.session_models import SessionMode
 from relay_teams.sessions.runs.background_tasks.repository import (
     BackgroundTaskRepository,
@@ -81,12 +87,28 @@ class _FakeBackgroundTaskManager:
     def list_for_run(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
         return tuple(record for record in self.records if record.run_id == run_id)
 
+    def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        return tuple(
+            record for record in self.records if record.session_id == session_id
+        )
+
     def get_for_run(
         self, *, run_id: str, background_task_id: str
     ) -> BackgroundTaskRecord:
         for record in self.records:
             if (
                 record.run_id == run_id
+                and record.background_task_id == background_task_id
+            ):
+                return record
+        raise KeyError(background_task_id)
+
+    def get_for_session(
+        self, *, session_id: str, background_task_id: str
+    ) -> BackgroundTaskRecord:
+        for record in self.records:
+            if (
+                record.session_id == session_id
                 and record.background_task_id == background_task_id
             ):
                 return record
@@ -171,6 +193,29 @@ class _FakeBackgroundTaskManager:
         if self.wait_result is None:
             raise AssertionError("wait_result not configured")
         return self.wait_result
+
+    async def wait_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> tuple[BackgroundTaskRecord, bool]:
+        _ = (session_id, background_task_id)
+        if self.wait_result is None:
+            raise AssertionError("wait_result not configured")
+        return self.wait_result
+
+    async def stop_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        record = self.get_for_session(
+            session_id=session_id,
+            background_task_id=background_task_id,
+        )
+        return record.model_copy(update={"status": BackgroundTaskStatus.STOPPED})
 
 
 class _CapturingCompletionSink:
@@ -787,6 +832,53 @@ async def test_wait_for_run_marks_completed_background_task_as_consumed(
 
 
 @pytest.mark.asyncio
+async def test_wait_for_session_accepts_background_task_from_previous_run(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(tmp_path / "background-task-session-wait.db")
+    manager = _FakeBackgroundTaskManager()
+    service = BackgroundTaskService(
+        background_task_manager=cast(BackgroundTaskManager, manager),
+        repository=repo,
+    )
+    completed = repo.upsert(
+        _build_record().model_copy(update={"run_id": "run-previous"})
+    )
+    manager.records = (completed,)
+
+    updated, done = await service.wait_for_session(
+        session_id="session-1",
+        background_task_id="exec-1",
+    )
+
+    assert done is True
+    assert updated.run_id == "run-previous"
+    assert updated.completion_notified_at is not None
+
+
+@pytest.mark.asyncio
+async def test_wait_for_session_rejects_cross_session_background_task(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-session-cross-session.db"
+    )
+    manager = _FakeBackgroundTaskManager()
+    service = BackgroundTaskService(
+        background_task_manager=cast(BackgroundTaskManager, manager),
+        repository=repo,
+    )
+    record = repo.upsert(_build_record().model_copy(update={"run_id": "run-previous"}))
+    manager.records = (record,)
+
+    with pytest.raises(KeyError, match="Unknown background task"):
+        await service.wait_for_session(
+            session_id="session-2",
+            background_task_id="exec-1",
+        )
+
+
+@pytest.mark.asyncio
 async def test_background_task_service_skips_notification_when_wait_already_consumed_completion(
     tmp_path: Path,
 ) -> None:
@@ -1023,6 +1115,7 @@ async def test_background_task_service_start_subagent_publishes_start_event_asyn
     assert [event.event_type for event in run_event_hub.events] == [
         RunEventType.BACKGROUND_TASK_STARTED,
         RunEventType.SUBAGENT_SESSION_STATUS_CHANGED,
+        RunEventType.RUN_COMPLETED,
         RunEventType.BACKGROUND_TASK_COMPLETED,
         RunEventType.SUBAGENT_SESSION_STATUS_CHANGED,
     ]
@@ -1056,6 +1149,7 @@ async def test_background_task_service_start_subagent_publishes_start_event_asyn
         False,
         False,
     ]
+    assert run_event_hub.events[1].run_id == started.subagent_run_id
 
 
 @pytest.mark.asyncio
@@ -1596,6 +1690,8 @@ async def test_background_task_service_run_subagent_returns_synchronous_result(
     assert isinstance(result, SynchronousSubagentResult)
     assert result.output == "analysis complete"
     assert result.role_id == "Crafter"
+    assert result.sync_subagent_wait_released_capacity is True
+    assert result.sync_subagent_total_ms >= result.sync_subagent_execute_ms
     assert agent_repo.calls[0]["run_id"] == result.run_id
     assert executor.calls[0]["role_id"] == "Crafter"
     assert result.run_id in intent_repo._records
@@ -1605,6 +1701,116 @@ async def test_background_task_service_run_subagent_returns_synchronous_result(
     assert runtime is not None
     assert runtime.status == RunRuntimeStatus.COMPLETED
     assert runtime.phase == RunRuntimePhase.TERMINAL
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_run_subagent_publishes_terminal_run_state(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "background-task-service-subagent-sync-terminal.db"
+    repo = BackgroundTaskRepository(db_path)
+    runtime_repo = RunRuntimeRepository(db_path)
+    run_state_repo = RunStateRepository(db_path)
+    run_event_hub = RunEventHub(
+        event_log=EventLog(db_path),
+        run_state_repo=run_state_repo,
+    )
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        )
+    )
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        run_event_hub=run_event_hub,
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=runtime_repo,
+    )
+
+    result = await service.run_subagent(
+        run_id="run-1",
+        session_id="session-1",
+        workspace_id="workspace-1",
+        subagent_role_id="Crafter",
+        title="Investigate failures",
+        prompt="Inspect the failing tests and summarize the cause.",
+    )
+
+    run_state = run_state_repo.get_run_state(result.run_id)
+    assert run_state is not None
+    assert run_state.status == RunStateStatus.COMPLETED
+    assert run_state.phase == RunStatePhase.TERMINAL
+    assert run_state.recoverable is False
+    assert run_state.last_event_id > 0
+    assert run_state.checkpoint_event_id == run_state.last_event_id
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_run_subagent_emits_wait_heartbeat(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-sync-heartbeat.db"
+    )
+    gate = asyncio.Event()
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        ),
+        gate=gate,
+    )
+    run_event_hub = _LoopGuardRunEventHub()
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        run_event_hub=cast(RunEventHub, run_event_hub),
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+    )
+    service._sync_subagent_wait_heartbeat_seconds = 0.01
+
+    run_task = asyncio.create_task(
+        service.run_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests and summarize the cause.",
+        )
+    )
+    try:
+        for _ in range(100):
+            await asyncio.sleep(0.01)
+            if any(
+                event.event_type == RunEventType.BACKGROUND_TASK_UPDATED
+                for event in run_event_hub.events
+            ):
+                break
+        gate.set()
+        result = await asyncio.wait_for(run_task, timeout=1.0)
+    finally:
+        if not run_task.done():
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+
+    heartbeat_events = [
+        event
+        for event in run_event_hub.events
+        if event.event_type == RunEventType.BACKGROUND_TASK_UPDATED
+    ]
+    assert heartbeat_events
+    assert result.output == "analysis complete"
 
 
 @pytest.mark.asyncio
@@ -1713,6 +1919,7 @@ async def test_background_task_service_run_subagent_persists_launch_before_execu
     assert persisted.instance_id == "inst-parent"
     assert persisted.role_id == "writer"
     assert persisted.subagent_run_id == result.run_id
+    assert agent_repo.calls[0]["parent_instance_id"] == "inst-parent"
 
 
 @pytest.mark.asyncio
@@ -2227,7 +2434,12 @@ async def test_background_task_service_wait_for_subagent_run_recovers_persisted_
         record for record in repo.list_all() if record.subagent_run_id == result.run_id
     ]
 
-    assert recovered == result
+    assert recovered.run_id == result.run_id
+    assert recovered.instance_id == result.instance_id
+    assert recovered.role_id == result.role_id
+    assert recovered.task_id == result.task_id
+    assert recovered.title == result.title
+    assert recovered.output == result.output
     assert len(persisted_records) == 1
     assert persisted_records[0].execution_mode == "foreground"
     assert persisted_records[0].status == BackgroundTaskStatus.COMPLETED
@@ -2290,13 +2502,23 @@ async def test_background_task_service_wait_for_subagent_run_recovers_active_syn
         subagent_run_id="subagent-run-recover",
     )
 
-    assert result == SynchronousSubagentResult(
+    assert result.model_copy(
+        update={
+            "sync_subagent_queue_wait_ms": 0,
+            "sync_subagent_launch_prepare_ms": 0,
+            "sync_subagent_start_hooks_ms": 0,
+            "sync_subagent_execute_ms": 0,
+            "sync_subagent_finalize_ms": 0,
+            "sync_subagent_total_ms": 0,
+        }
+    ) == SynchronousSubagentResult(
         run_id="subagent-run-recover",
         instance_id="inst-sub-recover",
         role_id="Crafter",
         task_id="task-sub-recover",
         title="Investigate failures",
         output="recovered analysis",
+        sync_subagent_wait_released_capacity=True,
     )
     assert executor.calls == [
         {
@@ -2900,6 +3122,108 @@ def test_append_subagent_start_context_handles_empty_prompt_and_context() -> Non
         )
         == "delegate\n\nAdditional context from SubagentStart hooks:\nreview scope"
     )
+
+
+@pytest.mark.asyncio
+async def test_sync_subagent_gate_limits_active_runs_per_parent(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(tmp_path / "sync-subagent-gate.db")
+    service = BackgroundTaskService(background_task_manager=None, repository=repo)
+    service._sync_subagent_active_limit = 2
+    gate = await service._sync_subagent_gate_for_parent("parent-run")
+    active = 0
+    max_active = 0
+
+    async def worker() -> None:
+        nonlocal active
+        nonlocal max_active
+        async with gate:
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+
+    await asyncio.gather(*(worker() for _ in range(6)))
+
+    assert max_active == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_subagent_global_gate_limits_active_runs(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "sync-subagent-global-gate.db"
+    release_executor = asyncio.Event()
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        ),
+        gate=release_executor,
+    )
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=BackgroundTaskRepository(db_path),
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=RunRuntimeRepository(db_path),
+    )
+    service._sync_subagent_active_limit = 3
+    service._sync_subagent_global_active_limit = 1
+    service._sync_subagent_global_gate = asyncio.Semaphore(1)
+
+    async def _launch(parent_run_id: str) -> SynchronousSubagentResult:
+        return await service.run_subagent(
+            run_id=parent_run_id,
+            session_id="session-1",
+            workspace_id="workspace-1",
+            subagent_role_id="Crafter",
+            title=f"Investigate {parent_run_id}",
+            prompt="Inspect the failing tests and summarize the cause.",
+        )
+
+    first = asyncio.create_task(_launch("parent-run-1"))
+    second = asyncio.create_task(_launch("parent-run-2"))
+    while not executor.calls:
+        await asyncio.sleep(0)
+
+    await asyncio.sleep(0.05)
+    assert len(executor.calls) == 1
+
+    release_executor.set()
+    results = await asyncio.gather(first, second)
+
+    assert len(executor.calls) == 2
+    assert all(result.sync_subagent_wait_released_capacity for result in results)
+    assert max(result.sync_subagent_queue_wait_ms for result in results) > 0
+
+
+def test_sync_subagent_global_gate_default_matches_pressure_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RELAY_TEAMS_SYNC_SUBAGENT_GLOBAL_ACTIVE_LIMIT", raising=False)
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=BackgroundTaskRepository(tmp_path / "sync-subagent-default.db"),
+        task_execution_service=_FakeTaskExecutionService(
+            result=TaskExecutionResult(
+                output="analysis complete",
+                completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+            ),
+        ),
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=RunRuntimeRepository(tmp_path / "sync-subagent-default.db"),
+    )
+
+    assert service._sync_subagent_global_active_limit == 16
 
 
 def test_raise_for_subagent_stop_decision_raises_retry_reason() -> None:

--- a/tests/unit_tests/sessions/runs/test_event_log.py
+++ b/tests/unit_tests/sessions/runs/test_event_log.py
@@ -41,6 +41,40 @@ async def test_event_log_async_methods_share_persisted_state(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_event_log_batch_emit_assigns_contiguous_event_ids(
+    tmp_path: Path,
+) -> None:
+    event_log = EventLog(tmp_path / "event_log_batch_emit.db")
+    events = tuple(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id=f"task-{index}",
+            instance_id=f"instance-{index}",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json=f'{{"index": {index}}}',
+        )
+        for index in range(5)
+    )
+
+    try:
+        event_ids = await event_log.emit_run_events_async(events)
+        legacy_ids = await event_log.emit_run_events_legacy_async(events[:2])
+        rows = await event_log.list_by_trace_with_ids_async("run-1")
+        empty_batch = await event_log.emit_run_events_async(())
+        empty_legacy_batch = await event_log.emit_run_events_legacy_async(())
+    finally:
+        await event_log.close_async()
+
+    assert event_ids == (1, 2, 3, 4, 5)
+    assert legacy_ids == (6, 7)
+    assert tuple(row["id"] for row in rows) == (1, 2, 3, 4, 5, 6, 7)
+    assert empty_batch == ()
+    assert empty_legacy_batch == ()
+
+
+@pytest.mark.asyncio
 async def test_event_log_async_hot_paths_do_not_reinitialize_schema(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -174,6 +208,11 @@ async def test_event_log_lists_session_events_after_id_and_filters_subagent_runs
         "session-1",
         0,
     )
+    run_id_rows = event_log.list_by_session_run_ids_after_id(
+        "session-1",
+        ("subagent_run_1", "delegated-run-1"),
+        0,
+    )
     async_session_rows = await event_log.list_by_session_after_id_async(
         "session-1",
         first_id,
@@ -184,12 +223,19 @@ async def test_event_log_lists_session_events_after_id_and_filters_subagent_runs
             0,
         )
     )
+    async_run_id_rows = await event_log.list_by_session_run_ids_after_id_async(
+        "session-1",
+        ("subagent_run_1", "delegated-run-1"),
+        0,
+    )
     await event_log.close_async()
 
     assert tuple(row["id"] for row in session_rows) == (subagent_id,)
     assert tuple(row["id"] for row in async_session_rows) == (subagent_id,)
     assert tuple(row["id"] for row in subagent_rows) == (subagent_id,)
     assert tuple(row["id"] for row in async_subagent_rows) == (subagent_id,)
+    assert tuple(row["id"] for row in run_id_rows) == (subagent_id,)
+    assert tuple(row["id"] for row in async_run_id_rows) == (subagent_id,)
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_event_stream.py
+++ b/tests/unit_tests/sessions/runs/test_event_stream.py
@@ -10,6 +10,7 @@ import pytest
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs import event_stream as event_stream_module
 from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.run_state_models import RunStateRecord
 from relay_teams.sessions.runs.run_state_repo import RunStateRepository
@@ -32,13 +33,26 @@ class _SequencedEventLog:
             self._next_event_id += 1
             return self._next_event_id
 
+    async def emit_run_events_async(
+        self, events: tuple[RunEvent, ...]
+    ) -> tuple[int, ...]:
+        _ = events
+        with self._lock:
+            event_ids: list[int] = []
+            for _event in events:
+                self._next_event_id += 1
+                event_ids.append(self._next_event_id)
+            return tuple(event_ids)
+
 
 class _ObservedRunStateRepository:
-    def __init__(self) -> None:
+    def __init__(self, *, block_first_async_update: bool = False) -> None:
         self.active_updates = 0
         self.max_active_updates = 0
         self.applied_event_ids: list[int] = []
         self.async_update_entered = asyncio.Event()
+        self.release_first_async_update = asyncio.Event()
+        self._block_first_async_update = block_first_async_update
         self._lock = Lock()
 
     def apply_event(self, *, event_id: int, event: RunEvent) -> RunStateRecord:
@@ -55,12 +69,28 @@ class _ObservedRunStateRepository:
         try:
             if event_id == 1:
                 self.async_update_entered.set()
-                await asyncio.sleep(0.01)
+                if self._block_first_async_update:
+                    await self.release_first_async_update.wait()
+                else:
+                    await asyncio.sleep(0)
             else:
                 await asyncio.sleep(0)
             return self._state_record(event_id=event_id, event=event)
         finally:
             self._finish_update()
+
+    async def apply_events_async(
+        self,
+        *,
+        event_ids: tuple[int, ...],
+        events: tuple[RunEvent, ...],
+    ) -> tuple[RunStateRecord, ...]:
+        return tuple(
+            [
+                await self.apply_event_async(event_id=event_id, event=event)
+                for event_id, event in zip(event_ids, events, strict=True)
+            ]
+        )
 
     def _begin_update(self, event_id: int) -> None:
         with self._lock:
@@ -82,15 +112,27 @@ class _ObservedRunStateRepository:
         )
 
 
-def _event(event_type: RunEventType) -> RunEvent:
+def _event(event_type: RunEventType, *, run_id: str = "run-1") -> RunEvent:
     return RunEvent(
         session_id="session-1",
-        run_id="run-1",
+        run_id=run_id,
         trace_id="trace-1",
         task_id="task-1",
         instance_id="instance-1",
         event_type=event_type,
         payload_json="{}",
+    )
+
+
+def _tool_result_event(tool_name: str) -> RunEvent:
+    return _event(RunEventType.TOOL_RESULT).model_copy(
+        update={
+            "payload_json": (
+                '{"tool_name": "'
+                + tool_name
+                + '", "tool_call_id": "call-1", "result": {"ok": true}}'
+            )
+        }
     )
 
 
@@ -120,6 +162,70 @@ async def test_run_event_hub_publish_async_serializes_state_updates() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_event_hub_advances_state_projection_for_tool_result_batch() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    queue = hub.subscribe("run-1")
+
+    event_ids = await hub.publish_many_async(
+        (_tool_result_event("spawn_subagent"), _tool_result_event("spawn_subagent"))
+    )
+
+    assert event_ids == (1, 2)
+    assert run_state_repo.applied_event_ids == [1, 2]
+    assert queue.get_nowait().event_type is RunEventType.TOOL_RESULT
+    assert queue.get_nowait().event_type is RunEventType.TOOL_RESULT
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_deferred_lightweight_batch_skips_state_projection() -> (
+    None
+):
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    queue = hub.subscribe("run-1")
+
+    event_ids = await hub.publish_many_deferred_async(
+        (_tool_result_event("read"), _tool_result_event("grep"))
+    )
+    delivered = (queue.get_nowait(), queue.get_nowait())
+
+    assert event_ids == (1, 2)
+    assert tuple(event.event_id for event in delivered) == (1, 2)
+    assert run_state_repo.applied_event_ids == []
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_deferred_non_lightweight_batch_advances_state_projection() -> (
+    None
+):
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    queue = hub.subscribe("run-1")
+
+    event_ids = await hub.publish_many_deferred_async(
+        (_tool_result_event("write"), _tool_result_event("read"))
+    )
+    delivered = (queue.get_nowait(), queue.get_nowait())
+
+    assert event_ids == (1, 2)
+    assert tuple(event.event_id for event in delivered) == (1, 2)
+    assert run_state_repo.applied_event_ids == [1, 2]
+
+
+@pytest.mark.asyncio
 async def test_run_event_hub_publishes_to_session_subscribers() -> None:
     event_log = _SequencedEventLog()
     run_state_repo = _ObservedRunStateRepository()
@@ -141,6 +247,24 @@ async def test_run_event_hub_publishes_to_session_subscribers() -> None:
     hub.unsubscribe_session("session-1", queue)
 
     assert hub.has_session_subscribers("session-1") is False
+
+
+@pytest.mark.asyncio
+async def test_run_event_hub_wakes_subscriber_loop_from_thread_publish() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository()
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+    queue = hub.subscribe("run-1")
+
+    event_id = await asyncio.to_thread(hub.publish, _event(RunEventType.RUN_COMPLETED))
+    delivered = await asyncio.wait_for(queue.get(), timeout=1)
+
+    assert event_id == 1
+    assert delivered.event_type is RunEventType.RUN_COMPLETED
+    assert delivered.event_id == 1
 
 
 def test_run_event_hub_sync_publish_delivers_to_session_subscribers() -> None:
@@ -173,10 +297,114 @@ def test_run_event_hub_unsubscribe_session_ignores_unknown_queue() -> None:
     assert hub.has_session_subscribers("session-1") is False
 
 
+def test_run_event_hub_bounded_queue_drops_high_frequency_events_first() -> None:
+    queue: asyncio.Queue[RunEvent] = asyncio.Queue(maxsize=1)
+    queue.put_nowait(_event(RunEventType.TEXT_DELTA))
+
+    RunEventHub._offer_event_on_owner_loop(
+        queue,
+        _event(RunEventType.THINKING_DELTA),
+    )
+
+    delivered = queue.get_nowait()
+    assert delivered.event_type is RunEventType.TEXT_DELTA
+
+
+def test_run_event_hub_bounded_queue_preserves_terminal_events() -> None:
+    queue: asyncio.Queue[RunEvent] = asyncio.Queue(maxsize=1)
+    queue.put_nowait(_event(RunEventType.TEXT_DELTA))
+
+    RunEventHub._offer_event_on_owner_loop(
+        queue,
+        _event(RunEventType.RUN_COMPLETED),
+    )
+
+    delivered = queue.get_nowait()
+    assert delivered.event_type is RunEventType.RUN_COMPLETED
+
+
+def test_run_event_hub_bounded_queue_drops_only_droppable_events() -> None:
+    queue: asyncio.Queue[RunEvent] = asyncio.Queue(maxsize=3)
+    queue.put_nowait(
+        _event(RunEventType.TOOL_RESULT).model_copy(update={"event_id": 1})
+    )
+    queue.put_nowait(_event(RunEventType.TEXT_DELTA).model_copy(update={"event_id": 2}))
+    queue.put_nowait(
+        _event(RunEventType.RUN_STARTED).model_copy(update={"event_id": 3})
+    )
+
+    RunEventHub._offer_event_on_owner_loop(
+        queue,
+        _event(RunEventType.RUN_COMPLETED).model_copy(update={"event_id": 4}),
+    )
+
+    delivered = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert [event.event_id for event in delivered] == [1, 3, 4]
+    assert [event.event_type for event in delivered] == [
+        RunEventType.TOOL_RESULT,
+        RunEventType.RUN_STARTED,
+        RunEventType.RUN_COMPLETED,
+    ]
+
+
+def test_run_event_hub_subscriber_queue_keeps_non_droppable_overflow() -> None:
+    queue = event_stream_module._RunEventSubscriberQueue(soft_maxsize=1)
+    queue.put_nowait(
+        _event(RunEventType.TOOL_RESULT).model_copy(update={"event_id": 1})
+    )
+
+    RunEventHub._offer_event_on_owner_loop(
+        queue,
+        _event(RunEventType.RUN_COMPLETED).model_copy(update={"event_id": 2}),
+    )
+
+    assert queue.qsize() == 2
+    assert queue.get_nowait().event_type is RunEventType.TOOL_RESULT
+    assert queue.get_nowait().event_type is RunEventType.RUN_COMPLETED
+
+
+def test_lightweight_tool_result_batch_requires_supported_tool_results() -> None:
+    assert event_stream_module._is_lightweight_tool_result_batch(()) is False
+    assert (
+        event_stream_module._is_lightweight_tool_result_batch(
+            (_tool_result_event("read"), _tool_result_event("grep"))
+        )
+        is True
+    )
+    assert (
+        event_stream_module._is_lightweight_tool_result_batch(
+            (_event(RunEventType.TEXT_DELTA),)
+        )
+        is False
+    )
+    assert (
+        event_stream_module._is_lightweight_tool_result_batch(
+            (_event(RunEventType.TOOL_RESULT).model_copy(update={"payload_json": "{"}),)
+        )
+        is False
+    )
+    assert (
+        event_stream_module._is_lightweight_tool_result_batch(
+            (
+                _event(RunEventType.TOOL_RESULT).model_copy(
+                    update={"payload_json": '{"tool_name": 123}'}
+                ),
+            )
+        )
+        is False
+    )
+    assert (
+        event_stream_module._is_lightweight_tool_result_batch(
+            (_tool_result_event("write"),)
+        )
+        is False
+    )
+
+
 @pytest.mark.asyncio
 async def test_run_event_hub_publish_async_finishes_projection_when_cancelled() -> None:
     event_log = _SequencedEventLog()
-    run_state_repo = _ObservedRunStateRepository()
+    run_state_repo = _ObservedRunStateRepository(block_first_async_update=True)
     hub = RunEventHub(
         event_log=cast(EventLog, event_log),
         run_state_repo=cast(RunStateRepository, run_state_repo),
@@ -186,6 +414,7 @@ async def test_run_event_hub_publish_async_finishes_projection_when_cancelled() 
     task = asyncio.create_task(hub.publish_async(_event(RunEventType.RUN_STARTED)))
     await run_state_repo.async_update_entered.wait()
     task.cancel()
+    run_state_repo.release_first_async_update.set()
 
     with pytest.raises(asyncio.CancelledError):
         await task
@@ -214,9 +443,32 @@ def test_run_event_hub_publish_returns_event_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_event_hub_allows_different_runs_to_publish_in_parallel() -> None:
+    event_log = _SequencedEventLog()
+    run_state_repo = _ObservedRunStateRepository(block_first_async_update=True)
+    hub = RunEventHub(
+        event_log=cast(EventLog, event_log),
+        run_state_repo=cast(RunStateRepository, run_state_repo),
+    )
+
+    first_task = asyncio.create_task(
+        hub.publish_async(_event(RunEventType.RUN_STARTED, run_id="run-1"))
+    )
+    await run_state_repo.async_update_entered.wait()
+    second_event_id = await hub.publish_async(
+        _event(RunEventType.RUN_STARTED, run_id="run-2")
+    )
+    run_state_repo.release_first_async_update.set()
+    first_event_id = await first_task
+
+    assert run_state_repo.max_active_updates == 2
+    assert sorted([first_event_id, second_event_id]) == [1, 2]
+
+
+@pytest.mark.asyncio
 async def test_run_event_hub_serializes_mixed_sync_and_async_publishes() -> None:
     event_log = _SequencedEventLog()
-    run_state_repo = _ObservedRunStateRepository()
+    run_state_repo = _ObservedRunStateRepository(block_first_async_update=True)
     hub = RunEventHub(
         event_log=cast(EventLog, event_log),
         run_state_repo=cast(RunStateRepository, run_state_repo),
@@ -226,6 +478,7 @@ async def test_run_event_hub_serializes_mixed_sync_and_async_publishes() -> None
         hub.publish_async(_event(RunEventType.RUN_STARTED))
     )
     await run_state_repo.async_update_entered.wait()
+    run_state_repo.release_first_async_update.set()
 
     await asyncio.gather(
         async_task,
@@ -239,7 +492,7 @@ async def test_run_event_hub_serializes_mixed_sync_and_async_publishes() -> None
 @pytest.mark.asyncio
 async def test_run_event_hub_rejects_sync_publish_from_loop_when_async_locked() -> None:
     event_log = _SequencedEventLog()
-    run_state_repo = _ObservedRunStateRepository()
+    run_state_repo = _ObservedRunStateRepository(block_first_async_update=True)
     hub = RunEventHub(
         event_log=cast(EventLog, event_log),
         run_state_repo=cast(RunStateRepository, run_state_repo),
@@ -253,6 +506,7 @@ async def test_run_event_hub_rejects_sync_publish_from_loop_when_async_locked() 
     with pytest.raises(RuntimeError, match="use publish_async"):
         hub.publish(_event(RunEventType.RUN_PAUSED))
 
+    run_state_repo.release_first_async_update.set()
     await asyncio.wait_for(async_task, timeout=1)
 
     assert run_state_repo.max_active_updates == 1

--- a/tests/unit_tests/sessions/runs/test_run_auxiliary.py
+++ b/tests/unit_tests/sessions/runs/test_run_auxiliary.py
@@ -132,8 +132,18 @@ class _AsyncOnlyBackgroundTaskService:
         _ = run_id
         raise AssertionError("sync list_for_run must not run")
 
+    def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        _ = session_id
+        raise AssertionError("sync list_for_session must not run")
+
     async def list_for_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
         self.calls.append(f"list:{run_id}")
+        return (self.record,)
+
+    async def list_for_session_async(
+        self, session_id: str
+    ) -> tuple[BackgroundTaskRecord, ...]:
+        self.calls.append(f"list:{session_id}")
         return (self.record,)
 
     def get_for_run(
@@ -145,6 +155,15 @@ class _AsyncOnlyBackgroundTaskService:
         _ = (run_id, background_task_id)
         raise AssertionError("sync get_for_run must not run")
 
+    def get_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        _ = (session_id, background_task_id)
+        raise AssertionError("sync get_for_session must not run")
+
     async def get_for_run_async(
         self,
         *,
@@ -154,6 +173,20 @@ class _AsyncOnlyBackgroundTaskService:
         self.calls.append(f"get:{background_task_id}")
         if (
             self.record.run_id != run_id
+            or self.record.background_task_id != background_task_id
+        ):
+            raise KeyError(background_task_id)
+        return self.record
+
+    async def get_for_session_async(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        self.calls.append(f"get:{background_task_id}")
+        if (
+            self.record.session_id != session_id
             or self.record.background_task_id != background_task_id
         ):
             raise KeyError(background_task_id)
@@ -174,8 +207,22 @@ class _AsyncOnlyBackgroundTaskManager:
         _ = run_id
         raise AssertionError("sync manager list_for_run must not run")
 
+    def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        _ = session_id
+        raise AssertionError("sync manager list_for_session must not run")
+
     async def list_for_run_async(self, run_id: str) -> tuple[BackgroundTaskRecord, ...]:
         self.calls.append(f"list:{run_id}")
+        return tuple(
+            record
+            for record in (self.background_record, self.foreground_record)
+            if record.run_id == run_id
+        )
+
+    async def list_for_session_async(
+        self, session_id: str
+    ) -> tuple[BackgroundTaskRecord, ...]:
+        self.calls.append(f"list:{session_id}")
         return (self.background_record, self.foreground_record)
 
     def get_for_run(
@@ -186,6 +233,15 @@ class _AsyncOnlyBackgroundTaskManager:
     ) -> BackgroundTaskRecord:
         _ = (run_id, background_task_id)
         raise AssertionError("sync manager get_for_run must not run")
+
+    def get_for_session(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        _ = (session_id, background_task_id)
+        raise AssertionError("sync manager get_for_session must not run")
 
     async def get_for_run_async(
         self,
@@ -201,6 +257,25 @@ class _AsyncOnlyBackgroundTaskManager:
             return self.background_record
         if (
             self.foreground_record.run_id == run_id
+            and self.foreground_record.background_task_id == background_task_id
+        ):
+            return self.foreground_record
+        raise KeyError(background_task_id)
+
+    async def get_for_session_async(
+        self,
+        *,
+        session_id: str,
+        background_task_id: str,
+    ) -> BackgroundTaskRecord:
+        self.calls.append(f"get:{background_task_id}")
+        if (
+            self.background_record.session_id == session_id
+            and self.background_record.background_task_id == background_task_id
+        ):
+            return self.background_record
+        if (
+            self.foreground_record.session_id == session_id
             and self.foreground_record.background_task_id == background_task_id
         ):
             return self.foreground_record
@@ -307,7 +382,50 @@ async def test_run_auxiliary_background_task_async_uses_manager_fallback() -> No
         "background_task_1",
     )
     assert fetched["background_task_id"] == "background_task_1"
-    assert manager.calls == ["list:run-1", "get:background_task_1"]
+    assert manager.calls == [
+        "list:run-1",
+        "get:background_task_1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_auxiliary_background_task_async_rejects_sibling_run_tasks() -> None:
+    background_record = _background_record(
+        background_task_id="background_task_1",
+        execution_mode="background",
+    )
+    sibling_record = _background_record(
+        background_task_id="sibling_background_task_1",
+        execution_mode="background",
+        run_id="run-2",
+    )
+    manager = _AsyncOnlyBackgroundTaskManager(
+        background_record=background_record,
+        foreground_record=sibling_record,
+    )
+    service = RunAuxiliaryService(
+        get_monitor_service=lambda: None,
+        get_background_task_manager=lambda: cast(BackgroundTaskManager, manager),
+        get_background_task_service=lambda: None,
+        get_todo_service=lambda: None,
+        get_run_session_id=_fail_sync_session_id,
+        get_run_session_id_async=_session_id_async,
+    )
+
+    listed = await service.list_background_tasks_async("run-1")
+
+    assert tuple(item["background_task_id"] for item in listed) == (
+        "background_task_1",
+    )
+    with pytest.raises(KeyError):
+        await service.get_background_task_async(
+            run_id="run-1",
+            background_task_id="sibling_background_task_1",
+        )
+    assert manager.calls == [
+        "list:run-1",
+        "get:sibling_background_task_1",
+    ]
 
 
 @pytest.mark.asyncio
@@ -341,11 +459,12 @@ def _background_record(
     *,
     background_task_id: str,
     execution_mode: Literal["foreground", "background"],
+    run_id: str = "run-1",
 ) -> BackgroundTaskRecord:
     return BackgroundTaskRecord(
         background_task_id=background_task_id,
-        run_id="run-1",
-        session_id="session-1",
+        run_id=run_id,
+        session_id="session-for-run-1",
         instance_id="instance-1",
         role_id="role-1",
         tool_call_id="tool-call-1",

--- a/tests/unit_tests/sessions/runs/test_run_hook_pipeline.py
+++ b/tests/unit_tests/sessions/runs/test_run_hook_pipeline.py
@@ -94,6 +94,7 @@ class TestRunHookPipelineMemoryConsolidation:
         handler.on_run_completed_async.assert_awaited_once_with(
             workspace_id="ws-1",
             session_id="sess-1",
+            run_id="run-1",
         )
 
     def test_on_session_completed_called(self) -> None:

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -50,6 +50,7 @@ from relay_teams.sessions.runs.background_tasks.manager import (
 )
 from relay_teams.sessions.runs.run_recovery import AutoRecoveryReason
 from relay_teams.sessions.runs.run_service import SessionRunService
+from relay_teams.sessions.runs.run_worker_capacity import RunWorkerCapacityLimiter
 from relay_teams.sessions.runs.run_models import (
     AudioGenerationConfig,
     ImageGenerationConfig,
@@ -129,6 +130,89 @@ class _MetaAgent:
         raise AssertionError(f"not expected: {trace_id}")
 
 
+class _BlockingQueuedRunRuntimeRepo:
+    def __init__(self) -> None:
+        self.queued_started = asyncio.Event()
+        self.release_queued = asyncio.Event()
+        self.ensure_statuses: list[RunRuntimeStatus] = []
+
+    async def ensure_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        root_task_id: str | None = None,
+        status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
+        phase: RunRuntimePhase = RunRuntimePhase.IDLE,
+    ) -> RunRuntimeRecord:
+        del root_task_id
+        self.ensure_statuses.append(status)
+        if status == RunRuntimeStatus.QUEUED:
+            self.queued_started.set()
+            await self.release_queued.wait()
+        return RunRuntimeRecord(
+            run_id=run_id,
+            session_id=session_id,
+            status=status,
+            phase=phase,
+        )
+
+    async def update_async(self, run_id: str, **changes: object) -> RunRuntimeRecord:
+        status = changes.get("status")
+        phase = changes.get("phase")
+        return RunRuntimeRecord(
+            run_id=run_id,
+            session_id="session-1",
+            status=(
+                status
+                if isinstance(status, RunRuntimeStatus)
+                else RunRuntimeStatus.RUNNING
+            ),
+            phase=(
+                phase
+                if isinstance(phase, RunRuntimePhase)
+                else RunRuntimePhase.COORDINATOR_RUNNING
+            ),
+        )
+
+
+class _FailingQueuedRunRuntimeRepo:
+    async def ensure_async(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        root_task_id: str | None = None,
+        status: RunRuntimeStatus = RunRuntimeStatus.QUEUED,
+        phase: RunRuntimePhase = RunRuntimePhase.IDLE,
+    ) -> RunRuntimeRecord:
+        _ = (run_id, session_id, root_task_id, status, phase)
+        raise RuntimeError("queued runtime persist failed")
+
+    async def get_async(self, run_id: str) -> RunRuntimeRecord | None:
+        _ = run_id
+        return None
+
+    def get(self, run_id: str) -> RunRuntimeRecord | None:
+        _ = run_id
+        return None
+
+
+class _BlockingQueuedRunIntentRepo:
+    def __init__(self) -> None:
+        self.upsert_started = asyncio.Event()
+        self.release_upsert = asyncio.Event()
+        self.upserted_run_ids: list[str] = []
+
+    async def upsert_async(
+        self, *, run_id: str, session_id: str, intent: IntentInput
+    ) -> None:
+        del session_id, intent
+        self.upsert_started.set()
+        await self.release_upsert.wait()
+        self.upserted_run_ids.append(run_id)
+
+
 class _SessionRepo:
     def get(self, session_id: str) -> SessionRecord:
         return SessionRecord(
@@ -154,6 +238,17 @@ class _SessionRepo:
         return self.get(session_id)
 
     async def mark_started_async(self, session_id: str) -> SessionRecord:
+        return self.mark_started(session_id)
+
+
+class _BlockingMarkStartedSessionRepo(_SessionRepo):
+    def __init__(self) -> None:
+        self.mark_started_called = asyncio.Event()
+        self.release_mark_started = asyncio.Event()
+
+    async def mark_started_async(self, session_id: str) -> SessionRecord:
+        self.mark_started_called.set()
+        await self.release_mark_started.wait()
         return self.mark_started(session_id)
 
 
@@ -706,6 +801,112 @@ async def test_media_generation_returns_terminal_error_for_empty_output(
     assert result.error_message == "Provider returned no media output"
 
 
+@pytest.mark.asyncio
+async def test_create_run_async_awaits_started_marker_before_queued_run_persistence(
+    tmp_path: Path,
+) -> None:
+    manager = _build_manager(tmp_path / "deferred_queue_persist.db")
+    runtime_repo = _BlockingQueuedRunRuntimeRepo()
+    intent_repo = _BlockingQueuedRunIntentRepo()
+    session_repo = _BlockingMarkStartedSessionRepo()
+    manager._run_runtime_repo = cast(RunRuntimeRepository, cast(object, runtime_repo))
+    manager._run_intent_repo = cast(RunIntentRepository, cast(object, intent_repo))
+    manager._session_repo = cast(SessionRepository, cast(object, session_repo))
+
+    create_task = asyncio.create_task(
+        manager.create_run_async(
+            IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("hello"),
+            )
+        )
+    )
+
+    await asyncio.wait_for(session_repo.mark_started_called.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert not create_task.done()
+    assert manager._active_run_registry.get_active_run_id("session-1") is None
+
+    session_repo.release_mark_started.set()
+    run_id, session_id = await asyncio.wait_for(create_task, timeout=0.2)
+
+    assert session_id == "session-1"
+    assert manager._active_run_registry.get_active_run_id("session-1") == run_id
+    assert run_id in manager._pending_runs
+    await asyncio.wait_for(runtime_repo.queued_started.wait(), timeout=1)
+    assert intent_repo.upserted_run_ids == []
+
+    start_task = asyncio.create_task(manager.ensure_run_started_async(run_id))
+    await asyncio.sleep(0)
+    assert not start_task.done()
+    assert run_id in manager._running_run_ids
+
+    runtime_repo.release_queued.set()
+    session_repo.release_mark_started.set()
+    await asyncio.wait_for(intent_repo.upsert_started.wait(), timeout=1)
+    intent_repo.release_upsert.set()
+    await asyncio.wait_for(start_task, timeout=1)
+
+    assert intent_repo.upserted_run_ids == [run_id]
+    assert runtime_repo.ensure_statuses == [
+        RunRuntimeStatus.QUEUED,
+        RunRuntimeStatus.RUNNING,
+    ]
+    assert run_id in manager._running_run_ids
+
+
+@pytest.mark.asyncio
+async def test_create_run_async_cleans_pending_state_when_fast_persist_fails(
+    tmp_path: Path,
+) -> None:
+    manager = _build_manager(tmp_path / "failed_deferred_queue_persist.db")
+    runtime_repo = _FailingQueuedRunRuntimeRepo()
+    manager._run_runtime_repo = cast(RunRuntimeRepository, cast(object, runtime_repo))
+
+    with pytest.raises(RuntimeError, match="queued runtime persist failed"):
+        await manager.create_run_async(
+            IntentInput(
+                session_id="session-1",
+                input=content_parts_from_text("hello"),
+            )
+        )
+
+    assert manager._pending_runs == {}
+    assert manager._pending_run_persist_tasks == {}
+    assert manager._active_run_registry.get_active_run_id("session-1") is None
+
+
+@pytest.mark.asyncio
+async def test_start_new_run_worker_cleans_up_cancelled_persistence(
+    tmp_path: Path,
+) -> None:
+    manager = _build_manager(tmp_path / "cancelled_deferred_queue_persist.db")
+    run_id = "run-cancelled-persist"
+    session_id = "session-1"
+    manager._pending_runs[run_id] = IntentInput(
+        session_id=session_id,
+        input=content_parts_from_text("hello"),
+    )
+    manager._active_run_registry.remember_active_run(
+        session_id=session_id,
+        run_id=run_id,
+    )
+    persist_task = asyncio.create_task(asyncio.sleep(60))
+    persist_task.cancel()
+    try:
+        await persist_task
+    except asyncio.CancelledError:
+        pass
+    manager._pending_run_persist_tasks[run_id] = persist_task
+
+    await manager._start_new_run_worker_async(run_id)
+
+    assert run_id not in manager._running_run_ids
+    assert run_id not in manager._pending_runs
+    assert manager._injection_manager.is_active(run_id) is False
+    assert manager._active_run_registry.get_active_run_id(session_id) is None
+
+
 def test_create_run_injects_into_active_run(tmp_path: Path) -> None:
     db_path = tmp_path / "run_recovery.db"
     manager = _build_manager(db_path)
@@ -1099,16 +1300,34 @@ async def test_run_service_background_task_endpoints_delegate_to_service(
             self.calls.append(("list", (run_id,)))
             return (self.record,)
 
+        def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+            self.calls.append(("list", (session_id,)))
+            return (self.record,)
+
         def get_for_run(
             self, *, run_id: str, background_task_id: str
         ) -> BackgroundTaskRecord:
             self.calls.append(("get", (run_id, background_task_id)))
             return self.record
 
+        def get_for_session(
+            self, *, session_id: str, background_task_id: str
+        ) -> BackgroundTaskRecord:
+            self.calls.append(("get", (session_id, background_task_id)))
+            return self.record
+
         async def stop_for_run(
             self, *, run_id: str, background_task_id: str
         ) -> BackgroundTaskRecord:
             self.calls.append(("stop", (run_id, background_task_id)))
+            return self.record.model_copy(
+                update={"status": BackgroundTaskStatus.STOPPED}
+            )
+
+        async def stop_for_session(
+            self, *, session_id: str, background_task_id: str
+        ) -> BackgroundTaskRecord:
+            self.calls.append(("stop", (session_id, background_task_id)))
             return self.record.model_copy(
                 update={"status": BackgroundTaskStatus.STOPPED}
             )
@@ -1152,16 +1371,39 @@ async def test_run_service_background_task_endpoints_fall_back_to_manager(
             self.calls.append(("list", (run_id,)))
             return (self.record,)
 
+        def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+            self.calls.append(("list", (session_id,)))
+            return (self.record,)
+
         def get_for_run(
             self, *, run_id: str, background_task_id: str
         ) -> BackgroundTaskRecord:
             self.calls.append(("get", (run_id, background_task_id)))
             return self.record
 
+        def get_for_session(
+            self, *, session_id: str, background_task_id: str
+        ) -> BackgroundTaskRecord:
+            self.calls.append(("get", (session_id, background_task_id)))
+            return self.record
+
         async def stop_for_run(
             self, *, run_id: str, background_task_id: str
         ) -> BackgroundTaskRecord:
             self.calls.append(("stop", (run_id, background_task_id)))
+            return self.record.model_copy(
+                update={"status": BackgroundTaskStatus.STOPPED}
+            )
+
+        async def stop_for_session(
+            self,
+            *,
+            session_id: str,
+            background_task_id: str,
+            reason: str = "stopped_by_user",
+        ) -> BackgroundTaskRecord:
+            _ = reason
+            self.calls.append(("stop", (session_id, background_task_id)))
             return self.record.model_copy(
                 update={"status": BackgroundTaskStatus.STOPPED}
             )
@@ -1204,10 +1446,22 @@ def test_create_monitor_validates_background_task_belongs_to_run(
             _ = run_id
             return (self.record,)
 
+        def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+            _ = session_id
+            return (self.record,)
+
         def get_for_run(
             self, *, run_id: str, background_task_id: str
         ) -> BackgroundTaskRecord:
             _ = run_id
+            if background_task_id != self.record.background_task_id:
+                raise KeyError(background_task_id)
+            return self.record
+
+        def get_for_session(
+            self, *, session_id: str, background_task_id: str
+        ) -> BackgroundTaskRecord:
+            _ = session_id
             if background_task_id != self.record.background_task_id:
                 raise KeyError(background_task_id)
             return self.record
@@ -3952,7 +4206,7 @@ async def test_create_run_async_rejects_detached_and_media_followups(
 
 
 @pytest.mark.asyncio
-async def test_create_run_async_enqueues_followup_to_active_run(
+async def test_create_run_async_merges_starting_followup_before_coordinator_startup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3990,9 +4244,64 @@ async def test_create_run_async_enqueues_followup_to_active_run(
     )
 
     persisted = RunIntentRepository(db_path).get(run_id)
+    pending = manager._pending_runs[run_id]
     assert (next_run_id, next_session_id) == (run_id, session_id)
-    assert appended == [(run_id, "follow", True, InjectionSource.USER)]
+    assert appended == []
+    assert pending.intent == "first\n\nfollow"
+    assert pending.yolo is True
+    assert persisted.intent == "first\n\nfollow"
     assert persisted.yolo is True
+
+
+@pytest.mark.asyncio
+async def test_create_run_async_ignores_terminal_stale_active_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_async_terminal_stale_active.db"
+    manager = _build_manager(db_path)
+
+    run_id, session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("first"),
+        )
+    )
+    assert await manager._await_pending_run_persistence_async(run_id) is True
+    _ = manager._pending_runs.pop(run_id)
+    manager._running_run_ids.add(run_id)
+    manager._injection_manager.activate(run_id)
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.update(
+        run_id,
+        status=RunRuntimeStatus.COMPLETED,
+        phase=RunRuntimePhase.TERMINAL,
+    )
+
+    def _append_followup(
+        run_id: str,
+        content: str,
+        *,
+        enqueue: bool,
+        source: InjectionSource = InjectionSource.USER,
+    ) -> bool:
+        _ = (run_id, content, enqueue, source)
+        raise AssertionError("terminal stale run must not receive follow-up")
+
+    monkeypatch.setattr(manager, "_append_followup_to_coordinator", _append_followup)
+
+    next_run_id, next_session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("second"),
+            yolo=True,
+        )
+    )
+
+    assert next_session_id == session_id
+    assert next_run_id != run_id
+    assert manager._active_run_registry.get_active_run_id(session_id) == next_run_id
+    assert next_run_id in manager._pending_runs
 
 
 @pytest.mark.asyncio
@@ -4009,6 +4318,7 @@ async def test_create_run_async_queues_followup_for_recoverable_run(
             input=content_parts_from_text("first"),
         )
     )
+    assert await manager._await_pending_run_persistence_async(run_id) is True
     _ = manager._pending_runs.pop(run_id)
     runtime_repo = RunRuntimeRepository(db_path)
     runtime_repo.update(
@@ -4249,6 +4559,7 @@ async def test_stop_run_async_cancels_worker_during_startup_writes(
             input=content_parts_from_text("hello"),
         )
     )
+    assert await manager._await_pending_run_persistence_async(run_id) is True
 
     startup_entered = asyncio.Event()
     allow_startup = asyncio.Event()
@@ -4699,6 +5010,109 @@ async def test_stop_run_async_stops_pending_run_without_sync_entrypoint(
     assert json.loads(str(events[-1]["payload_json"])) == {
         "reason": "stopped_before_start"
     }
+
+
+@pytest.mark.asyncio
+async def test_stop_run_async_stops_pending_run_after_persist_failure(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_stop_pending_failed_persist.db"
+    manager = _build_manager(db_path)
+    run_id = "run-pending-failed-persist"
+    session_id = "session-1"
+    manager._pending_runs[run_id] = IntentInput(
+        session_id=session_id,
+        input=content_parts_from_text("hello"),
+    )
+
+    async def _failed_persist() -> None:
+        raise RuntimeError("queued persist failed")
+
+    failed_task = asyncio.create_task(_failed_persist())
+    await asyncio.wait({failed_task}, timeout=1)
+    manager._pending_run_persist_tasks[run_id] = failed_task
+
+    await manager.stop_run_async(run_id)
+
+    assert run_id not in manager._pending_runs
+    assert run_id not in manager._pending_run_persist_tasks
+    runtime = RunRuntimeRepository(db_path).get(run_id)
+    assert runtime is not None
+    assert runtime.status == RunRuntimeStatus.STOPPED
+    assert runtime.last_error == "stopped_before_start"
+
+
+@pytest.mark.asyncio
+async def test_stop_run_async_finalizes_run_waiting_for_worker_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_stop_waiting_capacity.db"
+    manager = _build_manager(db_path)
+    limiter = RunWorkerCapacityLimiter(limit=1)
+    manager._run_worker_capacity = limiter
+
+    capacity_occupied = asyncio.Event()
+    release_capacity = asyncio.Event()
+
+    async def _occupy_capacity() -> None:
+        capacity_occupied.set()
+        await release_capacity.wait()
+
+    occupy_task = asyncio.create_task(
+        limiter.run(
+            run_id="run-occupying-capacity",
+            session_id="session-1",
+            worker=_occupy_capacity,
+        )
+    )
+    await asyncio.wait_for(capacity_occupied.wait(), timeout=5)
+
+    worker_started = asyncio.Event()
+    cleanup_called = asyncio.Event()
+
+    async def _capture_worker(
+        *,
+        run_id: str,
+        session_id: str,
+        runner: Callable[[], Awaitable[RunResult]],
+    ) -> None:
+        _ = (run_id, session_id, runner)
+        worker_started.set()
+
+    monkeypatch.setattr(manager, "_worker", _capture_worker)
+
+    async def _capture_cleanup(*, run_id: str, session_id: str) -> None:
+        assert run_id == "run-waiting"
+        assert session_id == "session-1"
+        cleanup_called.set()
+
+    monkeypatch.setattr(
+        manager,
+        "_handle_startup_cancelled_async",
+        _capture_cleanup,
+    )
+
+    async def _runner() -> RunResult:
+        raise AssertionError("runner must not start while capacity is saturated")
+
+    startup_ready, startup_done, _startup_failed, task = (
+        manager._register_startup_gated_worker(
+            run_id="run-waiting",
+            session_id="session-1",
+            runner=_runner,
+        )
+    )
+    startup_done.set()
+    startup_ready.set()
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.wait_for(task, timeout=5)
+    release_capacity.set()
+    await asyncio.wait_for(occupy_task, timeout=5)
+
+    assert not worker_started.is_set()
+    assert cleanup_called.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_run_split_helpers.py
+++ b/tests/unit_tests/sessions/runs/test_run_split_helpers.py
@@ -26,6 +26,7 @@ from relay_teams.notifications import (
 from relay_teams.providers.provider_contracts import LLMProvider, LLMRequest
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.sessions.runs.media_run_executor import MediaRunExecutor
+import relay_teams.sessions.runs.run_event_publisher as run_event_publisher_module
 from relay_teams.sessions.runs.run_event_publisher import RunEventPublisher
 from relay_teams.sessions.runs.run_interactions import parse_tool_approval_action
 from relay_teams.sessions.runs.enums import RunEventType
@@ -36,7 +37,11 @@ from relay_teams.sessions.runs.run_models import (
     RunKind,
     RunTopologySnapshot,
 )
-from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
+from relay_teams.sessions.runs.run_runtime_repo import (
+    RunRuntimeRecord,
+    RunRuntimeRepository,
+    RunRuntimeStatus,
+)
 from relay_teams.sessions.runs.run_terminal_results import RunTerminalResultService
 from relay_teams.sessions.session_repository import SessionRepository
 from relay_teams.sessions.session_models import SessionMode
@@ -197,6 +202,149 @@ async def test_run_event_publisher_async_runtime_update_does_not_call_sync() -> 
     await publisher.safe_runtime_update_async("run-1", phase="terminal")
 
     assert runtime_repo.async_changes == {"run_id": "run-1", "phase": "terminal"}
+
+
+@pytest.mark.asyncio
+async def test_run_event_publisher_runtime_update_timeout_returns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _SlowRuntimeRepo:
+        def update(self, run_id: str, **changes: object) -> None:
+            _ = (run_id, changes)
+            raise AssertionError("sync update should not be called")
+
+        async def update_async(self, run_id: str, **changes: object) -> None:
+            _ = (run_id, changes)
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        run_event_publisher_module,
+        "_RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        run_event_publisher_module,
+        "_RUN_RUNTIME_UPDATE_RETRY_ATTEMPTS",
+        0,
+    )
+    publisher = RunEventPublisher(
+        run_event_hub=RunEventHub(),
+        get_runtime=lambda _run_id: None,
+        get_run_runtime_repo=lambda: cast(RunRuntimeRepository, _SlowRuntimeRepo()),
+        get_notification_service=lambda: None,
+    )
+
+    await publisher.safe_runtime_update_async("run-1", phase="terminal")
+
+
+@pytest.mark.asyncio
+async def test_run_event_publisher_runtime_update_retries_after_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _RetryRuntimeRepo:
+        def __init__(self) -> None:
+            self.attempts = 0
+            self.retry_completed = asyncio.Event()
+            self.async_changes: dict[str, object] | None = None
+
+        def update(self, run_id: str, **changes: object) -> None:
+            _ = (run_id, changes)
+            raise AssertionError("sync update should not be called")
+
+        async def update_async(self, run_id: str, **changes: object) -> None:
+            self.attempts += 1
+            if self.attempts == 1:
+                await asyncio.Event().wait()
+            self.async_changes = {"run_id": run_id, **changes}
+            self.retry_completed.set()
+
+    monkeypatch.setattr(
+        run_event_publisher_module,
+        "_RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        run_event_publisher_module,
+        "_RUN_RUNTIME_UPDATE_RETRY_ATTEMPTS",
+        2,
+    )
+    monkeypatch.setattr(
+        run_event_publisher_module,
+        "_RUN_RUNTIME_UPDATE_RETRY_DELAY_SECONDS",
+        0.01,
+    )
+    runtime_repo = _RetryRuntimeRepo()
+    publisher = RunEventPublisher(
+        run_event_hub=RunEventHub(),
+        get_runtime=lambda _run_id: None,
+        get_run_runtime_repo=lambda: cast(RunRuntimeRepository, runtime_repo),
+        get_notification_service=lambda: None,
+    )
+
+    await publisher.safe_runtime_update_async("run-1", phase="terminal")
+    await asyncio.wait_for(runtime_repo.retry_completed.wait(), timeout=1)
+
+    assert runtime_repo.attempts == 2
+    assert runtime_repo.async_changes == {"run_id": "run-1", "phase": "terminal"}
+
+
+@pytest.mark.asyncio
+async def test_run_event_publisher_runtime_update_retry_skips_terminal_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _RetryRuntimeRepo:
+        def __init__(self) -> None:
+            self.attempts = 0
+            self.retry_attempted = asyncio.Event()
+
+        def update(self, run_id: str, **changes: object) -> None:
+            _ = (run_id, changes)
+            raise AssertionError("sync update should not be called")
+
+        async def update_async(self, run_id: str, **changes: object) -> None:
+            self.attempts += 1
+            if self.attempts == 1:
+                await asyncio.Event().wait()
+            self.retry_attempted.set()
+            _ = (run_id, changes)
+
+    monkeypatch.setattr(
+        run_event_publisher_module,
+        "_RUN_RUNTIME_UPDATE_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        run_event_publisher_module,
+        "_RUN_RUNTIME_UPDATE_RETRY_ATTEMPTS",
+        2,
+    )
+    monkeypatch.setattr(
+        run_event_publisher_module,
+        "_RUN_RUNTIME_UPDATE_RETRY_DELAY_SECONDS",
+        0.01,
+    )
+    runtime = RunRuntimeRecord(
+        run_id="run-1",
+        session_id="session-1",
+        status=RunRuntimeStatus.RUNNING,
+    )
+    runtime_repo = _RetryRuntimeRepo()
+    publisher = RunEventPublisher(
+        run_event_hub=RunEventHub(),
+        get_runtime=lambda _run_id: runtime,
+        get_run_runtime_repo=lambda: cast(RunRuntimeRepository, runtime_repo),
+        get_notification_service=lambda: None,
+    )
+
+    await publisher.safe_runtime_update_async(
+        "run-1",
+        status=RunRuntimeStatus.RUNNING,
+    )
+    runtime.status = RunRuntimeStatus.COMPLETED
+    await asyncio.sleep(0.05)
+
+    assert runtime_repo.retry_attempted.is_set() is False
+    assert runtime_repo.attempts == 1
 
 
 def test_execute_native_generation_rejects_inline_media_output() -> None:

--- a/tests/unit_tests/sessions/runs/test_run_state_repo.py
+++ b/tests/unit_tests/sessions/runs/test_run_state_repo.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -132,3 +134,60 @@ async def test_run_state_async_schema_init_and_snapshot_upserts(
     assert latest_snapshot is not None
     assert latest_snapshot.checkpoint_event_id == 3
     assert tuple(item.run_id for item in recoverable) == ("run-1",)
+
+
+@pytest.mark.asyncio
+async def test_apply_events_async_coalesces_consecutive_tool_result_snapshots(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "run_state_repo_batch_snapshots.db"
+    repository = RunStateRepository(db_path)
+    started = RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="run-1",
+        task_id="task-1",
+        instance_id="instance-1",
+        event_type=RunEventType.RUN_STARTED,
+        payload_json="{}",
+    )
+    tool_events = tuple(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-1",
+            trace_id="run-1",
+            task_id="task-1",
+            instance_id="instance-1",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json=json.dumps(
+                {
+                    "tool_call_id": f"tool-{index}",
+                    "tool_name": "read",
+                    "status": "completed",
+                }
+            ),
+        )
+        for index in range(50)
+    )
+
+    try:
+        await repository.apply_event_async(event_id=1, event=started)
+        await repository.apply_events_async(
+            event_ids=tuple(range(2, 52)),
+            events=tool_events,
+        )
+    finally:
+        await repository.close_async()
+
+    with sqlite3.connect(db_path) as conn:
+        snapshot_count = conn.execute(
+            "SELECT COUNT(*) FROM run_snapshots WHERE run_id=?",
+            ("run-1",),
+        ).fetchone()[0]
+        latest_checkpoint = conn.execute(
+            "SELECT MAX(checkpoint_event_id) FROM run_snapshots WHERE run_id=?",
+            ("run-1",),
+        ).fetchone()[0]
+
+    assert snapshot_count == 2
+    assert latest_checkpoint == 51

--- a/tests/unit_tests/sessions/runs/test_run_worker_capacity.py
+++ b/tests/unit_tests/sessions/runs/test_run_worker_capacity.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from relay_teams.sessions.runs.run_worker_capacity import RunWorkerCapacityLimiter
+from relay_teams.sessions.runs.run_worker_capacity import run_worker_active_limit
+
+
+@pytest.mark.asyncio
+async def test_run_worker_capacity_limiter_caps_concurrent_workers() -> None:
+    limiter = RunWorkerCapacityLimiter(limit=2)
+    active_count = 0
+    max_active_count = 0
+    active_count_lock = asyncio.Lock()
+    release = asyncio.Event()
+
+    async def worker() -> None:
+        nonlocal active_count, max_active_count
+        async with active_count_lock:
+            active_count += 1
+            max_active_count = max(max_active_count, active_count)
+        await release.wait()
+        async with active_count_lock:
+            active_count -= 1
+
+    tasks = tuple(
+        asyncio.create_task(
+            limiter.run(
+                run_id=f"run-{index}",
+                session_id=f"session-{index}",
+                worker=worker,
+            )
+        )
+        for index in range(5)
+    )
+
+    await asyncio.sleep(0)
+    assert max_active_count == 2
+
+    release.set()
+    await asyncio.gather(*tasks)
+
+
+def test_run_worker_capacity_default_allows_pressure_session_fanout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("RELAY_TEAMS_RUN_WORKER_ACTIVE_LIMIT", raising=False)
+
+    assert run_worker_active_limit() == 32

--- a/tests/unit_tests/sessions/test_session_list_status.py
+++ b/tests/unit_tests/sessions/test_session_list_status.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from json import dumps
 from pathlib import Path
 import sqlite3
+
+import pytest
 
 from relay_teams.sessions.session_service import SessionService
 from relay_teams.agent_runtimes.instances.instance_repository import (
     AgentInstanceRepository,
 )
+from relay_teams.agent_runtimes.instances.enums import (
+    InstanceLifecycle,
+    InstanceStatus,
+)
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.sessions.runs.event_log import EventLog
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
@@ -94,6 +103,224 @@ def test_list_sessions_includes_active_run_overlay(tmp_path: Path) -> None:
     assert idle.active_run_status is None
     assert idle.active_run_phase is None
     assert idle.pending_tool_approval_count == 0
+
+
+def test_get_session_uses_fresh_list_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "session_get_cache.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-active", workspace_id="default")
+    _ = service.list_sessions()
+
+    def _fail_get(session_id: str) -> object:
+        raise AssertionError(f"unexpected repository get for {session_id}")
+
+    monkeypatch.setattr(service._session_repo, "get", _fail_get)
+
+    record = service.get_session("session-active")
+
+    assert record.session_id == "session-active"
+
+
+def test_get_session_includes_subagent_session_count(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_get_subagent_count.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="run-root",
+        trace_id="run-root",
+        session_id="session-1",
+        instance_id="main",
+        role_id="MainAgent",
+        workspace_id="default",
+        status=InstanceStatus.RUNNING,
+        lifecycle=InstanceLifecycle.REUSABLE,
+        parent_instance_id=None,
+    )
+    agent_repo.upsert_instance(
+        run_id="run-sub-1",
+        trace_id="run-sub-1",
+        session_id="session-1",
+        instance_id="sub-1",
+        role_id="Explorer",
+        workspace_id="default",
+        status=InstanceStatus.COMPLETED,
+        lifecycle=InstanceLifecycle.EPHEMERAL,
+        parent_instance_id="main",
+    )
+    agent_repo.upsert_instance(
+        run_id="run-sub-2",
+        trace_id="run-sub-2",
+        session_id="session-1",
+        instance_id="sub-2",
+        role_id="Explorer",
+        workspace_id="default",
+        status=InstanceStatus.RUNNING,
+        lifecycle=InstanceLifecycle.EPHEMERAL,
+        parent_instance_id="main",
+    )
+
+    record = service.get_session("session-1")
+
+    assert record.subagent_session_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_session_async_includes_subagent_session_count(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_get_subagent_count_async.db"
+    service = _build_service(db_path)
+    _ = await service.create_session_async(
+        session_id="session-1",
+        workspace_id="default",
+    )
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="run-sub-1",
+        trace_id="run-sub-1",
+        session_id="session-1",
+        instance_id="sub-1",
+        role_id="Explorer",
+        workspace_id="default",
+        status=InstanceStatus.COMPLETED,
+        lifecycle=InstanceLifecycle.EPHEMERAL,
+        parent_instance_id="main",
+    )
+
+    record = await service.get_session_async("session-1")
+
+    assert record.subagent_session_count == 1
+
+
+def test_spawn_subagent_tool_event_invalidates_session_count_list_cache(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_subagent_count_dirty.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+    cached_sessions = service.list_sessions()
+    assert cached_sessions[0].subagent_session_count == 0
+
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="run-sub-1",
+        trace_id="run-root",
+        session_id="session-1",
+        instance_id="sub-1",
+        role_id="Explorer",
+        workspace_id="default",
+        status=InstanceStatus.RUNNING,
+        lifecycle=InstanceLifecycle.EPHEMERAL,
+        parent_instance_id="main",
+    )
+
+    service._observe_run_event_for_snapshot_dirty(
+        RunEvent(
+            session_id="session-1",
+            run_id="run-root",
+            trace_id="run-root",
+            event_type=RunEventType.TOOL_RESULT,
+            payload_json=dumps({"tool_name": "spawn_subagent"}),
+        )
+    )
+
+    sessions = service.list_sessions()
+
+    assert sessions[0].subagent_session_count == 1
+
+
+def test_create_session_seeds_fast_recovery_snapshot(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_recovery_seed.db"
+    service = _build_service(db_path)
+
+    _ = service.create_session(session_id="session-seeded", workspace_id="default")
+    snapshot = service.get_fast_cached_recovery_snapshot("session-seeded")
+
+    assert snapshot is not None
+    assert snapshot["active_run"] is None
+    assert snapshot["snapshot_cache_hit"] is True
+
+
+def test_delete_session_removes_record_from_stale_list_cache(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_delete_list_cache.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-delete", workspace_id="default")
+    _ = service.list_sessions()
+
+    service.delete_session("session-delete")
+    sessions = service.list_sessions()
+
+    assert [record.session_id for record in sessions] == []
+
+
+def test_terminal_viewed_updates_record_in_stale_list_cache(tmp_path: Path) -> None:
+    db_path = tmp_path / "session_terminal_viewed_list_cache.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-terminal", workspace_id="default")
+    runtime_repo = RunRuntimeRepository(db_path)
+    runtime_repo.ensure(
+        run_id="run-terminal",
+        session_id="session-terminal",
+        root_task_id="task-root-1",
+    )
+    runtime_repo.update(
+        "run-terminal",
+        status=RunRuntimeStatus.COMPLETED,
+        phase=RunRuntimePhase.TERMINAL,
+    )
+    _ = service.list_sessions()
+
+    service.mark_latest_terminal_run_viewed("session-terminal")
+    sessions = service.list_sessions()
+
+    record = sessions[0]
+    assert record.latest_terminal_run_id == "run-terminal"
+    assert record.last_viewed_terminal_run_id == "run-terminal"
+
+
+@pytest.mark.asyncio
+async def test_get_session_async_uses_list_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "session_get_async_cache.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-active", workspace_id="default")
+    _ = service.list_sessions()
+
+    async def _fail_get_async(session_id: str) -> object:
+        raise AssertionError(f"unexpected repository get_async for {session_id}")
+
+    monkeypatch.setattr(service._session_repo, "get_async", _fail_get_async)
+
+    record = await service.get_session_async("session-active")
+
+    assert record.session_id == "session-active"
+
+
+@pytest.mark.asyncio
+async def test_create_session_async_merges_new_session_into_stale_list_cache(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_list_cache_create_merge.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-existing", workspace_id="default")
+    _ = service.list_sessions()
+
+    created = await service.create_session_async(
+        session_id="session-created",
+        workspace_id="default",
+    )
+    sessions = await service.list_sessions_async()
+
+    assert created.session_id == "session-created"
+    assert [record.session_id for record in sessions][:2] == [
+        "session-created",
+        "session-existing",
+    ]
 
 
 def test_list_sessions_by_workspace_filters_sessions(tmp_path: Path) -> None:

--- a/tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py
+++ b/tests/unit_tests/sessions/test_session_rounds_run_state_overlay.py
@@ -13,7 +13,7 @@ from relay_teams.media import content_parts_from_text
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_models import IntentInput
-from relay_teams.sessions import session_service as session_service_module
+from relay_teams.sessions import session_read_models as session_read_models_module
 from relay_teams.sessions.runs.todo_models import TodoItem
 from relay_teams.sessions.runs.todo_models import TodoStatus
 from relay_teams.sessions.runs.todo_repository import TodoRepository
@@ -228,7 +228,7 @@ def test_session_rounds_timeline_bypasses_full_round_projection(
         raise AssertionError("timeline requests should not build full round payloads")
 
     monkeypatch.setattr(
-        session_service_module,
+        session_read_models_module,
         "build_session_rounds",
         fail_full_round_projection,
     )
@@ -270,7 +270,7 @@ def test_session_rounds_summary_pages_lightweight_timeline_without_full_projecti
         raise AssertionError("summary requests should not build full round payloads")
 
     monkeypatch.setattr(
-        session_service_module,
+        session_read_models_module,
         "build_session_rounds",
         fail_full_round_projection,
     )

--- a/tests/unit_tests/sessions/test_session_snapshot_cache.py
+++ b/tests/unit_tests/sessions/test_session_snapshot_cache.py
@@ -1,0 +1,868 @@
+from __future__ import annotations
+
+import asyncio
+from threading import Event, Lock
+from time import monotonic
+from typing import cast
+
+import pytest
+
+from relay_teams.sessions import session_list_cache as session_list_cache_module
+from relay_teams.sessions import session_read_models as session_read_models_module
+from relay_teams.sessions.session_models import SessionRecord
+from relay_teams.sessions.session_repository import SessionRepository
+from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.session_service import (
+    SessionService,
+    _RecoverySnapshotCacheEntry,
+)
+from relay_teams.providers.token_usage_repo import SessionTokenUsage
+
+
+class _SessionRepo:
+    def __init__(self) -> None:
+        self.get_count = 0
+
+    def get(self, session_id: str) -> SessionRecord:
+        self.get_count += 1
+        return SessionRecord(session_id=session_id, workspace_id="workspace-1")
+
+
+def _snapshot_service() -> SessionService:
+    service = cast(SessionService, object.__new__(SessionService))
+    service._recovery_cache_ms = 500
+    service._snapshot_refresh_min_interval_ms = 250
+    service._rounds_snapshot_cache = {}
+    service._rounds_snapshot_cache_lock = Lock()
+    service._rounds_refresh_tasks = {}
+    service._rounds_snapshot_args_by_key = {}
+    service._subagents_snapshot_cache = {}
+    service._subagents_snapshot_cache_lock = Lock()
+    service._subagents_refresh_tasks = {}
+    service._agents_snapshot_cache = {}
+    service._agents_snapshot_cache_lock = Lock()
+    service._agents_refresh_tasks = {}
+    service._tasks_snapshot_cache = {}
+    service._tasks_snapshot_cache_lock = Lock()
+    service._tasks_refresh_tasks = {}
+    service._token_usage_snapshot_cache = {}
+    service._token_usage_snapshot_cache_lock = Lock()
+    service._token_usage_refresh_tasks = {}
+    service._recovery_snapshot_cache = {}
+    service._recovery_snapshot_cache_lock = Lock()
+    service._recovery_refresh_tasks = {}
+    service._session_repo = cast(SessionRepository, _SessionRepo())
+    return service
+
+
+def _run_event(event_type: RunEventType) -> RunEvent:
+    return RunEvent(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="trace-1",
+        event_type=event_type,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_async_stale_hit_returns_cached_records() -> None:
+    service = cast(SessionService, object.__new__(SessionService))
+    service._list_sessions_cache_lock = Lock()
+    service._list_sessions_cache_dirty = True
+    service._list_sessions_cache_ttl_seconds = 0.5
+    service._list_sessions_refresh_task = None
+    service._list_sessions_refresh_started_monotonic = 0.0
+    cached_record = SessionRecord(session_id="session-1", workspace_id="workspace-1")
+    service._list_sessions_cache = (monotonic() - 10, (cached_record,))
+    refresh_count = 0
+    refresh_force_values: list[bool] = []
+
+    def ensure_refresh_task(*, force: bool = False) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        refresh_force_values.append(force)
+
+    service._ensure_list_sessions_refresh_task = ensure_refresh_task
+
+    records = await service.list_sessions_async()
+
+    assert records == (cached_record,)
+    assert refresh_count == 1
+    assert refresh_force_values == [True]
+
+
+def test_merge_session_record_does_not_seed_cold_list_cache_after_create() -> None:
+    service = cast(SessionService, object.__new__(SessionService))
+    service._list_sessions_cache_lock = Lock()
+    service._list_sessions_cache_dirty = False
+    service._list_sessions_cache = None
+    record = SessionRecord(session_id="session-new", workspace_id="workspace-1")
+
+    service._merge_record_into_list_sessions_cache(record)
+
+    assert service._list_sessions_cache is None
+    assert service._list_sessions_cache_dirty is True
+
+
+def test_merge_session_record_updates_existing_list_cache() -> None:
+    service = cast(SessionService, object.__new__(SessionService))
+    service._list_sessions_cache_lock = Lock()
+    service._list_sessions_cache_dirty = False
+    existing = SessionRecord(session_id="session-old", workspace_id="workspace-1")
+    record = SessionRecord(session_id="session-new", workspace_id="workspace-1")
+    service._list_sessions_cache = (monotonic(), (existing,))
+
+    service._merge_record_into_list_sessions_cache(record)
+
+    cached = service._list_sessions_cache
+    assert cached is not None
+    assert cached[1] == (record, existing)
+    assert service._list_sessions_cache_dirty is False
+
+
+def test_list_sessions_cache_env_resolver_ignores_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CACHE_MS", "bad")
+    assert session_list_cache_module.resolve_positive_int_env("CACHE_MS", 500) == 500
+    monkeypatch.setenv("CACHE_MS", "0")
+    assert session_list_cache_module.resolve_positive_int_env("CACHE_MS", 500) == 500
+    monkeypatch.setenv("CACHE_MS", "250")
+    assert session_list_cache_module.resolve_positive_int_env("CACHE_MS", 500) == 250
+    monkeypatch.delenv("CACHE_MS")
+    assert session_list_cache_module.resolve_positive_int_env("CACHE_MS", 500) == 500
+
+
+def test_list_sessions_cache_get_respects_stale_policy() -> None:
+    service = cast(SessionService, object.__new__(SessionService))
+    service._list_sessions_cache_lock = Lock()
+    service._list_sessions_cache_dirty = True
+    service._list_sessions_cache_ttl_seconds = 0.5
+    cached_record = SessionRecord(session_id="session-1", workspace_id="workspace-1")
+    service._list_sessions_cache = (monotonic() - 10, (cached_record,))
+
+    assert service._get_session_from_list_cache("session-1", allow_stale=False) is None
+    assert (
+        service._get_session_from_list_cache("session-1", allow_stale=True)
+        == cached_record
+    )
+    assert service._get_session_from_list_cache("missing", allow_stale=True) is None
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_async_cold_miss_timeout_returns_empty_and_refreshes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = cast(SessionService, object.__new__(SessionService))
+    service._list_sessions_cache_lock = Lock()
+    service._list_sessions_cache_dirty = False
+    service._list_sessions_cache = None
+    service._list_sessions_refresh_task = None
+    refresh_started = 0
+
+    def slow_list_sessions() -> tuple[SessionRecord, ...]:
+        Event().wait(timeout=0.1)
+        return ()
+
+    def ensure_refresh_task(*, force: bool = False) -> None:
+        nonlocal refresh_started
+        _ = force
+        refresh_started += 1
+
+    monkeypatch.setattr(
+        session_list_cache_module,
+        "LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS",
+        0.01,
+    )
+    service.list_sessions = slow_list_sessions
+    service._ensure_list_sessions_refresh_task = ensure_refresh_task
+
+    records = await service.list_sessions_async()
+
+    assert records == ()
+    assert refresh_started == 1
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_refresh_observer_clears_task_and_retries_dirty_cache() -> (
+    None
+):
+    service = cast(SessionService, object.__new__(SessionService))
+    service._list_sessions_cache_lock = Lock()
+    service._list_sessions_cache_dirty = True
+    refresh_force_values: list[bool] = []
+
+    async def fail_refresh() -> None:
+        raise RuntimeError("refresh failed")
+
+    def ensure_refresh_task(*, force: bool = False) -> None:
+        refresh_force_values.append(force)
+
+    task = asyncio.create_task(fail_refresh())
+    service._list_sessions_refresh_task = task
+    service._ensure_list_sessions_refresh_task = ensure_refresh_task
+
+    await asyncio.gather(task, return_exceptions=True)
+    service._observe_list_sessions_refresh_result(task)
+
+    assert service._list_sessions_refresh_task is None
+    assert refresh_force_values == [True]
+
+
+def test_seed_empty_session_snapshot_caches_primes_switch_read_models() -> None:
+    service = _snapshot_service()
+
+    service._seed_empty_session_snapshot_caches("session-1")
+
+    recovery_snapshot = service.get_fast_cached_recovery_snapshot("session-1")
+    agents_snapshot = service.get_fast_cached_agents_snapshot("session-1")
+    subagents_snapshot = service.get_fast_cached_normal_mode_subagents_snapshot(
+        "session-1"
+    )
+    assert recovery_snapshot is not None
+    assert agents_snapshot is not None
+    assert subagents_snapshot is not None
+    assert agents_snapshot["items"] == []
+    assert subagents_snapshot["items"] == []
+    assert service._tasks_snapshot_cache["tasks|session-1"].snapshot["items"] == []
+    assert (
+        service._token_usage_snapshot_cache["token_usage|session-1"].snapshot[
+            "total_tokens"
+        ]
+        == 0
+    )
+    assert service._rounds_snapshot_cache["session-1|4||0|1"].snapshot["items"] == []
+    assert service._rounds_snapshot_args_by_key["session-1|4||0|1"] == (
+        "session-1",
+        4,
+        None,
+        False,
+        True,
+    )
+    assert service._rounds_snapshot_args_by_key["session-1|8||0|0"] == (
+        "session-1",
+        8,
+        None,
+        False,
+        False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_session_snapshot_caches_removes_deleted_session_entries() -> None:
+    service = _snapshot_service()
+    service._seed_empty_session_snapshot_caches("session-1")
+    service._seed_empty_session_snapshot_caches("session-2")
+    never_complete = asyncio.Event()
+
+    async def wait_forever() -> None:
+        await never_complete.wait()
+
+    recovery_task = asyncio.create_task(wait_forever())
+    rounds_task = asyncio.create_task(wait_forever())
+    service._recovery_refresh_tasks["session-1"] = recovery_task
+    service._rounds_refresh_tasks["session-1|8||0|0"] = rounds_task
+
+    service._clear_session_snapshot_caches("session-1")
+    await asyncio.sleep(0)
+    _ = await asyncio.gather(recovery_task, rounds_task, return_exceptions=True)
+
+    assert service.get_fast_cached_recovery_snapshot("session-1") is None
+    assert service.get_fast_cached_recovery_snapshot("session-2") is not None
+    assert service._subagents_snapshot_key("session-1") not in (
+        service._subagents_snapshot_cache
+    )
+    assert (
+        service._agents_snapshot_key("session-1") not in service._agents_snapshot_cache
+    )
+    assert service._tasks_snapshot_key("session-1") not in service._tasks_snapshot_cache
+    assert (
+        service._token_usage_snapshot_key("session-1")
+        not in service._token_usage_snapshot_cache
+    )
+    assert all(
+        not key.startswith("session-1|") for key in service._rounds_snapshot_cache
+    )
+    assert all(
+        not key.startswith("session-1|") for key in service._rounds_snapshot_args_by_key
+    )
+    assert "session-1" not in service._recovery_refresh_tasks
+    assert "session-1|8||0|0" not in service._rounds_refresh_tasks
+    assert recovery_task.cancelled()
+    assert rounds_task.cancelled()
+
+
+def test_stream_delta_event_does_not_dirty_session_list_cache() -> None:
+    service = _snapshot_service()
+    service._list_sessions_cache_dirty = False
+    refresh_count = 0
+
+    def ensure_list_sessions_refresh_task(*, force: bool = False) -> None:
+        nonlocal refresh_count
+        _ = force
+        refresh_count += 1
+
+    service._ensure_list_sessions_refresh_task = ensure_list_sessions_refresh_task
+
+    service._observe_run_event_for_snapshot_dirty(_run_event(RunEventType.TEXT_DELTA))
+
+    assert service._list_sessions_cache_dirty is False
+    assert refresh_count == 0
+
+
+def test_snapshot_cache_env_resolver_and_key_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _snapshot_service()
+
+    monkeypatch.setenv("RELAY_TEAMS_SESSION_SNAPSHOT_CACHE_MS", "750")
+    assert service._resolve_session_snapshot_cache_ms() == 750
+    monkeypatch.delenv("RELAY_TEAMS_SESSION_SNAPSHOT_CACHE_MS")
+    monkeypatch.setenv("RELAY_TEAMS_SESSION_RECOVERY_CACHE_MS", "650")
+    assert service._resolve_session_snapshot_cache_ms() == 650
+    monkeypatch.setenv("RELAY_TEAMS_SESSION_RECOVERY_CACHE_MS", "bad")
+    assert service._resolve_session_snapshot_cache_ms() == 1000
+
+    assert service._subagents_snapshot_key("session-1") == "subagents|session-1"
+    assert service._agents_snapshot_key("session-1") == "agents|session-1"
+    assert service._tasks_snapshot_key("session-1") == "tasks|session-1"
+    assert service._token_usage_snapshot_key("session-1") == "token_usage|session-1"
+
+
+def test_mark_dirty_and_schedule_refresh_cover_all_snapshot_kinds() -> None:
+    service = _snapshot_service()
+    service._seed_empty_session_snapshot_caches("session-1")
+    service._rounds_snapshot_cache["session-1|custom||0|0"] = (
+        _RecoverySnapshotCacheEntry(
+            snapshot={"items": []}, updated_monotonic=monotonic()
+        )
+    )
+    service._rounds_snapshot_args_by_key["session-1|custom||0|0"] = (
+        "session-1",
+        4,
+        None,
+        False,
+        False,
+    )
+    called: list[tuple[str, str]] = []
+    service._ensure_recovery_refresh_task = lambda session_id: called.append(
+        ("recovery", session_id)
+    )
+    service._ensure_subagents_refresh_task = lambda session_id: called.append(
+        ("subagents", session_id)
+    )
+    service._ensure_agents_refresh_task = lambda session_id: called.append(
+        ("agents", session_id)
+    )
+    service._ensure_tasks_refresh_task = lambda session_id: called.append(
+        ("tasks", session_id)
+    )
+    service._ensure_token_usage_refresh_task = lambda session_id: called.append(
+        ("token_usage", session_id)
+    )
+    service._ensure_rounds_refresh_task = lambda cache_key: called.append(
+        ("rounds", cache_key)
+    )
+
+    service._mark_session_snapshot_cache_dirty(
+        "session-1",
+        requires_fresh_read=True,
+    )
+    service._schedule_dirty_session_snapshot_refresh("session-1")
+
+    assert service._recovery_snapshot_cache["session-1"].requires_fresh_read is True
+    assert (
+        service._subagents_snapshot_cache["subagents|session-1"].requires_fresh_read
+        is True
+    )
+    assert (
+        service._agents_snapshot_cache["agents|session-1"].requires_fresh_read is True
+    )
+    assert service._tasks_snapshot_cache["tasks|session-1"].requires_fresh_read is True
+    assert (
+        service._token_usage_snapshot_cache["token_usage|session-1"].requires_fresh_read
+        is True
+    )
+    assert ("recovery", "session-1") in called
+    assert ("subagents", "session-1") in called
+    assert ("agents", "session-1") in called
+    assert ("tasks", "session-1") in called
+    assert ("token_usage", "session-1") in called
+    assert ("rounds", "session-1|custom||0|0") in called
+
+
+@pytest.mark.asyncio
+async def test_run_started_event_dirties_session_list_cache_once() -> None:
+    service = _snapshot_service()
+    service._list_sessions_cache_lock = Lock()
+    service._list_sessions_cache_dirty = False
+    service._list_sessions_cache_version = 0
+    refresh_force_values: list[bool] = []
+
+    def ensure_list_sessions_refresh_task(*, force: bool = False) -> None:
+        refresh_force_values.append(force)
+
+    service._ensure_list_sessions_refresh_task = ensure_list_sessions_refresh_task
+
+    service._observe_run_event_for_snapshot_dirty(_run_event(RunEventType.RUN_STARTED))
+
+    assert service._list_sessions_cache_dirty is True
+    assert service._list_sessions_cache_version == 1
+    assert refresh_force_values == [True]
+
+
+def test_fast_rounds_snapshot_returns_cached_response_without_thread_hop() -> None:
+    service = _snapshot_service()
+    key = "session-1|8||0|0"
+    service._rounds_snapshot_cache[key] = _RecoverySnapshotCacheEntry(
+        snapshot={"items": ["cached"]},
+        updated_monotonic=monotonic(),
+    )
+
+    snapshot = service.get_fast_cached_session_rounds_snapshot("session-1")
+
+    assert snapshot is not None
+    assert snapshot["items"] == ["cached"]
+    assert snapshot["stale"] is False
+    assert snapshot["snapshot_cache_hit"] is True
+
+
+@pytest.mark.asyncio
+async def test_rounds_snapshot_cache_fresh_hit_skips_projection_refresh() -> None:
+    service = _snapshot_service()
+    key = "session-1|8||0|0"
+    service._rounds_snapshot_cache[key] = _RecoverySnapshotCacheEntry(
+        snapshot={"items": ["cached"]},
+        updated_monotonic=asyncio.get_running_loop().time(),
+    )
+
+    async def fail_build_rounds_snapshot_async(
+        session_id: str,
+        *,
+        limit: int,
+        cursor_run_id: str | None,
+        timeline: bool,
+        summary: bool,
+    ) -> dict[str, object]:
+        _ = (session_id, limit, cursor_run_id, timeline, summary)
+        raise AssertionError("fresh cache hit should not rebuild rounds")
+
+    service._build_rounds_snapshot_async = fail_build_rounds_snapshot_async
+
+    snapshot = await service.get_cached_session_rounds_async("session-1")
+
+    assert snapshot["items"] == ["cached"]
+    assert snapshot["stale"] is False
+    assert snapshot["snapshot_cache_hit"] is True
+
+
+@pytest.mark.asyncio
+async def test_rounds_snapshot_cache_stale_hit_returns_and_refreshes_once() -> None:
+    service = _snapshot_service()
+    key = "session-1|8||0|0"
+    entry = _RecoverySnapshotCacheEntry(
+        snapshot={"items": ["old"]},
+        updated_monotonic=asyncio.get_running_loop().time() - 10.0,
+    )
+    service._rounds_snapshot_cache[key] = entry
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+    refresh_count = 0
+
+    async def build_rounds_snapshot_async(
+        session_id: str,
+        *,
+        limit: int,
+        cursor_run_id: str | None,
+        timeline: bool,
+        summary: bool,
+    ) -> dict[str, object]:
+        nonlocal refresh_count
+        _ = (session_id, limit, cursor_run_id, timeline, summary)
+        refresh_count += 1
+        refresh_started.set()
+        await release_refresh.wait()
+        return {"items": ["new"]}
+
+    service._build_rounds_snapshot_async = build_rounds_snapshot_async
+
+    first = await service.get_cached_session_rounds_async("session-1")
+    second = await service.get_cached_session_rounds_async("session-1")
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+    release_refresh.set()
+    await asyncio.gather(*service._rounds_refresh_tasks.values())
+
+    assert first["items"] == ["old"]
+    assert first["stale"] is True
+    assert second["items"] == ["old"]
+    assert refresh_count == 1
+    assert service._rounds_snapshot_cache[key].snapshot["items"] == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_rounds_snapshot_requires_fresh_read_returns_stale_then_refreshes() -> (
+    None
+):
+    service = _snapshot_service()
+    key = "session-1|8||0|0"
+    entry = _RecoverySnapshotCacheEntry(
+        snapshot={"items": ["old"]},
+        updated_monotonic=asyncio.get_running_loop().time(),
+    )
+    entry.dirty = True
+    entry.requires_fresh_read = True
+    service._rounds_snapshot_cache[key] = entry
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+    build_count = 0
+
+    async def build_rounds_snapshot_async(
+        session_id: str,
+        *,
+        limit: int,
+        cursor_run_id: str | None,
+        timeline: bool,
+        summary: bool,
+    ) -> dict[str, object]:
+        nonlocal build_count
+        _ = (session_id, limit, cursor_run_id, timeline, summary)
+        build_count += 1
+        refresh_started.set()
+        await release_refresh.wait()
+        return {"items": ["fresh"]}
+
+    service._build_rounds_snapshot_async = build_rounds_snapshot_async
+
+    fast_snapshot = service.get_fast_cached_session_rounds_snapshot("session-1")
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+    snapshot = await service.get_cached_session_rounds_async("session-1")
+    release_refresh.set()
+    await asyncio.gather(*service._rounds_refresh_tasks.values())
+
+    assert fast_snapshot is not None
+    assert fast_snapshot["items"] == ["old"]
+    assert fast_snapshot["stale"] is True
+    assert snapshot["items"] == ["old"]
+    assert snapshot["stale"] is True
+    assert service._rounds_snapshot_cache[key].snapshot["items"] == ["fresh"]
+    assert build_count == 1
+
+
+@pytest.mark.asyncio
+async def test_rounds_snapshot_cold_miss_builds_once_within_fast_budget() -> None:
+    service = _snapshot_service()
+    key = "session-1|8||0|0"
+    build_count = 0
+
+    async def build_rounds_snapshot_async(
+        session_id: str,
+        *,
+        limit: int,
+        cursor_run_id: str | None,
+        timeline: bool,
+        summary: bool,
+    ) -> dict[str, object]:
+        nonlocal build_count
+        _ = (session_id, limit, cursor_run_id, timeline, summary)
+        build_count += 1
+        return {"items": ["new"]}
+
+    service._build_rounds_snapshot_async = build_rounds_snapshot_async
+
+    snapshot = await service.get_cached_session_rounds_async("session-1")
+
+    assert snapshot["items"] == ["new"]
+    assert snapshot["stale"] is False
+    assert snapshot["snapshot_cache_hit"] is False
+    assert build_count == 1
+    assert service._rounds_snapshot_cache[key].snapshot["items"] == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_recovery_snapshot_cold_miss_builds_once_within_fast_budget() -> None:
+    service = _snapshot_service()
+    build_count = 0
+
+    async def get_recovery_snapshot_async(session_id: str) -> dict[str, object]:
+        nonlocal build_count
+        _ = session_id
+        build_count += 1
+        return {"active_run": {"run_id": "new-run"}}
+
+    service.get_recovery_snapshot_async = get_recovery_snapshot_async
+
+    snapshot = await service.get_cached_recovery_snapshot_async("session-1")
+
+    assert snapshot["active_run"] == {"run_id": "new-run"}
+    assert snapshot["stale"] is False
+    assert snapshot["snapshot_cache_hit"] is False
+    assert build_count == 1
+    session_repo = cast(_SessionRepo, service._session_repo)
+    assert session_repo.get_count == 1
+    assert service._recovery_snapshot_cache["session-1"].snapshot["active_run"] == {
+        "run_id": "new-run"
+    }
+
+
+@pytest.mark.asyncio
+async def test_fast_recovery_snapshot_stale_dirty_hit_refreshes_once() -> None:
+    service = _snapshot_service()
+    entry = _RecoverySnapshotCacheEntry(
+        snapshot={"active_run": None},
+        updated_monotonic=asyncio.get_running_loop().time() - 10.0,
+    )
+    entry.dirty = True
+    service._recovery_snapshot_cache["session-1"] = entry
+    refresh_started = asyncio.Event()
+    release_refresh = Event()
+    refresh_count = 0
+
+    def get_recovery_snapshot(session_id: str) -> dict[str, object]:
+        nonlocal refresh_count
+        _ = session_id
+        refresh_count += 1
+        refresh_started.set()
+        release_refresh.wait(timeout=1)
+        return {"active_run": {"run_id": "fresh-run"}}
+
+    service.get_recovery_snapshot = get_recovery_snapshot
+
+    first = service.get_fast_cached_recovery_snapshot("session-1")
+    second = service.get_fast_cached_recovery_snapshot("session-1")
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+    release_refresh.set()
+    await asyncio.gather(*service._recovery_refresh_tasks.values())
+
+    assert first is not None
+    assert second is not None
+    assert first["active_run"] is None
+    assert first["stale"] is True
+    assert second["active_run"] is None
+    assert refresh_count == 1
+    assert service._recovery_snapshot_cache["session-1"].snapshot["active_run"] == {
+        "run_id": "fresh-run"
+    }
+
+
+@pytest.mark.asyncio
+async def test_recovery_snapshot_requires_fresh_read_returns_stale_then_refreshes() -> (
+    None
+):
+    service = _snapshot_service()
+    entry = _RecoverySnapshotCacheEntry(
+        snapshot={"active_run": None},
+        updated_monotonic=asyncio.get_running_loop().time(),
+    )
+    entry.requires_fresh_read = True
+    service._recovery_snapshot_cache["session-1"] = entry
+    refresh_started = asyncio.Event()
+    release_refresh = Event()
+    refresh_count = 0
+
+    def get_recovery_snapshot(session_id: str) -> dict[str, object]:
+        nonlocal refresh_count
+        _ = session_id
+        refresh_count += 1
+        refresh_started.set()
+        release_refresh.wait(timeout=1)
+        return {"active_run": {"run_id": "fresh-run"}}
+
+    service.get_recovery_snapshot = get_recovery_snapshot
+
+    fast_snapshot = service.get_fast_cached_recovery_snapshot("session-1")
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+    snapshot = await service.get_cached_recovery_snapshot_async("session-1")
+    release_refresh.set()
+    await asyncio.gather(*service._recovery_refresh_tasks.values())
+
+    assert fast_snapshot is not None
+    assert fast_snapshot["active_run"] is None
+    assert fast_snapshot["stale"] is True
+    assert snapshot["active_run"] is None
+    assert snapshot["stale"] is True
+    assert service._recovery_snapshot_cache["session-1"].snapshot["active_run"] == {
+        "run_id": "fresh-run"
+    }
+    assert refresh_count == 1
+
+
+@pytest.mark.asyncio
+async def test_agents_snapshot_cache_fresh_hit_skips_repository_scan() -> None:
+    service = _snapshot_service()
+    key = "agents|session-1"
+    service._agents_snapshot_cache[key] = _RecoverySnapshotCacheEntry(
+        snapshot={"items": [{"role_id": "cached"}]},
+        updated_monotonic=asyncio.get_running_loop().time(),
+    )
+
+    async def fail_build_agents_snapshot_async(session_id: str) -> dict[str, object]:
+        _ = session_id
+        raise AssertionError("fresh agents cache hit should not rebuild")
+
+    service._build_agents_snapshot_async = fail_build_agents_snapshot_async
+
+    agents = await service.list_cached_agents_in_session_async("session-1")
+
+    assert agents == ({"role_id": "cached"},)
+
+
+@pytest.mark.asyncio
+async def test_agents_snapshot_cache_cold_miss_returns_built_snapshot() -> None:
+    service = _snapshot_service()
+    build_count = 0
+
+    async def build_agents_snapshot_async(session_id: str) -> dict[str, object]:
+        nonlocal build_count
+        assert session_id == "session-1"
+        build_count += 1
+        return {
+            "items": [{"role_id": "coordinator", "instance_id": "agent-1"}],
+            "snapshot_refresh_ms": 1,
+            "snapshot_cache_hit": False,
+        }
+
+    service._build_agents_snapshot_async = build_agents_snapshot_async
+
+    agents = await service.list_cached_agents_in_session_async("session-1")
+
+    assert agents == ({"role_id": "coordinator", "instance_id": "agent-1"},)
+    assert build_count == 1
+    cached = service._agents_snapshot_cache["agents|session-1"]
+    assert cached.snapshot["items"] == [
+        {"role_id": "coordinator", "instance_id": "agent-1"}
+    ]
+    assert cached.dirty is False
+
+
+@pytest.mark.asyncio
+async def test_tasks_snapshot_cache_cold_miss_returns_built_snapshot() -> None:
+    service = _snapshot_service()
+    build_count = 0
+
+    async def build_tasks_snapshot_async(session_id: str) -> dict[str, object]:
+        nonlocal build_count
+        assert session_id == "session-1"
+        build_count += 1
+        return {
+            "items": [{"task_id": "task-1", "status": "running"}],
+            "snapshot_refresh_ms": 1,
+            "snapshot_cache_hit": False,
+        }
+
+    service._build_tasks_snapshot_async = build_tasks_snapshot_async
+
+    tasks = await service.list_cached_session_tasks_async("session-1")
+
+    assert tasks == ({"task_id": "task-1", "status": "running"},)
+    assert build_count == 1
+    cached = service._tasks_snapshot_cache["tasks|session-1"]
+    assert cached.snapshot["items"] == [{"task_id": "task-1", "status": "running"}]
+    assert cached.dirty is False
+
+
+@pytest.mark.asyncio
+async def test_tasks_snapshot_stale_hit_refreshes_once() -> None:
+    service = _snapshot_service()
+    key = "tasks|session-1"
+    service._tasks_snapshot_cache[key] = _RecoverySnapshotCacheEntry(
+        snapshot={"items": [{"task_id": "old"}]},
+        updated_monotonic=asyncio.get_running_loop().time() - 10.0,
+    )
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+    refresh_count = 0
+
+    async def build_tasks_snapshot_async(session_id: str) -> dict[str, object]:
+        nonlocal refresh_count
+        _ = session_id
+        refresh_count += 1
+        refresh_started.set()
+        await release_refresh.wait()
+        return {"items": [{"task_id": "new"}]}
+
+    service._build_tasks_snapshot_async = build_tasks_snapshot_async
+
+    first = await service.list_cached_session_tasks_async("session-1")
+    second = await service.list_cached_session_tasks_async("session-1")
+    tasks = tuple(service._tasks_refresh_tasks.values())
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+    release_refresh.set()
+    await asyncio.gather(*tasks)
+
+    assert first == ({"task_id": "old"},)
+    assert second == ({"task_id": "old"},)
+    assert refresh_count == 1
+    assert service._tasks_snapshot_cache[key].snapshot["items"] == [{"task_id": "new"}]
+
+
+@pytest.mark.asyncio
+async def test_token_usage_snapshot_cold_miss_returns_built_snapshot() -> None:
+    service = _snapshot_service()
+    key = "token_usage|session-1"
+
+    async def build_token_usage_snapshot_async(session_id: str) -> dict[str, object]:
+        _ = session_id
+        return {"session_id": "session-1", "total_tokens": 42, "by_role": {}}
+
+    service._build_token_usage_snapshot_async = build_token_usage_snapshot_async
+
+    snapshot = await service.get_cached_token_usage_by_session_snapshot_async(
+        "session-1"
+    )
+
+    assert snapshot["session_id"] == "session-1"
+    assert snapshot["stale"] is False
+    assert snapshot["total_tokens"] == 42
+    assert service._token_usage_snapshot_cache[key].snapshot["total_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_token_usage_snapshot_cold_miss_timeout_returns_stale_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _snapshot_service()
+    key = "token_usage|session-1"
+    refresh_started = asyncio.Event()
+
+    async def build_token_usage_snapshot_async(session_id: str) -> dict[str, object]:
+        _ = session_id
+        refresh_started.set()
+        await asyncio.sleep(0.1)
+        return {"session_id": "session-1", "total_tokens": 42, "by_role": {}}
+
+    service._build_token_usage_snapshot_async = build_token_usage_snapshot_async
+    monkeypatch.setattr(
+        session_read_models_module,
+        "LIST_SESSIONS_COLD_MISS_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    snapshot = await service.get_cached_token_usage_by_session_snapshot_async(
+        "session-1"
+    )
+
+    assert snapshot["session_id"] == "session-1"
+    assert snapshot["stale"] is True
+    assert snapshot["total_tokens"] == 0
+    assert service._token_usage_snapshot_cache[key].snapshot["total_tokens"] == 0
+
+
+def test_token_usage_snapshot_projects_session_summary() -> None:
+    snapshot = SessionService._token_usage_snapshot(
+        SessionTokenUsage(
+            session_id="session-1",
+            total_input_tokens=10,
+            total_cached_input_tokens=2,
+            total_output_tokens=3,
+            total_reasoning_output_tokens=1,
+            total_tokens=13,
+            total_requests=4,
+            total_tool_calls=5,
+            by_role={},
+        )
+    )
+
+    assert snapshot["session_id"] == "session-1"
+    assert snapshot["total_tokens"] == 13
+    assert snapshot["snapshot_cache_hit"] is False

--- a/tests/unit_tests/sessions/test_session_subagent_events.py
+++ b/tests/unit_tests/sessions/test_session_subagent_events.py
@@ -5,6 +5,7 @@ import asyncio
 
 import pytest
 
+from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.agent_runtimes.instances.instance_repository import (
     AgentInstanceRepository,
@@ -51,6 +52,16 @@ async def test_stream_normal_mode_subagent_events_replays_only_subagent_runs(
     event_log = EventLog(db_path)
     service = _build_service(db_path, event_log)
     _ = service.create_session(session_id="session-1", workspace_id="default")
+    service._agent_repo.upsert_instance(
+        run_id="delegated-run-1",
+        trace_id="delegated-run-1",
+        session_id="session-1",
+        instance_id="instance-sub-1",
+        role_id="Explorer",
+        workspace_id="default",
+        status=InstanceStatus.RUNNING,
+        parent_instance_id="instance-main",
+    )
     _ = event_log.emit_run_event(
         RunEvent(
             session_id="session-1",
@@ -63,8 +74,8 @@ async def test_stream_normal_mode_subagent_events_replays_only_subagent_runs(
     subagent_event_id = event_log.emit_run_event(
         RunEvent(
             session_id="session-1",
-            run_id="subagent_run_1",
-            trace_id="subagent_run_1",
+            run_id="delegated-run-1",
+            trace_id="delegated-run-1",
             instance_id="instance-sub-1",
             role_id="Explorer",
             event_type=RunEventType.MODEL_STEP_STARTED,
@@ -80,7 +91,7 @@ async def test_stream_normal_mode_subagent_events_replays_only_subagent_runs(
         )
     ]
 
-    assert [event.run_id for event in events] == ["subagent_run_1"]
+    assert [event.run_id for event in events] == ["delegated-run-1"]
     assert events[0].event_id == subagent_event_id
     assert events[0].instance_id == "instance-sub-1"
 
@@ -97,6 +108,16 @@ async def test_stream_normal_mode_subagent_events_delivers_live_session_events(
     )
     service = _build_service(db_path, event_log, run_event_hub=run_event_hub)
     _ = service.create_session(session_id="session-1", workspace_id="default")
+    service._agent_repo.upsert_instance(
+        run_id="delegated-run-live",
+        trace_id="delegated-run-live",
+        session_id="session-1",
+        instance_id="instance-sub-live",
+        role_id="Explorer",
+        workspace_id="default",
+        status=InstanceStatus.RUNNING,
+        parent_instance_id="instance-main",
+    )
 
     async def read_first_live_subagent_event() -> RunEvent:
         async for event in service.stream_normal_mode_subagent_events(
@@ -125,8 +146,8 @@ async def test_stream_normal_mode_subagent_events_delivers_live_session_events(
     await run_event_hub.publish_async(
         RunEvent(
             session_id="session-1",
-            run_id="subagent_run_live",
-            trace_id="subagent_run_live",
+            run_id="delegated-run-live",
+            trace_id="delegated-run-live",
             event_type=RunEventType.MODEL_STEP_STARTED,
             payload_json="{}",
         )
@@ -134,7 +155,7 @@ async def test_stream_normal_mode_subagent_events_delivers_live_session_events(
 
     delivered = await asyncio.wait_for(task, timeout=1.0)
 
-    assert delivered.run_id == "subagent_run_live"
+    assert delivered.run_id == "delegated-run-live"
     assert delivered.event_id == 2
     for _ in range(20):
         if not run_event_hub.has_session_subscribers("session-1"):
@@ -208,5 +229,5 @@ def test_run_event_from_log_row_rejects_invalid_persisted_rows() -> None:
     assert event is not None
     assert event.event_id == 2
     assert event.run_id == "subagent_run_1"
-    assert SessionService._is_subagent_run_id("subagent_run_1") is True
-    assert SessionService._is_subagent_run_id("run-main") is False
+    assert SessionService._is_legacy_subagent_run_id("subagent_run_1") is True
+    assert SessionService._is_legacy_subagent_run_id("run-main") is False

--- a/tests/unit_tests/tools/runtime/test_argument_binding.py
+++ b/tests/unit_tests/tools/runtime/test_argument_binding.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import inspect
+from enum import Enum
+
+import pytest
+from pydantic import BaseModel
+
+from relay_teams.tools.runtime import argument_binding
+
+
+class _Mode(Enum):
+    FAST = "fast"
+    SLOW = "slow"
+
+
+class _Payload(BaseModel):
+    value: int
+
+
+def test_capture_tool_input_filters_private_excluded_and_unknown_args() -> None:
+    def action(name: str, count: int) -> None:
+        _ = (name, count)
+
+    captured = argument_binding._capture_tool_input(
+        raw_args={
+            "ctx": object(),
+            "_internal": "hidden",
+            "name": "demo",
+            "count": 2,
+            "extra": "ignored",
+        },
+        action=action,
+        exclude=("ctx",),
+    )
+
+    assert captured == {"name": "demo", "count": 2}
+
+
+def test_capture_tool_input_dict_action_accepts_all_public_args() -> None:
+    def action(tool_input: dict[str, object]) -> None:
+        _ = tool_input
+
+    captured = argument_binding._capture_tool_input(
+        raw_args={"ctx": object(), "name": "demo", "enabled": True},
+        action=action,
+        exclude=("ctx",),
+    )
+
+    assert captured == {"name": "demo", "enabled": True}
+
+
+def test_tool_input_parameter_names_handles_non_callable_and_var_kwargs() -> None:
+    def action(name: str, *args: object, **kwargs: object) -> None:
+        _ = (name, args, kwargs)
+
+    assert argument_binding._tool_input_parameter_names(object()) is None
+    assert argument_binding._tool_input_parameter_names(action) == {"name"}
+
+
+def test_bind_tool_action_kwargs_coerces_common_types() -> None:
+    def action(
+        payload: _Payload,
+        payloads: list[_Payload],
+        mode: _Mode,
+        enabled: bool,
+        count: int,
+        ratio: float,
+        names: tuple,
+        items: list,
+        **kwargs: object,
+    ) -> None:
+        _ = (payload, payloads, mode, enabled, count, ratio, names, items, kwargs)
+
+    parameters = list(inspect.signature(action).parameters.values())
+    kwargs = argument_binding._bind_tool_action_kwargs(
+        parameters=parameters,
+        tool_input={
+            "payload": {"value": 1},
+            "payloads": [{"value": 2}],
+            "mode": "fast",
+            "enabled": "yes",
+            "count": "3",
+            "ratio": "4.5",
+            "names": ["a", "b"],
+            "items": ["x", "y"],
+            "extra": "kept",
+        },
+        resolved_annotations={
+            "payload": _Payload,
+            "payloads": list[_Payload],
+            "mode": _Mode,
+            "enabled": bool,
+            "count": int,
+            "ratio": float,
+            "names": tuple,
+            "items": list,
+        },
+    )
+
+    assert kwargs["payload"] == _Payload(value=1)
+    assert kwargs["payloads"] == [_Payload(value=2)]
+    assert kwargs["mode"] is _Mode.FAST
+    assert kwargs["enabled"] is True
+    assert kwargs["count"] == 3
+    assert kwargs["ratio"] == 4.5
+    assert kwargs["names"] == ("a", "b")
+    assert kwargs["items"] == ["x", "y"]
+    assert kwargs["extra"] == "kept"
+
+
+def test_bind_tool_action_kwargs_uses_defaults_for_type_coercion() -> None:
+    def action(
+        enabled: bool = False,
+        count: int = 0,
+        ratio: float = 0.0,
+        mode: _Mode = _Mode.SLOW,
+    ) -> None:
+        _ = (enabled, count, ratio, mode)
+
+    kwargs = argument_binding._bind_tool_action_kwargs(
+        parameters=list(inspect.signature(action).parameters.values()),
+        tool_input={
+            "enabled": 1,
+            "count": 2.8,
+            "ratio": True,
+            "mode": "fast",
+        },
+    )
+
+    assert kwargs == {
+        "enabled": True,
+        "count": 2,
+        "ratio": 1.0,
+        "mode": _Mode.FAST,
+    }
+
+
+def test_bind_tool_action_kwargs_resolves_optional_model_and_enum_annotations() -> None:
+    def action(payload: _Payload | None, mode: _Mode | None) -> None:
+        _ = (payload, mode)
+
+    kwargs = argument_binding._bind_tool_action_kwargs(
+        parameters=list(inspect.signature(action).parameters.values()),
+        tool_input={"payload": {"value": 5}, "mode": "slow"},
+        resolved_annotations=argument_binding._resolve_tool_action_annotations(action),
+    )
+
+    assert kwargs["payload"] == _Payload(value=5)
+    assert kwargs["mode"] is _Mode.SLOW
+
+
+def test_resolve_tool_action_annotations_returns_empty_for_unresolvable_hints() -> None:
+    def action(name: object) -> None:
+        _ = name
+
+    action.__annotations__["name"] = "MissingType"
+
+    assert argument_binding._resolve_tool_action_annotations(object()) == {}
+    assert argument_binding._resolve_tool_action_annotations(action) == {}
+
+
+def test_bind_tool_action_rejects_unsupported_positional_only() -> None:
+    def action(name: str, /) -> None:
+        _ = name
+
+    with pytest.raises(TypeError, match="Unsupported tool action parameter kind"):
+        argument_binding._bind_tool_action_kwargs(
+            parameters=list(inspect.signature(action).parameters.values()),
+            tool_input={"name": "demo"},
+        )
+
+
+def test_coercion_rejects_blank_numbers() -> None:
+    parameter = inspect.Parameter(
+        "count",
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=int,
+    )
+
+    with pytest.raises(ValueError, match="Cannot coerce tool argument to int"):
+        argument_binding._coerce_tool_argument_for_parameter(
+            value=" ",
+            parameter=parameter,
+            annotation=int,
+        )
+
+
+def test_bool_and_float_coercion_cover_falsey_and_invalid_inputs() -> None:
+    bool_parameter = inspect.Parameter(
+        "enabled",
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=bool,
+    )
+    float_parameter = inspect.Parameter(
+        "ratio",
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=float,
+    )
+
+    assert (
+        argument_binding._coerce_tool_argument_for_parameter(
+            value="off",
+            parameter=bool_parameter,
+            annotation=bool,
+        )
+        is False
+    )
+    assert (
+        argument_binding._coerce_tool_argument_for_parameter(
+            value=[],
+            parameter=bool_parameter,
+            annotation=bool,
+        )
+        is False
+    )
+    with pytest.raises(ValueError, match="Cannot coerce tool argument to float"):
+        argument_binding._coerce_tool_argument_for_parameter(
+            value=" ",
+            parameter=float_parameter,
+            annotation=float,
+        )

--- a/tests/unit_tests/tools/runtime/test_batching_helpers.py
+++ b/tests/unit_tests/tools/runtime/test_batching_helpers.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pydantic import BaseModel
+
+from relay_teams.tools.runtime.json_helpers import (
+    normalize_json_object,
+    normalize_json_value,
+    safe_json,
+)
+from relay_teams.tools.runtime.tool_result_batching import (
+    ToolResultCommitBuffer,
+    ToolResultCommitItem,
+    current_tool_result_commit_buffer,
+    suspended_tool_result_batching,
+    tool_result_batch_scope,
+)
+from relay_teams.tools.runtime.context import ToolContext
+from relay_teams.tools.runtime.persisted_state import ToolExecutionStatus
+
+
+class _JsonPayload(BaseModel):
+    value: int
+
+
+def test_json_helpers_normalize_models_collections_and_fallbacks() -> None:
+    assert normalize_json_object("not-a-dict") == {}
+    assert normalize_json_object({1: _JsonPayload(value=3)}) == {"1": {"value": 3}}
+    normalized = normalize_json_value((_JsonPayload(value=1), object()))
+    assert isinstance(normalized, list)
+    assert normalized[0] == {"value": 1}
+    assert safe_json(object())
+    assert safe_json("x" * 600).endswith("...(truncated)")
+
+
+@pytest.mark.asyncio
+async def test_tool_result_commit_buffer_pop_and_singleflight() -> None:
+    buffer = ToolResultCommitBuffer()
+    item = ToolResultCommitItem(
+        ctx=cast(ToolContext, SimpleNamespace()),
+        tool_call_id="call-1",
+        tool_name="read",
+        args_summary={},
+        visible_envelope={"ok": True},
+        internal_data=None,
+        runtime_meta={},
+        execution_status=ToolExecutionStatus.COMPLETED,
+        tool_content_parts=(),
+        duration_ms=1,
+        success=True,
+    )
+    await buffer.add_async(cast(ToolResultCommitItem, item))
+    assert await buffer.pop_items_async() == (item,)
+    assert await buffer.pop_items_async() == ()
+
+    calls = 0
+
+    async def factory() -> object:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.01)
+        return "value"
+
+    first, second = await asyncio.gather(
+        buffer.invoke_action_singleflight_async(key="shared", factory=factory),
+        buffer.invoke_action_singleflight_async(key="shared", factory=factory),
+    )
+
+    assert calls == 1
+    assert first.value == "value"
+    assert second.value == "value"
+    assert {first.shared, second.shared} == {False, True}
+
+
+@pytest.mark.asyncio
+async def test_allowed_tools_singleflight_and_batch_contexts() -> None:
+    calls = 0
+    with tool_result_batch_scope() as buffer:
+        assert current_tool_result_commit_buffer() is buffer
+
+        async def factory() -> tuple[str, ...] | None:
+            nonlocal calls
+            calls += 1
+            await asyncio.sleep(0.01)
+            return ("read", "grep")
+
+        first, second = await asyncio.gather(
+            buffer.allowed_tools_for_policy_async(key="policy", factory=factory),
+            buffer.allowed_tools_for_policy_async(key="policy", factory=factory),
+        )
+        assert first == ("read", "grep")
+        assert second == ("read", "grep")
+        assert calls == 1
+        with suspended_tool_result_batching():
+            assert current_tool_result_commit_buffer() is None
+        assert current_tool_result_commit_buffer() is buffer
+    assert current_tool_result_commit_buffer() is None

--- a/tests/unit_tests/tools/runtime/test_execution.py
+++ b/tests/unit_tests/tools/runtime/test_execution.py
@@ -8,7 +8,6 @@ import asyncio
 import sqlite3
 import threading
 import time
-from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkdtemp
 from types import SimpleNamespace
@@ -59,6 +58,8 @@ from relay_teams.tools.runtime.execution import (
     _apply_permission_denied_hooks,
     execute_tool,
     execute_tool_call,
+    flush_tool_result_batch_async,
+    tool_result_batch_scope,
 )
 from relay_teams.tools.runtime.models import (
     ToolExecutionError,
@@ -88,9 +89,13 @@ class _TaskDraftPayload(BaseModel):
 class _FakeRunEventHub:
     def __init__(self) -> None:
         self.events = []
+        self.next_event_id = 1
 
-    def publish(self, event) -> None:
+    def publish(self, event) -> int:
         self.events.append(event)
+        event_id = self.next_event_id
+        self.next_event_id += 1
+        return event_id
 
 
 class _FakeInjectionRecord:
@@ -173,17 +178,17 @@ class _FakeApprovalManager:
         _ = kwargs
 
 
-@dataclass(frozen=True)
 class _FakePolicy:
-    needs_approval: bool
-    timeout_seconds: float = 0.01
+    def __init__(self, *, needs_approval: bool, timeout_seconds: float = 0.01) -> None:
+        self.needs_approval = needs_approval
+        self.timeout_seconds = timeout_seconds
 
     def requires_approval(self, tool_name: str) -> bool:
         _ = tool_name
         return self.needs_approval
 
 
-def test_execute_tool_persists_terminal_state_before_publishing_result_event(
+def test_execute_tool_publishes_result_event_before_single_terminal_state_write(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     order: list[tuple[str, bool, int]] = []
@@ -239,27 +244,31 @@ def test_execute_tool_persists_terminal_state_before_publishing_result_event(
 
     assert cast(dict[str, JsonValue], result)["ok"] is True
     assert order == [
-        ("persist", False, 0),
         ("publish", True, 42),
         ("persist", True, 42),
     ]
 
 
-def test_execute_tool_ignores_post_publish_result_linkage_write_failure(
+def test_execute_tool_persists_recovery_state_when_result_event_publish_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    order: list[tuple[str, int]] = []
+    order: list[tuple[str, bool, int]] = []
 
     async def fake_persist_tool_record_async(**kwargs: object) -> None:
+        runtime_meta = cast(dict[str, JsonValue], kwargs["runtime_meta"])
         result_event_id = cast(int, kwargs.get("result_event_id", 0))
-        order.append(("persist", result_event_id))
-        if result_event_id == 42:
-            raise sqlite3.OperationalError("database is locked")
+        order.append(
+            (
+                "persist",
+                runtime_meta.get("tool_result_event_published") is True,
+                result_event_id,
+            )
+        )
 
     async def fake_publish_tool_result_event_async(**kwargs: object) -> int:
         _ = kwargs
-        order.append(("publish", 42))
-        return 42
+        order.append(("publish", True, 0))
+        raise sqlite3.OperationalError("database is locked")
 
     monkeypatch.setattr(
         execution_module,
@@ -289,9 +298,8 @@ def test_execute_tool_ignores_post_publish_result_linkage_write_failure(
 
     assert cast(dict[str, JsonValue], result)["ok"] is True
     assert order == [
-        ("persist", 0),
-        ("publish", 42),
-        ("persist", 42),
+        ("publish", True, 0),
+        ("persist", False, 0),
     ]
 
 
@@ -340,17 +348,20 @@ class _FakeDeps:
         *,
         manager: _FakeApprovalManager,
         policy: _FakePolicy | ToolApprovalPolicy,
+        is_root_task_context: bool = False,
     ) -> None:
         db_path = Path(mkdtemp()) / "runtime.db"
         self.run_id = "run-1"
         self.trace_id = "trace-1"
         self.task_id = "task-1"
+        self.is_root_task_context = is_root_task_context
         self.session_id = "session-1"
         self.session_mode = "orchestration"
         self.run_kind = "generate_image"
         self.workspace_id = "workspace-1"
         self.instance_id = "inst-1"
         self.role_id = "spec_coder"
+        self.runtime_role_resolver: object | None = None
         self.role_registry = RoleRegistry()
         self.role_registry.register(
             RoleDefinition(
@@ -478,6 +489,348 @@ def test_execute_tool_returns_standard_envelope() -> None:
     assert tool_result_payloads[0]["result"] == result
 
 
+@pytest.mark.timeout(5)
+def test_tool_result_batch_scope_flushes_results_and_state_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    manage_states_calls = 0
+    original_manage_states_async = deps.shared_store.manage_states_async
+
+    async def counting_manage_states_async(
+        mutations: tuple[StateMutation, ...],
+        ttl_seconds: int | None = None,
+    ) -> None:
+        nonlocal manage_states_calls
+        manage_states_calls += 1
+        await original_manage_states_async(mutations, ttl_seconds=ttl_seconds)
+
+    monkeypatch.setattr(
+        deps.shared_store,
+        "manage_states_async",
+        counting_manage_states_async,
+    )
+
+    async def run_batch() -> None:
+        with tool_result_batch_scope() as buffer:
+            for index in range(3):
+                ctx = _FakeCtx(deps)
+                ctx.tool_call_id = f"call-read-{index}"
+                result = await execute_tool(
+                    cast(ToolContext, cast(object, ctx)),
+                    tool_name="custom_tool",
+                    args_summary={"path": f"file-{index}.txt"},
+                    action=lambda: "hello",
+                )
+                assert result["ok"] is True
+            assert _tool_result_payloads(deps) == []
+            flushed = await flush_tool_result_batch_async(
+                buffer,
+                published_tool_outcome_ids=set(),
+            )
+            assert flushed is True
+
+    asyncio.run(run_batch())
+
+    assert len(_tool_result_payloads(deps)) == 3
+    assert manage_states_calls == 1
+    state = load_tool_call_state(
+        shared_store=deps.shared_store,
+        task_id=deps.task_id,
+        tool_call_id="call-read-0",
+    )
+    assert state is not None
+    assert state.execution_status == ToolExecutionStatus.COMPLETED
+    assert state.result_event_id > 0
+
+
+def test_lightweight_tool_result_batch_skips_state_persist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    manage_states_calls = 0
+
+    async def counting_manage_states_async(
+        mutations: tuple[StateMutation, ...],
+        ttl_seconds: int | None = None,
+    ) -> None:
+        _ = (mutations, ttl_seconds)
+        nonlocal manage_states_calls
+        manage_states_calls += 1
+
+    monkeypatch.setattr(
+        deps.shared_store,
+        "manage_states_async",
+        counting_manage_states_async,
+    )
+
+    async def run_batch() -> None:
+        with tool_result_batch_scope() as buffer:
+            for index in range(3):
+                ctx = _FakeCtx(deps)
+                ctx.tool_call_id = f"call-read-lightweight-{index}"
+                result = await execute_tool(
+                    cast(ToolContext, cast(object, ctx)),
+                    tool_name="read",
+                    args_summary={"path": f"file-{index}.txt"},
+                    action=lambda: "hello",
+                )
+                assert result["ok"] is True
+            flushed = await flush_tool_result_batch_async(
+                buffer,
+                published_tool_outcome_ids=set(),
+            )
+            assert flushed is True
+
+    asyncio.run(run_batch())
+
+    assert len(_tool_result_payloads(deps)) == 3
+    assert manage_states_calls == 0
+    state = load_tool_call_state(
+        shared_store=deps.shared_store,
+        task_id=deps.task_id,
+        tool_call_id="call-read-lightweight-0",
+    )
+    assert state is None
+
+
+def test_spawn_subagent_tool_result_batch_skips_state_persist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    manage_states_calls = 0
+
+    async def counting_manage_states_async(
+        mutations: tuple[StateMutation, ...],
+        ttl_seconds: int | None = None,
+    ) -> None:
+        _ = (mutations, ttl_seconds)
+        nonlocal manage_states_calls
+        manage_states_calls += 1
+
+    monkeypatch.setattr(
+        deps.shared_store,
+        "manage_states_async",
+        counting_manage_states_async,
+    )
+
+    async def run_batch() -> None:
+        with tool_result_batch_scope() as buffer:
+            for index in range(2):
+                ctx = _FakeCtx(deps)
+                ctx.tool_call_id = f"call-spawn-{index}"
+                result = await execute_tool(
+                    cast(ToolContext, cast(object, ctx)),
+                    tool_name="spawn_subagent",
+                    args_summary={"role_id": "Crafter", "index": index},
+                    action=lambda: {"run_id": f"subagent-run-{index}"},
+                )
+                assert result["ok"] is True
+            flushed = await flush_tool_result_batch_async(
+                buffer,
+                published_tool_outcome_ids=set(),
+            )
+            assert flushed is True
+
+    asyncio.run(run_batch())
+
+    assert len(_tool_result_payloads(deps)) == 2
+    assert manage_states_calls == 0
+    state = load_tool_call_state(
+        shared_store=deps.shared_store,
+        task_id=deps.task_id,
+        tool_call_id="call-spawn-0",
+    )
+    assert state is None
+
+
+@pytest.mark.timeout(5)
+def test_tool_result_batch_scope_singleflights_identical_read_actions() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    action_count = 0
+
+    async def run_batch() -> None:
+        nonlocal action_count
+        with tool_result_batch_scope() as buffer:
+            for index in range(3):
+                ctx = _FakeCtx(deps)
+                ctx.tool_call_id = f"call-read-shared-{index}"
+
+                async def action() -> str:
+                    nonlocal action_count
+                    action_count += 1
+                    return "shared"
+
+                result = await execute_tool(
+                    cast(ToolContext, cast(object, ctx)),
+                    tool_name="read",
+                    args_summary={"path": "same-file.txt"},
+                    action=action,
+                )
+                assert result["ok"] is True
+            flushed = await flush_tool_result_batch_async(
+                buffer,
+                published_tool_outcome_ids=set(),
+            )
+            assert flushed is True
+
+    asyncio.run(run_batch())
+
+    assert action_count == 1
+    assert len(_tool_result_payloads(deps)) == 3
+
+
+def test_tool_result_batch_flush_timeout_covers_publish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+
+    async def slow_publish(
+        items: tuple[execution_module.ToolResultCommitItem, ...],
+    ) -> tuple[int, ...]:
+        await asyncio.sleep(0.05)
+        return tuple(range(1, len(items) + 1))
+
+    monkeypatch.setattr(
+        execution_module,
+        "TOOL_RESULT_BATCH_FLUSH_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        execution_module,
+        "_publish_tool_result_events_batch_async",
+        slow_publish,
+    )
+
+    async def run_batch() -> None:
+        with tool_result_batch_scope() as buffer:
+            ctx = _FakeCtx(deps)
+            ctx.tool_call_id = "call-read-timeout"
+            result = await execute_tool(
+                cast(ToolContext, cast(object, ctx)),
+                tool_name="read",
+                args_summary={"path": "slow.txt"},
+                action=lambda: "hello",
+            )
+            assert result["ok"] is True
+            with pytest.raises(RuntimeError, match="tool_result_batch_flush timed out"):
+                await flush_tool_result_batch_async(
+                    buffer,
+                    published_tool_outcome_ids=set(),
+                )
+
+    asyncio.run(run_batch())
+
+
+def test_execute_tool_root_task_context_keeps_coordinator_runtime_phase() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+        is_root_task_context=True,
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-root-read-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=lambda: "hello",
+        )
+    )
+
+    runtime = deps.run_runtime_repo.get(deps.run_id)
+    assert result["ok"] is True
+    assert runtime is not None
+    assert runtime.phase == RunRuntimePhase.COORDINATOR_RUNNING
+    assert runtime.active_subagent_instance_id is None
+
+
+def test_execute_tool_delegated_task_context_keeps_subagent_runtime_phase() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+        is_root_task_context=False,
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-subagent-read-1"
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=lambda: "hello",
+        )
+    )
+
+    runtime = deps.run_runtime_repo.get(deps.run_id)
+    assert result["ok"] is True
+    assert runtime is not None
+    assert runtime.phase == RunRuntimePhase.SUBAGENT_RUNNING
+    assert runtime.active_subagent_instance_id == deps.instance_id
+
+
+def test_execute_tool_compacts_large_read_result_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        execution_module,
+        "READ_TOOL_STATE_COMPACT_THRESHOLD_BYTES",
+        32,
+    )
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+        is_root_task_context=True,
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-large-read-1"
+    large_content = "x" * 128
+
+    result = asyncio.run(
+        execute_tool(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=lambda: large_content,
+        )
+    )
+
+    state = load_tool_call_state(
+        shared_store=deps.shared_store,
+        task_id=deps.task_id,
+        tool_call_id="call-large-read-1",
+    )
+    assert result["data"] == large_content
+    assert state is not None
+    assert state.result_event_id > 0
+    assert state.result_envelope is not None
+    record = cast(dict[str, JsonValue], state.result_envelope)
+    visible_result = cast(dict[str, JsonValue], record["visible_result"])
+    compact_data = cast(dict[str, JsonValue], visible_result["data"])
+    assert compact_data["state_compacted"] is True
+    assert compact_data["result_event_id"] == state.result_event_id
+    tool_result_payloads = _tool_result_payloads(deps)
+    assert tool_result_payloads[0]["result"] == result
+
+
 def test_execute_tool_marks_reported_failed_result_event_as_error() -> None:
     deps = _FakeDeps(
         manager=_FakeApprovalManager(wait_result=("approve", "")),
@@ -546,6 +899,7 @@ def test_tool_action_limits_live_unpersisted_batch_per_run(
                     ctx=cast(ToolContext, cast(object, ctx)),
                     action=action,
                     tool_input={},
+                    runtime_meta={},
                 )
             )
             for _ in range(10)
@@ -600,6 +954,7 @@ def test_tool_action_run_gate_waiters_do_not_hold_global_capacity(
                 ctx=cast(ToolContext, cast(object, ctx_a)),
                 action=slow_run_a_action,
                 tool_input={},
+                runtime_meta={},
             )
         )
         await first_a_started.wait()
@@ -608,6 +963,7 @@ def test_tool_action_run_gate_waiters_do_not_hold_global_capacity(
                 ctx=cast(ToolContext, cast(object, ctx_a)),
                 action=queued_run_a_action,
                 tool_input={},
+                runtime_meta={},
             )
         )
         await asyncio.sleep(0.02)
@@ -616,6 +972,7 @@ def test_tool_action_run_gate_waiters_do_not_hold_global_capacity(
                 ctx=cast(ToolContext, cast(object, ctx_b)),
                 action=run_b_action,
                 tool_input={},
+                runtime_meta={},
             )
         )
 
@@ -632,6 +989,44 @@ def test_tool_action_run_gate_waiters_do_not_hold_global_capacity(
         assert run_b_started_before_first_a_released is True
         assert results == ["a1", "a2", "b1"]
         assert execution_module._RUN_TOOL_ACTION_GATES == {}
+
+    asyncio.run(_run())
+
+
+def test_tool_action_can_skip_global_capacity_for_sync_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        monkeypatch.setattr(
+            execution_module,
+            "_GLOBAL_TOOL_ACTION_SEMAPHORE",
+            asyncio.Semaphore(0),
+        )
+        execution_module._RUN_TOOL_ACTION_GATES.clear()
+
+        ctx = SimpleNamespace(
+            deps=SimpleNamespace(run_id="run-sync", session_id="session-sync"),
+            tool_call_id="tool-sync",
+        )
+        runtime_meta: dict[str, JsonValue] = {}
+
+        async def action() -> str:
+            return "ok"
+
+        result = await asyncio.wait_for(
+            execution_module._invoke_tool_action_with_limits(
+                ctx=cast(ToolContext, cast(object, ctx)),
+                action=action,
+                tool_input={},
+                runtime_meta=runtime_meta,
+                hold_action_capacity=False,
+            ),
+            timeout=0.1,
+        )
+
+        assert result == "ok"
+        assert runtime_meta["tool_action_capacity_held"] is False
+        assert runtime_meta["action_queue_wait_ms"] == 0
 
     asyncio.run(_run())
 
@@ -1411,6 +1806,53 @@ def test_execute_tool_ignores_domain_failed_status_for_successful_tools() -> Non
     assert observation.error_message == ""
 
 
+@pytest.mark.asyncio
+async def test_tool_result_state_persist_deferred_retries_completed_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=_FakePolicy(needs_approval=False),
+    )
+    ctx = _FakeCtx(deps)
+    calls: list[str] = []
+
+    async def _fake_persist_tool_record_async(**kwargs: object) -> None:
+        calls.append(str(kwargs["tool_call_id"]))
+        if len(calls) == 1:
+            raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(
+        execution_module,
+        "_persist_tool_record_async",
+        _fake_persist_tool_record_async,
+    )
+    monkeypatch.setattr(
+        execution_module,
+        "_DEFERRED_TOOL_STATE_PERSIST_RETRY_DELAYS_SECONDS",
+        (0.001,),
+    )
+
+    persisted = await execution_module._persist_tool_record_best_effort_async(
+        ctx=cast(ToolContext, cast(object, ctx)),
+        tool_call_id="call-deferred",
+        tool_name="shell",
+        args_summary={"command": "echo ok"},
+        visible_envelope={"ok": True},
+        internal_data={"stdout": "ok\n"},
+        runtime_meta={},
+        execution_status=ToolExecutionStatus.COMPLETED,
+        result_event_id=7,
+    )
+    for _ in range(20):
+        if len(calls) >= 2:
+            break
+        await asyncio.sleep(0.01)
+
+    assert persisted is False
+    assert calls == ["call-deferred", "call-deferred"]
+
+
 def test_reported_failure_helper_scopes_to_shell_failure_projections() -> None:
     assert (
         execution_module._reported_failure_from_success_envelope(
@@ -2152,6 +2594,188 @@ def test_execute_tool_denies_pre_tool_use_when_hook_blocks_call() -> None:
     assert result["ok"] is False
     assert error["type"] == "hook_denied"
     assert "blocked" in str(error["message"]).lower()
+
+
+def test_batched_fast_path_does_not_bypass_pre_tool_hook_denial() -> None:
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(
+            yolo=True,
+            guardrails=RuntimeGuardrailPolicy(enabled=False),
+        ),
+    )
+    deps.hook_service = _FakeHookService(
+        HookDecisionType.DENY,
+        reason="Read calls are blocked by hook policy.",
+    )
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-batch-hook-deny"
+    action_calls: list[str] = []
+
+    def action(path: str) -> dict[str, JsonValue]:
+        action_calls.append(path)
+        return {"path": path}
+
+    with tool_result_batch_scope():
+        raw_result = asyncio.run(
+            execute_tool_call(
+                cast(ToolContext, cast(object, ctx)),
+                tool_name="read",
+                args_summary={"path": "README.md"},
+                action=action,
+                raw_args={"ctx": ctx, "path": "README.md"},
+                allow_tool_return=True,
+            )
+        )
+
+    result = cast(dict[str, JsonValue], raw_result)
+    error = cast(dict[str, JsonValue], result["error"])
+    meta = cast(dict[str, JsonValue], result["meta"])
+    assert action_calls == []
+    assert result["ok"] is False
+    assert error["type"] == "hook_denied"
+    assert meta.get("lightweight_batch_fast_path") is None
+
+
+def test_batched_fast_path_allows_noop_hook_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class NoopHookService:
+        def __init__(self) -> None:
+            self.config_reads = 0
+
+        def get_effective_config(self) -> SimpleNamespace:
+            self.config_reads += 1
+            return SimpleNamespace(hooks={})
+
+    monkeypatch.setattr(execution_module, "HookService", NoopHookService)
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(
+            yolo=True,
+            guardrails=RuntimeGuardrailPolicy(enabled=False),
+        ),
+    )
+    hook_service = NoopHookService()
+    deps.hook_service = hook_service
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-batch-noop-hook-service"
+    action_calls: list[str] = []
+
+    def action(path: str) -> dict[str, JsonValue]:
+        action_calls.append(path)
+        return {"path": path}
+
+    async def run_calls() -> tuple[dict[str, JsonValue], dict[str, JsonValue]]:
+        first = await execute_tool_call(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=action,
+            raw_args={"ctx": ctx, "path": "README.md"},
+            allow_tool_return=True,
+        )
+        ctx.tool_call_id = "call-batch-noop-hook-service-2"
+        second = await execute_tool_call(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=action,
+            raw_args={"ctx": ctx, "path": "README.md"},
+            allow_tool_return=True,
+        )
+        return (
+            cast(dict[str, JsonValue], first),
+            cast(dict[str, JsonValue], second),
+        )
+
+    with tool_result_batch_scope():
+        first_result, second_result = asyncio.run(run_calls())
+
+    first_meta = cast(dict[str, JsonValue], first_result["meta"])
+    second_meta = cast(dict[str, JsonValue], second_result["meta"])
+    assert action_calls == ["README.md"]
+    assert first_result["ok"] is True
+    assert second_result["ok"] is True
+    assert first_meta.get("lightweight_batch_fast_path") is True
+    assert second_meta.get("lightweight_batch_fast_path") is True
+    assert hook_service.config_reads == 1
+
+
+def test_batched_fast_path_caches_role_contract_lookup() -> None:
+    class CountingRoleResolver:
+        def __init__(self) -> None:
+            self.reads = 0
+            self.role = RoleDefinition(
+                role_id="spec_coder",
+                name="Spec Coder",
+                description="Implements requested changes.",
+                version="1",
+                tools=("read",),
+                system_prompt="Implement tasks.",
+            )
+
+        def get_effective_role(
+            self,
+            *,
+            run_id: str | None,
+            role_id: str,
+        ) -> RoleDefinition:
+            _ = (run_id, role_id)
+            self.reads += 1
+            return self.role
+
+    deps = _FakeDeps(
+        manager=_FakeApprovalManager(wait_result=("approve", "")),
+        policy=ToolApprovalPolicy(
+            yolo=True,
+            guardrails=RuntimeGuardrailPolicy(enabled=False),
+        ),
+    )
+    role_resolver = CountingRoleResolver()
+    deps.runtime_role_resolver = role_resolver
+    ctx = _FakeCtx(deps)
+    ctx.tool_call_id = "call-batch-role-cache"
+    action_calls: list[str] = []
+
+    def action(path: str) -> dict[str, JsonValue]:
+        action_calls.append(path)
+        return {"path": path}
+
+    async def run_calls() -> tuple[dict[str, JsonValue], dict[str, JsonValue]]:
+        first = await execute_tool_call(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=action,
+            raw_args={"ctx": ctx, "path": "README.md"},
+            allow_tool_return=True,
+        )
+        ctx.tool_call_id = "call-batch-role-cache-2"
+        second = await execute_tool_call(
+            cast(ToolContext, cast(object, ctx)),
+            tool_name="read",
+            args_summary={"path": "README.md"},
+            action=action,
+            raw_args={"ctx": ctx, "path": "README.md"},
+            allow_tool_return=True,
+        )
+        return (
+            cast(dict[str, JsonValue], first),
+            cast(dict[str, JsonValue], second),
+        )
+
+    with tool_result_batch_scope():
+        first_result, second_result = asyncio.run(run_calls())
+
+    first_meta = cast(dict[str, JsonValue], first_result["meta"])
+    second_meta = cast(dict[str, JsonValue], second_result["meta"])
+    assert action_calls == ["README.md"]
+    assert first_result["ok"] is True
+    assert second_result["ok"] is True
+    assert first_meta.get("lightweight_batch_fast_path") is True
+    assert second_meta.get("lightweight_batch_fast_path") is True
+    assert role_resolver.reads == 1
 
 
 def test_execute_tool_runs_permission_denied_hook_when_user_denies() -> None:

--- a/tests/unit_tests/tools/runtime/test_role_contract_interception.py
+++ b/tests/unit_tests/tools/runtime/test_role_contract_interception.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from relay_teams.roles.role_contracts import (
     RoleContract,
     RoleContractInvariant,
     RoleContractInvariantType,
 )
 from relay_teams.roles.role_models import RoleDefinition
-from relay_teams.tools.runtime.execution import _apply_role_contract_check
+from relay_teams.tools.runtime.execution import _apply_role_contract_check_async
 
 
 def _make_role(
@@ -47,7 +49,9 @@ def _make_ctx(
 class TestRoleContractInterception:
     """Test cases for _apply_role_contract_check."""
 
-    def test_tool_not_denied_passes_through(self) -> None:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_tool_not_denied_passes_through(self) -> None:
         """AC-4: Tool not in denied set passes through without error."""
         contract = RoleContract(
             invariants=(
@@ -59,10 +63,10 @@ class TestRoleContractInterception:
         )
         role = _make_role(contract=contract)
         ctx = _make_ctx(role)
-        result = _apply_role_contract_check(ctx=ctx, tool_name="read")
+        result = await _apply_role_contract_check_async(ctx=ctx, tool_name="read")
         assert result is None
 
-    def test_tool_in_must_not_have_tools_denied(self) -> None:
+    async def test_tool_in_must_not_have_tools_denied(self) -> None:
         """AC-1: Tool in must_not_have_tools gets tool_policy_denied error."""
         contract = RoleContract(
             invariants=(
@@ -74,21 +78,21 @@ class TestRoleContractInterception:
         )
         role = _make_role(contract=contract)
         ctx = _make_ctx(role)
-        result = _apply_role_contract_check(ctx=ctx, tool_name="shell")
+        result = await _apply_role_contract_check_async(ctx=ctx, tool_name="shell")
         assert result is not None
         assert result.type == "tool_policy_denied"
         assert result.retryable is False
         assert "shell" in result.message
         assert "test_role" in result.message
 
-    def test_role_with_empty_contract_no_interception(self) -> None:
+    async def test_role_with_empty_contract_no_interception(self) -> None:
         """No contract invariants means no interception."""
         role = _make_role(contract=RoleContract())
         ctx = _make_ctx(role)
-        result = _apply_role_contract_check(ctx=ctx, tool_name="shell")
+        result = await _apply_role_contract_check_async(ctx=ctx, tool_name="shell")
         assert result is None
 
-    def test_role_with_must_have_only_no_interception(self) -> None:
+    async def test_role_with_must_have_only_no_interception(self) -> None:
         """AC-4: MUST_HAVE_TOOLS invariant does not trigger denial."""
         contract = RoleContract(
             invariants=(
@@ -100,11 +104,11 @@ class TestRoleContractInterception:
         )
         role = _make_role(contract=contract)
         ctx = _make_ctx(role)
-        result = _apply_role_contract_check(ctx=ctx, tool_name="shell")
+        result = await _apply_role_contract_check_async(ctx=ctx, tool_name="shell")
         assert result is None
 
     @patch("relay_teams.tools.runtime.execution.log_event")
-    def test_error_envelope_meta_fields(self, mock_log: MagicMock) -> None:
+    async def test_error_envelope_meta_fields(self, mock_log: MagicMock) -> None:
         """AC-2/AC-5: Error includes proper type and message."""
         contract = RoleContract(
             invariants=(
@@ -116,7 +120,7 @@ class TestRoleContractInterception:
         )
         role = _make_role(contract=contract)
         ctx = _make_ctx(role)
-        result = _apply_role_contract_check(ctx=ctx, tool_name="shell")
+        result = await _apply_role_contract_check_async(ctx=ctx, tool_name="shell")
         assert result is not None
         assert result.type == "tool_policy_denied"
         assert result.retryable is False
@@ -128,7 +132,7 @@ class TestRoleContractInterception:
         )
 
     @patch("relay_teams.tools.runtime.execution.log_event")
-    def test_runtime_role_resolver_used(self, mock_log: MagicMock) -> None:
+    async def test_runtime_role_resolver_used(self, mock_log: MagicMock) -> None:
         """AC-5: runtime_role_resolver takes precedence."""
         contract = RoleContract(
             invariants=(
@@ -143,11 +147,11 @@ class TestRoleContractInterception:
         resolver.get_effective_role = MagicMock(return_value=dynamic_role)
         static_role = _make_role(role_id="dynamic_role", contract=RoleContract())
         ctx = _make_ctx(static_role, runtime_role_resolver=resolver)
-        result = _apply_role_contract_check(ctx=ctx, tool_name="shell")
+        result = await _apply_role_contract_check_async(ctx=ctx, tool_name="shell")
         assert result is not None
         assert result.type == "tool_policy_denied"
 
-    def test_multiple_must_not_have_invariants_union(self) -> None:
+    async def test_multiple_must_not_have_invariants_union(self) -> None:
         """Multiple MUST_NOT_HAVE_TOOLS invariants combine."""
         contract = RoleContract(
             invariants=(
@@ -163,6 +167,12 @@ class TestRoleContractInterception:
         )
         role = _make_role(contract=contract)
         ctx = _make_ctx(role)
-        assert _apply_role_contract_check(ctx=ctx, tool_name="shell") is not None
-        assert _apply_role_contract_check(ctx=ctx, tool_name="write") is not None
-        assert _apply_role_contract_check(ctx=ctx, tool_name="read") is None
+        assert (
+            await _apply_role_contract_check_async(ctx=ctx, tool_name="shell")
+            is not None
+        )
+        assert (
+            await _apply_role_contract_check_async(ctx=ctx, tool_name="write")
+            is not None
+        )
+        assert await _apply_role_contract_check_async(ctx=ctx, tool_name="read") is None

--- a/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
+++ b/tests/unit_tests/tools/workspace_tools/test_background_task_tools.py
@@ -187,6 +187,75 @@ class _CapturingBackgroundTaskService:
             True,
         )
 
+    def list_for_session(self, session_id: str) -> tuple[BackgroundTaskRecord, ...]:
+        self.calls.append({"session_id": session_id})
+        return (
+            BackgroundTaskRecord(
+                background_task_id="subagent_123",
+                run_id="run-previous",
+                session_id=session_id,
+                kind=BackgroundTaskKind.SUBAGENT,
+                instance_id="inst-1",
+                role_id="writer",
+                title="Investigate test failures",
+                command="subagent:Crafter",
+                cwd="C:/workspace",
+                execution_mode="background",
+                status=BackgroundTaskStatus.COMPLETED,
+                output_excerpt="root cause found",
+                subagent_role_id="Crafter",
+                subagent_run_id="subagent-run-1",
+                subagent_task_id="task-1",
+                subagent_instance_id="subagent-inst-1",
+            ),
+        )
+
+    async def wait_for_session(self, **kwargs: object):
+        self.calls.append(dict(kwargs))
+        return (
+            BackgroundTaskRecord(
+                background_task_id="subagent_123",
+                run_id="run-previous",
+                session_id=str(kwargs["session_id"]),
+                kind=BackgroundTaskKind.SUBAGENT,
+                instance_id="inst-1",
+                role_id="writer",
+                tool_call_id=cast(str | None, kwargs.get("tool_call_id")),
+                title="Investigate test failures",
+                command="subagent:Crafter",
+                cwd="C:/workspace",
+                execution_mode="background",
+                status=BackgroundTaskStatus.COMPLETED,
+                output_excerpt="root cause found",
+                subagent_role_id="Crafter",
+                subagent_run_id="subagent-run-1",
+                subagent_task_id="task-1",
+                subagent_instance_id="subagent-inst-1",
+            ),
+            True,
+        )
+
+    async def stop_for_session(self, **kwargs: object):
+        self.calls.append(dict(kwargs))
+        return BackgroundTaskRecord(
+            background_task_id="subagent_123",
+            run_id="run-previous",
+            session_id=str(kwargs["session_id"]),
+            kind=BackgroundTaskKind.SUBAGENT,
+            instance_id="inst-1",
+            role_id="writer",
+            title="Investigate test failures",
+            command="subagent:Crafter",
+            cwd="C:/workspace",
+            execution_mode="background",
+            status=BackgroundTaskStatus.STOPPED,
+            output_excerpt="stopped",
+            subagent_role_id="Crafter",
+            subagent_run_id="subagent-run-1",
+            subagent_task_id="task-1",
+            subagent_instance_id="subagent-inst-1",
+        )
+
 
 class _RuntimeRoleResolverWithTemporaryRole:
     def __init__(self, role: RoleDefinition) -> None:
@@ -335,6 +404,12 @@ async def test_spawn_subagent_runs_synchronously_by_default(
     assert result == {
         "completed": True,
         "output": "root cause found",
+        "session_id": "session-1",
+        "subagent_run_id": "subagent-run-1",
+        "subagent_instance_id": "subagent-inst-1",
+        "subagent_role_id": "Crafter",
+        "subagent_task_id": "task-1",
+        "title": "Investigate test failures",
     }
     state = load_tool_call_state(
         shared_store=shared_store,
@@ -667,7 +742,7 @@ async def test_wait_background_task_waits_without_optional_timeout_argument(
     result = await tool(ctx, background_task_id="subagent_123")
 
     assert service.calls[0] == {
-        "run_id": "run-1",
+        "session_id": "session-1",
         "background_task_id": "subagent_123",
     }
     assert captured_args == {"background_task_id": "subagent_123"}

--- a/tests/unit_tests/tools/workspace_tools/test_ripgrep.py
+++ b/tests/unit_tests/tools/workspace_tools/test_ripgrep.py
@@ -126,7 +126,11 @@ class TestRipgrepFilepath:
                     "relay_teams.tools.workspace_tools.ripgrep._download_rg",
                     new=AsyncMock(side_effect=RuntimeError("no network")),
                 ):
-                    path = await ripgrep.get_rg_path()
+                    with patch(
+                        "relay_teams.tools.workspace_tools.ripgrep._is_usable_rg",
+                        return_value=True,
+                    ):
+                        path = await ripgrep.get_rg_path()
                     assert path == system_rg
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add full and switch-focused pressure benchmarks for session/subagent load and send-then-switch latency
- batch and bound read/query tool steps, tool-result commits, session read models, and SQLite/event write contention paths
- harden stream recovery/session switching UI, subagent expansion, running indicators, MCP slow-load handling, and recovery question card stability
- split large runtime/session responsibilities into focused internal modules with regression coverage

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests
- uv run --extra dev python benchmarks\session_switch_after_send_pressure.py --mcp-load-workers 4 --expected-immediate-switch-p95-ms 200 --expected-repeated-switch-p95-ms 200 --expected-repeated-switch-endpoint-p95-ms 250
- uv run --extra dev python benchmarks\extreme_session_pressure.py --fail-fast-probes

## Benchmark Notes
- Full pressure summary: .tmp\extreme-session-pressure-20260508T044304Z\summary.json
- Full pressure passed: 10 root runs completed, 100 subagents completed, probe failure 0/217603, global p95 864ms, max 5319ms
- Send/switch pressure summary: .tmp\session-switch-after-send-20260508T053530Z\summary.json
- Send/switch passed: immediate switch p95 130ms/max 149ms, repeated switch p95 148ms/max 906ms

Fixes #588