### PR TITLE
Fix async runtime stream and SQLite paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@
 - `tests/unit_tests/` should mirror `src/relay_teams/`. Add matching `__init__.py` files for new test directories.
 - Prefer focused unit tests first. Add integration coverage when run/SSE/interface flows change.
 - New tools should follow the shared runtime middleware path via `execute_tool_call(..., raw_args=locals())`; do not reimplement hook-aware input parsing or approval plumbing inside each tool.
+- Runtime, service, and repository code must not add paired synchronous and asynchronous public methods for the same operation, such as `get_entry()` plus `get_entry_async()`, when they only delegate to matching lower-layer methods. Use one real runtime interface, normally async, and migrate callers through the stack instead of adding shallow wrappers.
+- Async request, run, hook, memory, retrieval, network, and LLM paths must not call synchronous SQLite, HTTP, retrieval, or provider helpers internally. Add or use the real async downstream API and await it through the stack.
 
 ## Interface Boundaries
 - Public backend contract is `/api/*`.

--- a/docs/core/system-module-boundaries.md
+++ b/docs/core/system-module-boundaries.md
@@ -108,6 +108,35 @@ Boundary:
 Cross-cutting behavior should land in these shared modules when it is reused across
 features.
 
+### Async-Only Runtime Interfaces
+
+Runtime, service, and repository layers must not expose paired synchronous and
+asynchronous public methods for the same operation. A pair such as
+`get_entry()` plus `get_entry_async()` is not an acceptable compatibility layer
+when both methods simply delegate to matching lower-layer calls.
+
+Do not write shallow facades like this:
+
+```python
+def get_entry(self, memory_id: str) -> MemoryEntry | None:
+    return self._repo.get_by_id(memory_id)
+
+async def get_entry_async(self, memory_id: str) -> MemoryEntry | None:
+    return await self._repo.get_by_id_async(memory_id)
+```
+
+Choose one runtime interface and migrate callers to it. For database, network,
+and LLM runtime paths, that interface is async unless a documented process
+boundary requires otherwise. If a synchronous public API is still required for a
+CLI, script, or SDK compatibility boundary, keep the blocking adapter at that
+boundary only. Do not duplicate the domain service or repository API with a
+parallel sync path.
+
+Async runtime methods must not call synchronous SQLite, network, retrieval, or
+LLM helpers internally. If the method is part of an async request, run, hook, or
+memory path, each downstream repository/provider call must also use its async
+API so the event loop is never held behind a hidden blocking adapter.
+
 ## Runtime Injection Boundary
 
 Runtime injection semantics are defined in `runtime-injection-semantics.md`.

--- a/docs/modules/automation/ao4-async-path-unification.md
+++ b/docs/modules/automation/ao4-async-path-unification.md
@@ -62,6 +62,23 @@ returning and reload records when callers expect stored database state.
 still exists for a deliberate boundary, its async equivalent must contain its own
 async SQL implementation rather than wrapping the sync method.
 
+Runtime services and repositories must not keep shallow paired methods for the
+same operation. Do not add a synchronous public method and a matching `_async`
+method where each one only forwards to a lower layer, for example
+`get_entry()` delegating to `repo.get_by_id()` beside `get_entry_async()`
+delegating to `repo.get_by_id_async()`. That pattern recreates the old split
+runtime surface even when the async method itself uses `await`.
+
+The required shape is a single runtime path. For runtime database operations,
+define the async method as the primary service/repository API and migrate
+callers to `await` it through the stack. A synchronous adapter may exist only at
+a documented process or compatibility boundary, such as a CLI or SDK wrapper,
+and it must not become a second domain-service implementation.
+
+Async services must also stay async internally. Do not call synchronous SQLite,
+network, retrieval, or LLM methods from an async run, hook, or memory path; add
+or use the real async downstream API and await it instead.
+
 Claim and queue operations must remain atomic. Each claim updates a row only
 from its eligible pending state, or from a stale in-progress state, and then
 reloads the same row inside the write operation. A zero-row update means another

--- a/src/relay_teams/agents/evaluation/run_sampling_service.py
+++ b/src/relay_teams/agents/evaluation/run_sampling_service.py
@@ -96,7 +96,9 @@ class RunSamplingService:
                     limit=100,
                 )
                 try:
-                    result = self._memory_bank_service.list_entries(ws_query)
+                    result = await self._memory_bank_service.list_entries_async(
+                        ws_query
+                    )
                     if result.total_count > 0:
                         # Session has classified runs; exclude all runs from it
                         classified_run_ids.update(

--- a/src/relay_teams/agents/execution/prompt_history.py
+++ b/src/relay_teams/agents/execution/prompt_history.py
@@ -79,7 +79,6 @@ from relay_teams.sessions.runs.assistant_errors import (
     AssistantRunError,
     AssistantRunErrorPayload,
 )
-from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.workspace import build_conversation_id
 
 LOGGER = get_logger(__name__)
@@ -167,8 +166,8 @@ class PromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None:
-        pass  # pragma: no cover
+    ) -> bool:
+        raise NotImplementedError  # pragma: no cover
 
     def replace_pending_user_prompt(
         self,
@@ -228,8 +227,8 @@ class PromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None:
-        pass  # pragma: no cover
+    ) -> bool:
+        raise NotImplementedError  # pragma: no cover
 
     async def replace_pending_user_prompt_async(
         self,
@@ -293,8 +292,8 @@ class AsyncPromptHistoryMessageRepository(Protocol):
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None:
-        pass  # pragma: no cover
+    ) -> bool:
+        raise NotImplementedError  # pragma: no cover
 
     async def replace_pending_user_prompt_async(
         self,
@@ -355,7 +354,7 @@ class PromptHistoryService:
         self,
         *,
         config: ModelEndpointConfig,
-        run_intent_repo: RunIntentRepository,
+        run_intent_repo: AsyncRunIntentRepository,
         message_repo: PromptHistoryMessageRepository,
         conversation_compaction_service: ConversationCompactionService | None,
         conversation_microcompact_service: ConversationMicrocompactService | None,
@@ -366,13 +365,9 @@ class PromptHistoryService:
         hook_service: object | None,
         reminder_service: SystemReminderService | None,
         run_event_hub: object,
-        load_safe_history_for_conversation: Callable[
-            [str], list[ModelRequest | ModelResponse]
-        ],
         load_safe_history_for_conversation_async: Callable[
             [str], Awaitable[list[ModelRequest | ModelResponse]]
-        ]
-        | None = None,
+        ],
     ) -> None:
         self._config = config
         self._run_intent_repo = run_intent_repo
@@ -386,7 +381,6 @@ class PromptHistoryService:
         self._hook_service = hook_service
         self._reminder_service = reminder_service
         self._run_event_hub = run_event_hub
-        self._load_safe_history_for_conversation = load_safe_history_for_conversation
         self._load_safe_history_for_conversation_async = (
             load_safe_history_for_conversation_async
         )
@@ -399,27 +393,25 @@ class PromptHistoryService:
             mcp_discovery_service=self._mcp_discovery_service,
         )
 
+    def _async_message_repo(self) -> AsyncPromptHistoryMessageRepository:
+        if not isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
+            raise RuntimeError("Prompt history runtime requires async message storage")
+        return self._message_repo
+
     async def _get_history_for_conversation_async(
         self,
         conversation_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
-            return await self._message_repo.get_history_for_conversation_async(
-                conversation_id
-            )
-        return self._message_repo.get_history_for_conversation(conversation_id)
+        return await self._async_message_repo().get_history_for_conversation_async(
+            conversation_id
+        )
 
     async def _get_history_for_conversation_task_async(
         self,
         conversation_id: str,
         task_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
-            return await self._message_repo.get_history_for_conversation_task_async(
-                conversation_id,
-                task_id,
-            )
-        return self._message_repo.get_history_for_conversation_task(
+        return await self._async_message_repo().get_history_for_conversation_task_async(
             conversation_id,
             task_id,
         )
@@ -428,12 +420,9 @@ class PromptHistoryService:
         self,
         conversation_id: str,
     ) -> None:
-        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
-            await self._message_repo.prune_conversation_history_to_safe_boundary_async(
-                conversation_id
-            )
-            return
-        self._message_repo.prune_conversation_history_to_safe_boundary(conversation_id)
+        await self._async_message_repo().prune_conversation_history_to_safe_boundary_async(
+            conversation_id
+        )
 
     async def _append_async(
         self,
@@ -447,19 +436,7 @@ class PromptHistoryService:
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
     ) -> None:
-        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
-            await self._message_repo.append_async(
-                session_id=session_id,
-                workspace_id=workspace_id,
-                conversation_id=conversation_id,
-                agent_role_id=agent_role_id,
-                instance_id=instance_id,
-                task_id=task_id,
-                trace_id=trace_id,
-                messages=messages,
-            )
-            return
-        self._message_repo.append(
+        await self._async_message_repo().append_async(
             session_id=session_id,
             workspace_id=workspace_id,
             conversation_id=conversation_id,
@@ -482,19 +459,7 @@ class PromptHistoryService:
         trace_id: str,
         content: str,
     ) -> None:
-        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
-            await self._message_repo.append_system_prompt_if_missing_async(
-                session_id=session_id,
-                workspace_id=workspace_id,
-                conversation_id=conversation_id,
-                agent_role_id=agent_role_id,
-                instance_id=instance_id,
-                task_id=task_id,
-                trace_id=trace_id,
-                content=content,
-            )
-            return
-        self._message_repo.append_system_prompt_if_missing(
+        await self._async_message_repo().append_system_prompt_if_missing_async(
             session_id=session_id,
             workspace_id=workspace_id,
             conversation_id=conversation_id,
@@ -517,18 +482,7 @@ class PromptHistoryService:
         trace_id: str,
         content: UserPromptContent,
     ) -> bool:
-        if isinstance(self._message_repo, AsyncPromptHistoryMessageRepository):
-            return await self._message_repo.replace_pending_user_prompt_async(
-                session_id=session_id,
-                workspace_id=workspace_id,
-                conversation_id=conversation_id,
-                agent_role_id=agent_role_id,
-                instance_id=instance_id,
-                task_id=task_id,
-                trace_id=trace_id,
-                content=content,
-            )
-        return self._message_repo.replace_pending_user_prompt(
+        return await self._async_message_repo().replace_pending_user_prompt_async(
             session_id=session_id,
             workspace_id=workspace_id,
             conversation_id=conversation_id,
@@ -550,12 +504,7 @@ class PromptHistoryService:
         allowed_mcp_servers: tuple[str, ...],
         allowed_skills: tuple[str, ...],
     ) -> PreparedPromptContext:
-        if self._load_safe_history_for_conversation_async is not None:
-            history = await self._load_safe_history_for_conversation_async(
-                conversation_id
-            )
-        else:
-            history = self._load_safe_history_for_conversation(conversation_id)
+        history = await self._load_safe_history_for_conversation_async(conversation_id)
         (
             history,
             protected_current_prompt,
@@ -759,90 +708,6 @@ class PromptHistoryService:
             return request
         return request.model_copy(update={"user_prompt": prompt_text, "input": ()})
 
-    def coerce_history_to_provider_safe_sequence(
-        self,
-        *,
-        request: LLMRequest,
-        history: Sequence[ModelRequest | ModelResponse],
-    ) -> list[ModelRequest | ModelResponse]:
-        candidate_history = list(history)
-        if is_replayable_history(candidate_history):
-            return candidate_history
-        replayable_start = self.first_tool_replayable_history_index(candidate_history)
-        if replayable_start > 0:
-            candidate_history = candidate_history[replayable_start:]
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="llm.history.replayable_prefix.dropped",
-                message=(
-                    "Dropped a non-replayable history prefix before sending the "
-                    "provider request"
-                ),
-                payload={
-                    "role_id": request.role_id,
-                    "instance_id": request.instance_id,
-                    "dropped_message_count": replayable_start,
-                },
-            )
-        if candidate_history and is_replayable_history(candidate_history):
-            return candidate_history
-        if (
-            candidate_history
-            and not request_has_prompt_content(request)
-            and history_has_valid_tool_replay(candidate_history)
-        ):
-            bridge_message = self.build_history_replay_bridge_message(request=request)
-            if bridge_message is not None:
-                log_event(
-                    LOGGER,
-                    logging.WARNING,
-                    event="llm.history.replay_bridge.inserted",
-                    message=(
-                        "Inserted a synthetic user bridge before replaying "
-                        "assistant/tool-only history"
-                    ),
-                    payload={
-                        "role_id": request.role_id,
-                        "instance_id": request.instance_id,
-                        "message_count": len(candidate_history),
-                    },
-                )
-                return [bridge_message, *candidate_history]
-        if request_has_prompt_content(request):
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="llm.history.invalid_suffix.dropped",
-                message=(
-                    "Dropped non-replayable history and relied on the current user "
-                    "prompt to restart the provider request"
-                ),
-                payload={
-                    "role_id": request.role_id,
-                    "instance_id": request.instance_id,
-                    "message_count": len(candidate_history),
-                },
-            )
-            return []
-        bridge_message = self.build_history_replay_bridge_message(request=request)
-        if bridge_message is not None:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="llm.history.replay_bridge.synthetic_only",
-                message=(
-                    "Fell back to a synthetic user bridge because no replayable "
-                    "history suffix remained"
-                ),
-                payload={
-                    "role_id": request.role_id,
-                    "instance_id": request.instance_id,
-                },
-            )
-            return [bridge_message]
-        return []
-
     async def coerce_history_to_provider_safe_sequence_async(
         self,
         *,
@@ -942,16 +807,6 @@ class PromptHistoryService:
                 return index
         return len(history)
 
-    def build_history_replay_bridge_message(
-        self,
-        *,
-        request: LLMRequest,
-    ) -> ModelRequest | None:
-        prompt = self.build_history_replay_bridge_prompt(request=request)
-        if not prompt:
-            return None
-        return ModelRequest(parts=[UserPromptPart(content=prompt)])
-
     async def build_history_replay_bridge_message_async(
         self,
         *,
@@ -962,48 +817,16 @@ class PromptHistoryService:
             return None
         return ModelRequest(parts=[UserPromptPart(content=prompt)])
 
-    def build_history_replay_bridge_prompt(
-        self,
-        *,
-        request: LLMRequest,
-    ) -> str:
-        try:
-            intent_text = self._run_intent_repo.get(
-                request.run_id,
-                fallback_session_id=request.session_id,
-            ).intent.strip()
-        except KeyError:
-            intent_text = ""
-        lines = [
-            "Continue the existing task using the compacted summary and preserved execution history.",
-            "Resume from the latest in-progress state without discarding prior decisions or artifacts.",
-        ]
-        if intent_text:
-            lines.extend(
-                [
-                    "",
-                    "Original task intent:",
-                    intent_text,
-                ]
-            )
-        return "\n".join(lines).strip()
-
     async def build_history_replay_bridge_prompt_async(
         self,
         *,
         request: LLMRequest,
     ) -> str:
         try:
-            if isinstance(self._run_intent_repo, AsyncRunIntentRepository):
-                record = await self._run_intent_repo.get_async(
-                    request.run_id,
-                    fallback_session_id=request.session_id,
-                )
-            else:
-                record = self._run_intent_repo.get(
-                    request.run_id,
-                    fallback_session_id=request.session_id,
-                )
+            record = await self._run_intent_repo.get_async(
+                request.run_id,
+                fallback_session_id=request.session_id,
+            )
             intent_text = str(getattr(record, "intent", "")).strip()
         except KeyError:
             intent_text = ""

--- a/src/relay_teams/agents/execution/prompt_instruction_state.py
+++ b/src/relay_teams/agents/execution/prompt_instruction_state.py
@@ -17,22 +17,6 @@ def normalize_instruction_path(path: Path) -> str:
     return resolved
 
 
-def record_prompt_instruction_loaded(
-    *,
-    shared_store: SharedStateRepository,
-    task_id: str,
-    path: Path,
-) -> None:
-    resolved_path = path.expanduser().resolve()
-    shared_store.manage_state(
-        StateMutation(
-            scope=_task_scope(task_id),
-            key=_state_key(resolved_path),
-            value_json='"loaded"',
-        )
-    )
-
-
 async def record_prompt_instruction_loaded_async(
     *,
     shared_store: SharedStateRepository,
@@ -49,20 +33,6 @@ async def record_prompt_instruction_loaded_async(
     )
 
 
-def record_prompt_instruction_paths_loaded(
-    *,
-    shared_store: SharedStateRepository,
-    task_id: str,
-    paths: tuple[Path, ...],
-) -> None:
-    for path in paths:
-        record_prompt_instruction_loaded(
-            shared_store=shared_store,
-            task_id=task_id,
-            path=path,
-        )
-
-
 async def record_prompt_instruction_paths_loaded_async(
     *,
     shared_store: SharedStateRepository,
@@ -77,15 +47,6 @@ async def record_prompt_instruction_paths_loaded_async(
         )
 
 
-def is_prompt_instruction_loaded(
-    *,
-    shared_store: SharedStateRepository,
-    task_id: str,
-    path: Path,
-) -> bool:
-    return shared_store.get_state(_task_scope(task_id), _state_key(path)) is not None
-
-
 async def is_prompt_instruction_loaded_async(
     *,
     shared_store: SharedStateRepository,
@@ -95,23 +56,6 @@ async def is_prompt_instruction_loaded_async(
     return (
         await shared_store.get_state_async(_task_scope(task_id), _state_key(path))
         is not None
-    )
-
-
-def filter_unloaded_prompt_instruction_paths(
-    *,
-    shared_store: SharedStateRepository,
-    task_id: str,
-    paths: tuple[Path, ...],
-) -> tuple[Path, ...]:
-    return tuple(
-        path
-        for path in paths
-        if not is_prompt_instruction_loaded(
-            shared_store=shared_store,
-            task_id=task_id,
-            path=path,
-        )
     )
 
 

--- a/src/relay_teams/agents/execution/session_mixin_base.py
+++ b/src/relay_teams/agents/execution/session_mixin_base.py
@@ -481,7 +481,9 @@ class AgentLlmSessionMixinBase:  # pragma: no cover
     def _conversation_id(self, request: LLMRequest) -> str:
         raise NotImplementedError
 
-    def _resolve_tool_approval_policy(self, run_id: str) -> ToolApprovalPolicy:
+    async def _resolve_tool_approval_policy_async(
+        self, run_id: str
+    ) -> ToolApprovalPolicy:
         raise NotImplementedError
 
     async def _maybe_recover_from_tool_args_parse_failure(

--- a/src/relay_teams/agents/execution/session_prompt.py
+++ b/src/relay_teams/agents/execution/session_prompt.py
@@ -248,41 +248,12 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
         )
         return prepared_prompt, history, prepared_system_prompt, cast(object, agent)
 
-    def _coerce_history_to_provider_safe_sequence(
-        self,
-        *,
-        request: LLMRequest,
-        history: Sequence[ModelRequest | ModelResponse],
-    ) -> list[ModelRequest | ModelResponse]:
-        return self._prompt_history_service().coerce_history_to_provider_safe_sequence(
-            request=request,
-            history=history,
-        )
-
     def _first_tool_replayable_history_index(
         self,
         history: Sequence[ModelRequest | ModelResponse],
     ) -> int:
         return self._prompt_history_service().first_tool_replayable_history_index(
             history
-        )
-
-    def _build_history_replay_bridge_message(
-        self,
-        *,
-        request: LLMRequest,
-    ) -> ModelRequest | None:
-        return self._prompt_history_service().build_history_replay_bridge_message(
-            request=request
-        )
-
-    def _build_history_replay_bridge_prompt(
-        self,
-        *,
-        request: LLMRequest,
-    ) -> str:
-        return self._prompt_history_service().build_history_replay_bridge_prompt(
-            request=request
         )
 
     async def _estimate_compaction_budget(
@@ -1014,9 +985,11 @@ class SessionPromptMixin(AgentLlmSessionMixinBase):
             request.role_id,
         )
 
-    def _resolve_tool_approval_policy(self, run_id: str) -> ToolApprovalPolicy:
+    async def _resolve_tool_approval_policy_async(
+        self, run_id: str
+    ) -> ToolApprovalPolicy:
         try:
-            yolo = self._run_intent_repo.get(run_id).yolo
+            yolo = (await self._run_intent_repo.get_async(run_id)).yolo
         except KeyError:
             yolo = False
         return self._tool_approval_policy.with_yolo(yolo)

--- a/src/relay_teams/agents/execution/session_runtime.py
+++ b/src/relay_teams/agents/execution/session_runtime.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import logging
+from contextlib import asynccontextmanager
 from copy import deepcopy
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterable, AsyncIterator, Sequence
 from json import dumps, loads
-from typing import Any, Protocol, cast
+from typing import Protocol, TypeVar, cast
 
+import httpx
 from pydantic_ai._agent_graph import CallToolsNode, ModelRequestNode
 from pydantic import JsonValue
 from pydantic_ai.exceptions import ModelAPIError
@@ -36,7 +39,7 @@ from relay_teams.agents.execution.spec_checkpoint import (
     SpecCheckpointDecision,
     build_spec_checkpoint_decision,
 )
-from relay_teams.agents.tasks.models import TaskRecord
+from relay_teams.agents.tasks.models import TaskRecord, TaskSpecArtifact
 from relay_teams.agents.tasks.task_repository import TaskRepository as _TaskRepo
 from relay_teams.logger import (
     close_model_stream,
@@ -55,7 +58,11 @@ from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.roles.runtime_tools import runtime_tools_for_role
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
-from relay_teams.sessions.runs.event_stream import publish_run_event_async
+from relay_teams.sessions.runs.event_stream import (
+    AsyncRunEventPublisher,
+    SyncRunEventPublisher,
+    publish_run_event_async,
+)
 from relay_teams.sessions.runs.injection_classification import (
     INJECTION_CLASSIFIER,
     InjectionBoundaryContext,
@@ -76,6 +83,8 @@ from relay_teams.workspace import build_conversation_id
 
 LOGGER = get_logger(__name__)
 LLM_REQUEST_LIMIT = 500
+_LLM_CLIENT_CLOSE_TASKS: set[asyncio.Task[None]] = set()
+StreamItemT = TypeVar("StreamItemT")
 
 
 class _InjectionRestartApplied(Exception):
@@ -277,6 +286,50 @@ def model_step_payload(
 
 
 class SessionRuntimeMixin(AgentLlmSessionMixinBase):
+    def _schedule_run_scoped_llm_http_client_close(
+        self,
+        *,
+        request: LLMRequest,
+    ) -> None:
+        close_task = asyncio.create_task(
+            self._close_run_scoped_llm_http_client(request=request)
+        )
+        _LLM_CLIENT_CLOSE_TASKS.add(close_task)
+
+        def _finish(completed_task: asyncio.Task[None]) -> None:
+            _LLM_CLIENT_CLOSE_TASKS.discard(completed_task)
+            try:
+                completed_task.result()
+            except asyncio.CancelledError:
+                log_event(
+                    LOGGER,
+                    logging.DEBUG,
+                    event="llm.http_client.close.cancelled",
+                    message="Run-scoped LLM HTTP client close was cancelled",
+                    payload={
+                        "run_id": request.run_id,
+                        "task_id": request.task_id,
+                        "instance_id": request.instance_id,
+                        "role_id": request.role_id,
+                    },
+                )
+            except Exception as exc:
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    event="llm.http_client.close.failed",
+                    message="Run-scoped LLM HTTP client close failed",
+                    payload={
+                        "run_id": request.run_id,
+                        "task_id": request.task_id,
+                        "instance_id": request.instance_id,
+                        "role_id": request.role_id,
+                    },
+                    exc_info=exc,
+                )
+
+        close_task.add_done_callback(_finish)
+
     async def _publish_tool_outcome_event_from_stream_async(
         self,
         *,
@@ -385,6 +438,13 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 allowed_skills=self._allowed_skills,
             )
             coordination_agent = cast(CoordinationAgent, agent)
+            workspace = await self._workspace_manager.resolve_async(
+                session_id=request.session_id,
+                role_id=request.role_id,
+                instance_id=request.instance_id,
+                workspace_id=resolved_workspace_id,
+                conversation_id=resolved_conversation_id,
+            )
             deps = ToolDeps(
                 task_repo=self._task_repo,
                 shared_store=self._shared_store,
@@ -396,13 +456,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 injection_manager=self._injection_manager,
                 run_event_hub=self._run_event_hub,
                 agent_repo=self._agent_repo,
-                workspace=self._workspace_manager.resolve(
-                    session_id=request.session_id,
-                    role_id=request.role_id,
-                    instance_id=request.instance_id,
-                    workspace_id=resolved_workspace_id,
-                    conversation_id=resolved_conversation_id,
-                ),
+                workspace=workspace,
                 role_memory=self._role_memory_service,
                 media_asset_service=self._media_asset_service,
                 computer_runtime=self._computer_runtime,
@@ -430,7 +484,9 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                 run_control_manager=self._run_control_manager,
                 tool_approval_manager=self._tool_approval_manager,
                 user_question_manager=self._user_question_manager,
-                tool_approval_policy=self._resolve_tool_approval_policy(request.run_id),
+                tool_approval_policy=await self._resolve_tool_approval_policy_async(
+                    request.run_id
+                ),
                 shell_approval_repo=self._shell_approval_repo,
                 metric_recorder=self._metric_recorder,
                 notification_service=self._notification_service,
@@ -455,6 +511,9 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
             control_ctx = self._run_control_manager.context(
                 run_id=request.run_id,
                 instance_id=request.instance_id,
+            )
+            llm_event_timeout_seconds = _llm_stream_event_timeout_seconds(
+                self._config.connect_timeout_seconds
             )
 
             printed_any = False
@@ -1001,7 +1060,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                     and await apply_spec_checkpoint_if_due()
                 )
         except BaseException:
-            await self._close_run_scoped_llm_http_client(request=request)
+            self._schedule_run_scoped_llm_http_client_close(request=request)
             raise
 
         try:
@@ -1027,7 +1086,10 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                     ) as agent_run:
                         boundary_checked_after_latest_batch = False
                         observed_stream_messages = []
-                        async for node in agent_run:
+                        async for node in _aiter_with_timeout(
+                            cast(AsyncIterable[object], agent_run),
+                            timeout_seconds=llm_event_timeout_seconds,
+                        ):
                             try:
                                 control_ctx.raise_if_cancelled()
                                 if await apply_interrupt_injections():
@@ -1048,15 +1110,24 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                     )
                                     streamed_text_start = len(emitted_text_chunks)
                                     usage_before = deepcopy(agent_run.usage())
-                                    async with streamable_node.stream(
+                                    stream_context = streamable_node.stream(
                                         agent_run.ctx
+                                    )
+                                    async with _llm_stream_context_with_timeout(
+                                        stream_context,
+                                        timeout_seconds=llm_event_timeout_seconds,
                                     ) as stream:
                                         stream_iter = getattr(stream, "__aiter__", None)
                                         if callable(stream_iter):
                                             text_lengths: dict[int, int] = {}
                                             thinking_lengths: dict[int, int] = {}
                                             started_thinking_parts: set[int] = set()
-                                            async for stream_event in stream:
+                                            async for (
+                                                stream_event
+                                            ) in _aiter_with_timeout(
+                                                cast(AsyncIterable[object], stream),
+                                                timeout_seconds=llm_event_timeout_seconds,
+                                            ):
                                                 control_ctx.raise_if_cancelled()
                                                 if await apply_interrupt_injections():
                                                     raise _InjectionRestartApplied
@@ -1095,8 +1166,9 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                                     if active_retry_number > 0:
                                                         active_retry_number = 0
                                         else:
-                                            async for text_delta in stream.stream_text(
-                                                delta=True
+                                            async for text_delta in _aiter_with_timeout(
+                                                stream.stream_text(delta=True),
+                                                timeout_seconds=llm_event_timeout_seconds,
                                             ):
                                                 control_ctx.raise_if_cancelled()
                                                 if await apply_interrupt_injections():
@@ -1117,6 +1189,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
                                                         request=request,
                                                         text=text_delta,
                                                     )
+                                    _raise_if_stream_finished_without_reason(stream)
                                     if await apply_interrupt_injections():
                                         raise _InjectionRestartApplied
                                     usage_after = stream.usage()
@@ -1558,7 +1631,7 @@ class SessionRuntimeMixin(AgentLlmSessionMixinBase):
             )
             return text
         finally:
-            await self._close_run_scoped_llm_http_client(request=request)
+            self._schedule_run_scoped_llm_http_client_close(request=request)
 
 
 def _observed_tool_result_message(
@@ -1574,6 +1647,77 @@ def _observed_tool_result_message(
     if isinstance(result, ToolReturnPart):
         return ModelRequest(parts=[result])
     return None
+
+
+def _raise_if_stream_finished_without_reason(stream: object) -> None:
+    raw_stream = getattr(stream, "_raw_stream_response", None)
+    if raw_stream is None:
+        return
+    raw_stream_type = type(raw_stream).__name__
+    if "OpenAI" not in raw_stream_type and "OpenRouter" not in raw_stream_type:
+        return
+    if getattr(raw_stream, "finish_reason", None) is not None:
+        return
+    raise httpx.RemoteProtocolError(
+        "LLM stream ended before the provider sent a finish reason."
+    )
+
+
+async def _aiter_with_timeout(
+    aiterable: AsyncIterable[StreamItemT],
+    *,
+    timeout_seconds: float,
+) -> AsyncIterator[StreamItemT]:
+    iterator = aiter(aiterable)
+    while True:
+        try:
+            yield await asyncio.wait_for(
+                anext(iterator),
+                timeout=timeout_seconds,
+            )
+        except StopAsyncIteration:
+            return
+        except TimeoutError as exc:
+            raise httpx.ReadTimeout(
+                "Timed out waiting for the next LLM stream event."
+            ) from exc
+
+
+@asynccontextmanager
+async def _llm_stream_context_with_timeout(
+    context: AgentNodeStreamContext,
+    *,
+    timeout_seconds: float,
+) -> AsyncIterator[AgentNodeStream]:
+    try:
+        stream = await asyncio.wait_for(
+            context.__aenter__(),
+            timeout=timeout_seconds,
+        )
+    except TimeoutError as exc:
+        raise httpx.ReadTimeout(
+            "Timed out waiting for the LLM stream to open."
+        ) from exc
+    try:
+        yield stream
+    except asyncio.CancelledError as exc:
+        suppress = await context.__aexit__(type(exc), exc, exc.__traceback__)
+        if not suppress:
+            raise
+    except GeneratorExit as exc:
+        suppress = await context.__aexit__(type(exc), exc, exc.__traceback__)
+        if not suppress:
+            raise
+    except Exception as exc:
+        suppress = await context.__aexit__(type(exc), exc, exc.__traceback__)
+        if not suppress:
+            raise
+    else:
+        await context.__aexit__(None, None, None)
+
+
+def _llm_stream_event_timeout_seconds(connect_timeout_seconds: float) -> float:
+    return max(5.0, connect_timeout_seconds * 2)
 
 
 def _missing_stream_observed_messages(
@@ -1720,7 +1864,7 @@ class _SpecCheckpointTaskRepository(Protocol):
         raise NotImplementedError  # pragma: no cover
 
     @staticmethod
-    async def get_spec_artifact_async(artifact_id: str) -> Any:
+    async def get_spec_artifact_async(artifact_id: str) -> TaskSpecArtifact:
         raise NotImplementedError  # pragma: no cover
 
 
@@ -1799,11 +1943,11 @@ def _spec_checkpoint_event_payload(
 
 async def _evaluate_checkpoint_drift(
     *,
-    task_repo: Any,
+    task_repo: object,
     task_record: TaskRecord | None,
     request: LLMRequest,
     decision: SpecCheckpointDecision,
-    run_event_hub: Any,
+    run_event_hub: AsyncRunEventPublisher | SyncRunEventPublisher,
 ) -> None:
     if task_record is None:
         return

--- a/src/relay_teams/agents/execution/session_support.py
+++ b/src/relay_teams/agents/execution/session_support.py
@@ -30,7 +30,10 @@ from pydantic_ai.messages import (
 from relay_teams.agents.execution.event_publishing import EventPublishingService
 from relay_teams.agents.execution.failure_reporting import FailureHandlingService
 from relay_teams.agents.execution.message_commit import MessageCommitService
-from relay_teams.agents.execution.prompt_history import PromptHistoryService
+from relay_teams.agents.execution.prompt_history import (
+    AsyncRunIntentRepository,
+    PromptHistoryService,
+)
 from relay_teams.agents.execution.recovery_flow import AttemptRecoveryService
 from relay_teams.agents.execution.recovery_flow import (
     RESUME_SUPERSEDED_TOOL_CALL_ERROR_CODE,
@@ -55,16 +58,15 @@ from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskReco
 from relay_teams.sessions.runs.background_tasks.projection import (
     build_background_task_result_payload,
 )
-from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.tools.runtime.persisted_state import (
     PersistedToolCallBatchState,
     PersistedToolCallState,
     ToolCallBatchStatus,
     ToolExecutionStatus,
+    load_or_recover_tool_call_state_async,
     merge_tool_call_state_async,
-    load_or_recover_tool_call_state,
-    recover_tool_call_batches_from_event_log,
+    recover_tool_call_batches_from_event_log_async,
 )
 from relay_teams.tools.runtime.context import ToolDeps
 from relay_teams.tools.runtime.recoverable_invoker import RecoverableToolInvoker
@@ -84,6 +86,24 @@ class _AsyncConversationHistoryRepo(Protocol):
         raise NotImplementedError  # pragma: no cover
 
 
+@runtime_checkable
+class _AsyncTraceEventLog(Protocol):
+    async def list_by_trace_async(
+        self,
+        trace_id: str,
+    ) -> tuple[dict[str, JsonValue], ...]:
+        raise NotImplementedError  # pragma: no cover
+
+
+@runtime_checkable
+class _AsyncSharedStateSnapshotStore(Protocol):
+    async def snapshot_async(
+        self,
+        scope: ScopeRef,
+    ) -> tuple[tuple[str, str], ...]:
+        raise NotImplementedError  # pragma: no cover
+
+
 class _NullPromptHistoryMessageRepo:
     def get_history_for_conversation(
         self,
@@ -92,11 +112,12 @@ class _NullPromptHistoryMessageRepo:
         _ = conversation_id
         return []
 
+    @staticmethod
     async def get_history_for_conversation_async(
-        self,
         conversation_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        return self.get_history_for_conversation(conversation_id)
+        _ = conversation_id
+        return []
 
     def get_history_for_conversation_task(
         self,
@@ -106,12 +127,13 @@ class _NullPromptHistoryMessageRepo:
         _ = (conversation_id, task_id)
         return []
 
+    @staticmethod
     async def get_history_for_conversation_task_async(
-        self,
         conversation_id: str,
         task_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        return self.get_history_for_conversation_task(conversation_id, task_id)
+        _ = (conversation_id, task_id)
+        return []
 
     def prune_conversation_history_to_safe_boundary(
         self,
@@ -119,11 +141,11 @@ class _NullPromptHistoryMessageRepo:
     ) -> None:
         _ = conversation_id
 
+    @staticmethod
     async def prune_conversation_history_to_safe_boundary_async(
-        self,
         conversation_id: str,
     ) -> None:
-        self.prune_conversation_history_to_safe_boundary(conversation_id)
+        _ = conversation_id
 
     def append(
         self,
@@ -148,8 +170,8 @@ class _NullPromptHistoryMessageRepo:
             messages,
         )
 
+    @staticmethod
     async def append_async(
-        self,
         *,
         session_id: str,
         workspace_id: str,
@@ -160,15 +182,15 @@ class _NullPromptHistoryMessageRepo:
         trace_id: str,
         messages: list[ModelRequest | ModelResponse],
     ) -> None:
-        self.append(
-            session_id=session_id,
-            workspace_id=workspace_id,
-            conversation_id=conversation_id,
-            agent_role_id=agent_role_id,
-            instance_id=instance_id,
-            task_id=task_id,
-            trace_id=trace_id,
-            messages=messages,
+        _ = (
+            session_id,
+            workspace_id,
+            conversation_id,
+            agent_role_id,
+            instance_id,
+            task_id,
+            trace_id,
+            messages,
         )
 
     def append_system_prompt_if_missing(
@@ -182,7 +204,7 @@ class _NullPromptHistoryMessageRepo:
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None:
+    ) -> bool:
         _ = (
             session_id,
             workspace_id,
@@ -193,9 +215,10 @@ class _NullPromptHistoryMessageRepo:
             trace_id,
             content,
         )
+        return False
 
+    @staticmethod
     async def append_system_prompt_if_missing_async(
-        self,
         *,
         session_id: str,
         workspace_id: str,
@@ -205,17 +228,18 @@ class _NullPromptHistoryMessageRepo:
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None:
-        self.append_system_prompt_if_missing(
-            session_id=session_id,
-            workspace_id=workspace_id,
-            conversation_id=conversation_id,
-            agent_role_id=agent_role_id,
-            instance_id=instance_id,
-            task_id=task_id,
-            trace_id=trace_id,
-            content=content,
+    ) -> bool:
+        _ = (
+            session_id,
+            workspace_id,
+            conversation_id,
+            agent_role_id,
+            instance_id,
+            task_id,
+            trace_id,
+            content,
         )
+        return False
 
     def replace_pending_user_prompt(
         self,
@@ -241,8 +265,8 @@ class _NullPromptHistoryMessageRepo:
         )
         return False
 
+    @staticmethod
     async def replace_pending_user_prompt_async(
-        self,
         *,
         session_id: str,
         workspace_id: str,
@@ -253,16 +277,17 @@ class _NullPromptHistoryMessageRepo:
         trace_id: str,
         content: object,
     ) -> bool:
-        return self.replace_pending_user_prompt(
-            session_id=session_id,
-            workspace_id=workspace_id,
-            conversation_id=conversation_id,
-            agent_role_id=agent_role_id,
-            instance_id=instance_id,
-            task_id=task_id,
-            trace_id=trace_id,
-            content=content,
+        _ = (
+            session_id,
+            workspace_id,
+            conversation_id,
+            agent_role_id,
+            instance_id,
+            task_id,
+            trace_id,
+            content,
         )
+        return False
 
 
 @runtime_checkable
@@ -293,14 +318,12 @@ class _SubagentRecordLookupService(Protocol):
 
 
 class _NullRunIntentRepo:
-    def get(self, run_id: str, *, fallback_session_id: str | None = None) -> object:
+    @staticmethod
+    async def get_async(
+        run_id: str, *, fallback_session_id: str | None = None
+    ) -> object:
         _ = (run_id, fallback_session_id)
         return type("_Intent", (), {"intent": ""})()
-
-    async def get_async(
-        self, run_id: str, *, fallback_session_id: str | None = None
-    ) -> object:
-        return self.get(run_id, fallback_session_id=fallback_session_id)
 
 
 def _tool_result_error_code(result: dict[str, JsonValue]) -> str:
@@ -334,6 +357,13 @@ def _tool_args_from_preview(value: str) -> dict[str, JsonValue] | str:
     if isinstance(decoded, dict):
         return decoded
     return text
+
+
+async def _empty_safe_history_async(
+    conversation_id: str,
+) -> list[ModelRequest | ModelResponse]:
+    _ = conversation_id
+    return []
 
 
 class SessionSupportMixin(AgentLlmSessionMixinBase):
@@ -942,11 +972,15 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
                 pending_messages
             )
         }
-        committed_tool_call_ids = self._committed_tool_call_ids_for_request(request)
-        recovered_tool_call_messages = self._recover_orphaned_spawn_subagent_calls(
-            request=request,
-            pending_tool_calls=pending_tool_calls,
-            committed_tool_call_ids=committed_tool_call_ids,
+        committed_tool_call_ids = await self._committed_tool_call_ids_for_request_async(
+            request
+        )
+        recovered_tool_call_messages = (
+            await self._recover_orphaned_spawn_subagent_calls_async(
+                request=request,
+                pending_tool_calls=pending_tool_calls,
+                committed_tool_call_ids=committed_tool_call_ids,
+            )
         )
         recovered_orphaned_tool_call_ids = {
             str(part.tool_call_id or "").strip()
@@ -968,7 +1002,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         recovered_tool_call_ids: list[str] = []
         recovered_tool_names: list[str] = []
         for tool_call_id, tool_name in pending_tool_calls.items():
-            state = load_or_recover_tool_call_state(
+            state = await load_or_recover_tool_call_state_async(
                 shared_store=self._shared_store,
                 event_log=self._event_bus,
                 trace_id=request.trace_id,
@@ -1050,7 +1084,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         if self._shared_store is None or self._event_bus is None:
             return history, 0
         try:
-            _ = recover_tool_call_batches_from_event_log(
+            _ = await recover_tool_call_batches_from_event_log_async(
                 event_log=self._event_bus,
                 shared_store=self._shared_store,
                 trace_id=request.trace_id,
@@ -1077,7 +1111,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         committed_tool_call_ids = self._committed_tool_call_ids_from_history(history)
         recovered_count = 0
         current_history = history
-        for batch in self._task_tool_call_batch_states(request.task_id):
+        for batch in await self._task_tool_call_batch_states_async(request.task_id):
             if not self._batch_matches_request(batch=batch, request=request):
                 continue
             if not self._is_recoverable_tool_call_batch(batch):
@@ -1132,7 +1166,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         result_parts: list[ToolReturnPart] = []
         for item in sorted(batch.items, key=lambda candidate: candidate.index):
             try:
-                state = load_or_recover_tool_call_state(
+                state = await load_or_recover_tool_call_state_async(
                     shared_store=self._shared_store,
                     event_log=self._event_bus,
                     trace_id=request.trace_id,
@@ -1350,7 +1384,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
                 interleaved.append(ModelRequest(parts=message_recovered_parts))
         return interleaved
 
-    def _recover_orphaned_spawn_subagent_calls(
+    async def _recover_orphaned_spawn_subagent_calls_async(
         self,
         *,
         request: LLMRequest,
@@ -1358,8 +1392,10 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         committed_tool_call_ids: set[str],
     ) -> list[ModelResponse]:
         recovered_parts: list[ToolCallPart] = []
-        superseded_tool_call_ids = self._superseded_tool_call_ids_for_request(request)
-        for state in self._task_tool_call_states(request.task_id):
+        superseded_tool_call_ids = (
+            await self._superseded_tool_call_ids_for_request_async(request)
+        )
+        for state in await self._task_tool_call_states_async(request.task_id):
             if str(state.run_id or "").strip() != request.run_id:
                 continue
             if str(state.instance_id or "").strip() != request.instance_id:
@@ -1467,12 +1503,14 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             return value.strip().lower() in {"1", "true", "yes", "on"}
         return False
 
-    def _superseded_tool_call_ids_for_request(self, request: LLMRequest) -> set[str]:
+    async def _superseded_tool_call_ids_for_request_async(
+        self, request: LLMRequest
+    ) -> set[str]:
         event_bus = getattr(self, "_event_bus", None)
-        if event_bus is None:
+        if not isinstance(event_bus, _AsyncTraceEventLog):
             return set()
         try:
-            events = event_bus.list_by_trace(request.trace_id)
+            events = await event_bus.list_by_trace_async(request.trace_id)
         except (KeyError, RuntimeError, ValueError, sqlite3.Error):
             return set()
         superseded_ids: set[str] = set()
@@ -1490,7 +1528,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
                 continue
             payload_map = payload
             if not self._tool_result_event_matches_request_scope(
-                event=cast(dict[str, JsonValue], event),
+                event=event,
                 payload=payload_map,
                 request=request,
             ):
@@ -1534,16 +1572,18 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             RESUME_SUPERSEDED_TOOL_CALL_ERROR_CODE,
         }
 
-    def _committed_tool_call_ids_for_request(self, request: LLMRequest) -> set[str]:
+    async def _committed_tool_call_ids_for_request_async(
+        self, request: LLMRequest
+    ) -> set[str]:
         message_repo = getattr(self, "_message_repo", None)
-        if message_repo is None:
+        if not isinstance(message_repo, _AsyncConversationHistoryRepo):
             return set()
         resolved_conversation_id = request.conversation_id or build_conversation_id(
             request.session_id,
             request.role_id,
         )
         try:
-            history = message_repo.get_history_for_conversation(
+            history = await message_repo.get_history_for_conversation_async(
                 resolved_conversation_id
             )
         except (KeyError, RuntimeError, ValueError, sqlite3.Error):
@@ -1564,15 +1604,15 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
                         committed_ids.add(tool_call_id)
         return committed_ids
 
-    def _task_tool_call_states(
+    async def _task_tool_call_states_async(
         self,
         task_id: str,
     ) -> tuple[PersistedToolCallState, ...]:
         shared_store = getattr(self, "_shared_store", None)
-        if shared_store is None:
+        if not isinstance(shared_store, _AsyncSharedStateSnapshotStore):
             return ()
         try:
-            entries = shared_store.snapshot(
+            entries = await shared_store.snapshot_async(
                 ScopeRef(scope_type=ScopeType.TASK, scope_id=task_id)
             )
         except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
@@ -1603,15 +1643,15 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         states.sort(key=lambda item: item.updated_at)
         return tuple(states)
 
-    def _task_tool_call_batch_states(
+    async def _task_tool_call_batch_states_async(
         self,
         task_id: str,
     ) -> tuple[PersistedToolCallBatchState, ...]:
         shared_store = getattr(self, "_shared_store", None)
-        if shared_store is None:
+        if not isinstance(shared_store, _AsyncSharedStateSnapshotStore):
             return ()
         try:
-            entries = shared_store.snapshot(
+            entries = await shared_store.snapshot_async(
                 ScopeRef(scope_type=ScopeType.TASK, scope_id=task_id)
             )
         except (KeyError, RuntimeError, ValueError, sqlite3.Error) as exc:
@@ -1837,26 +1877,15 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         safe_index = self._last_committable_index(messages)
         return messages[:safe_index]
 
-    def _load_safe_history_for_conversation(
-        self,
-        conversation_id: str,
-    ) -> list[ModelRequest | ModelResponse]:
-        return self._truncate_history_to_safe_boundary(
-            self._filter_model_messages(
-                self._message_repo.get_history_for_conversation(conversation_id)
-            )
-        )
-
     async def _load_safe_history_for_conversation_async(
         self,
         conversation_id: str,
     ) -> list[ModelRequest | ModelResponse]:
-        if isinstance(self._message_repo, _AsyncConversationHistoryRepo):
-            history = await self._message_repo.get_history_for_conversation_async(
-                conversation_id
-            )
-        else:
-            history = self._message_repo.get_history_for_conversation(conversation_id)
+        if not isinstance(self._message_repo, _AsyncConversationHistoryRepo):
+            return []
+        history = await self._message_repo.get_history_for_conversation_async(
+            conversation_id
+        )
         return self._truncate_history_to_safe_boundary(
             self._filter_model_messages(history)
         )
@@ -1870,6 +1899,9 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
         if not isinstance(mcp_tool_context_token_cache, dict):
             mcp_tool_context_token_cache = {}
         self._mcp_tool_context_token_cache = mcp_tool_context_token_cache
+        run_intent_repo = getattr(self, "_run_intent_repo", None)
+        if not isinstance(run_intent_repo, AsyncRunIntentRepository):
+            run_intent_repo = _NullRunIntentRepo()
         return PromptHistoryService(
             config=getattr(
                 self,
@@ -1880,10 +1912,7 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
                     api_key="secret",
                 ),
             ),
-            run_intent_repo=cast(
-                RunIntentRepository,
-                getattr(self, "_run_intent_repo", _NullRunIntentRepo()),
-            ),
+            run_intent_repo=run_intent_repo,
             message_repo=getattr(
                 self,
                 "_message_repo",
@@ -1906,15 +1935,10 @@ class SessionSupportMixin(AgentLlmSessionMixinBase):
             hook_service=getattr(self, "_hook_service", None),
             reminder_service=getattr(self, "_reminder_service", None),
             run_event_hub=getattr(self, "_run_event_hub", None),
-            load_safe_history_for_conversation=getattr(
-                self,
-                "_load_safe_history_for_conversation",
-                lambda _conversation_id: [],
-            ),
             load_safe_history_for_conversation_async=getattr(
                 self,
                 "_load_safe_history_for_conversation_async",
-                None,
+                _empty_safe_history_async,
             ),
         )
 

--- a/src/relay_teams/agents/execution/subagent_reflection.py
+++ b/src/relay_teams/agents/execution/subagent_reflection.py
@@ -24,7 +24,10 @@ from pydantic_ai.settings import ModelSettings
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.logger import get_logger, log_event
 from relay_teams.media import user_prompt_content_to_text
-from relay_teams.net.llm_client import build_llm_http_client
+from relay_teams.net.llm_client import (
+    build_llm_http_client,
+    reset_llm_http_client_cache_entry,
+)
 from relay_teams.providers.llm_retry import (
     extract_retry_error_info,
     run_with_llm_retry,
@@ -158,12 +161,12 @@ class SubagentReflectionService:
             source_char_budget=plan.source_char_budget,
         )
         if summary:
-            _ = self._role_memory_service.update_reflection_memory(
+            _ = await self._role_memory_service.update_reflection_memory_async(
                 role_id=role.role_id,
                 workspace_id=workspace_id,
                 content_markdown=summary,
             )
-        self._message_repo.compact_conversation_history(
+        await self._message_repo.compact_conversation_history_async(
             conversation_id,
             keep_message_count=len(recent_history),
         )
@@ -188,9 +191,11 @@ class SubagentReflectionService:
         workspace_id: str,
         conversation_id: str,
     ) -> RoleMemoryRecord:
-        history = self._message_repo.get_history_for_conversation(conversation_id)
+        history = await self._message_repo.get_history_for_conversation_async(
+            conversation_id
+        )
         if not history or role.memory_profile.enabled is False:
-            return self._role_memory_service.get_reflection_record(
+            return await self._role_memory_service.get_reflection_record_async(
                 role_id=role.role_id,
                 workspace_id=workspace_id,
             )
@@ -201,11 +206,11 @@ class SubagentReflectionService:
             source_char_budget=24000,
         )
         if not summary:
-            return self._role_memory_service.get_reflection_record(
+            return await self._role_memory_service.get_reflection_record_async(
                 role_id=role.role_id,
                 workspace_id=workspace_id,
             )
-        record = self._role_memory_service.update_reflection_memory(
+        record = await self._role_memory_service.update_reflection_memory_async(
             role_id=role.role_id,
             workspace_id=workspace_id,
             content_markdown=summary,
@@ -232,7 +237,7 @@ class SubagentReflectionService:
         fallback_hop: int = 0,
         visited_profiles: tuple[str, ...] | None = None,
     ) -> str:
-        existing_summary = self._role_memory_service.build_injected_memory(
+        existing_summary = await self._role_memory_service.build_injected_memory_async(
             role_id=role.role_id,
             workspace_id=workspace_id,
         )
@@ -242,16 +247,9 @@ class SubagentReflectionService:
         )
         if not transcript.strip():
             return existing_summary.strip()
-        agent = Agent[None, str](
-            model=self._build_model(),
-            output_type=str,
-            instructions=(
-                "You maintain long-term reflection memory for a reusable subagent. "
-                "Rewrite the memory as concise markdown bullets. Keep only stable strategies, preferences, workflow lessons, and recurring warnings that will help future sessions. "
-                "Remove duplicates, stale points, task-specific facts, timestamps, and narration. Output only the final markdown. Keep it under 8 bullets."
-            ),
-            model_settings=self._model_settings(),
-            retries=3,
+        cache_scope = _reflection_llm_cache_scope(
+            role_id=role.role_id,
+            workspace_id=workspace_id,
         )
         prompt = (
             f"Role: {role.role_id}\n\n"
@@ -260,12 +258,18 @@ class SubagentReflectionService:
         )
         try:
             result = await run_with_llm_retry(
-                operation=lambda: self._run_streaming_reflection(
-                    agent=agent, prompt=prompt
+                operation=lambda: self._run_reflection_rewrite_attempt(
+                    prompt=prompt,
+                    cache_scope=cache_scope,
                 ),
                 config=self._retry_config,
                 is_retry_allowed=lambda: True,
-                on_retry_scheduled=lambda _schedule: None,
+                on_retry_scheduled=lambda schedule: (
+                    self._reset_reflection_llm_client_on_transport_retry(
+                        cache_scope=cache_scope,
+                        transport_error=schedule.error.transport_error,
+                    )
+                ),
             )
             return result.strip()
         except Exception as exc:
@@ -302,6 +306,27 @@ class SubagentReflectionService:
                 visited_profiles=resolved_visited_profiles
                 + (decision.to_profile_name,),
             )
+        finally:
+            await self._reset_reflection_llm_client(cache_scope=cache_scope)
+
+    async def _run_reflection_rewrite_attempt(
+        self,
+        *,
+        prompt: str,
+        cache_scope: str,
+    ) -> str:
+        agent = Agent[None, str](
+            model=self._build_model(cache_scope=cache_scope),
+            output_type=str,
+            instructions=(
+                "You maintain long-term reflection memory for a reusable subagent. "
+                "Rewrite the memory as concise markdown bullets. Keep only stable strategies, preferences, workflow lessons, and recurring warnings that will help future sessions. "
+                "Remove duplicates, stale points, task-specific facts, timestamps, and narration. Output only the final markdown. Keep it under 8 bullets."
+            ),
+            model_settings=self._model_settings(),
+            retries=3,
+        )
+        return await self._run_streaming_reflection(agent=agent, prompt=prompt)
 
     async def _run_streaming_reflection(
         self,
@@ -320,13 +345,31 @@ class SubagentReflectionService:
                 raise RuntimeError("Reflection rewrite did not produce a final result")
             return agent_run.result.output.strip()
 
-    def _build_model(self) -> RuntimeChatModel:
+    def _build_model(self, *, cache_scope: str) -> RuntimeChatModel:
         return build_runtime_chat_model(
             config=self._config,
             http_client=build_llm_http_client(
                 connect_timeout_seconds=self._config.connect_timeout_seconds,
                 ssl_verify=self._config.ssl_verify,
+                cache_scope=cache_scope,
             ),
+        )
+
+    async def _reset_reflection_llm_client_on_transport_retry(
+        self,
+        *,
+        cache_scope: str,
+        transport_error: bool,
+    ) -> None:
+        if not transport_error:
+            return
+        await self._reset_reflection_llm_client(cache_scope=cache_scope)
+
+    async def _reset_reflection_llm_client(self, *, cache_scope: str) -> None:
+        await reset_llm_http_client_cache_entry(
+            connect_timeout_seconds=self._config.connect_timeout_seconds,
+            ssl_verify=self._config.ssl_verify,
+            cache_scope=cache_scope,
         )
 
     def _model_settings(self) -> ModelSettings:
@@ -366,6 +409,10 @@ def _render_transcript(
         if remaining <= 0:
             break
     return "\n\n".join(lines).strip()
+
+
+def _reflection_llm_cache_scope(*, role_id: str, workspace_id: str) -> str:
+    return f"subagent_reflection:{workspace_id}:{role_id}"
 
 
 def _render_message(message: ModelRequest | ModelResponse) -> str:

--- a/src/relay_teams/agents/orchestration/coordinator.py
+++ b/src/relay_teams/agents/orchestration/coordinator.py
@@ -1814,7 +1814,7 @@ class CoordinatorGraph(BaseModel):
             return allowed_tools, None
         try:
             instance = await self.agent_repo.get_instance_async(instance_id)
-            workspace = workspace_manager.resolve(
+            workspace = await workspace_manager.resolve_async(
                 session_id=task.session_id,
                 role_id=role_id,
                 instance_id=instance_id,

--- a/src/relay_teams/agents/orchestration/harnesses/control_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/control_harness.py
@@ -251,11 +251,11 @@ class TaskControlHarness:
         """Append an artifact entry. Returns entry count or None if repo unavailable."""
         if self._artifact_repo is None:
             return None
-        artifact = await asyncio.to_thread(self._artifact_repo.get_artifact, task_id)
+        artifact = await self._artifact_repo.get_artifact_async(task_id)
         if artifact is None:
             return None
-        await asyncio.to_thread(self._artifact_repo.append_entry, task_id, entry)
-        updated = await asyncio.to_thread(self._artifact_repo.get_artifact, task_id)
+        await self._artifact_repo.append_entry_async(task_id, entry)
+        updated = await self._artifact_repo.get_artifact_async(task_id)
         return len(updated.entries) if updated else None
 
     async def _maybe_enqueue_retry(self, task: TaskEnvelope) -> None:

--- a/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
@@ -15,6 +15,7 @@ from relay_teams.agents.execution.system_prompts import (
     RuntimePromptBuilder,
     RuntimePromptSections,
 )
+from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.agents.instances.instance_repository import AgentInstanceRepository
 from relay_teams.agents.instances.models import (
     AgentRuntimeRecord,
@@ -67,8 +68,6 @@ from relay_teams.sessions.runs.todo_service import TodoService
 from relay_teams.skills.skill_models import SkillInstructionEntry
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
 from relay_teams.workspace import WorkspaceHandle, WorkspaceManager
-
-from relay_teams.agents.instances.enums import InstanceStatus
 
 LOGGER = get_logger(__name__)
 
@@ -196,7 +195,7 @@ class ExecutionHarness(BaseModel):
             role = self.role_registry.get(role_id)
 
         prompt_harness = self._prompt_harness()
-        role_for_run = prompt_harness.role_with_memory(
+        role_for_run = await prompt_harness.role_with_memory_async(
             role=role,
             role_id=role_id,
             workspace_id=workspace.ref.workspace_id,
@@ -205,7 +204,7 @@ class ExecutionHarness(BaseModel):
         run_kind = RunKind.CONVERSATION
         if self.run_intent_repo is not None:
             try:
-                intent = self.run_intent_repo.get(
+                intent = await self.run_intent_repo.get_async(
                     task.trace_id,
                     fallback_session_id=task.session_id,
                 )
@@ -337,30 +336,15 @@ class ExecutionHarness(BaseModel):
                 payload_json="{}",
             )
         )
-        await persistence.record_memory_if_needed_async(
+        await self._record_completed_task_memory_async(
+            task=task,
             role_id=role_id,
             workspace_id=workspace.ref.workspace_id,
-            task=task,
             conversation_id=workspace.ref.conversation_id,
             instance_id=instance_id,
             lifecycle=instance_record.lifecycle.value,
             result=result,
         )
-        # Memory bank lifecycle: record task result as a WORKING entry
-        # and trigger run/session consolidation.  The handler is a
-        # no-op when ``memory_event_handler`` is ``None`` (e.g. tests or
-        # lightweight runtimes that skip the container wiring).
-        memory_handler = self.memory_event_handler
-        if memory_handler is not None:
-            memory_handler.on_task_completed(
-                workspace_id=workspace.ref.workspace_id,
-                role_id=role_id,
-                session_id=task.session_id,
-                run_id=task.trace_id,
-                task_id=task.task_id,
-                objective=task.objective or "",
-                result=result,
-            )
         log_event(
             LOGGER,
             logging.DEBUG,
@@ -372,6 +356,39 @@ class ExecutionHarness(BaseModel):
                 "role_id": role_id,
             },
         )
+
+    async def _record_completed_task_memory_async(
+        self,
+        *,
+        task: TaskEnvelope,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        instance_id: str,
+        lifecycle: str,
+        result: str,
+    ) -> None:
+        persistence = self._full_persistence_harness()
+        await persistence.record_memory_if_needed_async(
+            role_id=role_id,
+            workspace_id=workspace_id,
+            task=task,
+            conversation_id=conversation_id,
+            instance_id=instance_id,
+            lifecycle=lifecycle,
+            result=result,
+        )
+        memory_handler = self.memory_event_handler
+        if memory_handler is not None:
+            await memory_handler.on_task_completed_async(
+                workspace_id=workspace_id,
+                role_id=role_id,
+                session_id=task.session_id,
+                run_id=task.trace_id,
+                task_id=task.task_id,
+                objective=task.objective or "",
+                result=result,
+            )
 
     @staticmethod
     async def handle_execution_error(
@@ -474,36 +491,6 @@ class ExecutionHarness(BaseModel):
             persistence_harness=TaskPersistenceHarness.model_construct(),
         ).thinking_for_run_async(run_id)
 
-    def evaluate_completion_guard(
-        self,
-        *,
-        task: TaskEnvelope,
-        instance_id: str,
-        role_id: str,
-        workspace: WorkspaceHandle,
-        conversation_id: str,
-        output_text: str,
-    ) -> ReminderDecision:
-        return TaskLlmHarness.model_construct(
-            run_intent_repo=self.run_intent_repo,
-            todo_service=self.todo_service,
-            reminder_service=self.reminder_service,
-            persistence_harness=TaskPersistenceHarness.model_construct(),
-        ).evaluate_completion_guard(
-            task=task,
-            instance_id=instance_id,
-            role_id=role_id,
-            workspace=workspace,
-            conversation_id=conversation_id,
-            output_text=output_text,
-        )
-
-    def thinking_for_run(self, run_id: str) -> RunThinkingConfig:
-        return TaskLlmHarness.model_construct(
-            run_intent_repo=self.run_intent_repo,
-            persistence_harness=TaskPersistenceHarness.model_construct(),
-        ).thinking_for_run(run_id)
-
     # ── Hook execution ────────────────────────────────────────────────
 
     async def execute_task_completed_hooks(
@@ -525,31 +512,6 @@ class ExecutionHarness(BaseModel):
         )
 
     # ── Persistence helpers ───────────────────────────────────────────
-
-    def complete_with_assistant_error(
-        self,
-        *,
-        task: TaskEnvelope,
-        instance_id: str,
-        role_id: str,
-        conversation_id: str,
-        workspace_id: str,
-        assistant_message: str,
-        error_code: str,
-        error_message: str,
-        append_message: bool = True,
-    ) -> TaskExecutionResult:
-        return self._full_persistence_harness().complete_with_assistant_error(
-            task=task,
-            instance_id=instance_id,
-            role_id=role_id,
-            conversation_id=conversation_id,
-            workspace_id=workspace_id,
-            assistant_message=assistant_message,
-            error_code=error_code,
-            error_message=error_message,
-            append_message=append_message,
-        )
 
     async def complete_with_assistant_error_async(
         self,
@@ -578,29 +540,6 @@ class ExecutionHarness(BaseModel):
             )
         )
 
-    def record_memory_if_needed(
-        self,
-        *,
-        role_id: str,
-        workspace_id: str,
-        task: TaskEnvelope,
-        conversation_id: str,
-        instance_id: str,
-        lifecycle: str,
-        result: str,
-    ) -> None:
-        TaskPersistenceHarness.model_construct(
-            shared_store=self.shared_store,
-        ).record_memory_if_needed(
-            role_id=role_id,
-            workspace_id=workspace_id,
-            task=task,
-            conversation_id=conversation_id,
-            instance_id=instance_id,
-            lifecycle=lifecycle,
-            result=result,
-        )
-
     async def record_memory_if_needed_async(
         self,
         *,
@@ -624,17 +563,6 @@ class ExecutionHarness(BaseModel):
             result=result,
         )
 
-    def mark_runtime_idle_after_success(
-        self,
-        *,
-        run_id: str,
-        completed_task_id: str,
-    ) -> None:
-        self._runtime_persistence_harness().mark_runtime_idle_after_success(
-            run_id=run_id,
-            completed_task_id=completed_task_id,
-        )
-
     async def mark_runtime_idle_after_success_async(
         self,
         *,
@@ -648,31 +576,6 @@ class ExecutionHarness(BaseModel):
         ).mark_runtime_idle_after_success_async(
             run_id=run_id,
             completed_task_id=completed_task_id,
-        )
-
-    def mark_runtime_after_terminal_task_update(
-        self,
-        *,
-        run_id: str,
-        terminal_task_id: str,
-        status: RunRuntimeStatus,
-        phase: RunRuntimePhase,
-        active_instance_id: str | None,
-        active_task_id: str | None,
-        active_role_id: str | None,
-        active_subagent_instance_id: str | None,
-        last_error: str | None,
-    ) -> None:
-        self._runtime_persistence_harness().mark_runtime_after_terminal_task_update(
-            run_id=run_id,
-            terminal_task_id=terminal_task_id,
-            status=status,
-            phase=phase,
-            active_instance_id=active_instance_id,
-            active_task_id=active_task_id,
-            active_role_id=active_role_id,
-            active_subagent_instance_id=active_subagent_instance_id,
-            last_error=last_error,
         )
 
     async def mark_runtime_after_terminal_task_update_async(
@@ -704,19 +607,6 @@ class ExecutionHarness(BaseModel):
             last_error=last_error,
         )
 
-    def promote_running_runtime_lane(
-        self,
-        *,
-        run_id: str,
-        terminal_task_id: str,
-        last_error: str | None,
-    ) -> bool:
-        return self._runtime_persistence_harness().promote_running_runtime_lane(
-            run_id=run_id,
-            terminal_task_id=terminal_task_id,
-            last_error=last_error,
-        )
-
     async def promote_running_runtime_lane_async(
         self,
         *,
@@ -729,19 +619,6 @@ class ExecutionHarness(BaseModel):
             run_runtime_repo=self.run_runtime_repo,
             run_control_manager=self.run_control_manager,
         ).promote_running_runtime_lane_async(
-            run_id=run_id,
-            terminal_task_id=terminal_task_id,
-            last_error=last_error,
-        )
-
-    def promote_paused_runtime_lane(
-        self,
-        *,
-        run_id: str,
-        terminal_task_id: str,
-        last_error: str | None,
-    ) -> bool:
-        return self._runtime_persistence_harness().promote_paused_runtime_lane(
             run_id=run_id,
             terminal_task_id=terminal_task_id,
             last_error=last_error,
@@ -766,18 +643,6 @@ class ExecutionHarness(BaseModel):
 
     # ── Prompt helpers ────────────────────────────────────────────────
 
-    def topology_for_run(self, run_id: str) -> RunTopologySnapshot | None:
-        return TaskPromptHarness.model_construct(
-            run_intent_repo=self.run_intent_repo,
-        ).topology_for_run(run_id)
-
-    def conversation_context_for_run(
-        self, run_id: str
-    ) -> RuntimePromptConversationContext | None:
-        return TaskPromptHarness.model_construct(
-            run_intent_repo=self.run_intent_repo,
-        ).conversation_context_for_run(run_id)
-
     async def topology_for_run_async(self, run_id: str) -> RunTopologySnapshot | None:
         return await TaskPromptHarness.model_construct(
             run_intent_repo=self.run_intent_repo,
@@ -790,13 +655,13 @@ class ExecutionHarness(BaseModel):
             run_intent_repo=self.run_intent_repo,
         ).conversation_context_for_run_async(run_id)
 
-    def role_with_memory(
+    async def role_with_memory_async(
         self, *, role: RoleDefinition, role_id: str, workspace_id: str
     ) -> RoleDefinition:
-        return TaskPromptHarness.model_construct(
+        return await TaskPromptHarness.model_construct(
             role_registry=self.role_registry,
             role_memory_service=self.role_memory_service,
-        ).role_with_memory(role=role, role_id=role_id, workspace_id=workspace_id)
+        ).role_with_memory_async(role=role, role_id=role_id, workspace_id=workspace_id)
 
     async def prepare_runtime_snapshot(
         self,
@@ -841,17 +706,6 @@ class ExecutionHarness(BaseModel):
             skill_instructions=skill_instructions,
         )
 
-    def shared_state_snapshot(
-        self, *, session_id: str, role_id: str, conversation_id: str
-    ) -> tuple[tuple[str, str], ...]:
-        return TaskPromptHarness.model_construct(
-            shared_store=self.shared_store,
-        ).shared_state_snapshot(
-            session_id=session_id,
-            role_id=role_id,
-            conversation_id=conversation_id,
-        )
-
     async def shared_state_snapshot_async(
         self, *, session_id: str, role_id: str, conversation_id: str
     ) -> tuple[tuple[str, str], ...]:
@@ -861,31 +715,6 @@ class ExecutionHarness(BaseModel):
             session_id=session_id,
             role_id=role_id,
             conversation_id=conversation_id,
-        )
-
-    def ensure_committed_task_prompt(
-        self,
-        *,
-        role_id: str,
-        workspace_id: str,
-        conversation_id: str,
-        instance_id: str,
-        task: TaskEnvelope,
-        user_prompt_text: str,
-        user_prompt_override: str | None,
-    ) -> None:
-        TaskPromptHarness.model_construct(
-            message_repo=self.message_repo,
-            run_intent_repo=self.run_intent_repo,
-            media_asset_service=self.media_asset_service,
-        ).ensure_committed_task_prompt(
-            role_id=role_id,
-            workspace_id=workspace_id,
-            conversation_id=conversation_id,
-            instance_id=instance_id,
-            task=task,
-            user_prompt_text=user_prompt_text,
-            user_prompt_override=user_prompt_override,
         )
 
     async def ensure_committed_task_prompt_async(
@@ -911,27 +740,6 @@ class ExecutionHarness(BaseModel):
             task=task,
             user_prompt_text=user_prompt_text,
             user_prompt_override=user_prompt_override,
-        )
-
-    def build_user_prompt(
-        self,
-        *,
-        role: RoleDefinition,
-        objective: str,
-        shared_state_snapshot: tuple[tuple[str, str], ...],
-        conversation_context: RuntimePromptConversationContext | None,
-        orchestration_prompt: str,
-        skill_names: tuple[str, ...] | None = None,
-    ) -> tuple[str, tuple[PromptSkillInstruction, ...]]:
-        return TaskPromptHarness.model_construct(
-            skill_runtime_service=self.skill_runtime_service,
-        ).build_user_prompt(
-            role=role,
-            objective=objective,
-            shared_state_snapshot=shared_state_snapshot,
-            conversation_context=conversation_context,
-            orchestration_prompt=orchestration_prompt,
-            skill_names=skill_names,
         )
 
     @staticmethod

--- a/src/relay_teams/agents/orchestration/harnesses/llm_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/llm_harness.py
@@ -181,102 +181,10 @@ class TaskLlmHarness(BaseModel):
         except KeyError:
             return RunThinkingConfig()
 
-    def evaluate_completion_guard(
-        self,
-        *,
-        task: TaskEnvelope,
-        instance_id: str,
-        role_id: str,
-        workspace: WorkspaceHandle,
-        conversation_id: str,
-        output_text: str,
-    ) -> ReminderDecision:
-        if task.parent_task_id is not None:
-            if self.todo_service is not None:
-                self._finalize_subtask_todos(task, instance_id)
-            return ReminderDecision()
-        if self.reminder_service is None or self.todo_service is None:
-            return ReminderDecision()
-        snapshot = self.todo_service.get_for_run(
-            run_id=task.trace_id,
-            session_id=task.session_id,
-        )
-        incomplete = tuple(
-            IncompleteTodoItem(content=item.content, status=item.status.value)
-            for item in snapshot.items
-            if item.status != TodoStatus.COMPLETED
-        )
-        return self.reminder_service.evaluate_completion_attempt(
-            CompletionAttemptObservation(
-                session_id=task.session_id,
-                run_id=task.trace_id,
-                trace_id=task.trace_id,
-                task_id=task.task_id,
-                instance_id=instance_id,
-                role_id=role_id,
-                workspace_id=workspace.ref.workspace_id,
-                conversation_id=conversation_id,
-                output_text=output_text,
-                incomplete_todos=incomplete,
-            )
-        )
-
-    def thinking_for_run(self, run_id: str) -> RunThinkingConfig:
-        if self.run_intent_repo is None:
-            return RunThinkingConfig()
-        try:
-            return self.run_intent_repo.get(run_id).thinking
-        except KeyError:
-            return RunThinkingConfig()
-
-    def _finalize_subtask_todos(self, task: TaskEnvelope, instance_id: str) -> None:
-        """Finalize sub-task-scoped todos.
-
-        Only marks ``IN_PROGRESS`` items as ``COMPLETED``.  ``PENDING``
-        items are left untouched because concurrent sub-tasks may own
-        them.  This avoids corrupting shared todo state when parallel
-        delegation is active.
-        """
-        assert self.todo_service is not None  # guarded by caller
-        snapshot = self.todo_service.get_for_run(
-            run_id=task.trace_id,
-            session_id=task.session_id,
-        )
-        in_progress_indices = tuple(
-            idx
-            for idx, item in enumerate(snapshot.items)
-            if item.status == TodoStatus.IN_PROGRESS
-        )
-        if not in_progress_indices:
-            return
-        finalized = tuple(
-            TodoItem(content=item.content, status=TodoStatus.COMPLETED)
-            if idx in in_progress_indices
-            else item
-            for idx, item in enumerate(snapshot.items)
-        )
-        self.todo_service.replace_for_run(
-            run_id=task.trace_id,
-            session_id=task.session_id,
-            items=finalized,
-            updated_by_instance_id=instance_id,
-        )
-        log_event(
-            LOGGER,
-            logging.INFO,
-            event="task.execution.subtask_todos_finalized",
-            message="Finalized in-progress sub-task todos as completed",
-            payload={
-                "task_id": task.task_id,
-                "trace_id": task.trace_id,
-                "finalized_count": len(in_progress_indices),
-            },
-        )
-
     async def _finalize_subtask_todos_async(
         self, task: TaskEnvelope, instance_id: str
     ) -> None:
-        """Async counterpart of :meth:`_finalize_subtask_todos`."""
+        """Finalize sub-task-scoped todos without touching pending sibling work."""
         assert self.todo_service is not None  # guarded by caller
         snapshot = await self.todo_service.get_for_run_async(
             run_id=task.trace_id,

--- a/src/relay_teams/agents/orchestration/harnesses/persistence_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/persistence_harness.py
@@ -91,87 +91,6 @@ class TaskPersistenceHarness(BaseModel):
                 bundle.reason or "Task completion denied by runtime hooks."
             )
 
-    def complete_with_assistant_error(
-        self,
-        *,
-        task: TaskEnvelope,
-        instance_id: str,
-        role_id: str,
-        conversation_id: str,
-        workspace_id: str,
-        assistant_message: str,
-        error_code: str,
-        error_message: str,
-        append_message: bool = True,
-    ) -> TaskExecutionResult:
-        message_repo = self.message_repo
-        task_repo = self.task_repo
-        agent_repo = self.agent_repo
-        event_bus = self.event_bus
-        assert message_repo is not None
-        assert task_repo is not None
-        assert agent_repo is not None
-        assert event_bus is not None
-        if append_message:
-            message_repo.prune_conversation_history_to_safe_boundary(conversation_id)
-            message_repo.append(
-                session_id=task.session_id,
-                workspace_id=workspace_id,
-                conversation_id=conversation_id,
-                agent_role_id=role_id,
-                instance_id=instance_id,
-                task_id=task.task_id,
-                trace_id=task.trace_id,
-                messages=[build_assistant_error_response(assistant_message)],
-            )
-        task_repo.update_status(
-            task.task_id,
-            TaskStatus.FAILED,
-            assigned_instance_id=instance_id,
-            result=assistant_message,
-            error_message=error_message or assistant_message,
-        )
-        agent_repo.mark_status(instance_id, InstanceStatus.FAILED)
-        self.mark_runtime_after_terminal_task_update(
-            run_id=task.trace_id,
-            terminal_task_id=task.task_id,
-            status=RunRuntimeStatus.RUNNING,
-            phase=RunRuntimePhase.IDLE,
-            active_instance_id=None,
-            active_task_id=None,
-            active_role_id=None,
-            active_subagent_instance_id=None,
-            last_error=error_message or assistant_message,
-        )
-        event_bus.emit(
-            EventEnvelope(
-                event_type=EventType.TASK_FAILED,
-                trace_id=task.trace_id,
-                session_id=task.session_id,
-                task_id=task.task_id,
-                instance_id=instance_id,
-                payload_json="{}",
-            )
-        )
-        log_event(
-            LOGGER,
-            logging.WARNING,
-            event="task.execution.failed_with_assistant_error",
-            message="Task execution failed after assistant error message was persisted",
-            payload={
-                "task_id": task.task_id,
-                "instance_id": instance_id,
-                "role_id": role_id,
-                "error_code": error_code,
-            },
-        )
-        return TaskExecutionResult(
-            output=assistant_message,
-            completion_reason=RunCompletionReason.ASSISTANT_ERROR,
-            error_code=error_code,
-            error_message=error_message or assistant_message,
-        )
-
     async def complete_with_assistant_error_async(
         self,
         *,
@@ -255,53 +174,6 @@ class TaskPersistenceHarness(BaseModel):
             error_message=error_message or assistant_message,
         )
 
-    def record_memory_if_needed(
-        self,
-        *,
-        role_id: str,
-        workspace_id: str,
-        task: TaskEnvelope,
-        conversation_id: str,
-        instance_id: str,
-        lifecycle: str,
-        result: str,
-    ) -> None:
-        shared_store = self.shared_store
-        assert shared_store is not None
-        payload: dict[str, JsonValue] = {
-            "task_id": task.task_id,
-            "title": task.title or "",
-            "objective": task.objective[:500],
-            "role_id": role_id,
-            "workspace_id": workspace_id,
-            "conversation_id": conversation_id,
-            "instance_id": instance_id,
-            "lifecycle": lifecycle,
-            "result_excerpt": truncate_task_memory_result(result),
-            "completed_at": datetime.now(tz=timezone.utc).isoformat(),
-        }
-        try:
-            shared_store.manage_state(
-                StateMutation(
-                    scope=ScopeRef(
-                        scope_type=ScopeType.ROLE,
-                        scope_id=f"{task.session_id}:{role_id}",
-                    ),
-                    key=f"task_result:{task.task_id}",
-                    value_json=json.dumps(payload, ensure_ascii=False, sort_keys=True),
-                )
-            )
-        except (AttributeError, RuntimeError, sqlite3.Error):
-            LOGGER.warning(
-                "Failed to persist completed task memory",
-                extra={
-                    "task_id": task.task_id,
-                    "role_id": role_id,
-                    "instance_id": instance_id,
-                },
-                exc_info=True,
-            )
-
     async def record_memory_if_needed_async(
         self,
         *,
@@ -349,24 +221,6 @@ class TaskPersistenceHarness(BaseModel):
                 exc_info=True,
             )
 
-    def mark_runtime_idle_after_success(
-        self,
-        *,
-        run_id: str,
-        completed_task_id: str,
-    ) -> None:
-        self.mark_runtime_after_terminal_task_update(
-            run_id=run_id,
-            terminal_task_id=completed_task_id,
-            status=RunRuntimeStatus.RUNNING,
-            phase=RunRuntimePhase.IDLE,
-            active_instance_id=None,
-            active_task_id=None,
-            active_role_id=None,
-            active_subagent_instance_id=None,
-            last_error=None,
-        )
-
     async def mark_runtime_idle_after_success_async(
         self,
         *,
@@ -383,52 +237,6 @@ class TaskPersistenceHarness(BaseModel):
             active_role_id=None,
             active_subagent_instance_id=None,
             last_error=None,
-        )
-
-    def mark_runtime_after_terminal_task_update(
-        self,
-        *,
-        run_id: str,
-        terminal_task_id: str,
-        status: RunRuntimeStatus,
-        phase: RunRuntimePhase,
-        active_instance_id: str | None,
-        active_task_id: str | None,
-        active_role_id: str | None,
-        active_subagent_instance_id: str | None,
-        last_error: str | None,
-    ) -> None:
-        run_runtime_repo = self.run_runtime_repo
-        assert run_runtime_repo is not None
-        current = run_runtime_repo.get(run_id)
-        if current is not None and current.active_task_id not in {
-            None,
-            terminal_task_id,
-        }:
-            if last_error is not None:
-                run_runtime_repo.update(run_id, last_error=last_error)
-            return
-        if self.promote_running_runtime_lane(
-            run_id=run_id,
-            terminal_task_id=terminal_task_id,
-            last_error=last_error,
-        ):
-            return
-        if self.promote_paused_runtime_lane(
-            run_id=run_id,
-            terminal_task_id=terminal_task_id,
-            last_error=last_error,
-        ):
-            return
-        run_runtime_repo.update(
-            run_id,
-            status=status,
-            phase=phase,
-            active_instance_id=active_instance_id,
-            active_task_id=active_task_id,
-            active_role_id=active_role_id,
-            active_subagent_instance_id=active_subagent_instance_id,
-            last_error=last_error,
         )
 
     async def mark_runtime_after_terminal_task_update_async(
@@ -476,57 +284,6 @@ class TaskPersistenceHarness(BaseModel):
             active_subagent_instance_id=active_subagent_instance_id,
             last_error=last_error,
         )
-
-    def promote_running_runtime_lane(
-        self,
-        *,
-        run_id: str,
-        terminal_task_id: str,
-        last_error: str | None,
-    ) -> bool:
-        task_repo = self.task_repo
-        run_runtime_repo = self.run_runtime_repo
-        assert task_repo is not None
-        assert run_runtime_repo is not None
-        coordinator_record: TaskRecord | None = None
-        promoted_record: TaskRecord | None = None
-        for record in task_repo.list_by_trace(run_id):
-            task = record.envelope
-            if task.task_id == terminal_task_id:
-                continue
-            if record.status != TaskStatus.RUNNING:
-                continue
-            if not record.assigned_instance_id:
-                continue
-            if task.parent_task_id is not None:
-                promoted_record = record
-                break
-            if coordinator_record is None:
-                coordinator_record = record
-        if promoted_record is None:
-            promoted_record = coordinator_record
-        if promoted_record is None:
-            return False
-        task = promoted_record.envelope
-        instance_id = promoted_record.assigned_instance_id
-        if not instance_id:
-            return False
-        is_coordinator = task.parent_task_id is None
-        run_runtime_repo.update(
-            run_id,
-            status=RunRuntimeStatus.RUNNING,
-            phase=(
-                RunRuntimePhase.COORDINATOR_RUNNING
-                if is_coordinator
-                else RunRuntimePhase.SUBAGENT_RUNNING
-            ),
-            active_instance_id=instance_id,
-            active_task_id=task.task_id,
-            active_role_id=task.role_id,
-            active_subagent_instance_id=(None if is_coordinator else instance_id),
-            last_error=last_error,
-        )
-        return True
 
     async def promote_running_runtime_lane_async(
         self,
@@ -578,56 +335,6 @@ class TaskPersistenceHarness(BaseModel):
             last_error=last_error,
         )
         return True
-
-    def promote_paused_runtime_lane(
-        self,
-        *,
-        run_id: str,
-        terminal_task_id: str,
-        last_error: str | None,
-    ) -> bool:
-        task_repo = self.task_repo
-        run_runtime_repo = self.run_runtime_repo
-        assert task_repo is not None
-        assert run_runtime_repo is not None
-        if self.run_control_manager is None:
-            return False
-        if self.run_control_manager.is_run_stop_requested(run_id):
-            return False
-        for record in task_repo.list_by_trace(run_id):
-            task = record.envelope
-            instance_id = record.assigned_instance_id
-            if task.task_id == terminal_task_id:
-                continue
-            if task.parent_task_id is None:
-                continue
-            if record.status != TaskStatus.STOPPED:
-                continue
-            if not instance_id:
-                continue
-            if not (
-                self.run_control_manager.is_subagent_stop_requested(
-                    run_id=run_id,
-                    instance_id=instance_id,
-                )
-                or self.run_control_manager.is_subagent_paused(
-                    session_id=task.session_id,
-                    instance_id=instance_id,
-                )
-            ):
-                continue
-            run_runtime_repo.update(
-                run_id,
-                status=RunRuntimeStatus.STOPPED,
-                phase=RunRuntimePhase.AWAITING_SUBAGENT_FOLLOWUP,
-                active_instance_id=None,
-                active_task_id=task.task_id,
-                active_role_id=task.role_id,
-                active_subagent_instance_id=instance_id,
-                last_error=last_error or record.error_message or "Task stopped by user",
-            )
-            return True
-        return False
 
     async def promote_paused_runtime_lane_async(
         self,

--- a/src/relay_teams/agents/orchestration/harnesses/prompt_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/prompt_harness.py
@@ -30,7 +30,7 @@ from relay_teams.agents.tasks.models import TaskEnvelope
 from relay_teams.media import MediaAssetService, merge_user_prompt_content
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
-from relay_teams.roles.memory_injection import build_role_with_memory
+from relay_teams.roles.memory_injection import build_role_with_memory_async
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
@@ -72,25 +72,6 @@ class TaskPromptHarness(BaseModel):
     run_intent_repo: RunIntentRepository | None = None
     media_asset_service: MediaAssetService | None = None
 
-    def topology_for_run(self, run_id: str) -> RunTopologySnapshot | None:
-        if self.run_intent_repo is None:
-            return None
-        try:
-            return self.run_intent_repo.get(run_id).topology
-        except KeyError:
-            return None
-
-    def conversation_context_for_run(
-        self,
-        run_id: str,
-    ) -> RuntimePromptConversationContext | None:
-        if self.run_intent_repo is None:
-            return None
-        try:
-            return self.run_intent_repo.get(run_id).conversation_context
-        except KeyError:
-            return None
-
     async def topology_for_run_async(self, run_id: str) -> RunTopologySnapshot | None:
         if self.run_intent_repo is None:
             return None
@@ -110,14 +91,14 @@ class TaskPromptHarness(BaseModel):
         except KeyError:
             return None
 
-    def role_with_memory(
+    async def role_with_memory_async(
         self,
         *,
         role: RoleDefinition,
         role_id: str,
         workspace_id: str,
     ) -> RoleDefinition:
-        return build_role_with_memory(
+        return await build_role_with_memory_async(
             role_registry=self.role_registry,
             role_memory_service=self.role_memory_service,
             role=role,
@@ -176,7 +157,7 @@ class TaskPromptHarness(BaseModel):
             task_id=task.task_id,
             paths=prompt_sections.local_instruction_paths,
         )
-        user_prompt, skill_instructions = self.build_user_prompt(
+        user_prompt, skill_instructions = await self.build_user_prompt_async(
             role=role,
             objective=objective,
             shared_state_snapshot=shared_state_snapshot,
@@ -219,23 +200,6 @@ class TaskPromptHarness(BaseModel):
             skill_instructions=skill_instructions,
         )
 
-    def shared_state_snapshot(
-        self,
-        *,
-        session_id: str,
-        role_id: str,
-        conversation_id: str,
-    ) -> tuple[tuple[str, str], ...]:
-        scopes = (
-            ScopeRef(scope_type=ScopeType.SESSION, scope_id=session_id),
-            ScopeRef(scope_type=ScopeType.ROLE, scope_id=f"{session_id}:{role_id}"),
-            ScopeRef(scope_type=ScopeType.CONVERSATION, scope_id=conversation_id),
-        )
-        return self.shared_store.snapshot_many(
-            scopes,
-            exclude_key_prefixes=(READ_STATE_PREFIX,),
-        )
-
     async def shared_state_snapshot_async(
         self,
         *,
@@ -251,98 +215,6 @@ class TaskPromptHarness(BaseModel):
         return await self.shared_store.snapshot_many_async(
             scopes,
             exclude_key_prefixes=(READ_STATE_PREFIX,),
-        )
-
-    def ensure_committed_task_prompt(
-        self,
-        *,
-        role_id: str,
-        workspace_id: str,
-        conversation_id: str,
-        instance_id: str,
-        task: TaskEnvelope,
-        user_prompt_text: str,
-        user_prompt_override: str | None,
-    ) -> None:
-        prompt = user_prompt_text.strip()
-        override_prompt = str(user_prompt_override or "").strip()
-        if override_prompt:
-            self.message_repo.append_user_prompt_if_missing(
-                session_id=task.session_id,
-                workspace_id=workspace_id,
-                conversation_id=conversation_id,
-                agent_role_id=role_id,
-                instance_id=instance_id,
-                task_id=task.task_id,
-                trace_id=task.trace_id,
-                content=override_prompt,
-            )
-            return
-
-        task_history = self.message_repo.get_history_for_conversation_task(
-            conversation_id,
-            task.task_id,
-        )
-        if task_history:
-            return
-        if (
-            task.parent_task_id is None
-            and self.run_intent_repo is not None
-            and self.media_asset_service is not None
-        ):
-            try:
-                run_intent = self.run_intent_repo.get(task.trace_id)
-            except KeyError:
-                run_intent = None
-            if run_intent is not None and run_intent.input:
-                provider_content = (
-                    self.media_asset_service.to_persisted_user_prompt_content(
-                        parts=run_intent.input
-                    )
-                )
-                merged_provider_content = self.merge_provider_prompt_content(
-                    provider_content=provider_content,
-                    user_prompt_text=prompt,
-                )
-                self.message_repo.prune_conversation_history_to_safe_boundary(
-                    conversation_id
-                )
-                self.message_repo.append(
-                    session_id=task.session_id,
-                    workspace_id=workspace_id,
-                    conversation_id=conversation_id,
-                    agent_role_id=role_id,
-                    instance_id=instance_id,
-                    task_id=task.task_id,
-                    trace_id=task.trace_id,
-                    messages=[
-                        ModelRequest(
-                            parts=[UserPromptPart(content=merged_provider_content)]
-                        )
-                    ],
-                )
-                return
-        if prompt:
-            self.message_repo.append_user_prompt_if_missing(
-                session_id=task.session_id,
-                workspace_id=workspace_id,
-                conversation_id=conversation_id,
-                agent_role_id=role_id,
-                instance_id=instance_id,
-                task_id=task.task_id,
-                trace_id=task.trace_id,
-                content=prompt,
-            )
-            return
-        self.message_repo.append_user_prompt_if_missing(
-            session_id=task.session_id,
-            workspace_id=workspace_id,
-            conversation_id=conversation_id,
-            agent_role_id=role_id,
-            instance_id=instance_id,
-            task_id=task.task_id,
-            trace_id=task.trace_id,
-            content=task.objective,
         )
 
     async def ensure_committed_task_prompt_async(
@@ -439,7 +311,7 @@ class TaskPromptHarness(BaseModel):
             content=task.objective,
         )
 
-    def build_user_prompt(
+    async def build_user_prompt_async(
         self,
         *,
         role: RoleDefinition,
@@ -459,7 +331,7 @@ class TaskPromptHarness(BaseModel):
             SkillRuntimeService,
             self.skill_runtime_service,
         )
-        prepared_prompt = skill_runtime_service.prepare_prompt(
+        prepared_prompt = await skill_runtime_service.prepare_prompt_async(
             role=role,
             objective=resolved_objective,
             shared_state_snapshot=shared_state_snapshot,

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -398,13 +398,11 @@ class TaskExecutionService(BaseModel):
         # OP-3: Create artifact container (spec phase).
         if self.artifact_repo is not None:
             try:
-                await asyncio.to_thread(
-                    self.artifact_repo.ensure_artifact,
+                await self.artifact_repo.ensure_artifact_async(
                     task_id=task.task_id,
                     spec_artifact_id=task.spec_artifact_id or "",
                 )
-                await asyncio.to_thread(
-                    self.artifact_repo.append_entry,
+                await self.artifact_repo.append_entry_async(
                     task_id=task.task_id,
                     entry=TaskArtifactEntry(
                         entry_id=f"start-{task.task_id}",
@@ -429,7 +427,7 @@ class TaskExecutionService(BaseModel):
         # Compute: resolve workspace before try for error-path access
         harness = self._execution_harness()
         instance_record = await self.agent_repo.get_instance_async(instance_id)
-        workspace = self.workspace_manager.resolve(
+        workspace = await self.workspace_manager.resolve_async(
             session_id=task.session_id,
             role_id=role_id,
             instance_id=instance_id,
@@ -441,8 +439,7 @@ class TaskExecutionService(BaseModel):
             # OP-3: Append implementation phase entry.
             if self.artifact_repo is not None:
                 try:
-                    await asyncio.to_thread(
-                        self.artifact_repo.append_entry,
+                    await self.artifact_repo.append_entry_async(
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"impl-{task.task_id}",
@@ -546,8 +543,7 @@ class TaskExecutionService(BaseModel):
             # OP-3: Append verification phase entry.
             if self.artifact_repo is not None:
                 try:
-                    await asyncio.to_thread(
-                        self.artifact_repo.append_entry,
+                    await self.artifact_repo.append_entry_async(
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"verify-{task.task_id}",
@@ -572,8 +568,7 @@ class TaskExecutionService(BaseModel):
             # OP-3: Append delivery phase entry and update summary.
             if self.artifact_repo is not None:
                 try:
-                    await asyncio.to_thread(
-                        self.artifact_repo.append_entry,
+                    await self.artifact_repo.append_entry_async(
                         task_id=task.task_id,
                         entry=TaskArtifactEntry(
                             entry_id=f"delivery-{task.task_id}",
@@ -586,8 +581,7 @@ class TaskExecutionService(BaseModel):
                             payload_json="{}",
                         ),
                     )
-                    await asyncio.to_thread(
-                        self.artifact_repo.update_summary,
+                    await self.artifact_repo.update_summary_async(
                         task_id=task.task_id,
                         summary=result,
                     )

--- a/src/relay_teams/agents/tasks/artifact_repository.py
+++ b/src/relay_teams/agents/tasks/artifact_repository.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import RLock
 from typing import TypeVar, cast
+
+import aiosqlite
 
 from relay_teams.agents.tasks.enums import TaskArtifactPhase
 from relay_teams.logger import get_logger
@@ -21,8 +23,11 @@ from relay_teams.persistence.db import (
     BlockingSqliteConnection,
     SQLITE_BUSY_TIMEOUT_MS,
     SQLITE_TIMEOUT_SECONDS,
+    open_async_sqlite,
+    run_async_sqlite_write_with_retry,
     run_sqlite_write_with_retry,
 )
+from relay_teams.persistence.sqlite_repository import async_fetchall, async_fetchone
 
 ResultT = TypeVar("ResultT")
 
@@ -84,6 +89,11 @@ class TaskArtifactRepository:
         _enable_wal_if_available(conn)
         return conn
 
+    async def _connect_async(self) -> aiosqlite.Connection:
+        conn = await open_async_sqlite(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
     def _run_write(
         self,
         *,
@@ -102,6 +112,25 @@ class TaskArtifactRepository:
             )
         finally:
             conn.close()
+
+    async def _run_async_write(
+        self,
+        *,
+        operation_name: str,
+        operation: Callable[[aiosqlite.Connection], Awaitable[ResultT]],
+    ) -> ResultT:
+        conn = await self._connect_async()
+        try:
+            return await run_async_sqlite_write_with_retry(
+                conn=conn,
+                db_path=self._db_path,
+                operation=lambda: operation(conn),
+                lock=None,
+                repository_name=type(self).__name__,
+                operation_name=operation_name,
+            )
+        finally:
+            await conn.close()
 
     def get_artifact(self, task_id: str) -> TaskArtifact | None:
         """Load the full artifact including all entries."""
@@ -146,9 +175,82 @@ class TaskArtifactRepository:
         finally:
             conn.close()
 
+    async def get_artifact_async(self, task_id: str) -> TaskArtifact | None:
+        """Load the full artifact including all entries."""
+        conn = await self._connect_async()
+        try:
+            row = await async_fetchone(
+                conn,
+                "SELECT * FROM task_artifacts WHERE task_id = ?",
+                (task_id,),
+            )
+            if row is None:
+                return None
+
+            artifact_row = dict(row)
+            entry_rows = await async_fetchall(
+                conn,
+                "SELECT * FROM task_artifact_entries WHERE task_id = ? ORDER BY id ASC",
+                (task_id,),
+            )
+            entries = [self._row_to_entry(dict(row)) for row in entry_rows]
+
+            evidence_bundle = None
+            eb_json = artifact_row.get("evidence_bundle_json")
+            if eb_json:
+                try:
+                    evidence_bundle = VerificationEvidenceBundle.model_validate_json(
+                        eb_json
+                    )
+                except (json.JSONDecodeError, ValueError):
+                    get_logger(__name__).debug(
+                        "Malformed evidence_bundle_json tolerated; falling back to None"
+                    )
+
+            return TaskArtifact(
+                task_id=artifact_row["task_id"],
+                spec_artifact_id=artifact_row.get("spec_artifact_id", ""),
+                entries=entries,
+                evidence_bundle=evidence_bundle,
+                summary=artifact_row.get("summary", ""),
+                created_at=artifact_row.get("created_at", ""),
+                updated_at=artifact_row.get("updated_at", ""),
+            )
+        finally:
+            await conn.close()
+
     def get_artifact_summary(self, task_id: str) -> TaskArtifactSummary | None:
         """Compute and return a summary view of the artifact."""
         artifact = self.get_artifact(task_id)
+        if artifact is None:
+            return None
+
+        phase_counts: dict[str, int] = {}
+        for entry in artifact.entries:
+            phase = entry.phase.value
+            phase_counts[phase] = phase_counts.get(phase, 0) + 1
+
+        evidence_count = 0
+        if artifact.evidence_bundle is not None:
+            evidence_count = len(artifact.evidence_bundle.items)
+
+        return TaskArtifactSummary(
+            task_id=artifact.task_id,
+            spec_artifact_id=artifact.spec_artifact_id,
+            total_entries=len(artifact.entries),
+            phase_counts=phase_counts,
+            evidence_item_count=evidence_count,
+            has_verification_bundle=artifact.evidence_bundle is not None,
+            has_summary=bool(artifact.summary),
+            created_at=artifact.created_at,
+            updated_at=artifact.updated_at,
+        )
+
+    async def get_artifact_summary_async(
+        self, task_id: str
+    ) -> TaskArtifactSummary | None:
+        """Compute and return a summary view of the artifact."""
+        artifact = await self.get_artifact_async(task_id)
         if artifact is None:
             return None
 
@@ -192,6 +294,31 @@ class TaskArtifactRepository:
             raise RuntimeError(f"Failed to create task artifact for task_id={task_id}")
         return artifact
 
+    async def ensure_artifact_async(
+        self, task_id: str, spec_artifact_id: str
+    ) -> TaskArtifact:
+        """Create the artifact record if it does not exist."""
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                "INSERT OR IGNORE INTO task_artifacts "
+                "(task_id, spec_artifact_id, summary, "
+                "created_at, updated_at) "
+                "VALUES (?, ?, '', ?, ?)",
+                (task_id, spec_artifact_id, now, now),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="ensure_artifact_async",
+            operation=operation,
+        )
+        artifact = await self.get_artifact_async(task_id)
+        if artifact is None:
+            raise RuntimeError(f"Failed to create task artifact for task_id={task_id}")
+        return artifact
+
     def append_entry(
         self,
         task_id: str,
@@ -228,6 +355,50 @@ class TaskArtifactRepository:
 
         return self._run_write(operation_name="append_entry", operation=operation)
 
+    async def append_entry_async(
+        self,
+        task_id: str,
+        entry: TaskArtifactEntry,
+    ) -> int:
+        """Append an entry to the artifact."""
+
+        async def operation(conn: aiosqlite.Connection) -> int:
+            cursor = await conn.execute(
+                "INSERT INTO task_artifact_entries "
+                "(entry_id, task_id, phase, timestamp, role_id, "
+                "instance_id, event_type, description, payload_json, "
+                "linked_evidence_ids) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    entry.entry_id,
+                    task_id,
+                    entry.phase.value,
+                    entry.timestamp,
+                    entry.role_id,
+                    entry.instance_id,
+                    entry.event_type,
+                    entry.description,
+                    entry.payload_json,
+                    json.dumps(list(entry.linked_evidence_ids)),
+                ),
+            )
+            inserted_row_id = cursor.lastrowid
+            await cursor.close()
+            now = datetime.now(tz=timezone.utc).isoformat()
+            cursor = await conn.execute(
+                "UPDATE task_artifacts SET updated_at = ? WHERE task_id = ?",
+                (now, task_id),
+            )
+            await cursor.close()
+            if inserted_row_id is None:
+                raise RuntimeError("SQLite append_entry returned no row id")
+            return int(inserted_row_id)
+
+        return await self._run_async_write(
+            operation_name="append_entry_async",
+            operation=operation,
+        )
+
     def update_evidence_bundle(
         self,
         task_id: str,
@@ -246,6 +417,28 @@ class TaskArtifactRepository:
 
         self._run_write(operation_name="update_evidence_bundle", operation=operation)
 
+    async def update_evidence_bundle_async(
+        self,
+        task_id: str,
+        bundle: VerificationEvidenceBundle,
+    ) -> None:
+        """Update the evidence bundle for an artifact."""
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                "UPDATE task_artifacts "
+                "SET evidence_bundle_json = ?, updated_at = ? "
+                "WHERE task_id = ?",
+                (bundle.model_dump_json(), now, task_id),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="update_evidence_bundle_async",
+            operation=operation,
+        )
+
     def update_summary(
         self,
         task_id: str,
@@ -262,6 +455,27 @@ class TaskArtifactRepository:
             )
 
         self._run_write(operation_name="update_summary", operation=operation)
+
+    async def update_summary_async(
+        self,
+        task_id: str,
+        summary: str,
+    ) -> None:
+        """Update the summary text for an artifact."""
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                "UPDATE task_artifacts SET summary = ?, updated_at = ? "
+                "WHERE task_id = ?",
+                (summary, now, task_id),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="update_summary_async",
+            operation=operation,
+        )
 
     def query_entries(
         self,
@@ -307,6 +521,53 @@ class TaskArtifactRepository:
             return entries, total
         finally:
             conn.close()
+
+    async def query_entries_async(
+        self,
+        *,
+        task_id: str,
+        phase: TaskArtifactPhase | None = None,
+        event_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[TaskArtifactEntry], int]:
+        """Query artifact entries with optional filters.
+
+        Returns (entries, total_count).
+        """
+        conn = await self._connect_async()
+        try:
+            conditions: list[str] = ["task_id = ?"]
+            params: list[object] = [task_id]
+
+            if phase is not None:
+                conditions.append("phase = ?")
+                params.append(phase.value)
+            if event_type is not None:
+                conditions.append("event_type = ?")
+                params.append(event_type)
+
+            where = " AND ".join(conditions)
+            count_row = await async_fetchone(
+                conn,
+                f"SELECT COUNT(*) FROM task_artifact_entries WHERE {where}",
+                tuple(params),
+            )
+            total = int(count_row[0]) if count_row else 0
+
+            params.append(limit)
+            params.append(offset)
+            rows = await async_fetchall(
+                conn,
+                f"SELECT * FROM task_artifact_entries "
+                f"WHERE {where} "
+                f"ORDER BY id ASC LIMIT ? OFFSET ?",
+                tuple(params),
+            )
+            entries = [self._row_to_entry(dict(row)) for row in rows]
+            return entries, total
+        finally:
+            await conn.close()
 
     @staticmethod
     def _row_to_entry(raw: dict[str, object]) -> TaskArtifactEntry:

--- a/src/relay_teams/external_agents/host_tool_bridge.py
+++ b/src/relay_teams/external_agents/host_tool_bridge.py
@@ -484,7 +484,7 @@ class ExternalAcpHostToolBridge:
                     message="Host tool bridge is not configured with a role.",
                 )
             )
-        deps = self._build_tool_deps(request=request)
+        deps = await self._build_tool_deps_async(request=request)
         tool = definition.tool
         tool_call_id = f"acp_mcp_{uuid4().hex[:12]}"
         ctx = RunContext[ToolDeps](
@@ -515,16 +515,23 @@ class ExternalAcpHostToolBridge:
             ctx,
         )
 
-    def _build_tool_deps(self, *, request: LLMRequest) -> ToolDeps:
+    async def _build_tool_deps_async(self, *, request: LLMRequest) -> ToolDeps:
         resolved_conversation_id = request.conversation_id or build_conversation_id(
             request.session_id,
             request.role_id,
         )
         yolo = False
         try:
-            yolo = self._run_intent_repo.get(request.run_id).yolo
+            yolo = (await self._run_intent_repo.get_async(request.run_id)).yolo
         except KeyError:
             yolo = False
+        workspace = await self._workspace_manager.resolve_async(
+            session_id=request.session_id,
+            role_id=request.role_id,
+            instance_id=request.instance_id,
+            workspace_id=request.workspace_id,
+            conversation_id=resolved_conversation_id,
+        )
         return ToolDeps(
             task_repo=self._task_repo,
             shared_store=self._shared_store,
@@ -536,13 +543,7 @@ class ExternalAcpHostToolBridge:
             injection_manager=self._injection_manager,
             run_event_hub=self._run_event_hub,
             agent_repo=self._agent_repo,
-            workspace=self._workspace_manager.resolve(
-                session_id=request.session_id,
-                role_id=request.role_id,
-                instance_id=request.instance_id,
-                workspace_id=request.workspace_id,
-                conversation_id=resolved_conversation_id,
-            ),
+            workspace=workspace,
             role_memory=self._role_memory_service,
             media_asset_service=self._media_asset_service,
             computer_runtime=self._computer_runtime,

--- a/src/relay_teams/external_agents/provider.py
+++ b/src/relay_teams/external_agents/provider.py
@@ -365,7 +365,7 @@ class ExternalAcpSessionManager:
         request: LLMRequest,
     ) -> str:
         prompt_text = self._resolve_external_user_prompt(request)
-        workspace = self._resolve_workspace(request)
+        workspace = await self._resolve_workspace_async(request)
         workspace_path = workspace.resolve_workdir()
 
         # OP-4: native config + skill bridge injection
@@ -413,7 +413,7 @@ class ExternalAcpSessionManager:
         request: LLMRequest,
     ) -> str:
         prompt_text = self._resolve_external_user_prompt(request)
-        workspace = self._resolve_workspace(request)
+        workspace = await self._resolve_workspace_async(request)
         workspace_path = workspace.resolve_workdir()
 
         # OP-4: native config + skill bridge injection
@@ -756,7 +756,7 @@ class ExternalAcpSessionManager:
                 message_id=message_id,
             )
 
-        workspace = self._resolve_workspace(request)
+        workspace = await self._resolve_workspace_async(request)
         transport = build_acp_transport(
             config=runtime_agent,
             on_message=on_message,
@@ -899,7 +899,7 @@ class ExternalAcpSessionManager:
             send_request=handle.transport.send_request,
             send_notification=handle.transport.send_notification,
         )
-        workspace = self._resolve_workspace(request)
+        workspace = await self._resolve_workspace_async(request)
         mcp_servers = _build_mcp_servers_for_role(
             role=role,
             mcp_registry=self._get_mcp_registry(),
@@ -1091,8 +1091,8 @@ class ExternalAcpSessionManager:
                 ),
             )
 
-    def _resolve_workspace(self, request: LLMRequest):
-        return self._workspace_manager.resolve(
+    async def _resolve_workspace_async(self, request: LLMRequest):
+        return await self._workspace_manager.resolve_async(
             session_id=request.session_id,
             role_id=request.role_id,
             instance_id=request.instance_id,

--- a/src/relay_teams/interfaces/server/routers/prompts.py
+++ b/src/relay_teams/interfaces/server/routers/prompts.py
@@ -151,10 +151,10 @@ async def preview_prompts(
     workspace: WorkspaceHandle | None = None
     if req.workspace_id is not None:
         try:
-            workspace_service.require_workspace(req.workspace_id)
+            await workspace_service.require_workspace_async(req.workspace_id)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail="Workspace not found") from exc
-        workspace = workspace_manager.resolve(
+        workspace = await workspace_manager.resolve_async(
             session_id="prompt-preview",
             role_id=role.role_id,
             instance_id=None,
@@ -194,7 +194,7 @@ async def preview_prompts(
             conversation_context=req.conversation_context,
         )
     )
-    skill_prompt_result = skill_runtime_service.prepare_prompt(
+    skill_prompt_result = await skill_runtime_service.prepare_prompt_async(
         role=role,
         objective=objective,
         shared_state_snapshot=shared_state_snapshot,

--- a/src/relay_teams/interfaces/server/routers/system.py
+++ b/src/relay_teams/interfaces/server/routers/system.py
@@ -881,12 +881,14 @@ async def test_agent_runtime(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     runtime_cwd = None
     if config.protocol == ExternalAgentProtocol.CLI:
-        runtime_cwd = workspace_manager.resolve(
-            session_id=_AGENT_RUNTIME_PROBE_SESSION_ID,
-            role_id=_AGENT_RUNTIME_PROBE_ROLE_ID,
-            instance_id=None,
-            workspace_id=_AGENT_RUNTIME_PROBE_WORKSPACE_ID,
-            conversation_id=_AGENT_RUNTIME_PROBE_SESSION_ID,
+        runtime_cwd = (
+            await workspace_manager.resolve_async(
+                session_id=_AGENT_RUNTIME_PROBE_SESSION_ID,
+                role_id=_AGENT_RUNTIME_PROBE_ROLE_ID,
+                instance_id=None,
+                workspace_id=_AGENT_RUNTIME_PROBE_WORKSPACE_ID,
+                conversation_id=_AGENT_RUNTIME_PROBE_SESSION_ID,
+            )
         ).resolve_workdir()
     result = await probe_agent_runtime(config, runtime_cwd=runtime_cwd)
     if result.ok:

--- a/src/relay_teams/memory/event_handler.py
+++ b/src/relay_teams/memory/event_handler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import asyncio
+import sqlite3
 
 from relay_teams.agents.tasks.models import VerificationReport
 from relay_teams.logger import get_logger
@@ -41,7 +41,7 @@ class MemoryEventHandler:
         self._memory_bank = memory_bank_service
         self._role_memory_service = role_memory_service
 
-    def on_task_completed(
+    async def on_task_completed_async(
         self,
         *,
         workspace_id: str,
@@ -56,7 +56,7 @@ class MemoryEventHandler:
         """Create a WORKING memory entry for a completed task.
 
         Also performs a dual-write to the legacy role_memories table so that
-        ``build_injected_memory()`` continues to work during the migration
+        ``build_injected_memory_async()`` continues to work during the migration
         period.
         """
         content = MemoryContent(
@@ -78,8 +78,8 @@ class MemoryEventHandler:
             source_ref=task_id,
         )
         try:
-            self._memory_bank.create_entry(request)
-        except (ValueError, OSError, RuntimeError):
+            await self._memory_bank.create_entry_async(request)
+        except (ValueError, OSError, RuntimeError, sqlite3.Error):
             LOGGER.warning(
                 "failed to create WORKING memory entry for task %s",
                 task_id,
@@ -89,7 +89,7 @@ class MemoryEventHandler:
         # Dual-write bridge: also record in legacy role_memories
         if self._role_memory_service is not None:
             try:
-                self._role_memory_service.record_task_result(
+                await self._role_memory_service.record_task_result_async(
                     role_id=role_id,
                     workspace_id=workspace_id,
                     session_id=session_id,
@@ -98,7 +98,7 @@ class MemoryEventHandler:
                     result=result,
                     transcript_lines=(),
                 )
-            except (ValueError, OSError, RuntimeError):
+            except (ValueError, OSError, RuntimeError, sqlite3.Error):
                 LOGGER.warning(
                     "failed to dual-write task result to role_memories for task %s",
                     task_id,
@@ -108,53 +108,17 @@ class MemoryEventHandler:
         # RP-2: record verification outcome for role performance metrics
         if self._role_memory_service is not None and verification_report is not None:
             try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = None
-            if loop is not None:
-                loop.create_task(
-                    self._role_memory_service.record_verification_outcome(
-                        role_id=role_id,
-                        workspace_id=workspace_id,
-                        verification_report=verification_report,
-                    )
+                await self._role_memory_service.record_verification_outcome(
+                    role_id=role_id,
+                    workspace_id=workspace_id,
+                    verification_report=verification_report,
                 )
-
-    def on_run_completed(
-        self,
-        *,
-        workspace_id: str,
-        session_id: str,
-        role_id: str | None = None,
-        run_id: str | None = None,
-    ) -> None:
-        """Consolidate WORKING entries -> MEDIUM_TERM on run completion."""
-        request = MemoryConsolidationRequest(
-            workspace_id=workspace_id,
-            session_id=session_id,
-            role_id=role_id,
-            source_run_id=run_id,
-            target_tier=MemoryTier.MEDIUM_TERM,
-            target_scope=MemoryScope.SESSION if session_id else MemoryScope.ROLE,
-        )
-        try:
-            result = self._memory_bank.consolidate(request)
-            if result.source_entry_count > 0:
-                LOGGER.info(
-                    "run consolidation: %d WORKING -> %d MEDIUM_TERM "
-                    "workspace=%s session=%s",
-                    result.source_entry_count,
-                    result.consolidated_entry_count,
-                    workspace_id,
-                    session_id,
+            except (ValueError, OSError, RuntimeError, sqlite3.Error):
+                LOGGER.warning(
+                    "failed to record verification outcome for task %s",
+                    task_id,
+                    exc_info=True,
                 )
-        except (ValueError, OSError, RuntimeError):
-            LOGGER.warning(
-                "failed to consolidate WORKING->MEDIUM_TERM workspace=%s session=%s",
-                workspace_id,
-                session_id,
-                exc_info=True,
-            )
 
     async def on_run_completed_async(
         self,
@@ -166,11 +130,11 @@ class MemoryEventHandler:
     ) -> None:
         """Consolidate WORKING entries -> MEDIUM_TERM on run completion.
 
-        Performs structural consolidation (sync) and then additionally
+        Performs structural consolidation and then additionally
         triggers SEMANTIC mode consolidation for high-signal extraction.
         SEMANTIC failures do not affect the structural path.
         """
-        # 1. Structural consolidation (same as sync version)
+        # 1. Structural consolidation.
         structural_request = MemoryConsolidationRequest(
             workspace_id=workspace_id,
             session_id=session_id,
@@ -236,7 +200,7 @@ class MemoryEventHandler:
                     exc_info=True,
                 )
 
-    def on_session_completed(
+    async def on_session_completed_async(
         self,
         *,
         workspace_id: str,
@@ -252,7 +216,7 @@ class MemoryEventHandler:
             target_scope=MemoryScope.WORKSPACE,
         )
         try:
-            result = self._memory_bank.consolidate(request)
+            result = await self._memory_bank.consolidate_async(request)
             if result.source_entry_count > 0:
                 LOGGER.info(
                     "session consolidation: %d MEDIUM_TERM -> %d PERSISTENT "
@@ -270,7 +234,7 @@ class MemoryEventHandler:
                 exc_info=True,
             )
 
-    def get_injectable_memory_text(
+    async def get_injectable_memory_text_async(
         self,
         *,
         workspace_id: str,
@@ -291,7 +255,7 @@ class MemoryEventHandler:
                 limit=20,
             )
             try:
-                result = self._memory_bank.list_entries(query)
+                result = await self._memory_bank.list_entries_async(query)
             except (ValueError, OSError, RuntimeError):
                 LOGGER.warning(
                     "failed to query %s memory for injection workspace=%s",

--- a/src/relay_teams/memory/repository.py
+++ b/src/relay_teams/memory/repository.py
@@ -173,13 +173,6 @@ class MemoryBankRepository(SharedSqliteRepository):
     # Create
     # ------------------------------------------------------------------
 
-    def create_entry(self, *, entry: MemoryEntry) -> MemoryEntry:
-        self._run_write(
-            operation_name="create_memory_entry",
-            operation=lambda: self._insert_entry(entry),
-        )
-        return entry
-
     async def create_entry_async(self, *, entry: MemoryEntry) -> MemoryEntry:
         async def op(conn: aiosqlite.Connection) -> None:
             await self._async_insert_entry(conn, entry)
@@ -189,19 +182,6 @@ class MemoryBankRepository(SharedSqliteRepository):
             operation=op,
         )
         return entry
-
-    def _insert_entry(self, entry: MemoryEntry) -> None:
-        self._conn.execute(
-            """INSERT INTO memory_entries(
-                memory_id, tier, scope, workspace_id, session_id, run_id, role_id,
-                kind, status, content_title, content_body, content_context, content_outcome,
-                tags, confidence_score, source, source_ref,
-                superseded_by_id, parent_entry_id, version,
-                created_at, updated_at, expires_at, last_accessed_at, access_count,
-                metadata_json
-            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-            self._entry_to_params(entry),
-        )
 
     async def _async_insert_entry(
         self, conn: aiosqlite.Connection, entry: MemoryEntry
@@ -223,17 +203,6 @@ class MemoryBankRepository(SharedSqliteRepository):
     # Read
     # ------------------------------------------------------------------
 
-    def get_by_id(self, memory_id: str) -> MemoryEntry | None:
-        row = self._run_read(
-            lambda: self._conn.execute(
-                "SELECT * FROM memory_entries WHERE memory_id=?",
-                (memory_id,),
-            ).fetchone()
-        )
-        if row is None:
-            return None
-        return _row_to_entry(row)
-
     async def get_by_id_async(self, memory_id: str) -> MemoryEntry | None:
         async def op(conn: aiosqlite.Connection) -> MemoryEntry | None:
             row = await async_fetchone(
@@ -251,13 +220,6 @@ class MemoryBankRepository(SharedSqliteRepository):
     # Update
     # ------------------------------------------------------------------
 
-    def update_entry(self, memory_id: str, *, entry: MemoryEntry) -> MemoryEntry:
-        self._run_write(
-            operation_name="update_memory_entry",
-            operation=lambda: self._do_update_entry(memory_id, entry),
-        )
-        return entry
-
     async def update_entry_async(
         self, memory_id: str, *, entry: MemoryEntry
     ) -> MemoryEntry:
@@ -269,19 +231,6 @@ class MemoryBankRepository(SharedSqliteRepository):
             operation=op,
         )
         return entry
-
-    def _do_update_entry(self, memory_id: str, entry: MemoryEntry) -> None:
-        self._conn.execute(
-            """UPDATE memory_entries SET
-                tier=?, scope=?, workspace_id=?, session_id=?, run_id=?, role_id=?,
-                kind=?, status=?, content_title=?, content_body=?, content_context=?, content_outcome=?,
-                tags=?, confidence_score=?, source=?, source_ref=?,
-                superseded_by_id=?, parent_entry_id=?, version=?,
-                created_at=?, updated_at=?, expires_at=?, last_accessed_at=?, access_count=?,
-                metadata_json=?
-            WHERE memory_id=?""",
-            (*self._entry_to_params(entry)[1:], memory_id),
-        )
 
     async def _async_do_update_entry(
         self,
@@ -306,16 +255,6 @@ class MemoryBankRepository(SharedSqliteRepository):
     # Delete
     # ------------------------------------------------------------------
 
-    def delete_entry(self, memory_id: str) -> bool:
-        result = self._run_write(
-            operation_name="delete_memory_entry",
-            operation=lambda: self._conn.execute(
-                "DELETE FROM memory_entries WHERE memory_id=?",
-                (memory_id,),
-            ),
-        )
-        return result.rowcount > 0
-
     async def delete_entry_async(self, memory_id: str) -> bool:
         async def op(conn: aiosqlite.Connection) -> bool:
             cursor = await conn.execute(
@@ -334,32 +273,6 @@ class MemoryBankRepository(SharedSqliteRepository):
     # ------------------------------------------------------------------
     # Query
     # ------------------------------------------------------------------
-
-    def query_entries(self, query: MemoryQuery) -> MemoryQueryResult:
-        where_clause, params = self._build_where(query)
-        count_sql = f"SELECT COUNT(*) as cnt FROM memory_entries {where_clause}"
-        data_sql = (
-            f"SELECT * FROM memory_entries {where_clause} "
-            f"ORDER BY updated_at DESC LIMIT ? OFFSET ?"
-        )
-
-        count_row = self._run_read(
-            lambda: self._conn.execute(count_sql, tuple(params)).fetchone()
-        )
-        total_count = int(count_row["cnt"]) if count_row is not None else 0
-
-        rows = self._run_read(
-            lambda: self._conn.execute(
-                data_sql, tuple(params) + (query.limit, query.offset)
-            ).fetchall()
-        )
-        items = tuple(_row_to_summary(row) for row in rows)
-        return MemoryQueryResult(
-            items=items,
-            total_count=total_count,
-            offset=query.offset,
-            limit=query.limit,
-        )
 
     async def query_entries_async(self, query: MemoryQuery) -> MemoryQueryResult:
         where_clause, params = self._build_where(query)
@@ -430,19 +343,6 @@ class MemoryBankRepository(SharedSqliteRepository):
     # Expiry sweep
     # ------------------------------------------------------------------
 
-    def expire_entries(self, now: datetime | None = None) -> int:
-        """Mark TTL-expired active entries as EXPIRED. Returns count updated."""
-        now_iso = (now or datetime.now(tz=timezone.utc)).isoformat()
-        result = self._run_write(
-            operation_name="expire_memory_entries",
-            operation=lambda: self._conn.execute(
-                "UPDATE memory_entries SET status='expired', updated_at=? "
-                "WHERE status='active' AND expires_at IS NOT NULL AND expires_at < ?",
-                (now_iso, now_iso),
-            ),
-        )
-        return result.rowcount
-
     async def expire_entries_async(self, now: datetime | None = None) -> int:
         now_iso = (now or datetime.now(tz=timezone.utc)).isoformat()
 
@@ -464,48 +364,6 @@ class MemoryBankRepository(SharedSqliteRepository):
     # ------------------------------------------------------------------
     # Confidence decay
     # ------------------------------------------------------------------
-
-    def apply_confidence_decay(
-        self, *, min_confidence: float = 0.2, now: datetime | None = None
-    ) -> int:
-        """Apply confidence decay and expire below-threshold entries.
-
-        Returns count of entries that dropped below min_confidence.
-        """
-        now = now or datetime.now(tz=timezone.utc)
-        now_iso = now.isoformat()
-
-        affected = self._run_write(
-            operation_name="apply_confidence_decay",
-            operation=lambda: self._do_confidence_decay(now_iso, min_confidence),
-        )
-        return affected
-
-    def _do_confidence_decay(self, now_iso: str, min_confidence: float) -> int:
-        from relay_teams.memory.memory_defaults import (
-            MEDIUM_TERM_DECAY_FACTOR,
-            PERSISTENT_DECAY_FACTOR,
-        )
-
-        # Medium-term decay
-        self._conn.execute(
-            "UPDATE memory_entries SET confidence_score = confidence_score * ?, updated_at=? "
-            "WHERE tier='medium_term' AND status='active'",
-            (MEDIUM_TERM_DECAY_FACTOR, now_iso),
-        )
-        # Persistent decay
-        self._conn.execute(
-            "UPDATE memory_entries SET confidence_score = confidence_score * ?, updated_at=? "
-            "WHERE tier='persistent' AND status='active'",
-            (PERSISTENT_DECAY_FACTOR, now_iso),
-        )
-        # Expire below threshold
-        result = self._conn.execute(
-            "UPDATE memory_entries SET status='expired', updated_at=? "
-            "WHERE status='active' AND confidence_score < ?",
-            (now_iso, min_confidence),
-        )
-        return result.rowcount
 
     async def apply_confidence_decay_async(
         self, *, min_confidence: float = 0.2, now: datetime | None = None
@@ -549,7 +407,7 @@ class MemoryBankRepository(SharedSqliteRepository):
     # Capacity helpers
     # ------------------------------------------------------------------
 
-    def count_entries(
+    async def count_entries_async(
         self,
         *,
         workspace_id: str,
@@ -569,15 +427,18 @@ class MemoryBankRepository(SharedSqliteRepository):
             clauses.append("status = ?")
             params.append(status.value)
         where_sql = "WHERE " + " AND ".join(clauses)
-        row = self._run_read(
-            lambda: self._conn.execute(
+
+        async def op(conn: aiosqlite.Connection) -> int:
+            row = await async_fetchone(
+                conn,
                 f"SELECT COUNT(*) as cnt FROM memory_entries {where_sql}",
                 tuple(params),
-            ).fetchone()
-        )
-        return int(row["cnt"]) if row is not None else 0
+            )
+            return int(row["cnt"]) if row is not None else 0
 
-    def expire_oldest(
+        return await self._run_async_read(op)
+
+    async def expire_oldest_async(
         self,
         *,
         workspace_id: str,
@@ -601,27 +462,28 @@ class MemoryBankRepository(SharedSqliteRepository):
 
         now_iso = datetime.now(tz=timezone.utc).isoformat()
 
-        def op() -> int:
-            ids = self._conn.execute(
+        async def op(conn: aiosqlite.Connection) -> int:
+            ids = await async_fetchall(
+                conn,
                 f"SELECT memory_id FROM memory_entries {where_sql} "
                 f"ORDER BY created_at ASC LIMIT ?",
                 tuple(params) + (count,),
-            ).fetchall()
+            )
             affected = 0
             for row in ids:
-                cursor = self._conn.execute(
+                cursor = await conn.execute(
                     "UPDATE memory_entries SET status='expired', updated_at=? "
                     "WHERE memory_id=?",
                     (now_iso, str(row["memory_id"])),
                 )
                 affected += cursor.rowcount
+                await cursor.close()
             return affected
 
-        result = self._run_write(
-            operation_name="expire_oldest_memory_entries",
+        return await self._run_async_write(
+            operation_name="expire_oldest_memory_entries_async",
             operation=op,
         )
-        return result
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/relay_teams/memory/service.py
+++ b/src/relay_teams/memory/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from relay_teams.logger import get_logger
+from relay_teams.memory import memory_defaults
 from relay_teams.memory.memory_defaults import (
     MIN_CONFIDENCE_ACTIVE,
     MIN_CONFIDENCE_CONSOLIDATION,
@@ -28,6 +29,12 @@ from relay_teams.memory.models import (
 )
 from relay_teams.memory.repository import MemoryBankRepository, generate_memory_id
 from relay_teams.providers.provider_contracts import LLMProvider
+from relay_teams.retrieval.retrieval_models import (
+    RetrievalDocument,
+    RetrievalQuery,
+    RetrievalScopeConfig,
+    RetrievalScopeKind,
+)
 from relay_teams.retrieval.retrieval_service import RetrievalService
 
 LOGGER = get_logger(__name__)
@@ -48,45 +55,6 @@ class MemoryBankService:
     # ------------------------------------------------------------------
     # 1. Create
     # ------------------------------------------------------------------
-
-    def create_entry(self, request: CreateMemoryEntryRequest) -> MemoryEntry:
-        now = datetime.now(tz=timezone.utc)
-        memory_id = generate_memory_id()
-        expires_at = request.expires_at
-        if expires_at is None:
-            expires_at = default_ttl_for_tier(request.tier)
-
-        entry = MemoryEntry(
-            id=memory_id,
-            tier=request.tier,
-            scope=request.scope,
-            workspace_id=request.workspace_id,
-            session_id=request.session_id,
-            run_id=request.run_id,
-            role_id=request.role_id,
-            kind=request.kind,
-            status=MemoryEntryStatus.ACTIVE,
-            content=request.content,
-            tags=request.tags,
-            confidence_score=request.confidence_score,
-            source=request.source,
-            source_ref=request.source_ref,
-            expires_at=expires_at,
-            created_at=now,
-            updated_at=now,
-            metadata=request.metadata,
-        )
-        self.enforce_capacity(
-            workspace_id=request.workspace_id,
-            tier=request.tier,
-            scope=request.scope,
-            session_id=request.session_id,
-            role_id=request.role_id,
-            run_id=request.run_id,
-        )
-        created = self._repo.create_entry(entry=entry)
-        self._index_entry(created)
-        return created
 
     async def create_entry_async(
         self, request: CreateMemoryEntryRequest
@@ -117,7 +85,7 @@ class MemoryBankService:
             updated_at=now,
             metadata=request.metadata,
         )
-        self.enforce_capacity(
+        await self.enforce_capacity_async(
             workspace_id=request.workspace_id,
             tier=request.tier,
             scope=request.scope,
@@ -126,21 +94,15 @@ class MemoryBankService:
             run_id=request.run_id,
         )
         created = await self._repo.create_entry_async(entry=entry)
-        self._index_entry(created)
+        await self._index_entry_async(created)
         return created
 
     # ------------------------------------------------------------------
     # 2. Get / List
     # ------------------------------------------------------------------
 
-    def get_entry(self, memory_id: str) -> MemoryEntry | None:
-        return self._repo.get_by_id(memory_id)
-
     async def get_entry_async(self, memory_id: str) -> MemoryEntry | None:
         return await self._repo.get_by_id_async(memory_id)
-
-    def list_entries(self, query: MemoryQuery) -> MemoryQueryResult:
-        return self._repo.query_entries(query)
 
     async def list_entries_async(self, query: MemoryQuery) -> MemoryQueryResult:
         return await self._repo.query_entries_async(query)
@@ -148,18 +110,6 @@ class MemoryBankService:
     # ------------------------------------------------------------------
     # 3. Update
     # ------------------------------------------------------------------
-
-    def update_entry(
-        self, memory_id: str, request: UpdateMemoryEntryRequest
-    ) -> MemoryEntry | None:
-        entry = self._repo.get_by_id(memory_id)
-        if entry is None:
-            return None
-        updated = self._apply_update(entry, request)
-        result = self._repo.update_entry(memory_id, entry=updated)
-        if result is not None:
-            self._index_entry(result)
-        return result
 
     async def update_entry_async(
         self, memory_id: str, request: UpdateMemoryEntryRequest
@@ -170,7 +120,7 @@ class MemoryBankService:
         updated = self._apply_update(entry, request)
         result = await self._repo.update_entry_async(memory_id, entry=updated)
         if result is not None:
-            self._index_entry(result)
+            await self._index_entry_async(result)
         return result
 
     @staticmethod
@@ -211,9 +161,6 @@ class MemoryBankService:
     # 4. Delete
     # ------------------------------------------------------------------
 
-    def delete_entry(self, memory_id: str) -> bool:
-        return self._repo.delete_entry(memory_id)
-
     async def delete_entry_async(self, memory_id: str) -> bool:
         return await self._repo.delete_entry_async(memory_id)
 
@@ -221,7 +168,7 @@ class MemoryBankService:
     # 4b. Capacity enforcement
     # ------------------------------------------------------------------
 
-    def enforce_capacity(
+    async def enforce_capacity_async(
         self,
         *,
         workspace_id: str,
@@ -236,25 +183,19 @@ class MemoryBankService:
         Returns the number of entries pruned.  Called automatically before
         ``create_entry`` so the capacity cap is never exceeded.
         """
-        from relay_teams.memory.memory_defaults import (
-            MAX_MEDIUM_TERM_PER_SESSION_ROLE,
-            MAX_PERSISTENT_PER_WORKSPACE,
-            MAX_WORKING_PER_RUN,
-        )
-
         _ = (session_id, role_id, scope)  # reserved for granular capacity counting
 
         limit: int
         if tier == MemoryTier.WORKING and run_id is not None:
-            limit = MAX_WORKING_PER_RUN
+            limit = memory_defaults.MAX_WORKING_PER_RUN
         elif tier == MemoryTier.MEDIUM_TERM:
-            limit = MAX_MEDIUM_TERM_PER_SESSION_ROLE
+            limit = memory_defaults.MAX_MEDIUM_TERM_PER_SESSION_ROLE
         elif tier == MemoryTier.PERSISTENT:
-            limit = MAX_PERSISTENT_PER_WORKSPACE
+            limit = memory_defaults.MAX_PERSISTENT_PER_WORKSPACE
         else:
             return 0
 
-        current_count = self._repo.count_entries(
+        current_count = await self._repo.count_entries_async(
             workspace_id=workspace_id,
             tier=tier,
             status=MemoryEntryStatus.ACTIVE,
@@ -264,7 +205,7 @@ class MemoryBankService:
 
         overflow = current_count - limit + 1
         if tier == MemoryTier.WORKING and run_id is not None:
-            return self._repo.expire_oldest(
+            return await self._repo.expire_oldest_async(
                 workspace_id=workspace_id,
                 tier=tier,
                 run_id=run_id,
@@ -273,7 +214,7 @@ class MemoryBankService:
             )
 
         # For medium_term/persistent, prune by confidence then age
-        return self._repo.expire_oldest(
+        return await self._repo.expire_oldest_async(
             workspace_id=workspace_id,
             tier=tier,
             status=MemoryEntryStatus.ACTIVE,
@@ -283,96 +224,6 @@ class MemoryBankService:
     # ------------------------------------------------------------------
     # 5. Consolidation
     # ------------------------------------------------------------------
-
-    def consolidate(
-        self, request: MemoryConsolidationRequest
-    ) -> MemoryConsolidationResult:
-        """Promote entries from a lower tier to the target tier.
-
-        For STRUCTURAL mode this is a direct tier promotion (no LLM
-        extraction).  For SEMANTIC mode the LLM extracts structured
-        entries from the conversation history.
-        """
-        if request.consolidation_mode == ConsolidationMode.SEMANTIC:
-            LOGGER.warning(
-                "SEMANTIC consolidation invoked via sync consolidate();"
-                " async consolidate_async() is preferred for LLM calls."
-                " Falling back to STRUCTURAL."
-            )
-        return self._consolidate_structural(request)
-
-    def _consolidate_structural(
-        self, request: MemoryConsolidationRequest
-    ) -> MemoryConsolidationResult:
-        source_tier = self._source_tier_for(request.target_tier)
-
-        query = MemoryQuery(
-            workspace_id=request.workspace_id,
-            tier=source_tier,
-            status=MemoryEntryStatus.ACTIVE,
-            min_confidence=MIN_CONFIDENCE_CONSOLIDATION,
-        )
-        if request.session_id is not None:
-            query = query.model_copy(update={"session_id": request.session_id})
-        if request.role_id is not None:
-            query = query.model_copy(update={"role_id": request.role_id})
-        if request.filter_kind is not None:
-            query = query.model_copy(update={"kind": request.filter_kind})
-
-        result = self._repo.query_entries(query)
-        source_entries: list[MemoryEntry] = []
-        for summary in result.items:
-            entry = self._repo.get_by_id(summary.id)
-            if entry is not None:
-                source_entries.append(entry)
-
-        new_ids: list[str] = []
-        superseded_ids: list[str] = []
-
-        now = datetime.now(tz=timezone.utc)
-        for src in source_entries:
-            new_id = generate_memory_id()
-            new_entry = MemoryEntry(
-                id=new_id,
-                tier=request.target_tier,
-                scope=request.target_scope,
-                workspace_id=request.workspace_id,
-                session_id=request.session_id,
-                run_id=None,
-                role_id=request.role_id,
-                kind=src.kind,
-                status=MemoryEntryStatus.ACTIVE,
-                content=src.content.model_copy(),
-                tags=src.tags,
-                confidence_score=src.confidence_score,
-                source=src.source,
-                source_ref=src.source_ref,
-                parent_entry_id=src.id,
-                created_at=now,
-                updated_at=now,
-                expires_at=default_ttl_for_tier(request.target_tier),
-                metadata=src.metadata.copy(),
-            )
-            self._repo.create_entry(entry=new_entry)
-            new_ids.append(new_id)
-
-            # Mark source as superseded
-            updated_src = src.model_copy(
-                update={
-                    "status": MemoryEntryStatus.SUPERSEDED,
-                    "superseded_by_id": new_id,
-                    "updated_at": now,
-                }
-            )
-            self._repo.update_entry(src.id, entry=updated_src)
-            superseded_ids.append(src.id)
-
-        return MemoryConsolidationResult(
-            source_entry_count=result.total_count,
-            consolidated_entry_count=len(new_ids),
-            superseded_entry_ids=tuple(superseded_ids),
-            new_entry_ids=tuple(new_ids),
-        )
 
     async def consolidate_async(
         self, request: MemoryConsolidationRequest
@@ -487,14 +338,6 @@ class MemoryBankService:
     # 6. Forgetting
     # ------------------------------------------------------------------
 
-    def forget_expired(self, now: datetime | None = None) -> int:
-        """Run TTL expiry and confidence decay. Returns count of entries expired."""
-        ttl_expired = self._repo.expire_entries(now)
-        decay_expired = self._repo.apply_confidence_decay(
-            min_confidence=MIN_CONFIDENCE_ACTIVE, now=now
-        )
-        return ttl_expired + decay_expired
-
     async def forget_expired_async(self, now: datetime | None = None) -> int:
         ttl_expired = await self._repo.expire_entries_async(now)
         decay_expired = await self._repo.apply_confidence_decay_async(
@@ -506,30 +349,17 @@ class MemoryBankService:
     # 7. Search (FTS5-backed)
     # ------------------------------------------------------------------
 
-    def search(self, request: MemorySearchRequest) -> MemorySearchResult:
-        """Full-text search over memory entries.
-
-        Uses the FTS5 retrieval store when a ``retrieval_service`` is
-        configured.  Falls back to structural ``LIKE`` matching otherwise.
-        """
-        if self._retrieval_service is not None:
-            return self._search_fts(request)
-        return self._search_fallback(request)
-
     async def search_async(self, request: MemorySearchRequest) -> MemorySearchResult:
         if self._retrieval_service is not None:
-            return self._search_fts(request)
-        return self._search_fallback(request)
+            return await self._search_fts_async(request)
+        return await self._search_fallback_async(request)
 
-    def _search_fts(self, request: MemorySearchRequest) -> MemorySearchResult:
+    async def _search_fts_async(
+        self, request: MemorySearchRequest
+    ) -> MemorySearchResult:
         """Query the FTS5 retrieval index and cross-reference with the memory table."""
-        from relay_teams.retrieval.retrieval_models import (
-            RetrievalQuery,
-            RetrievalScopeKind,
-        )
-
         assert self._retrieval_service is not None
-        fts_hits = self._retrieval_service.search(
+        fts_hits = await self._retrieval_service.search_async(
             query=RetrievalQuery(
                 scope_kind=RetrievalScopeKind.MEMORY,
                 scope_id=request.workspace_id,
@@ -558,7 +388,7 @@ class MemoryBankService:
             limit=request.limit,
             offset=0,
         )
-        result = self._repo.query_entries(query)
+        result = await self._repo.query_entries_async(query)
 
         items: list[MemorySearchHit] = []
         for summary in result.items:
@@ -583,7 +413,9 @@ class MemoryBankService:
             total_count=len(items),
         )
 
-    def _search_fallback(self, request: MemorySearchRequest) -> MemorySearchResult:
+    async def _search_fallback_async(
+        self, request: MemorySearchRequest
+    ) -> MemorySearchResult:
         """Fallback text search when no FTS5 retrieval service is available."""
         query = MemoryQuery(
             workspace_id=request.workspace_id,
@@ -597,7 +429,7 @@ class MemoryBankService:
             limit=request.limit,
             offset=0,
         )
-        result = self._repo.query_entries(query)
+        result = await self._repo.query_entries_async(query)
 
         items: list[MemorySearchHit] = []
         rank = 1
@@ -638,7 +470,7 @@ class MemoryBankService:
     # FTS5 indexing integration
     # ------------------------------------------------------------------
 
-    def _index_entry(self, entry: MemoryEntry) -> None:
+    async def _index_entry_async(self, entry: MemoryEntry) -> None:
         """Index a memory entry into the FTS5 retrieval store.
 
         Silently skips indexing if no retrieval_service is configured or if
@@ -646,12 +478,6 @@ class MemoryBankService:
         """
         if self._retrieval_service is None:
             return
-        from relay_teams.retrieval.retrieval_models import (
-            RetrievalDocument,
-            RetrievalScopeConfig,
-            RetrievalScopeKind,
-        )
-
         if entry.status != MemoryEntryStatus.ACTIVE:
             return
 
@@ -676,7 +502,7 @@ class MemoryBankService:
             keywords=entry.tags,
         )
         try:
-            self._retrieval_service.upsert_documents(
+            await self._retrieval_service.upsert_documents_async(
                 config=config,
                 documents=(doc,),
             )

--- a/src/relay_teams/metrics/adapters/__init__.py
+++ b/src/relay_teams/metrics/adapters/__init__.py
@@ -8,8 +8,11 @@ from relay_teams.metrics.adapters.llm_metrics import (
 )
 from relay_teams.metrics.adapters.retrieval_metrics import (
     record_retrieval_document_count,
+    record_retrieval_document_count_async,
     record_retrieval_rebuild,
+    record_retrieval_rebuild_async,
     record_retrieval_search,
+    record_retrieval_search_async,
 )
 from relay_teams.metrics.adapters.session_metrics import (
     record_session_step,
@@ -25,8 +28,11 @@ __all__ = [
     "record_gateway_operation",
     "ToolSource",
     "record_retrieval_document_count",
+    "record_retrieval_document_count_async",
     "record_retrieval_rebuild",
+    "record_retrieval_rebuild_async",
     "record_retrieval_search",
+    "record_retrieval_search_async",
     "record_session_step",
     "record_session_step_async",
     "record_token_usage",

--- a/src/relay_teams/metrics/adapters/retrieval_metrics.py
+++ b/src/relay_teams/metrics/adapters/retrieval_metrics.py
@@ -42,6 +42,38 @@ def record_retrieval_search(
         )
 
 
+async def record_retrieval_search_async(
+    recorder: MetricRecorder,
+    *,
+    backend: str,
+    scope_kind: str,
+    duration_ms: int,
+    success: bool,
+) -> None:
+    tags = _build_tags(
+        backend=backend,
+        scope_kind=scope_kind,
+        operation="search",
+        status="success" if success else "failure",
+    )
+    await recorder.emit_async(
+        definition_name=RETRIEVAL_SEARCHES.name,
+        value=1,
+        tags=tags,
+    )
+    await recorder.emit_async(
+        definition_name=RETRIEVAL_SEARCH_DURATION_MS.name,
+        value=duration_ms,
+        tags=tags,
+    )
+    if not success:
+        await recorder.emit_async(
+            definition_name=RETRIEVAL_SEARCH_FAILURES.name,
+            value=1,
+            tags=tags,
+        )
+
+
 def record_retrieval_rebuild(
     recorder: MetricRecorder,
     *,
@@ -64,6 +96,32 @@ def record_retrieval_rebuild(
     )
 
 
+async def record_retrieval_rebuild_async(
+    recorder: MetricRecorder,
+    *,
+    backend: str,
+    scope_kind: str,
+    duration_ms: int,
+    success: bool,
+) -> None:
+    tags = _build_tags(
+        backend=backend,
+        scope_kind=scope_kind,
+        operation="rebuild",
+        status="success" if success else "failure",
+    )
+    await recorder.emit_async(
+        definition_name=RETRIEVAL_REBUILDS.name,
+        value=1,
+        tags=tags,
+    )
+    await recorder.emit_async(
+        definition_name=RETRIEVAL_REBUILD_DURATION_MS.name,
+        value=duration_ms,
+        tags=tags,
+    )
+
+
 def record_retrieval_document_count(
     recorder: MetricRecorder,
     *,
@@ -73,6 +131,26 @@ def record_retrieval_document_count(
     document_count: int,
 ) -> None:
     recorder.emit(
+        definition_name=RETRIEVAL_DOCUMENT_COUNT.name,
+        value=document_count,
+        tags=_build_tags(
+            backend=backend,
+            scope_kind=scope_kind,
+            operation=operation,
+            status="success",
+        ),
+    )
+
+
+async def record_retrieval_document_count_async(
+    recorder: MetricRecorder,
+    *,
+    backend: str,
+    scope_kind: str,
+    operation: str,
+    document_count: int,
+) -> None:
+    await recorder.emit_async(
         definition_name=RETRIEVAL_DOCUMENT_COUNT.name,
         value=document_count,
         tags=_build_tags(

--- a/src/relay_teams/net/proxy_transports.py
+++ b/src/relay_teams/net/proxy_transports.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
+import json
 from typing import Protocol
 
 import httpx
 
 from relay_teams.env.proxy_env import ProxyEnvConfig, proxy_applies_to_url
+
+_TERMINAL_SSE_SCAN_BUFFER_BYTES = 64 * 1024
 
 
 class AsyncRequestLimitLease(Protocol):
@@ -118,10 +121,13 @@ class _ReleasingAsyncByteStream(httpx.AsyncByteStream):
         self._stream = stream
         self._lease = lease
         self._released = False
+        self._terminal_scan_buffer = b""
 
     async def __aiter__(self) -> AsyncIterator[bytes]:
         try:
             async for chunk in self._stream:
+                if self._chunk_has_terminal_sse_marker(chunk):
+                    self._release()
                 yield chunk
         finally:
             self._release()
@@ -137,3 +143,119 @@ class _ReleasingAsyncByteStream(httpx.AsyncByteStream):
             return
         self._released = True
         self._lease.release()
+
+    def _chunk_has_terminal_sse_marker(self, chunk: bytes) -> bool:
+        scan_target = self._terminal_scan_buffer + chunk
+        self._terminal_scan_buffer = scan_target[-_TERMINAL_SSE_SCAN_BUFFER_BYTES:]
+        return _chunk_has_terminal_sse_marker(scan_target)
+
+
+def _chunk_has_terminal_sse_marker(chunk: bytes) -> bool:
+    decoded = chunk.decode("utf-8", errors="ignore")
+    for payload_text in _iter_sse_data_payloads(decoded):
+        if payload_text.upper() == "[DONE]":
+            return True
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError:
+            continue
+        if _payload_has_terminal_finish_reason(payload):
+            return True
+        if _payload_has_complete_tool_call_delta(payload):
+            return True
+    return False
+
+
+def _chunk_has_complete_tool_call_delta(chunk: bytes) -> bool:
+    decoded = chunk.decode("utf-8", errors="ignore")
+    for payload_text in _iter_sse_data_payloads(decoded):
+        if payload_text.upper() == "[DONE]":
+            continue
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError:
+            continue
+        if _payload_has_complete_tool_call_delta(payload):
+            return True
+    return False
+
+
+def _iter_sse_data_payloads(decoded: str) -> Iterator[str]:
+    for line in decoded.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("data:"):
+            continue
+        payload_text = stripped[5:].strip()
+        if payload_text:
+            yield payload_text
+
+
+def _payload_has_terminal_finish_reason(payload: object) -> bool:
+    payload_object = _object_dict(payload)
+    if payload_object is None:
+        return False
+    choices = payload_object.get("choices")
+    if not isinstance(choices, list):
+        return False
+    for raw_choice in choices:
+        choice = _object_dict(raw_choice)
+        if choice is None:
+            continue
+        if choice.get("finish_reason") is not None:
+            return True
+    return False
+
+
+def _payload_has_complete_tool_call_delta(payload: object) -> bool:
+    payload_object = _object_dict(payload)
+    if payload_object is None:
+        return False
+    choices = payload_object.get("choices")
+    if not isinstance(choices, list):
+        return False
+    for raw_choice in choices:
+        choice = _object_dict(raw_choice)
+        if choice is None:
+            continue
+        delta = _object_dict(choice.get("delta"))
+        if delta is None:
+            continue
+        tool_calls = delta.get("tool_calls")
+        if not isinstance(tool_calls, list) or not tool_calls:
+            continue
+        if _tool_call_deltas_have_complete_arguments(tool_calls):
+            return True
+    return False
+
+
+def _tool_call_deltas_have_complete_arguments(tool_calls: list[object]) -> bool:
+    saw_tool_call = False
+    for raw_tool_call in tool_calls:
+        tool_call = _object_dict(raw_tool_call)
+        if tool_call is None:
+            return False
+        saw_tool_call = True
+        function_payload = _object_dict(tool_call.get("function"))
+        if function_payload is None:
+            return False
+        arguments = function_payload.get("arguments")
+        if not isinstance(arguments, str) or not arguments.strip():
+            return False
+        try:
+            parsed_arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(parsed_arguments, dict):
+            return False
+    return saw_tool_call
+
+
+def _object_dict(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    object_dict: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            return None
+        object_dict[key] = item
+    return object_dict

--- a/src/relay_teams/retrieval/retrieval_service.py
+++ b/src/relay_teams/retrieval/retrieval_service.py
@@ -7,8 +7,11 @@ from relay_teams.logger import get_logger
 from relay_teams.metrics import MetricRecorder
 from relay_teams.metrics.adapters import (
     record_retrieval_document_count,
+    record_retrieval_document_count_async,
     record_retrieval_rebuild,
+    record_retrieval_rebuild_async,
     record_retrieval_search,
+    record_retrieval_search_async,
 )
 from relay_teams.retrieval.retrieval_models import (
     RetrievalDocument,
@@ -78,6 +81,31 @@ class RetrievalService:
         self._record_document_count(stats=stats, operation="upsert")
         return stats
 
+    async def upsert_documents_async(
+        self,
+        *,
+        config: RetrievalScopeConfig,
+        documents: tuple[RetrievalDocument, ...],
+    ) -> RetrievalStats:
+        self._validate_scope_documents(config=config, documents=documents)
+        with trace_span(
+            LOGGER,
+            component="retrieval.service",
+            operation="upsert_documents_async",
+            attributes={
+                "backend": self._store.backend_kind.value,
+                "scope_kind": config.scope_kind.value,
+                "scope_id": config.scope_id,
+                "document_count": len(documents),
+            },
+        ):
+            stats = await self._store.upsert_documents_async(
+                config=config,
+                documents=documents,
+            )
+        await self._record_document_count_async(stats=stats, operation="upsert")
+        return stats
+
     def delete_documents(
         self,
         *,
@@ -130,6 +158,36 @@ class RetrievalService:
                 return result
             finally:
                 self._record_search_metric(
+                    scope_kind=query.scope_kind,
+                    duration_ms=int((time.perf_counter() - started) * 1000),
+                    success=success,
+                )
+
+    async def search_async(
+        self,
+        *,
+        query: RetrievalQuery,
+    ) -> tuple[RetrievalHit, ...]:
+        started = time.perf_counter()
+        success = False
+        with trace_span(
+            LOGGER,
+            component="retrieval.service",
+            operation="search_async",
+            attributes={
+                "backend": self._store.backend_kind.value,
+                "scope_kind": query.scope_kind.value,
+                "scope_id": query.scope_id,
+                "limit": query.limit,
+                "query_term_count": _query_term_count(query.text),
+            },
+        ):
+            try:
+                result = await self._store.search_async(query=query)
+                success = True
+                return result
+            finally:
+                await self._record_search_metric_async(
                     scope_kind=query.scope_kind,
                     duration_ms=int((time.perf_counter() - started) * 1000),
                     success=success,
@@ -203,6 +261,23 @@ class RetrievalService:
             success=success,
         )
 
+    async def _record_search_metric_async(
+        self,
+        *,
+        scope_kind: RetrievalScopeKind,
+        duration_ms: int,
+        success: bool,
+    ) -> None:
+        if self._metric_recorder is None:
+            return
+        await record_retrieval_search_async(
+            self._metric_recorder,
+            backend=self._store.backend_kind.value,
+            scope_kind=scope_kind.value,
+            duration_ms=duration_ms,
+            success=success,
+        )
+
     def _record_rebuild_metric(
         self,
         *,
@@ -220,6 +295,23 @@ class RetrievalService:
             success=success,
         )
 
+    async def _record_rebuild_metric_async(
+        self,
+        *,
+        scope_kind: RetrievalScopeKind,
+        duration_ms: int,
+        success: bool,
+    ) -> None:
+        if self._metric_recorder is None:
+            return
+        await record_retrieval_rebuild_async(
+            self._metric_recorder,
+            backend=self._store.backend_kind.value,
+            scope_kind=scope_kind.value,
+            duration_ms=duration_ms,
+            success=success,
+        )
+
     def _record_document_count(
         self,
         *,
@@ -229,6 +321,22 @@ class RetrievalService:
         if self._metric_recorder is None:
             return
         record_retrieval_document_count(
+            self._metric_recorder,
+            backend=stats.backend.value,
+            scope_kind=stats.scope_kind.value,
+            operation=operation,
+            document_count=stats.document_count,
+        )
+
+    async def _record_document_count_async(
+        self,
+        *,
+        stats: RetrievalStats,
+        operation: str,
+    ) -> None:
+        if self._metric_recorder is None:
+            return
+        await record_retrieval_document_count_async(
             self._metric_recorder,
             backend=stats.backend.value,
             scope_kind=stats.scope_kind.value,

--- a/src/relay_teams/retrieval/retrieval_store.py
+++ b/src/relay_teams/retrieval/retrieval_store.py
@@ -24,14 +24,24 @@ class RetrievalStore(Protocol):
         *,
         config: RetrievalScopeConfig,
         documents: tuple[RetrievalDocument, ...],
-    ) -> RetrievalStats: ...
+    ) -> RetrievalStats:
+        raise NotImplementedError  # pragma: no cover
 
     def upsert_documents(
         self,
         *,
         config: RetrievalScopeConfig,
         documents: tuple[RetrievalDocument, ...],
-    ) -> RetrievalStats: ...
+    ) -> RetrievalStats:
+        raise NotImplementedError  # pragma: no cover
+
+    async def upsert_documents_async(
+        self,
+        *,
+        config: RetrievalScopeConfig,
+        documents: tuple[RetrievalDocument, ...],
+    ) -> RetrievalStats:
+        raise NotImplementedError  # pragma: no cover
 
     def delete_documents(
         self,
@@ -39,24 +49,35 @@ class RetrievalStore(Protocol):
         scope_kind: RetrievalScopeKind,
         scope_id: str,
         document_ids: tuple[str, ...],
-    ) -> RetrievalStats: ...
+    ) -> RetrievalStats:
+        raise NotImplementedError  # pragma: no cover
 
     def search(
         self,
         *,
         query: RetrievalQuery,
-    ) -> tuple[RetrievalHit, ...]: ...
+    ) -> tuple[RetrievalHit, ...]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def search_async(
+        self,
+        *,
+        query: RetrievalQuery,
+    ) -> tuple[RetrievalHit, ...]:
+        raise NotImplementedError  # pragma: no cover
 
     def rebuild_scope(
         self,
         *,
         scope_kind: RetrievalScopeKind,
         scope_id: str,
-    ) -> RetrievalStats: ...
+    ) -> RetrievalStats:
+        raise NotImplementedError  # pragma: no cover
 
     def stats(
         self,
         *,
         scope_kind: RetrievalScopeKind,
         scope_id: str,
-    ) -> RetrievalStats: ...
+    ) -> RetrievalStats:
+        raise NotImplementedError  # pragma: no cover

--- a/src/relay_teams/roles/evolution_history.py
+++ b/src/relay_teams/roles/evolution_history.py
@@ -69,7 +69,7 @@ class RoleEvolutionHistoryService:
         self._adjustment_repository = adjustment_repository
         self._memory_bank_service = memory_bank_service
 
-    def record_event(
+    async def record_event_async(
         self,
         *,
         role_id: str,
@@ -102,7 +102,7 @@ class RoleEvolutionHistoryService:
             },
         )
 
-        self._memory_bank_service.create_entry(
+        await self._memory_bank_service.create_entry_async(
             CreateMemoryEntryRequest(
                 tier=MemoryTier.MEDIUM_TERM,
                 scope=MemoryScope.ROLE,
@@ -133,14 +133,14 @@ class RoleEvolutionHistoryService:
         )
         return event
 
-    def get_timeline(
+    async def get_timeline_async(
         self,
         *,
         role_id: str,
         workspace_id: str,
         limit: int = 50,
     ) -> RoleEvolutionTimeline:
-        result = self._memory_bank_service.list_entries(
+        result = await self._memory_bank_service.list_entries_async(
             MemoryQuery(
                 workspace_id=workspace_id,
                 role_id=role_id,
@@ -154,7 +154,7 @@ class RoleEvolutionHistoryService:
 
         events: list[RoleEvolutionEvent] = []
         for summary in result.items:
-            entry = self._memory_bank_service.get_entry(summary.id)
+            entry = await self._memory_bank_service.get_entry_async(summary.id)
             if entry is not None:
                 event = _entry_to_evolution_event(entry)
                 if event is not None:
@@ -168,13 +168,13 @@ class RoleEvolutionHistoryService:
             adjustment_repository=self._adjustment_repository,
         )
 
-    def get_current_state(
+    async def get_current_state_async(
         self,
         *,
         role_id: str,
         workspace_id: str,
     ) -> RoleEvolutionTimeline:
-        return self.get_timeline(
+        return await self.get_timeline_async(
             role_id=role_id,
             workspace_id=workspace_id,
             limit=100,

--- a/src/relay_teams/roles/memory_injection.py
+++ b/src/relay_teams/roles/memory_injection.py
@@ -15,7 +15,7 @@ from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 
 
-def build_role_with_memory(
+async def build_role_with_memory_async(
     *,
     role_registry: RoleRegistry,
     role_memory_service: RoleMemoryService | None,
@@ -37,7 +37,7 @@ def build_role_with_memory(
 
     # Legacy reflection memory section
     if role_memory_service is not None:
-        reflection_text = role_memory_service.build_injected_memory(
+        reflection_text = await role_memory_service.build_injected_memory_async(
             role_id=role_id,
             workspace_id=workspace_id,
         )
@@ -46,7 +46,7 @@ def build_role_with_memory(
 
     # New structured memory bank section (PERSISTENT + MEDIUM_TERM only)
     if memory_bank_service is not None:
-        project_memory = _build_project_memory_section(
+        project_memory = await _build_project_memory_section_async(
             memory_bank_service=memory_bank_service,
             workspace_id=workspace_id,
             role_id=role_id,
@@ -56,12 +56,12 @@ def build_role_with_memory(
 
     # RP-2: Role Evolution section (performance + maturity)
     if role_memory_service is not None:
-        performance = role_memory_service.get_performance_metrics(
+        performance = await role_memory_service.get_performance_metrics_async(
             role_id=role_id,
             workspace_id=workspace_id,
         )
         if performance is not None and performance.task_counts.total_tasks > 0:
-            evolution = _build_role_evolution_section(
+            evolution = await _build_role_evolution_section_async(
                 memory_bank_service=memory_bank_service,
                 workspace_id=workspace_id,
                 role_id=role_id,
@@ -81,7 +81,7 @@ def build_role_with_memory(
     )
 
 
-def _build_role_evolution_section(
+async def _build_role_evolution_section_async(
     *,
     memory_bank_service: MemoryBankService | None,
     workspace_id: str,
@@ -106,12 +106,12 @@ def _build_role_evolution_section(
     maturity_level: str | None = None
     adjustment_count: int | None = None
     if memory_bank_service is not None:
-        maturity_level = _find_latest_maturity_level(
+        maturity_level = await _find_latest_maturity_level_async(
             memory_bank_service=memory_bank_service,
             workspace_id=workspace_id,
             role_id=role_id,
         )
-        adjustment_count = _count_applied_adjustments(
+        adjustment_count = await _count_applied_adjustments_async(
             memory_bank_service=memory_bank_service,
             workspace_id=workspace_id,
             role_id=role_id,
@@ -125,7 +125,7 @@ def _build_role_evolution_section(
     return "\n".join(lines)
 
 
-def _find_latest_maturity_level(
+async def _find_latest_maturity_level_async(
     *,
     memory_bank_service: MemoryBankService,
     workspace_id: str,
@@ -141,7 +141,7 @@ def _find_latest_maturity_level(
         limit=10,
     )
     try:
-        result = memory_bank_service.list_entries(query)
+        result = await memory_bank_service.list_entries_async(query)
     except (ValueError, OSError, RuntimeError):
         return None
 
@@ -160,7 +160,7 @@ def _find_latest_maturity_level(
     return None
 
 
-def _count_applied_adjustments(
+async def _count_applied_adjustments_async(
     *,
     memory_bank_service: MemoryBankService,
     workspace_id: str,
@@ -176,7 +176,7 @@ def _count_applied_adjustments(
         limit=50,
     )
     try:
-        result = memory_bank_service.list_entries(query)
+        result = await memory_bank_service.list_entries_async(query)
     except (ValueError, OSError, RuntimeError):
         return None
 
@@ -188,7 +188,7 @@ def _count_applied_adjustments(
     return count
 
 
-def _build_project_memory_section(
+async def _build_project_memory_section_async(
     *,
     memory_bank_service: MemoryBankService,
     workspace_id: str,
@@ -205,7 +205,7 @@ def _build_project_memory_section(
             limit=20,
         )
         try:
-            result = memory_bank_service.list_entries(query)
+            result = await memory_bank_service.list_entries_async(query)
         except (ValueError, OSError, RuntimeError):
             continue
         if not result.items:

--- a/src/relay_teams/roles/memory_service.py
+++ b/src/relay_teams/roles/memory_service.py
@@ -18,7 +18,7 @@ class RoleMemoryService:
     def __init__(self, *, repository: RoleMemoryRepository) -> None:
         self._repository = repository
 
-    def build_injected_memory(
+    async def build_injected_memory_async(
         self,
         *,
         role_id: str,
@@ -26,58 +26,59 @@ class RoleMemoryService:
         memory_date: str | None = None,
     ) -> str:
         del memory_date
-        return self.get_reflection_record(
+        record = await self.get_reflection_record_async(
             role_id=role_id,
             workspace_id=workspace_id,
-        ).content_markdown.strip()
+        )
+        return record.content_markdown.strip()
 
-    def get_reflection_record(
+    async def get_reflection_record_async(
         self,
         *,
         role_id: str,
         workspace_id: str,
     ) -> RoleMemoryRecord:
-        return self._repository.read_role_memory(
+        return await self._repository.read_role_memory_async(
             role_id=role_id,
             workspace_id=workspace_id,
         )
 
-    def update_reflection_memory(
+    async def update_reflection_memory_async(
         self,
         *,
         role_id: str,
         workspace_id: str,
         content_markdown: str,
     ) -> RoleMemoryRecord:
-        self._repository.write_role_memory(
+        await self._repository.write_role_memory_async(
             role_id=role_id,
             workspace_id=workspace_id,
             content_markdown=content_markdown.strip(),
         )
-        return self.get_reflection_record(
+        return await self.get_reflection_record_async(
             role_id=role_id,
             workspace_id=workspace_id,
         )
 
-    def delete_reflection_memory(
+    async def delete_reflection_memory_async(
         self,
         *,
         role_id: str,
         workspace_id: str,
     ) -> None:
-        self._repository.delete_role_memory(
+        await self._repository.delete_role_memory_async(
             role_id=role_id,
             workspace_id=workspace_id,
         )
 
-    def build_reflection_preview(
+    async def build_reflection_preview_async(
         self,
         *,
         role_id: str,
         workspace_id: str,
         max_chars: int = 180,
     ) -> str:
-        text = self.build_injected_memory(
+        text = await self.build_injected_memory_async(
             role_id=role_id,
             workspace_id=workspace_id,
         )
@@ -193,18 +194,6 @@ class RoleMemoryService:
             workspace_id=workspace_id,
         )
 
-    def get_performance_metrics(
-        self,
-        *,
-        role_id: str,
-        workspace_id: str,
-    ) -> RolePerformanceMetrics | None:
-        record = self._repository.read_role_memory(
-            role_id=role_id,
-            workspace_id=workspace_id,
-        )
-        return record.performance
-
     async def get_performance_metrics_async(
         self,
         *,
@@ -217,7 +206,7 @@ class RoleMemoryService:
         )
         return record.performance
 
-    def record_task_result(
+    async def record_task_result_async(
         self,
         *,
         role_id: str,
@@ -230,23 +219,31 @@ class RoleMemoryService:
         memory_date: str | None = None,
     ) -> None:
         del session_id, task_id, transcript_lines, memory_date
-        trimmed_result = result.strip()
-        trimmed_objective = objective.strip()
-        current = self._repository.read_role_memory(
+        record = await self._repository.read_role_memory_async(
             role_id=role_id,
             workspace_id=workspace_id,
-        ).content_markdown.strip()
-        durable_entry = f"- {trimmed_objective}: {trimmed_result or '(empty)'}"
+        )
+        current = record.content_markdown.strip()
+        durable_entry = _build_task_result_memory_entry(
+            objective=objective,
+            result=result,
+        )
         if durable_entry in current.splitlines():
             return
         next_text = "\n".join(
             line for line in (current, durable_entry) if line.strip()
         ).strip()
-        self._repository.write_role_memory(
+        await self._repository.write_role_memory_async(
             role_id=role_id,
             workspace_id=workspace_id,
             content_markdown=next_text,
         )
+
+
+def _build_task_result_memory_entry(*, objective: str, result: str) -> str:
+    trimmed_result = result.strip()
+    trimmed_objective = objective.strip()
+    return f"- {trimmed_objective}: {trimmed_result or '(empty)'}"
 
 
 def _compute_report_score(verification_report: VerificationReport) -> float:

--- a/src/relay_teams/roles/prompt_adjustment_engine.py
+++ b/src/relay_teams/roles/prompt_adjustment_engine.py
@@ -8,8 +8,10 @@ from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 
+import aiosqlite
 from pydantic import BaseModel, ConfigDict, Field
 
+from relay_teams.persistence import async_fetchone
 from relay_teams.persistence.sqlite_repository import SharedSqliteRepository
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
@@ -157,12 +159,101 @@ class PromptAdjustmentRepository(SharedSqliteRepository):
             )
         return _decision
 
+    async def save_decision_async(
+        self,
+        decision: PromptAdjustmentDecision,
+    ) -> PromptAdjustmentDecision:
+        now = decision.proposed_at.isoformat()
+        rec_json = json.dumps(
+            [r.model_dump() for r in decision.recommendations],
+            ensure_ascii=False,
+        )
+
+        async def operation(conn: aiosqlite.Connection) -> None:
+            cursor = await conn.execute(
+                """
+                INSERT INTO prompt_adjustments(
+                    decision_id, role_id, workspace_id, version,
+                    previous_prompt, proposed_prompt, recommendations_json,
+                    status, trigger_source, triggered_by, proposed_at,
+                    reviewed_at, reviewed_by, rejection_reason,
+                    applied_at, rolled_back_at, rollback_reason
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(decision_id)
+                DO UPDATE SET
+                    role_id=excluded.role_id,
+                    workspace_id=excluded.workspace_id,
+                    version=excluded.version,
+                    previous_prompt=excluded.previous_prompt,
+                    proposed_prompt=excluded.proposed_prompt,
+                    recommendations_json=excluded.recommendations_json,
+                    status=excluded.status,
+                    trigger_source=excluded.trigger_source,
+                    triggered_by=excluded.triggered_by,
+                    reviewed_at=excluded.reviewed_at,
+                    reviewed_by=excluded.reviewed_by,
+                    rejection_reason=excluded.rejection_reason,
+                    applied_at=excluded.applied_at,
+                    rolled_back_at=excluded.rolled_back_at,
+                    rollback_reason=excluded.rollback_reason
+                """,
+                (
+                    decision.decision_id,
+                    decision.role_id,
+                    decision.workspace_id,
+                    decision.version,
+                    decision.previous_prompt,
+                    decision.proposed_prompt,
+                    rec_json,
+                    decision.status.value,
+                    decision.trigger_source,
+                    decision.triggered_by,
+                    now,
+                    decision.reviewed_at.isoformat() if decision.reviewed_at else None,
+                    decision.reviewed_by,
+                    decision.rejection_reason,
+                    decision.applied_at.isoformat() if decision.applied_at else None,
+                    decision.rolled_back_at.isoformat()
+                    if decision.rolled_back_at
+                    else None,
+                    decision.rollback_reason,
+                ),
+            )
+            await cursor.close()
+
+        await self._run_async_write(
+            operation_name="save_decision_async",
+            operation=operation,
+        )
+        _decision = await self.get_decision_async(decision.decision_id)
+        if _decision is None:
+            raise ValueError(
+                f"Failed to retrieve decision after save: {decision.decision_id}"
+            )
+        return _decision
+
     def get_decision(self, decision_id: str) -> PromptAdjustmentDecision | None:
         row = self._run_read(
             lambda: self._conn.execute(
                 "SELECT * FROM prompt_adjustments WHERE decision_id=?",
                 (decision_id,),
             ).fetchone()
+        )
+        if row is None:
+            return None
+        return _row_to_decision(row)
+
+    async def get_decision_async(
+        self,
+        decision_id: str,
+    ) -> PromptAdjustmentDecision | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT * FROM prompt_adjustments WHERE decision_id=?",
+                (decision_id,),
+            )
         )
         if row is None:
             return None
@@ -203,6 +294,23 @@ class PromptAdjustmentRepository(SharedSqliteRepository):
                 "ORDER BY applied_at DESC LIMIT 1",
                 (role_id, workspace_id, PromptAdjustmentStatus.APPLIED.value),
             ).fetchone()
+        )
+        if row is None:
+            return None
+        return _row_to_decision(row)
+
+    async def get_latest_applied_async(
+        self,
+        role_id: str,
+        workspace_id: str,
+    ) -> PromptAdjustmentDecision | None:
+        row = await self._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT * FROM prompt_adjustments WHERE role_id=? AND workspace_id=? AND status=? "
+                "ORDER BY applied_at DESC LIMIT 1",
+                (role_id, workspace_id, PromptAdjustmentStatus.APPLIED.value),
+            )
         )
         if row is None:
             return None
@@ -343,6 +451,38 @@ class SystemPromptAdjustmentEngine:
             proposed_at=datetime.now(tz=timezone.utc),
         )
         return self._repository.save_decision(decision)
+
+    async def propose_adjustment_async(
+        self,
+        *,
+        role_id: str,
+        workspace_id: str,
+        current_prompt: str,
+        recommendations: tuple[PromptAdjustmentRecommendation, ...],
+        trigger_source: str,
+        triggered_by: str,
+    ) -> PromptAdjustmentDecision:
+        latest = await self._repository.get_latest_applied_async(
+            role_id=role_id,
+            workspace_id=workspace_id,
+        )
+        version = 1 if latest is None else latest.version + 1
+        proposed_prompt = _merge_sections(current_prompt, recommendations)
+
+        decision = PromptAdjustmentDecision(
+            decision_id=_new_decision_id(),
+            role_id=role_id,
+            workspace_id=workspace_id,
+            version=version,
+            previous_prompt=current_prompt,
+            proposed_prompt=proposed_prompt,
+            recommendations=recommendations,
+            status=PromptAdjustmentStatus.PROPOSED,
+            trigger_source=trigger_source,
+            triggered_by=triggered_by,
+            proposed_at=datetime.now(tz=timezone.utc),
+        )
+        return await self._repository.save_decision_async(decision)
 
     def approve_adjustment(
         self,

--- a/src/relay_teams/roles/self_assessment_service.py
+++ b/src/relay_teams/roles/self_assessment_service.py
@@ -69,7 +69,7 @@ class RoleSelfAssessmentService:
         if run_count_since_last < self._config.trigger_every_n_runs:
             return None
 
-        record = self._role_memory_service.get_reflection_record(
+        record = await self._role_memory_service.get_reflection_record_async(
             role_id=role_id,
             workspace_id=workspace_id,
         )

--- a/src/relay_teams/roles/temporary_knowledge_capture.py
+++ b/src/relay_teams/roles/temporary_knowledge_capture.py
@@ -49,7 +49,7 @@ class TemporaryRoleKnowledgeCaptureService:
     ) -> TemporaryKnowledgeCapture | None:
 
         try:
-            record = self._temporary_role_repository.get(
+            record = await self._temporary_role_repository.get_async(
                 run_id=subagent_run_id,
                 role_id=subagent_role_id,
             )
@@ -78,7 +78,7 @@ class TemporaryRoleKnowledgeCaptureService:
             prompt_diff_markdown=diff,
         )
 
-        self._adjustment_engine.propose_adjustment(
+        await self._adjustment_engine.propose_adjustment_async(
             role_id=template_role_id,
             workspace_id=workspace_id,
             current_prompt=original_prompt,

--- a/src/relay_teams/sessions/runs/run_hook_pipeline.py
+++ b/src/relay_teams/sessions/runs/run_hook_pipeline.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 import logging
 from typing import Protocol
 
@@ -14,6 +14,7 @@ from relay_teams.hooks import (
     StopFailureInput,
     StopInput,
 )
+from relay_teams.memory.event_handler import MemoryEventHandler
 from relay_teams.sessions.runs.enums import InjectionSource
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.run_models import IntentInput
@@ -33,6 +34,16 @@ class AppendCoordinatorFollowup(Protocol):
     ) -> bool: ...
 
 
+class TemporaryKnowledgeCaptureServiceLike(Protocol):
+    async def capture_all_for_session(
+        self,
+        *,
+        _session_id: str,
+        _workspace_id: str,
+    ) -> object:
+        raise NotImplementedError  # pragma: no cover
+
+
 class RunHookPipeline:
     def __init__(
         self,
@@ -41,31 +52,27 @@ class RunHookPipeline:
         session_repo: SessionRepository,
         run_event_hub: RunEventHub,
         append_followup_to_coordinator: AppendCoordinatorFollowup,
-        memory_event_handler: object | None = None,
+        memory_event_handler: MemoryEventHandler | None = None,
     ) -> None:
         self._get_hook_service = get_hook_service
         self._session_repo = session_repo
         self._run_event_hub = run_event_hub
         self._append_followup_to_coordinator = append_followup_to_coordinator
-        # MemoryEventHandler is optional to avoid import cycles --
-        # the class is passed through as an opaque object and cast
-        # only at call-sites where the methods are needed.
         self._memory_event_handler = memory_event_handler
-        # RP-2: bound capture_all_for_session callable (optional, best-effort).
-        self._capture_all_for_session: Callable[..., Awaitable[object]] | None = None
+        self._temporary_knowledge_capture_service: (
+            TemporaryKnowledgeCaptureServiceLike | None
+        ) = None
 
     def set_temporary_knowledge_capture_service(
         self,
-        service: object,
+        service: TemporaryKnowledgeCaptureServiceLike,
     ) -> None:
         """Wire the RP-2 TemporaryRoleKnowledgeCaptureService after construction.
 
-        Extracts the bound ``capture_all_for_session`` method so the pipeline
-        can call it directly without importing the concrete service class.
+        The pipeline keeps a protocol reference here so session shutdown can
+        remain decoupled from the concrete role-memory capture implementation.
         """
-        self._capture_all_for_session = getattr(
-            service, "capture_all_for_session", None
-        )
+        self._temporary_knowledge_capture_service = service
 
     async def execute_session_start_hooks(
         self,
@@ -77,7 +84,7 @@ class RunHookPipeline:
         hook_service = self._get_hook_service()
         if hook_service is None:
             return
-        session = self._session_repo.get(session_id)
+        session = await self._session_repo.get_async(session_id)
         _ = await hook_service.execute(
             event_input=SessionStartInput(
                 event_name=HookEventName.SESSION_START,
@@ -105,14 +112,11 @@ class RunHookPipeline:
     ) -> None:
         # Memory bank lifecycle: trigger run and session consolidation.
         if self._memory_event_handler is not None:
-            from relay_teams.memory.event_handler import MemoryEventHandler
-
             handler = self._memory_event_handler
-            assert isinstance(handler, MemoryEventHandler)
-            workspace_id = self._resolve_workspace_id(session_id)
+            workspace_id = await self._resolve_workspace_id_async(session_id)
             if workspace_id is not None:
                 try:
-                    handler.on_run_completed(
+                    await handler.on_run_completed_async(
                         workspace_id=workspace_id,
                         session_id=session_id,
                     )
@@ -126,7 +130,7 @@ class RunHookPipeline:
                         session_id,
                     )
                 try:
-                    handler.on_session_completed(
+                    await handler.on_session_completed_async(
                         workspace_id=workspace_id,
                         session_id=session_id,
                     )
@@ -141,9 +145,10 @@ class RunHookPipeline:
                     )
 
                 # RP-2: capture temporary role knowledge before roles expire.
-                if self._capture_all_for_session is not None:
+                capture_service = self._temporary_knowledge_capture_service
+                if capture_service is not None:
                     try:
-                        await self._capture_all_for_session(
+                        await capture_service.capture_all_for_session(
                             _session_id=session_id,
                             _workspace_id=workspace_id,
                         )
@@ -173,11 +178,12 @@ class RunHookPipeline:
             run_event_hub=self._run_event_hub,
         )
 
-    def _resolve_workspace_id(self, session_id: str) -> str | None:
-        session = self._session_repo.get(session_id)
-        if session is not None:
-            return session.workspace_id
-        return None
+    async def _resolve_workspace_id_async(self, session_id: str) -> str | None:
+        try:
+            session = await self._session_repo.get_async(session_id)
+        except KeyError:
+            return None
+        return session.workspace_id
 
     async def execute_stop_hooks(
         self,

--- a/src/relay_teams/sessions/runs/run_service.py
+++ b/src/relay_teams/sessions/runs/run_service.py
@@ -11,6 +11,7 @@ from pydantic import JsonValue
 
 from relay_teams.agents.orchestration.meta_agent import MetaAgent
 from relay_teams.logger import get_logger, log_event
+from relay_teams.memory.event_handler import MemoryEventHandler
 from relay_teams.media import MediaAssetService
 from relay_teams.monitors import (
     MonitorActionType,
@@ -155,7 +156,7 @@ class SessionRunService:
         shell_approval_repo: ShellApprovalRepository | None = None,
         user_question_manager: UserQuestionManager | None = None,
         hook_service: HookService | None = None,
-        memory_event_handler: object | None = None,
+        memory_event_handler: MemoryEventHandler | None = None,
     ) -> None:
         self._meta_agent: MetaAgent = meta_agent
         self._provider_factory = provider_factory or (
@@ -536,7 +537,11 @@ class SessionRunService:
         run_id = self._active_run_registry.get_active_run_id(session_id)
         if not run_id:
             return None
-        return run_id, self._runtime_for_run(run_id)
+        runtime = self._runtime_for_run(run_id)
+        if runtime is not None and not runtime.is_recoverable:
+            self._drop_active_run(session_id, run_id)
+            return None
+        return run_id, runtime
 
     async def _active_recoverable_run_async(
         self, session_id: str
@@ -544,7 +549,11 @@ class SessionRunService:
         run_id = self._active_run_registry.get_active_run_id(session_id)
         if not run_id:
             return None
-        return run_id, await self._runtime_for_run_async(run_id)
+        runtime = await self._runtime_for_run_async(run_id)
+        if runtime is not None and not runtime.is_recoverable:
+            self._drop_active_run(session_id, run_id)
+            return None
+        return run_id, runtime
 
     def _remember_active_run(self, session_id: str, run_id: str) -> None:
         self._active_run_registry.remember_active_run(

--- a/src/relay_teams/sessions/session_service.py
+++ b/src/relay_teams/sessions/session_service.py
@@ -1319,24 +1319,35 @@ class SessionService:
     async def list_agents_in_session_async(
         self, session_id: str
     ) -> tuple[dict[str, object], ...]:
-        return await asyncio.to_thread(self.list_agents_in_session, session_id)
+        session = await self._session_repo.get_async(session_id)
+        latest_by_role: dict[str, AgentRuntimeRecord] = {}
+        for record in await self._agent_repo.list_by_session_async(session_id):
+            if self._is_normal_mode_subagent_record(record, session=session):
+                continue
+            existing = latest_by_role.get(record.role_id)
+            if existing is None or (
+                record.updated_at,
+                record.created_at,
+            ) >= (
+                existing.updated_at,
+                existing.created_at,
+            ):
+                latest_by_role[record.role_id] = record
 
-    def get_agent_reflection(
-        self,
-        session_id: str,
-        instance_id: str,
-    ) -> dict[str, object]:
-        agent = self._require_session_agent(session_id, instance_id)
-        return self._reflection_projection(agent)
+        projections: list[dict[str, object]] = []
+        for role_id in sorted(latest_by_role.keys()):
+            projections.append(
+                await self._agent_projection_async(latest_by_role[role_id])
+            )
+        return tuple(projections)
 
     async def get_agent_reflection_async(
         self,
         session_id: str,
         instance_id: str,
     ) -> dict[str, object]:
-        return await asyncio.to_thread(
-            self.get_agent_reflection, session_id, instance_id
-        )
+        agent = await self._require_session_agent_async(session_id, instance_id)
+        return await self._reflection_projection_async(agent)
 
     async def refresh_subagent_reflection(
         self,
@@ -1345,7 +1356,7 @@ class SessionService:
     ) -> dict[str, object]:
         if self._subagent_reflection_service is None or self._role_registry is None:
             raise RuntimeError("Subagent reflection is not available")
-        agent = self._require_session_agent(session_id, instance_id)
+        agent = await self._require_session_agent_async(session_id, instance_id)
         if self._role_registry.is_coordinator_role(agent.role_id):
             raise RuntimeError("Coordinator reflection refresh is not supported")
         role = self._role_registry.get(agent.role_id)
@@ -1354,27 +1365,10 @@ class SessionService:
             workspace_id=agent.workspace_id,
             conversation_id=agent.conversation_id,
         )
-        return self._reflection_projection(agent, role_record=record, source="manual")
-
-    def update_agent_reflection(
-        self,
-        session_id: str,
-        instance_id: str,
-        *,
-        summary: str,
-    ) -> dict[str, object]:
-        if self._role_memory_service is None:
-            raise RuntimeError("Subagent reflection is not available")
-        agent = self._require_session_agent(session_id, instance_id)
-        record = self._role_memory_service.update_reflection_memory(
-            role_id=agent.role_id,
-            workspace_id=agent.workspace_id,
-            content_markdown=summary,
-        )
-        return self._reflection_projection(
+        return await self._reflection_projection_async(
             agent,
             role_record=record,
-            source="manual_edit",
+            source="manual",
         )
 
     async def update_agent_reflection_async(
@@ -1384,32 +1378,33 @@ class SessionService:
         *,
         summary: str,
     ) -> dict[str, object]:
-        return await asyncio.to_thread(
-            self.update_agent_reflection, session_id, instance_id, summary=summary
-        )
-
-    def delete_agent_reflection(
-        self,
-        session_id: str,
-        instance_id: str,
-    ) -> dict[str, object]:
         if self._role_memory_service is None:
             raise RuntimeError("Subagent reflection is not available")
-        agent = self._require_session_agent(session_id, instance_id)
-        self._role_memory_service.delete_reflection_memory(
+        agent = await self._require_session_agent_async(session_id, instance_id)
+        record = await self._role_memory_service.update_reflection_memory_async(
             role_id=agent.role_id,
             workspace_id=agent.workspace_id,
+            content_markdown=summary,
         )
-        return self._reflection_projection(agent, source="manual_delete")
+        return await self._reflection_projection_async(
+            agent,
+            role_record=record,
+            source="manual_edit",
+        )
 
     async def delete_agent_reflection_async(
         self,
         session_id: str,
         instance_id: str,
     ) -> dict[str, object]:
-        return await asyncio.to_thread(
-            self.delete_agent_reflection, session_id, instance_id
+        if self._role_memory_service is None:
+            raise RuntimeError("Subagent reflection is not available")
+        agent = await self._require_session_agent_async(session_id, instance_id)
+        await self._role_memory_service.delete_reflection_memory_async(
+            role_id=agent.role_id,
+            workspace_id=agent.workspace_id,
         )
+        return await self._reflection_projection_async(agent, source="manual_delete")
 
     def get_agent_messages(
         self, session_id: str, instance_id: str
@@ -2340,8 +2335,29 @@ class SessionService:
             raise KeyError(instance_id)
         return agent
 
+    async def _require_session_agent_async(
+        self,
+        session_id: str,
+        instance_id: str,
+    ) -> AgentRuntimeRecord:
+        agent = await self._agent_repo.get_instance_async(instance_id)
+        if agent.session_id != session_id:
+            raise KeyError(instance_id)
+        return agent
+
     def _agent_projection(self, record: AgentRuntimeRecord) -> dict[str, object]:
         reflection = self._reflection_projection(record)
+        return {
+            **record.model_dump(mode="json"),
+            "reflection_summary_preview": reflection["preview"],
+            "reflection_updated_at": reflection["updated_at"],
+        }
+
+    async def _agent_projection_async(
+        self,
+        record: AgentRuntimeRecord,
+    ) -> dict[str, object]:
+        reflection = await self._reflection_projection_async(record)
         return {
             **record.model_dump(mode="json"),
             "reflection_summary_preview": reflection["preview"],
@@ -2410,7 +2426,20 @@ class SessionService:
         projected["stream_connected"] = stream_connected
         return projected
 
+    @staticmethod
     def _reflection_projection(
+        record: AgentRuntimeRecord,
+        *,
+        source: str = "stored",
+        role_record: object | None = None,
+    ) -> dict[str, object]:
+        return _build_reflection_projection(
+            record=record,
+            source=source,
+            memory=role_record,
+        )
+
+    async def _reflection_projection_async(
         self,
         record: AgentRuntimeRecord,
         *,
@@ -2419,35 +2448,15 @@ class SessionService:
     ) -> dict[str, object]:
         memory = role_record
         if memory is None and self._role_memory_service is not None:
-            memory = self._role_memory_service.get_reflection_record(
+            memory = await self._role_memory_service.get_reflection_record_async(
                 role_id=record.role_id,
                 workspace_id=record.workspace_id,
             )
-        if memory is None:
-            return {
-                "instance_id": record.instance_id,
-                "role_id": record.role_id,
-                "summary": "",
-                "preview": "",
-                "updated_at": None,
-                "source": source,
-            }
-        updated_at = getattr(memory, "updated_at", None)
-        summary = str(getattr(memory, "content_markdown", "") or "").strip()
-        preview = ""
-        if self._role_memory_service is not None:
-            preview = self._role_memory_service.build_reflection_preview(
-                role_id=record.role_id,
-                workspace_id=record.workspace_id,
-            )
-        return {
-            "instance_id": record.instance_id,
-            "role_id": record.role_id,
-            "summary": summary,
-            "preview": preview,
-            "updated_at": updated_at.isoformat() if updated_at is not None else None,
-            "source": source,
-        }
+        return _build_reflection_projection(
+            record=record,
+            source=source,
+            memory=memory,
+        )
 
     def _public_phase(
         self,
@@ -2579,24 +2588,39 @@ class SessionService:
             record.run_id
         ).strip().startswith("subagent_run_")
 
-    def _shared_state_snapshot(
-        self,
-        *,
-        session_id: str,
-        role_id: str,
-        conversation_id: str,
-    ) -> tuple[tuple[str, str], ...]:
-        if self._shared_store is None:
-            return ()
-        scopes = (
-            ScopeRef(scope_type=ScopeType.SESSION, scope_id=session_id),
-            ScopeRef(scope_type=ScopeType.ROLE, scope_id=f"{session_id}:{role_id}"),
-            ScopeRef(scope_type=ScopeType.CONVERSATION, scope_id=conversation_id),
-        )
-        return self._shared_store.snapshot_many(
-            scopes,
-            exclude_key_prefixes=(READ_STATE_PREFIX,),
-        )
+
+def _build_reflection_projection(
+    *,
+    record: AgentRuntimeRecord,
+    source: str,
+    memory: object | None,
+) -> dict[str, object]:
+    if memory is None:
+        return {
+            "instance_id": record.instance_id,
+            "role_id": record.role_id,
+            "summary": "",
+            "preview": "",
+            "updated_at": None,
+            "source": source,
+        }
+    updated_at = getattr(memory, "updated_at", None)
+    summary = str(getattr(memory, "content_markdown", "") or "").strip()
+    return {
+        "instance_id": record.instance_id,
+        "role_id": record.role_id,
+        "summary": summary,
+        "preview": _reflection_preview_from_text(summary),
+        "updated_at": updated_at.isoformat() if updated_at is not None else None,
+        "source": source,
+    }
+
+
+def _reflection_preview_from_text(text: str, *, max_chars: int = 180) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= max_chars:
+        return normalized
+    return normalized[: max_chars - 3].rstrip() + "..."
 
 
 def _history_marker_label(marker: SessionHistoryMarkerRecord) -> str:

--- a/src/relay_teams/skills/skill_routing_service.py
+++ b/src/relay_teams/skills/skill_routing_service.py
@@ -13,6 +13,7 @@ from relay_teams.agents.execution.user_prompts import (
 from relay_teams.logger import get_logger, log_event
 from relay_teams.retrieval import (
     RetrievalDocument,
+    RetrievalHit,
     RetrievalQuery,
     RetrievalScopeConfig,
     RetrievalScopeKind,
@@ -91,24 +92,17 @@ class SkillRoutingService:
         self._top_k = top_k
         self._search_limit = search_limit
 
-    def route(
+    async def route_async(
         self,
         *,
         authorized_skills: tuple[str, ...],
         context: SkillRoutingContext,
     ) -> SkillRoutingResult:
         query_text = build_skill_routing_query_text(context)
-        authorized_count = len(authorized_skills)
-        if authorized_count <= self._top_k:
-            return SkillRoutingResult(
+        if len(authorized_skills) <= self._top_k:
+            return self._passthrough_result(
                 authorized_skills=authorized_skills,
-                visible_skills=authorized_skills,
-                diagnostics=SkillRoutingDiagnostics(
-                    mode=SkillRoutingMode.PASSTHROUGH,
-                    query_text=query_text,
-                    authorized_count=authorized_count,
-                    visible_skills=authorized_skills,
-                ),
+                query_text=query_text,
             )
         if not query_text:
             return self._fallback_result(
@@ -118,7 +112,7 @@ class SkillRoutingService:
             )
 
         try:
-            hits = self._retrieval_service.search(
+            hits = await self._retrieval_service.search_async(
                 query=RetrievalQuery(
                     scope_kind=self._scope_config.scope_kind,
                     scope_id=self._scope_config.scope_id,
@@ -143,6 +137,36 @@ class SkillRoutingService:
                 reason=SkillRoutingFallbackReason.SEARCH_FAILED,
             )
 
+        return self._search_result_from_hits(
+            authorized_skills=authorized_skills,
+            query_text=query_text,
+            hits=hits,
+        )
+
+    @staticmethod
+    def _passthrough_result(
+        *,
+        authorized_skills: tuple[str, ...],
+        query_text: str,
+    ) -> SkillRoutingResult:
+        return SkillRoutingResult(
+            authorized_skills=authorized_skills,
+            visible_skills=authorized_skills,
+            diagnostics=SkillRoutingDiagnostics(
+                mode=SkillRoutingMode.PASSTHROUGH,
+                query_text=query_text,
+                authorized_count=len(authorized_skills),
+                visible_skills=authorized_skills,
+            ),
+        )
+
+    def _search_result_from_hits(
+        self,
+        *,
+        authorized_skills: tuple[str, ...],
+        query_text: str,
+        hits: tuple[RetrievalHit, ...],
+    ) -> SkillRoutingResult:
         authorized_set = set(authorized_skills)
         filtered_hits = tuple(hit for hit in hits if hit.document_id in authorized_set)
         if not filtered_hits:
@@ -172,7 +196,7 @@ class SkillRoutingService:
             diagnostics=SkillRoutingDiagnostics(
                 mode=SkillRoutingMode.SEARCH,
                 query_text=query_text,
-                authorized_count=authorized_count,
+                authorized_count=len(authorized_skills),
                 visible_skills=visible_skills,
                 candidates=candidates,
             ),
@@ -220,7 +244,7 @@ class SkillRuntimeService:
             skill_registry=self._skill_registry
         )
 
-    def prepare_prompt(
+    async def prepare_prompt_async(
         self,
         *,
         role: RoleDefinition,
@@ -235,7 +259,7 @@ class SkillRuntimeService:
             skill_names=role.skills if skill_names is None else skill_names,
             consumer=consumer,
         )
-        routing = self._route_for_authorized_skills(
+        routing = await self._route_for_authorized_skills_async(
             role=role,
             objective=objective,
             shared_state_snapshot=shared_state_snapshot,
@@ -243,6 +267,19 @@ class SkillRuntimeService:
             orchestration_prompt=orchestration_prompt,
             authorized_skills=authorized_skills,
         )
+        return self._build_prompt_result_from_routing(
+            objective=objective,
+            authorized_skills=authorized_skills,
+            routing=routing,
+        )
+
+    def _build_prompt_result_from_routing(
+        self,
+        *,
+        objective: str,
+        authorized_skills: tuple[Skill, ...],
+        routing: SkillRoutingResult,
+    ) -> SkillPromptResult:
         authorized_skill_map = _skill_map_by_name(authorized_skills)
         instruction_entries = self._instruction_entries_for_names(
             skill_names=routing.authorized_skills,
@@ -286,7 +323,7 @@ class SkillRuntimeService:
             routing=routing,
         )
 
-    def route_for_role(
+    async def route_for_role_async(
         self,
         *,
         role: RoleDefinition,
@@ -301,7 +338,7 @@ class SkillRuntimeService:
             skill_names=role.skills if skill_names is None else skill_names,
             consumer=consumer,
         )
-        return self._route_for_authorized_skills(
+        return await self._route_for_authorized_skills_async(
             role=role,
             objective=objective,
             shared_state_snapshot=shared_state_snapshot,
@@ -310,7 +347,7 @@ class SkillRuntimeService:
             authorized_skills=authorized_skills,
         )
 
-    def _route_for_authorized_skills(
+    async def _route_for_authorized_skills_async(
         self,
         *,
         role: RoleDefinition,
@@ -326,13 +363,13 @@ class SkillRuntimeService:
         with trace_span(
             LOGGER,
             component="skills.runtime",
-            operation="route_for_role",
+            operation="route_for_role_async",
             attributes={
                 "role_id": role.role_id,
                 "authorized_count": len(authorized_skill_names),
             },
         ):
-            result = self._routing_service.route(
+            result = await self._routing_service.route_async(
                 authorized_skills=authorized_skill_names,
                 context=SkillRoutingContext(
                     objective=objective.strip(),

--- a/src/relay_teams/tools/runtime/persisted_state.py
+++ b/src/relay_teams/tools/runtime/persisted_state.py
@@ -511,6 +511,48 @@ def load_or_recover_tool_call_state(
     return current
 
 
+async def load_or_recover_tool_call_state_async(
+    *,
+    shared_store: SharedStateRepository,
+    event_log: EventLog | None,
+    trace_id: str,
+    task_id: str,
+    tool_call_id: str,
+    task_repo: TaskRepository | None = None,
+) -> PersistedToolCallState | None:
+    current = await load_tool_call_state_async(
+        shared_store=shared_store,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+    )
+    if (
+        current is not None
+        and current.execution_status in _TERMINAL_TOOL_EXECUTION_STATUSES
+        and _state_has_published_tool_result_linkage(current)
+    ):
+        return current
+    if event_log is None:
+        return current
+    recovered = await recover_tool_call_state_from_event_log_async(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id=trace_id,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+        task_repo=task_repo,
+        current_state=current,
+    )
+    if recovered is None:
+        return current
+    if current is None:
+        return recovered
+    if recovered.execution_status in _TERMINAL_TOOL_EXECUTION_STATUSES:
+        return recovered
+    if recovered.result_event_id > current.result_event_id:
+        return recovered
+    return current
+
+
 def _state_has_published_tool_result_linkage(state: PersistedToolCallState) -> bool:
     if state.result_event_id > 0:
         return True
@@ -808,6 +850,226 @@ def recover_tool_call_state_from_event_log(
     )
 
 
+async def recover_tool_call_state_from_event_log_async(
+    *,
+    event_log: EventLog,
+    shared_store: SharedStateRepository,
+    trace_id: str,
+    task_id: str,
+    tool_call_id: str,
+    task_repo: TaskRepository | None = None,
+    current_state: PersistedToolCallState | None = None,
+) -> PersistedToolCallState | None:
+    if current_state is None:
+        recovered = await load_tool_call_state_async(
+            shared_store=shared_store,
+            task_id=task_id,
+            tool_call_id=tool_call_id,
+        )
+        if recovered is not None:
+            return recovered
+
+    state: PersistedToolCallState | None = current_state
+    observed_terminal_event = False
+    tool_args: dict[str, JsonValue] = {}
+    for row in await event_log.list_by_trace_with_ids_async(trace_id):
+        if str(row.get("task_id") or "") != task_id:
+            continue
+        payload = _parse_payload(row.get("payload_json"))
+        if str(payload.get("tool_call_id") or "") != tool_call_id:
+            continue
+        event_type = str(row.get("event_type") or "")
+        if event_type == RunEventType.TOOL_CALL.value:
+            tool_args = _parse_tool_args(payload)
+        raw_result_event_id = (
+            row.get("id") if event_type == RunEventType.TOOL_RESULT.value else None
+        )
+        result_event_id = (
+            raw_result_event_id if isinstance(raw_result_event_id, int) else 0
+        )
+        batch_id = str(payload.get("batch_id") or (state.batch_id if state else ""))
+        batch_index = _batch_index_from_payload(
+            payload, default=state.batch_index if state else -1
+        )
+        raw_batch_size = payload.get("batch_size")
+        batch_size = (
+            raw_batch_size
+            if isinstance(raw_batch_size, int)
+            else (state.batch_size if state else 0)
+        )
+        tool_name = str(payload.get("tool_name") or (state.tool_name if state else ""))
+        run_id = str(payload.get("run_id") or (state.run_id if state else trace_id))
+        session_id = str(
+            payload.get("session_id")
+            or row.get("session_id")
+            or (state.session_id if state else "")
+        )
+        instance_id = str(
+            payload.get("instance_id")
+            or row.get("instance_id")
+            or (state.instance_id if state else "")
+        )
+        role_id = str(payload.get("role_id") or (state.role_id if state else ""))
+        args_preview = (
+            _args_preview_from_value(payload.get("args_preview"))
+            or _args_preview_from_value(payload.get("args"))
+            or (state.args_preview if state else "")
+        )
+        if not tool_name or not instance_id or not role_id:
+            continue
+        if state is None:
+            state = PersistedToolCallState(
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                run_id=run_id,
+                session_id=session_id,
+                instance_id=instance_id,
+                role_id=role_id,
+                args_preview=args_preview,
+                run_yolo=False,
+                approval_mode=ToolApprovalMode.UNKNOWN,
+                approval_status=ToolApprovalStatus.NOT_REQUIRED,
+                execution_status=ToolExecutionStatus.READY,
+                batch_id=batch_id,
+                batch_index=batch_index,
+                batch_size=batch_size,
+            )
+        else:
+            state = state.model_copy(
+                update={
+                    "tool_name": tool_name,
+                    "run_id": run_id,
+                    "session_id": session_id,
+                    "instance_id": instance_id,
+                    "role_id": role_id,
+                    "args_preview": args_preview,
+                    "batch_id": batch_id,
+                    "batch_index": batch_index,
+                    "batch_size": batch_size,
+                }
+            )
+
+        if event_type == RunEventType.TOOL_APPROVAL_REQUESTED.value:
+            state = state.model_copy(
+                update={
+                    "approval_mode": ToolApprovalMode.APPROVAL_FLOW,
+                    "approval_status": ToolApprovalStatus.PENDING,
+                    "execution_status": ToolExecutionStatus.WAITING_APPROVAL,
+                }
+            )
+        elif event_type == RunEventType.TOOL_APPROVAL_RESOLVED.value:
+            action = str(payload.get("action") or "").strip().lower()
+            if action in {"approve", "approve_once", "approve_exact", "approve_prefix"}:
+                state = state.model_copy(
+                    update={
+                        "approval_status": ToolApprovalStatus.APPROVE,
+                        "approval_feedback": str(payload.get("feedback") or ""),
+                        "approval_mode": ToolApprovalMode.APPROVAL_FLOW,
+                        "execution_status": ToolExecutionStatus.READY,
+                    }
+                )
+            elif action == "deny":
+                observed_terminal_event = True
+                state = state.model_copy(
+                    update={
+                        "approval_status": ToolApprovalStatus.DENY,
+                        "approval_feedback": str(payload.get("feedback") or ""),
+                        "approval_mode": ToolApprovalMode.APPROVAL_FLOW,
+                        "execution_status": ToolExecutionStatus.FAILED,
+                    }
+                )
+            elif action == "timeout":
+                observed_terminal_event = True
+                state = state.model_copy(
+                    update={
+                        "approval_status": ToolApprovalStatus.TIMEOUT,
+                        "approval_mode": ToolApprovalMode.APPROVAL_FLOW,
+                        "execution_status": ToolExecutionStatus.FAILED,
+                    }
+                )
+        elif event_type == RunEventType.TOOL_RESULT.value:
+            result = payload.get("result")
+            if isinstance(result, dict):
+                observed_terminal_event = True
+                meta = result.get("meta")
+                approval_status = None
+                approval_mode = None
+                run_yolo = None
+                if isinstance(meta, dict):
+                    approval_text = (
+                        str(meta.get("approval_status") or "").strip().lower()
+                    )
+                    if approval_text == ToolApprovalStatus.APPROVE.value:
+                        approval_status = ToolApprovalStatus.APPROVE
+                    elif approval_text == ToolApprovalStatus.DENY.value:
+                        approval_status = ToolApprovalStatus.DENY
+                    elif approval_text == ToolApprovalStatus.TIMEOUT.value:
+                        approval_status = ToolApprovalStatus.TIMEOUT
+                    elif approval_text == ToolApprovalStatus.NOT_REQUIRED.value:
+                        approval_status = ToolApprovalStatus.NOT_REQUIRED
+                    approval_mode = _parse_approval_mode(meta.get("approval_mode"))
+                    if isinstance(meta.get("run_yolo"), bool):
+                        run_yolo = bool(meta["run_yolo"])
+                result_failed = (
+                    payload.get("error") is True or result.get("ok") is False
+                )
+                state = state.model_copy(
+                    update={
+                        "run_yolo": state.run_yolo if run_yolo is None else run_yolo,
+                        "approval_mode": (
+                            state.approval_mode
+                            if approval_mode is None
+                            else approval_mode
+                        ),
+                        "approval_status": approval_status or state.approval_status,
+                        "execution_status": ToolExecutionStatus.FAILED
+                        if result_failed
+                        else ToolExecutionStatus.COMPLETED,
+                        "result_envelope": result,
+                        "result_event_id": result_event_id,
+                    }
+                )
+
+    if state is None:
+        return None
+    if current_state is not None and not observed_terminal_event:
+        return current_state
+    recovered_call_state = dict(state.call_state)
+    if not recovered_call_state:
+        recovered_call_state = await _recover_call_state_async(
+            tool_name=state.tool_name,
+            trace_id=trace_id,
+            task_id=task_id,
+            tool_args=tool_args,
+            shared_store=shared_store,
+            task_repo=task_repo,
+        )
+    return await merge_tool_call_state_async(
+        shared_store=shared_store,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+        tool_name=state.tool_name,
+        run_id=state.run_id,
+        session_id=state.session_id,
+        instance_id=state.instance_id,
+        role_id=state.role_id,
+        args_preview=state.args_preview,
+        run_yolo=state.run_yolo,
+        approval_mode=state.approval_mode,
+        approval_status=state.approval_status,
+        approval_feedback=state.approval_feedback,
+        execution_status=state.execution_status,
+        result_envelope=state.result_envelope,
+        call_state=recovered_call_state,
+        batch_id=state.batch_id,
+        batch_index=state.batch_index,
+        batch_size=state.batch_size,
+        result_event_id=state.result_event_id,
+        started_at=state.started_at,
+        finished_at=state.finished_at,
+    )
+
+
 def recover_tool_call_batches_from_event_log(
     *,
     event_log: EventLog,
@@ -856,6 +1118,67 @@ def recover_tool_call_batches_from_event_log(
         if not items:
             continue
         recovered[batch_id] = merge_tool_call_batch_state(
+            shared_store=shared_store,
+            task_id=task_id,
+            batch_id=batch_id,
+            run_id=str(payload.get("run_id") or row.get("trace_id") or trace_id),
+            session_id=str(payload.get("session_id") or row.get("session_id") or ""),
+            instance_id=str(payload.get("instance_id") or ""),
+            role_id=str(payload.get("role_id") or ""),
+            status=ToolCallBatchStatus.SEALED,
+            items=items,
+        )
+    return tuple(sorted(recovered.values(), key=lambda state: state.updated_at))
+
+
+async def recover_tool_call_batches_from_event_log_async(
+    *,
+    event_log: EventLog,
+    shared_store: SharedStateRepository,
+    trace_id: str,
+    task_id: str,
+) -> tuple[PersistedToolCallBatchState, ...]:
+    recovered: dict[str, PersistedToolCallBatchState] = {}
+    for row in await event_log.list_by_trace_with_ids_async(trace_id):
+        if str(row.get("task_id") or "") != task_id:
+            continue
+        event_type = str(row.get("event_type") or "")
+        payload = _parse_payload(row.get("payload_json"))
+        batch_id = str(payload.get("batch_id") or "").strip()
+        if not batch_id:
+            continue
+        if event_type == RunEventType.TOOL_CALL.value:
+            item = _batch_item_from_tool_call_payload(payload)
+            if item is None:
+                continue
+            current = recovered.get(batch_id) or await load_tool_call_batch_state_async(
+                shared_store=shared_store,
+                task_id=task_id,
+                batch_id=batch_id,
+            )
+            recovered[batch_id] = await merge_tool_call_batch_state_async(
+                shared_store=shared_store,
+                task_id=task_id,
+                batch_id=batch_id,
+                run_id=str(payload.get("run_id") or row.get("trace_id") or trace_id),
+                session_id=str(
+                    payload.get("session_id") or row.get("session_id") or ""
+                ),
+                instance_id=str(payload.get("instance_id") or ""),
+                role_id=str(payload.get("role_id") or ""),
+                status=ToolCallBatchStatus.OPEN if current is None else current.status,
+                items=_merge_batch_items(
+                    () if current is None else current.items,
+                    (item,),
+                ),
+            )
+            continue
+        if event_type != RunEventType.TOOL_CALL_BATCH_SEALED.value:
+            continue
+        items = _batch_items_from_payload(payload)
+        if not items:
+            continue
+        recovered[batch_id] = await merge_tool_call_batch_state_async(
             shared_store=shared_store,
             task_id=task_id,
             batch_id=batch_id,
@@ -1009,6 +1332,25 @@ def _recover_call_state(
     )
 
 
+async def _recover_call_state_async(
+    *,
+    tool_name: str,
+    trace_id: str,
+    task_id: str,
+    tool_args: dict[str, JsonValue],
+    shared_store: SharedStateRepository,
+    task_repo: TaskRepository | None,
+) -> dict[str, JsonValue]:
+    _ = (task_id, shared_store)
+    if tool_name != "orch_dispatch_task" or task_repo is None:
+        return {}
+    return await _recover_dispatch_task_call_state_async(
+        trace_id=trace_id,
+        tool_args=tool_args,
+        task_repo=task_repo,
+    )
+
+
 def _recover_dispatch_task_call_state(
     *,
     trace_id: str,
@@ -1019,6 +1361,30 @@ def _recover_dispatch_task_call_state(
     if not dispatched_task_id:
         return {}
     record = task_repo.get(dispatched_task_id)
+    if record.envelope.trace_id != trace_id:
+        return {}
+    prompt = str(tool_args.get("prompt") or "")
+    return {
+        "kind": "orch_dispatch_task",
+        "task_id": dispatched_task_id,
+        "prompt": prompt,
+        "role_id": str(tool_args.get("role_id") or record.envelope.role_id or ""),
+        "instance_id": str(record.assigned_instance_id or ""),
+        "execution_started": record.status
+        not in {TaskStatus.CREATED, TaskStatus.ASSIGNED},
+    }
+
+
+async def _recover_dispatch_task_call_state_async(
+    *,
+    trace_id: str,
+    tool_args: dict[str, JsonValue],
+    task_repo: TaskRepository,
+) -> dict[str, JsonValue]:
+    dispatched_task_id = str(tool_args.get("task_id") or "").strip()
+    if not dispatched_task_id:
+        return {}
+    record = await task_repo.get_async(dispatched_task_id)
     if record.envelope.trace_id != trace_id:
         return {}
     prompt = str(tool_args.get("prompt") or "")

--- a/src/relay_teams/workspace/workspace_manager.py
+++ b/src/relay_teams/workspace/workspace_manager.py
@@ -49,11 +49,51 @@ class WorkspaceManager(BaseModel):
             session_id, role_id
         )
         record = self._resolve_record(workspace_id)
+        return self._build_handle(
+            record=record,
+            session_id=session_id,
+            role_id=role_id,
+            instance_id=instance_id,
+            conversation_id=resolved_conversation_id,
+        )
+
+    async def resolve_async(
+        self,
+        *,
+        session_id: str,
+        role_id: str,
+        instance_id: str | None,
+        profile: object | None = None,
+        workspace_id: str,
+        conversation_id: str | None = None,
+    ) -> WorkspaceHandle:
+        del profile
+        resolved_conversation_id = conversation_id or build_conversation_id(
+            session_id, role_id
+        )
+        record = await self._resolve_record_async(workspace_id)
+        return self._build_handle(
+            record=record,
+            session_id=session_id,
+            role_id=role_id,
+            instance_id=instance_id,
+            conversation_id=resolved_conversation_id,
+        )
+
+    def _build_handle(
+        self,
+        *,
+        record: WorkspaceRecord,
+        session_id: str,
+        role_id: str,
+        instance_id: str | None,
+        conversation_id: str,
+    ) -> WorkspaceHandle:
         ref = WorkspaceRef(
             workspace_id=record.workspace_id,
             session_id=session_id,
             role_id=role_id,
-            conversation_id=resolved_conversation_id,
+            conversation_id=conversation_id,
             default_mount_name=record.default_mount_name,
             mount_names=tuple(mount.mount_name for mount in record.mounts),
             instance_id=instance_id,
@@ -67,10 +107,17 @@ class WorkspaceManager(BaseModel):
 
     def locations_for(self, workspace_id: str) -> WorkspaceLocations:
         record = self._resolve_record(workspace_id)
+        return self._locations_for_record(record)
+
+    async def locations_for_async(self, workspace_id: str) -> WorkspaceLocations:
+        record = await self._resolve_record_async(workspace_id)
+        return self._locations_for_record(record)
+
+    def _locations_for_record(self, record: WorkspaceRecord) -> WorkspaceLocations:
         config_dir = self._resolve_app_config_dir(
             project_root=self._config_root(record)
         )
-        workspace_dir = config_dir / "workspaces" / workspace_id
+        workspace_dir = config_dir / "workspaces" / record.workspace_id
         tmp_root = workspace_dir / "tmp"
         default_remote_root = self._materialize_default_remote_mount(
             record=record,
@@ -121,7 +168,7 @@ class WorkspaceManager(BaseModel):
         return config_dir / "sessions" / workspace_id / session_id
 
     def _resolve_locations(self, *, record: WorkspaceRecord) -> WorkspaceLocations:
-        return self.locations_for(record.workspace_id)
+        return self._locations_for_record(record)
 
     def _build_local_mount_locations(
         self,
@@ -268,6 +315,16 @@ class WorkspaceManager(BaseModel):
     def _resolve_record(self, workspace_id: str) -> WorkspaceRecord:
         if self.workspace_repo is not None and self.workspace_repo.exists(workspace_id):
             return self.workspace_repo.get(workspace_id)
+        return self._default_workspace_record(workspace_id)
+
+    async def _resolve_record_async(self, workspace_id: str) -> WorkspaceRecord:
+        if self.workspace_repo is not None and await self.workspace_repo.exists_async(
+            workspace_id
+        ):
+            return await self.workspace_repo.get_async(workspace_id)
+        return self._default_workspace_record(workspace_id)
+
+    def _default_workspace_record(self, workspace_id: str) -> WorkspaceRecord:
         mount = legacy_workspace_mount_from_profile(
             root_path=self.project_root.resolve(),
             profile=default_workspace_profile(),

--- a/tests/integration_tests/api/test_memory_semantic_consolidation.py
+++ b/tests/integration_tests/api/test_memory_semantic_consolidation.py
@@ -13,6 +13,7 @@ from relay_teams.memory.models import (
     MemoryScope,
     MemoryTier,
 )
+from relay_teams.memory.event_handler import MemoryEventHandler
 from relay_teams.memory.repository import MemoryBankRepository
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.providers.provider_contracts import EchoProvider
@@ -81,8 +82,6 @@ class TestRunCompletionTriggersSemantic:
     async def test_on_run_completed_async_structural(
         self, service: MemoryBankService
     ) -> None:
-        from relay_teams.memory.event_handler import MemoryEventHandler
-
         handler = MemoryEventHandler(memory_bank_service=service)
         # Should not raise
         await handler.on_run_completed_async(
@@ -95,24 +94,11 @@ class TestRunCompletionTriggersSemantic:
     async def test_on_run_completed_async_with_semantic(
         self, service: MemoryBankService
     ) -> None:
-        from relay_teams.memory.event_handler import MemoryEventHandler
-
         handler = MemoryEventHandler(memory_bank_service=service)
         # Should not raise even if semantic fails
         await handler.on_run_completed_async(
             workspace_id="ws-test",
             session_id="sess-1",
             role_id="crafter",
-            run_id="run-1",
-        )
-
-    def test_on_run_completed_sync_unchanged(self, service: MemoryBankService) -> None:
-        from relay_teams.memory.event_handler import MemoryEventHandler
-
-        handler = MemoryEventHandler(memory_bank_service=service)
-        # Sync version should still work
-        handler.on_run_completed(
-            workspace_id="ws-test",
-            session_id="sess-1",
             run_id="run-1",
         )

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -19,6 +19,7 @@ from relay_teams.env.web_config_models import (
 from relay_teams.gateway.acp_stdio import AcpGatewayServer, _AcpRequestContext
 from relay_teams.interfaces.cli.gateway_cli import _build_acp_stdio_runtime
 from pydantic import JsonValue
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Locator, Page, Request, Response
 from playwright.sync_api import expect
 from playwright.sync_api import sync_playwright
@@ -2076,9 +2077,7 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
 
     switch_targets = [subagent_session_id, *reversed(seed_session_ids[-8:])]
     for session_id in switch_targets:
-        page.locator(f'.session-item[data-session-id="{session_id}"]').first.click(
-            force=True,
-        )
+        _click_visible_session_item(page, session_id)
     expect(page.locator(".session-item.active")).to_have_attribute(
         "data-session-id",
         switch_targets[-1],
@@ -2103,9 +2102,7 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
     send_feedback_ms = int((time.perf_counter() - send_started) * 1000)
     assert send_feedback_ms < 2500
 
-    page.locator(f'.session-item[data-session-id="{subagent_session_id}"]').first.click(
-        force=True,
-    )
+    _click_visible_session_item(page, subagent_session_id)
     expect(page.locator(".session-item.active")).to_have_attribute(
         "data-session-id",
         subagent_session_id,
@@ -2128,9 +2125,7 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
     assert child_feedback_ms < 2500
 
     parent_started = time.perf_counter()
-    page.locator(f'.session-item[data-session-id="{subagent_session_id}"]').first.click(
-        force=True,
-    )
+    _click_visible_session_item(page, subagent_session_id)
     expect(
         page.locator(".subagent-main-session-loading, .session-round-section").first
     ).to_be_visible(timeout=1000)
@@ -2169,9 +2164,7 @@ def test_browser_session_send_switch_and_subagent_view_stay_responsive_under_loa
         re.compile(r"\bis-active\b"),
         timeout=_WAIT_TIMEOUT_MS,
     )
-    page.locator(f'.session-item[data-session-id="{subagent_session_id}"]').first.click(
-        force=True,
-    )
+    _click_visible_session_item(page, subagent_session_id)
     expect(page.locator(".session-item.active")).to_have_attribute(
         "data-session-id",
         subagent_session_id,
@@ -2377,6 +2370,25 @@ def _open_app(page: Page, integration_env: IntegrationEnvironment) -> None:
         timeout=_WAIT_TIMEOUT_MS,
     )
     expect(page.locator("#projects-list")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+
+
+def _click_visible_session_item(page: Page, session_id: str) -> None:
+    deadline = time.monotonic() + (_WAIT_TIMEOUT_MS / 1000)
+    last_error: AssertionError | PlaywrightError | None = None
+    selector = f'.session-item[data-session-id="{session_id}"]'
+    while time.monotonic() < deadline:
+        session_item = page.locator(selector).filter(visible=True).first
+        try:
+            expect(session_item).to_be_visible(timeout=500)
+            session_item.scroll_into_view_if_needed(timeout=500)
+            session_item.click(force=True, timeout=500)
+            return
+        except (AssertionError, PlaywrightError) as exc:
+            last_error = exc
+            page.wait_for_timeout(100)
+    raise AssertionError(
+        f"Timed out clicking visible session item: {session_id}"
+    ) from last_error
 
 
 def _api_path(integration_env: IntegrationEnvironment, url: str) -> str:

--- a/tests/integration_tests/support/fake_llm_server.py
+++ b/tests/integration_tests/support/fake_llm_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+import asyncio
+from collections.abc import AsyncIterator, Iterator
 import json
 import re
 import sys
@@ -113,15 +114,15 @@ def _end_chat_completion() -> None:
         _active_chat_completions = max(0, _active_chat_completions - 1)
 
 
-def stream_chat_completions(
+async def stream_chat_completions(
     *,
     model: str,
     response_spec: dict[str, object],
-) -> Iterator[bytes]:
+) -> AsyncIterator[bytes]:
     try:
         created = int(time.time())
         completion_id = f"chatcmpl-{_chat_completions_calls}"
-        _sleep_ms(response_spec.get("delay_before_ms"))
+        await _sleep_ms_async(response_spec.get("delay_before_ms"))
 
         response_kind = str(response_spec.get("kind") or "")
         if response_kind in {"tool_call", "invalid_tool_call", "tool_calls"}:
@@ -159,8 +160,9 @@ def stream_chat_completions(
                 ],
             }
             yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8")
-            _maybe_abort_stream(response_spec, emitted_chunk_count=1)
-            _sleep_ms(response_spec.get("delay_between_chunks_ms"))
+            if _should_abort_stream(response_spec, emitted_chunk_count=1):
+                return
+            await _sleep_ms_async(response_spec.get("delay_between_chunks_ms"))
             final_chunk = {
                 "id": completion_id,
                 "object": "chat.completion.chunk",
@@ -190,10 +192,11 @@ def stream_chat_completions(
                 "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
             }
             yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode("utf-8")
-            _maybe_abort_stream(response_spec, emitted_chunk_count=index + 1)
-            _sleep_ms(response_spec.get("delay_between_chunks_ms"))
+            if _should_abort_stream(response_spec, emitted_chunk_count=index + 1):
+                return
+            await _sleep_ms_async(response_spec.get("delay_between_chunks_ms"))
 
-        _sleep_ms(response_spec.get("delay_after_content_ms"))
+        await _sleep_ms_async(response_spec.get("delay_after_content_ms"))
         final_chunk = {
             "id": completion_id,
             "object": "chat.completion.chunk",
@@ -2054,24 +2057,35 @@ def _sleep_ms(value: object) -> None:
     time.sleep(milliseconds / 1000)
 
 
+async def _sleep_ms_async(value: object) -> None:
+    milliseconds = _coerce_int(value, default=0)
+    if milliseconds <= 0:
+        return
+    await asyncio.sleep(milliseconds / 1000)
+
+
 def _coerce_int(value: object, *, default: int) -> int:
     if isinstance(value, int):
         return value
     return default
 
 
-def _maybe_abort_stream(
+def _should_abort_stream(
     response_spec: dict[str, object],
     *,
     emitted_chunk_count: int,
-) -> None:
+) -> bool:
     drop_after_chunk_count = response_spec.get("drop_after_chunk_count")
-    if (
+    return (
         isinstance(drop_after_chunk_count, int)
         and drop_after_chunk_count > 0
         and emitted_chunk_count >= drop_after_chunk_count
-    ):
-        raise RuntimeError("Simulated stream interruption")
+    )
+
+
+def _drops_stream(response_spec: dict[str, object]) -> bool:
+    drop_after_chunk_count = response_spec.get("drop_after_chunk_count")
+    return isinstance(drop_after_chunk_count, int) and drop_after_chunk_count > 0
 
 
 def split_text(text: str, *, size: int) -> list[str]:

--- a/tests/unit_tests/agents/evaluation/test_run_sampling_service.py
+++ b/tests/unit_tests/agents/evaluation/test_run_sampling_service.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -43,7 +43,7 @@ def _make_run_state(
 
 def _make_memory_bank_service(*, total_count: int = 0) -> MagicMock:
     svc = MagicMock()
-    svc.list_entries = MagicMock(
+    svc.list_entries_async = AsyncMock(
         return_value=MemoryQueryResult(
             items=(),
             total_count=total_count,
@@ -61,13 +61,7 @@ def _make_sampling_service(
     memory_total: int = 0,
 ) -> RunSamplingService:
     event_log = MagicMock()
-    event_log.list_run_states_async = MagicMock(return_value=run_states)
-    # Make the returned value awaitable
-
-    async def _return_states() -> tuple[RunStateRecord, ...]:
-        return run_states
-
-    event_log.list_run_states_async = _return_states
+    event_log.list_run_states_async = AsyncMock(return_value=run_states)
 
     memory_bank_service = _make_memory_bank_service(total_count=memory_total)
     return RunSamplingService(

--- a/tests/unit_tests/agents/execution/agent_llm_session_test_support.py
+++ b/tests/unit_tests/agents/execution/agent_llm_session_test_support.py
@@ -142,6 +142,13 @@ class _FakeMessageRepo:
         self.requested_conversation_ids.append(conversation_id)
         return list(self._history)
 
+    async def get_history_for_conversation_async(
+        self,
+        conversation_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        self.requested_conversation_ids.append(conversation_id)
+        return list(self._history)
+
     def get_history_for_conversation_task(
         self,
         conversation_id: str,
@@ -150,10 +157,46 @@ class _FakeMessageRepo:
         _ = task_id
         return self.get_history_for_conversation(conversation_id)
 
+    async def get_history_for_conversation_task_async(
+        self,
+        conversation_id: str,
+        task_id: str,
+    ) -> list[ModelRequest | ModelResponse]:
+        _ = task_id
+        return await self.get_history_for_conversation_async(conversation_id)
+
     def prune_conversation_history_to_safe_boundary(self, conversation_id: str) -> None:
         self.pruned_conversation_ids.append(conversation_id)
 
+    async def prune_conversation_history_to_safe_boundary_async(
+        self, conversation_id: str
+    ) -> None:
+        self.pruned_conversation_ids.append(conversation_id)
+
     def append(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        messages: list[ModelRequest | ModelResponse],
+    ) -> None:
+        _ = (
+            session_id,
+            workspace_id,
+            conversation_id,
+            agent_role_id,
+            instance_id,
+            task_id,
+            trace_id,
+        )
+        self.append_calls.append(list(messages))
+
+    async def append_async(
         self,
         *,
         session_id: str,
@@ -187,7 +230,7 @@ class _FakeMessageRepo:
         task_id: str,
         trace_id: str,
         content: str,
-    ) -> None:
+    ) -> bool:
         _ = (
             session_id,
             workspace_id,
@@ -198,6 +241,31 @@ class _FakeMessageRepo:
             trace_id,
         )
         self.appended_system_prompts.append(content)
+        return True
+
+    async def append_system_prompt_if_missing_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: str,
+    ) -> bool:
+        _ = (
+            session_id,
+            workspace_id,
+            conversation_id,
+            agent_role_id,
+            instance_id,
+            task_id,
+            trace_id,
+        )
+        self.appended_system_prompts.append(content)
+        return True
 
     def replace_pending_user_prompt(
         self,
@@ -210,6 +278,30 @@ class _FakeMessageRepo:
         task_id: str,
         trace_id: str,
         content: str,
+    ) -> bool:
+        _ = (
+            session_id,
+            workspace_id,
+            conversation_id,
+            agent_role_id,
+            instance_id,
+            task_id,
+            trace_id,
+            content,
+        )
+        return False
+
+    async def replace_pending_user_prompt_async(
+        self,
+        *,
+        session_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        agent_role_id: str,
+        instance_id: str,
+        task_id: str,
+        trace_id: str,
+        content: object,
     ) -> bool:
         _ = (
             session_id,
@@ -304,6 +396,12 @@ class _FakeRunIntentRepo:
         self._intent = intent
 
     def get(self, run_id: str, *, fallback_session_id: str | None = None) -> object:
+        _ = (run_id, fallback_session_id)
+        return type("_Intent", (), {"intent": self._intent})()
+
+    async def get_async(
+        self, run_id: str, *, fallback_session_id: str | None = None
+    ) -> object:
         _ = (run_id, fallback_session_id)
         return type("_Intent", (), {"intent": self._intent})()
 

--- a/tests/unit_tests/agents/execution/session_prompt_core_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_prompt_core_test_cases.py
@@ -568,7 +568,10 @@ async def test_prepare_prompt_context_keeps_persisted_media_urls_for_prompt_dedu
     assert next_history == prepared_history
 
 
-def test_coerce_history_to_provider_safe_sequence_drops_orphan_tool_prefix() -> None:
+@pytest.mark.asyncio
+async def test_coerce_history_to_provider_safe_sequence_drops_orphan_tool_prefix() -> (
+    None
+):
     session = object.__new__(AgentLlmSession)
     session._run_intent_repo = cast(
         RunIntentRepository,
@@ -604,8 +607,9 @@ def test_coerce_history_to_provider_safe_sequence_drops_orphan_tool_prefix() -> 
         ),
     ]
 
-    repaired = AgentLlmSession._coerce_history_to_provider_safe_sequence(
-        session,
+    repaired = await AgentLlmSession._prompt_history_service(
+        session
+    ).coerce_history_to_provider_safe_sequence_async(
         request=_build_request(user_prompt=None),
         history=history,
     )
@@ -619,7 +623,8 @@ def test_coerce_history_to_provider_safe_sequence_drops_orphan_tool_prefix() -> 
     assert repaired[1:] == history[1:]
 
 
-def test_coerce_history_to_provider_safe_sequence_keeps_bridge_when_prefix_drop_empties_history() -> (
+@pytest.mark.asyncio
+async def test_coerce_history_to_provider_safe_sequence_keeps_bridge_when_prefix_drop_empties_history() -> (
     None
 ):
     session = object.__new__(AgentLlmSession)
@@ -639,8 +644,9 @@ def test_coerce_history_to_provider_safe_sequence_keeps_bridge_when_prefix_drop_
         )
     ]
 
-    repaired = AgentLlmSession._coerce_history_to_provider_safe_sequence(
-        session,
+    repaired = await AgentLlmSession._prompt_history_service(
+        session
+    ).coerce_history_to_provider_safe_sequence_async(
         request=_build_request(user_prompt=None),
         history=history,
     )
@@ -748,7 +754,8 @@ def test_validate_history_input_capabilities_rejects_unsupported_image() -> None
         )
 
 
-def test_coerce_history_to_provider_safe_sequence_prefers_explicit_user_prompt_over_bridge() -> (
+@pytest.mark.asyncio
+async def test_coerce_history_to_provider_safe_sequence_prefers_explicit_user_prompt_over_bridge() -> (
     None
 ):
     session = object.__new__(AgentLlmSession)
@@ -768,8 +775,9 @@ def test_coerce_history_to_provider_safe_sequence_prefers_explicit_user_prompt_o
         )
     ]
 
-    repaired = AgentLlmSession._coerce_history_to_provider_safe_sequence(
-        session,
+    repaired = await AgentLlmSession._prompt_history_service(
+        session
+    ).coerce_history_to_provider_safe_sequence_async(
         request=_build_request(user_prompt="restart from the latest user request"),
         history=history,
     )

--- a/tests/unit_tests/agents/execution/session_recovery_test_cases.py
+++ b/tests/unit_tests/agents/execution/session_recovery_test_cases.py
@@ -374,10 +374,16 @@ async def test_resume_after_tool_outcomes_commits_backfilled_tool_results(
         },
     )
 
+    async def _load_or_recover_tool_call_state_async(
+        **kwargs: object,
+    ) -> PersistedToolCallState:
+        _ = kwargs
+        return persisted_state
+
     monkeypatch.setattr(
         session_support_module,
-        "load_or_recover_tool_call_state",
-        lambda **kwargs: persisted_state,
+        "load_or_recover_tool_call_state_async",
+        _load_or_recover_tool_call_state_async,
     )
 
     captured_pending_messages: list[ModelRequest | ModelResponse] = []

--- a/tests/unit_tests/agents/execution/test_session_runtime.py
+++ b/tests/unit_tests/agents/execution/test_session_runtime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import cast
 
 import pytest
@@ -21,6 +21,7 @@ from relay_teams.agents.tasks.models import (
     TaskLifecyclePolicy,
     TaskRecord,
     TaskSpec,
+    TaskSpecArtifact,
     VerificationPlan,
 )
 from relay_teams.roles.role_models import RoleDefinition
@@ -46,6 +47,64 @@ from .agent_llm_session_test_support import (
 )
 
 
+async def _none_tool_approval_policy_async(_run_id: str) -> object:
+    return cast(object, None)
+
+
+async def _none_workspace_async(_self: object, **_kwargs: object) -> object:
+    return cast(object, None)
+
+
+class _OpenAIRawStreamWithoutFinish:
+    finish_reason = None
+
+
+class _OpenAIRawStreamWithFinish:
+    finish_reason = "stop"
+
+
+class _ForeignRawStream:
+    finish_reason = None
+
+
+class _SlowStreamContext:
+    async def __aenter__(self) -> session_runtime_module.AgentNodeStream:
+        await asyncio.sleep(0.05)
+        return cast(session_runtime_module.AgentNodeStream, object())
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        _ = (exc_type, exc, traceback)
+        return None
+
+
+class _ClosingStreamContext:
+    def __init__(self) -> None:
+        self.exited = False
+
+    async def __aenter__(self) -> session_runtime_module.AgentNodeStream:
+        return cast(session_runtime_module.AgentNodeStream, object())
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        _ = (exc_type, exc, traceback)
+        self.exited = True
+        return None
+
+
+async def _slow_items() -> Sequence[object]:
+    await asyncio.sleep(0.05)
+    return (object(),)
+
+
 @pytest.mark.asyncio
 async def test_spec_checkpoint_decision_reads_task_spec_from_runtime_repo() -> None:
     task = TaskEnvelope(
@@ -69,7 +128,7 @@ async def test_spec_checkpoint_decision_reads_task_spec_from_runtime_repo() -> N
             assert task_id == "task-1"
             return TaskRecord(envelope=task)
 
-        async def get_spec_artifact_async(self, artifact_id: str) -> object:
+        async def get_spec_artifact_async(self, artifact_id: str) -> TaskSpecArtifact:
             raise AssertionError(artifact_id)
 
     class _RoleRegistry:
@@ -100,13 +159,67 @@ async def test_spec_checkpoint_decision_reads_task_spec_from_runtime_repo() -> N
     assert "keep the route stable" in decision.content
 
 
+def test_raise_if_stream_finished_without_reason_validates_provider_streams() -> None:
+    session_runtime_module._raise_if_stream_finished_without_reason(object())
+    session_runtime_module._raise_if_stream_finished_without_reason(
+        SimpleNamespace(_raw_stream_response=_ForeignRawStream())
+    )
+    session_runtime_module._raise_if_stream_finished_without_reason(
+        SimpleNamespace(_raw_stream_response=_OpenAIRawStreamWithFinish())
+    )
+
+    with pytest.raises(httpx.RemoteProtocolError):
+        session_runtime_module._raise_if_stream_finished_without_reason(
+            SimpleNamespace(_raw_stream_response=_OpenAIRawStreamWithoutFinish())
+        )
+
+
+def test_llm_stream_event_timeout_has_no_hard_upper_cap() -> None:
+    assert session_runtime_module._llm_stream_event_timeout_seconds(1.0) == 5.0
+    assert session_runtime_module._llm_stream_event_timeout_seconds(60.0) == 120.0
+
+
+@pytest.mark.asyncio
+async def test_llm_stream_timeout_helpers_raise_read_timeout() -> None:
+    async def slow_generator():
+        _ = await _slow_items()
+        yield object()
+
+    with pytest.raises(httpx.ReadTimeout):
+        async for _item in session_runtime_module._aiter_with_timeout(
+            slow_generator(),
+            timeout_seconds=0.001,
+        ):
+            pass
+
+    with pytest.raises(httpx.ReadTimeout):
+        async with session_runtime_module._llm_stream_context_with_timeout(
+            cast(session_runtime_module.AgentNodeStreamContext, _SlowStreamContext()),
+            timeout_seconds=0.001,
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_llm_stream_context_closes_entered_context() -> None:
+    context = _ClosingStreamContext()
+
+    async with session_runtime_module._llm_stream_context_with_timeout(
+        cast(session_runtime_module.AgentNodeStreamContext, context),
+        timeout_seconds=1.0,
+    ):
+        pass
+
+    assert context.exited is True
+
+
 @pytest.mark.asyncio
 async def test_spec_checkpoint_decision_skips_coordinator_roles() -> None:
     class _TaskRepo:
         async def get_async(self, task_id: str) -> TaskRecord:
             raise AssertionError(task_id)
 
-        async def get_spec_artifact_async(self, artifact_id: str) -> object:
+        async def get_spec_artifact_async(self, artifact_id: str) -> TaskSpecArtifact:
             raise AssertionError(artifact_id)
 
     class _RoleRegistry:
@@ -133,7 +246,7 @@ async def test_spec_checkpoint_decision_ignores_missing_task_record() -> None:
             assert task_id == "missing-task"
             raise KeyError(task_id)
 
-        async def get_spec_artifact_async(self, artifact_id: str) -> object:
+        async def get_spec_artifact_async(self, artifact_id: str) -> TaskSpecArtifact:
             raise AssertionError(artifact_id)
 
     class _RoleRegistry:
@@ -429,7 +542,7 @@ async def test_generate_async_persists_only_provider_canonical_tool_messages(
     session.__dict__["_workspace_manager"] = type(
         "_WorkspaceManager",
         (),
-        {"resolve": lambda self, **kwargs: cast(object, None)},
+        {"resolve_async": _none_workspace_async},
     )()
     session.__dict__["_media_asset_service"] = cast(object, None)
     session.__dict__["_role_memory_service"] = None
@@ -457,8 +570,8 @@ async def test_generate_async_persists_only_provider_canonical_tool_messages(
         "_RunEventHub", (), {"publish": lambda self, event: None}
     )()
     session.__dict__["_agent_repo"] = cast(object, None)
-    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
-        object, None
+    session.__dict__["_resolve_tool_approval_policy_async"] = (
+        _none_tool_approval_policy_async
     )
     session.__dict__["_publish_committed_tool_outcome_events_from_messages"] = (
         lambda **kwargs: None
@@ -614,7 +727,7 @@ async def test_generate_async_passes_retry_after_to_retry_schedule() -> None:
     session.__dict__["_workspace_manager"] = type(
         "_WorkspaceManager",
         (),
-        {"resolve": lambda self, **kwargs: cast(object, None)},
+        {"resolve_async": _none_workspace_async},
     )()
     session.__dict__["_role_memory_service"] = None
     session.__dict__["_media_asset_service"] = None
@@ -631,8 +744,8 @@ async def test_generate_async_passes_retry_after_to_retry_schedule() -> None:
     session.__dict__["_shell_approval_repo"] = None
     session.__dict__["_notification_service"] = None
     session.__dict__["_im_tool_service"] = None
-    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
-        object, None
+    session.__dict__["_resolve_tool_approval_policy_async"] = (
+        _none_tool_approval_policy_async
     )
     session.__dict__["_build_model_api_error_message"] = lambda error: "rate limited"
 
@@ -741,7 +854,7 @@ async def test_generate_async_closes_scoped_transport_cache_on_cancellation() ->
     session.__dict__["_workspace_manager"] = type(
         "_WorkspaceManager",
         (),
-        {"resolve": lambda self, **kwargs: cast(object, None)},
+        {"resolve_async": _none_workspace_async},
     )()
     session.__dict__["_role_memory_service"] = None
     session.__dict__["_media_asset_service"] = None
@@ -758,8 +871,8 @@ async def test_generate_async_closes_scoped_transport_cache_on_cancellation() ->
     session.__dict__["_shell_approval_repo"] = None
     session.__dict__["_notification_service"] = None
     session.__dict__["_im_tool_service"] = None
-    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
-        object, None
+    session.__dict__["_resolve_tool_approval_policy_async"] = (
+        _none_tool_approval_policy_async
     )
     session.__dict__["_persist_user_prompt_if_needed"] = lambda **kwargs: (
         kwargs["history"],
@@ -805,6 +918,8 @@ async def test_generate_async_closes_scoped_transport_cache_on_cancellation() ->
             _build_request(),
         )
 
+    await asyncio.sleep(0)
+
     assert closed_run_ids == ["run-1"]
 
 
@@ -842,7 +957,7 @@ async def test_generate_async_closes_scoped_transport_cache_on_setup_failure() -
     session.__dict__["_workspace_manager"] = type(
         "_WorkspaceManager",
         (),
-        {"resolve": lambda self, **kwargs: cast(object, None)},
+        {"resolve_async": _none_workspace_async},
     )()
     session.__dict__["_role_memory_service"] = None
     session.__dict__["_media_asset_service"] = None
@@ -859,8 +974,8 @@ async def test_generate_async_closes_scoped_transport_cache_on_setup_failure() -
     session.__dict__["_shell_approval_repo"] = None
     session.__dict__["_notification_service"] = None
     session.__dict__["_im_tool_service"] = None
-    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
-        object, None
+    session.__dict__["_resolve_tool_approval_policy_async"] = (
+        _none_tool_approval_policy_async
     )
 
     async def _build_agent_iteration_context(**kwargs: object) -> object:
@@ -883,6 +998,8 @@ async def test_generate_async_closes_scoped_transport_cache_on_setup_failure() -
             session,
             _build_request(),
         )
+
+    await asyncio.sleep(0)
 
     assert closed_run_ids == ["run-1"]
 
@@ -973,7 +1090,7 @@ async def test_generate_async_does_not_emit_retry_exhausted_after_fallback_exhau
     session.__dict__["_workspace_manager"] = type(
         "_WorkspaceManager",
         (),
-        {"resolve": lambda self, **kwargs: cast(object, None)},
+        {"resolve_async": _none_workspace_async},
     )()
     session.__dict__["_role_memory_service"] = None
     session.__dict__["_media_asset_service"] = None
@@ -990,8 +1107,8 @@ async def test_generate_async_does_not_emit_retry_exhausted_after_fallback_exhau
     session.__dict__["_shell_approval_repo"] = None
     session.__dict__["_notification_service"] = None
     session.__dict__["_im_tool_service"] = None
-    session.__dict__["_resolve_tool_approval_policy"] = lambda run_id: cast(
-        object, None
+    session.__dict__["_resolve_tool_approval_policy_async"] = (
+        _none_tool_approval_policy_async
     )
     session.__dict__["_build_model_api_error_message"] = lambda error: "rate limited"
     session.__dict__["_persist_user_prompt_if_needed"] = lambda **kwargs: (

--- a/tests/unit_tests/agents/execution/test_session_support.py
+++ b/tests/unit_tests/agents/execution/test_session_support.py
@@ -61,9 +61,72 @@ class _FakeEventLog:
         self.requested_trace_ids.append(trace_id)
         return self._events
 
+    async def list_by_trace_async(
+        self, trace_id: str
+    ) -> tuple[dict[str, JsonValue], ...]:
+        self.requested_trace_ids.append(trace_id)
+        return self._events
+
     def list_by_trace_with_ids(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
         self.requested_trace_ids.append(trace_id)
         return self._events
+
+    async def list_by_trace_with_ids_async(
+        self, trace_id: str
+    ) -> tuple[dict[str, JsonValue], ...]:
+        self.requested_trace_ids.append(trace_id)
+        return self._events
+
+
+@pytest.mark.asyncio
+async def test_null_prompt_history_repo_async_contracts_return_empty() -> None:
+    repo = session_support_module._NullPromptHistoryMessageRepo()
+
+    assert await repo.get_history_for_conversation_async("conversation-1") == []
+    assert (
+        await repo.get_history_for_conversation_task_async("conversation-1", "task-1")
+        == []
+    )
+    await repo.prune_conversation_history_to_safe_boundary_async("conversation-1")
+    await repo.append_async(
+        session_id="session-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        agent_role_id="writer",
+        instance_id="inst-1",
+        task_id="task-1",
+        trace_id="run-1",
+        messages=[],
+    )
+    assert (
+        await repo.append_system_prompt_if_missing_async(
+            session_id="session-1",
+            workspace_id="workspace-1",
+            conversation_id="conversation-1",
+            agent_role_id="writer",
+            instance_id="inst-1",
+            task_id="task-1",
+            trace_id="run-1",
+            content="system",
+        )
+        is False
+    )
+    assert (
+        await repo.replace_pending_user_prompt_async(
+            session_id="session-1",
+            workspace_id="workspace-1",
+            conversation_id="conversation-1",
+            agent_role_id="writer",
+            instance_id="inst-1",
+            task_id="task-1",
+            trace_id="run-1",
+            content="prompt",
+        )
+        is False
+    )
+    assert (
+        await session_support_module._empty_safe_history_async("conversation-1") == []
+    )
 
 
 def test_apply_streamed_text_fallback_repairs_truncated_final_message() -> None:
@@ -670,10 +733,16 @@ async def test_restore_pending_tool_results_from_state_backfills_completed_dispa
         },
     )
 
+    async def _load_persisted_dispatch_state(
+        **kwargs: object,
+    ) -> PersistedToolCallState:
+        _ = kwargs
+        return persisted_state
+
     monkeypatch.setattr(
         session_support_module,
-        "load_or_recover_tool_call_state",
-        lambda **kwargs: persisted_state,
+        "load_or_recover_tool_call_state_async",
+        _load_persisted_dispatch_state,
     )
 
     (
@@ -1202,12 +1271,16 @@ async def test_running_spawn_subagent_without_durable_launch_reinvokes_batch_ite
     assert invoke_calls[0]["tool_call_id"] == "call-subagent-prelaunch"
 
 
-def test_task_tool_call_batch_states_handles_missing_store_and_invalid_rows(
+@pytest.mark.asyncio
+async def test_task_tool_call_batch_states_handles_missing_store_and_invalid_rows(
     tmp_path: Path,
 ) -> None:
     session = object.__new__(AgentLlmSession)
     setattr(session, "_shared_store", None)
-    assert AgentLlmSession._task_tool_call_batch_states(session, "task-1") == ()
+    assert (
+        await AgentLlmSession._task_tool_call_batch_states_async(session, "task-1")
+        == ()
+    )
 
     shared_store = SharedStateRepository(tmp_path / "session-batch-states.db")
     shared_store.manage_state(
@@ -1240,7 +1313,9 @@ def test_task_tool_call_batch_states_handles_missing_store_and_invalid_rows(
     )
     session._shared_store = shared_store
 
-    assert AgentLlmSession._task_tool_call_batch_states(session, "task-1") == (good,)
+    assert await AgentLlmSession._task_tool_call_batch_states_async(
+        session, "task-1"
+    ) == (good,)
 
 
 @pytest.mark.asyncio
@@ -1252,7 +1327,7 @@ async def test_recover_uncommitted_tool_batches_ignores_event_log_read_failures(
     history: list[ModelRequest | ModelResponse] = []
 
     class _FailingBatchReplayEventLog:
-        def list_by_trace_with_ids(
+        async def list_by_trace_with_ids_async(
             self,
             trace_id: str,
         ) -> tuple[dict[str, JsonValue], ...]:
@@ -1289,7 +1364,7 @@ async def test_recover_uncommitted_tool_batches_ignores_batch_snapshot_failures(
     history: list[ModelRequest | ModelResponse] = []
 
     class _FailingBatchSnapshotStore:
-        def snapshot(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
+        async def snapshot_async(self, scope: ScopeRef) -> tuple[tuple[str, str], ...]:
             _ = scope
             raise sqlite3.OperationalError("database is locked")
 
@@ -1603,7 +1678,7 @@ async def test_recover_uncommitted_tool_batches_skips_item_state_read_failures(
         ),
     )
 
-    def _raise_state_read_failure(
+    async def _raise_state_read_failure(
         *,
         shared_store: object,
         event_log: object,
@@ -1631,7 +1706,7 @@ async def test_recover_uncommitted_tool_batches_skips_item_state_read_failures(
 
     monkeypatch.setattr(
         session_support_module,
-        "load_or_recover_tool_call_state",
+        "load_or_recover_tool_call_state_async",
         _raise_state_read_failure,
     )
     session.__dict__["_shared_store"] = shared_store
@@ -2256,7 +2331,8 @@ async def test_restore_pending_tool_results_ignores_committed_orphaned_subagent_
     assert message_repo.requested_conversation_ids == ["conv_session_1_writer"]
 
 
-def test_superseded_tool_call_ids_scope_to_current_instance_and_role() -> None:
+@pytest.mark.asyncio
+async def test_superseded_tool_call_ids_scope_to_current_instance_and_role() -> None:
     session = object.__new__(AgentLlmSession)
     session.__dict__["_event_bus"] = _FakeEventLog(
         (
@@ -2335,7 +2411,7 @@ def test_superseded_tool_call_ids_scope_to_current_instance_and_role() -> None:
         )
     )
 
-    superseded_ids = AgentLlmSession._superseded_tool_call_ids_for_request(
+    superseded_ids = await AgentLlmSession._superseded_tool_call_ids_for_request_async(
         session,
         _build_request(),
     )
@@ -2343,17 +2419,20 @@ def test_superseded_tool_call_ids_scope_to_current_instance_and_role() -> None:
     assert superseded_ids == {"call-current"}
 
 
-def test_best_effort_replay_lookups_ignore_sqlite_read_failures() -> None:
+@pytest.mark.asyncio
+async def test_best_effort_replay_lookups_ignore_sqlite_read_failures() -> None:
     request = _build_request()
     session = object.__new__(AgentLlmSession)
 
     class _FailingEventBus:
-        def list_by_trace(self, trace_id: str) -> tuple[dict[str, JsonValue], ...]:
+        async def list_by_trace_async(
+            self, trace_id: str
+        ) -> tuple[dict[str, JsonValue], ...]:
             _ = trace_id
             raise sqlite3.OperationalError("database is locked")
 
     class _FailingMessageRepo:
-        def get_history_for_conversation(
+        async def get_history_for_conversation_async(
             self,
             conversation_id: str,
         ) -> list[ModelRequest | ModelResponse]:
@@ -2364,10 +2443,16 @@ def test_best_effort_replay_lookups_ignore_sqlite_read_failures() -> None:
     session.__dict__["_message_repo"] = _FailingMessageRepo()
 
     assert (
-        AgentLlmSession._superseded_tool_call_ids_for_request(session, request) == set()
+        await AgentLlmSession._superseded_tool_call_ids_for_request_async(
+            session, request
+        )
+        == set()
     )
     assert (
-        AgentLlmSession._committed_tool_call_ids_for_request(session, request) == set()
+        await AgentLlmSession._committed_tool_call_ids_for_request_async(
+            session, request
+        )
+        == set()
     )
 
 

--- a/tests/unit_tests/agents/execution/test_subagent_reflection.py
+++ b/tests/unit_tests/agents/execution/test_subagent_reflection.py
@@ -19,7 +19,9 @@ from pydantic_ai.messages import ModelRequest, UserPromptPart
 
 
 class _FakeRoleMemoryService:
-    def build_injected_memory(self, *, role_id: str, workspace_id: str) -> str:
+    async def build_injected_memory_async(
+        self, *, role_id: str, workspace_id: str
+    ) -> str:
         _ = (role_id, workspace_id)
         return ""
 
@@ -103,7 +105,12 @@ async def test_rewrite_reflection_summary_retries_provider_errors(
     )
     monkeypatch.setattr(reflection_module, "Agent", _FakeAgent)
     monkeypatch.setattr(reflection_module, "ModelRequestNode", _FakeModelRequestNode)
-    monkeypatch.setattr(service, "_build_model", lambda: object())
+
+    def build_model(*, cache_scope: str) -> object:
+        _ = cache_scope
+        return object()
+
+    monkeypatch.setattr(service, "_build_model", build_model)
 
     summary = await service._rewrite_reflection_summary(
         role=RoleDefinition(

--- a/tests/unit_tests/agents/orchestration/test_control_harness_coverage.py
+++ b/tests/unit_tests/agents/orchestration/test_control_harness_coverage.py
@@ -52,7 +52,10 @@ def wakeup_repo() -> AsyncMock:
 
 @pytest.fixture()
 def artifact_repo() -> MagicMock:
-    return MagicMock()
+    repo = MagicMock()
+    repo.get_artifact_async = AsyncMock()
+    repo.append_entry_async = AsyncMock()
+    return repo
 
 
 @pytest.fixture()
@@ -329,7 +332,7 @@ class TestAppendArtifactEntry:
     async def test_returns_none_when_no_artifact(
         self, harness: TaskControlHarness, artifact_repo: MagicMock
     ) -> None:
-        artifact_repo.get_artifact.return_value = None
+        artifact_repo.get_artifact_async.return_value = None
         result = await harness.append_artifact_entry("task_1", MagicMock())
         assert result is None
 
@@ -341,7 +344,7 @@ class TestAppendArtifactEntry:
         artifact1.entries = [MagicMock()]
         artifact2 = MagicMock()
         artifact2.entries = [MagicMock(), MagicMock()]
-        artifact_repo.get_artifact.side_effect = [artifact1, artifact2]
+        artifact_repo.get_artifact_async.side_effect = [artifact1, artifact2]
         result = await harness.append_artifact_entry("task_1", MagicMock())
         assert result == 2
 

--- a/tests/unit_tests/agents/orchestration/test_task_execution_memory.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_memory.py
@@ -13,6 +13,7 @@ from relay_teams.agents.instances.instance_repository import AgentInstanceReposi
 from relay_teams.agents.orchestration.harnesses.execution_harness import (
     ExecutionHarness,
 )
+from relay_teams.agents.orchestration.harnesses.prompt_harness import TaskPromptHarness
 from relay_teams.agents.orchestration.task_execution_service import (
     TaskExecutionService,
 )
@@ -57,6 +58,10 @@ class _FailingSharedStore:
         self.keys.append(mutation.key)
         raise RuntimeError("write failed")
 
+    async def manage_state_async(self, mutation: StateMutation) -> None:
+        self.keys.append(mutation.key)
+        raise RuntimeError("write failed")
+
 
 def _task_envelope(
     *,
@@ -88,7 +93,10 @@ def test_truncate_task_memory_result_limits_long_normalized_results() -> None:
     assert "\n" not in truncated
 
 
-def test_record_memory_if_needed_does_not_fail_completed_task_on_store_error() -> None:
+@pytest.mark.asyncio
+async def test_record_memory_if_needed_does_not_fail_completed_task_on_store_error() -> (
+    None
+):
     shared_store = _FailingSharedStore()
     service = TaskExecutionService.model_construct(
         shared_store=cast(SharedStateRepository, shared_store)
@@ -103,7 +111,7 @@ def test_record_memory_if_needed_does_not_fail_completed_task_on_store_error() -
         verification=VerificationPlan(checklist=("non_empty_response",)),
     )
 
-    service._execution_harness().record_memory_if_needed(
+    await service._execution_harness().record_memory_if_needed_async(
         role_id="writer",
         workspace_id="workspace-1",
         task=task,
@@ -116,7 +124,8 @@ def test_record_memory_if_needed_does_not_fail_completed_task_on_store_error() -
     assert shared_store.keys == ["task_result:task-1"]
 
 
-def test_mark_runtime_idle_after_success_preserves_other_running_lane(
+@pytest.mark.asyncio
+async def test_mark_runtime_idle_after_success_preserves_other_running_lane(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "task_execution_runtime_lane.db"
@@ -170,7 +179,7 @@ def test_mark_runtime_idle_after_success_preserves_other_running_lane(
         )
     )
 
-    service._execution_harness().mark_runtime_idle_after_success(
+    await service._execution_harness().mark_runtime_idle_after_success_async(
         run_id="run-1",
         completed_task_id=completed_task.task_id,
     )
@@ -184,7 +193,8 @@ def test_mark_runtime_idle_after_success_preserves_other_running_lane(
     assert runtime.active_subagent_instance_id == "inst-running"
 
 
-def test_mark_runtime_idle_after_success_restores_paused_lane(
+@pytest.mark.asyncio
+async def test_mark_runtime_idle_after_success_restores_paused_lane(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "task_execution_runtime_paused_lane.db"
@@ -248,7 +258,7 @@ def test_mark_runtime_idle_after_success_restores_paused_lane(
         )
     )
 
-    service._execution_harness().mark_runtime_idle_after_success(
+    await service._execution_harness().mark_runtime_idle_after_success_async(
         run_id="run-1",
         completed_task_id=completed_task.task_id,
     )
@@ -264,7 +274,8 @@ def test_mark_runtime_idle_after_success_restores_paused_lane(
     assert runtime.last_error == "Task stopped by user"
 
 
-def test_mark_runtime_idle_after_success_prefers_subagent_over_coordinator(
+@pytest.mark.asyncio
+async def test_mark_runtime_idle_after_success_prefers_subagent_over_coordinator(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "task_execution_runtime_subagent_priority.db"
@@ -333,7 +344,7 @@ def test_mark_runtime_idle_after_success_prefers_subagent_over_coordinator(
         )
     )
 
-    service._execution_harness().mark_runtime_idle_after_success(
+    await service._execution_harness().mark_runtime_idle_after_success_async(
         run_id="run-1",
         completed_task_id=completed_task.task_id,
     )
@@ -347,7 +358,8 @@ def test_mark_runtime_idle_after_success_prefers_subagent_over_coordinator(
     assert runtime.active_subagent_instance_id == "inst-running-subagent"
 
 
-def test_mark_runtime_after_terminal_failure_promotes_other_running_lane(
+@pytest.mark.asyncio
+async def test_mark_runtime_after_terminal_failure_promotes_other_running_lane(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "task_execution_runtime_failure_lane.db"
@@ -402,7 +414,7 @@ def test_mark_runtime_after_terminal_failure_promotes_other_running_lane(
         )
     )
 
-    service._execution_harness().mark_runtime_after_terminal_task_update(
+    await service._execution_harness().mark_runtime_after_terminal_task_update_async(
         run_id="run-1",
         terminal_task_id=failed_task.task_id,
         status=RunRuntimeStatus.FAILED,
@@ -425,7 +437,8 @@ def test_mark_runtime_after_terminal_failure_promotes_other_running_lane(
     assert runtime.last_error == "model failed"
 
 
-def test_complete_with_assistant_error_persists_failure_state(
+@pytest.mark.asyncio
+async def test_complete_with_assistant_error_persists_failure_state(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "task_execution_assistant_error.db"
@@ -471,7 +484,7 @@ def test_complete_with_assistant_error_persists_failure_state(
         )
     )
 
-    result = service._execution_harness().complete_with_assistant_error(
+    result = await service._execution_harness().complete_with_assistant_error_async(
         task=task,
         instance_id="inst-1",
         role_id="writer",
@@ -573,18 +586,19 @@ async def test_promote_paused_runtime_lane_async_restores_paused_lane(
     assert runtime.last_error == "Task stopped by user"
 
 
-def test_prompt_tool_and_state_compatibility_helpers(
+@pytest.mark.asyncio
+async def test_prompt_tool_and_state_compatibility_helpers(
     tmp_path: Path,
 ) -> None:
     shared_store = SharedStateRepository(tmp_path / "task_execution_state.db")
-    shared_store.manage_state(
+    await shared_store.manage_state_async(
         StateMutation(
             scope=ScopeRef(scope_type=ScopeType.SESSION, scope_id="session-1"),
             key="session-key",
             value_json='"session-value"',
         )
     )
-    shared_store.manage_state(
+    await shared_store.manage_state_async(
         StateMutation(
             scope=ScopeRef(scope_type=ScopeType.ROLE, scope_id="session-1:writer"),
             key="role-key",
@@ -604,7 +618,7 @@ def test_prompt_tool_and_state_compatibility_helpers(
     )
     task = _task_envelope(task_id="task-1")
 
-    snapshot = service._execution_harness().shared_state_snapshot(
+    snapshot = await service._execution_harness().shared_state_snapshot_async(
         session_id="session-1",
         role_id="writer",
         conversation_id="conversation-1",
@@ -618,7 +632,9 @@ def test_prompt_tool_and_state_compatibility_helpers(
         sequential=False,
         parameters_json_schema={"type": "object"},
     )
-    user_prompt, skill_instructions = service._execution_harness().build_user_prompt(
+    user_prompt, skill_instructions = await TaskPromptHarness.model_construct(
+        skill_runtime_service=None
+    ).build_user_prompt_async(
         role=role,
         objective="Draft summary",
         shared_state_snapshot=snapshot,
@@ -726,14 +742,15 @@ def test_resolve_turn_objective_appends_task_contract_sections() -> None:
     assert "- Handoff Required:" in objective
 
 
-def test_completion_guard_wrappers_default_to_no_issue() -> None:
+@pytest.mark.asyncio
+async def test_completion_guard_wrappers_default_to_no_issue() -> None:
     service = TaskExecutionService.model_construct(
         run_intent_repo=None,
         todo_service=None,
         reminder_service=None,
     )
     task = _task_envelope(task_id="task-1", parent_task_id=None)
-    decision = service._execution_harness().evaluate_completion_guard(
+    decision = await service._execution_harness().evaluate_completion_guard_async(
         task=task,
         instance_id="inst-1",
         role_id="writer",
@@ -741,7 +758,7 @@ def test_completion_guard_wrappers_default_to_no_issue() -> None:
         conversation_id="conversation-1",
         output_text="done",
     )
-    thinking = service._execution_harness().thinking_for_run("missing-run")
+    thinking = await service._execution_harness().thinking_for_run_async("missing-run")
 
     assert decision.issue is False
     assert thinking.enabled is False
@@ -787,7 +804,8 @@ class _FakeTodoService:
         self.replaced_async_items = items
 
 
-def test_finalize_subtask_todos_marks_in_progress_as_completed() -> None:
+@pytest.mark.asyncio
+async def test_finalize_subtask_todos_marks_in_progress_as_completed() -> None:
     snapshot = TodoSnapshot(
         run_id="run-1",
         session_id="session-1",
@@ -806,15 +824,16 @@ def test_finalize_subtask_todos_marks_in_progress_as_completed() -> None:
     )
     task = _task_envelope(task_id="sub-1", parent_task_id="task-root")
 
-    harness._finalize_subtask_todos(task, instance_id="inst-1")
+    await harness._finalize_subtask_todos_async(task, instance_id="inst-1")
 
-    assert todo_svc.replaced_items is not None
+    assert todo_svc.replaced_async_items is not None
     # Only IN_PROGRESS items are finalized; PENDING items are left untouched
-    statuses = [item.status for item in todo_svc.replaced_items]
+    statuses = [item.status for item in todo_svc.replaced_async_items]
     assert statuses == [TodoStatus.COMPLETED, TodoStatus.COMPLETED, TodoStatus.PENDING]
 
 
-def test_finalize_subtask_todos_skips_when_all_completed() -> None:
+@pytest.mark.asyncio
+async def test_finalize_subtask_todos_skips_when_all_completed() -> None:
     snapshot = TodoSnapshot(
         run_id="run-1",
         session_id="session-1",
@@ -832,12 +851,13 @@ def test_finalize_subtask_todos_skips_when_all_completed() -> None:
     )
     task = _task_envelope(task_id="sub-1", parent_task_id="task-root")
 
-    harness._finalize_subtask_todos(task, instance_id="inst-1")
+    await harness._finalize_subtask_todos_async(task, instance_id="inst-1")
 
-    assert todo_svc.replaced_items is None
+    assert todo_svc.replaced_async_items is None
 
 
-def test_finalize_subtask_todos_skips_when_only_pending() -> None:
+@pytest.mark.asyncio
+async def test_finalize_subtask_todos_skips_when_only_pending() -> None:
     snapshot = TodoSnapshot(
         run_id="run-1",
         session_id="session-1",
@@ -855,9 +875,9 @@ def test_finalize_subtask_todos_skips_when_only_pending() -> None:
     )
     task = _task_envelope(task_id="sub-1", parent_task_id="task-root")
 
-    harness._finalize_subtask_todos(task, instance_id="inst-1")
+    await harness._finalize_subtask_todos_async(task, instance_id="inst-1")
 
-    assert todo_svc.replaced_items is None
+    assert todo_svc.replaced_async_items is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -225,7 +225,7 @@ class _StaticSkillRuntimeService:
     def __init__(self) -> None:
         self.skill_name_calls: list[tuple[str, ...] | None] = []
 
-    def prepare_prompt(
+    async def prepare_prompt_async(
         self,
         *,
         role: RoleDefinition,
@@ -1784,7 +1784,7 @@ async def test_execute_injects_memory_and_records_role_memory(tmp_path: Path) ->
     message_repo = MessageRepository(db_path)
     shared_store = SharedStateRepository(db_path)
     role_memory_service = RoleMemoryService(repository=RoleMemoryRepository(db_path))
-    role_memory_service.record_task_result(
+    await role_memory_service.record_task_result_async(
         role_id="time",
         workspace_id="default",
         session_id="seed-session",
@@ -1793,7 +1793,7 @@ async def test_execute_injects_memory_and_records_role_memory(tmp_path: Path) ->
         result="Prefer concise output.",
         transcript_lines=(),
     )
-    role_memory_service.record_task_result(
+    await role_memory_service.record_task_result_async(
         role_id="time",
         workspace_id="other-workspace",
         session_id="other-session",
@@ -1841,7 +1841,7 @@ async def test_execute_injects_memory_and_records_role_memory(tmp_path: Path) ->
     assert "## Reflection Memory" in provider.system_prompts[0]
     assert "Prefer concise output." in provider.system_prompts[0]
     assert "/d/workspace/aider" not in provider.system_prompts[0]
-    durable = role_memory_service.build_injected_memory(
+    durable = await role_memory_service.build_injected_memory_async(
         role_id="time",
         workspace_id="default",
     )

--- a/tests/unit_tests/agents/tasks/test_artifact_repository.py
+++ b/tests/unit_tests/agents/tasks/test_artifact_repository.py
@@ -73,6 +73,113 @@ def test_append_entry(repo: TaskArtifactRepository):
     assert row_id > 0
 
 
+@pytest.mark.asyncio
+async def test_async_artifact_lifecycle(repo: TaskArtifactRepository) -> None:
+    artifact = await repo.ensure_artifact_async("task-async-1", "spec-async-1")
+    assert artifact.task_id == "task-async-1"
+
+    row_id = await repo.append_entry_async(
+        "task-async-1",
+        TaskArtifactEntry(
+            entry_id="entry-async-1",
+            phase=TaskArtifactPhase.EXECUTION,
+            timestamp="2024-01-01T00:00:00",
+            event_type="tool_call",
+            description="Ran async artifact write",
+        ),
+    )
+    assert row_id > 0
+
+    await repo.update_summary_async("task-async-1", "Async checks passed")
+    loaded = await repo.get_artifact_async("task-async-1")
+    assert loaded is not None
+    assert loaded.summary == "Async checks passed"
+    assert len(loaded.entries) == 1
+
+    entries, total = await repo.query_entries_async(task_id="task-async-1")
+    assert total == 1
+    assert entries[0].entry_id == "entry-async-1"
+
+
+@pytest.mark.asyncio
+async def test_async_artifact_summary_evidence_and_filters(
+    repo: TaskArtifactRepository,
+) -> None:
+    assert await repo.get_artifact_async("missing") is None
+    assert await repo.get_artifact_summary_async("missing") is None
+
+    _ = await repo.ensure_artifact_async("task-async-2", "spec-async-2")
+    await repo.append_entry_async(
+        "task-async-2",
+        TaskArtifactEntry(
+            entry_id="entry-async-2a",
+            phase=TaskArtifactPhase.EXECUTION,
+            timestamp="2024-01-01T00:00:00",
+            event_type="tool_call",
+            description="Ran async tool",
+        ),
+    )
+    await repo.append_entry_async(
+        "task-async-2",
+        TaskArtifactEntry(
+            entry_id="entry-async-2b",
+            phase=TaskArtifactPhase.VERIFICATION,
+            timestamp="2024-01-01T00:00:01",
+            event_type="check",
+            description="Verified async tool",
+        ),
+    )
+    bundle = VerificationEvidenceBundle(
+        task_id="task-async-2",
+        items=(
+            VerificationEvidenceItem(
+                evidence_id="ev-async-1",
+                kind=VerificationEvidenceKind.TASK_RESULT,
+                summary="Async task completed",
+            ),
+        ),
+    )
+    await repo.update_evidence_bundle_async("task-async-2", bundle)
+
+    artifact = await repo.get_artifact_async("task-async-2")
+    assert artifact is not None
+    assert artifact.evidence_bundle is not None
+    assert len(artifact.evidence_bundle.items) == 1
+
+    summary = await repo.get_artifact_summary_async("task-async-2")
+    assert summary is not None
+    assert summary.phase_counts == {"execution": 1, "verification": 1}
+    assert summary.evidence_item_count == 1
+    assert summary.has_verification_bundle is True
+
+    phase_entries, phase_total = await repo.query_entries_async(
+        task_id="task-async-2",
+        phase=TaskArtifactPhase.VERIFICATION,
+    )
+    event_entries, event_total = await repo.query_entries_async(
+        task_id="task-async-2",
+        event_type="tool_call",
+    )
+    assert phase_total == 1
+    assert phase_entries[0].entry_id == "entry-async-2b"
+    assert event_total == 1
+    assert event_entries[0].entry_id == "entry-async-2a"
+
+
+@pytest.mark.asyncio
+async def test_ensure_artifact_async_raises_when_insert_cannot_be_read(
+    repo: TaskArtifactRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def missing_artifact(_task_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(repo, "get_artifact_async", missing_artifact)
+
+    with pytest.raises(RuntimeError, match="Failed to create task artifact"):
+        await repo.ensure_artifact_async("task-1", "spec-1")
+
+
 class _WalFailingConnection:
     def execute(self, sql: str) -> object:
         if sql == "PRAGMA journal_mode = WAL":

--- a/tests/unit_tests/external_agents/test_host_tool_bridge.py
+++ b/tests/unit_tests/external_agents/test_host_tool_bridge.py
@@ -6,6 +6,7 @@ from types import ModuleType
 from types import SimpleNamespace
 from typing import cast
 
+import pytest
 import relay_teams.external_agents.host_tool_bridge as host_tool_bridge_module
 from pydantic_ai.messages import BinaryContent, ToolReturn
 from relay_teams.providers.model_config import (
@@ -34,7 +35,7 @@ class _LegacyToolResult:
 
 
 class _MissingRunIntentRepo:
-    def get(self, _run_id: str) -> object:
+    async def get_async(self, _run_id: str) -> object:
         raise KeyError
 
 
@@ -44,7 +45,7 @@ class _FakeToolApprovalPolicy:
 
 
 class _FakeWorkspaceManager:
-    def resolve(self, **_kwargs: object) -> object:
+    async def resolve_async(self, **_kwargs: object) -> object:
         return object()
 
 
@@ -133,7 +134,8 @@ def test_tool_return_to_fastmcp_result_preserves_scalar_value_with_media_content
     assert tool_result.content[1].data == "cG5nLWJ5dGVz"
 
 
-def test_build_tool_deps_uses_resolved_model_capabilities() -> None:
+@pytest.mark.asyncio
+async def test_build_tool_deps_uses_resolved_model_capabilities() -> None:
     resolved_config = ModelEndpointConfig(
         provider=ProviderType.OPENAI_COMPATIBLE,
         model="qwen3-vl",
@@ -220,7 +222,7 @@ def test_build_tool_deps_uses_resolved_model_capabilities() -> None:
         }
     )
 
-    deps = bridge._build_tool_deps(request=request)
+    deps = await bridge._build_tool_deps_async(request=request)
 
     assert requested == [(role, request)]
     assert deps.model_capabilities == resolved_config.capabilities

--- a/tests/unit_tests/external_agents/test_provider.py
+++ b/tests/unit_tests/external_agents/test_provider.py
@@ -140,7 +140,7 @@ class _FakeWorkspaceManager:
     def __init__(self, workdir: Path) -> None:
         self._workdir = workdir
 
-    def resolve(self, **_kwargs: object) -> _FakeWorkspaceHandle:
+    async def resolve_async(self, **_kwargs: object) -> _FakeWorkspaceHandle:
         return _FakeWorkspaceHandle(self._workdir)
 
 

--- a/tests/unit_tests/interfaces/server/test_prompts_router.py
+++ b/tests/unit_tests/interfaces/server/test_prompts_router.py
@@ -55,7 +55,7 @@ class _FakeWorkspaceService:
     def __init__(self, known_workspace_ids: set[str]) -> None:
         self._known_workspace_ids = known_workspace_ids
 
-    def require_workspace(self, workspace_id: str) -> None:
+    async def require_workspace_async(self, workspace_id: str) -> None:
         if workspace_id not in self._known_workspace_ids:
             raise KeyError(workspace_id)
 
@@ -72,7 +72,7 @@ class _FakeWorkspaceHandle:
 
 
 class _FakeWorkspaceManager:
-    def resolve(
+    async def resolve_async(
         self,
         *,
         session_id: str,
@@ -148,7 +148,7 @@ class _FakeSkillRuntimeService:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
-    def prepare_prompt(
+    async def prepare_prompt_async(
         self,
         *,
         role: RoleDefinition,

--- a/tests/unit_tests/interfaces/server/test_system_router.py
+++ b/tests/unit_tests/interfaces/server/test_system_router.py
@@ -957,7 +957,7 @@ class _FakeWorkspaceManager:
         self.workdir = workdir
         self.resolve_calls: list[dict[str, object]] = []
 
-    def resolve(
+    async def resolve_async(
         self,
         *,
         session_id: str,

--- a/tests/unit_tests/memory/test_async_only_contract.py
+++ b/tests/unit_tests/memory/test_async_only_contract.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import relay_teams.roles.memory_injection as memory_injection
+from relay_teams.memory.event_handler import MemoryEventHandler
+from relay_teams.memory.repository import MemoryBankRepository
+from relay_teams.memory.service import MemoryBankService
+from relay_teams.roles.evolution_history import RoleEvolutionHistoryService
+from relay_teams.roles.memory_service import RoleMemoryService
+
+
+def _public_callables(cls: type[object]) -> set[str]:
+    return {
+        name
+        for name, value in vars(cls).items()
+        if not name.startswith("_") and callable(value)
+    }
+
+
+def test_memory_runtime_has_no_public_sync_async_method_pairs() -> None:
+    for cls in (
+        MemoryBankRepository,
+        MemoryBankService,
+        MemoryEventHandler,
+        RoleMemoryService,
+        RoleEvolutionHistoryService,
+    ):
+        methods = _public_callables(cls)
+        sync_async_pairs = sorted(
+            method for method in methods if f"{method}_async" in methods
+        )
+        assert sync_async_pairs == []
+
+
+def test_removed_sync_memory_facades_do_not_return() -> None:
+    forbidden_methods: dict[type[object], tuple[str, ...]] = {
+        MemoryBankRepository: (
+            "create_entry",
+            "get_by_id",
+            "update_entry",
+            "delete_entry",
+            "query_entries",
+            "expire_entries",
+            "apply_confidence_decay",
+            "count_entries",
+            "expire_oldest",
+        ),
+        MemoryBankService: (
+            "create_entry",
+            "get_entry",
+            "list_entries",
+            "update_entry",
+            "delete_entry",
+            "consolidate",
+            "forget_expired",
+            "search",
+            "enforce_capacity",
+        ),
+        MemoryEventHandler: (
+            "on_task_completed",
+            "on_run_completed",
+            "on_session_completed",
+            "get_injectable_memory_text",
+        ),
+        RoleEvolutionHistoryService: (
+            "record_event",
+            "get_timeline",
+            "get_current_state",
+        ),
+        RoleMemoryService: (
+            "build_injected_memory",
+            "get_reflection_record",
+            "update_reflection_memory",
+            "delete_reflection_memory",
+            "build_reflection_preview",
+            "get_performance_metrics",
+            "record_task_result",
+        ),
+    }
+
+    for cls, method_names in forbidden_methods.items():
+        methods = _public_callables(cls)
+        returned_methods = sorted(name for name in method_names if name in methods)
+        assert returned_methods == []
+
+
+def test_memory_injection_old_sync_helpers_do_not_return() -> None:
+    exported_names = vars(memory_injection)
+    forbidden_helpers = (
+        "build_role_with_memory",
+        "_build_project_memory_section",
+        "_build_role_evolution_section",
+        "_find_latest_maturity_level",
+        "_count_applied_adjustments",
+    )
+
+    returned_helpers = sorted(
+        name for name in forbidden_helpers if name in exported_names
+    )
+    assert returned_helpers == []

--- a/tests/unit_tests/memory/test_event_handler_coverage.py
+++ b/tests/unit_tests/memory/test_event_handler_coverage.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -12,10 +13,10 @@ from relay_teams.memory.event_handler import MemoryEventHandler
 
 def _make_handler() -> tuple[MemoryEventHandler, MagicMock, MagicMock]:
     role_mem = MagicMock()
-    role_mem.record_task_result = MagicMock()
+    role_mem.record_task_result_async = AsyncMock()
     role_mem.record_verification_outcome = AsyncMock()
     bank = MagicMock()
-    bank.create_entry = MagicMock()
+    bank.create_entry_async = AsyncMock()
     return (
         MemoryEventHandler(
             memory_bank_service=bank,
@@ -29,14 +30,12 @@ def _make_handler() -> tuple[MemoryEventHandler, MagicMock, MagicMock]:
 @pytest.mark.asyncio
 async def test_on_task_completed_calls_record_verification_outcome() -> None:
     """Lines 107-120: RP-2 wiring fires when verification_report is provided."""
-    import asyncio
-
-    handler, role_mem, bank = _make_handler()
+    handler, role_mem, _bank = _make_handler()
 
     vr = MagicMock()
     vr.passed = True
 
-    handler.on_task_completed(
+    await handler.on_task_completed_async(
         task_id="t1",
         session_id="s1",
         workspace_id="w1",
@@ -46,19 +45,15 @@ async def test_on_task_completed_calls_record_verification_outcome() -> None:
         result="done",
         verification_report=vr,
     )
-    # Give the create_task'd coroutine a chance to run
-    await asyncio.sleep(0)
     role_mem.record_verification_outcome.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_on_task_completed_no_verification_report() -> None:
     """No verification_report = no call to record_verification_outcome."""
-    import asyncio
+    handler, role_mem, _bank = _make_handler()
 
-    handler, role_mem, bank = _make_handler()
-
-    handler.on_task_completed(
+    await handler.on_task_completed_async(
         task_id="t1",
         session_id="s1",
         workspace_id="w1",
@@ -68,5 +63,25 @@ async def test_on_task_completed_no_verification_report() -> None:
         result="done",
         verification_report=None,
     )
-    await asyncio.sleep(0)
     role_mem.record_verification_outcome.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_task_completed_tolerates_verification_sqlite_failure() -> None:
+    handler, role_mem, _bank = _make_handler()
+    role_mem.record_verification_outcome = AsyncMock(
+        side_effect=sqlite3.OperationalError("database is locked")
+    )
+
+    await handler.on_task_completed_async(
+        task_id="t1",
+        session_id="s1",
+        workspace_id="w1",
+        role_id="role1",
+        run_id="r1",
+        objective="do stuff",
+        result="done",
+        verification_report=MagicMock(),
+    )
+
+    role_mem.record_verification_outcome.assert_awaited_once()

--- a/tests/unit_tests/memory/test_memory_additional_coverage.py
+++ b/tests/unit_tests/memory/test_memory_additional_coverage.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
-
-import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -23,6 +21,8 @@ from relay_teams.memory.models import (
 )
 from relay_teams.memory.repository import MemoryBankRepository
 from relay_teams.memory.service import MemoryBankService
+
+pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
@@ -53,89 +53,93 @@ def _create_request(**overrides: object) -> CreateMemoryEntryRequest:
 
 
 class TestAsyncCreateEntry:
-    def test_create_async_persistent(self, service: MemoryBankService) -> None:
+    async def test_create_async_persistent(self, service: MemoryBankService) -> None:
         req = _create_request(
             tier=MemoryTier.PERSISTENT,
             scope=MemoryScope.WORKSPACE,
             session_id=None,
             run_id=None,
         )
-        entry = asyncio.run(service.create_entry_async(req))
+        entry = await service.create_entry_async(req)
         assert entry.id.startswith("mem-")
         assert entry.tier == MemoryTier.PERSISTENT
 
-    def test_create_async_with_ttl(self, service: MemoryBankService) -> None:
+    async def test_create_async_with_ttl(self, service: MemoryBankService) -> None:
         req = _create_request()
-        entry = asyncio.run(service.create_entry_async(req))
+        entry = await service.create_entry_async(req)
         assert entry.expires_at is not None
 
-    def test_create_async_with_confidence(self, service: MemoryBankService) -> None:
+    async def test_create_async_with_confidence(
+        self, service: MemoryBankService
+    ) -> None:
         req = _create_request(confidence_score=0.5, tags=("a", "b"))
-        entry = asyncio.run(service.create_entry_async(req))
+        entry = await service.create_entry_async(req)
         assert entry.confidence_score == 0.5
         assert entry.tags == ("a", "b")
 
 
 class TestAsyncGetEntry:
-    def test_get_async_existing(self, service: MemoryBankService) -> None:
+    async def test_get_async_existing(self, service: MemoryBankService) -> None:
         req = _create_request()
-        created = service.create_entry(req)
-        result = asyncio.run(service.get_entry_async(created.id))
+        created = await service.create_entry_async(req)
+        result = await service.get_entry_async(created.id)
         assert result is not None
         assert result.id == created.id
 
-    def test_get_async_missing(self, service: MemoryBankService) -> None:
-        result = asyncio.run(service.get_entry_async("mem-nonexistent"))
+    async def test_get_async_missing(self, service: MemoryBankService) -> None:
+        result = await service.get_entry_async("mem-nonexistent")
         assert result is None
 
 
 class TestAsyncListEntries:
-    def test_list_async_returns_entries(self, service: MemoryBankService) -> None:
-        service.create_entry(_create_request())
-        service.create_entry(_create_request(run_id="run-2"))
+    async def test_list_async_returns_entries(self, service: MemoryBankService) -> None:
+        await service.create_entry_async(_create_request())
+        await service.create_entry_async(_create_request(run_id="run-2"))
         query = MemoryQuery(workspace_id="ws-async")
-        result = asyncio.run(service.list_entries_async(query))
+        result = await service.list_entries_async(query)
         assert result.total_count == 2
 
 
 class TestAsyncUpdateEntry:
-    def test_update_async_existing(self, service: MemoryBankService) -> None:
-        created = service.create_entry(_create_request())
+    async def test_update_async_existing(self, service: MemoryBankService) -> None:
+        created = await service.create_entry_async(_create_request())
         update = UpdateMemoryEntryRequest(
             content=MemoryContent(title="Updated", body="New body"),
         )
-        result = asyncio.run(service.update_entry_async(created.id, update))
+        result = await service.update_entry_async(created.id, update)
         assert result is not None
         assert result.content.title == "Updated"
 
-    def test_update_async_missing(self, service: MemoryBankService) -> None:
+    async def test_update_async_missing(self, service: MemoryBankService) -> None:
         update = UpdateMemoryEntryRequest(
             content=MemoryContent(title="X", body="Y"),
         )
-        result = asyncio.run(service.update_entry_async("mem-nope", update))
+        result = await service.update_entry_async("mem-nope", update)
         assert result is None
 
-    def test_update_async_various_fields(self, service: MemoryBankService) -> None:
-        created = service.create_entry(_create_request())
+    async def test_update_async_various_fields(
+        self, service: MemoryBankService
+    ) -> None:
+        created = await service.create_entry_async(_create_request())
         update = UpdateMemoryEntryRequest(
             tags=("new-tag",),
             confidence_score=0.3,
             status=MemoryEntryStatus.EXPIRED,
         )
-        result = asyncio.run(service.update_entry_async(created.id, update))
+        result = await service.update_entry_async(created.id, update)
         assert result is not None
         assert result.tags == ("new-tag",)
         assert result.confidence_score == 0.3
 
 
 class TestAsyncDeleteEntry:
-    def test_delete_async_existing(self, service: MemoryBankService) -> None:
-        created = service.create_entry(_create_request())
-        result = asyncio.run(service.delete_entry_async(created.id))
+    async def test_delete_async_existing(self, service: MemoryBankService) -> None:
+        created = await service.create_entry_async(_create_request())
+        result = await service.delete_entry_async(created.id)
         assert result is True
 
-    def test_delete_async_missing(self, service: MemoryBankService) -> None:
-        result = asyncio.run(service.delete_entry_async("mem-nope"))
+    async def test_delete_async_missing(self, service: MemoryBankService) -> None:
+        result = await service.delete_entry_async("mem-nope")
         assert result is False
 
 
@@ -145,12 +149,12 @@ class TestAsyncDeleteEntry:
 
 
 class TestAsyncConsolidation:
-    def test_consolidate_async(self, service: MemoryBankService) -> None:
+    async def test_consolidate_async(self, service: MemoryBankService) -> None:
         req = _create_request(
             tier=MemoryTier.WORKING,
             confidence_score=0.95,
         )
-        service.create_entry(req)
+        await service.create_entry_async(req)
 
         consolidation = MemoryConsolidationRequest(
             workspace_id="ws-async",
@@ -158,14 +162,16 @@ class TestAsyncConsolidation:
             target_tier=MemoryTier.MEDIUM_TERM,
             target_scope=MemoryScope.SESSION,
         )
-        result = asyncio.run(service.consolidate_async(consolidation))
+        result = await service.consolidate_async(consolidation)
         assert result.consolidated_entry_count == 1
 
-    def test_consolidate_async_with_filters(self, service: MemoryBankService) -> None:
-        service.create_entry(
+    async def test_consolidate_async_with_filters(
+        self, service: MemoryBankService
+    ) -> None:
+        await service.create_entry_async(
             _create_request(kind=MemoryEntryKind.INSIGHT, confidence_score=0.95)
         )
-        service.create_entry(
+        await service.create_entry_async(
             _create_request(
                 kind=MemoryEntryKind.CONSTRAINT, confidence_score=0.95, run_id="r2"
             )
@@ -177,23 +183,25 @@ class TestAsyncConsolidation:
             target_scope=MemoryScope.SESSION,
             filter_kind=MemoryEntryKind.INSIGHT,
         )
-        result = asyncio.run(service.consolidate_async(consolidation))
+        result = await service.consolidate_async(consolidation)
         assert result.consolidated_entry_count == 1
 
-    def test_consolidate_async_persistent(self, service: MemoryBankService) -> None:
+    async def test_consolidate_async_persistent(
+        self, service: MemoryBankService
+    ) -> None:
         req = _create_request(
             tier=MemoryTier.MEDIUM_TERM,
             scope=MemoryScope.SESSION,
             confidence_score=0.95,
         )
-        service.create_entry(req)
+        await service.create_entry_async(req)
         consolidation = MemoryConsolidationRequest(
             workspace_id="ws-async",
             session_id="sess-1",
             target_tier=MemoryTier.PERSISTENT,
             target_scope=MemoryScope.WORKSPACE,
         )
-        result = asyncio.run(service.consolidate_async(consolidation))
+        result = await service.consolidate_async(consolidation)
         assert result.consolidated_entry_count == 1
 
 
@@ -203,17 +211,17 @@ class TestAsyncConsolidation:
 
 
 class TestAsyncForgetExpired:
-    def test_forget_async(self, service: MemoryBankService) -> None:
-        result = asyncio.run(service.forget_expired_async())
+    async def test_forget_async(self, service: MemoryBankService) -> None:
+        result = await service.forget_expired_async()
         assert result == 0
 
-    def test_forget_async_with_expired_entries(
+    async def test_forget_async_with_expired_entries(
         self, service: MemoryBankService
     ) -> None:
         past = datetime.now(tz=timezone.utc) - timedelta(hours=1)
         req = _create_request(expires_at=past)
-        service.create_entry(req)
-        count = asyncio.run(service.forget_expired_async())
+        await service.create_entry_async(req)
+        count = await service.forget_expired_async()
         assert count >= 1
 
 
@@ -223,8 +231,8 @@ class TestAsyncForgetExpired:
 
 
 class TestAsyncSearch:
-    def test_search_async_fallback(self, service: MemoryBankService) -> None:
-        service.create_entry(
+    async def test_search_async_fallback(self, service: MemoryBankService) -> None:
+        await service.create_entry_async(
             _create_request(
                 content=MemoryContent(title="Python tip", body="Use dataclasses"),
             )
@@ -233,16 +241,16 @@ class TestAsyncSearch:
             workspace_id="ws-async",
             text_query="python",
         )
-        result = asyncio.run(service.search_async(request))
+        result = await service.search_async(request)
         assert result.total_count == 1
 
-    def test_search_async_no_match(self, service: MemoryBankService) -> None:
-        service.create_entry(_create_request())
+    async def test_search_async_no_match(self, service: MemoryBankService) -> None:
+        await service.create_entry_async(_create_request())
         request = MemorySearchRequest(
             workspace_id="ws-async",
             text_query="nonexistent_query_xyz",
         )
-        result = asyncio.run(service.search_async(request))
+        result = await service.search_async(request)
         assert result.total_count == 0
 
 
@@ -252,41 +260,41 @@ class TestAsyncSearch:
 
 
 class TestUpdateEdgeCases:
-    def test_update_missing_entry(self, service: MemoryBankService) -> None:
+    async def test_update_missing_entry(self, service: MemoryBankService) -> None:
         update = UpdateMemoryEntryRequest(
             content=MemoryContent(title="X", body="Y"),
         )
-        result = service.update_entry("mem-nonexistent", update)
+        result = await service.update_entry_async("mem-nonexistent", update)
         assert result is None
 
-    def test_update_confidence_below_threshold_auto_expires(
+    async def test_update_confidence_below_threshold_auto_expires(
         self, service: MemoryBankService
     ) -> None:
-        created = service.create_entry(_create_request())
+        created = await service.create_entry_async(_create_request())
         update = UpdateMemoryEntryRequest(confidence_score=0.01)
-        result = service.update_entry(created.id, update)
+        result = await service.update_entry_async(created.id, update)
         assert result is not None
         assert result.status == MemoryEntryStatus.EXPIRED
 
-    def test_update_with_metadata(self, service: MemoryBankService) -> None:
-        created = service.create_entry(_create_request())
+    async def test_update_with_metadata(self, service: MemoryBankService) -> None:
+        created = await service.create_entry_async(_create_request())
         update = UpdateMemoryEntryRequest(metadata={"key": "value"})
-        result = service.update_entry(created.id, update)
+        result = await service.update_entry_async(created.id, update)
         assert result is not None
         assert result.metadata == {"key": "value"}
 
-    def test_update_expires_at(self, service: MemoryBankService) -> None:
-        created = service.create_entry(_create_request())
+    async def test_update_expires_at(self, service: MemoryBankService) -> None:
+        created = await service.create_entry_async(_create_request())
         new_expires = datetime.now(tz=timezone.utc) + timedelta(days=30)
         update = UpdateMemoryEntryRequest(expires_at=new_expires)
-        result = service.update_entry(created.id, update)
+        result = await service.update_entry_async(created.id, update)
         assert result is not None
         assert result.expires_at is not None
 
-    def test_update_status(self, service: MemoryBankService) -> None:
-        created = service.create_entry(_create_request())
+    async def test_update_status(self, service: MemoryBankService) -> None:
+        created = await service.create_entry_async(_create_request())
         update = UpdateMemoryEntryRequest(status=MemoryEntryStatus.EXPIRED)
-        result = service.update_entry(created.id, update)
+        result = await service.update_entry_async(created.id, update)
         assert result is not None
         assert result.status == MemoryEntryStatus.EXPIRED
 
@@ -297,8 +305,10 @@ class TestUpdateEdgeCases:
 
 
 class TestSearchFallback:
-    def test_search_fallback_with_tier_filter(self, service: MemoryBankService) -> None:
-        service.create_entry(
+    async def test_search_fallback_with_tier_filter(
+        self, service: MemoryBankService
+    ) -> None:
+        await service.create_entry_async(
             _create_request(
                 tier=MemoryTier.WORKING,
                 content=MemoryContent(title="pattern X", body="body content"),
@@ -309,15 +319,15 @@ class TestSearchFallback:
             text_query="pattern",
             tier=MemoryTier.WORKING,
         )
-        result = service.search(request)
+        result = await service.search_async(request)
         assert result.total_count == 1
 
-    def test_search_fallback_no_results(self, service: MemoryBankService) -> None:
+    async def test_search_fallback_no_results(self, service: MemoryBankService) -> None:
         request = MemorySearchRequest(
             workspace_id="ws-nonexistent",
             text_query="anything",
         )
-        result = service.search(request)
+        result = await service.search_async(request)
         assert result.total_count == 0
 
 
@@ -327,35 +337,39 @@ class TestSearchFallback:
 
 
 class TestFTSIndexing:
-    def test_index_entry_with_retrieval_service(self, tmp_path: Path) -> None:
+    async def test_index_entry_with_retrieval_service(self, tmp_path: Path) -> None:
         repo = MemoryBankRepository(tmp_path / "test_fts.db")
         mock_retrieval = MagicMock()
+        mock_retrieval.upsert_documents_async = AsyncMock()
         service = MemoryBankService(repository=repo, retrieval_service=mock_retrieval)
-        service.create_entry(_create_request())
-        mock_retrieval.upsert_documents.assert_called_once()
+        await service.create_entry_async(_create_request())
+        mock_retrieval.upsert_documents_async.assert_awaited_once()
 
-    def test_index_entry_skips_non_active(self, tmp_path: Path) -> None:
+    async def test_index_entry_skips_non_active(self, tmp_path: Path) -> None:
         repo = MemoryBankRepository(tmp_path / "test_fts_skip.db")
         mock_retrieval = MagicMock()
+        mock_retrieval.upsert_documents_async = AsyncMock()
         service = MemoryBankService(repository=repo, retrieval_service=mock_retrieval)
-        created = service.create_entry(_create_request())
+        created = await service.create_entry_async(_create_request())
         # Update status to expired
-        service.update_entry(
+        await service.update_entry_async(
             created.id, UpdateMemoryEntryRequest(status=MemoryEntryStatus.EXPIRED)
         )
-        # upsert_documents called only once (initial create)
-        assert mock_retrieval.upsert_documents.call_count == 1
+        # upsert_documents_async called only once (initial create)
+        assert mock_retrieval.upsert_documents_async.await_count == 1
 
-    def test_index_entry_handles_retrieval_failure(self, tmp_path: Path) -> None:
+    async def test_index_entry_handles_retrieval_failure(self, tmp_path: Path) -> None:
         repo = MemoryBankRepository(tmp_path / "test_fts_fail.db")
         mock_retrieval = MagicMock()
-        mock_retrieval.upsert_documents.side_effect = RuntimeError("FTS error")
+        mock_retrieval.upsert_documents_async = AsyncMock(
+            side_effect=RuntimeError("FTS error")
+        )
         service = MemoryBankService(repository=repo, retrieval_service=mock_retrieval)
         # Should not raise
-        entry = service.create_entry(_create_request())
+        entry = await service.create_entry_async(_create_request())
         assert entry is not None
 
-    def test_search_fts_with_hits(self, tmp_path: Path) -> None:
+    async def test_search_fts_with_hits(self, tmp_path: Path) -> None:
         repo = MemoryBankRepository(tmp_path / "test_fts_search.db")
         mock_retrieval = MagicMock()
         hit = MagicMock()
@@ -363,11 +377,12 @@ class TestFTSIndexing:
         hit.score = 0.95
         hit.rank = 1
         hit.snippet = "found text"
-        mock_retrieval.search.return_value = [hit]
+        mock_retrieval.upsert_documents_async = AsyncMock()
+        mock_retrieval.search_async = AsyncMock(return_value=[hit])
 
         service = MemoryBankService(repository=repo, retrieval_service=mock_retrieval)
         # Create an entry with matching id
-        created = service.create_entry(_create_request())
+        created = await service.create_entry_async(_create_request())
 
         # Change the hit to match the real entry id
         hit.document_id = created.id
@@ -376,19 +391,19 @@ class TestFTSIndexing:
             workspace_id="ws-async",
             text_query="test query",
         )
-        result = service.search(request)
+        result = await service.search_async(request)
         assert result.total_count >= 1
 
-    def test_search_fts_no_hits(self, tmp_path: Path) -> None:
+    async def test_search_fts_no_hits(self, tmp_path: Path) -> None:
         repo = MemoryBankRepository(tmp_path / "test_fts_no_hits.db")
         mock_retrieval = MagicMock()
-        mock_retrieval.search.return_value = []
+        mock_retrieval.search_async = AsyncMock(return_value=[])
         service = MemoryBankService(repository=repo, retrieval_service=mock_retrieval)
         request = MemorySearchRequest(
             workspace_id="ws-async",
             text_query="no match",
         )
-        result = service.search(request)
+        result = await service.search_async(request)
         assert result.total_count == 0
 
 
@@ -398,19 +413,19 @@ class TestFTSIndexing:
 
 
 class TestSourceTierFor:
-    def test_persistent_sources_medium_term(self) -> None:
+    async def test_persistent_sources_medium_term(self) -> None:
         assert (
             MemoryBankService._source_tier_for(MemoryTier.PERSISTENT)
             == MemoryTier.MEDIUM_TERM
         )
 
-    def test_medium_term_sources_working(self) -> None:
+    async def test_medium_term_sources_working(self) -> None:
         assert (
             MemoryBankService._source_tier_for(MemoryTier.MEDIUM_TERM)
             == MemoryTier.WORKING
         )
 
-    def test_working_sources_working(self) -> None:
+    async def test_working_sources_working(self) -> None:
         assert (
             MemoryBankService._source_tier_for(MemoryTier.WORKING) == MemoryTier.WORKING
         )
@@ -422,6 +437,8 @@ class TestSourceTierFor:
 
 
 class TestCondensation:
-    def test_condense_raises_not_implemented(self, service: MemoryBankService) -> None:
+    async def test_condense_raises_not_implemented(
+        self, service: MemoryBankService
+    ) -> None:
         with pytest.raises(NotImplementedError, match="FE-2"):
             service.condense("ws-async")

--- a/tests/unit_tests/memory/test_memory_event_handler.py
+++ b/tests/unit_tests/memory/test_memory_event_handler.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -19,6 +19,8 @@ from relay_teams.memory.models import (
 from relay_teams.memory.repository import MemoryBankRepository
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.roles.memory_service import RoleMemoryService
+
+pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
@@ -52,24 +54,24 @@ def handler_with_dual_write(
     )
 
 
-def _list_entries(
+async def _list_entries(
     svc: MemoryBankService,
     workspace_id: str,
     tier: MemoryTier,
 ) -> list[MemoryEntrySummary]:
-    result = svc.list_entries(
+    result = await svc.list_entries_async(
         MemoryQuery(workspace_id=workspace_id, tier=tier, limit=100)
     )
     return list(result.items)
 
 
 class TestOnTaskCompleted:
-    def test_creates_working_entry(
+    async def test_creates_working_entry(
         self,
         handler: MemoryEventHandler,
         memory_bank_service: MemoryBankService,
     ) -> None:
-        handler.on_task_completed(
+        await handler.on_task_completed_async(
             workspace_id="ws-1",
             role_id="role-1",
             session_id="sess-1",
@@ -78,7 +80,7 @@ class TestOnTaskCompleted:
             objective="Fix login bug",
             result="Fixed null pointer in auth module",
         )
-        entries = _list_entries(memory_bank_service, "ws-1", MemoryTier.WORKING)
+        entries = await _list_entries(memory_bank_service, "ws-1", MemoryTier.WORKING)
         assert len(entries) == 1
         e = entries[0]
         assert e.kind == MemoryEntryKind.SUMMARY
@@ -89,11 +91,11 @@ class TestOnTaskCompleted:
         assert e.status == MemoryEntryStatus.ACTIVE
         assert "Fix login bug" in e.content_title
 
-    def test_dual_writes_to_role_memories(
+    async def test_dual_writes_to_role_memories(
         self,
         handler_with_dual_write: MemoryEventHandler,
     ) -> None:
-        handler_with_dual_write.on_task_completed(
+        await handler_with_dual_write.on_task_completed_async(
             workspace_id="ws-1",
             role_id="role-1",
             session_id="sess-1",
@@ -104,7 +106,7 @@ class TestOnTaskCompleted:
         )
         rm = handler_with_dual_write._role_memory_service
         assert rm is not None
-        rm.record_task_result.assert_called_once_with(  # type: ignore[attr-defined]
+        rm.record_task_result_async.assert_awaited_once_with(  # type: ignore[attr-defined]
             role_id="role-1",
             workspace_id="ws-1",
             session_id="sess-1",
@@ -114,17 +116,19 @@ class TestOnTaskCompleted:
             transcript_lines=(),
         )
 
-    def test_dual_write_failure_does_not_block_entry(
+    async def test_dual_write_failure_does_not_block_entry(
         self,
         memory_bank_service: MemoryBankService,
     ) -> None:
         mock_rm = MagicMock(spec=RoleMemoryService)
-        mock_rm.record_task_result.side_effect = RuntimeError("db error")
+        mock_rm.record_task_result_async = AsyncMock(
+            side_effect=RuntimeError("db error")
+        )
         h = MemoryEventHandler(
             memory_bank_service=memory_bank_service,
             role_memory_service=mock_rm,
         )
-        h.on_task_completed(
+        await h.on_task_completed_async(
             workspace_id="ws-1",
             role_id="role-1",
             session_id="sess-1",
@@ -133,19 +137,19 @@ class TestOnTaskCompleted:
             objective="Test",
             result="OK",
         )
-        entries = _list_entries(memory_bank_service, "ws-1", MemoryTier.WORKING)
+        entries = await _list_entries(memory_bank_service, "ws-1", MemoryTier.WORKING)
         assert len(entries) == 1
 
 
 class TestOnRunCompleted:
-    def test_consolidates_working_to_medium_term(
+    async def test_consolidates_working_to_medium_term(
         self,
         handler: MemoryEventHandler,
         memory_bank_service: MemoryBankService,
     ) -> None:
         # Create some WORKING entries first
         for i in range(3):
-            handler.on_task_completed(
+            await handler.on_task_completed_async(
                 workspace_id="ws-1",
                 role_id="role-1",
                 session_id="sess-1",
@@ -155,29 +159,31 @@ class TestOnRunCompleted:
                 result=f"Result {i}",
             )
         # Verify entries are WORKING
-        working = _list_entries(memory_bank_service, "ws-1", MemoryTier.WORKING)
+        working = await _list_entries(memory_bank_service, "ws-1", MemoryTier.WORKING)
         assert len(working) == 3
 
         # Consolidate on run completion
-        handler.on_run_completed(
+        await handler.on_run_completed_async(
             workspace_id="ws-1",
             session_id="sess-1",
             role_id="role-1",
         )
         # After consolidation, entries should be promoted to MEDIUM_TERM
-        medium = _list_entries(memory_bank_service, "ws-1", MemoryTier.MEDIUM_TERM)
+        medium = await _list_entries(
+            memory_bank_service, "ws-1", MemoryTier.MEDIUM_TERM
+        )
         assert len(medium) >= 1
 
 
 class TestOnSessionCompleted:
-    def test_consolidates_medium_to_persistent(
+    async def test_consolidates_medium_to_persistent(
         self,
         handler: MemoryEventHandler,
         memory_bank_service: MemoryBankService,
     ) -> None:
         # Create and promote to MEDIUM_TERM via run consolidation
         for i in range(2):
-            handler.on_task_completed(
+            await handler.on_task_completed_async(
                 workspace_id="ws-1",
                 role_id="role-1",
                 session_id="sess-1",
@@ -186,41 +192,43 @@ class TestOnSessionCompleted:
                 objective=f"Obj {i}",
                 result=f"Res {i}",
             )
-        handler.on_run_completed(
+        await handler.on_run_completed_async(
             workspace_id="ws-1",
             session_id="sess-1",
             role_id="role-1",
         )
 
         # Now consolidate on session completion
-        handler.on_session_completed(
+        await handler.on_session_completed_async(
             workspace_id="ws-1",
             session_id="sess-1",
             role_id="role-1",
         )
 
-        persistent = _list_entries(memory_bank_service, "ws-1", MemoryTier.PERSISTENT)
+        persistent = await _list_entries(
+            memory_bank_service, "ws-1", MemoryTier.PERSISTENT
+        )
         assert len(persistent) >= 1
 
 
 class TestGetInjectableMemoryText:
-    def test_returns_empty_for_no_entries(
+    async def test_returns_empty_for_no_entries(
         self,
         handler: MemoryEventHandler,
     ) -> None:
-        text = handler.get_injectable_memory_text(
+        text = await handler.get_injectable_memory_text_async(
             workspace_id="ws-empty",
             role_id="role-1",
         )
         assert text == ""
 
-    def test_returns_text_for_persistent_entries(
+    async def test_returns_text_for_persistent_entries(
         self,
         handler: MemoryEventHandler,
         memory_bank_service: MemoryBankService,
     ) -> None:
         # Create and promote entries to PERSISTENT
-        handler.on_task_completed(
+        await handler.on_task_completed_async(
             workspace_id="ws-1",
             role_id="role-1",
             session_id="sess-1",
@@ -229,18 +237,18 @@ class TestGetInjectableMemoryText:
             objective="Important insight",
             result="Discovered X",
         )
-        handler.on_run_completed(
+        await handler.on_run_completed_async(
             workspace_id="ws-1",
             session_id="sess-1",
             role_id="role-1",
         )
-        handler.on_session_completed(
+        await handler.on_session_completed_async(
             workspace_id="ws-1",
             session_id="sess-1",
             role_id="role-1",
         )
 
-        text = handler.get_injectable_memory_text(
+        text = await handler.get_injectable_memory_text_async(
             workspace_id="ws-1",
             role_id="role-1",
         )

--- a/tests/unit_tests/memory/test_memory_repository.py
+++ b/tests/unit_tests/memory/test_memory_repository.py
@@ -17,6 +17,9 @@ from relay_teams.memory.models import (
     MemoryTier,
 )
 from relay_teams.memory.repository import MemoryBankRepository, generate_memory_id
+from relay_teams.persistence.sqlite_repository import async_fetchall, async_fetchone
+
+pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
@@ -55,19 +58,23 @@ def repo(tmp_path: Path) -> MemoryBankRepository:
 
 
 class TestSchemaInit:
-    def test_table_created_on_init(self, repo: MemoryBankRepository) -> None:
-        row = repo._run_read(
-            lambda: repo._conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_entries'"
-            ).fetchone()
+    async def test_table_created_on_init(self, repo: MemoryBankRepository) -> None:
+        row = await repo._run_async_read(
+            lambda conn: async_fetchone(
+                conn,
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='memory_entries'",
+            )
         )
         assert row is not None
 
-    def test_indexes_created(self, repo: MemoryBankRepository) -> None:
-        rows = repo._run_read(
-            lambda: repo._conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_memory_entries_%'"
-            ).fetchall()
+    async def test_indexes_created(self, repo: MemoryBankRepository) -> None:
+        rows = await repo._run_async_read(
+            lambda conn: async_fetchall(
+                conn,
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name LIKE 'idx_memory_entries_%'",
+            )
         )
         index_names = {str(row["name"]) for row in rows}
         expected = {
@@ -88,43 +95,45 @@ class TestSchemaInit:
 
 
 class TestCRUD:
-    def test_create_and_read(self, repo: MemoryBankRepository) -> None:
+    async def test_create_and_read(self, repo: MemoryBankRepository) -> None:
         entry = _make_entry()
-        repo.create_entry(entry=entry)
-        loaded = repo.get_by_id(entry.id)
+        await repo.create_entry_async(entry=entry)
+        loaded = await repo.get_by_id_async(entry.id)
         assert loaded is not None
         assert loaded.id == entry.id
         assert loaded.content.title == "Test entry"
         assert loaded.tier == MemoryTier.PERSISTENT
 
-    def test_read_nonexistent_returns_none(self, repo: MemoryBankRepository) -> None:
-        assert repo.get_by_id("mem-nonexistent") is None
+    async def test_read_nonexistent_returns_none(
+        self, repo: MemoryBankRepository
+    ) -> None:
+        assert await repo.get_by_id_async("mem-nonexistent") is None
 
-    def test_update(self, repo: MemoryBankRepository) -> None:
+    async def test_update(self, repo: MemoryBankRepository) -> None:
         entry = _make_entry()
-        repo.create_entry(entry=entry)
+        await repo.create_entry_async(entry=entry)
         updated = entry.model_copy(
             update={
                 "content": MemoryContent(title="Updated", body="New body"),
                 "version": 2,
             }
         )
-        result = repo.update_entry(entry.id, entry=updated)
+        result = await repo.update_entry_async(entry.id, entry=updated)
         assert result.content.title == "Updated"
         assert result.version == 2
 
-        reloaded = repo.get_by_id(entry.id)
+        reloaded = await repo.get_by_id_async(entry.id)
         assert reloaded is not None
         assert reloaded.content.title == "Updated"
 
-    def test_delete(self, repo: MemoryBankRepository) -> None:
+    async def test_delete(self, repo: MemoryBankRepository) -> None:
         entry = _make_entry()
-        repo.create_entry(entry=entry)
-        assert repo.delete_entry(entry.id) is True
-        assert repo.get_by_id(entry.id) is None
+        await repo.create_entry_async(entry=entry)
+        assert await repo.delete_entry_async(entry.id) is True
+        assert await repo.get_by_id_async(entry.id) is None
 
-    def test_delete_nonexistent(self, repo: MemoryBankRepository) -> None:
-        assert repo.delete_entry("mem-nonexistent") is False
+    async def test_delete_nonexistent(self, repo: MemoryBankRepository) -> None:
+        assert await repo.delete_entry_async("mem-nonexistent") is False
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +142,7 @@ class TestCRUD:
 
 
 class TestQuery:
-    def _seed_entries(self, repo: MemoryBankRepository) -> list[MemoryEntry]:
+    async def _seed_entries(self, repo: MemoryBankRepository) -> list[MemoryEntry]:
         entries = [
             _make_entry(
                 id="mem-p1",
@@ -162,35 +171,35 @@ class TestQuery:
             ),
         ]
         for e in entries:
-            repo.create_entry(entry=e)
+            await repo.create_entry_async(entry=e)
         return entries
 
-    def test_filter_by_tier(self, repo: MemoryBankRepository) -> None:
-        self._seed_entries(repo)
-        result = repo.query_entries(
+    async def test_filter_by_tier(self, repo: MemoryBankRepository) -> None:
+        await self._seed_entries(repo)
+        result = await repo.query_entries_async(
             MemoryQuery(workspace_id="ws-test", tier=MemoryTier.PERSISTENT)
         )
         assert result.total_count >= 1
         assert all(s.tier == MemoryTier.PERSISTENT for s in result.items)
 
-    def test_filter_by_kind(self, repo: MemoryBankRepository) -> None:
-        self._seed_entries(repo)
-        result = repo.query_entries(
+    async def test_filter_by_kind(self, repo: MemoryBankRepository) -> None:
+        await self._seed_entries(repo)
+        result = await repo.query_entries_async(
             MemoryQuery(workspace_id="ws-test", kind=MemoryEntryKind.INSIGHT)
         )
         assert result.total_count >= 1
         assert all(s.kind == MemoryEntryKind.INSIGHT for s in result.items)
 
-    def test_filter_by_min_confidence(self, repo: MemoryBankRepository) -> None:
-        self._seed_entries(repo)
-        result = repo.query_entries(
+    async def test_filter_by_min_confidence(self, repo: MemoryBankRepository) -> None:
+        await self._seed_entries(repo)
+        result = await repo.query_entries_async(
             MemoryQuery(workspace_id="ws-test", min_confidence=0.8)
         )
         assert all(s.confidence_score >= 0.8 for s in result.items)
 
-    def test_pagination(self, repo: MemoryBankRepository) -> None:
-        self._seed_entries(repo)
-        result = repo.query_entries(
+    async def test_pagination(self, repo: MemoryBankRepository) -> None:
+        await self._seed_entries(repo)
+        result = await repo.query_entries_async(
             MemoryQuery(workspace_id="ws-test", limit=2, offset=0)
         )
         assert len(result.items) <= 2
@@ -204,33 +213,33 @@ class TestQuery:
 
 
 class TestExpiry:
-    def test_expire_entries(self, repo: MemoryBankRepository) -> None:
+    async def test_expire_entries(self, repo: MemoryBankRepository) -> None:
         past = datetime.now(tz=timezone.utc) - timedelta(hours=1)
         entry = _make_entry(
             status=MemoryEntryStatus.ACTIVE,
             expires_at=past,
         )
-        repo.create_entry(entry=entry)
+        await repo.create_entry_async(entry=entry)
 
-        expired_count = repo.expire_entries()
+        expired_count = await repo.expire_entries_async()
         assert expired_count >= 1
 
-        loaded = repo.get_by_id(entry.id)
+        loaded = await repo.get_by_id_async(entry.id)
         assert loaded is not None
         assert loaded.status == MemoryEntryStatus.EXPIRED
 
-    def test_no_expire_future(self, repo: MemoryBankRepository) -> None:
+    async def test_no_expire_future(self, repo: MemoryBankRepository) -> None:
         future = datetime.now(tz=timezone.utc) + timedelta(hours=10)
         entry = _make_entry(
             status=MemoryEntryStatus.ACTIVE,
             expires_at=future,
         )
-        repo.create_entry(entry=entry)
+        await repo.create_entry_async(entry=entry)
 
-        expired_count = repo.expire_entries()
+        expired_count = await repo.expire_entries_async()
         assert expired_count == 0
 
-        loaded = repo.get_by_id(entry.id)
+        loaded = await repo.get_by_id_async(entry.id)
         assert loaded is not None
         assert loaded.status == MemoryEntryStatus.ACTIVE
 
@@ -241,35 +250,35 @@ class TestExpiry:
 
 
 class TestConfidenceDecay:
-    def test_decay_and_expire(self, repo: MemoryBankRepository) -> None:
+    async def test_decay_and_expire(self, repo: MemoryBankRepository) -> None:
         entry = _make_entry(
             tier=MemoryTier.MEDIUM_TERM,
             confidence_score=0.21,
         )
-        repo.create_entry(entry=entry)
+        await repo.create_entry_async(entry=entry)
 
         # With min_confidence=0.2, 0.21*0.98 = 0.2058 which is still >= 0.2
         # So we need min_confidence to be above that
-        count = repo.apply_confidence_decay(min_confidence=0.21)
+        count = await repo.apply_confidence_decay_async(min_confidence=0.21)
         # After decay: 0.21 * 0.98 = 0.2058, which is < 0.21 threshold
         assert count >= 1
 
-        loaded = repo.get_by_id(entry.id)
+        loaded = await repo.get_by_id_async(entry.id)
         assert loaded is not None
         assert loaded.status == MemoryEntryStatus.EXPIRED
 
-    def test_no_decay_working_tier(self, repo: MemoryBankRepository) -> None:
+    async def test_no_decay_working_tier(self, repo: MemoryBankRepository) -> None:
         entry = _make_entry(
             tier=MemoryTier.WORKING,
             run_id="run-1",
             confidence_score=0.5,
         )
-        repo.create_entry(entry=entry)
+        await repo.create_entry_async(entry=entry)
 
         # Working tier doesn't decay, but min_confidence check still applies
-        repo.apply_confidence_decay(min_confidence=0.4)
+        await repo.apply_confidence_decay_async(min_confidence=0.4)
 
-        loaded = repo.get_by_id(entry.id)
+        loaded = await repo.get_by_id_async(entry.id)
         assert loaded is not None
         assert loaded.confidence_score == 0.5  # unchanged -- working tier
 
@@ -280,7 +289,7 @@ class TestConfidenceDecay:
 
 
 class TestGenerateId:
-    def test_generates_mem_prefix(self) -> None:
+    async def test_generates_mem_prefix(self) -> None:
         mid = generate_memory_id()
         assert mid.startswith("mem-")
         assert len(mid) > 4

--- a/tests/unit_tests/memory/test_memory_service.py
+++ b/tests/unit_tests/memory/test_memory_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -16,12 +16,15 @@ from relay_teams.memory.models import (
     MemoryQuery,
     MemoryScope,
     MemorySearchRequest,
+    MemorySearchResult,
     MemorySourceKind,
     MemoryTier,
     UpdateMemoryEntryRequest,
 )
 from relay_teams.memory.repository import MemoryBankRepository
 from relay_teams.memory.service import MemoryBankService
+
+pytestmark = pytest.mark.asyncio
 
 
 # ---------------------------------------------------------------------------
@@ -57,26 +60,26 @@ def _create_request(**overrides: object) -> CreateMemoryEntryRequest:
 
 
 class TestCreateEntry:
-    def test_create_persistent(self, service: MemoryBankService) -> None:
+    async def test_create_persistent(self, service: MemoryBankService) -> None:
         req = _create_request(
             tier=MemoryTier.PERSISTENT,
             scope=MemoryScope.WORKSPACE,
         )
-        entry = service.create_entry(req)
+        entry = await service.create_entry_async(req)
         assert entry.id.startswith("mem-")
         assert entry.tier == MemoryTier.PERSISTENT
         assert entry.confidence_score == 1.0
         assert entry.expires_at is None  # persistent has no TTL
 
-    def test_create_working_has_ttl(self, service: MemoryBankService) -> None:
+    async def test_create_working_has_ttl(self, service: MemoryBankService) -> None:
         req = _create_request()
-        entry = service.create_entry(req)
+        entry = await service.create_entry_async(req)
         assert entry.expires_at is not None
         assert entry.expires_at > datetime.now(tz=timezone.utc)
 
-    def test_create_with_tags(self, service: MemoryBankService) -> None:
+    async def test_create_with_tags(self, service: MemoryBankService) -> None:
         req = _create_request(tags=("python", "pydantic"))
-        entry = service.create_entry(req)
+        entry = await service.create_entry_async(req)
         assert entry.tags == ("python", "pydantic")
 
 
@@ -86,32 +89,34 @@ class TestCreateEntry:
 
 
 class TestUpdateEntry:
-    def test_update_increments_version(self, service: MemoryBankService) -> None:
+    async def test_update_increments_version(self, service: MemoryBankService) -> None:
         req = _create_request()
-        entry = service.create_entry(req)
+        entry = await service.create_entry_async(req)
         original_updated_at = entry.updated_at
 
         update = UpdateMemoryEntryRequest(
             content=MemoryContent(title="Updated title", body="Updated body")
         )
-        updated = service.update_entry(entry.id, update)
+        updated = await service.update_entry_async(entry.id, update)
         assert updated is not None
         assert updated.version == 2
         assert updated.content.title == "Updated title"
         assert updated.updated_at >= original_updated_at
 
-    def test_update_nonexistent_returns_none(self, service: MemoryBankService) -> None:
+    async def test_update_nonexistent_returns_none(
+        self, service: MemoryBankService
+    ) -> None:
         update = UpdateMemoryEntryRequest(content=MemoryContent(title="X", body="Y"))
-        assert service.update_entry("mem-nonexistent", update) is None
+        assert await service.update_entry_async("mem-nonexistent", update) is None
 
-    def test_update_auto_expires_low_confidence(
+    async def test_update_auto_expires_low_confidence(
         self, service: MemoryBankService
     ) -> None:
         req = _create_request()
-        entry = service.create_entry(req)
+        entry = await service.create_entry_async(req)
 
         update = UpdateMemoryEntryRequest(confidence_score=0.1)
-        updated = service.update_entry(entry.id, update)
+        updated = await service.update_entry_async(entry.id, update)
         assert updated is not None
         assert updated.status == MemoryEntryStatus.EXPIRED
 
@@ -122,13 +127,13 @@ class TestUpdateEntry:
 
 
 class TestConsolidation:
-    def test_consolidate_working_to_medium_term(
+    async def test_consolidate_working_to_medium_term(
         self, service: MemoryBankService
     ) -> None:
         req = _create_request()
-        service.create_entry(req)
+        await service.create_entry_async(req)
 
-        result = service.consolidate(
+        result = await service.consolidate_async(
             MemoryConsolidationRequest(
                 workspace_id="ws-test",
                 session_id="sess-1",
@@ -141,11 +146,11 @@ class TestConsolidation:
         assert len(result.new_entry_ids) >= 1
         assert len(result.superseded_entry_ids) >= 1
 
-    def test_consolidate_target_cannot_be_working(
+    async def test_consolidate_target_cannot_be_working(
         self, service: MemoryBankService
     ) -> None:
         with pytest.raises(Exception):
-            service.consolidate(
+            await service.consolidate_async(
                 MemoryConsolidationRequest(
                     workspace_id="ws-test",
                     target_tier=MemoryTier.WORKING,
@@ -160,19 +165,19 @@ class TestConsolidation:
 
 
 class TestForgetting:
-    def test_forget_expired(self, service: MemoryBankService) -> None:
+    async def test_forget_expired(self, service: MemoryBankService) -> None:
         req = _create_request()
-        entry = service.create_entry(req)
+        entry = await service.create_entry_async(req)
 
         # Manually set expires_at to past
         past = datetime.now(tz=timezone.utc) - timedelta(hours=1)
         update = UpdateMemoryEntryRequest(expires_at=past)
-        service.update_entry(entry.id, update)
+        await service.update_entry_async(entry.id, update)
 
-        count = service.forget_expired()
+        count = await service.forget_expired_async()
         assert count >= 1
 
-        loaded = service.get_entry(entry.id)
+        loaded = await service.get_entry_async(entry.id)
         assert loaded is not None
         assert loaded.status == MemoryEntryStatus.EXPIRED
 
@@ -183,14 +188,14 @@ class TestForgetting:
 
 
 class TestSearch:
-    def test_search_finds_match(self, service: MemoryBankService) -> None:
+    async def test_search_finds_match(self, service: MemoryBankService) -> None:
         req = _create_request(
             content=MemoryContent(
                 title="Pydantic validation", body="Uses Pydantic v2 models"
             )
         )
-        service.create_entry(req)
-        result = service.search(
+        await service.create_entry_async(req)
+        result = await service.search_async(
             MemorySearchRequest(
                 workspace_id="ws-test",
                 text_query="pydantic",
@@ -199,10 +204,10 @@ class TestSearch:
         assert result.total_count >= 1
         assert "pydantic" in result.items[0].entry.content_title.lower()
 
-    def test_search_no_match(self, service: MemoryBankService) -> None:
+    async def test_search_no_match(self, service: MemoryBankService) -> None:
         req = _create_request()
-        service.create_entry(req)
-        result = service.search(
+        await service.create_entry_async(req)
+        result = await service.search_async(
             MemorySearchRequest(
                 workspace_id="ws-test",
                 text_query="xyznonexistent",
@@ -217,26 +222,26 @@ class TestSearch:
 
 
 class TestGetListDelete:
-    def test_get_existing(self, service: MemoryBankService) -> None:
+    async def test_get_existing(self, service: MemoryBankService) -> None:
         req = _create_request()
-        entry = service.create_entry(req)
-        loaded = service.get_entry(entry.id)
+        entry = await service.create_entry_async(req)
+        loaded = await service.get_entry_async(entry.id)
         assert loaded is not None
         assert loaded.id == entry.id
 
-    def test_get_nonexistent(self, service: MemoryBankService) -> None:
-        assert service.get_entry("mem-none") is None
+    async def test_get_nonexistent(self, service: MemoryBankService) -> None:
+        assert await service.get_entry_async("mem-none") is None
 
-    def test_list_entries(self, service: MemoryBankService) -> None:
-        service.create_entry(_create_request())
-        result = service.list_entries(MemoryQuery(workspace_id="ws-test"))
+    async def test_list_entries(self, service: MemoryBankService) -> None:
+        await service.create_entry_async(_create_request())
+        result = await service.list_entries_async(MemoryQuery(workspace_id="ws-test"))
         assert result.total_count >= 1
 
-    def test_delete_entry(self, service: MemoryBankService) -> None:
+    async def test_delete_entry(self, service: MemoryBankService) -> None:
         req = _create_request()
-        entry = service.create_entry(req)
-        assert service.delete_entry(entry.id) is True
-        assert service.get_entry(entry.id) is None
+        entry = await service.create_entry_async(req)
+        assert await service.delete_entry_async(entry.id) is True
+        assert await service.get_entry_async(entry.id) is None
 
 
 # ---------------------------------------------------------------------------
@@ -247,17 +252,17 @@ class TestGetListDelete:
 class TestSearchFTS5:
     """Tests for the search method covering both FTS5-backed and fallback paths."""
 
-    def test_search_method_exists(self, service: MemoryBankService) -> None:
+    async def test_search_method_exists(self, service: MemoryBankService) -> None:
         """The search method must be callable and return MemorySearchResult."""
         req = _create_request()
-        service.create_entry(req)
-        result = service.search(
+        await service.create_entry_async(req)
+        result = await service.search_async(
             MemorySearchRequest(workspace_id="ws-test", text_query="pattern")
         )
-        assert hasattr(result, "total_count")
-        assert hasattr(result, "items")
+        assert isinstance(result, MemorySearchResult)
+        assert result.total_count >= 0
 
-    def test_search_without_retrieval_service_uses_fallback(
+    async def test_search_without_retrieval_service_uses_fallback(
         self, service: MemoryBankService
     ) -> None:
         """When no retrieval_service is configured, fallback LIKE search is used."""
@@ -267,8 +272,8 @@ class TestSearchFTS5:
                 title="Pydantic patterns", body="Advanced Pydantic v2 usage"
             )
         )
-        service.create_entry(req)
-        result = service.search(
+        await service.create_entry_async(req)
+        result = await service.search_async(
             MemorySearchRequest(workspace_id="ws-test", text_query="pydantic")
         )
         assert result.total_count >= 1
@@ -277,7 +282,7 @@ class TestSearchFTS5:
         assert hit.rank >= 1
         assert "pydantic" in hit.entry.content_title.lower()
 
-    def test_search_with_retrieval_service_uses_fts(
+    async def test_search_with_retrieval_service_uses_fts(
         self, service: MemoryBankService
     ) -> None:
         """When a retrieval_service IS configured, the FTS5 path is used."""
@@ -289,46 +294,50 @@ class TestSearchFTS5:
         req = _create_request(
             content=MemoryContent(title="FastAPI tips", body="Use dependency injection")
         )
-        entry = service.create_entry(req)
+        entry = await service.create_entry_async(req)
 
         # Build a mock retrieval service
         mock_retrieval = MagicMock()
-        mock_retrieval.search.return_value = [
-            RetrievalHit(
-                document_id=entry.id,
-                title="FastAPI tips",
-                snippet="...FastAPI...",
-                score=0.85,
-                rank=1,
-            )
-        ]
+        mock_retrieval.search_async = AsyncMock(
+            return_value=[
+                RetrievalHit(
+                    document_id=entry.id,
+                    title="FastAPI tips",
+                    snippet="...FastAPI...",
+                    score=0.85,
+                    rank=1,
+                )
+            ]
+        )
         service._retrieval_service = mock_retrieval
 
-        result = service.search(
+        result = await service.search_async(
             MemorySearchRequest(workspace_id="ws-test", text_query="fastapi")
         )
         assert result.total_count >= 1
         assert result.items[0].entry.id == entry.id
         assert result.items[0].score == 0.85
 
-    def test_search_fts_no_hits_returns_empty(self, service: MemoryBankService) -> None:
+    async def test_search_fts_no_hits_returns_empty(
+        self, service: MemoryBankService
+    ) -> None:
         """FTS5 path with zero hits returns empty result."""
         mock_retrieval = MagicMock()
-        mock_retrieval.search.return_value = []
+        mock_retrieval.search_async = AsyncMock(return_value=[])
         service._retrieval_service = mock_retrieval
 
-        result = service.search(
+        result = await service.search_async(
             MemorySearchRequest(workspace_id="ws-test", text_query="nope")
         )
         assert result.total_count == 0
         assert len(result.items) == 0
 
-    def test_build_snippet_short_body(self) -> None:
+    async def test_build_snippet_short_body(self) -> None:
         """_build_snippet returns body preview when query not found."""
         result = MemoryBankService._build_snippet("Short body text", "missing")
         assert result == "Short body text"
 
-    def test_build_snippet_highlights_match(self) -> None:
+    async def test_build_snippet_highlights_match(self) -> None:
         """_build_snippet extracts context around the match."""
         body = "A" * 100 + "TARGET" + "B" * 100
         result = MemoryBankService._build_snippet(body, "target")
@@ -343,11 +352,11 @@ class TestSearchFTS5:
 class TestCapacityEnforcement:
     """Tests for enforce_capacity which prunes oldest entries when limits exceeded."""
 
-    def test_enforce_capacity_returns_zero_when_below_limit(
+    async def test_enforce_capacity_returns_zero_when_below_limit(
         self, service: MemoryBankService
     ) -> None:
         """No pruning when entry count is below the capacity limit."""
-        pruned = service.enforce_capacity(
+        pruned = await service.enforce_capacity_async(
             workspace_id="ws-test",
             tier=MemoryTier.PERSISTENT,
             scope=MemoryScope.WORKSPACE,
@@ -355,7 +364,7 @@ class TestCapacityEnforcement:
         # We have 0 persistent entries, well below 2000 limit
         assert pruned == 0
 
-    def test_enforce_capacity_prunes_working_entries(
+    async def test_enforce_capacity_prunes_working_entries(
         self, service: MemoryBankService
     ) -> None:
         """When WORKING entries exceed MAX_WORKING_PER_RUN limit, oldest are pruned."""
@@ -365,10 +374,10 @@ class TestCapacityEnforcement:
         run_id = "run-cap-test"
         for i in range(MAX_WORKING_PER_RUN + 1):
             req = _create_request(run_id=run_id)
-            service.create_entry(req)
+            await service.create_entry_async(req)
 
         # Verify capacity enforcement happened during create
-        result = service.list_entries(
+        result = await service.list_entries_async(
             MemoryQuery(
                 workspace_id="ws-test",
                 tier=MemoryTier.WORKING,
@@ -379,7 +388,7 @@ class TestCapacityEnforcement:
         active_count = result.total_count
         assert active_count <= MAX_WORKING_PER_RUN
 
-    def test_enforce_capacity_does_not_affect_different_tier(
+    async def test_enforce_capacity_does_not_affect_different_tier(
         self, service: MemoryBankService
     ) -> None:
         """Creating many WORKING entries should not prune PERSISTENT entries."""
@@ -388,20 +397,22 @@ class TestCapacityEnforcement:
             tier=MemoryTier.PERSISTENT,
             scope=MemoryScope.WORKSPACE,
         )
-        persistent = service.create_entry(req_p)
+        persistent = await service.create_entry_async(req_p)
 
         # Create many working entries
         for i in range(10):
             req_w = _create_request(run_id=f"run-{i}")
-            service.create_entry(req_w)
+            await service.create_entry_async(req_w)
 
         # Persistent entry should still exist and be active
-        loaded = service.get_entry(persistent.id)
+        loaded = await service.get_entry_async(persistent.id)
         assert loaded is not None
         assert loaded.status == MemoryEntryStatus.ACTIVE
         assert loaded.tier == MemoryTier.PERSISTENT
 
-    def test_enforce_capacity_prunes_by_age(self, service: MemoryBankService) -> None:
+    async def test_enforce_capacity_prunes_by_age(
+        self, service: MemoryBankService
+    ) -> None:
         """When PERSISTENT entries exceed capacity, oldest are expired first."""
         from relay_teams.memory import memory_defaults
 
@@ -415,11 +426,11 @@ class TestCapacityEnforcement:
                     tier=MemoryTier.PERSISTENT,
                     scope=MemoryScope.WORKSPACE,
                 )
-                entry = service.create_entry(req)
+                entry = await service.create_entry_async(req)
                 ids.append(entry.id)
 
             # Count active entries -- should be <= 3
-            result = service.list_entries(
+            result = await service.list_entries_async(
                 MemoryQuery(
                     workspace_id="ws-test",
                     tier=MemoryTier.PERSISTENT,
@@ -438,7 +449,9 @@ class TestCapacityEnforcement:
 
 
 class TestCondensation:
-    def test_condense_raises_not_implemented(self, service: MemoryBankService) -> None:
+    async def test_condense_raises_not_implemented(
+        self, service: MemoryBankService
+    ) -> None:
         """Condensation is a placeholder that raises NotImplementedError."""
         with pytest.raises(NotImplementedError, match="not yet implemented"):
             service.condense("ws-test")

--- a/tests/unit_tests/memory/test_semantic_consolidation.py
+++ b/tests/unit_tests/memory/test_semantic_consolidation.py
@@ -37,6 +37,8 @@ from relay_teams.providers.provider_contracts import (
     EchoProvider,
 )
 
+pytestmark = pytest.mark.asyncio
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -79,7 +81,7 @@ def _create_entry_request(**overrides: object) -> CreateMemoryEntryRequest:
 
 
 class TestSemanticModeRequiresSourceRunId:
-    def test_semantic_mode_without_source_run_id_raises(self) -> None:
+    async def test_semantic_mode_without_source_run_id_raises(self) -> None:
         with pytest.raises(ValueError, match="source_run_id is required"):
             MemoryConsolidationRequest(
                 workspace_id="ws-1",
@@ -89,7 +91,7 @@ class TestSemanticModeRequiresSourceRunId:
                 source_run_id=None,
             )
 
-    def test_semantic_mode_with_source_run_id_ok(self) -> None:
+    async def test_semantic_mode_with_source_run_id_ok(self) -> None:
         req = MemoryConsolidationRequest(
             workspace_id="ws-1",
             target_tier=MemoryTier.MEDIUM_TERM,
@@ -107,9 +109,11 @@ class TestSemanticModeRequiresSourceRunId:
 
 
 class TestStructuralModeUnchanged:
-    def test_structural_mode_still_works(self, service: MemoryBankService) -> None:
+    async def test_structural_mode_still_works(
+        self, service: MemoryBankService
+    ) -> None:
         # Create a WORKING entry
-        entry = service.create_entry(
+        entry = await service.create_entry_async(
             _create_entry_request(
                 tier=MemoryTier.WORKING,
                 scope=MemoryScope.WORKSPACE,
@@ -126,11 +130,11 @@ class TestStructuralModeUnchanged:
             target_scope=MemoryScope.SESSION,
             consolidation_mode=ConsolidationMode.STRUCTURAL,
         )
-        result = service.consolidate(req)
+        result = await service.consolidate_async(req)
         assert result.consolidated_entry_count >= 0
         assert result.source_entry_count >= 0
 
-    def test_default_mode_is_structural(self) -> None:
+    async def test_default_mode_is_structural(self) -> None:
         req = MemoryConsolidationRequest(
             workspace_id="ws-1",
             target_tier=MemoryTier.MEDIUM_TERM,
@@ -145,7 +149,7 @@ class TestStructuralModeUnchanged:
 
 
 class TestSemanticOutputParsingValidJson:
-    def test_valid_json_parses(self) -> None:
+    async def test_valid_json_parses(self) -> None:
         valid_json = """{
             "extractions": [
                 {
@@ -165,7 +169,7 @@ class TestSemanticOutputParsingValidJson:
         assert output.extractions[0].title == "Use Pydantic v2"
         assert output.extractions[0].confidence_score == 0.9
 
-    def test_json_with_code_fences_parses(self) -> None:
+    async def test_json_with_code_fences_parses(self) -> None:
         fenced = """```json
 {
     "extractions": [
@@ -189,7 +193,7 @@ class TestSemanticOutputParsingValidJson:
 
 
 class TestSemanticOutputParsingInvalidJson:
-    def test_invalid_json_falls_back(self) -> None:
+    async def test_invalid_json_falls_back(self) -> None:
         result = _strip_json_code_fences("not json at all")
         with pytest.raises(ValueError):
             SemanticExtractionOutput.model_validate_json(result)
@@ -201,7 +205,9 @@ class TestSemanticOutputParsingInvalidJson:
 
 
 class TestSemanticCreatesCorrectEntries:
-    def test_semantic_result_fields(self, service_with_llm: MemoryBankService) -> None:
+    async def test_semantic_result_fields(
+        self, service_with_llm: MemoryBankService
+    ) -> None:
         """Test that the semantic consolidation result has correct field values."""
         req = MemoryConsolidationRequest(
             workspace_id="ws-test",
@@ -212,7 +218,7 @@ class TestSemanticCreatesCorrectEntries:
             consolidation_mode=ConsolidationMode.SEMANTIC,
         )
         # With EchoProvider and no messages, it falls back to structural
-        result = service_with_llm.consolidate(req)
+        result = await service_with_llm.consolidate_async(req)
         assert isinstance(result, MemoryConsolidationResult)
         assert result.extraction_tokens_used >= 0
         assert result.extraction_duration_ms >= 0
@@ -224,7 +230,7 @@ class TestSemanticCreatesCorrectEntries:
 
 
 class TestExtractionKindsFilter:
-    def test_extraction_kinds_empty_returns_all(self) -> None:
+    async def test_extraction_kinds_empty_returns_all(self) -> None:
         # Empty kinds means all kinds
         kinds: tuple[MemoryEntryKind, ...] = ()
         prompt = _build_extraction_instructions(kinds)
@@ -232,7 +238,7 @@ class TestExtractionKindsFilter:
         for kind in tuple(MemoryEntryKind):
             assert kind.value in prompt
 
-    def test_extraction_kinds_filters(self) -> None:
+    async def test_extraction_kinds_filters(self) -> None:
         kinds = (MemoryEntryKind.DECISION, MemoryEntryKind.FAILURE_MODE)
         prompt = _build_extraction_instructions(kinds)
         assert "decision" in prompt
@@ -246,7 +252,7 @@ class TestExtractionKindsFilter:
 
 
 class TestMaxExtractedEntries:
-    def test_max_extracted_entries_default(self) -> None:
+    async def test_max_extracted_entries_default(self) -> None:
         req = MemoryConsolidationRequest(
             workspace_id="ws-1",
             target_tier=MemoryTier.MEDIUM_TERM,
@@ -254,7 +260,7 @@ class TestMaxExtractedEntries:
         )
         assert req.max_extracted_entries == 10
 
-    def test_max_extracted_entries_custom(self) -> None:
+    async def test_max_extracted_entries_custom(self) -> None:
         req = MemoryConsolidationRequest(
             workspace_id="ws-1",
             target_tier=MemoryTier.MEDIUM_TERM,
@@ -263,7 +269,7 @@ class TestMaxExtractedEntries:
         )
         assert req.max_extracted_entries == 5
 
-    def test_max_extracted_entries_bounds(self) -> None:
+    async def test_max_extracted_entries_bounds(self) -> None:
         with pytest.raises(ValueError):
             MemoryConsolidationRequest(
                 workspace_id="ws-1",
@@ -286,10 +292,10 @@ class TestMaxExtractedEntries:
 
 
 class TestSupersededMarking:
-    def test_structural_marks_source_superseded(
+    async def test_structural_marks_source_superseded(
         self, service: MemoryBankService
     ) -> None:
-        service.create_entry(
+        await service.create_entry_async(
             _create_entry_request(
                 tier=MemoryTier.WORKING,
                 scope=MemoryScope.WORKSPACE,
@@ -302,9 +308,9 @@ class TestSupersededMarking:
             target_tier=MemoryTier.MEDIUM_TERM,
             target_scope=MemoryScope.SESSION,
         )
-        result = service.consolidate(req)
+        result = await service.consolidate_async(req)
         if result.superseded_entry_ids:
-            superseded = service.get_entry(result.superseded_entry_ids[0])
+            superseded = await service.get_entry_async(result.superseded_entry_ids[0])
             assert superseded is not None
             assert superseded.status == MemoryEntryStatus.SUPERSEDED
             assert superseded.superseded_by_id in result.new_entry_ids
@@ -316,17 +322,17 @@ class TestSupersededMarking:
 
 
 class TestBuildExtractionInstructions:
-    def test_all_kinds_covered(self) -> None:
+    async def test_all_kinds_covered(self) -> None:
         for kind in tuple(MemoryEntryKind):
             instructions = _build_extraction_instructions((kind,))
             assert kind.value in instructions
 
-    def test_empty_kinds_covers_all(self) -> None:
+    async def test_empty_kinds_covers_all(self) -> None:
         instructions = _build_extraction_instructions(())
         for kind in tuple(MemoryEntryKind):
             assert kind.value in instructions
 
-    def test_multiple_kinds(self) -> None:
+    async def test_multiple_kinds(self) -> None:
         result = _build_extraction_instructions(
             (MemoryEntryKind.DECISION, MemoryEntryKind.FACT)
         )
@@ -341,16 +347,16 @@ class TestBuildExtractionInstructions:
 
 
 class TestStripJsonCodeFences:
-    def test_no_fences(self) -> None:
+    async def test_no_fences(self) -> None:
         assert _strip_json_code_fences('{"key": "value"}') == '{"key": "value"}'
 
-    def test_json_fence(self) -> None:
+    async def test_json_fence(self) -> None:
         assert (
             _strip_json_code_fences('```json\n{"key": "value"}\n```')
             == '{"key": "value"}'
         )
 
-    def test_generic_fence(self) -> None:
+    async def test_generic_fence(self) -> None:
         assert (
             _strip_json_code_fences('```\n{"key": "value"}\n```') == '{"key": "value"}'
         )
@@ -362,11 +368,11 @@ class TestStripJsonCodeFences:
 
 
 class TestFormatConversationMessages:
-    def test_empty_messages(self) -> None:
+    async def test_empty_messages(self) -> None:
         result = _format_conversation_messages([])
         assert result == ()
 
-    def test_user_and_assistant_messages(self) -> None:
+    async def test_user_and_assistant_messages(self) -> None:
         msgs: list[dict[str, object]] = [
             {"role": "user", "message_json": '{"content": "Hello"}'},
             {"role": "assistant", "message_json": '{"content": "Hi there"}'},
@@ -376,7 +382,7 @@ class TestFormatConversationMessages:
         assert "user" in result[0]
         assert "assistant" in result[1]
 
-    def test_string_message_json(self) -> None:
+    async def test_string_message_json(self) -> None:
         msgs: list[dict[str, object]] = [
             {"role": "system", "message_json": "System initialization"},
         ]
@@ -384,7 +390,7 @@ class TestFormatConversationMessages:
         assert len(result) == 1
         assert "System initialization" in result[0]
 
-    def test_dict_message_json_with_content(self) -> None:
+    async def test_dict_message_json_with_content(self) -> None:
         msgs: list[dict[str, object]] = [
             {"role": "user", "message_json": {"content": "Hello from dict"}},
         ]
@@ -392,7 +398,7 @@ class TestFormatConversationMessages:
         assert len(result) == 1
         assert "Hello from dict" in result[0]
 
-    def test_dict_message_json_without_content(self) -> None:
+    async def test_dict_message_json_without_content(self) -> None:
         msgs: list[dict[str, object]] = [
             {"role": "user", "message_json": {"other_key": "value"}},
         ]
@@ -400,7 +406,7 @@ class TestFormatConversationMessages:
         assert len(result) == 1
         assert "" in result[0]
 
-    def test_none_message_json(self) -> None:
+    async def test_none_message_json(self) -> None:
         msgs: list[dict[str, object]] = [
             {"role": "user"},
         ]
@@ -408,7 +414,7 @@ class TestFormatConversationMessages:
         assert len(result) == 1
         assert "[user]:" in result[0]
 
-    def test_token_truncation(self) -> None:
+    async def test_token_truncation(self) -> None:
         msgs: list[dict[str, object]] = [
             {"role": "user", "message_json": "a" * 100},
             {"role": "assistant", "message_json": "b" * 100},
@@ -418,7 +424,7 @@ class TestFormatConversationMessages:
         result = _format_conversation_messages(msgs, max_tokens=10)
         assert len(result) < 3
 
-    def test_token_truncation_keeps_latest(self) -> None:
+    async def test_token_truncation_keeps_latest(self) -> None:
         msgs: list[dict[str, object]] = [
             {"role": "user", "message_json": "first"},
             {"role": "assistant", "message_json": "last message content"},
@@ -435,7 +441,7 @@ class TestFormatConversationMessages:
 
 
 class TestSemanticExtractionInputModel:
-    def test_valid_input(self) -> None:
+    async def test_valid_input(self) -> None:
         inp = SemanticExtractionInput(
             conversation_messages=("msg1", "msg2"),
             task_objective="Build a memory system",
@@ -452,7 +458,7 @@ class TestSemanticExtractionInputModel:
 
 
 class TestExtractedMemoryEntryModel:
-    def test_minimal_entry(self) -> None:
+    async def test_minimal_entry(self) -> None:
         entry = _ExtractedMemoryEntry(
             kind=MemoryEntryKind.FACT,
             title="A fact",
@@ -461,7 +467,7 @@ class TestExtractedMemoryEntryModel:
         assert entry.confidence_score == 0.7
         assert entry.tags == ()
 
-    def test_confidence_out_of_bounds(self) -> None:
+    async def test_confidence_out_of_bounds(self) -> None:
         with pytest.raises(ValueError):
             _ExtractedMemoryEntry(
                 kind=MemoryEntryKind.FACT,
@@ -484,7 +490,7 @@ class TestExtractedMemoryEntryModel:
 
 
 class TestMemoryConsolidationResultFields:
-    def test_default_extraction_fields(self) -> None:
+    async def test_default_extraction_fields(self) -> None:
         result = MemoryConsolidationResult(
             source_entry_count=5,
             consolidated_entry_count=3,
@@ -494,7 +500,7 @@ class TestMemoryConsolidationResultFields:
         assert result.extraction_tokens_used == 0
         assert result.extraction_duration_ms == 0
 
-    def test_custom_extraction_fields(self) -> None:
+    async def test_custom_extraction_fields(self) -> None:
         result = MemoryConsolidationResult(
             source_entry_count=5,
             consolidated_entry_count=3,
@@ -521,7 +527,7 @@ class TestConsolidateAsync:
     ) -> None:
         """consolidate_async with STRUCTURAL mode hits
         _consolidate_structural_async."""
-        service.create_entry(
+        await service.create_entry_async(
             _create_entry_request(
                 tier=MemoryTier.WORKING,
                 confidence_score=0.85,
@@ -543,7 +549,7 @@ class TestConsolidateAsync:
     ) -> None:
         """consolidate_async with SEMANTIC + no llm_provider falls back
         to structural."""
-        service.create_entry(
+        await service.create_entry_async(
             _create_entry_request(
                 tier=MemoryTier.WORKING,
                 confidence_score=0.85,
@@ -567,7 +573,7 @@ class TestConsolidateAsync:
     ) -> None:
         """consolidate_async with SEMANTIC + llm_provider but no
         message_repo still falls back to structural."""
-        service_with_llm.create_entry(
+        await service_with_llm.create_entry_async(
             _create_entry_request(
                 tier=MemoryTier.WORKING,
                 confidence_score=0.85,
@@ -592,21 +598,21 @@ class TestConsolidateAsync:
 
 
 class TestEstimateTokens:
-    def test_empty_string(self) -> None:
+    async def test_empty_string(self) -> None:
         assert _estimate_tokens("") == 0
 
-    def test_none_text(self) -> None:
+    async def test_none_text(self) -> None:
         assert _estimate_tokens("") == 0
 
-    def test_short_text(self) -> None:
+    async def test_short_text(self) -> None:
         # 3 chars -> max(1, 3//4) = max(1, 0) = 1
         assert _estimate_tokens("abc") == 1
 
-    def test_longer_text(self) -> None:
+    async def test_longer_text(self) -> None:
         # 16 chars -> 16 // 4 = 4
         assert _estimate_tokens("a" * 16) == 4
 
-    def test_exactly_four_chars(self) -> None:
+    async def test_exactly_four_chars(self) -> None:
         assert _estimate_tokens("abcd") == 1
 
 

--- a/tests/unit_tests/net/test_proxy_transports.py
+++ b/tests/unit_tests/net/test_proxy_transports.py
@@ -2,12 +2,19 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Iterator
+import json
 
 import httpx
 import pytest
 
 from relay_teams.env.proxy_env import ProxyEnvConfig
-from relay_teams.net.proxy_transports import AsyncProxyRoutingTransport
+from relay_teams.net.proxy_transports import (
+    AsyncProxyRoutingTransport,
+    _chunk_has_complete_tool_call_delta,
+    _chunk_has_terminal_sse_marker,
+    _payload_has_complete_tool_call_delta,
+    _tool_call_deltas_have_complete_arguments,
+)
 
 
 class _FakeLease:
@@ -95,6 +102,54 @@ def _build_transport(
     return transport, fake_transport
 
 
+def test_terminal_sse_marker_helpers_cover_non_terminal_payloads() -> None:
+    assert _chunk_has_terminal_sse_marker(b"data: [DONE]\n\n") is True
+    assert (
+        _chunk_has_terminal_sse_marker(
+            b'data: {"choices":[{"finish_reason":null}]}\n\n'
+        )
+        is False
+    )
+    assert (
+        _chunk_has_terminal_sse_marker(
+            b'data: {"choices":[{"delta":{"content":{"finish_reason":"stop"}},'
+            b'"finish_reason":null}]}\n\n'
+        )
+        is False
+    )
+    assert _chunk_has_complete_tool_call_delta(b"event: ping\n\n") is False
+    assert _payload_has_complete_tool_call_delta([]) is False
+    assert _payload_has_complete_tool_call_delta({"choices": "bad"}) is False
+    assert _payload_has_complete_tool_call_delta({"choices": [None]}) is False
+    assert (
+        _payload_has_complete_tool_call_delta({"choices": [{"delta": None}]}) is False
+    )
+    assert (
+        _payload_has_complete_tool_call_delta(
+            {"choices": [{"delta": {"tool_calls": []}}]}
+        )
+        is False
+    )
+
+
+def test_tool_call_delta_argument_validation_rejects_incomplete_payloads() -> None:
+    assert _tool_call_deltas_have_complete_arguments([None]) is False
+    assert _tool_call_deltas_have_complete_arguments([{}]) is False
+    assert _tool_call_deltas_have_complete_arguments([{"function": {}}]) is False
+    assert (
+        _tool_call_deltas_have_complete_arguments(
+            [{"function": {"arguments": "{not-json"}}]
+        )
+        is False
+    )
+    assert (
+        _tool_call_deltas_have_complete_arguments(
+            [{"function": {"arguments": "[1, 2]"}}]
+        )
+        is False
+    )
+
+
 @pytest.mark.asyncio
 async def test_async_proxy_transport_releases_limiter_after_stream_consumed() -> None:
     limiter = _FakeLimiter()
@@ -111,6 +166,205 @@ async def test_async_proxy_transport_releases_limiter_after_stream_consumed() ->
     assert limiter.acquired_urls == ["https://provider.example/v1/chat/completions"]
     assert limiter.lease.release_count == 0
     assert await response.aread() == b"ok"
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_on_sse_finish_reason() -> None:
+    limiter = _FakeLimiter()
+    stream = _ChunkStream(
+        chunks=(
+            b'data: {"choices":[{"finish_reason":"stop"}]}\n\n',
+            b"data: [DONE]\n\n",
+        )
+    )
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=stream),
+    )
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+    iterator = response.aiter_bytes().__aiter__()
+
+    assert await anext(iterator) == b'data: {"choices":[{"finish_reason":"stop"}]}\n\n'
+    assert limiter.lease.release_count == 1
+
+    await response.aclose()
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_on_split_sse_finish_reason() -> (
+    None
+):
+    limiter = _FakeLimiter()
+    stream = _ChunkStream(
+        chunks=(
+            b'data: {"choices":[{"finish_',
+            b'reason":"stop"}]}\n\n',
+            b"data: [DONE]\n\n",
+        )
+    )
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=stream),
+    )
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+    iterator = response.aiter_bytes().__aiter__()
+
+    assert await anext(iterator) == b'data: {"choices":[{"finish_'
+    assert limiter.lease.release_count == 0
+    assert await anext(iterator) == b'reason":"stop"}]}\n\n'
+    assert limiter.lease.release_count == 1
+
+    await response.aclose()
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_on_complete_tool_call_delta() -> (
+    None
+):
+    limiter = _FakeLimiter()
+    payload = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "orch_dispatch_task",
+                                "arguments": json.dumps({"task_id": "task-1"}),
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ]
+    }
+    first_chunk = f"data: {json.dumps(payload)}\n\n".encode()
+    stream = _ChunkStream(
+        chunks=(
+            first_chunk,
+            b'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+            b"data: [DONE]\n\n",
+        )
+    )
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=stream),
+    )
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+    iterator = response.aiter_bytes().__aiter__()
+
+    assert await anext(iterator) == first_chunk
+    assert limiter.lease.release_count == 1
+
+    await response.aclose()
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_releases_limiter_on_split_complete_tool_call_delta() -> (
+    None
+):
+    limiter = _FakeLimiter()
+    payload = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "orch_dispatch_task",
+                                "arguments": json.dumps({"payload": "x" * 800}),
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ]
+    }
+    full_chunk = f"data: {json.dumps(payload)}\n\n".encode()
+    first_chunk = full_chunk[:320]
+    second_chunk = full_chunk[320:]
+    stream = _ChunkStream(chunks=(first_chunk, second_chunk))
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=stream),
+    )
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+    iterator = response.aiter_bytes().__aiter__()
+
+    assert await anext(iterator) == first_chunk
+    assert limiter.lease.release_count == 0
+    assert await anext(iterator) == second_chunk
+    assert limiter.lease.release_count == 1
+
+    await response.aclose()
+    assert limiter.lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_keeps_limiter_for_partial_tool_call_delta() -> (
+    None
+):
+    limiter = _FakeLimiter()
+    payload = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "orch_dispatch_task",
+                                "arguments": '{"task_id":',
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ]
+    }
+    first_chunk = f"data: {json.dumps(payload)}\n\n".encode()
+    final_chunk = b'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n'
+    stream = _ChunkStream(chunks=(first_chunk, final_chunk))
+    transport, _ = _build_transport(
+        limiter=limiter,
+        direct_transport=_FakeTransport(stream=stream),
+    )
+
+    response = await transport.handle_async_request(
+        httpx.Request("GET", "https://provider.example/v1/chat/completions")
+    )
+    iterator = response.aiter_bytes().__aiter__()
+
+    assert await anext(iterator) == first_chunk
+    assert limiter.lease.release_count == 0
+    assert await anext(iterator) == final_chunk
+    assert limiter.lease.release_count == 1
+
+    await response.aclose()
     assert limiter.lease.release_count == 1
 
 

--- a/tests/unit_tests/persistence/test_sessionservice_async_coverage.py
+++ b/tests/unit_tests/persistence/test_sessionservice_async_coverage.py
@@ -27,14 +27,6 @@ async def test_list_normal_mode_subagents_async_delegates() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_agents_in_session_async_delegates() -> None:
-    mock_self = MagicMock()
-    method = SessionService.list_agents_in_session_async
-    await method(mock_self, cast(Any, ""))
-    getattr(mock_self, "list_agents_in_session").assert_called_once()
-
-
-@pytest.mark.asyncio
 async def test_get_session_rounds_async_delegates() -> None:
     mock_self = MagicMock()
     method = SessionService.get_session_rounds_async

--- a/tests/unit_tests/retrieval/test_service.py
+++ b/tests/unit_tests/retrieval/test_service.py
@@ -14,6 +14,7 @@ from relay_teams.metrics import (
     MetricScope,
     SqliteMetricAggregateStore,
 )
+from relay_teams.metrics.adapters import record_retrieval_rebuild_async
 from relay_teams.metrics.sinks import AggregateStoreSink
 from relay_teams.retrieval import (
     RetrievalBackendKind,
@@ -90,6 +91,14 @@ class _FakeRetrievalStore:
         self._scope_stats[(config.scope_kind, config.scope_id)] = stats
         return stats
 
+    async def upsert_documents_async(
+        self,
+        *,
+        config: RetrievalScopeConfig,
+        documents: tuple[RetrievalDocument, ...],
+    ) -> RetrievalStats:
+        return self.upsert_documents(config=config, documents=documents)
+
     def delete_documents(
         self,
         *,
@@ -116,6 +125,13 @@ class _FakeRetrievalStore:
         if self.raise_on_search:
             raise RuntimeError("search failed")
         return self.search_result
+
+    async def search_async(
+        self,
+        *,
+        query: RetrievalQuery,
+    ) -> tuple[RetrievalHit, ...]:
+        return self.search(query=query)
 
     def rebuild_scope(
         self,
@@ -266,6 +282,73 @@ def test_retrieval_service_records_document_count_gauge(tmp_path: Path) -> None:
     assert any(
         point.metric_name == "relay_teams.retrieval.document_count" and point.value == 2
         for point in points
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrieval_service_records_async_metrics(tmp_path: Path) -> None:
+    metric_store = SqliteMetricAggregateStore(tmp_path / "retrieval-async-metrics.db")
+    recorder = MetricRecorder(
+        registry=MetricRegistry(DEFAULT_DEFINITIONS),
+        sinks=(AggregateStoreSink(metric_store),),
+    )
+    fake_store = _seeded_fake_store()
+    service = RetrievalService(store=fake_store, metric_recorder=recorder)
+
+    await service.upsert_documents_async(
+        config=RetrievalScopeConfig(
+            scope_kind=RetrievalScopeKind.SKILL,
+            scope_id="skills",
+        ),
+        documents=(
+            RetrievalDocument(
+                scope_kind=RetrievalScopeKind.SKILL,
+                scope_id="skills",
+                document_id="async-doc",
+                title="Async",
+            ),
+        ),
+    )
+    hits = await service.search_async(
+        query=RetrievalQuery(
+            scope_kind=RetrievalScopeKind.SKILL,
+            scope_id="skills",
+            text="routing",
+            limit=5,
+        )
+    )
+    fake_store.raise_on_search = True
+    with pytest.raises(RuntimeError, match="search failed"):
+        await service.search_async(
+            query=RetrievalQuery(
+                scope_kind=RetrievalScopeKind.SKILL,
+                scope_id="skills",
+                text="routing",
+                limit=5,
+            )
+        )
+    await record_retrieval_rebuild_async(
+        recorder,
+        backend=RetrievalBackendKind.SQLITE_FTS5.value,
+        scope_kind=RetrievalScopeKind.SKILL.value,
+        duration_ms=7,
+        success=True,
+    )
+
+    assert [hit.document_id for hit in hits] == ["skill-router"]
+    points = metric_store.query_points(
+        scope=MetricScope.GLOBAL,
+        scope_id="global",
+        time_window_minutes=60,
+    )
+    assert any(
+        point.metric_name == "relay_teams.retrieval.document_count" for point in points
+    )
+    assert any(
+        point.metric_name == "relay_teams.retrieval.search_failures" for point in points
+    )
+    assert any(
+        point.metric_name == "relay_teams.retrieval.rebuilds" for point in points
     )
 
 

--- a/tests/unit_tests/roles/test_evolution_history.py
+++ b/tests/unit_tests/roles/test_evolution_history.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from relay_teams.memory.models import (
     MemoryContent,
     MemoryEntry,
@@ -17,6 +19,8 @@ from relay_teams.memory.models import (
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.roles.evolution_history import RoleEvolutionHistoryService
 from relay_teams.roles.prompt_adjustment_engine import PromptAdjustmentRepository
+
+pytestmark = pytest.mark.asyncio
 
 
 def _make_memory_entry(
@@ -90,7 +94,7 @@ def _make_memory_summary(
     )
 
 
-def test_record_event_creates_memory_entry() -> None:
+async def test_record_event_creates_memory_entry() -> None:
     mock_adjustment = MagicMock(spec=PromptAdjustmentRepository)
     mock_bank = MagicMock(spec=MemoryBankService)
 
@@ -98,7 +102,7 @@ def test_record_event_creates_memory_entry() -> None:
         adjustment_repository=mock_adjustment,
         memory_bank_service=mock_bank,
     )
-    event = service.record_event(
+    event = await service.record_event_async(
         role_id="test-role",
         workspace_id="ws-1",
         event_type="prompt_applied",
@@ -114,14 +118,14 @@ def test_record_event_creates_memory_entry() -> None:
     assert event.trigger_source == "self_assessment"
     assert event.decision_id == "pad-1"
 
-    mock_bank.create_entry.assert_called_once()
-    call_args = mock_bank.create_entry.call_args[0][0]
+    mock_bank.create_entry_async.assert_awaited_once()
+    call_args = mock_bank.create_entry_async.call_args[0][0]
     assert call_args.scope == MemoryScope.ROLE
     assert call_args.kind == MemoryEntryKind.INSIGHT
     assert call_args.source == MemorySourceKind.REFLECTION
 
 
-def test_get_timeline_returns_events() -> None:
+async def test_get_timeline_returns_events() -> None:
     mock_adjustment = MagicMock(spec=PromptAdjustmentRepository)
     mock_adjustment.get_latest_applied.return_value = None
     mock_adjustment.list_decisions.return_value = ()
@@ -132,8 +136,8 @@ def test_get_timeline_returns_events() -> None:
         event_type="prompt_applied",
         body="Applied strategy improvement",
     )
-    mock_bank.get_entry.return_value = entry
-    mock_bank.list_entries.return_value = MemoryQueryResult(
+    mock_bank.get_entry_async.return_value = entry
+    mock_bank.list_entries_async.return_value = MemoryQueryResult(
         items=(_make_memory_summary(entry_id="evt-1"),),
         total_count=1,
         offset=0,
@@ -144,7 +148,7 @@ def test_get_timeline_returns_events() -> None:
         adjustment_repository=mock_adjustment,
         memory_bank_service=mock_bank,
     )
-    timeline = service.get_timeline(
+    timeline = await service.get_timeline_async(
         role_id="test-role",
         workspace_id="ws-1",
     )
@@ -155,7 +159,7 @@ def test_get_timeline_returns_events() -> None:
     assert timeline.events[0].summary == "Applied strategy improvement"
 
 
-def test_get_current_state() -> None:
+async def test_get_current_state() -> None:
     from relay_teams.roles.prompt_adjustment_engine import (
         PromptAdjustmentDecision,
         PromptAdjustmentStatus,
@@ -183,8 +187,8 @@ def test_get_current_state() -> None:
         body="Applied V3",
     )
     mock_bank = MagicMock(spec=MemoryBankService)
-    mock_bank.get_entry.return_value = entry
-    mock_bank.list_entries.return_value = MemoryQueryResult(
+    mock_bank.get_entry_async.return_value = entry
+    mock_bank.list_entries_async.return_value = MemoryQueryResult(
         items=(_make_memory_summary(entry_id="evt-1"),),
         total_count=1,
         offset=0,
@@ -195,7 +199,7 @@ def test_get_current_state() -> None:
         adjustment_repository=mock_adjustment,
         memory_bank_service=mock_bank,
     )
-    state = service.get_current_state(
+    state = await service.get_current_state_async(
         role_id="test-role",
         workspace_id="ws-1",
     )
@@ -203,7 +207,7 @@ def test_get_current_state() -> None:
     assert state.lifetime_adjustment_count == 1
 
 
-def test_event_links_decision_id() -> None:
+async def test_event_links_decision_id() -> None:
     mock_adjustment = MagicMock(spec=PromptAdjustmentRepository)
     mock_bank = MagicMock(spec=MemoryBankService)
 
@@ -211,7 +215,7 @@ def test_event_links_decision_id() -> None:
         adjustment_repository=mock_adjustment,
         memory_bank_service=mock_bank,
     )
-    event = service.record_event(
+    event = await service.record_event_async(
         role_id="test-role",
         workspace_id="ws-1",
         event_type="prompt_applied",
@@ -220,7 +224,7 @@ def test_event_links_decision_id() -> None:
     )
     assert event.decision_id == "pad-abc123"
 
-    call_args = mock_bank.create_entry.call_args[0][0]
+    call_args = mock_bank.create_entry_async.call_args[0][0]
     import json
 
     ctx = json.loads(call_args.content.context)

--- a/tests/unit_tests/roles/test_evolution_history_coverage.py
+++ b/tests/unit_tests/roles/test_evolution_history_coverage.py
@@ -3,22 +3,25 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 
 from relay_teams.roles.evolution_history import RoleEvolutionHistoryService
 from relay_teams.roles.maturity_scoring import MaturityLevel
+
+pytestmark = pytest.mark.asyncio
 
 
 def _make_service() -> tuple[RoleEvolutionHistoryService, MagicMock, MagicMock]:
     adj_repo = MagicMock()
     adj_repo.list_decisions.return_value = ()
     bank = MagicMock()
-    bank.create_entry = MagicMock()
-    bank.list_entries = MagicMock(
+    bank.create_entry_async = AsyncMock()
+    bank.list_entries_async = AsyncMock(
         return_value=MagicMock(items=(), total_count=0, offset=0, limit=50)
     )
-    bank.get_entry = MagicMock(return_value=None)
+    bank.get_entry_async = AsyncMock(return_value=None)
     return (
         RoleEvolutionHistoryService(
             adjustment_repository=adj_repo,
@@ -29,25 +32,25 @@ def _make_service() -> tuple[RoleEvolutionHistoryService, MagicMock, MagicMock]:
     )
 
 
-def test_get_timeline_returns_empty() -> None:
+async def test_get_timeline_returns_empty() -> None:
     svc, _, bank = _make_service()
-    timeline = svc.get_timeline(role_id="r1", workspace_id="w1")
+    timeline = await svc.get_timeline_async(role_id="r1", workspace_id="w1")
     assert timeline.role_id == "r1"
     assert timeline.events == ()
 
 
-def test_get_current_state_no_decisions() -> None:
+async def test_get_current_state_no_decisions() -> None:
     svc, adj_repo, bank = _make_service()
     adj_repo.list_decisions.return_value = ()
-    state = svc.get_current_state(role_id="r1", workspace_id="w1")
+    state = await svc.get_current_state_async(role_id="r1", workspace_id="w1")
     assert state.current_prompt_version == 1
     assert state.current_maturity_level is None
     assert state.lifetime_adjustment_count == 0
 
 
-def test_record_event_with_maturity_level() -> None:
+async def test_record_event_with_maturity_level() -> None:
     svc, adj_repo, bank = _make_service()
-    evt = svc.record_event(
+    evt = await svc.record_event_async(
         role_id="r1",
         workspace_id="w1",
         event_type="maturity_scored",
@@ -58,12 +61,12 @@ def test_record_event_with_maturity_level() -> None:
     assert evt.event_type == "maturity_scored"
     assert evt.maturity_level_before == MaturityLevel.L2_TASK_ORIENTED
     assert evt.maturity_level_after == MaturityLevel.L3_CONTEXT_AWARE
-    bank.create_entry.assert_called_once()
+    bank.create_entry_async.assert_awaited_once()
 
 
-def test_record_event_without_maturity() -> None:
+async def test_record_event_without_maturity() -> None:
     svc, _, bank = _make_service()
-    evt = svc.record_event(
+    evt = await svc.record_event_async(
         role_id="r2",
         workspace_id="w1",
         event_type="prompt_proposed",

--- a/tests/unit_tests/roles/test_memory_injection.py
+++ b/tests/unit_tests/roles/test_memory_injection.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import create_autospec
+from unittest.mock import AsyncMock, create_autospec
+
+import pytest
 
 from relay_teams.memory.models import (
     CreateMemoryEntryRequest,
     MemoryContent,
     MemoryEntryKind,
-    MemoryQuery,
     MemoryScope,
     MemorySourceKind,
     MemoryTier,
@@ -16,12 +17,14 @@ from relay_teams.memory.models import (
 from relay_teams.memory.repository import MemoryBankRepository
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.roles.memory_injection import (
-    _build_project_memory_section,
-    build_role_with_memory,
+    _build_project_memory_section_async,
+    build_role_with_memory_async,
 )
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import MemoryProfile, RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
+
+pytestmark = pytest.mark.asyncio
 
 
 def _make_role(**overrides: object) -> RoleDefinition:
@@ -37,7 +40,7 @@ def _make_role(**overrides: object) -> RoleDefinition:
     return RoleDefinition(**base)  # type: ignore[arg-type]
 
 
-def _create_entry(
+async def _create_entry(
     service: MemoryBankService, tier: MemoryTier, **overrides: object
 ) -> None:
     base: dict[str, object] = {
@@ -50,15 +53,15 @@ def _create_entry(
         "source": MemorySourceKind.MANUAL,
     }
     base.update(overrides)
-    service.create_entry(CreateMemoryEntryRequest(**base))  # type: ignore[arg-type]
+    await service.create_entry_async(CreateMemoryEntryRequest(**base))  # type: ignore[arg-type]
 
 
 class TestBuildRoleWithMemory:
-    def test_skips_coordinator_role(self, tmp_path: Path) -> None:
+    async def test_skips_coordinator_role(self, tmp_path: Path) -> None:
         registry = create_autospec(RoleRegistry, instance=True)
         registry.is_coordinator_role.return_value = True
         role = _make_role()
-        result = build_role_with_memory(
+        result = await build_role_with_memory_async(
             role_registry=registry,
             role_memory_service=None,
             role=role,
@@ -67,11 +70,11 @@ class TestBuildRoleWithMemory:
         )
         assert result.system_prompt == role.system_prompt
 
-    def test_skips_disabled_memory(self, tmp_path: Path) -> None:
+    async def test_skips_disabled_memory(self, tmp_path: Path) -> None:
         registry = create_autospec(RoleRegistry, instance=True)
         registry.is_coordinator_role.return_value = False
         role = _make_role(memory_profile=MemoryProfile(enabled=False))
-        result = build_role_with_memory(
+        result = await build_role_with_memory_async(
             role_registry=registry,
             role_memory_service=None,
             role=role,
@@ -80,11 +83,11 @@ class TestBuildRoleWithMemory:
         )
         assert result.system_prompt == role.system_prompt
 
-    def test_skips_when_no_services(self, tmp_path: Path) -> None:
+    async def test_skips_when_no_services(self, tmp_path: Path) -> None:
         registry = create_autospec(RoleRegistry, instance=True)
         registry.is_coordinator_role.return_value = False
         role = _make_role()
-        result = build_role_with_memory(
+        result = await build_role_with_memory_async(
             role_registry=registry,
             role_memory_service=None,
             memory_bank_service=None,
@@ -94,14 +97,14 @@ class TestBuildRoleWithMemory:
         )
         assert result.system_prompt == role.system_prompt
 
-    def test_appends_reflection_memory(self, tmp_path: Path) -> None:
+    async def test_appends_reflection_memory(self, tmp_path: Path) -> None:
         registry = create_autospec(RoleRegistry, instance=True)
         registry.is_coordinator_role.return_value = False
         role = _make_role()
         mock_role_memory = create_autospec(RoleMemoryService, instance=True)
-        mock_role_memory.build_injected_memory.return_value = "Past lessons"
-        mock_role_memory.get_performance_metrics.return_value = None
-        result = build_role_with_memory(
+        mock_role_memory.build_injected_memory_async.return_value = "Past lessons"
+        mock_role_memory.get_performance_metrics_async.return_value = None
+        result = await build_role_with_memory_async(
             role_registry=registry,
             role_memory_service=mock_role_memory,
             role=role,
@@ -111,14 +114,14 @@ class TestBuildRoleWithMemory:
         assert "Reflection Memory" in result.system_prompt
         assert "Past lessons" in result.system_prompt
 
-    def test_appends_project_memory(self, tmp_path: Path) -> None:
+    async def test_appends_project_memory(self, tmp_path: Path) -> None:
         registry = create_autospec(RoleRegistry, instance=True)
         registry.is_coordinator_role.return_value = False
         role = _make_role()
         repo = MemoryBankRepository(tmp_path / "test.db")
         service = MemoryBankService(repository=repo)
-        _create_entry(service, MemoryTier.PERSISTENT)
-        result = build_role_with_memory(
+        await _create_entry(service, MemoryTier.PERSISTENT)
+        result = await build_role_with_memory_async(
             role_registry=registry,
             role_memory_service=None,
             memory_bank_service=service,
@@ -128,14 +131,14 @@ class TestBuildRoleWithMemory:
         )
         assert "Project Memory" in result.system_prompt
 
-    def test_no_append_when_empty_memory(self, tmp_path: Path) -> None:
+    async def test_no_append_when_empty_memory(self, tmp_path: Path) -> None:
         registry = create_autospec(RoleRegistry, instance=True)
         registry.is_coordinator_role.return_value = False
         role = _make_role()
         mock_role_memory = create_autospec(RoleMemoryService, instance=True)
-        mock_role_memory.build_injected_memory.return_value = ""
-        mock_role_memory.get_performance_metrics.return_value = None
-        result = build_role_with_memory(
+        mock_role_memory.build_injected_memory_async.return_value = ""
+        mock_role_memory.get_performance_metrics_async.return_value = None
+        result = await build_role_with_memory_async(
             role_registry=registry,
             role_memory_service=mock_role_memory,
             role=role,
@@ -146,11 +149,11 @@ class TestBuildRoleWithMemory:
 
 
 class TestBuildProjectMemorySection:
-    def test_returns_text_for_entries(self, tmp_path: Path) -> None:
+    async def test_returns_text_for_entries(self, tmp_path: Path) -> None:
         repo = MemoryBankRepository(tmp_path / "test.db")
         service = MemoryBankService(repository=repo)
-        _create_entry(service, MemoryTier.PERSISTENT)
-        result = _build_project_memory_section(
+        await _create_entry(service, MemoryTier.PERSISTENT)
+        result = await _build_project_memory_section_async(
             memory_bank_service=service,
             workspace_id="ws-1",
             role_id="crafter",
@@ -158,45 +161,34 @@ class TestBuildProjectMemorySection:
         assert "Persistent" in result
         assert "Test insight" in result
 
-    def test_returns_empty_when_no_entries(self, tmp_path: Path) -> None:
+    async def test_returns_empty_when_no_entries(self, tmp_path: Path) -> None:
         repo = MemoryBankRepository(tmp_path / "test.db")
         service = MemoryBankService(repository=repo)
-        result = _build_project_memory_section(
+        result = await _build_project_memory_section_async(
             memory_bank_service=service,
             workspace_id="ws-1",
         )
         assert result == ""
 
-    def test_handles_service_exception(self, tmp_path: Path) -> None:
-        repo = MemoryBankRepository(tmp_path / "test.db")
-        service = MemoryBankService(repository=repo)
-        original_list = service.list_entries
-        call_count = 0
-
-        def failing_list(query: MemoryQuery) -> object:
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 2:
-                raise RuntimeError("db error")
-            return original_list(query)
-
-        service.list_entries = failing_list  # type: ignore[assignment]
-        result = _build_project_memory_section(
+    async def test_handles_service_exception(self, tmp_path: Path) -> None:
+        service = create_autospec(MemoryBankService, instance=True)
+        service.list_entries_async = AsyncMock(side_effect=RuntimeError("db error"))
+        result = await _build_project_memory_section_async(
             memory_bank_service=service,
             workspace_id="ws-1",
         )
         assert result == ""
 
-    def test_includes_medium_term_entries(self, tmp_path: Path) -> None:
+    async def test_includes_medium_term_entries(self, tmp_path: Path) -> None:
         repo = MemoryBankRepository(tmp_path / "test.db")
         service = MemoryBankService(repository=repo)
-        _create_entry(
+        await _create_entry(
             service,
             MemoryTier.MEDIUM_TERM,
             scope=MemoryScope.SESSION,
             session_id="s1",
         )
-        result = _build_project_memory_section(
+        result = await _build_project_memory_section_async(
             memory_bank_service=service,
             workspace_id="ws-1",
             role_id="crafter",

--- a/tests/unit_tests/roles/test_memory_injection_extended.py
+++ b/tests/unit_tests/roles/test_memory_injection_extended.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
+import pytest
+
 from relay_teams.memory.models import (
     MemoryEntryKind,
     MemoryEntryStatus,
@@ -16,10 +18,10 @@ from relay_teams.memory.models import (
 )
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.roles.memory_injection import (
-    build_role_with_memory,
-    _build_role_evolution_section,
-    _count_applied_adjustments,
-    _find_latest_maturity_level,
+    _build_role_evolution_section_async,
+    _count_applied_adjustments_async,
+    _find_latest_maturity_level_async,
+    build_role_with_memory_async,
 )
 from relay_teams.roles.memory_models import (
     MemoryProfile,
@@ -30,6 +32,8 @@ from relay_teams.roles.memory_models import (
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
+
+pytestmark = pytest.mark.asyncio
 
 
 def _make_role(
@@ -81,7 +85,7 @@ def _make_summary(
     )
 
 
-def test_build_role_with_memory_includes_evolution_section() -> None:
+async def test_build_role_with_memory_includes_evolution_section() -> None:
     perf = RolePerformanceMetrics(
         role_id="test-role",
         workspace_id="ws-1",
@@ -98,11 +102,13 @@ def test_build_role_with_memory_includes_evolution_section() -> None:
         average_verification_score=3.8,
     )
     mock_memory_service = MagicMock(spec=RoleMemoryService)
-    mock_memory_service.build_injected_memory.return_value = "- Learn: concise output"
-    mock_memory_service.get_performance_metrics.return_value = perf
+    mock_memory_service.build_injected_memory_async.return_value = (
+        "- Learn: concise output"
+    )
+    mock_memory_service.get_performance_metrics_async.return_value = perf
 
     mock_mbs = MagicMock(spec=MemoryBankService)
-    mock_mbs.list_entries.return_value = MemoryQueryResult(
+    mock_mbs.list_entries_async.return_value = MemoryQueryResult(
         items=(),
         total_count=0,
         offset=0,
@@ -112,7 +118,7 @@ def test_build_role_with_memory_includes_evolution_section() -> None:
     mock_registry = _make_mock_registry(is_coordinator=False)
     role = _make_role()
 
-    result = build_role_with_memory(
+    result = await build_role_with_memory_async(
         role_registry=mock_registry,
         role_memory_service=mock_memory_service,
         memory_bank_service=mock_mbs,
@@ -129,16 +135,18 @@ def test_build_role_with_memory_includes_evolution_section() -> None:
     assert "3.8/5.0" in result.system_prompt
 
 
-def test_build_role_with_memory_no_evolution_section() -> None:
+async def test_build_role_with_memory_no_evolution_section() -> None:
     mock_memory_service = MagicMock(spec=RoleMemoryService)
-    mock_memory_service.build_injected_memory.return_value = "- Learn: concise output"
-    mock_memory_service.get_performance_metrics.return_value = None
+    mock_memory_service.build_injected_memory_async.return_value = (
+        "- Learn: concise output"
+    )
+    mock_memory_service.get_performance_metrics_async.return_value = None
 
     mock_mbs = MagicMock(spec=MemoryBankService)
     mock_registry = _make_mock_registry(is_coordinator=False)
     role = _make_role()
 
-    result = build_role_with_memory(
+    result = await build_role_with_memory_async(
         role_registry=mock_registry,
         role_memory_service=mock_memory_service,
         memory_bank_service=mock_mbs,
@@ -151,15 +159,15 @@ def test_build_role_with_memory_no_evolution_section() -> None:
     assert "## Reflection Memory" in result.system_prompt
 
 
-def test_find_latest_maturity_level_with_maturity_entry() -> None:
+async def test_find_latest_maturity_level_with_maturity_entry() -> None:
     mock_mbs = MagicMock(spec=MemoryBankService)
-    mock_mbs.list_entries.return_value = MemoryQueryResult(
+    mock_mbs.list_entries_async.return_value = MemoryQueryResult(
         items=(_make_summary(title="Maturity Scored - Level: L3"),),
         total_count=1,
         offset=0,
         limit=10,
     )
-    result = _find_latest_maturity_level(
+    result = await _find_latest_maturity_level_async(
         memory_bank_service=mock_mbs,
         workspace_id="ws-1",
         role_id="role-1",
@@ -167,15 +175,15 @@ def test_find_latest_maturity_level_with_maturity_entry() -> None:
     assert result == "L3"
 
 
-def test_find_latest_maturity_level_no_match() -> None:
+async def test_find_latest_maturity_level_no_match() -> None:
     mock_mbs = MagicMock(spec=MemoryBankService)
-    mock_mbs.list_entries.return_value = MemoryQueryResult(
+    mock_mbs.list_entries_async.return_value = MemoryQueryResult(
         items=(_make_summary(title="Other insight"),),
         total_count=1,
         offset=0,
         limit=10,
     )
-    result = _find_latest_maturity_level(
+    result = await _find_latest_maturity_level_async(
         memory_bank_service=mock_mbs,
         workspace_id="ws-1",
         role_id="role-1",
@@ -183,15 +191,15 @@ def test_find_latest_maturity_level_no_match() -> None:
     assert result is None
 
 
-def test_find_latest_maturity_level_l_prefix() -> None:
+async def test_find_latest_maturity_level_l_prefix() -> None:
     mock_mbs = MagicMock(spec=MemoryBankService)
-    mock_mbs.list_entries.return_value = MemoryQueryResult(
+    mock_mbs.list_entries_async.return_value = MemoryQueryResult(
         items=(_make_summary(title="L5 assessment"),),
         total_count=1,
         offset=0,
         limit=10,
     )
-    result = _find_latest_maturity_level(
+    result = await _find_latest_maturity_level_async(
         memory_bank_service=mock_mbs,
         workspace_id="ws-1",
         role_id="role-1",
@@ -200,10 +208,10 @@ def test_find_latest_maturity_level_l_prefix() -> None:
     assert "L5" in result
 
 
-def test_find_latest_maturity_level_service_error() -> None:
+async def test_find_latest_maturity_level_service_error() -> None:
     mock_mbs = MagicMock(spec=MemoryBankService)
-    mock_mbs.list_entries.side_effect = RuntimeError("db error")
-    result = _find_latest_maturity_level(
+    mock_mbs.list_entries_async.side_effect = RuntimeError("db error")
+    result = await _find_latest_maturity_level_async(
         memory_bank_service=mock_mbs,
         workspace_id="ws-1",
         role_id="role-1",
@@ -211,9 +219,9 @@ def test_find_latest_maturity_level_service_error() -> None:
     assert result is None
 
 
-def test_count_applied_adjustments_with_matches() -> None:
+async def test_count_applied_adjustments_with_matches() -> None:
     mock_mbs = MagicMock(spec=MemoryBankService)
-    mock_mbs.list_entries.return_value = MemoryQueryResult(
+    mock_mbs.list_entries_async.return_value = MemoryQueryResult(
         items=(
             _make_summary(entry_id="me-0", title="prompt_applied v1"),
             _make_summary(entry_id="me-1", title="Adjustment applied v2"),
@@ -222,7 +230,7 @@ def test_count_applied_adjustments_with_matches() -> None:
         offset=0,
         limit=50,
     )
-    result = _count_applied_adjustments(
+    result = await _count_applied_adjustments_async(
         memory_bank_service=mock_mbs,
         workspace_id="ws-1",
         role_id="role-1",
@@ -230,10 +238,10 @@ def test_count_applied_adjustments_with_matches() -> None:
     assert result == 2
 
 
-def test_count_applied_adjustments_service_error() -> None:
+async def test_count_applied_adjustments_service_error() -> None:
     mock_mbs = MagicMock(spec=MemoryBankService)
-    mock_mbs.list_entries.side_effect = ValueError("err")
-    result = _count_applied_adjustments(
+    mock_mbs.list_entries_async.side_effect = ValueError("err")
+    result = await _count_applied_adjustments_async(
         memory_bank_service=mock_mbs,
         workspace_id="ws-1",
         role_id="role-1",
@@ -241,7 +249,7 @@ def test_count_applied_adjustments_service_error() -> None:
     assert result is None
 
 
-def test_build_role_evolution_section_with_maturity_and_adjustments() -> None:
+async def test_build_role_evolution_section_with_maturity_and_adjustments() -> None:
     mock_mbs = MagicMock(spec=MemoryBankService)
 
     def mock_list(query: object) -> MemoryQueryResult:
@@ -260,7 +268,7 @@ def test_build_role_evolution_section_with_maturity_and_adjustments() -> None:
             limit=50,
         )
 
-    mock_mbs.list_entries.side_effect = mock_list
+    mock_mbs.list_entries_async.side_effect = mock_list
     perf = RolePerformanceMetrics(
         role_id="role-1",
         workspace_id="ws-1",
@@ -276,7 +284,7 @@ def test_build_role_evolution_section_with_maturity_and_adjustments() -> None:
         ),
         average_verification_score=3.8,
     )
-    result = _build_role_evolution_section(
+    result = await _build_role_evolution_section_async(
         performance=perf,
         memory_bank_service=mock_mbs,
         workspace_id="ws-1",
@@ -287,9 +295,9 @@ def test_build_role_evolution_section_with_maturity_and_adjustments() -> None:
     assert "Prompt Adjustments Applied" in result
 
 
-def test_build_role_evolution_section_no_maturity_no_adjustments() -> None:
+async def test_build_role_evolution_section_no_maturity_no_adjustments() -> None:
     mock_mbs = MagicMock(spec=MemoryBankService)
-    mock_mbs.list_entries.return_value = MemoryQueryResult(
+    mock_mbs.list_entries_async.return_value = MemoryQueryResult(
         items=(),
         total_count=0,
         offset=0,
@@ -306,7 +314,7 @@ def test_build_role_evolution_section_no_maturity_no_adjustments() -> None:
         task_counts=RoleTaskCounts(total_tasks=10, successful_tasks=8, failed_tasks=2),
         average_verification_score=4.0,
     )
-    result = _build_role_evolution_section(
+    result = await _build_role_evolution_section_async(
         performance=perf,
         memory_bank_service=mock_mbs,
         workspace_id="ws-1",

--- a/tests/unit_tests/roles/test_memory_service.py
+++ b/tests/unit_tests/roles/test_memory_service.py
@@ -3,29 +3,32 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from relay_teams.roles.memory_repository import RoleMemoryRepository
 from relay_teams.roles.memory_service import RoleMemoryService
 
 
-def test_role_memory_service_builds_injected_memory_and_preview(
+@pytest.mark.asyncio
+async def test_role_memory_service_builds_injected_memory_and_preview(
     tmp_path: Path,
 ) -> None:
     service = RoleMemoryService(
         repository=RoleMemoryRepository(tmp_path / "role_memory.db")
     )
 
-    service.update_reflection_memory(
+    await service.update_reflection_memory_async(
         role_id="writer",
         workspace_id="workspace-a",
         content_markdown="- Prefer concise output\n- Check tool results before responding",
     )
 
-    injected = service.build_injected_memory(
+    injected = await service.build_injected_memory_async(
         role_id="writer",
         workspace_id="workspace-a",
         memory_date="2026-03-14",
     )
-    preview = service.build_reflection_preview(
+    preview = await service.build_reflection_preview_async(
         role_id="writer",
         workspace_id="workspace-a",
         max_chars=40,
@@ -36,28 +39,29 @@ def test_role_memory_service_builds_injected_memory_and_preview(
     assert preview.startswith("- Prefer concise output")
 
 
-def test_role_memory_service_isolates_memory_by_workspace(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_role_memory_service_isolates_memory_by_workspace(tmp_path: Path) -> None:
     service = RoleMemoryService(
         repository=RoleMemoryRepository(tmp_path / "role_memory_scoped.db")
     )
 
-    service.update_reflection_memory(
+    await service.update_reflection_memory_async(
         role_id="writer",
         workspace_id="workspace-a",
         content_markdown="- Memory A",
     )
-    service.update_reflection_memory(
+    await service.update_reflection_memory_async(
         role_id="writer",
         workspace_id="workspace-b",
         content_markdown="- Memory B",
     )
 
-    injected_a = service.build_injected_memory(
+    injected_a = await service.build_injected_memory_async(
         role_id="writer",
         workspace_id="workspace-a",
         memory_date="2026-03-14",
     )
-    injected_b = service.build_injected_memory(
+    injected_b = await service.build_injected_memory_async(
         role_id="writer",
         workspace_id="workspace-b",
         memory_date="2026-03-14",
@@ -69,25 +73,26 @@ def test_role_memory_service_isolates_memory_by_workspace(tmp_path: Path) -> Non
     assert "Memory A" not in injected_b
 
 
-def test_role_memory_service_delete_clears_summary_and_timestamp(
+@pytest.mark.asyncio
+async def test_role_memory_service_delete_clears_summary_and_timestamp(
     tmp_path: Path,
 ) -> None:
     service = RoleMemoryService(
         repository=RoleMemoryRepository(tmp_path / "role_memory_delete.db")
     )
 
-    service.update_reflection_memory(
+    await service.update_reflection_memory_async(
         role_id="writer",
         workspace_id="workspace-a",
         content_markdown="- Temporary note",
     )
 
-    service.delete_reflection_memory(
+    await service.delete_reflection_memory_async(
         role_id="writer",
         workspace_id="workspace-a",
     )
 
-    record = service.get_reflection_record(
+    record = await service.get_reflection_record_async(
         role_id="writer",
         workspace_id="workspace-a",
     )

--- a/tests/unit_tests/roles/test_memory_service_extended.py
+++ b/tests/unit_tests/roles/test_memory_service_extended.py
@@ -139,7 +139,8 @@ async def test_record_verification_outcome_trend_trimmed(tmp_path: Path) -> None
     assert len(record.performance.trend) == 20
 
 
-def test_get_performance_metrics() -> None:
+@pytest.mark.asyncio
+async def test_get_performance_metrics() -> None:
     perf = RolePerformanceMetrics(
         role_id="test-role",
         workspace_id="ws-1",
@@ -161,10 +162,10 @@ def test_get_performance_metrics() -> None:
     )
 
     mock_repo = MagicMock(spec=RoleMemoryRepository)
-    mock_repo.read_role_memory.return_value = record
+    mock_repo.read_role_memory_async.return_value = record
 
     service = RoleMemoryService(repository=mock_repo)
-    result = service.get_performance_metrics(
+    result = await service.get_performance_metrics_async(
         role_id="test-role",
         workspace_id="ws-1",
     )
@@ -173,7 +174,8 @@ def test_get_performance_metrics() -> None:
     assert result.verification_pass_rate.pass_rate == 0.6
 
 
-def test_get_performance_metrics_none() -> None:
+@pytest.mark.asyncio
+async def test_get_performance_metrics_none() -> None:
     record = RoleMemoryRecord(
         role_id="test-role",
         workspace_id="ws-1",
@@ -181,10 +183,10 @@ def test_get_performance_metrics_none() -> None:
     )
 
     mock_repo = MagicMock(spec=RoleMemoryRepository)
-    mock_repo.read_role_memory.return_value = record
+    mock_repo.read_role_memory_async.return_value = record
 
     service = RoleMemoryService(repository=mock_repo)
-    result = service.get_performance_metrics(
+    result = await service.get_performance_metrics_async(
         role_id="test-role",
         workspace_id="ws-1",
     )

--- a/tests/unit_tests/roles/test_prompt_adjustment_engine.py
+++ b/tests/unit_tests/roles/test_prompt_adjustment_engine.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -62,6 +63,55 @@ def test_propose_adjustment_creates_proposed(
     assert decision.trigger_source == "self_assessment"
     assert decision.triggered_by == "assessment-1"
     assert decision.version == 1
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_adjustment_repository_and_engine(
+    repo: PromptAdjustmentRepository,
+    mock_registry: MagicMock,
+) -> None:
+    assert await repo.get_decision_async("missing") is None
+    assert (
+        await repo.get_latest_applied_async(role_id="test-role", workspace_id="ws-1")
+        is None
+    )
+
+    engine = SystemPromptAdjustmentEngine(repository=repo, role_registry=mock_registry)
+    first = await engine.propose_adjustment_async(
+        role_id="test-role",
+        workspace_id="ws-1",
+        current_prompt="## strategy\nOld",
+        recommendations=(_make_rec(text="Async v1"),),
+        trigger_source="self_assessment",
+        triggered_by="async-1",
+    )
+    applied = first.model_copy(
+        update={
+            "status": PromptAdjustmentStatus.APPLIED,
+            "applied_at": datetime.now(tz=timezone.utc),
+        }
+    )
+    _ = await repo.save_decision_async(applied)
+
+    second = await engine.propose_adjustment_async(
+        role_id="test-role",
+        workspace_id="ws-1",
+        current_prompt="## strategy\nAsync v1",
+        recommendations=(_make_rec(text="Async v2"),),
+        trigger_source="self_assessment",
+        triggered_by="async-2",
+    )
+
+    latest = await repo.get_latest_applied_async(
+        role_id="test-role",
+        workspace_id="ws-1",
+    )
+    retrieved = await repo.get_decision_async(second.decision_id)
+    assert latest is not None
+    assert latest.decision_id == first.decision_id
+    assert retrieved is not None
+    assert retrieved.version == 2
+    assert second.version == 2
 
 
 def test_approve_transitions_to_approved(

--- a/tests/unit_tests/roles/test_self_assessment.py
+++ b/tests/unit_tests/roles/test_self_assessment.py
@@ -30,7 +30,9 @@ def mock_llm_evaluator() -> MagicMock:
 
 @pytest.fixture
 def mock_role_memory_service() -> MagicMock:
-    return MagicMock()
+    service = MagicMock()
+    service.get_reflection_record_async = AsyncMock()
+    return service
 
 
 def _make_performance(
@@ -109,7 +111,7 @@ async def test_maybe_assess_below_task_threshold(
         workspace_id="ws-1",
         performance=perf,
     )
-    mock_role_memory_service.get_reflection_record.return_value = record
+    mock_role_memory_service.get_reflection_record_async.return_value = record
 
     service = RoleSelfAssessmentService(
         llm_evaluator=mock_llm_evaluator,
@@ -140,7 +142,7 @@ async def test_maybe_assess_success(
         workspace_id="ws-1",
         performance=perf,
     )
-    mock_role_memory_service.get_reflection_record.return_value = record
+    mock_role_memory_service.get_reflection_record_async.return_value = record
 
     mock_llm_evaluator.evaluate_role_performance.return_value = LLMEvaluationResult(
         scores=[
@@ -190,7 +192,7 @@ async def test_self_assessment_result_stored(
         workspace_id="ws-1",
         performance=perf,
     )
-    mock_role_memory_service.get_reflection_record.return_value = record
+    mock_role_memory_service.get_reflection_record_async.return_value = record
 
     mock_llm_evaluator.evaluate_role_performance.return_value = LLMEvaluationResult(
         scores=[
@@ -228,7 +230,7 @@ async def test_maybe_assess_performance_none(
     config = SelfAssessmentConfig(trigger_every_n_runs=10, enabled=True)
     record = RoleMemoryRecord(role_id="test-role", workspace_id="ws-1")
     assert record.performance is None
-    mock_role_memory_service.get_reflection_record.return_value = record
+    mock_role_memory_service.get_reflection_record_async.return_value = record
 
     service = RoleSelfAssessmentService(
         llm_evaluator=mock_llm_evaluator,
@@ -259,7 +261,7 @@ async def test_maybe_assess_llm_fallback(
         workspace_id="ws-1",
         performance=perf,
     )
-    mock_role_memory_service.get_reflection_record.return_value = record
+    mock_role_memory_service.get_reflection_record_async.return_value = record
     mock_llm_evaluator.evaluate_role_performance.side_effect = OSError("API down")
 
     service = RoleSelfAssessmentService(
@@ -296,7 +298,7 @@ async def test_maybe_assess_empty_recommendations(
         workspace_id="ws-1",
         performance=perf,
     )
-    mock_role_memory_service.get_reflection_record.return_value = record
+    mock_role_memory_service.get_reflection_record_async.return_value = record
     mock_llm_evaluator.evaluate_role_performance.return_value = LLMEvaluationResult(
         scores=[],
         overall_score=3.0,

--- a/tests/unit_tests/roles/test_temporary_knowledge_capture.py
+++ b/tests/unit_tests/roles/test_temporary_knowledge_capture.py
@@ -8,6 +8,7 @@ import pytest
 from relay_teams.roles.prompt_adjustment_engine import SystemPromptAdjustmentEngine
 from relay_teams.roles.temporary_knowledge_capture import (
     TemporaryRoleKnowledgeCaptureService,
+    _extract_additions,
 )
 from relay_teams.roles.temporary_role_models import (
     TemporaryRoleRecord,
@@ -41,7 +42,7 @@ def _make_temp_record(
 async def test_capture_returns_none_for_non_template() -> None:
     mock_engine = MagicMock(spec=SystemPromptAdjustmentEngine)
     mock_repo = MagicMock(spec=TemporaryRoleRepository)
-    mock_repo.get.return_value = _make_temp_record(template_role_id=None)
+    mock_repo.get_async.return_value = _make_temp_record(template_role_id=None)
     mock_memory = MagicMock()
 
     service = TemporaryRoleKnowledgeCaptureService(
@@ -58,14 +59,14 @@ async def test_capture_returns_none_for_non_template() -> None:
         _session_id="sess-1",
     )
     assert result is None
-    mock_engine.propose_adjustment.assert_not_called()
+    mock_engine.propose_adjustment_async.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_capture_returns_none_for_identical_prompt() -> None:
     mock_engine = MagicMock(spec=SystemPromptAdjustmentEngine)
     mock_repo = MagicMock(spec=TemporaryRoleRepository)
-    mock_repo.get.return_value = _make_temp_record()
+    mock_repo.get_async.return_value = _make_temp_record()
     mock_memory = MagicMock()
 
     service = TemporaryRoleKnowledgeCaptureService(
@@ -88,7 +89,7 @@ async def test_capture_returns_none_for_identical_prompt() -> None:
 async def test_capture_detects_additions() -> None:
     mock_engine = MagicMock(spec=SystemPromptAdjustmentEngine)
     mock_repo = MagicMock(spec=TemporaryRoleRepository)
-    mock_repo.get.return_value = _make_temp_record()
+    mock_repo.get_async.return_value = _make_temp_record()
     mock_memory = MagicMock()
 
     service = TemporaryRoleKnowledgeCaptureService(
@@ -114,8 +115,8 @@ async def test_capture_detects_additions() -> None:
     assert result.original_prompt == original
     assert len(result.prompt_diff_markdown) > 0
 
-    mock_engine.propose_adjustment.assert_called_once()
-    call_kwargs = mock_engine.propose_adjustment.call_args.kwargs
+    mock_engine.propose_adjustment_async.assert_awaited_once()
+    call_kwargs = mock_engine.propose_adjustment_async.await_args.kwargs
     assert call_kwargs["role_id"] == "template-1"
     assert call_kwargs["workspace_id"] == "ws-1"
     assert call_kwargs["trigger_source"] == "temporary_role_capture"
@@ -125,7 +126,7 @@ async def test_capture_detects_additions() -> None:
 async def test_capture_ignores_whitespace_only() -> None:
     mock_engine = MagicMock(spec=SystemPromptAdjustmentEngine)
     mock_repo = MagicMock(spec=TemporaryRoleRepository)
-    mock_repo.get.return_value = _make_temp_record()
+    mock_repo.get_async.return_value = _make_temp_record()
     mock_memory = MagicMock()
 
     service = TemporaryRoleKnowledgeCaptureService(
@@ -168,7 +169,7 @@ async def test_capture_diff_with_removals_and_additions() -> None:
     """Cover _compute_prompt_diff_markdown when original content is replaced."""
     mock_engine = MagicMock(spec=SystemPromptAdjustmentEngine)
     mock_repo = MagicMock(spec=TemporaryRoleRepository)
-    mock_repo.get.return_value = _make_temp_record()
+    mock_repo.get_async.return_value = _make_temp_record()
     mock_memory = MagicMock()
 
     service = TemporaryRoleKnowledgeCaptureService(
@@ -190,7 +191,7 @@ async def test_capture_diff_with_removals_and_additions() -> None:
     assert result is not None
     # The diff should contain both removal and addition lines
     assert "-" in result.prompt_diff_markdown or "+" in result.prompt_diff_markdown
-    mock_engine.propose_adjustment.assert_called_once()
+    mock_engine.propose_adjustment_async.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -198,7 +199,7 @@ async def test_capture_below_min_diff_chars() -> None:
     """Cover the min_diff_chars threshold in _compute_prompt_diff_markdown."""
     mock_engine = MagicMock(spec=SystemPromptAdjustmentEngine)
     mock_repo = MagicMock(spec=TemporaryRoleRepository)
-    mock_repo.get.return_value = _make_temp_record()
+    mock_repo.get_async.return_value = _make_temp_record()
     mock_memory = MagicMock()
 
     service = TemporaryRoleKnowledgeCaptureService(
@@ -224,7 +225,7 @@ async def test_capture_below_min_diff_chars() -> None:
 async def test_capture_keyerror() -> None:
     mock_engine = MagicMock(spec=SystemPromptAdjustmentEngine)
     mock_repo = MagicMock(spec=TemporaryRoleRepository)
-    mock_repo.get.side_effect = KeyError("not found")
+    mock_repo.get_async.side_effect = KeyError("not found")
     mock_memory = MagicMock()
 
     service = TemporaryRoleKnowledgeCaptureService(
@@ -241,14 +242,14 @@ async def test_capture_keyerror() -> None:
         _session_id="sess-1",
     )
     assert result is None
-    mock_engine.propose_adjustment.assert_not_called()
+    mock_engine.propose_adjustment_async.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_capture_non_prefix_effective() -> None:
     mock_engine = MagicMock(spec=SystemPromptAdjustmentEngine)
     mock_repo = MagicMock(spec=TemporaryRoleRepository)
-    mock_repo.get.return_value = _make_temp_record()
+    mock_repo.get_async.return_value = _make_temp_record()
     mock_memory = MagicMock()
 
     service = TemporaryRoleKnowledgeCaptureService(
@@ -269,7 +270,7 @@ async def test_capture_non_prefix_effective() -> None:
     )
     assert result is not None
     assert result.prompt_diff_markdown != ""
-    mock_engine.propose_adjustment.assert_called_once()
+    mock_engine.propose_adjustment_async.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -292,8 +293,6 @@ async def test_capture_all_for_session_returns_empty() -> None:
 
 def test_extract_additions_prefix_match() -> None:
     """Cover _extract_additions when effective starts with original."""
-    from relay_teams.roles.temporary_knowledge_capture import _extract_additions
-
     result = _extract_additions(
         "Be helpful\n\nAdditional strategy content here.",
         "Be helpful",
@@ -304,16 +303,12 @@ def test_extract_additions_prefix_match() -> None:
 
 def test_extract_additions_no_prefix() -> None:
     """Cover _extract_additions when effective does NOT start with original."""
-    from relay_teams.roles.temporary_knowledge_capture import _extract_additions
-
     result = _extract_additions("Completely different prompt text.", "Be helpful")
     assert "Completely different prompt text." in result
 
 
 def test_extract_additions_identical() -> None:
     """Cover _extract_additions when effective equals original (returns empty)."""
-    from relay_teams.roles.temporary_knowledge_capture import _extract_additions
-
     result = _extract_additions("Be helpful", "Be helpful")
     assert result == ""
 

--- a/tests/unit_tests/sessions/runs/test_run_hook_pipeline.py
+++ b/tests/unit_tests/sessions/runs/test_run_hook_pipeline.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Coroutine
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, create_autospec
+from unittest.mock import MagicMock, create_autospec
 
 from relay_teams.hooks import HookService
 from relay_teams.memory.event_handler import MemoryEventHandler
@@ -13,9 +12,26 @@ from relay_teams.sessions.runs.run_hook_pipeline import RunHookPipeline
 from relay_teams.sessions.session_repository import SessionRepository
 
 
+class _FakeCaptureService:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.calls: list[tuple[str, str]] = []
+
+    async def capture_all_for_session(
+        self,
+        *,
+        _session_id: str,
+        _workspace_id: str,
+    ) -> tuple[object, ...]:
+        self.calls.append((_session_id, _workspace_id))
+        if self.fail:
+            raise RuntimeError("capture error")
+        return ()
+
+
 def _make_pipeline(
     *,
-    memory_event_handler: object | None = None,
+    memory_event_handler: MemoryEventHandler | None = None,
     session_workspace_id: str | None = "ws-1",
 ) -> tuple[RunHookPipeline, MagicMock]:
     hook_service = create_autospec(HookService, instance=True)
@@ -26,7 +42,10 @@ def _make_pipeline(
     session_repo = create_autospec(SessionRepository, instance=True)
     mock_session = MagicMock()
     mock_session.workspace_id = session_workspace_id
-    session_repo.get.return_value = mock_session if session_workspace_id else None
+    if session_workspace_id is None:
+        session_repo.get_async.side_effect = KeyError("missing session")
+    else:
+        session_repo.get_async.return_value = mock_session
     run_event_hub = create_autospec(RunEventHub, instance=True)
     append_followup = MagicMock(return_value=True)
 
@@ -40,7 +59,7 @@ def _make_pipeline(
     return pipeline, hook_service
 
 
-def _run(coro: Coroutine[Any, Any, None]) -> None:
+def _run(coro: Coroutine[object, object, None]) -> None:
     asyncio.run(coro)
 
 
@@ -72,7 +91,7 @@ class TestRunHookPipelineMemoryConsolidation:
                 output_text="ok",
             )
         )
-        handler.on_run_completed.assert_called_once_with(
+        handler.on_run_completed_async.assert_awaited_once_with(
             workspace_id="ws-1",
             session_id="sess-1",
         )
@@ -90,7 +109,7 @@ class TestRunHookPipelineMemoryConsolidation:
                 output_text="ok",
             )
         )
-        handler.on_session_completed.assert_called_once_with(
+        handler.on_session_completed_async.assert_awaited_once_with(
             workspace_id="ws-1",
             session_id="sess-1",
         )
@@ -111,12 +130,12 @@ class TestRunHookPipelineMemoryConsolidation:
                 output_text="ok",
             )
         )
-        handler.on_run_completed.assert_not_called()
-        handler.on_session_completed.assert_not_called()
+        handler.on_run_completed_async.assert_not_awaited()
+        handler.on_session_completed_async.assert_not_awaited()
 
     def test_run_completed_exception_suppressed(self) -> None:
         handler = create_autospec(MemoryEventHandler, instance=True)
-        handler.on_run_completed.side_effect = RuntimeError("db error")
+        handler.on_run_completed_async.side_effect = RuntimeError("db error")
         pipeline, _ = _make_pipeline(memory_event_handler=handler)
 
         _run(
@@ -129,11 +148,11 @@ class TestRunHookPipelineMemoryConsolidation:
             )
         )
         # on_session_completed should still be called after failure
-        handler.on_session_completed.assert_called_once()
+        handler.on_session_completed_async.assert_awaited_once()
 
     def test_session_completed_exception_suppressed(self) -> None:
         handler = create_autospec(MemoryEventHandler, instance=True)
-        handler.on_session_completed.side_effect = RuntimeError("db error")
+        handler.on_session_completed_async.side_effect = RuntimeError("db error")
         pipeline, _ = _make_pipeline(memory_event_handler=handler)
 
         _run(
@@ -145,7 +164,7 @@ class TestRunHookPipelineMemoryConsolidation:
                 output_text="ok",
             )
         )
-        handler.on_run_completed.assert_called_once()
+        handler.on_run_completed_async.assert_awaited_once()
 
 
 class TestRunHookPipelineTemporaryKnowledgeCapture:
@@ -155,8 +174,7 @@ class TestRunHookPipelineTemporaryKnowledgeCapture:
         handler = create_autospec(MemoryEventHandler, instance=True)
         pipeline, _ = _make_pipeline(memory_event_handler=handler)
 
-        capture_svc = MagicMock()
-        capture_svc.capture_all_for_session = AsyncMock(return_value=())
+        capture_svc = _FakeCaptureService()
         pipeline.set_temporary_knowledge_capture_service(capture_svc)
 
         _run(
@@ -168,7 +186,7 @@ class TestRunHookPipelineTemporaryKnowledgeCapture:
                 output_text="ok",
             )
         )
-        capture_svc.capture_all_for_session.assert_called_once()
+        assert capture_svc.calls == [("sess-1", "ws-1")]
 
     def test_capture_service_not_called_when_none(self) -> None:
         handler = create_autospec(MemoryEventHandler, instance=True)
@@ -189,10 +207,7 @@ class TestRunHookPipelineTemporaryKnowledgeCapture:
         handler = create_autospec(MemoryEventHandler, instance=True)
         pipeline, _ = _make_pipeline(memory_event_handler=handler)
 
-        capture_svc = MagicMock()
-        capture_svc.capture_all_for_session = AsyncMock(
-            side_effect=RuntimeError("capture error")
-        )
+        capture_svc = _FakeCaptureService(fail=True)
         pipeline.set_temporary_knowledge_capture_service(capture_svc)
 
         _run(
@@ -205,14 +220,14 @@ class TestRunHookPipelineTemporaryKnowledgeCapture:
             )
         )
         # Should not raise — capture failure is suppressed
-        capture_svc.capture_all_for_session.assert_called_once()
+        assert capture_svc.calls == [("sess-1", "ws-1")]
 
     def test_resolve_workspace_id_returns_workspace(self) -> None:
         pipeline, _ = _make_pipeline(session_workspace_id="ws-42")
-        result = pipeline._resolve_workspace_id("sess-1")
+        result = asyncio.run(pipeline._resolve_workspace_id_async("sess-1"))
         assert result == "ws-42"
 
     def test_resolve_workspace_id_returns_none_when_no_session(self) -> None:
         pipeline, _ = _make_pipeline(session_workspace_id=None)
-        result = pipeline._resolve_workspace_id("sess-missing")
+        result = asyncio.run(pipeline._resolve_workspace_id_async("sess-missing"))
         assert result is None

--- a/tests/unit_tests/sessions/runs/test_run_service_recovery.py
+++ b/tests/unit_tests/sessions/runs/test_run_service_recovery.py
@@ -4044,6 +4044,57 @@ async def test_create_run_async_queues_followup_for_recoverable_run(
 
 
 @pytest.mark.asyncio
+async def test_create_run_async_queues_new_run_after_terminal_active_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "run_async_terminal_active_record.db"
+    manager = _build_manager(db_path)
+
+    run_id, session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("first"),
+        )
+    )
+    _ = manager._pending_runs.pop(run_id)
+    manager._running_run_ids.add(run_id)
+    manager._injection_manager.activate(run_id)
+    RunRuntimeRepository(db_path).update(
+        run_id,
+        status=RunRuntimeStatus.COMPLETED,
+        phase=RunRuntimePhase.TERMINAL,
+    )
+    appended: list[str] = []
+
+    def _append_followup(
+        run_id: str,
+        content: str,
+        *,
+        enqueue: bool,
+        source: InjectionSource = InjectionSource.USER,
+    ) -> bool:
+        _ = (content, enqueue, source)
+        appended.append(run_id)
+        return True
+
+    monkeypatch.setattr(manager, "_append_followup_to_coordinator", _append_followup)
+
+    next_run_id, next_session_id = await manager.create_run_async(
+        IntentInput(
+            session_id="session-1",
+            input=content_parts_from_text("second"),
+        )
+    )
+
+    assert next_session_id == session_id
+    assert next_run_id != run_id
+    assert next_run_id in manager._pending_runs
+    assert appended == []
+    assert manager._active_run_registry.get_active_run_id(session_id) == next_run_id
+
+
+@pytest.mark.asyncio
 async def test_async_run_start_helpers_cover_missing_and_failed_startup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_tests/sessions/test_session_reflection_memory.py
+++ b/tests/unit_tests/sessions/test_session_reflection_memory.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
@@ -45,7 +47,8 @@ def _build_workspace_service(db_path: Path) -> WorkspaceService:
     return WorkspaceService(repository=WorkspaceRepository(db_path))
 
 
-def test_session_service_updates_and_deletes_agent_reflection(
+@pytest.mark.asyncio
+async def test_session_service_updates_and_deletes_agent_reflection(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "session_reflection_memory.db"
@@ -63,7 +66,7 @@ def test_session_service_updates_and_deletes_agent_reflection(
         status=InstanceStatus.IDLE,
     )
 
-    updated = service.update_agent_reflection(
+    updated = await service.update_agent_reflection_async(
         "session-1",
         "inst-1",
         summary="- Prefer concise implementation notes",
@@ -74,11 +77,11 @@ def test_session_service_updates_and_deletes_agent_reflection(
     assert updated["source"] == "manual_edit"
     assert updated["updated_at"] is not None
 
-    stored = service.get_agent_reflection("session-1", "inst-1")
+    stored = await service.get_agent_reflection_async("session-1", "inst-1")
     assert stored["summary"] == "- Prefer concise implementation notes"
     assert stored["updated_at"] is not None
 
-    deleted = service.delete_agent_reflection("session-1", "inst-1")
+    deleted = await service.delete_agent_reflection_async("session-1", "inst-1")
     assert deleted == {
         "instance_id": "inst-1",
         "role_id": "writer",
@@ -88,7 +91,7 @@ def test_session_service_updates_and_deletes_agent_reflection(
         "source": "manual_delete",
     }
 
-    empty = service.get_agent_reflection("session-1", "inst-1")
+    empty = await service.get_agent_reflection_async("session-1", "inst-1")
     assert empty == {
         "instance_id": "inst-1",
         "role_id": "writer",
@@ -99,7 +102,39 @@ def test_session_service_updates_and_deletes_agent_reflection(
     }
 
 
-def test_rebind_session_workspace_keeps_old_role_memory_without_migration(
+@pytest.mark.asyncio
+async def test_list_agents_in_session_async_projects_reflection_memory(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "session_agent_reflection_list.db"
+    service = _build_service(db_path)
+    _ = service.create_session(session_id="session-1", workspace_id="default")
+
+    agent_repo = AgentInstanceRepository(db_path)
+    agent_repo.upsert_instance(
+        run_id="run-1",
+        trace_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="writer",
+        workspace_id="default",
+        status=InstanceStatus.IDLE,
+    )
+    _ = await service.update_agent_reflection_async(
+        "session-1",
+        "inst-1",
+        summary="- Prefer concise drafts",
+    )
+
+    agents = await service.list_agents_in_session_async("session-1")
+
+    assert len(agents) == 1
+    assert agents[0]["reflection_summary_preview"] == "- Prefer concise drafts"
+    assert agents[0]["reflection_updated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_rebind_session_workspace_keeps_old_role_memory_without_migration(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "session_reflection_rebind.db"
@@ -133,7 +168,7 @@ def test_rebind_session_workspace_keeps_old_role_memory_without_migration(
         workspace_id=default_workspace.workspace_id,
         status=InstanceStatus.IDLE,
     )
-    _ = service.update_agent_reflection(
+    _ = await service.update_agent_reflection_async(
         "session-1",
         "inst-1",
         summary="- Keep the old workspace memory",
@@ -148,7 +183,7 @@ def test_rebind_session_workspace_keeps_old_role_memory_without_migration(
     assert (
         agent_repo.get_instance("inst-1").workspace_id == target_workspace.workspace_id
     )
-    assert service.get_agent_reflection("session-1", "inst-1") == {
+    assert await service.get_agent_reflection_async("session-1", "inst-1") == {
         "instance_id": "inst-1",
         "role_id": "writer",
         "summary": "",

--- a/tests/unit_tests/skills/test_async_only_contract.py
+++ b/tests/unit_tests/skills/test_async_only_contract.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from relay_teams.agents.orchestration.harnesses.execution_harness import (
+    ExecutionHarness,
+)
+from relay_teams.agents.orchestration.harnesses.llm_harness import TaskLlmHarness
+from relay_teams.agents.orchestration.harnesses.persistence_harness import (
+    TaskPersistenceHarness,
+)
+from relay_teams.agents.orchestration.harnesses.prompt_harness import TaskPromptHarness
+from relay_teams.skills.skill_routing_service import (
+    SkillRoutingService,
+    SkillRuntimeService,
+)
+
+
+def _public_callables(cls: type[object]) -> set[str]:
+    return {
+        name
+        for name, value in vars(cls).items()
+        if not name.startswith("_") and callable(value)
+    }
+
+
+def test_skill_runtime_shallow_sync_facades_do_not_return() -> None:
+    forbidden_methods: dict[type[object], tuple[str, ...]] = {
+        SkillRoutingService: ("route",),
+        SkillRuntimeService: ("prepare_prompt", "route_for_role"),
+        TaskLlmHarness: (
+            "evaluate_completion_guard",
+            "thinking_for_run",
+        ),
+        TaskPersistenceHarness: (
+            "complete_with_assistant_error",
+            "mark_runtime_after_terminal_task_update",
+            "mark_runtime_idle_after_success",
+            "promote_paused_runtime_lane",
+            "promote_running_runtime_lane",
+            "record_memory_if_needed",
+        ),
+        TaskPromptHarness: (
+            "build_user_prompt",
+            "conversation_context_for_run",
+            "ensure_committed_task_prompt",
+            "shared_state_snapshot",
+            "topology_for_run",
+        ),
+        ExecutionHarness: (
+            "build_user_prompt",
+            "complete_with_assistant_error",
+            "conversation_context_for_run",
+            "ensure_committed_task_prompt",
+            "evaluate_completion_guard",
+            "mark_runtime_after_terminal_task_update",
+            "mark_runtime_idle_after_success",
+            "promote_paused_runtime_lane",
+            "promote_running_runtime_lane",
+            "record_memory_if_needed",
+            "shared_state_snapshot",
+            "thinking_for_run",
+            "topology_for_run",
+        ),
+    }
+
+    for cls, method_names in forbidden_methods.items():
+        methods = _public_callables(cls)
+        returned_methods = sorted(name for name in method_names if name in methods)
+        assert returned_methods == []

--- a/tests/unit_tests/skills/test_skill_routing_service.py
+++ b/tests/unit_tests/skills/test_skill_routing_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from relay_teams.retrieval import RetrievalService, SqliteFts5RetrievalStore
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.sessions.runs.run_models import RuntimePromptConversationContext
@@ -146,7 +148,8 @@ def test_build_skill_routing_query_text_uses_stable_context_fields() -> None:
     assert "AGENTS.md" not in query_text
 
 
-def test_skill_runtime_service_passthrough_when_authorized_count_is_small(
+@pytest.mark.asyncio
+async def test_skill_runtime_service_passthrough_when_authorized_count_is_small(
     tmp_path: Path,
 ) -> None:
     registry = _build_registry(
@@ -163,7 +166,7 @@ def test_skill_runtime_service_passthrough_when_authorized_count_is_small(
     _ = service.rebuild_index()
     role = _build_role(("time", "planner"))
 
-    result = service.prepare_prompt(
+    result = await service.prepare_prompt_async(
         role=role,
         objective="Fix the timestamp bug.",
         shared_state_snapshot=(),
@@ -186,7 +189,8 @@ def test_skill_runtime_service_passthrough_when_authorized_count_is_small(
     )
 
 
-def test_skill_runtime_service_routes_hits_and_caps_visible_skills(
+@pytest.mark.asyncio
+async def test_skill_runtime_service_routes_hits_and_caps_visible_skills(
     tmp_path: Path,
 ) -> None:
     registry = _build_registry(
@@ -222,7 +226,7 @@ def test_skill_runtime_service_routes_hits_and_caps_visible_skills(
         )
     )
 
-    result = service.prepare_prompt(
+    result = await service.prepare_prompt_async(
         role=role,
         objective="Convert all PST timestamps in the report to UTC.",
         shared_state_snapshot=(("ticket", "TZ-12"),),
@@ -244,7 +248,8 @@ def test_skill_runtime_service_routes_hits_and_caps_visible_skills(
     )
 
 
-def test_skill_runtime_service_falls_back_when_search_has_no_hits(
+@pytest.mark.asyncio
+async def test_skill_runtime_service_falls_back_when_search_has_no_hits(
     tmp_path: Path,
 ) -> None:
     registry = _build_registry(
@@ -280,7 +285,7 @@ def test_skill_runtime_service_falls_back_when_search_has_no_hits(
         )
     )
 
-    result = service.prepare_prompt(
+    result = await service.prepare_prompt_async(
         role=role,
         objective="neutrino kaleidoscope harmonic lattice",
         shared_state_snapshot=(),
@@ -295,7 +300,8 @@ def test_skill_runtime_service_falls_back_when_search_has_no_hits(
     assert result.routing.visible_skills == result.routing.authorized_skills
 
 
-def test_skill_runtime_service_uses_user_override_for_duplicate_skill_name(
+@pytest.mark.asyncio
+async def test_skill_runtime_service_uses_user_override_for_duplicate_skill_name(
     tmp_path: Path,
 ) -> None:
     app_skill_dir = tmp_path / ".agent-teams" / "skills" / "time"
@@ -321,7 +327,7 @@ def test_skill_runtime_service_uses_user_override_for_duplicate_skill_name(
     _ = service.rebuild_index()
     role = _build_role(("time",))
 
-    result = service.prepare_prompt(
+    result = await service.prepare_prompt_async(
         role=role,
         objective="Fix the timestamp bug.",
         shared_state_snapshot=(),

--- a/tests/unit_tests/test_async_wrapper_coverage.py
+++ b/tests/unit_tests/test_async_wrapper_coverage.py
@@ -1459,6 +1459,9 @@ class _PermissiveAsyncReceiver:
     async def _get_async_conn(self) -> "_PermissiveAsyncReceiver":
         return self
 
+    def _async_message_repo(self) -> "_PermissiveAsyncReceiver":
+        return self
+
     async def _run_async_read(self, operation: Callable[[object], object]) -> object:
         result = operation(self)
         if inspect.isawaitable(result):

--- a/tests/unit_tests/tools/runtime/test_persisted_state.py
+++ b/tests/unit_tests/tools/runtime/test_persisted_state.py
@@ -20,12 +20,16 @@ from relay_teams.tools.runtime.persisted_state import (
     ToolCallBatchStatus,
     ToolExecutionStatus,
     load_or_recover_tool_call_state,
+    load_or_recover_tool_call_state_async,
     load_tool_call_batch_state,
     load_tool_call_batch_state_async,
     load_tool_call_state,
     merge_tool_call_state,
+    merge_tool_call_state_async,
     recover_tool_call_batches_from_event_log,
+    recover_tool_call_batches_from_event_log_async,
     recover_tool_call_state_from_event_log,
+    recover_tool_call_state_from_event_log_async,
     update_tool_call_call_state_async,
 )
 
@@ -156,6 +160,227 @@ def test_recover_tool_call_batch_and_result_from_event_log(tmp_path: Path) -> No
         expected_tool_name="current_time",
         to_json_compatible=lambda value: cast(JsonValue, value),
     ) == {"time": "2026-03-07T10:00:00Z"}
+
+
+@pytest.mark.asyncio
+async def test_async_recover_tool_call_batch_and_result_from_event_log(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_async_recovery.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-a",
+                "args": {"timezone": "UTC"},
+                "batch_id": "batch-1",
+                "batch_index": 0,
+                "batch_size": 1,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    result_event_id = await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_RESULT,
+            payload={
+                "tool_name": "current_time",
+                "tool_call_id": "call-a",
+                "result": {"time": "2026-03-07T10:00:00Z"},
+                "error": False,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    batches = await recover_tool_call_batches_from_event_log_async(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+    )
+    recovered_call = await recover_tool_call_state_from_event_log_async(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+        tool_call_id="call-a",
+    )
+
+    assert len(batches) == 1
+    assert batches[0].status == ToolCallBatchStatus.OPEN
+    assert [item.tool_call_id for item in batches[0].items] == ["call-a"]
+    assert recovered_call is not None
+    assert recovered_call.execution_status == ToolExecutionStatus.COMPLETED
+    assert recovered_call.result_event_id == result_event_id
+    assert recovered_call.result_envelope == {"time": "2026-03-07T10:00:00Z"}
+
+
+@pytest.mark.asyncio
+async def test_async_recover_tool_call_state_handles_approval_and_result_meta(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_async_approval.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-approval",
+                "args_preview": {"timezone": "UTC"},
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_APPROVAL_REQUESTED,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-approval",
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_APPROVAL_RESOLVED,
+            payload={
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "tool_name": "current_time",
+                "tool_call_id": "call-approval",
+                "action": "approve_exact",
+                "feedback": "ok",
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_RESULT,
+            payload={
+                "tool_name": "current_time",
+                "tool_call_id": "call-approval",
+                "result": {
+                    "ok": False,
+                    "meta": {
+                        "approval_status": "deny",
+                        "approval_mode": "approval_flow",
+                        "run_yolo": True,
+                    },
+                },
+                "error": True,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    recovered_call = await recover_tool_call_state_from_event_log_async(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+        tool_call_id="call-approval",
+    )
+
+    assert recovered_call is not None
+    assert recovered_call.approval_status == ToolApprovalStatus.DENY
+    assert recovered_call.execution_status == ToolExecutionStatus.FAILED
+    assert recovered_call.run_yolo is True
+    assert recovered_call.result_envelope == {
+        "ok": False,
+        "meta": {
+            "approval_status": "deny",
+            "approval_mode": "approval_flow",
+            "run_yolo": True,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_recover_tool_call_batches_skips_invalid_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_async_invalid_batches.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "batch_id": "batch-other-task",
+                "tool_call_id": "call-other",
+                "tool_name": "current_time",
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        ).model_copy(update={"task_id": "task-other"})
+    )
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_CALL,
+            payload={
+                "batch_id": "batch-invalid-call",
+                "tool_call_id": "",
+                "tool_name": "current_time",
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_CALL_BATCH_SEALED,
+            payload={
+                "batch_id": "batch-non-list",
+                "tool_calls": "bad",
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+    await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_CALL_BATCH_SEALED,
+            payload={
+                "batch_id": "batch-good",
+                "tool_calls": (
+                    {"tool_call_id": "call-good", "tool_name": "current_time"},
+                ),
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    batches = await recover_tool_call_batches_from_event_log_async(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+    )
+
+    assert len(batches) == 1
+    assert batches[0].batch_id == "batch-good"
+    assert batches[0].status == ToolCallBatchStatus.SEALED
 
 
 def test_recover_open_tool_call_batch_preserves_json_args_preview(
@@ -317,6 +542,58 @@ def test_load_or_recover_replays_result_event_over_stale_running_state(
         "data": {"time": "2026-03-07T10:00:00Z"},
         "meta": {"tool_result_event_published": True},
     }
+
+
+@pytest.mark.asyncio
+async def test_load_or_recover_async_replays_result_event_over_stale_running_state(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "persisted_state_async_stale_running.db"
+    event_log = EventLog(db_path)
+    shared_store = SharedStateRepository(db_path)
+    await merge_tool_call_state_async(
+        shared_store=shared_store,
+        task_id="task-1",
+        tool_call_id="call-a",
+        tool_name="current_time",
+        run_id="run-1",
+        session_id="session-1",
+        instance_id="inst-1",
+        role_id="time",
+        args_preview='{"timezone":"UTC"}',
+        execution_status=ToolExecutionStatus.RUNNING,
+        call_state={"resume_token": "token-1"},
+    )
+    result_event_id = await event_log.emit_run_event_async(
+        _event(
+            RunEventType.TOOL_RESULT,
+            payload={
+                "tool_name": "current_time",
+                "tool_call_id": "call-a",
+                "result": {
+                    "ok": True,
+                    "data": {"time": "2026-03-07T10:00:00Z"},
+                    "meta": {"tool_result_event_published": True},
+                },
+                "error": False,
+                "role_id": "time",
+                "instance_id": "inst-1",
+            },
+        )
+    )
+
+    recovered_call = await load_or_recover_tool_call_state_async(
+        event_log=event_log,
+        shared_store=shared_store,
+        trace_id="trace-1",
+        task_id="task-1",
+        tool_call_id="call-a",
+    )
+
+    assert recovered_call is not None
+    assert recovered_call.execution_status == ToolExecutionStatus.COMPLETED
+    assert recovered_call.result_event_id == result_event_id
+    assert recovered_call.call_state == {"resume_token": "token-1"}
 
 
 def test_parallel_load_or_recover_replays_result_events_without_state_corruption(

--- a/tests/unit_tests/tools/workspace_tools/test_office_read_markdown.py
+++ b/tests/unit_tests/tools/workspace_tools/test_office_read_markdown.py
@@ -223,10 +223,10 @@ async def test_office_read_markdown_tool_converts_supported_pdf(
         is not None
     )
     from relay_teams.agents.execution.prompt_instruction_state import (
-        is_prompt_instruction_loaded,
+        is_prompt_instruction_loaded_async,
     )
 
-    assert is_prompt_instruction_loaded(
+    assert await is_prompt_instruction_loaded_async(
         shared_store=shared_store,
         task_id="task-1",
         path=instruction_path,

--- a/tests/unit_tests/tools/workspace_tools/test_read.py
+++ b/tests/unit_tests/tools/workspace_tools/test_read.py
@@ -537,10 +537,10 @@ async def test_read_tool_reads_notebook_cell_without_outputs(
     assert '"source": "print(1)\\n"' in output
     assert '"outputs"' not in output
     from relay_teams.agents.execution.prompt_instruction_state import (
-        is_prompt_instruction_loaded,
+        is_prompt_instruction_loaded_async,
     )
 
-    assert is_prompt_instruction_loaded(
+    assert await is_prompt_instruction_loaded_async(
         shared_store=shared_store,
         task_id="task-1",
         path=instruction_path,
@@ -665,7 +665,7 @@ async def test_resolve_read_instruction_sections_skips_preloaded_paths(
     tmp_path: Path,
 ) -> None:
     from relay_teams.agents.execution.prompt_instruction_state import (
-        record_prompt_instruction_loaded,
+        record_prompt_instruction_loaded_async,
     )
     from relay_teams.tools.workspace_tools.read import resolve_read_instruction_sections
 
@@ -679,7 +679,7 @@ async def test_resolve_read_instruction_sections_skips_preloaded_paths(
     instruction_path.write_text("Nested instructions.", encoding="utf-8")
     file_path.write_text("print('hello')\n", encoding="utf-8")
     shared_store = SharedStateRepository(db_path)
-    record_prompt_instruction_loaded(
+    await record_prompt_instruction_loaded_async(
         shared_store=shared_store,
         task_id="task-1",
         path=instruction_path,

--- a/tests/unit_tests/workspace/test_manager.py
+++ b/tests/unit_tests/workspace/test_manager.py
@@ -79,6 +79,38 @@ def test_workspace_manager_uses_worktree_root_for_git_worktree_workspace(
     )
 
 
+@pytest.mark.asyncio
+async def test_workspace_manager_resolve_async_uses_async_repository_path(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "workspace.db"
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    service = WorkspaceService(repository=WorkspaceRepository(db_path))
+    _ = service.create_workspace(
+        workspace_id="async-project",
+        root_path=project_root,
+    )
+    manager = WorkspaceManager(
+        project_root=tmp_path,
+        app_config_dir=tmp_path / ".agent-teams",
+        workspace_repo=WorkspaceRepository(db_path),
+    )
+
+    handle = await manager.resolve_async(
+        session_id="session-1",
+        role_id="designer",
+        instance_id="instance-1",
+        workspace_id="async-project",
+    )
+    locations = await manager.locations_for_async("async-project")
+
+    assert handle.ref.workspace_id == "async-project"
+    assert handle.ref.conversation_id == "conv_session_1_designer"
+    assert handle.locations.scope_root == project_root.resolve()
+    assert locations.scope_root == project_root.resolve()
+
+
 def test_workspace_manager_includes_builtin_and_app_skill_roots_in_read_scope(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- remove shallow sync/async bridge APIs from memory, retrieval, prompt history, and runtime support paths
- move runtime SQLite, workspace, run intent, persisted tool-state, and retrieval metric writes onto real async paths
- harden LLM streaming/proxy cleanup around incomplete streams and run-scoped HTTP clients
- document the async-only contract that forbids paired shallow sync/async wrappers

Fixes #749

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH="$HOME/.cache/ms-playwright" uv run --extra dev pytest -q tests/integration_tests