### PR TITLE
fix: load skill-local agent roles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ This directory is organized by documentation purpose and runtime module.
 - [Sessions](modules/sessions/)
 - [SP-3 spec checkpoint refresh](modules/sessions/spec-checkpoint-refresh-design.md)
 - [Skills](modules/skills/)
+- [Skill-local agent roles](modules/skills/skill-local-agent-roles-spec.md)
 - [Workspace runtime](modules/workspace/)
 
 ## Interfaces And Operations

--- a/docs/modules/skills/skill-local-agent-roles-spec.md
+++ b/docs/modules/skills/skill-local-agent-roles-spec.md
@@ -1,0 +1,93 @@
+# Skill-Local Agent Roles
+
+## Purpose
+
+Skills may carry local subagent role documents so a model can discover a skill,
+inspect its available helper roles, and activate only the roles needed for the
+current run. These roles are exposed through `list_skill_roles(skill_name)` and
+materialized through `activate_skill_roles(skill_name, role_ids)`.
+
+## Discovery
+
+`list_skill_roles` scans Markdown files under the selected skill directory.
+`SKILL.md` is excluded. Any other Markdown file with YAML front matter containing
+`role_id` is treated as a candidate skill-local role.
+
+The `agents/` directory is a first-class convention for skill-local subagents.
+For example:
+
+```text
+my-skill/
+  SKILL.md
+  agents/
+    ci-analyzer.md
+```
+
+Directory names are not part of the authorization boundary. Authorization is
+still based on whether the calling role is allowed to use the parent skill.
+
+## Role Document Format
+
+A skill-local role document is a Markdown file with YAML front matter followed by
+the role system prompt body.
+
+Required fields:
+
+- `role_id`
+- `name`
+- `description`
+- `tools`
+
+Optional fields:
+
+- `version`, defaults to `"1"`
+- `mode`, defaults to `subagent`
+- `mcp_servers`, defaults to an empty list
+- `skills`, defaults to an empty list
+- `model_profile`, defaults to `default`
+- `bound_agent_id`
+- `execution_surface`, defaults to `api`
+- `memory_profile`
+- `contract`
+- `hooks`
+
+Example:
+
+```markdown
+---
+role_id: ci-analyzer
+name: CI Pipeline Analyzer
+description: Analyzes CI pipeline failures and fixes targeted issues.
+tools:
+  - read
+  - edit
+  - shell
+---
+
+You are a CI Pipeline Fixer agent.
+```
+
+## Runtime Semantics
+
+Skill-local roles are always activated as run-scoped subagent roles. If a role
+document sets another `mode`, `activate_skill_roles` still produces a
+`TemporaryRoleSpec` with `mode=subagent` so the effective role can be used by
+`spawn_subagent` and orchestration dispatch.
+
+The effective role id is deterministic:
+
+```text
+skill_team_<skill-fragment>_<role-fragment>_<hash>
+```
+
+The original `role_id` remains the selector used by `activate_skill_roles`.
+
+## Validation
+
+Invalid role documents are ignored and logged with the skill name, source path,
+and validation error. Duplicate `role_id` values within the same skill keep the
+first sorted document and ignore later duplicates.
+
+Explicit role mutations outside skill directories remain strict and must still
+provide the full role document fields required by the role editor and role
+validation APIs.

--- a/docs/modules/skills/skill-routing-design.md
+++ b/docs/modules/skills/skill-routing-design.md
@@ -164,8 +164,9 @@ flag. The normal flow is:
 The `skill-teams` group contains:
 
 - `list_skill_roles(skill_name)`: scans skill-local markdown files that expose role
-  front matter and returns role summaries only; directory and workflow file names
-  are not part of the contract.
+  front matter and returns role summaries only. `agents/*.md` is the preferred
+  convention for skill-local subagents, and the full document contract is defined
+  in [Skill-local agent roles](skill-local-agent-roles-spec.md).
 - `activate_skill_roles(skill_name, role_ids)`: materializes selected skill-local
   roles as run-scoped effective roles. Returned `effective_role_id` values may be
   passed to existing `spawn_subagent` or `orch_dispatch_task`.

--- a/src/relay_teams/skills/skill_team_roles.py
+++ b/src/relay_teams/skills/skill_team_roles.py
@@ -6,9 +6,12 @@ import logging
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from relay_teams.computer import ExecutionSurface
 from relay_teams.logger import get_logger, log_event
+from relay_teams.roles.memory_models import MemoryProfile, default_memory_profile
+from relay_teams.roles.role_contracts import RoleContract
 from relay_teams.roles.role_models import RoleDefinition, RoleMode
 from relay_teams.roles.role_registry import RoleLoader
 from relay_teams.roles.temporary_role_models import TemporaryRoleSpec
@@ -39,11 +42,37 @@ class SkillTeamRoleDefinition(BaseModel):
     role: RoleDefinition
 
 
+class SkillLocalRoleFrontMatter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role_id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    version: str = Field(default="1", min_length=1, coerce_numbers_to_str=True)
+    tools: tuple[str, ...] = Field(min_length=1)
+    mcp_servers: tuple[str, ...] = ()
+    skills: tuple[str, ...] = ()
+    model_profile: str = Field(default="default", min_length=1)
+    bound_agent_id: str | None = None
+    execution_surface: ExecutionSurface = ExecutionSurface.API
+    mode: RoleMode = RoleMode.SUBAGENT
+    memory_profile: MemoryProfile = Field(default_factory=default_memory_profile)
+    contract: RoleContract = Field(default_factory=RoleContract)
+    hooks: object | None = None
+
+    @field_validator("mcp_servers", "skills", mode="before")
+    @classmethod
+    def _blank_optional_lists_to_empty_tuple(cls, value: object) -> object:
+        if value is None:
+            return ()
+        return value
+
+
 def list_skill_team_roles(skill: Skill) -> tuple[SkillTeamRoleDefinition, ...]:
     roles_by_id: dict[str, SkillTeamRoleDefinition] = {}
     for role_path in _iter_skill_role_files(skill.directory):
         try:
-            role = RoleLoader().load_one(role_path)
+            role = _load_skill_local_role(role_path)
             if role.role_id in roles_by_id:
                 log_event(
                     LOGGER,
@@ -152,6 +181,43 @@ def _iter_skill_role_files(skill_dir: Path) -> tuple[Path, ...]:
         for path in sorted(skill_dir.rglob("*.md"))
         if path.name.casefold() != "skill.md" and _looks_like_role_file(path)
     )
+
+
+def _load_skill_local_role(path: Path) -> RoleDefinition:
+    raw = path.read_text(encoding="utf-8")
+    front_matter, body = _split_markdown_front_matter(raw)
+    parsed = yaml.safe_load(front_matter)
+    role_front_matter = SkillLocalRoleFrontMatter.model_validate(parsed)
+    normalized_front_matter = yaml.safe_dump(
+        role_front_matter.model_dump(mode="json", exclude_none=True),
+        allow_unicode=True,
+        sort_keys=False,
+    )
+    normalized_content = f"---\n{normalized_front_matter}---\n{body}"
+    return RoleLoader().load_from_text(normalized_content, source_name=str(path))
+
+
+def _split_markdown_front_matter(content: str) -> tuple[str, str]:
+    content = content.lstrip("\ufeff")
+    if not content.startswith("---"):
+        raise ValueError("Markdown front matter is missing")
+
+    lines = content.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise ValueError("Markdown front matter is missing")
+
+    end_index: int | None = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            end_index = idx
+            break
+
+    if end_index is None:
+        raise ValueError("Markdown front matter is incomplete")
+
+    front_matter = "".join(lines[1:end_index])
+    body = "".join(lines[end_index + 1 :])
+    return front_matter, body
 
 
 def _looks_like_role_file(path: Path) -> bool:

--- a/tests/unit_tests/skills/test_skill_team_roles.py
+++ b/tests/unit_tests/skills/test_skill_team_roles.py
@@ -48,6 +48,94 @@ def test_build_skill_team_role_spec_forces_subagent_mode(tmp_path: Path) -> None
     assert spec.tools == ("read", "office_read_markdown")
 
 
+def test_list_skill_team_roles_loads_agents_directory_subagents(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "skills" / "ci-loop"
+    agents_dir = skill_dir / "agents"
+    agents_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: ci-loop\n"
+        "description: Fix CI pipeline failures.\n"
+        "---\n"
+        "Use the CI workflow.\n",
+        encoding="utf-8",
+    )
+    (agents_dir / "ci-analyzer.md").write_text(
+        "---\n"
+        "role_id: ci-analyzer\n"
+        "name: CI Pipeline Analyzer\n"
+        "description: Analyzes CI pipeline failures and fixes issues.\n"
+        "tools:\n"
+        "  - read\n"
+        "  - edit\n"
+        "  - shell\n"
+        "---\n"
+        "You are a CI Pipeline Fixer agent.\n",
+        encoding="utf-8",
+    )
+    registry = SkillRegistry(
+        directory=SkillsDirectory(
+            sources=((SkillSource.USER_RELAY_TEAMS, tmp_path / "skills"),)
+        )
+    )
+    skill = registry.get_skill_definition("ci-loop")
+    assert skill is not None
+
+    role_entry = list_skill_team_roles(skill)[0]
+
+    assert role_entry.summary.role_id == "ci-analyzer"
+    assert role_entry.summary.name == "CI Pipeline Analyzer"
+    assert role_entry.summary.source_path == "agents/ci-analyzer.md"
+    assert {"read", "edit", "shell"}.issubset(set(role_entry.summary.tools))
+    assert "office_read_markdown" in role_entry.summary.tools
+    assert role_entry.role.version == "1"
+    assert role_entry.role.mode == RoleMode.SUBAGENT
+
+
+def test_list_skill_team_roles_accepts_blank_optional_lists(
+    tmp_path: Path,
+) -> None:
+    skill_dir = tmp_path / "skills" / "ci-loop"
+    agents_dir = skill_dir / "agents"
+    agents_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: ci-loop\n"
+        "description: Fix CI pipeline failures.\n"
+        "---\n"
+        "Use the CI workflow.\n",
+        encoding="utf-8",
+    )
+    (agents_dir / "ci-analyzer.md").write_text(
+        "---\n"
+        "role_id: ci-analyzer\n"
+        "name: CI Pipeline Analyzer\n"
+        "description: Analyzes CI pipeline failures and fixes issues.\n"
+        "tools:\n"
+        "  - read\n"
+        "mcp_servers:\n"
+        "skills:\n"
+        "---\n"
+        "You are a CI Pipeline Fixer agent.\n",
+        encoding="utf-8",
+    )
+    registry = SkillRegistry(
+        directory=SkillsDirectory(
+            sources=((SkillSource.USER_RELAY_TEAMS, tmp_path / "skills"),)
+        )
+    )
+    skill = registry.get_skill_definition("ci-loop")
+    assert skill is not None
+
+    role_entry = list_skill_team_roles(skill)[0]
+
+    assert role_entry.summary.role_id == "ci-analyzer"
+    assert role_entry.summary.mcp_servers == ()
+    assert role_entry.summary.skills == ()
+
+
 def test_list_skill_team_roles_reports_activation_effective_tools(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Load skill-local `agents/*.md` subagent documents with default `version` and `subagent` mode.
- Keep activation on the existing temporary-role path while preserving declared tools and default subagent tools.
- Document the skill-local agent role format and add regression coverage for `agents/ci-analyzer.md`.

## Tests
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests`

Closes #756