### PR TITLE
fix: render terminal run output

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -1121,7 +1121,9 @@ Notes:
 - `compaction_marker_before.label` is `History compacted (rolling summary)` when the marker metadata reports `compaction_strategy = rolling_summary`; older markers without strategy metadata may still render as `History compacted`.
 - `microcompact` and `compaction_marker_before` may both be present on the same round. In that case the request first used microcompact and then also crossed a persisted full-compaction boundary.
 - Automatic history compaction is logical only. Older messages are marked hidden-from-context for model reads, but remain available to raw/history endpoints.
-- When legacy destructive clear behavior left a completed run with no persisted coordinator message rows, the round projection may synthesize one assistant text message from the persisted `run_completed.output`.
+- A terminal `run_completed` event with non-empty `output` is a valid final-answer source. The live frontend must render that terminal output when no `text_delta` or `output_delta` has already produced final coordinator content for the run.
+- A terminal `run_failed` event with `completion_reason = "assistant_response"` follows the same final-output rule; other failed terminal outputs remain diagnostic and are not treated as final answers.
+- When legacy destructive clear behavior left a completed run with no persisted coordinator message rows, the round projection may synthesize one assistant text message from the persisted terminal event output.
 
 ### `GET /sessions/{session_id}/rounds/{run_id}`
 

--- a/frontend/dist/js/core/eventRouter/index.js
+++ b/frontend/dist/js/core/eventRouter/index.js
@@ -176,7 +176,7 @@ export function routeEvent(evType, payload, eventMeta) {
     } else if (evType === 'model_step_finished') {
         handleModelStepFinished(eventMeta, instanceId, roleId);
     } else if (evType === 'run_completed') {
-        handleRunCompleted(eventMeta);
+        handleRunCompleted(eventMeta, payload);
         roundsTimeline.syncRoundTodoVisibility?.();
     } else if (evType === 'run_stopped') {
         handleRunStopped(eventMeta, payload);

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -43,6 +43,7 @@ import {
     appendStreamOutputParts,
     finalizeThinking,
     finalizeStream,
+    getCoordinatorStreamOverlay,
     getOrCreateStreamBlock,
     reconcileTerminalRunStreamState,
     startThinkingBlock,
@@ -448,7 +449,7 @@ export function handleSubagentRunTerminal(instanceId, status, eventMeta = null, 
     }
 }
 
-export function handleRunCompleted(eventMeta) {
+export function handleRunCompleted(eventMeta, payload = null) {
     sysLog('Run completed.');
     const runId = eventMeta?.run_id || eventMeta?.trace_id || state.activeRunId || '';
     markLlmRetrySucceeded(runId);
@@ -473,6 +474,12 @@ export function handleRunCompleted(eventMeta) {
             els.promptInput.focus();
         }
     }
+    appendMissingTerminalOutput(runId, payload, {
+        roleId: getRunPrimaryRoleId(runId),
+        label: getRunPrimaryRoleLabel(runId),
+        eventMeta,
+        allowFailedAssistantResponse: false,
+    });
     finalizeStream('primary', getRunPrimaryRoleId(runId), { runId });
     reconcileTerminalRunStreamState(runId);
     clearRunPrimaryRole(runId);
@@ -537,6 +544,12 @@ export function handleRunFailed(eventMeta, payload) {
         els.stopBtn.style.display = 'none';
     }
     if (els.promptInput) els.promptInput.disabled = !!state.activeSubagentSession;
+    appendMissingTerminalOutput(runId, payload, {
+        roleId: getRunPrimaryRoleId(runId),
+        label: getRunPrimaryRoleLabel(runId),
+        eventMeta,
+        allowFailedAssistantResponse: true,
+    });
     finalizeStream('primary', getRunPrimaryRoleId(runId), { runId });
     reconcileTerminalRunStreamState(runId);
     clearRunPrimaryRole(runId);
@@ -558,6 +571,96 @@ function markCurrentSessionTerminalViewed(eventMeta = null) {
             'log-error',
         );
     });
+}
+
+function appendMissingTerminalOutput(
+    runId,
+    payload,
+    {
+        roleId = '',
+        label = '',
+        eventMeta = null,
+        allowFailedAssistantResponse = false,
+    } = {},
+) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId || !payload || typeof payload !== 'object') {
+        return;
+    }
+    if (!isDisplayableTerminalOutput(payload, allowFailedAssistantResponse)) {
+        return;
+    }
+    if (coordinatorOverlayHasFinalContent(safeRunId)) {
+        return;
+    }
+    const outputParts = normalizeTerminalOutputParts(payload.output);
+    if (outputParts.length === 0) {
+        return;
+    }
+    const container = coordinatorContainerFor(eventMeta);
+    const primaryRoleId = String(roleId || getRunPrimaryRoleId(safeRunId) || '').trim();
+    const primaryLabel = String(label || getRunPrimaryRoleLabel(safeRunId) || 'Main Agent');
+    getOrCreateStreamBlock(container, 'primary', primaryRoleId, primaryLabel, safeRunId);
+    appendStreamOutputParts('primary', outputParts, {
+        container,
+        runId: safeRunId,
+        roleId: primaryRoleId,
+        label: primaryLabel,
+    });
+}
+
+function isDisplayableTerminalOutput(payload, allowFailedAssistantResponse) {
+    const status = String(payload.status || '').trim().toLowerCase();
+    if (status === 'completed') {
+        return true;
+    }
+    if (!allowFailedAssistantResponse || status !== 'failed') {
+        return false;
+    }
+    const completionReason = String(payload.completion_reason || '').trim().toLowerCase();
+    return completionReason === 'assistant_response';
+}
+
+function coordinatorOverlayHasFinalContent(runId) {
+    const overlay = getCoordinatorStreamOverlay(runId);
+    if (!overlay || !Array.isArray(overlay.parts)) {
+        return false;
+    }
+    return overlay.parts.some(part => {
+        const kind = String(part?.kind || '').trim();
+        if (kind === 'text') {
+            return String(part.content || part.text || '').trim().length > 0;
+        }
+        return kind === 'media_ref' || kind === 'inline_media';
+    });
+}
+
+function normalizeTerminalOutputParts(output) {
+    if (typeof output === 'string') {
+        const text = output.trim();
+        return text ? [{ kind: 'text', text }] : [];
+    }
+    if (!Array.isArray(output)) {
+        return [];
+    }
+    return output
+        .map(normalizeTerminalOutputPart)
+        .filter(part => part !== null);
+}
+
+function normalizeTerminalOutputPart(part) {
+    if (!part || typeof part !== 'object') {
+        return null;
+    }
+    const kind = String(part.kind || '').trim();
+    if (kind === 'text') {
+        const text = String(part.text || part.content || '').trim();
+        return text ? { ...part, kind: 'text', text } : null;
+    }
+    if (kind === 'media_ref' || kind === 'inline_media') {
+        return { ...part, kind };
+    }
+    return null;
 }
 
 async function markSessionTerminalRunViewedWithRetry(sessionId) {

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -478,7 +478,7 @@ export function handleRunCompleted(eventMeta, payload = null) {
         roleId: getRunPrimaryRoleId(runId),
         label: getRunPrimaryRoleLabel(runId),
         eventMeta,
-        allowFailedAssistantResponse: false,
+        terminalStatus: 'completed',
     });
     finalizeStream('primary', getRunPrimaryRoleId(runId), { runId });
     reconcileTerminalRunStreamState(runId);
@@ -548,7 +548,7 @@ export function handleRunFailed(eventMeta, payload) {
         roleId: getRunPrimaryRoleId(runId),
         label: getRunPrimaryRoleLabel(runId),
         eventMeta,
-        allowFailedAssistantResponse: true,
+        terminalStatus: 'failed',
     });
     finalizeStream('primary', getRunPrimaryRoleId(runId), { runId });
     reconcileTerminalRunStreamState(runId);
@@ -580,14 +580,14 @@ function appendMissingTerminalOutput(
         roleId = '',
         label = '',
         eventMeta = null,
-        allowFailedAssistantResponse = false,
+        terminalStatus = '',
     } = {},
 ) {
     const safeRunId = String(runId || '').trim();
     if (!safeRunId || !payload || typeof payload !== 'object') {
         return;
     }
-    if (!isDisplayableTerminalOutput(payload, allowFailedAssistantResponse)) {
+    if (!isDisplayableTerminalOutput(payload, terminalStatus)) {
         return;
     }
     if (coordinatorOverlayHasFinalContent(safeRunId)) {
@@ -609,12 +609,12 @@ function appendMissingTerminalOutput(
     });
 }
 
-function isDisplayableTerminalOutput(payload, allowFailedAssistantResponse) {
-    const status = String(payload.status || '').trim().toLowerCase();
+function isDisplayableTerminalOutput(payload, terminalStatus) {
+    const status = String(terminalStatus || '').trim().toLowerCase();
     if (status === 'completed') {
         return true;
     }
-    if (!allowFailedAssistantResponse || status !== 'failed') {
+    if (status !== 'failed') {
         return false;
     }
     const completionReason = String(payload.completion_reason || '').trim().toLowerCase();

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -1832,7 +1832,6 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
           {{
             trace_id: runId,
             root_task_id: 'task-terminal-output',
-            status: 'completed',
             output: [{{ kind: 'text', text: 'terminal payload final answer' }}],
           }},
           {{
@@ -1850,7 +1849,6 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
           {{
             trace_id: failedRunId,
             root_task_id: 'task-terminal-failed-output',
-            status: 'failed',
             completion_reason: 'assistant_response',
             output: [{{ kind: 'text', text: 'failed assistant final answer' }}],
           }},

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -463,6 +463,26 @@ def test_terminal_completed_overlay_does_not_block_processed_group_in_browser(
     assert payload["groupToolCount"] == 1
 
 
+def test_terminal_payload_output_renders_when_stream_has_no_text_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderTerminalPayloadOutput()
+        """
+    )
+
+    assert "terminal payload final answer" in payload["text"]
+    assert payload["occurrences"] == 1
+    assert "failed assistant final answer" in payload["failedText"]
+    assert "stopped diagnostic output" not in payload["stoppedText"]
+    assert payload["cursorCount"] == 0
+
+
 def test_terminal_rounds_collapse_only_when_final_output_is_projected_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -513,6 +533,7 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
         history_module = (
             f"{base_url}/frontend/dist/js/components/messageRenderer/history.js"
         )
+        event_router_module = f"{base_url}/frontend/dist/js/core/eventRouter/index.js"
         html_path.write_text(
             f"""
 <!doctype html>
@@ -524,6 +545,7 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
   <link rel="stylesheet" href="{base_url}/frontend/dist/css/components/subagent.css">
 </head>
 <body>
+  <div id="chat-messages"></div>
   <script type="module">
     import {{
       appendStreamChunk,
@@ -543,6 +565,9 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
     import {{
       renderHistoricalMessageList,
     }} from {json.dumps(history_module)};
+    import {{
+      routeEvent,
+    }} from {json.dumps(event_router_module)};
 
     function makeContainer(id) {{
       const container = document.createElement('section');
@@ -1793,6 +1818,72 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
         return {{
           groupCount: container.querySelectorAll('.tool-group').length,
           groupToolCount: container.querySelectorAll('.tool-group .tool-block').length,
+        }};
+      }},
+
+      renderTerminalPayloadOutput() {{
+        clearAllStreamState();
+        const runId = 'run-terminal-payload-output';
+        const container = makeContainer('terminal-payload-output');
+        container.className = 'session-round-section';
+        container.dataset.runId = runId;
+        routeEvent(
+          'run_completed',
+          {{
+            trace_id: runId,
+            root_task_id: 'task-terminal-output',
+            status: 'completed',
+            output: [{{ kind: 'text', text: 'terminal payload final answer' }}],
+          }},
+          {{
+            run_id: runId,
+            trace_id: runId,
+            event_id: 'terminal-payload-output-event',
+          }},
+        );
+        const failedRunId = 'run-terminal-payload-failed-output';
+        const failedContainer = makeContainer('terminal-payload-failed-output');
+        failedContainer.className = 'session-round-section';
+        failedContainer.dataset.runId = failedRunId;
+        routeEvent(
+          'run_failed',
+          {{
+            trace_id: failedRunId,
+            root_task_id: 'task-terminal-failed-output',
+            status: 'failed',
+            completion_reason: 'assistant_response',
+            output: [{{ kind: 'text', text: 'failed assistant final answer' }}],
+          }},
+          {{
+            run_id: failedRunId,
+            trace_id: failedRunId,
+            event_id: 'terminal-payload-failed-output-event',
+          }},
+        );
+        const stoppedRunId = 'run-terminal-payload-stopped-output';
+        const stoppedContainer = makeContainer('terminal-payload-stopped-output');
+        stoppedContainer.className = 'session-round-section';
+        stoppedContainer.dataset.runId = stoppedRunId;
+        routeEvent(
+          'run_stopped',
+          {{
+            trace_id: stoppedRunId,
+            root_task_id: 'task-terminal-stopped-output',
+            status: 'stopped',
+            output: [{{ kind: 'text', text: 'stopped diagnostic output' }}],
+          }},
+          {{
+            run_id: stoppedRunId,
+            trace_id: stoppedRunId,
+            event_id: 'terminal-payload-stopped-output-event',
+          }},
+        );
+        return {{
+          text: container.textContent || '',
+          failedText: failedContainer.textContent || '',
+          stoppedText: stoppedContainer.textContent || '',
+          occurrences: countSubstring(container.textContent || '', 'terminal payload final answer'),
+          cursorCount: container.querySelectorAll('.streaming-cursor').length,
         }};
       }},
 

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -914,6 +914,10 @@ export function reconcileTerminalRunStreamState(runId) {
     globalThis.__reconcileTerminalRunStreamStateCalls.push(runId);
 }
 
+export function getCoordinatorStreamOverlay() {
+    return null;
+}
+
 export function getOrCreateStreamBlock() {
     return undefined;
 }


### PR DESCRIPTION
## Summary
- render terminal `run_completed.output` when a live stream reaches completion without prior coordinator text/output deltas
- apply the same rule to failed runs only when `completion_reason` is `assistant_response`, while keeping stopped diagnostic output hidden
- document terminal event output semantics and cover them in browser integration tests

## Tests
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright RELAY_TEAMS_INTEGRATION_TEST_TIMEOUT_SECONDS=480 uv run --extra dev pytest -q tests/integration_tests`

Closes #742