### PR TITLE
fix: dedupe terminal payload output

### DIFF
--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -44,6 +44,7 @@ import {
     finalizeThinking,
     finalizeStream,
     getCoordinatorStreamOverlay,
+    getRunTimelineSnapshot,
     getOrCreateStreamBlock,
     reconcileTerminalRunStreamState,
     startThinkingBlock,
@@ -590,11 +591,14 @@ function appendMissingTerminalOutput(
     if (!isDisplayableTerminalOutput(payload, terminalStatus)) {
         return;
     }
-    if (coordinatorOverlayHasFinalContent(safeRunId)) {
-        return;
-    }
     const outputParts = normalizeTerminalOutputParts(payload.output);
     if (outputParts.length === 0) {
+        return;
+    }
+    if (
+        coordinatorOverlayHasFinalContent(safeRunId)
+        || coordinatorTimelineHasTerminalOutput(safeRunId, outputParts)
+    ) {
         return;
     }
     const container = coordinatorContainerFor(eventMeta);
@@ -635,6 +639,22 @@ function coordinatorOverlayHasFinalContent(runId) {
     });
 }
 
+function coordinatorTimelineHasTerminalOutput(runId, outputParts) {
+    const expectedText = normalizeTerminalOutputText(outputParts);
+    if (!expectedText) {
+        return false;
+    }
+    const timeline = getRunTimelineSnapshot(runId);
+    const parts = Array.isArray(timeline?.coordinator?.parts)
+        ? timeline.coordinator.parts
+        : [];
+    const actualText = normalizeTerminalOutputText(parts);
+    if (actualText === expectedText) {
+        return true;
+    }
+    return parts.some(part => normalizeTerminalOutputText([part]) === expectedText);
+}
+
 function normalizeTerminalOutputParts(output) {
     if (typeof output === 'string') {
         const text = output.trim();
@@ -646,6 +666,21 @@ function normalizeTerminalOutputParts(output) {
     return output
         .map(normalizeTerminalOutputPart)
         .filter(part => part !== null);
+}
+
+function normalizeTerminalOutputText(parts) {
+    if (!Array.isArray(parts)) {
+        return '';
+    }
+    return parts
+        .filter(part => {
+            const kind = String(part?.kind || part?.part_kind || '').trim();
+            return kind === 'text';
+        })
+        .map(part => String(part.text || part.content || '').trim())
+        .filter(Boolean)
+        .join('\n\n')
+        .trim();
 }
 
 function normalizeTerminalOutputPart(part) {

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -483,6 +483,23 @@ def test_terminal_payload_output_renders_when_stream_has_no_text_in_browser(
     assert payload["cursorCount"] == 0
 
 
+def test_terminal_payload_output_dedupes_hydrated_history_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderTerminalPayloadDedupesHydratedHistory()
+        """
+    )
+
+    assert payload["occurrences"] == 1
+    assert payload["messageCount"] == 1
+
+
 def test_terminal_rounds_collapse_only_when_final_output_is_projected_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -1882,6 +1899,52 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
           stoppedText: stoppedContainer.textContent || '',
           occurrences: countSubstring(container.textContent || '', 'terminal payload final answer'),
           cursorCount: container.querySelectorAll('.streaming-cursor').length,
+        }};
+      }},
+
+      renderTerminalPayloadDedupesHydratedHistory() {{
+        clearAllStreamState();
+        const runId = 'run-terminal-payload-history-dedupe';
+        const container = makeContainer('terminal-payload-history-dedupe');
+        container.className = 'session-round-section';
+        container.dataset.runId = runId;
+        const terminalText = [
+          'codehub-mr-loop skill defines these available roles:',
+          '| Role | File | Responsibility |',
+          '| --- | --- | --- |',
+          '| ci-analyzer | `agents/ci-analyzer.md` | Query CI pipeline status |',
+          'The previous request could not be completed because of an API or execution error.',
+        ].join('\\n\\n');
+        renderHistory(container, [{{
+          role: 'assistant',
+          role_id: 'Coordinator',
+          instance_id: 'primary',
+          message: {{
+            parts: [{{ part_kind: 'text', content: terminalText }}],
+          }},
+        }}], {{
+          runId,
+          runStatus: 'completed',
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+        }});
+        routeEvent(
+          'run_completed',
+          {{
+            trace_id: runId,
+            root_task_id: 'task-terminal-history-dedupe',
+            output: [{{ kind: 'text', text: terminalText }}],
+          }},
+          {{
+            run_id: runId,
+            trace_id: runId,
+            event_id: 'terminal-payload-history-dedupe-event',
+          }},
+        );
+        return {{
+          text: container.textContent || '',
+          occurrences: countSubstring(container.textContent || '', 'codehub-mr-loop skill'),
+          messageCount: container.querySelectorAll('.message').length,
         }};
       }},
 

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -918,6 +918,10 @@ export function getCoordinatorStreamOverlay() {
     return null;
 }
 
+export function getRunTimelineSnapshot() {
+    return null;
+}
+
 export function getOrCreateStreamBlock() {
     return undefined;
 }


### PR DESCRIPTION
## Summary
- Prevent terminal completion payload fallback from appending duplicate coordinator output when the same final text is already hydrated in the run timeline.
- Keep the existing fallback for completed runs and assistant-response failures when no streamed or hydrated final content exists.
- Add browser regression coverage for the session UI duplicate-output case shown in #761.

## Spec
- Terminal run payload output is a fallback only. It may render when the coordinator stream overlay has no final text/media and the run timeline has not already hydrated equivalent final text.
- Hydrated primary/coordinator timeline text is authoritative for duplicate prevention, including persisted `part_kind: text` history parts.
- Stopped runs continue to ignore terminal payload output. Failed runs only render assistant-response terminal output.

## Tests
- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright`
- `uv run --extra dev pytest -q tests/unit_tests/frontend/test_run_events_ui.py`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests/browser/test_streaming_message_timeline.py -k "terminal_payload"`
- `uv run --extra dev pytest -q tests/unit_tests`
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright RELAY_TEAMS_INTEGRATION_TEST_TIMEOUT_SECONDS=480 uv run --extra dev pytest -q tests/integration_tests` (one unrelated browser settings timing failure; the failed test passed on immediate single-test rerun)
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright RELAY_TEAMS_INTEGRATION_TEST_TIMEOUT_SECONDS=480 uv run --extra dev pytest -q tests/integration_tests/browser/test_browser_smoke.py::test_browser_web_settings_complex_fallback_roundtrip`

Closes #761