### PR TITLE
Fix SWE-bench eval Docker runtime

### DIFF
--- a/.agent_teams/evals/configs/normal/eval-swebench-10.yaml
+++ b/.agent_teams/evals/configs/normal/eval-swebench-10.yaml
@@ -15,7 +15,7 @@ agent_teams:
   orchestration_preset_id: null
   yolo: true
   timeout_seconds: 600
-  config_dir: "~/.config/agent-teams"
+  config_dir: "~/.relay-teams"
 
 workspace_mode: docker
 evals_workdir: .agent_teams/evals/workspaces

--- a/.agent_teams/evals/configs/normal/eval-swebench-100.yaml
+++ b/.agent_teams/evals/configs/normal/eval-swebench-100.yaml
@@ -15,7 +15,7 @@ agent_teams:
   orchestration_preset_id: null
   yolo: true
   timeout_seconds: 600
-  config_dir: "~/.config/agent-teams"
+  config_dir: "~/.relay-teams"
 
 workspace_mode: docker
 evals_workdir: .agent_teams/evals/workspaces

--- a/.agent_teams/evals/configs/normal/eval-swebench-full.yaml
+++ b/.agent_teams/evals/configs/normal/eval-swebench-full.yaml
@@ -15,7 +15,7 @@ agent_teams:
   orchestration_preset_id: null
   yolo: true
   timeout_seconds: 600
-  config_dir: "~/.config/agent-teams"
+  config_dir: "~/.relay-teams"
 
 workspace_mode: docker
 evals_workdir: .agent_teams/evals/workspaces

--- a/.agent_teams/evals/configs/normal/eval-swebench.yaml
+++ b/.agent_teams/evals/configs/normal/eval-swebench.yaml
@@ -15,7 +15,7 @@ agent_teams:
   orchestration_preset_id: null
   yolo: true
   timeout_seconds: 600
-  config_dir: "~/.config/agent-teams"
+  config_dir: "~/.relay-teams"
 
 workspace_mode: docker
 evals_workdir: .agent_teams/evals/workspaces

--- a/.agent_teams/evals/configs/orchestration/eval-swebench-10.yaml
+++ b/.agent_teams/evals/configs/orchestration/eval-swebench-10.yaml
@@ -15,7 +15,7 @@ agent_teams:
   orchestration_preset_id: default
   yolo: true
   timeout_seconds: 600
-  config_dir: "~/.config/agent-teams"
+  config_dir: "~/.relay-teams"
 
 workspace_mode: docker
 evals_workdir: .agent_teams/evals/workspaces

--- a/.agent_teams/evals/configs/orchestration/eval-swebench-100.yaml
+++ b/.agent_teams/evals/configs/orchestration/eval-swebench-100.yaml
@@ -15,7 +15,7 @@ agent_teams:
   orchestration_preset_id: default
   yolo: true
   timeout_seconds: 600
-  config_dir: "~/.config/agent-teams"
+  config_dir: "~/.relay-teams"
 
 workspace_mode: docker
 evals_workdir: .agent_teams/evals/workspaces

--- a/.agent_teams/evals/configs/orchestration/eval-swebench-full.yaml
+++ b/.agent_teams/evals/configs/orchestration/eval-swebench-full.yaml
@@ -15,7 +15,7 @@ agent_teams:
   orchestration_preset_id: default
   yolo: true
   timeout_seconds: 600
-  config_dir: "~/.config/agent-teams"
+  config_dir: "~/.relay-teams"
 
 workspace_mode: docker
 evals_workdir: .agent_teams/evals/workspaces

--- a/.agent_teams/evals/configs/orchestration/eval-swebench.yaml
+++ b/.agent_teams/evals/configs/orchestration/eval-swebench.yaml
@@ -15,7 +15,7 @@ agent_teams:
   orchestration_preset_id: default
   yolo: true
   timeout_seconds: 600
-  config_dir: "~/.config/agent-teams"
+  config_dir: "~/.relay-teams"
 
 workspace_mode: docker
 evals_workdir: .agent_teams/evals/workspaces

--- a/docker/Dockerfile.agent-runtime
+++ b/docker/Dockerfile.agent-runtime
@@ -57,7 +57,11 @@ RUN python3 -m pip wheel --quiet --no-cache-dir \
         --wheel-dir /opt/agent-runtime/wheels \
         pydantic">=2.7.0" pydantic-ai "pydantic-ai-slim[fastmcp]" \
         PyYAML">=6.0.1" typer">=0.12.3" "fastapi>=0.100.0" \
-        "uvicorn[standard]>=0.23.0" "httpx>=0.27.0"
+        "uvicorn[standard]>=0.23.0" "httpx>=0.27.0" \
+        "json-repair>=0.58.7" "lark-oapi==1.5.3" \
+        "markitdown[pdf,docx,pptx,xlsx]>=0.1.5,<0.2" \
+        "markdownify>=1.2.0" "defusedxml>=0.7.1" \
+        "qrcode>=8.0" "aiosqlite>=0.22.1"
 
 # -- Stage 2: project wheel (rebuilds when source changes) --
 COPY src/relay_teams/ src/relay_teams/
@@ -78,6 +82,7 @@ mkdir -p "$WORK_ROOT"\n\
 "$RUNTIME_ROOT/bin/uv" -q venv --clear --no-project \\\n\
     --python "$RUNTIME_ROOT/bin/python3.12" "$VENV_PATH"\n\
 "$RUNTIME_ROOT/bin/uv" -q pip install --offline --no-index --no-build \\\n\
+    --prerelease=allow \\\n\
     --python "$VENV_PATH/bin/python" \\\n\
     --find-links "$RUNTIME_ROOT/wheels" relay-teams\n\
 cd "$RUNTIME_ROOT"\n\
@@ -99,4 +104,3 @@ RUN /opt/agent-runtime/bin/rg --version > /dev/null && \
 
 # Declare volume so --volumes-from mounts /opt/agent-runtime/ into eval containers.
 VOLUME /opt/agent-runtime
-

--- a/docker/eval-entrypoint.sh
+++ b/docker/eval-entrypoint.sh
@@ -13,7 +13,7 @@
 #       /opt/agent-runtime/bin/relay-teams server start ...
 
 CONFIG_STAGING="${AGENT_TEAMS_CONFIG_STAGING:-/tmp/agent-config-host}"
-CONFIG_TARGET="${AGENT_TEAMS_CONFIG_TARGET:-/root/.config/agent-teams}"
+CONFIG_TARGET="${AGENT_TEAMS_CONFIG_TARGET:-/root/.relay-teams}"
 
 if [ -d "$CONFIG_STAGING" ]; then
     mkdir -p "$CONFIG_TARGET"

--- a/src/relay_teams/interfaces/sdk/client.py
+++ b/src/relay_teams/interfaces/sdk/client.py
@@ -12,6 +12,8 @@ from relay_teams.media import content_parts_from_text
 from relay_teams.env import load_proxy_env_config
 from relay_teams.net import create_async_http_client
 
+_STREAM_TERMINAL_EVENTS = frozenset({"run_completed", "run_failed", "run_stopped"})
+
 
 class RunHandle(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -337,6 +339,8 @@ class AsyncAgentTeamsClient:
                         parsed = json.loads(payload)
                         if isinstance(parsed, dict):
                             yield parsed
+                            if parsed.get("event_type") in _STREAM_TERMINAL_EVENTS:
+                                return
             except httpx.HTTPStatusError as exc:
                 body = (await exc.response.aread()).decode("utf-8", errors="replace")
                 raise RuntimeError(

--- a/src/relay_teams_evals/backends/agent_teams.py
+++ b/src/relay_teams_evals/backends/agent_teams.py
@@ -476,6 +476,7 @@ class AgentTeamsBackend(AgentBackend):
 
             _log(workspace.item_id, "streaming events ...")
             event_count = 0
+            terminal_event_type: str | None = None
             stream = await _maybe_await(client.stream_run_events(run_id))
             async for raw_event in _iter_raw_events(stream):
                 event_count += 1
@@ -523,15 +524,16 @@ class AgentTeamsBackend(AgentBackend):
                         str(event_type),
                         data,
                     )
-                    if event_type == "run_completed":
-                        yield AgentEvent(type="completed")
-                    elif event_type == "run_failed":
-                        yield AgentEvent(type="failed")
-                    elif event_type == "run_stopped":
-                        yield AgentEvent(type="stopped")
 
                 if event_type in _TERMINAL_EVENTS:
-                    break
+                    terminal_event_type = str(event_type)
+
+            if terminal_event_type == "run_completed":
+                yield AgentEvent(type="completed")
+            elif terminal_event_type == "run_failed":
+                yield AgentEvent(type="failed")
+            elif terminal_event_type == "run_stopped":
+                yield AgentEvent(type="stopped")
 
         finally:
             if not keep_workspace:

--- a/src/relay_teams_evals/checkpoint.py
+++ b/src/relay_teams_evals/checkpoint.py
@@ -74,7 +74,7 @@ def build_checkpoint_signature(
         agent_yolo=cfg.agent_teams.yolo,
         agent_timeout_seconds=cfg.agent_teams.timeout_seconds,
         agent_config_dir=(
-            str(cfg.agent_teams.config_dir.resolve())
+            str(cfg.agent_teams.config_dir.expanduser().resolve())
             if cfg.agent_teams.config_dir is not None
             else None
         ),

--- a/src/relay_teams_evals/models.py
+++ b/src/relay_teams_evals/models.py
@@ -108,6 +108,7 @@ class EvalResult(BaseModel):
     workspace_path: str | None = None
     started_at: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
     error: str | None = None
+    log_path: str | None = None
     build_log_path: str | None = None
     build_error_summary: str | None = None
 

--- a/src/relay_teams_evals/reporter.py
+++ b/src/relay_teams_evals/reporter.py
@@ -87,6 +87,8 @@ def _report_log_path(result: EvalResult) -> str:
         return result.build_log_path
     if result.scorer_log:
         return _artifact_log_path(result.item_id, "scorer_log.txt")
+    if result.log_path:
+        return result.log_path
     if result.error:
         return _artifact_log_path(result.item_id, "container.log")
     return ""
@@ -98,7 +100,7 @@ def _report_payload(report: EvalReport) -> dict[str, object]:
     assert isinstance(raw_results, list)
     for raw_result, result in zip(raw_results, report.results):
         assert isinstance(raw_result, dict)
-        raw_result["error"] = _report_log_path(result) or None
+        raw_result["log_path"] = _report_log_path(result) or None
         raw_result.pop("scorer_log", None)
         raw_result.pop("build_error_summary", None)
     return payload

--- a/src/relay_teams_evals/workspace/artifact_collector.py
+++ b/src/relay_teams_evals/workspace/artifact_collector.py
@@ -117,16 +117,18 @@ class ArtifactCollector:
         self, artifact_dir: Path, workspace: PreparedWorkspace
     ) -> None:
         db_src = "/root/.relay-teams/relay_teams.db"
-        db_dest = artifact_dir / "relay_teams.db"
-        try:
-            container_id = workspace.container_id or ""
-            subprocess.run(
-                ["docker", "cp", f"{container_id}:{db_src}", str(db_dest)],
-                capture_output=True,
-                check=True,
-            )
-        except (subprocess.CalledProcessError, OSError):
-            pass
+        for suffix in ("", "-wal", "-shm"):
+            src = f"{db_src}{suffix}"
+            dest = artifact_dir / f"relay_teams.db{suffix}"
+            try:
+                container_id = workspace.container_id or ""
+                subprocess.run(
+                    ["docker", "cp", f"{container_id}:{src}", str(dest)],
+                    capture_output=True,
+                    check=True,
+                )
+            except (subprocess.CalledProcessError, OSError):
+                _log(workspace.item_id, f"skipped missing container DB artifact: {src}")
 
     def _collect_container_log(
         self, artifact_dir: Path, workspace: PreparedWorkspace

--- a/tests/unit_tests/relay_teams_evals/test_agent_teams_backend.py
+++ b/tests/unit_tests/relay_teams_evals/test_agent_teams_backend.py
@@ -385,3 +385,72 @@ def test_agent_teams_backend_configures_orchestration_session(
 
     assert [event.type for event in events] == ["metadata", "token_usage", "completed"]
     assert "configuring session mode: orchestration preset=default" in out
+
+
+class _FakeFailedClient(_FakeClient):
+    def stream_run_events(self, run_id: str) -> Iterator[dict[str, object]]:
+        assert run_id == "run-1"
+        yield {
+            "event_type": "run_failed",
+            "payload_json": (
+                '{"trace_id": "run-1", "root_task_id": "root_12345678", '
+                '"error_message": "assistant error"}'
+            ),
+        }
+
+
+class _FakeStoppedClient(_FakeClient):
+    def stream_run_events(self, run_id: str) -> Iterator[dict[str, object]]:
+        assert run_id == "run-1"
+        yield {
+            "event_type": "run_stopped",
+            "payload_json": '{"trace_id": "run-1", "root_task_id": "root_12345678"}',
+        }
+
+
+def test_agent_teams_backend_maps_failed_terminal_event(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "relay_teams_evals.backends.agent_teams.AgentTeamsClient",
+        _FakeFailedClient,
+    )
+    backend = AgentTeamsBackend(
+        AgentTeamsConfig(
+            base_url="http://localhost:8000",
+            timeout_seconds=30.0,
+            yolo=True,
+        )
+    )
+    workspace = PreparedWorkspace(
+        item_id="demo",
+        repo_path=Path("."),
+        base_commit="abc123",
+        container_repo_path="/testbed",
+    )
+
+    events = list(backend.run("demo intent", workspace))
+
+    assert [event.type for event in events] == ["metadata", "failed"]
+
+
+def test_agent_teams_backend_maps_stopped_terminal_event(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "relay_teams_evals.backends.agent_teams.AgentTeamsClient",
+        _FakeStoppedClient,
+    )
+    backend = AgentTeamsBackend(
+        AgentTeamsConfig(
+            base_url="http://localhost:8000",
+            timeout_seconds=30.0,
+            yolo=True,
+        )
+    )
+    workspace = PreparedWorkspace(
+        item_id="demo",
+        repo_path=Path("."),
+        base_commit="abc123",
+        container_repo_path="/testbed",
+    )
+
+    events = list(backend.run("demo intent", workspace))
+
+    assert [event.type for event in events] == ["metadata", "stopped"]

--- a/tests/unit_tests/relay_teams_evals/test_checkpoint.py
+++ b/tests/unit_tests/relay_teams_evals/test_checkpoint.py
@@ -109,3 +109,22 @@ def test_build_checkpoint_signature_includes_session_mode_and_orchestration(
 
     assert signature.agent_session_mode == "orchestration"
     assert signature.agent_orchestration_preset_id == "default"
+
+
+def test_build_checkpoint_signature_expands_agent_config_dir(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    dataset_path.write_text('{"item_id":"a","intent":"demo"}\n', encoding="utf-8")
+    config_dir = Path("~/.config/agent-teams")
+    cfg = RunConfig(
+        dataset_path=dataset_path,
+        workspace_mode="docker",
+        agent_teams=AgentTeamsConfig(config_dir=config_dir),
+    )
+
+    signature = build_checkpoint_signature(
+        cfg,
+        dataset_path=dataset_path,
+        item_ids=("a",),
+    )
+
+    assert signature.agent_config_dir == str(config_dir.expanduser().resolve())

--- a/tests/unit_tests/relay_teams_evals/test_eval_configs.py
+++ b/tests/unit_tests/relay_teams_evals/test_eval_configs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import yaml
+
+from relay_teams.paths.root_paths import get_app_config_dir
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _mapping(value: object) -> Mapping[object, object]:
+    assert isinstance(value, Mapping)
+    return value
+
+
+def test_bundled_swebench_configs_use_current_app_config_dir() -> None:
+    expected_config_dir = f"~/{get_app_config_dir(Path('~')).name}"
+    configs_dir = _repo_root() / ".agent_teams" / "evals" / "configs"
+    config_paths = sorted(configs_dir.glob("**/eval-swebench*.yaml"))
+
+    assert config_paths
+    for config_path in config_paths:
+        raw_config: object = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        config = _mapping(raw_config)
+        agent_teams = _mapping(config["agent_teams"])
+
+        assert agent_teams["config_dir"] == expected_config_dir

--- a/tests/unit_tests/relay_teams_evals/test_reporter.py
+++ b/tests/unit_tests/relay_teams_evals/test_reporter.py
@@ -173,8 +173,69 @@ def test_write_json_includes_swebench_diagnostics() -> None:
     ]
     assert "rerun_command" not in payload["results"][0]
     assert payload["results"][0]["error"] is None
+    assert payload["results"][0]["log_path"] is None
     assert "scorer_log" not in payload["results"][0]
     assert "build_error_summary" not in payload["results"][0]
+
+
+def test_write_json_keeps_error_separate_from_log_path() -> None:
+    report = build_report(
+        [
+            EvalResult(
+                item_id="demo",
+                dataset="swebench",
+                run_id="run-1",
+                session_id="session-1",
+                outcome=RunOutcome.FAILED,
+                passed=False,
+                score=0.0,
+                scorer_name="swebench_docker",
+                error=None,
+                scorer_log="pytest output",
+                token_usage=TokenUsage(),
+            )
+        ],
+        dataset="swebench",
+        scorer_name="swebench_docker",
+    )
+    path = _local_tmp_dir("reporter-json-log") / "report.json"
+
+    EvalReporter().write_json(report, path)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["errored"] == 0
+    assert payload["results"][0]["error"] is None
+    assert payload["results"][0]["log_path"] == "artifacts/demo/scorer_log.txt"
+    assert "scorer_log" not in payload["results"][0]
+
+
+def test_write_json_preserves_serialized_log_path_without_scorer_log() -> None:
+    report = build_report(
+        [
+            EvalResult(
+                item_id="demo",
+                dataset="swebench",
+                run_id="run-1",
+                session_id="session-1",
+                outcome=RunOutcome.FAILED,
+                passed=False,
+                score=0.0,
+                scorer_name="swebench_docker",
+                error="docker failed",
+                log_path="artifacts/demo/scorer_log.txt",
+                token_usage=TokenUsage(),
+            )
+        ],
+        dataset="swebench",
+        scorer_name="swebench_docker",
+    )
+    path = _local_tmp_dir("reporter-json-preserve-log") / "report.json"
+
+    EvalReporter().write_json(report, path)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["results"][0]["error"] == "docker failed"
+    assert payload["results"][0]["log_path"] == "artifacts/demo/scorer_log.txt"
 
 
 def test_write_html_shows_log_path_instead_of_error_text() -> None:

--- a/tests/unit_tests/relay_teams_evals/workspace/test_artifact_collector.py
+++ b/tests/unit_tests/relay_teams_evals/workspace/test_artifact_collector.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import subprocess
+
+import pytest
 
 from relay_teams_evals.models import (
     AuxiliaryScore,
@@ -9,6 +12,7 @@ from relay_teams_evals.models import (
     RunOutcome,
     TokenUsage,
 )
+from relay_teams_evals.workspace.base import PreparedWorkspace
 from relay_teams_evals.workspace.artifact_collector import ArtifactCollector
 
 
@@ -206,3 +210,130 @@ def test_artifact_collector_overwrites_previous_artifacts_for_rerun(tmp_path) ->
     assert not (artifact_dir / "patch.diff").exists()
     assert not (artifact_dir / "raw_patch.diff").exists()
     assert not (artifact_dir / "scorer_log.txt").exists()
+
+
+def test_artifact_collector_copies_sqlite_wal_sidecars(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    def fake_run(
+        command: list[str],
+        capture_output: bool,
+        check: bool = False,
+        text: bool = False,
+        encoding: str | None = None,
+        errors: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output, check, text, encoding, errors
+        commands.append(tuple(command))
+        return subprocess.CompletedProcess(
+            args=command, returncode=0, stdout="", stderr=""
+        )
+
+    monkeypatch.setattr(
+        "relay_teams_evals.workspace.artifact_collector.subprocess.run",
+        fake_run,
+    )
+    collector = ArtifactCollector(tmp_path)
+    item = EvalItem(item_id="demo-db", dataset="swebench", intent="demo")
+    result = EvalResult(
+        item_id="demo-db",
+        dataset="swebench",
+        run_id="run-1",
+        session_id="session-1",
+        outcome=RunOutcome.COMPLETED,
+        passed=True,
+        score=1.0,
+        scorer_name="swebench_docker",
+        token_usage=TokenUsage(),
+    )
+    workspace = PreparedWorkspace(
+        item_id="demo-db",
+        repo_path=tmp_path / "repo",
+        base_commit="abc123",
+        container_id="container-1",
+    )
+
+    collector.collect(item, result, workspace=workspace)
+
+    artifact_dir = tmp_path / "artifacts" / "demo-db"
+    docker_cp_commands = [
+        command for command in commands if command[:2] == ("docker", "cp")
+    ]
+    assert docker_cp_commands == [
+        (
+            "docker",
+            "cp",
+            "container-1:/root/.relay-teams/relay_teams.db",
+            str(artifact_dir / "relay_teams.db"),
+        ),
+        (
+            "docker",
+            "cp",
+            "container-1:/root/.relay-teams/relay_teams.db-wal",
+            str(artifact_dir / "relay_teams.db-wal"),
+        ),
+        (
+            "docker",
+            "cp",
+            "container-1:/root/.relay-teams/relay_teams.db-shm",
+            str(artifact_dir / "relay_teams.db-shm"),
+        ),
+    ]
+
+
+def test_artifact_collector_logs_missing_container_db_sidecars(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_run(
+        command: list[str],
+        capture_output: bool,
+        check: bool = False,
+        text: bool = False,
+        encoding: str | None = None,
+        errors: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output, check, text, encoding, errors
+        if command[:2] == ["docker", "cp"] and command[2].endswith(
+            "relay_teams.db-wal"
+        ):
+            raise subprocess.CalledProcessError(returncode=1, cmd=command)
+        return subprocess.CompletedProcess(
+            args=command, returncode=0, stdout="", stderr=""
+        )
+
+    monkeypatch.setattr(
+        "relay_teams_evals.workspace.artifact_collector.subprocess.run",
+        fake_run,
+    )
+    collector = ArtifactCollector(tmp_path)
+    item = EvalItem(item_id="demo-missing-wal", dataset="swebench", intent="demo")
+    result = EvalResult(
+        item_id="demo-missing-wal",
+        dataset="swebench",
+        run_id="run-1",
+        session_id="session-1",
+        outcome=RunOutcome.COMPLETED,
+        passed=True,
+        score=1.0,
+        scorer_name="swebench_docker",
+        token_usage=TokenUsage(),
+    )
+    workspace = PreparedWorkspace(
+        item_id="demo-missing-wal",
+        repo_path=tmp_path / "repo",
+        base_commit="abc123",
+        container_id="container-1",
+    )
+
+    collector.collect(item, result, workspace=workspace)
+
+    out = capsys.readouterr().out
+    assert (
+        "[demo-missing-wal] skipped missing container DB artifact: "
+        "/root/.relay-teams/relay_teams.db-wal"
+    ) in out

--- a/tests/unit_tests/relay_teams_evals/workspace/test_docker_runtime_image_contract.py
+++ b/tests/unit_tests/relay_teams_evals/workspace/test_docker_runtime_image_contract.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_runtime_dockerfile_wheelhouse_contains_project_runtime_dependencies() -> None:
+    dockerfile = (
+        Path(__file__).resolve().parents[4] / "docker" / "Dockerfile.agent-runtime"
+    ).read_text(encoding="utf-8")
+
+    assert '"lark-oapi==1.5.3"' in dockerfile
+    assert '"markitdown[pdf,docx,pptx,xlsx]>=0.1.5,<0.2"' in dockerfile
+
+
+def test_runtime_dockerfile_allows_dev_project_version_offline_install() -> None:
+    dockerfile = (
+        Path(__file__).resolve().parents[4] / "docker" / "Dockerfile.agent-runtime"
+    ).read_text(encoding="utf-8")
+
+    assert "--prerelease=allow" in dockerfile

--- a/tests/unit_tests/relay_teams_evals/workspace/test_eval_entrypoint.py
+++ b/tests/unit_tests/relay_teams_evals/workspace/test_eval_entrypoint.py
@@ -56,3 +56,11 @@ def test_eval_entrypoint_copies_only_whitelisted_config_entries(tmp_path: Path) 
     assert not (target_dir / "relay_teams.db").exists()
     assert not (target_dir / "log").exists()
     assert not (target_dir / "secrets.txt").exists()
+
+
+def test_eval_entrypoint_defaults_to_runtime_config_dir() -> None:
+    script_path = Path(__file__).resolve().parents[4] / "docker" / "eval-entrypoint.sh"
+
+    assert 'CONFIG_TARGET="${AGENT_TEAMS_CONFIG_TARGET:-/root/.relay-teams}"' in (
+        script_path.read_text(encoding="utf-8")
+    )


### PR DESCRIPTION
﻿## Summary
- fix the Docker SWE-bench eval runtime image so the packaged server can start offline with required runtime dependencies
- copy eval config into the container's actual runtime config directory and expand `~` in checkpoint signatures
- preserve report error semantics, collect SQLite WAL/SHM sidecars, and avoid SSE cleanup RuntimeError noise after terminal events

## Validation
- `uv run --no-sync --with pytest --with pytest-timeout python -m pytest -q tests/unit_tests/relay_teams_evals/test_agent_teams_backend.py tests/unit_tests/relay_teams_evals/workspace/test_artifact_collector.py tests/unit_tests/relay_teams_evals/workspace/test_eval_entrypoint.py tests/unit_tests/relay_teams_evals/workspace/test_docker_runtime_image_contract.py tests/unit_tests/relay_teams_evals/workspace/test_docker_setup.py tests/unit_tests/relay_teams_evals/test_checkpoint.py tests/unit_tests/relay_teams_evals/test_reporter.py`
- `uv run --no-sync --with ruff ruff check ...`
- `uv run --no-sync --with ruff ruff format --check ...`
- `uv run --no-sync --with basedpyright basedpyright ...`
- `.venv\Scripts\python.exe -m relay_teams_evals.run run --config .agent_teams/evals/configs/normal/eval-swebench.yaml --restart` => 1/1 PASS
- `.venv\Scripts\python.exe -m relay_teams_evals.run run --config .agent_teams/evals/configs/normal/eval-swebench-10.yaml --restart` => 7/10 PASS, completed=10, errored=0; report/checkpoint statistics and artifact DB snapshots verified


Fixes #764

