### PR TITLE
Consolidate HTTP client usage through net

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,19 +38,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install dev dependencies
+        run: uv sync --extra dev --no-default-groups
+
       - name: Require linked issue for PRs into main
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           GITHUB_API_URL: ${{ github.api_url }}
-        run: python src/relay_teams/release/pull_request_issue_link.py
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
-
-      - name: Install dev dependencies
-        run: uv sync --extra dev --no-default-groups
+        run: uv run --extra dev python src/relay_teams/release/pull_request_issue_link.py
 
       - name: Unit tests with coverage
         env:
@@ -89,19 +89,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install dev dependencies
+        run: uv sync --extra dev --no-default-groups
+
       - name: Require linked issue for PRs into main
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           GITHUB_API_URL: ${{ github.api_url }}
-        run: python src/relay_teams/release/pull_request_issue_link.py
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
-
-      - name: Install dev dependencies
-        run: uv sync --extra dev --no-default-groups
+        run: uv run --extra dev python src/relay_teams/release/pull_request_issue_link.py
 
       - name: Ruff lint gate
         run: uv run --extra dev ruff check --no-cache --force-exclude .

--- a/src/relay_teams/env/env_cli.py
+++ b/src/relay_teams/env/env_cli.py
@@ -5,19 +5,10 @@ from enum import Enum
 import json
 import os
 import shutil
-import subprocess
-import sys
-import time
-from urllib.parse import urlparse
 from typing import TypedDict
 
-import httpx
 import typer
 
-from relay_teams.env.proxy_env import (
-    load_proxy_env_config,
-    sync_proxy_env_to_process_env,
-)
 from relay_teams.env.runtime_env import (
     get_app_env_file_path,
     get_project_env_file_path,
@@ -34,7 +25,6 @@ TABLE_MAX_KEY_WIDTH = 42
 TABLE_MAX_VALUE_WIDTH = 96
 TABLE_MIN_VALUE_WIDTH = 24
 TABLE_FALLBACK_TERMINAL_WIDTH = 120
-DEFAULT_BASE_URL = "http://127.0.0.1:8000"
 
 
 class EnvOutputFormat(str, Enum):
@@ -47,11 +37,6 @@ class EnvListEntry(TypedDict):
     value: str
     source: str
     masked: bool
-
-
-class ProbeOutputFormat(str, Enum):
-    TABLE = "table"
-    JSON = "json"
 
 
 @env_app.command("list")
@@ -74,82 +59,6 @@ def env_list(
         typer.echo(json.dumps(entries, ensure_ascii=False))
         return
     render_env_table(entries)
-
-
-@env_app.command("proxy-reload")
-def proxy_reload(
-    base_url: str = typer.Option(
-        DEFAULT_BASE_URL,
-        "--base-url",
-        help="Agent Teams server base URL.",
-    ),
-    autostart: bool = typer.Option(
-        True,
-        "--autostart/--no-autostart",
-        help="Auto-start local server when not already running.",
-    ),
-    daemon: bool = typer.Option(
-        False,
-        "--daemon",
-        "-d",
-        help="Run the server as a background process when autostarting.",
-    ),
-    force: bool = typer.Option(
-        False,
-        "--force",
-        help="Force kill any existing server process before autostarting.",
-    ),
-) -> None:
-    _auto_start_if_needed(base_url, autostart, daemon, force)
-    payload = _request_json(base_url, "POST", "/api/system/configs/proxy:reload")
-    typer.echo(json.dumps(payload, ensure_ascii=False))
-
-
-@env_app.command("probe-web")
-def probe_web(
-    url: str = typer.Argument(..., help="Target http/https URL to probe."),
-    timeout_ms: int | None = typer.Option(
-        None,
-        "--timeout-ms",
-        help="Optional request timeout in milliseconds.",
-    ),
-    output_format: ProbeOutputFormat = typer.Option(
-        ProbeOutputFormat.TABLE,
-        "--format",
-        help="Output format: table or json.",
-        case_sensitive=False,
-    ),
-    base_url: str = typer.Option(
-        DEFAULT_BASE_URL,
-        "--base-url",
-        help="Agent Teams server base URL.",
-    ),
-    autostart: bool = typer.Option(
-        True,
-        "--autostart/--no-autostart",
-        help="Auto-start local server when not already running.",
-    ),
-    daemon: bool = typer.Option(
-        False,
-        "--daemon",
-        "-d",
-        help="Run the server as a background process when autostarting.",
-    ),
-    force: bool = typer.Option(
-        False,
-        "--force",
-        help="Force kill any existing server process before autostarting.",
-    ),
-) -> None:
-    _auto_start_if_needed(base_url, autostart, daemon, force)
-    payload: dict[str, object] = {"url": url}
-    if timeout_ms is not None:
-        payload["timeout_ms"] = timeout_ms
-    result = _request_json(base_url, "POST", "/api/system/configs/web:probe", payload)
-    if output_format == ProbeOutputFormat.JSON:
-        typer.echo(json.dumps(result, ensure_ascii=False))
-        return
-    _render_probe_table(result)
 
 
 def collect_env_entries(
@@ -256,175 +165,3 @@ def truncate_for_table(value: str, width: int) -> str:
     if len(value) <= width:
         return value
     return f"{value[: width - 3]}..."
-
-
-def _render_probe_table(payload: dict[str, object]) -> None:
-    diagnostics = payload.get("diagnostics", {})
-    redirected = False
-    used_proxy = False
-    if isinstance(diagnostics, dict):
-        redirected = bool(diagnostics.get("redirected", False))
-        used_proxy = bool(diagnostics.get("used_proxy", False))
-
-    rows = [
-        ("OK", str(payload.get("ok", False)).lower()),
-        ("URL", str(payload.get("url", ""))),
-        ("Final URL", str(payload.get("final_url", ""))),
-        ("Method", str(payload.get("used_method", ""))),
-        ("Status", str(payload.get("status_code", ""))),
-        ("Latency(ms)", str(payload.get("latency_ms", ""))),
-        ("Used Proxy", str(used_proxy).lower()),
-        ("Redirected", str(redirected).lower()),
-        ("Error Code", str(payload.get("error_code", ""))),
-        ("Error", str(payload.get("error_message", ""))),
-    ]
-    key_width = max(len("Field"), *(len(row[0]) for row in rows))
-    value_width = max(len("Value"), *(len(row[1]) for row in rows))
-    border = f"+-{'-' * key_width}-+-{'-' * value_width}-+"
-    typer.echo(border)
-    typer.echo(f"| {'Field'.ljust(key_width)} | {'Value'.ljust(value_width)} |")
-    typer.echo(border)
-    for key, value in rows:
-        typer.echo(f"| {key.ljust(key_width)} | {value.ljust(value_width)} |")
-    typer.echo(border)
-
-
-def _request_json(
-    base_url: str,
-    method: str,
-    path: str,
-    payload: dict[str, object] | None = None,
-    timeout_seconds: float = 30.0,
-) -> dict[str, object]:
-    url = f"{base_url.rstrip('/')}{path}"
-    proxy_config = load_proxy_env_config()
-    sync_proxy_env_to_process_env(proxy_config)
-    try:
-        with httpx.Client(timeout=timeout_seconds) as client:
-            if payload is not None:
-                response = client.request(
-                    method,
-                    url,
-                    json=payload,
-                    headers={"Accept": "application/json"},
-                )
-            else:
-                response = client.request(
-                    method,
-                    url,
-                    headers={"Accept": "application/json"},
-                )
-            response.raise_for_status()
-            raw = response.text
-            if not raw:
-                return {}
-            data = response.json()
-            if isinstance(data, dict):
-                return data
-            return {"data": data}
-    except httpx.HTTPStatusError as exc:
-        detail = exc.response.text
-        raise RuntimeError(
-            f"HTTP {exc.response.status_code} {method} {path}: {detail}"
-        ) from exc
-    except httpx.TransportError as exc:
-        raise RuntimeError(f"Failed to connect to {base_url}: {exc}") from exc
-
-
-def _is_server_healthy(base_url: str) -> bool:
-    try:
-        response = _request_json(
-            base_url,
-            "GET",
-            "/api/system/health",
-            timeout_seconds=1.5,
-        )
-        return response.get("status") == "ok"
-    except Exception:
-        return False
-
-
-def _auto_start_if_needed(
-    base_url: str,
-    autostart: bool,
-    daemon: bool = False,
-    force: bool = False,
-) -> None:
-    if _is_server_healthy(base_url):
-        return
-    if not autostart:
-        raise RuntimeError(
-            "Agent Teams server is not running and --no-autostart was provided"
-        )
-
-    parsed = urlparse(base_url)
-    host = parsed.hostname or "127.0.0.1"
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    if host not in {"127.0.0.1", "localhost"}:
-        raise RuntimeError(
-            f"Refusing to autostart server for non-local base URL: {base_url}"
-        )
-
-    if force:
-        subprocess.run(
-            [sys.executable, "-m", "relay_teams", "server", "stop", "--force"],
-            check=False,
-            timeout=30,
-        )
-
-    _start_server_daemon(host=host, port=port, daemon=daemon)
-    if not _wait_until_healthy(base_url):
-        raise RuntimeError("Failed to start local Agent Teams server")
-
-
-def _start_server_daemon(host: str, port: int, *, daemon: bool = False) -> None:
-    sync_proxy_env_to_process_env(load_proxy_env_config())
-    command = [
-        sys.executable,
-        "-m",
-        "relay_teams",
-        "server",
-        "serve",
-        "--host",
-        host,
-        "--port",
-        str(port),
-    ]
-    if daemon:
-        command.append("--daemon")
-    if sys.platform.startswith("win"):
-        create_new_process_group = int(
-            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-        )
-        detached_process = int(getattr(subprocess, "DETACHED_PROCESS", 0))
-        create_no_window = int(getattr(subprocess, "CREATE_NO_WINDOW", 0))
-        creationflags = create_new_process_group | detached_process | create_no_window
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= int(getattr(subprocess, "STARTF_USESHOWWINDOW", 0))
-        startupinfo.wShowWindow = int(getattr(subprocess, "SW_HIDE", 0))
-        subprocess.Popen(
-            command,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            stdin=subprocess.DEVNULL,
-            creationflags=creationflags,
-            startupinfo=startupinfo,
-        )
-        return
-
-    subprocess.Popen(
-        command,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        stdin=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-
-
-def _wait_until_healthy(base_url: str, timeout_seconds: float = 20.0) -> bool:
-    deadline = time.time() + timeout_seconds
-    while time.time() < deadline:
-        if _is_server_healthy(base_url):
-            return True
-        time.sleep(0.25)
-    return False

--- a/src/relay_teams/interfaces/cli/app.py
+++ b/src/relay_teams/interfaces/cli/app.py
@@ -13,8 +13,8 @@ import typer
 
 from relay_teams.commands.command_cli import build_commands_app
 from relay_teams.env import load_proxy_env_config, sync_proxy_env_to_process_env
-from relay_teams.env.env_cli import env_app
 from relay_teams.agent_runtimes.agent_cli import build_agent_runtimes_app
+from relay_teams.interfaces.cli.env_commands import build_env_app
 from relay_teams.interfaces.cli.gateway_cli import build_gateway_app
 from relay_teams.interfaces.cli.approvals_cli import build_approvals_app
 from relay_teams.interfaces.cli.hooks_cli import build_hooks_app
@@ -307,6 +307,11 @@ memories_app = build_memories_app(
     default_base_url=DEFAULT_BASE_URL,
 )
 commands_app = build_commands_app(
+    request_json=_module_request_json,
+    auto_start_if_needed=_module_auto_start,
+    default_base_url=DEFAULT_BASE_URL,
+)
+env_app = build_env_app(
     request_json=_module_request_json,
     auto_start_if_needed=_module_auto_start,
     default_base_url=DEFAULT_BASE_URL,

--- a/src/relay_teams/interfaces/cli/env_commands.py
+++ b/src/relay_teams/interfaces/cli/env_commands.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Callable
+from enum import Enum
+import json
+
+import typer
+
+from relay_teams.env.env_cli import (
+    EnvOutputFormat,
+    collect_env_entries,
+    render_env_table,
+)
+
+type RequestJsonCallable = Callable[
+    [str, str, str, dict[str, object] | None], dict[str, object] | list[object]
+]
+type AutoStartCallable = Callable[[str, bool, bool, bool], None]
+
+
+class ProbeOutputFormat(str, Enum):
+    TABLE = "table"
+    JSON = "json"
+
+
+def build_env_app(
+    *,
+    request_json: RequestJsonCallable,
+    auto_start_if_needed: AutoStartCallable,
+    default_base_url: str,
+) -> typer.Typer:
+    env_app = typer.Typer(no_args_is_help=True, pretty_exceptions_enable=False)
+
+    @env_app.command("list")
+    def env_list(
+        output_format: EnvOutputFormat = typer.Option(
+            EnvOutputFormat.TABLE,
+            "--format",
+            help="Output format: table or json.",
+            case_sensitive=False,
+        ),
+        show_secrets: bool = typer.Option(
+            False, "--show-secrets", help="Show secret values without masking."
+        ),
+        prefix: str | None = typer.Option(
+            None,
+            "--prefix",
+            help="Only list environment variables with this key prefix.",
+        ),
+    ) -> None:
+        entries = collect_env_entries(prefix=prefix, show_secrets=show_secrets)
+        if output_format == EnvOutputFormat.JSON:
+            typer.echo(json.dumps(entries, ensure_ascii=False))
+            return
+        render_env_table(entries)
+
+    @env_app.command("proxy-reload")
+    def proxy_reload(
+        base_url: str = typer.Option(
+            default_base_url,
+            "--base-url",
+            help="Agent Teams server base URL.",
+        ),
+        autostart: bool = typer.Option(
+            True,
+            "--autostart/--no-autostart",
+            help="Auto-start local server when not already running.",
+        ),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
+    ) -> None:
+        auto_start_if_needed(base_url, autostart, daemon, force)
+        result = request_json(
+            base_url,
+            "POST",
+            "/api/system/configs/proxy:reload",
+            None,
+        )
+        typer.echo(json.dumps(_require_object_response(result), ensure_ascii=False))
+
+    @env_app.command("probe-web")
+    def probe_web(
+        url: str = typer.Argument(..., help="Target http/https URL to probe."),
+        timeout_ms: int | None = typer.Option(
+            None,
+            "--timeout-ms",
+            help="Optional request timeout in milliseconds.",
+        ),
+        output_format: ProbeOutputFormat = typer.Option(
+            ProbeOutputFormat.TABLE,
+            "--format",
+            help="Output format: table or json.",
+            case_sensitive=False,
+        ),
+        base_url: str = typer.Option(
+            default_base_url,
+            "--base-url",
+            help="Agent Teams server base URL.",
+        ),
+        autostart: bool = typer.Option(
+            True,
+            "--autostart/--no-autostart",
+            help="Auto-start local server when not already running.",
+        ),
+        daemon: bool = typer.Option(
+            False,
+            "--daemon",
+            "-d",
+            help="Run the server as a background process when autostarting.",
+        ),
+        force: bool = typer.Option(
+            False,
+            "--force",
+            help="Force kill any existing server process before autostarting.",
+        ),
+    ) -> None:
+        auto_start_if_needed(base_url, autostart, daemon, force)
+        payload: dict[str, object] = {"url": url}
+        if timeout_ms is not None:
+            payload["timeout_ms"] = timeout_ms
+        result = _require_object_response(
+            request_json(
+                base_url,
+                "POST",
+                "/api/system/configs/web:probe",
+                payload,
+            )
+        )
+        if output_format == ProbeOutputFormat.JSON:
+            typer.echo(json.dumps(result, ensure_ascii=False))
+            return
+        _render_probe_table(result)
+
+    return env_app
+
+
+def _render_probe_table(payload: dict[str, object]) -> None:
+    diagnostics = payload.get("diagnostics", {})
+    redirected = False
+    used_proxy = False
+    if isinstance(diagnostics, dict):
+        redirected = bool(diagnostics.get("redirected", False))
+        used_proxy = bool(diagnostics.get("used_proxy", False))
+
+    rows = [
+        ("OK", str(payload.get("ok", False)).lower()),
+        ("URL", str(payload.get("url", ""))),
+        ("Final URL", str(payload.get("final_url", ""))),
+        ("Method", str(payload.get("used_method", ""))),
+        ("Status", str(payload.get("status_code", ""))),
+        ("Latency(ms)", str(payload.get("latency_ms", ""))),
+        ("Used Proxy", str(used_proxy).lower()),
+        ("Redirected", str(redirected).lower()),
+        ("Error Code", str(payload.get("error_code", ""))),
+        ("Error", str(payload.get("error_message", ""))),
+    ]
+    key_width = max(len("Field"), *(len(row[0]) for row in rows))
+    value_width = max(len("Value"), *(len(row[1]) for row in rows))
+    border = f"+-{'-' * key_width}-+-{'-' * value_width}-+"
+    typer.echo(border)
+    typer.echo(f"| {'Field'.ljust(key_width)} | {'Value'.ljust(value_width)} |")
+    typer.echo(border)
+    for key, value in rows:
+        typer.echo(f"| {key.ljust(key_width)} | {value.ljust(value_width)} |")
+    typer.echo(border)
+
+
+def _require_object_response(
+    payload: dict[str, object] | list[object],
+) -> dict[str, object]:
+    if isinstance(payload, dict):
+        return payload
+    raise RuntimeError("Expected JSON object from env command endpoint")

--- a/src/relay_teams/release/pull_request_issue_link.py
+++ b/src/relay_teams/release/pull_request_issue_link.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
 from typing import NamedTuple, Protocol
+
+import httpx
+
+from relay_teams.net import create_runtime_async_http_client
 
 _GRAPHQL_TIMEOUT_SECONDS = 30.0
 _GITHUB_GRAPHQL_QUERY = """
@@ -77,42 +80,13 @@ def fetch_linked_issue_count(
     token: str,
     graphql_url: str,
 ) -> int:
-    request_payload = json.dumps(
-        {
-            "query": _GITHUB_GRAPHQL_QUERY,
-            "variables": {
-                "owner": context.owner,
-                "name": context.repository_name,
-                "number": context.pull_request_number,
-            },
-        }
-    ).encode("utf-8")
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-    try:
-        req = urllib.request.Request(
-            graphql_url,
-            data=request_payload,
-            headers=headers,
-            method="POST",
+    response_text = asyncio.run(
+        _fetch_linked_issue_count_response_text(
+            context=context,
+            token=token,
+            graphql_url=graphql_url,
         )
-        with urllib.request.urlopen(  # nosec B310: HTTPS-only GitHub GraphQL endpoint
-            req, timeout=_GRAPHQL_TIMEOUT_SECONDS
-        ) as resp:
-            response_text = resp.read().decode("utf-8")
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace").strip()
-        raise IssueLinkRequirementError(
-            f"GitHub GraphQL request failed with HTTP {exc.code}: {detail}"
-        ) from exc
-    except urllib.error.URLError as exc:
-        raise IssueLinkRequirementError(
-            f"Failed to reach GitHub GraphQL endpoint: {exc}"
-        ) from exc
-
+    )
     payload = json.loads(response_text)
     errors = payload.get("errors")
     if isinstance(errors, list) and errors:
@@ -145,6 +119,50 @@ def fetch_linked_issue_count(
             "GitHub GraphQL response did not include a valid linked issue count"
         )
     return total_count
+
+
+async def _fetch_linked_issue_count_response_text(
+    *,
+    context: PullRequestIssueLinkContext,
+    token: str,
+    graphql_url: str,
+) -> str:
+    request_payload = {
+        "query": _GITHUB_GRAPHQL_QUERY,
+        "variables": {
+            "owner": context.owner,
+            "name": context.repository_name,
+            "number": context.pull_request_number,
+        },
+    }
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    try:
+        async with create_runtime_async_http_client(
+            ssl_verify=True,
+            timeout_seconds=_GRAPHQL_TIMEOUT_SECONDS,
+            connect_timeout_seconds=_GRAPHQL_TIMEOUT_SECONDS,
+        ) as client:
+            response = await client.post(
+                graphql_url,
+                headers=headers,
+                json=request_payload,
+            )
+            response.raise_for_status()
+            return response.text
+    except httpx.HTTPStatusError as exc:
+        detail = exc.response.text.strip()
+        raise IssueLinkRequirementError(
+            "GitHub GraphQL request failed with HTTP "
+            f"{exc.response.status_code}: {detail}"
+        ) from exc
+    except httpx.RequestError as exc:
+        raise IssueLinkRequirementError(
+            f"Failed to reach GitHub GraphQL endpoint: {exc}"
+        ) from exc
 
 
 def ensure_pull_request_links_issue(

--- a/tests/unit_tests/env/test_env_cli.py
+++ b/tests/unit_tests/env/test_env_cli.py
@@ -1,51 +1,31 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from unittest.mock import patch
-
-from relay_teams.env.env_cli import _auto_start_if_needed
-
-
-def test_auto_start_force_calls_subprocess_stop() -> None:
-    """When force=True and server is not healthy, subprocess.run is called."""
-    with (
-        patch("relay_teams.env.env_cli._is_server_healthy", return_value=False),
-        patch("relay_teams.env.env_cli._start_server_daemon") as mock_start,
-        patch("relay_teams.env.env_cli._wait_until_healthy", return_value=True),
-        patch("relay_teams.env.env_cli.subprocess.run") as mock_subprocess,
-    ):
-        _auto_start_if_needed(
-            base_url="http://127.0.0.1:8080",
-            autostart=True,
-            force=True,
-        )
-        mock_subprocess.assert_called_once_with(
-            [
-                mock_subprocess.call_args[0][0][0],  # sys.executable
-                "-m",
-                "relay_teams",
-                "server",
-                "stop",
-                "--force",
-            ],
-            check=False,
-            timeout=30,
-        )
-        mock_start.assert_called_once()
+from relay_teams.env.env_cli import (
+    is_sensitive_env_key,
+    merge_env_source,
+    truncate_for_table,
+)
 
 
-def test_auto_start_no_force_skips_subprocess_stop() -> None:
-    """When force=False, subprocess.run is not called."""
-    with (
-        patch("relay_teams.env.env_cli._is_server_healthy", return_value=False),
-        patch("relay_teams.env.env_cli._start_server_daemon") as mock_start,
-        patch("relay_teams.env.env_cli._wait_until_healthy", return_value=True),
-        patch("relay_teams.env.env_cli.subprocess.run") as mock_subprocess,
-    ):
-        _auto_start_if_needed(
-            base_url="http://127.0.0.1:8080",
-            autostart=True,
-            force=False,
-        )
-        mock_subprocess.assert_not_called()
-        mock_start.assert_called_once()
+def test_merge_env_source_tracks_latest_source() -> None:
+    merged: dict[str, str] = {"TOKEN": "old"}
+    source_by_key: dict[str, str] = {"TOKEN": "process"}
+
+    merge_env_source(merged, source_by_key, {"TOKEN": "new"}, "app")
+
+    assert merged == {"TOKEN": "new"}
+    assert source_by_key == {"TOKEN": "app"}
+
+
+def test_truncate_for_table_preserves_short_values() -> None:
+    assert truncate_for_table("short", 10) == "short"
+
+
+def test_truncate_for_table_shortens_long_values() -> None:
+    assert truncate_for_table("abcdefghijklmnopqrstuvwxyz", 8) == "abcde..."
+
+
+def test_is_sensitive_env_key_delegates_sensitive_key_detection() -> None:
+    assert is_sensitive_env_key("SERVICE_TOKEN") is True
+    assert is_sensitive_env_key("SERVICE_URL") is False

--- a/tests/unit_tests/interfaces/cli/test_env_commands.py
+++ b/tests/unit_tests/interfaces/cli/test_env_commands.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from relay_teams.env.env_cli import EnvListEntry
+from relay_teams.interfaces.cli import env_commands
+from relay_teams.interfaces.cli import app as cli_app
+
+runner = CliRunner()
+
+
+def test_env_list_outputs_json_with_prefix_and_secret_options(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_collect_env_entries(
+        *, prefix: str | None, show_secrets: bool
+    ) -> list[EnvListEntry]:
+        captured["prefix"] = prefix
+        captured["show_secrets"] = show_secrets
+        return [
+            EnvListEntry(
+                key="FOO_TOKEN",
+                value="secret",
+                source="app",
+                masked=False,
+            )
+        ]
+
+    monkeypatch.setattr(env_commands, "collect_env_entries", fake_collect_env_entries)
+
+    result = runner.invoke(
+        cli_app.app,
+        [
+            "env",
+            "list",
+            "--format",
+            "json",
+            "--show-secrets",
+            "--prefix",
+            "FOO",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == [
+        {
+            "key": "FOO_TOKEN",
+            "value": "secret",
+            "source": "app",
+            "masked": False,
+        }
+    ]
+    assert captured == {"prefix": "FOO", "show_secrets": True}
+
+
+def test_env_proxy_reload_uses_interface_http_client_path(monkeypatch) -> None:
+    autostart_calls: list[tuple[str, bool, bool, bool]] = []
+    request_calls: list[tuple[str, str, str, dict[str, object] | None]] = []
+
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
+        autostart_calls.append((base_url, autostart, daemon, force))
+
+    def fake_request_json(
+        base_url: str,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+    ) -> dict[str, object] | list[object]:
+        request_calls.append((base_url, method, path, payload))
+        return {"reloaded": True}
+
+    monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
+    monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
+
+    result = runner.invoke(
+        cli_app.app,
+        [
+            "env",
+            "proxy-reload",
+            "--base-url",
+            "http://127.0.0.1:8123",
+            "--no-autostart",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {"reloaded": True}
+    assert autostart_calls == [("http://127.0.0.1:8123", False, False, False)]
+    assert request_calls == [
+        (
+            "http://127.0.0.1:8123",
+            "POST",
+            "/api/system/configs/proxy:reload",
+            None,
+        )
+    ]
+
+
+def test_env_probe_web_sends_probe_payload_and_outputs_json(monkeypatch) -> None:
+    request_calls: list[tuple[str, str, str, dict[str, object] | None]] = []
+
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
+        _ = (base_url, autostart, daemon, force)
+
+    def fake_request_json(
+        base_url: str,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+    ) -> dict[str, object] | list[object]:
+        request_calls.append((base_url, method, path, payload))
+        return {
+            "ok": True,
+            "url": "https://example.com",
+            "final_url": "https://example.com/",
+            "used_method": "HEAD",
+            "status_code": 200,
+            "latency_ms": 12,
+            "diagnostics": {"used_proxy": True, "redirected": False},
+        }
+
+    monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
+    monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
+
+    result = runner.invoke(
+        cli_app.app,
+        [
+            "env",
+            "probe-web",
+            "https://example.com",
+            "--timeout-ms",
+            "2500",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["ok"] is True
+    assert request_calls == [
+        (
+            "http://127.0.0.1:8000",
+            "POST",
+            "/api/system/configs/web:probe",
+            {"url": "https://example.com", "timeout_ms": 2500},
+        )
+    ]
+
+
+def test_env_probe_web_renders_table(monkeypatch) -> None:
+    def fake_autostart(
+        base_url: str, autostart: bool, daemon: bool = False, force: bool = False
+    ) -> None:
+        _ = (base_url, autostart, daemon, force)
+
+    def fake_request_json(
+        base_url: str,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+    ) -> dict[str, object] | list[object]:
+        _ = (base_url, method, path, payload)
+        return {
+            "ok": False,
+            "url": "https://example.com",
+            "final_url": "https://example.com",
+            "used_method": "GET",
+            "status_code": 502,
+            "latency_ms": 42,
+            "error_code": "bad_gateway",
+            "error_message": "proxy returned 502",
+            "diagnostics": {"used_proxy": True, "redirected": True},
+        }
+
+    monkeypatch.setattr(cli_app, "_auto_start_if_needed", fake_autostart)
+    monkeypatch.setattr(cli_app, "_request_json", fake_request_json)
+
+    result = runner.invoke(
+        cli_app.app,
+        ["env", "probe-web", "https://example.com"],
+    )
+
+    assert result.exit_code == 0
+    assert "Used Proxy" in result.output
+    assert "true" in result.output
+    assert "proxy returned 502" in result.output
+
+
+def test_require_object_response_rejects_list_payload() -> None:
+    with pytest.raises(RuntimeError, match="Expected JSON object"):
+        env_commands._require_object_response([])

--- a/tests/unit_tests/release/test_pull_request_issue_link.py
+++ b/tests/unit_tests/release/test_pull_request_issue_link.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import json
-from email.message import Message
 from pathlib import Path
+from types import TracebackType
 
+import httpx
 import pytest
 
 from relay_teams.release.pull_request_issue_link import (
@@ -14,6 +15,43 @@ from relay_teams.release.pull_request_issue_link import (
     ensure_pull_request_links_issue,
     load_pull_request_issue_link_context,
 )
+
+
+class _FakeGitHubGraphqlClient:
+    def __init__(
+        self,
+        *,
+        response: httpx.Response | None = None,
+        error: httpx.RequestError | None = None,
+    ) -> None:
+        self._response = response
+        self._error = error
+        self.posts: list[tuple[str, dict[str, str], dict[str, object]]] = []
+
+    async def __aenter__(self) -> _FakeGitHubGraphqlClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        _ = (exc_type, exc, traceback)
+
+    async def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, object],
+    ) -> httpx.Response:
+        self.posts.append((url, headers, json))
+        if self._error is not None:
+            raise self._error
+        if self._response is None:
+            raise RuntimeError("missing fake response")
+        return self._response
 
 
 def test_build_graphql_url_handles_github_dot_com() -> None:
@@ -94,9 +132,7 @@ def test_ensure_pull_request_links_issue_rejects_missing_link() -> None:
         )
 
 
-def test_fetch_linked_issue_count_returns_count() -> None:
-    from unittest.mock import MagicMock, patch
-
+def test_fetch_linked_issue_count_returns_count(monkeypatch) -> None:
     from relay_teams.release.pull_request_issue_link import (
         PullRequestIssueLinkContext,
         fetch_linked_issue_count,
@@ -109,11 +145,9 @@ def test_fetch_linked_issue_count_returns_count() -> None:
         base_ref="main",
     )
 
-    with patch(
-        "relay_teams.release.pull_request_issue_link.urllib.request.urlopen"
-    ) as mock_urlopen:
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(
+    response = httpx.Response(
+        200,
+        text=json.dumps(
             {
                 "data": {
                     "repository": {
@@ -121,22 +155,69 @@ def test_fetch_linked_issue_count_returns_count() -> None:
                     }
                 }
             }
-        ).encode("utf-8")
-        mock_resp.__enter__ = lambda s: mock_resp
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_resp
-        count = fetch_linked_issue_count(
+        ),
+        request=httpx.Request("POST", "https://api.github.com/graphql"),
+    )
+    fake_client = _FakeGitHubGraphqlClient(response=response)
+    captured_client_kwargs: dict[str, object] = {}
+
+    def fake_create_runtime_async_http_client(
+        **kwargs: object,
+    ) -> _FakeGitHubGraphqlClient:
+        captured_client_kwargs.update(kwargs)
+        return fake_client
+
+    monkeypatch.setattr(
+        "relay_teams.release.pull_request_issue_link.create_runtime_async_http_client",
+        fake_create_runtime_async_http_client,
+    )
+
+    count = fetch_linked_issue_count(
+        context=context,
+        token="ghp_secret",
+        graphql_url="https://api.github.com/graphql",
+    )
+
+    assert count == 3
+    assert fake_client.posts[0][0] == "https://api.github.com/graphql"
+    assert fake_client.posts[0][1]["Authorization"] == "Bearer ghp_secret"
+    assert captured_client_kwargs["ssl_verify"] is True
+
+
+def test_fetch_linked_issue_count_raises_on_http_error(monkeypatch) -> None:
+    from relay_teams.release.pull_request_issue_link import (
+        PullRequestIssueLinkContext,
+        fetch_linked_issue_count,
+    )
+
+    context = PullRequestIssueLinkContext(
+        owner="openai",
+        repository_name="agent-teams",
+        pull_request_number=42,
+        base_ref="main",
+    )
+
+    fake_client = _FakeGitHubGraphqlClient(
+        response=httpx.Response(
+            401,
+            text="Unauthorized",
+            request=httpx.Request("POST", "https://api.github.com/graphql"),
+        )
+    )
+    monkeypatch.setattr(
+        "relay_teams.release.pull_request_issue_link.create_runtime_async_http_client",
+        lambda **_kwargs: fake_client,
+    )
+
+    with pytest.raises(IssueLinkRequirementError, match="HTTP 401"):
+        fetch_linked_issue_count(
             context=context,
             token="ghp_secret",
             graphql_url="https://api.github.com/graphql",
         )
-        assert count == 3
 
 
-def test_fetch_linked_issue_count_raises_on_http_error() -> None:
-    from unittest.mock import patch
-    import urllib.error
-
+def test_fetch_linked_issue_count_raises_on_request_error(monkeypatch) -> None:
     from relay_teams.release.pull_request_issue_link import (
         PullRequestIssueLinkContext,
         fetch_linked_issue_count,
@@ -149,47 +230,20 @@ def test_fetch_linked_issue_count_raises_on_http_error() -> None:
         base_ref="main",
     )
 
-    with patch(
-        "relay_teams.release.pull_request_issue_link.urllib.request.urlopen"
-    ) as mock_urlopen:
-        mock_urlopen.side_effect = urllib.error.HTTPError(
-            url="https://api.github.com/graphql",
-            code=401,
-            msg="Unauthorized",
-            hdrs=Message(),
-            fp=None,
+    fake_client = _FakeGitHubGraphqlClient(
+        error=httpx.ConnectError(
+            "Connection refused",
+            request=httpx.Request("POST", "https://api.github.com/graphql"),
         )
-        with pytest.raises(IssueLinkRequirementError, match="HTTP 401"):
-            fetch_linked_issue_count(
-                context=context,
-                token="ghp_secret",
-                graphql_url="https://api.github.com/graphql",
-            )
-
-
-def test_fetch_linked_issue_count_raises_on_url_error() -> None:
-    from unittest.mock import patch
-    import urllib.error
-
-    from relay_teams.release.pull_request_issue_link import (
-        PullRequestIssueLinkContext,
-        fetch_linked_issue_count,
+    )
+    monkeypatch.setattr(
+        "relay_teams.release.pull_request_issue_link.create_runtime_async_http_client",
+        lambda **_kwargs: fake_client,
     )
 
-    context = PullRequestIssueLinkContext(
-        owner="openai",
-        repository_name="agent-teams",
-        pull_request_number=42,
-        base_ref="main",
-    )
-
-    with patch(
-        "relay_teams.release.pull_request_issue_link.urllib.request.urlopen"
-    ) as mock_urlopen:
-        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
-        with pytest.raises(IssueLinkRequirementError, match="Failed to reach"):
-            fetch_linked_issue_count(
-                context=context,
-                token="ghp_secret",
-                graphql_url="https://api.github.com/graphql",
-            )
+    with pytest.raises(IssueLinkRequirementError, match="Failed to reach"):
+        fetch_linked_issue_count(
+            context=context,
+            token="ghp_secret",
+            graphql_url="https://api.github.com/graphql",
+        )

--- a/tests/unit_tests/test_module_boundaries.py
+++ b/tests/unit_tests/test_module_boundaries.py
@@ -102,6 +102,31 @@ def test_package_exports_do_not_use_implicit_lazy_imports() -> None:
     )
 
 
+def test_source_modules_do_not_bypass_net_http_clients() -> None:
+    violations: list[str] = []
+    for path in _iter_python_files(SRC_ROOT):
+        relative_path = path.relative_to(SRC_ROOT)
+        if relative_path.parts[0] == "net":
+            continue
+        source = path.read_text(encoding="utf-8")
+        if not any(token in source for token in _HTTP_CLIENT_SCAN_TOKENS):
+            continue
+        tree = ast.parse(source, filename=str(path))
+        import_aliases = _http_import_aliases(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            call_name = _resolve_call_name(node.func, import_aliases)
+            if call_name in _FORBIDDEN_HTTP_CLIENT_CALLS:
+                violations.append(
+                    f"{path.relative_to(REPO_ROOT)}:{node.lineno} calls {call_name}"
+                )
+    assert not violations, (
+        "source modules must use relay_teams.net HTTP client factories:\n"
+        + "\n".join(sorted(violations))
+    )
+
+
 def _assert_no_forbidden_imports(
     scope: Path,
     is_forbidden: Callable[[str], bool],
@@ -151,6 +176,81 @@ def _imported_modules(path: Path) -> tuple[str, ...]:
         elif isinstance(node, ast.ImportFrom) and node.module is not None:
             modules.append(node.module)
     return tuple(modules)
+
+
+_FORBIDDEN_HTTP_CLIENT_CALLS = {
+    "aiohttp.ClientSession",
+    "httpx.AsyncClient",
+    "httpx.Client",
+    "requests.Session",
+    "requests.delete",
+    "requests.get",
+    "requests.patch",
+    "requests.post",
+    "requests.put",
+    "requests.request",
+    "urllib.request.urlopen",
+    "urllib3.PoolManager",
+    "urllib3.ProxyManager",
+}
+
+_HTTP_CLIENT_SCAN_TOKENS = (
+    "ClientSession",
+    "PoolManager",
+    "ProxyManager",
+    "httpx",
+    "requests",
+    "urlopen",
+    "urllib.request",
+    "urllib3",
+)
+
+
+def _http_import_aliases(tree: ast.AST) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_http_module_or_submodule(alias.name):
+                    if alias.asname is not None:
+                        aliases[alias.asname] = alias.name
+                    else:
+                        aliases[alias.name.split(".")[0]] = alias.name.split(".")[0]
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            if node.module == "urllib":
+                for alias in node.names:
+                    if alias.name == "request":
+                        aliases[alias.asname or alias.name] = "urllib.request"
+                continue
+            if not _is_http_module_or_submodule(node.module):
+                continue
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _resolve_call_name(
+    node: ast.expr,
+    import_aliases: dict[str, str],
+) -> str | None:
+    if isinstance(node, ast.Name):
+        return import_aliases.get(node.id, node.id)
+    if isinstance(node, ast.Attribute):
+        parent = _resolve_call_name(node.value, import_aliases)
+        if parent is None:
+            return None
+        return f"{parent}.{node.attr}"
+    return None
+
+
+def _is_http_module_or_submodule(module: str) -> bool:
+    return module in {"aiohttp", "httpx", "requests", "urllib.request", "urllib3"} or (
+        module.startswith("aiohttp.")
+        or module.startswith("httpx.")
+        or module.startswith("requests.")
+        or module.startswith("urllib.request.")
+        or module.startswith("urllib3.")
+    )
 
 
 def _is_net_import(module: str) -> bool:


### PR DESCRIPTION
## Summary

- move env CLI network commands to the interface CLI layer so env does not depend on net
- route release GraphQL checks through the shared runtime HTTP client factory with explicit TLS verification
- add boundary coverage to prevent direct HTTP client construction outside relay_teams.net
- update PR Checks so the linked-issue gate runs after project dependencies are available

## Validation

- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- GitHub Actions PR Checks #25588341214: unit coverage and quality/integration passed
- GitHub Actions CodeQL #25588340238, Qodana #25588341201, Micro-Benchmarks #25588341209, Spec-Compliance #25588341207 passed

Fixes #765