### PR TITLE
fix: project terminal final output in session rounds

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -1125,7 +1125,7 @@ Notes:
 - Automatic history compaction is logical only. Older messages are marked hidden-from-context for model reads, but remain available to raw/history endpoints.
 - A terminal `run_completed` event with non-empty `output` is a valid final-answer source. The live frontend must render that terminal output when no `text_delta` or `output_delta` has already produced final coordinator content for the run.
 - A terminal `run_failed` event with `completion_reason = "assistant_response"` follows the same final-output rule; other failed terminal outputs remain diagnostic and are not treated as final answers.
-- When legacy destructive clear behavior left a completed run with no persisted coordinator message rows, the round projection may synthesize one assistant text message from the persisted terminal event output.
+- The round projection synthesizes an assistant text message from terminal final output when persisted coordinator history does not already contain that final assistant text. This also covers runs that persisted intermediate tool or thinking history but lost the final answer row.
 
 ### `GET /sessions/{session_id}/rounds/{run_id}`
 

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -323,16 +323,14 @@ def build_session_rounds(
                 coordinator_instance_id=coordinator_instance_id,
             ),
         )
-        if not coordinator_messages:
-            reconstructed = _reconstruct_completed_output_message(
-                run_id=run_id,
-                root_task=root_task,
-                coordinator_role_id=coordinator_role_id,
-                role_instance_map=role_instance_by_run.get(run_id, {}),
-                output_event=final_output_by_run.get(run_id),
-            )
-            if reconstructed is not None:
-                coordinator_messages = [reconstructed]
+        coordinator_messages = _append_completed_output_message_if_missing(
+            coordinator_messages,
+            run_id=run_id,
+            root_task=root_task,
+            coordinator_role_id=coordinator_role_id,
+            role_instance_map=role_instance_by_run.get(run_id, {}),
+            output_event=final_output_by_run.get(run_id),
+        )
         created_at = _round_created_at(root_task, run_messages)
         runtime = run_runtime.get(run_id)
         run_started_at = runtime.created_at.isoformat() if runtime is not None else None
@@ -960,6 +958,77 @@ def _message_parts(message: dict[str, object]) -> list[dict[str, object]]:
     if not isinstance(raw_parts, list):
         return []
     return [part for part in raw_parts if isinstance(part, dict)]
+
+
+def _append_completed_output_message_if_missing(
+    coordinator_messages: list[dict[str, object]],
+    *,
+    run_id: str,
+    root_task: object | None,
+    coordinator_role_id: str | None,
+    role_instance_map: dict[str, str],
+    output_event: dict[str, str] | None,
+) -> list[dict[str, object]]:
+    reconstructed = _reconstruct_completed_output_message(
+        run_id=run_id,
+        root_task=root_task,
+        coordinator_role_id=coordinator_role_id,
+        role_instance_map=role_instance_map,
+        output_event=output_event,
+    )
+    if reconstructed is None:
+        return coordinator_messages
+    output = str(output_event.get("output") if output_event is not None else "").strip()
+    if _has_assistant_text_message(coordinator_messages, output):
+        return coordinator_messages
+    return [*coordinator_messages, reconstructed]
+
+
+def _has_assistant_text_message(
+    messages: list[dict[str, object]],
+    expected_text: str,
+) -> bool:
+    normalized_expected = _normalize_projected_text(expected_text)
+    if not normalized_expected:
+        return False
+    for message in messages:
+        if str(message.get("role") or "") != "assistant":
+            continue
+        text_parts = tuple(_message_text_parts(message))
+        if not text_parts:
+            continue
+        if any(
+            _normalize_projected_text(part_text) == normalized_expected
+            for part_text in text_parts
+        ):
+            return True
+        combined = "\n\n".join(
+            part_text.strip() for part_text in text_parts if part_text.strip()
+        )
+        if _normalize_projected_text(combined) == normalized_expected:
+            return True
+    return False
+
+
+def _message_text_parts(message: dict[str, object]) -> list[str]:
+    values: list[str] = []
+    raw_message = message.get("message")
+    if isinstance(raw_message, dict):
+        legacy_content = str(raw_message.get("content") or "").strip()
+        if legacy_content:
+            values.append(legacy_content)
+    for part in _message_parts(message):
+        part_kind = str(part.get("part_kind") or part.get("kind") or "").strip()
+        if part_kind != "text":
+            continue
+        value = str(part.get("content") or part.get("text") or "").strip()
+        if value:
+            values.append(value)
+    return values
+
+
+def _normalize_projected_text(value: str) -> str:
+    return str(value or "").strip()
 
 
 def _project_terminal_final_outputs(

--- a/tests/integration_tests/browser/test_streaming_message_timeline.py
+++ b/tests/integration_tests/browser/test_streaming_message_timeline.py
@@ -500,6 +500,25 @@ def test_terminal_payload_output_dedupes_hydrated_history_in_browser(
     assert payload["messageCount"] == 1
 
 
+def test_terminal_history_with_tool_history_and_final_output_renders_once_in_browser(
+    browser_page: Page,
+    tmp_path: Path,
+) -> None:
+    page = browser_page
+    _open_harness(page, tmp_path)
+
+    payload = page.evaluate(
+        """
+        () => window.__streamTimelineHarness.renderTerminalHistoryWithToolAndFinalOutput()
+        """
+    )
+
+    assert payload["occurrences"] == 1
+    assert payload["groupCount"] == 1
+    assert payload["messageCount"] == 2
+    assert "terminal projected final answer" in payload["text"]
+
+
 def test_terminal_rounds_collapse_only_when_final_output_is_projected_in_browser(
     browser_page: Page,
     tmp_path: Path,
@@ -1944,6 +1963,70 @@ def _open_harness(page: Page, tmp_path: Path) -> None:
         return {{
           text: container.textContent || '',
           occurrences: countSubstring(container.textContent || '', 'codehub-mr-loop skill'),
+          messageCount: container.querySelectorAll('.message').length,
+        }};
+      }},
+
+      renderTerminalHistoryWithToolAndFinalOutput() {{
+        clearAllStreamState();
+        const runId = 'run-terminal-history-tool-final';
+        const container = makeContainer('terminal-history-tool-final');
+        container.dataset.roundCreatedAt = '2026-04-25T12:00:00Z';
+        renderHistory(container, [
+          {{
+            role: 'assistant',
+            role_id: 'main-role',
+            instance_id: 'primary',
+            created_at: '2026-04-25T12:00:02Z',
+            message: {{
+              parts: [
+                {{
+                  part_kind: 'tool-call',
+                  tool_name: 'shell',
+                  tool_call_id: 'call-history-final',
+                  args: {{ command: 'date' }},
+                }},
+              ],
+            }},
+          }},
+          {{
+            role: 'user',
+            role_id: 'main-role',
+            instance_id: 'primary',
+            created_at: '2026-04-25T12:00:03Z',
+            message: {{
+              parts: [
+                {{
+                  part_kind: 'tool-return',
+                  tool_name: 'shell',
+                  tool_call_id: 'call-history-final',
+                  content: {{ ok: true, output: 'tool completed' }},
+                }},
+              ],
+            }},
+          }},
+          {{
+            role: 'assistant',
+            role_id: 'main-role',
+            instance_id: 'primary',
+            created_at: '2026-04-25T12:00:04Z',
+            reconstructed: true,
+            message: {{
+              parts: [{{ part_kind: 'text', content: 'terminal projected final answer' }}],
+            }},
+          }},
+        ], {{
+          runId,
+          runStatus: 'completed',
+          hasFinalOutput: true,
+          timelineView: 'main',
+          canonicalStreamKey: 'primary',
+          streamOverlayEntry: null,
+        }});
+        return {{
+          text: container.textContent || '',
+          occurrences: countSubstring(container.textContent || '', 'terminal projected final answer'),
+          groupCount: container.querySelectorAll('.tool-group').length,
           messageCount: container.querySelectorAll('.message').length,
         }};
       }},

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -22,6 +22,7 @@ from relay_teams.sessions.session_rounds_projection import build_session_rounds
 from relay_teams.sessions.session_rounds_projection import build_session_timeline_rounds
 from relay_teams.sessions.session_rounds_projection import (
     _coordinator_event_tool_messages,
+    _has_assistant_text_message,
     _merge_event_tool_messages,
 )
 from relay_teams.agent_runtimes.instances.instance_repository import (
@@ -62,6 +63,26 @@ def _tool_message(
     }
 
 
+def _assistant_history_message(
+    *,
+    run_id: str,
+    task_id: str,
+    created_at: str,
+    parts: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "conversation_id": "conv-session-1-Coordinator",
+        "agent_role_id": "Coordinator",
+        "instance_id": "inst-coordinator",
+        "task_id": task_id,
+        "trace_id": run_id,
+        "role": "assistant",
+        "role_id": "Coordinator",
+        "created_at": created_at,
+        "message": {"parts": parts},
+    }
+
+
 def test_coordinator_event_tool_messages_supports_instance_fallback() -> None:
     coordinator_message: dict[str, object] = {
         "role_id": "",
@@ -86,6 +107,48 @@ def test_coordinator_event_tool_messages_supports_instance_fallback() -> None:
             coordinator_instance_id=None,
         )
         == []
+    )
+
+
+def test_has_assistant_text_message_handles_non_matching_messages() -> None:
+    messages: list[dict[str, object]] = [
+        {
+            "role": "user",
+            "message": {
+                "parts": [
+                    {
+                        "part_kind": "text",
+                        "content": "terminal final answer",
+                    }
+                ]
+            },
+        },
+        {
+            "role": "assistant",
+            "message": {"parts": [{"part_kind": "tool-call", "tool_name": "shell"}]},
+        },
+    ]
+
+    assert _has_assistant_text_message(messages, "") is False
+    assert _has_assistant_text_message(messages, "terminal final answer") is False
+
+
+def test_has_assistant_text_message_matches_combined_text_parts() -> None:
+    messages: list[dict[str, object]] = [
+        {
+            "role": "assistant",
+            "message": {
+                "parts": [
+                    {"part_kind": "text", "content": "first paragraph"},
+                    {"part_kind": "text", "content": "second paragraph"},
+                ]
+            },
+        }
+    ]
+
+    assert (
+        _has_assistant_text_message(messages, "first paragraph\n\nsecond paragraph")
+        is True
     )
 
 
@@ -1465,6 +1528,226 @@ def test_build_session_rounds_reconstructs_structured_completed_output(
     assert parts[0]["content"] == "structured reconstructed output"
 
 
+def test_build_session_rounds_appends_completed_output_to_existing_history(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_appended_output.db"
+    session_id = "session-1"
+    run_id = "run-with-history"
+    task_id = "task-root-with-history"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id=task_id,
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="new objective",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    history_messages = [
+        _assistant_history_message(
+            run_id=run_id,
+            task_id=task_id,
+            created_at="2026-03-25T09:30:00+00:00",
+            parts=[
+                {
+                    "part_kind": "thinking",
+                    "part_index": 0,
+                    "content": "checking files",
+                },
+                {
+                    "part_kind": "tool-call",
+                    "tool_name": "shell",
+                    "tool_call_id": "call-1",
+                    "args": {"cmd": "date"},
+                },
+            ],
+        )
+    ]
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda _sid: history_messages,
+        get_session_events=lambda _sid: [
+            {
+                "event_type": RunEventType.RUN_COMPLETED.value,
+                "trace_id": run_id,
+                "payload_json": RunResult(
+                    trace_id=run_id,
+                    root_task_id=task_id,
+                    status="completed",
+                    output=content_parts_from_text("terminal final answer"),
+                ).model_dump_json(),
+                "occurred_at": "2026-03-25T09:31:00+00:00",
+            }
+        ],
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+    coordinator_messages = cast(
+        list[dict[str, object]],
+        round_item["coordinator_messages"],
+    )
+    reconstructed_message = cast(dict[str, object], coordinator_messages[1]["message"])
+    parts = cast(list[dict[str, object]], reconstructed_message["parts"])
+
+    assert round_item["has_final_output"] is True
+    assert len(coordinator_messages) == 2
+    assert coordinator_messages[1]["reconstructed"] is True
+    assert parts[0]["content"] == "terminal final answer"
+
+
+def test_build_session_rounds_dedupes_completed_output_from_existing_history(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_deduped_output.db"
+    session_id = "session-1"
+    run_id = "run-with-persisted-final"
+    task_id = "task-root-with-persisted-final"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id=task_id,
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="new objective",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    history_messages = [
+        _assistant_history_message(
+            run_id=run_id,
+            task_id=task_id,
+            created_at="2026-03-25T09:30:00+00:00",
+            parts=[
+                {
+                    "part_kind": "text",
+                    "content": "terminal final answer",
+                }
+            ],
+        )
+    ]
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda _sid: history_messages,
+        get_session_events=lambda _sid: [
+            {
+                "event_type": RunEventType.RUN_COMPLETED.value,
+                "trace_id": run_id,
+                "payload_json": RunResult(
+                    trace_id=run_id,
+                    root_task_id=task_id,
+                    status="completed",
+                    output=content_parts_from_text("terminal final answer"),
+                ).model_dump_json(),
+                "occurred_at": "2026-03-25T09:31:00+00:00",
+            }
+        ],
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+    coordinator_messages = cast(
+        list[dict[str, object]],
+        round_item["coordinator_messages"],
+    )
+
+    assert round_item["has_final_output"] is True
+    assert len(coordinator_messages) == 1
+    assert "reconstructed" not in coordinator_messages[0]
+
+
+def test_build_session_rounds_dedupes_completed_output_from_legacy_content(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_legacy_content_dedupe.db"
+    session_id = "session-1"
+    run_id = "run-with-legacy-final"
+    task_id = "task-root-with-legacy-final"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id=task_id,
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="new objective",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    history_messages = [
+        {
+            "conversation_id": "conv-session-1-Coordinator",
+            "agent_role_id": "Coordinator",
+            "instance_id": "inst-coordinator",
+            "task_id": task_id,
+            "trace_id": run_id,
+            "role": "assistant",
+            "role_id": "Coordinator",
+            "created_at": "2026-03-25T09:30:00+00:00",
+            "message": {"content": "terminal final answer"},
+        }
+    ]
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda _sid: history_messages,
+        get_session_events=lambda _sid: [
+            {
+                "event_type": RunEventType.RUN_COMPLETED.value,
+                "trace_id": run_id,
+                "payload_json": RunResult(
+                    trace_id=run_id,
+                    root_task_id=task_id,
+                    status="completed",
+                    output=content_parts_from_text("terminal final answer"),
+                ).model_dump_json(),
+                "occurred_at": "2026-03-25T09:31:00+00:00",
+            }
+        ],
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+    coordinator_messages = cast(
+        list[dict[str, object]],
+        round_item["coordinator_messages"],
+    )
+
+    assert round_item["has_final_output"] is True
+    assert len(coordinator_messages) == 1
+    assert "reconstructed" not in coordinator_messages[0]
+
+
 def test_build_session_rounds_projects_failed_assistant_response_output_as_final(
     tmp_path: Path,
 ) -> None:
@@ -1537,6 +1820,82 @@ def test_build_session_rounds_projects_failed_assistant_response_output_as_final
     assert parts[0]["content"] == "failed final output"
 
 
+def test_build_session_rounds_appends_failed_assistant_response_to_history(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_failed_appended_output.db"
+    session_id = "session-1"
+    run_id = "run-failed-with-history"
+    task_id = "task-root-failed-with-history"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id=task_id,
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="new objective",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    history_messages = [
+        _assistant_history_message(
+            run_id=run_id,
+            task_id=task_id,
+            created_at="2026-03-25T09:30:00+00:00",
+            parts=[
+                {
+                    "part_kind": "tool-call",
+                    "tool_name": "shell",
+                    "tool_call_id": "call-1",
+                    "args": {"cmd": "date"},
+                }
+            ],
+        )
+    ]
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda _sid: history_messages,
+        get_session_events=lambda _sid: [
+            {
+                "event_type": RunEventType.RUN_FAILED.value,
+                "trace_id": run_id,
+                "payload_json": RunResult(
+                    trace_id=run_id,
+                    root_task_id=task_id,
+                    status="failed",
+                    completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+                    output=content_parts_from_text("failed final output"),
+                ).model_dump_json(),
+                "occurred_at": "2026-03-25T09:31:00+00:00",
+            }
+        ],
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+    coordinator_messages = cast(
+        list[dict[str, object]],
+        round_item["coordinator_messages"],
+    )
+    reconstructed_message = cast(dict[str, object], coordinator_messages[1]["message"])
+    parts = cast(list[dict[str, object]], reconstructed_message["parts"])
+
+    assert round_item["has_final_output"] is True
+    assert len(coordinator_messages) == 2
+    assert coordinator_messages[1]["reconstructed"] is True
+    assert parts[0]["content"] == "failed final output"
+
+
 def test_build_session_rounds_ignores_assistant_error_output_for_final_flag(
     tmp_path: Path,
 ) -> None:
@@ -1582,6 +1941,59 @@ def test_build_session_rounds_ignores_assistant_error_output_for_final_flag(
                     completion_reason=RunCompletionReason.ASSISTANT_ERROR,
                     output=content_parts_from_text("assistant error output"),
                 ).model_dump_json(),
+                "occurred_at": "2026-03-25T09:31:00+00:00",
+            }
+        ],
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+
+    assert round_item["has_final_output"] is False
+    assert round_item["coordinator_messages"] == []
+
+
+def test_build_session_rounds_ignores_stopped_output_for_final_flag(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_stopped_output.db"
+    session_id = "session-1"
+    run_id = "run-stopped"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id="task-root-stopped",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="new objective",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda _sid: [],
+        get_session_events=lambda _sid: [
+            {
+                "event_type": RunEventType.RUN_STOPPED.value,
+                "trace_id": run_id,
+                "payload_json": json.dumps(
+                    {
+                        "trace_id": run_id,
+                        "root_task_id": "task-root-stopped",
+                        "status": "stopped",
+                        "output": "stopped diagnostic output",
+                    }
+                ),
                 "occurred_at": "2026-03-25T09:31:00+00:00",
             }
         ],


### PR DESCRIPTION
## Summary
- append terminal final output to session round coordinator history when existing persisted history only has intermediate tool/thinking messages
- dedupe terminal output when the assistant final text already exists
- document the session rounds terminal-output projection contract

Fixes #761
Fixes #742

## Tests
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
- uv run --extra dev pytest -q tests/unit_tests/frontend/test_round_retry_timeline_ui.py
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests/browser/test_streaming_message_timeline.py
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests