### PR TITLE
Make app env changes reload runtime

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -894,6 +894,7 @@ Returns environment variables grouped by `system` and `app` scope.
 `system` is read-only and reflects the effective runtime environment currently visible to the Agent Teams server and newly spawned child processes.
 `app` is editable and is stored across `.env` in the resolved config dir, by default `~/.relay-teams/.env`, and the unified secret store.
 Sensitive-looking app keys such as `*_API_KEY`, `*_TOKEN`, `*_SECRET`, and `*_PASSWORD` are stored in the secret store and excluded from `.env`.
+The server loads app environment values at startup and watches the app `.env` file for external edits, so saved or manually edited app values take effect without restarting the server.
 Each record includes `key`, `value`, `scope`, and `value_kind` (`string` or `expandable`).
 
 ### `PUT /system/configs/environment-variables/{scope}/{key}`

--- a/src/relay_teams/env/app_env_watcher.py
+++ b/src/relay_teams/env/app_env_watcher.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import logging
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from relay_teams.env.runtime_env import (
+    load_env_file,
+    load_secret_env_vars,
+    sync_app_env_to_process_env,
+)
+from relay_teams.logger import get_logger, log_event
+
+LOGGER = get_logger(__name__)
+_DEFAULT_POLL_INTERVAL_SECONDS = 2.0
+_DEFAULT_DEBOUNCE_SECONDS = 0.5
+
+
+class AppEnvFileStamp(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    mtime_ns: int = Field(ge=0)
+    size: int = Field(ge=0)
+
+
+class AppEnvFileWatcher:
+    def __init__(
+        self,
+        *,
+        env_file_path: Path,
+        on_changed: Callable[[frozenset[str]], None],
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+        debounce_seconds: float = _DEFAULT_DEBOUNCE_SECONDS,
+    ) -> None:
+        self._env_file_path = env_file_path
+        self._on_changed = on_changed
+        self._poll_interval_seconds = max(0.1, poll_interval_seconds)
+        self._debounce_seconds = max(0.0, debounce_seconds)
+        self._last_stamp: AppEnvFileStamp | None = None
+        self._last_env: dict[str, str] = {}
+        self._task: asyncio.Task[None] | None = None
+        self._reload_task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self.refresh_snapshot()
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(self._watch_loop())
+
+    async def stop(self) -> None:
+        task = self._task
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        reload_task = self._reload_task
+        if reload_task is not None and not reload_task.done():
+            await asyncio.gather(reload_task, return_exceptions=True)
+        self._reload_task = None
+        self._task = None
+
+    def refresh_snapshot(self) -> None:
+        self._last_stamp = self._read_stamp()
+        self._last_env = self._read_app_env()
+
+    def sync_current_env_for_handled_change(self) -> frozenset[str]:
+        previous_env = self._last_env
+        current_env = sync_app_env_to_process_env(self._env_file_path)
+        self._last_env = current_env
+        return frozenset(_changed_env_keys(previous_env, current_env))
+
+    async def _watch_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._poll_interval_seconds)
+            current_stamp = self._read_stamp()
+            if current_stamp == self._last_stamp:
+                continue
+            await asyncio.sleep(self._debounce_seconds)
+            stable_stamp = self._read_stamp()
+            if stable_stamp == self._last_stamp:
+                continue
+            reload_task = asyncio.create_task(self._run_reload(stable_stamp))
+            self._reload_task = reload_task
+            try:
+                await asyncio.shield(reload_task)
+            finally:
+                if self._reload_task is reload_task and reload_task.done():
+                    self._reload_task = None
+
+    async def _run_reload(self, stable_stamp: AppEnvFileStamp | None) -> None:
+        try:
+            changed_keys = await asyncio.to_thread(
+                self._sync_stable_change,
+                stable_stamp,
+            )
+            if changed_keys:
+                self._on_changed(changed_keys)
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="env.app.file_watch_reload_failed",
+                message="Failed to reload app environment after file change",
+                payload={"env_file_path": str(self._env_file_path)},
+                exc_info=exc,
+            )
+
+    def _sync_stable_change(
+        self,
+        stable_stamp: AppEnvFileStamp | None,
+    ) -> frozenset[str]:
+        previous_env = self._last_env
+        current_env = sync_app_env_to_process_env(self._env_file_path)
+        self._last_stamp = stable_stamp
+        self._last_env = current_env
+        changed_keys = _changed_env_keys(previous_env, current_env)
+        return frozenset(changed_keys)
+
+    def _read_stamp(self) -> AppEnvFileStamp | None:
+        try:
+            stat_result = self._env_file_path.stat()
+        except FileNotFoundError:
+            return None
+        return AppEnvFileStamp(
+            mtime_ns=stat_result.st_mtime_ns,
+            size=stat_result.st_size,
+        )
+
+    def _read_app_env(self) -> dict[str, str]:
+        values = load_env_file(self._env_file_path)
+        values.update(load_secret_env_vars(self._env_file_path.parent))
+        return values
+
+
+def _changed_env_keys(
+    previous_env: dict[str, str],
+    current_env: dict[str, str],
+) -> set[str]:
+    changed_keys: set[str] = set()
+    for key in previous_env.keys() | current_env.keys():
+        if previous_env.get(key) != current_env.get(key):
+            changed_keys.add(key)
+    return changed_keys

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -58,6 +58,7 @@ from relay_teams.agents.orchestration.task_orchestration_service import (
     TaskOrchestrationService,
 )
 from relay_teams.agents.orchestration.task_execution_service import TaskExecutionService
+from relay_teams.env.app_env_watcher import AppEnvFileWatcher
 from relay_teams.env.clawhub_config_service import ClawHubConfigService
 from relay_teams.env.environment_variable_service import EnvironmentVariableService
 from relay_teams.env.github_config_service import GitHubConfigService
@@ -377,8 +378,12 @@ class ServerContainer:
         self.environment_variable_service: EnvironmentVariableService = (
             EnvironmentVariableService(
                 app_env_file_path=runtime.paths.env_file,
-                on_app_env_changed=self._on_app_environment_changed,
+                on_app_env_changed=self._on_app_environment_saved,
             )
+        )
+        self.app_env_file_watcher: AppEnvFileWatcher = AppEnvFileWatcher(
+            env_file_path=runtime.paths.env_file,
+            on_changed=self._on_app_environment_changed,
         )
         self.mcp_config_manager: McpConfigManager = McpConfigManager(
             app_config_dir=app_config_dir
@@ -1381,6 +1386,7 @@ class ServerContainer:
 
     async def start(self) -> None:
         self.mcp_discovery_service.start_warmup(self.mcp_registry)
+        self.app_env_file_watcher.start()
         self.mcp_config_file_watcher.start()
         self.run_service.bind_event_loop(asyncio.get_running_loop())
         self.background_task_service.bind_completion_sink(self.run_service)
@@ -1395,6 +1401,7 @@ class ServerContainer:
         return None
 
     async def stop(self) -> None:
+        await self.app_env_file_watcher.stop()
         await self.automation_scheduler_service.stop()
         await self.github_trigger_action_worker.stop()
         await self.automation_bound_session_queue_worker.stop()
@@ -1647,6 +1654,12 @@ class ServerContainer:
         else:
             self.proxy_config_service.reload_proxy_config()
         self._reload_skills_runtime_after_app_env_change()
+
+    def _on_app_environment_saved(self, changed_keys: frozenset[str]) -> None:
+        synced_changed_keys = (
+            self.app_env_file_watcher.sync_current_env_for_handled_change()
+        )
+        self._on_app_environment_changed(changed_keys | synced_changed_keys)
 
     def _ensure_default_workspace(self) -> None:
         if self.workspace_repo.exists("default"):

--- a/tests/unit_tests/env/test_app_env_watcher.py
+++ b/tests/unit_tests/env/test_app_env_watcher.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import threading
+
+import pytest
+
+from relay_teams.env import runtime_env
+from relay_teams.env.app_env_watcher import AppEnvFileStamp, AppEnvFileWatcher
+
+
+def _reset_runtime_env_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    keys: tuple[str, ...],
+) -> None:
+    monkeypatch.setattr(runtime_env, "_PROCESS_ENV_BASELINE", {})
+    monkeypatch.setattr(runtime_env, "_SYNCED_APP_ENV_KEYS", set())
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_app_env_file_watcher_reloads_on_file_change(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    key = "APP_ENV_WATCHED_VALUE"
+    _reset_runtime_env_sync(monkeypatch, (key,))
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{key}=before\n", encoding="utf-8")
+    changed = asyncio.Event()
+    changed_events: list[frozenset[str]] = []
+    loop = asyncio.get_running_loop()
+    loop_thread_id = threading.get_ident()
+    callback_thread_ids: list[int] = []
+
+    def on_changed(changed_keys: frozenset[str]) -> None:
+        changed_events.append(changed_keys)
+        callback_thread_ids.append(threading.get_ident())
+        loop.call_soon_threadsafe(changed.set)
+
+    watcher = AppEnvFileWatcher(
+        env_file_path=env_file,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    watcher.start()
+    try:
+        env_file.write_text(f"{key}=after\n", encoding="utf-8")
+        await asyncio.wait_for(changed.wait(), timeout=1)
+    finally:
+        await watcher.stop()
+
+    assert changed_events == [frozenset((key,))]
+    assert callback_thread_ids == [loop_thread_id]
+    assert runtime_env.os.environ[key] == "after"
+
+
+@pytest.mark.asyncio
+async def test_app_env_file_watcher_reloads_on_file_creation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    key = "APP_ENV_WATCHED_CREATED"
+    _reset_runtime_env_sync(monkeypatch, (key,))
+    env_file = tmp_path / ".env"
+    changed = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def on_changed(_changed_keys: frozenset[str]) -> None:
+        loop.call_soon_threadsafe(changed.set)
+
+    watcher = AppEnvFileWatcher(
+        env_file_path=env_file,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    watcher.start()
+    try:
+        env_file.write_text(f"{key}=created\n", encoding="utf-8")
+        await asyncio.wait_for(changed.wait(), timeout=1)
+    finally:
+        await watcher.stop()
+
+    assert runtime_env.os.environ[key] == "created"
+
+
+@pytest.mark.asyncio
+async def test_app_env_file_watcher_reloads_on_file_deletion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    key = "APP_ENV_WATCHED_DELETED"
+    _reset_runtime_env_sync(monkeypatch, (key,))
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{key}=configured\n", encoding="utf-8")
+    runtime_env.sync_app_env_to_process_env(env_file)
+    changed = asyncio.Event()
+    changed_events: list[frozenset[str]] = []
+    loop = asyncio.get_running_loop()
+
+    def on_changed(changed_keys: frozenset[str]) -> None:
+        changed_events.append(changed_keys)
+        loop.call_soon_threadsafe(changed.set)
+
+    watcher = AppEnvFileWatcher(
+        env_file_path=env_file,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    watcher.start()
+    try:
+        env_file.unlink()
+        await asyncio.wait_for(changed.wait(), timeout=1)
+    finally:
+        await watcher.stop()
+
+    assert changed_events == [frozenset((key,))]
+    assert key not in runtime_env.os.environ
+
+
+@pytest.mark.asyncio
+async def test_app_env_file_watcher_start_and_stop_are_idempotent(
+    tmp_path: Path,
+) -> None:
+    changed = asyncio.Event()
+    watcher = AppEnvFileWatcher(
+        env_file_path=tmp_path / ".env",
+        on_changed=lambda _changed_keys: changed.set(),
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    await watcher.stop()
+    watcher.start()
+    watcher.start()
+    await watcher.stop()
+
+    assert not changed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_app_env_file_watcher_tolerates_reload_callback_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    key = "APP_ENV_WATCHED_CALLBACK_FAILURE"
+    _reset_runtime_env_sync(monkeypatch, (key,))
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{key}=before\n", encoding="utf-8")
+    attempted = asyncio.Event()
+    succeeded = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    attempts = 0
+
+    def on_changed(_changed_keys: frozenset[str]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            loop.call_soon_threadsafe(attempted.set)
+            raise RuntimeError("reload failed")
+        loop.call_soon_threadsafe(succeeded.set)
+
+    watcher = AppEnvFileWatcher(
+        env_file_path=env_file,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+
+    watcher.start()
+    try:
+        env_file.write_text(f"{key}=after-failure\n", encoding="utf-8")
+        await asyncio.wait_for(attempted.wait(), timeout=1)
+        env_file.write_text(f"{key}=after-success\n", encoding="utf-8")
+        await asyncio.wait_for(succeeded.wait(), timeout=1)
+    finally:
+        await watcher.stop()
+
+    assert attempts == 2
+    assert runtime_env.os.environ[key] == "after-success"
+
+
+@pytest.mark.asyncio
+async def test_app_env_file_watcher_stop_waits_for_inflight_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    key = "APP_ENV_WATCHED_STOP_WAIT"
+    _reset_runtime_env_sync(monkeypatch, (key,))
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{key}=before\n", encoding="utf-8")
+    entered = threading.Event()
+    release = threading.Event()
+
+    def on_changed(_changed_keys: frozenset[str]) -> None:
+        return None
+
+    watcher = AppEnvFileWatcher(
+        env_file_path=env_file,
+        on_changed=on_changed,
+        poll_interval_seconds=0.01,
+        debounce_seconds=0.0,
+    )
+    original_sync_stable_change = watcher._sync_stable_change
+
+    def sync_stable_change(stable_stamp: AppEnvFileStamp | None) -> frozenset[str]:
+        entered.set()
+        release.wait(timeout=2.0)
+        return original_sync_stable_change(stable_stamp)
+
+    monkeypatch.setattr(watcher, "_sync_stable_change", sync_stable_change)
+
+    watcher.start()
+    try:
+        env_file.write_text(f"{key}=after\n", encoding="utf-8")
+        assert await asyncio.to_thread(entered.wait, 1.0) is True
+        stop_task = asyncio.create_task(watcher.stop())
+        await asyncio.sleep(0.05)
+
+        assert not stop_task.done()
+
+        release.set()
+        await asyncio.wait_for(stop_task, timeout=1)
+    finally:
+        release.set()
+        await watcher.stop()

--- a/tests/unit_tests/env/test_runtime_env.py
+++ b/tests/unit_tests/env/test_runtime_env.py
@@ -57,6 +57,43 @@ def test_load_merged_env_vars_reads_secret_backed_app_env_values(
     assert merged["OPENAI_API_KEY"] == "secret-key"
 
 
+def test_sync_app_env_to_process_env_reads_secret_backed_values(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".relay-teams"
+    config_dir.mkdir(parents=True)
+    env_file = config_dir / ".env"
+    env_file.write_text("APP_ONLY=one\n", encoding="utf-8")
+    (config_dir / "secrets.json").write_text(
+        (
+            "{\n"
+            '  "version": 1,\n'
+            '  "entries": [\n'
+            "    {\n"
+            '      "namespace": "app_env",\n'
+            '      "owner_id": "app",\n'
+            '      "field_name": "OPENAI_API_KEY",\n'
+            '      "storage": "file",\n'
+            '      "value": "secret-key"\n'
+            "    }\n"
+            "  ]\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runtime_env, "_PROCESS_ENV_BASELINE", {})
+    monkeypatch.setattr(runtime_env, "_SYNCED_APP_ENV_KEYS", set())
+    monkeypatch.delenv("APP_ONLY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    synced = runtime_env.sync_app_env_to_process_env(env_file)
+
+    assert synced == {"APP_ONLY": "one", "OPENAI_API_KEY": "secret-key"}
+    assert runtime_env.os.environ["APP_ONLY"] == "one"
+    assert runtime_env.os.environ["OPENAI_API_KEY"] == "secret-key"
+
+
 def test_get_env_var_process_env_has_highest_priority(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit_tests/interfaces/server/test_container.py
+++ b/tests/unit_tests/interfaces/server/test_container.py
@@ -221,6 +221,145 @@ def test_app_env_plugin_dirs_change_reloads_plugin_runtime(
     ] == ["quality"]
 
 
+def test_container_app_env_file_watcher_refreshes_runtime_after_external_change(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    key = "APP_ENV_EXTERNAL_RELOAD_TEST"
+    monkeypatch.delenv(key, raising=False)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = ServerContainer(config_dir=config_dir)
+    calls: list[str] = []
+
+    def reload_model_config() -> None:
+        calls.append("model")
+
+    def reload_mcp_runtime() -> None:
+        calls.append("mcp")
+
+    def reload_skills_runtime() -> None:
+        calls.append("skills")
+
+    monkeypatch.setattr(
+        container.model_config_service,
+        "reload_model_config",
+        reload_model_config,
+    )
+    monkeypatch.setattr(
+        container,
+        "_reload_mcp_runtime_after_app_env_change",
+        reload_mcp_runtime,
+    )
+    monkeypatch.setattr(
+        container,
+        "_reload_skills_runtime_after_app_env_change",
+        reload_skills_runtime,
+    )
+
+    container.app_env_file_watcher.refresh_snapshot()
+    container.runtime.paths.env_file.write_text(f"{key}=after\n", encoding="utf-8")
+    changed_keys = container.app_env_file_watcher._sync_stable_change(
+        container.app_env_file_watcher._read_stamp()
+    )
+    container._on_app_environment_changed(changed_keys)
+
+    assert calls == ["model", "mcp", "skills"]
+    assert os.environ[key] == "after"
+
+
+def test_app_env_change_callback_does_not_advance_watcher_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = ServerContainer(config_dir=config_dir)
+
+    monkeypatch.setattr(
+        container.model_config_service,
+        "reload_model_config",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        container,
+        "_reload_mcp_runtime_after_app_env_change",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        container,
+        "_reload_skills_runtime_after_app_env_change",
+        lambda: None,
+    )
+
+    container.runtime.paths.env_file.write_text("FIRST=value\n", encoding="utf-8")
+    container.app_env_file_watcher.refresh_snapshot()
+    initial_stamp = container.app_env_file_watcher._last_stamp
+
+    container.runtime.paths.env_file.write_text("SECOND=value\n", encoding="utf-8")
+    changed_stamp = container.app_env_file_watcher._read_stamp()
+
+    container._on_app_environment_changed(frozenset(("UNRELATED_APP_ENV",)))
+
+    assert initial_stamp is not None
+    assert changed_stamp != initial_stamp
+    assert container.app_env_file_watcher._last_stamp == initial_stamp
+
+
+def test_app_env_api_save_does_not_duplicate_watcher_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_proxy_env(monkeypatch)
+    key = "APP_ENV_API_SAVE_TEST"
+    monkeypatch.delenv(key, raising=False)
+    config_dir = tmp_path / ".agent-teams"
+    _write_model_config(config_dir, api_key="initial-secret")
+    container = ServerContainer(config_dir=config_dir)
+    calls: list[str] = []
+
+    def reload_model_config() -> None:
+        calls.append("model")
+
+    def reload_mcp_runtime() -> None:
+        calls.append("mcp")
+
+    def reload_skills_runtime() -> None:
+        calls.append("skills")
+
+    monkeypatch.setattr(
+        container.model_config_service,
+        "reload_model_config",
+        reload_model_config,
+    )
+    monkeypatch.setattr(
+        container,
+        "_reload_mcp_runtime_after_app_env_change",
+        reload_mcp_runtime,
+    )
+    monkeypatch.setattr(
+        container,
+        "_reload_skills_runtime_after_app_env_change",
+        reload_skills_runtime,
+    )
+
+    container.app_env_file_watcher.refresh_snapshot()
+    container.environment_variable_service.save_environment_variable(
+        scope=EnvironmentVariableScope.APP,
+        key=key,
+        request=EnvironmentVariableSaveRequest(value="from-api"),
+    )
+    changed_keys = container.app_env_file_watcher._sync_stable_change(
+        container.app_env_file_watcher._read_stamp()
+    )
+    if changed_keys:
+        container._on_app_environment_changed(changed_keys)
+
+    assert calls == ["model", "mcp", "skills"]
+
+
 def test_container_injects_fallback_middleware_into_reflection_service(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- add an app .env file watcher that syncs external edits into the running process
- route watched app env changes through existing runtime reload paths for model config, MCP, skills, plugins, and proxy state
- document startup and live .env reload behavior for Settings > Environment

Closes #768

## Tests
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright src/relay_teams/env/app_env_watcher.py src/relay_teams/interfaces/server/container.py tests/unit_tests/env/test_app_env_watcher.py tests/unit_tests/env/test_runtime_env.py tests/unit_tests/interfaces/server/test_container.py
- uv run --extra dev pytest -q tests/unit_tests/env tests/unit_tests/interfaces/server/test_container.py tests/unit_tests/mcp/test_mcp_config_watcher.py
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests/api tests/integration_tests/cli
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests/browser/test_browser_smoke.py::test_browser_web_settings_complex_fallback_roundtrip -vv
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests/browser/test_voice_input_audio.py::test_voice_input_sends_pcm_bytes_and_stops_after_silence -vv

## Notes
- A full local `uv run --extra dev basedpyright` run also inspected ignored `tmp/migrate.py` and failed on pre-existing optional-int errors there; the pre-commit basedpyright hook passed for this commit.
- A full local integration run initially lacked the Playwright browser cache under the test HOME. After pinning `PLAYWRIGHT_BROWSERS_PATH`, sampled browser failures passed individually while API/CLI integration passed fully.