### PR TITLE
Fix subagent lifecycle state synchronization

### DIFF
--- a/frontend/dist/js/components/agentPanel/panelFactory.js
+++ b/frontend/dist/js/components/agentPanel/panelFactory.js
@@ -16,6 +16,11 @@ import { formatMessage, t } from '../../utils/i18n.js';
 import { sysLog } from '../../utils/logger.js';
 import { getDrawer } from './dom.js';
 import { loadAgentHistory } from './history.js';
+import {
+    getActiveSubagentSession,
+    updateNormalModeSubagentSessionStatus,
+} from '../subagentSessions.js';
+import { markSubagentStatus } from '../subagentRail.js';
 
 const REFLECTION_BUTTON_RESET_MS = 2400;
 
@@ -105,10 +110,13 @@ export function createPanel(instanceId, roleId, onClose) {
     const stopBtn = panelEl.querySelector('.agent-panel-stop');
     if (stopBtn) {
         stopBtn.onclick = async () => {
-            if (!state.activeRunId) return;
+            const control = resolveSubagentControlTarget(instanceId);
+            if (!control.runId) return;
             try {
-                await stopRun(state.activeRunId, { scope: 'subagent', instanceId });
-                state.pausedSubagent = { runId: state.activeRunId, instanceId, roleId };
+                await stopRun(control.runId, control.stopOptions);
+                markSubagentStatus(instanceId, 'stopped');
+                updateNormalModeSubagentSessionStatus(state.currentSessionId, instanceId, 'stopped');
+                state.pausedSubagent = { runId: control.runId, instanceId, roleId };
                 sysLog(formatMessage('subagent.log.paused', { agent: roleId || instanceId }), 'log-info');
             } catch (e) {
                 sysLog(formatMessage('subagent.error.pause_failed', { error: e.message }), 'log-error');
@@ -173,20 +181,37 @@ export function createPanel(instanceId, roleId, onClose) {
     bindPanelContextIndicator(panelEl, instanceId);
     async function sendInject() {
         const text = textarea.value.trim();
-        if (!text || !state.activeRunId) return;
-        const shouldResume = !!(
+        const controlRunId = resolveSubagentControlRunId(instanceId);
+        if (!text || !controlRunId) return;
+        const activeSubagent = getActiveSubagentSession();
+        const activeSubagentStatus = String(
+            activeSubagent?.instanceId === instanceId
+                ? activeSubagent?.status || activeSubagent?.runStatus || ''
+                : '',
+        ).trim();
+        const locallyPaused = (
+            state.pausedSubagent?.instanceId === instanceId
+            || ['paused', 'stopped'].includes(activeSubagentStatus)
+        );
+        const snapshotPaused = !!(
             state.currentRecoverySnapshot?.pausedSubagent
-            && state.currentRecoverySnapshot?.activeRun?.run_id === state.activeRunId
+            && state.currentRecoverySnapshot?.activeRun?.run_id === controlRunId
+        );
+        const shouldResume = !!(
+            locallyPaused
+            || snapshotPaused
         );
         textarea.value = '';
         textarea.style.height = 'auto';
         try {
-            await injectSubagentMessage(state.activeRunId, instanceId, text);
+            await injectSubagentMessage(controlRunId, instanceId, text);
+            markSubagentStatus(instanceId, 'running');
+            updateNormalModeSubagentSessionStatus(state.currentSessionId, instanceId, 'running');
             if (state.pausedSubagent && state.pausedSubagent.instanceId === instanceId) {
                 state.pausedSubagent = null;
             }
             if (shouldResume) {
-                await resumeRecoverableRun(state.activeRunId, {
+                await resumeRecoverableRun(controlRunId, {
                     sessionId: state.currentSessionId,
                     reason: 'subagent follow-up',
                     quiet: true,
@@ -220,6 +245,30 @@ export function createPanel(instanceId, roleId, onClose) {
         loadedSessionId: '',
         loadedRunId: '',
     };
+}
+
+function resolveSubagentControlTarget(instanceId) {
+    const safeInstanceId = String(instanceId || '').trim();
+    const activeSubagent = getActiveSubagentSession();
+    const subagentRunId = String(
+        activeSubagent?.instanceId === safeInstanceId
+            ? activeSubagent?.runId || ''
+            : '',
+    ).trim();
+    if (subagentRunId) {
+        return {
+            runId: subagentRunId,
+            stopOptions: { scope: 'main' },
+        };
+    }
+    return {
+        runId: String(state.activeRunId || '').trim(),
+        stopOptions: { scope: 'subagent', instanceId: safeInstanceId },
+    };
+}
+
+function resolveSubagentControlRunId(instanceId) {
+    return resolveSubagentControlTarget(instanceId).runId;
 }
 
 

--- a/frontend/dist/js/components/subagentSessions.js
+++ b/frontend/dist/js/components/subagentSessions.js
@@ -21,10 +21,15 @@ const loadingSessionIds = new Set();
 const loadingPromisesBySessionId = new Map();
 const expandedParentSessionIds = new Set();
 const terminalRefreshTimers = new Map();
+const statusRefreshTimers = new Map();
+const recentParentStopCandidateTimestampsBySession = new Map();
 const queuedSubagentSessionLoads = [];
+const parentStoppedSessionIds = new Set();
+const parentStoppedSubagentInstanceIdsBySession = new Map();
 let activeSubagentRenderSequence = 0;
 let activeSubagentRenderController = null;
 let subagentSessionsChangedFrame = 0;
+const RECENT_PARENT_STOP_CANDIDATE_WINDOW_MS = 5000;
 let pendingSubagentSessionsChangedDetail = null;
 let activeSubagentSessionLoadCount = 0;
 const MAX_PARALLEL_SUBAGENT_SESSION_LOADS = 2;
@@ -50,6 +55,33 @@ export function getActiveSubagentSession() {
     return state.activeSubagentSession && typeof state.activeSubagentSession === 'object'
         ? state.activeSubagentSession
         : null;
+}
+
+export function getNormalModeSubagentSessionByRunId(sessionId, runId) {
+    const safeSessionId = String(sessionId || '').trim();
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return null;
+    }
+    const active = getActiveSubagentSession();
+    if (
+        active
+        && active.runId === safeRunId
+        && (!safeSessionId || active.sessionId === safeSessionId)
+    ) {
+        return active;
+    }
+    const sessionIds = safeSessionId
+        ? [safeSessionId]
+        : Array.from(subagentSessionsBySessionId.keys());
+    for (const currentSessionId of sessionIds) {
+        const match = getSessionSubagentSessions(currentSessionId)
+            .find(item => item.runId === safeRunId);
+        if (match) {
+            return match;
+        }
+    }
+    return null;
 }
 
 export function isActiveSubagentSession(sessionId, instanceId) {
@@ -248,14 +280,17 @@ export function replaceSessionSubagents(
     if (!safeSessionId) {
         return [];
     }
-    const normalized = normalizeSubagentSessions(payload, safeSessionId);
+    const normalized = normalizeSubagentSessions(payload, safeSessionId)
+        .map(item => coerceParentStoppedSubagentSession(item));
     applySessionSubagentRecords(safeSessionId, normalized, { emitChange });
     return getSessionSubagentSessions(safeSessionId);
 }
 
 export function rememberNormalModeSubagentSession(sessionId, record) {
     const safeSessionId = String(sessionId || '').trim();
-    const normalized = normalizeSubagentSession(record, safeSessionId);
+    const normalized = coerceParentStoppedSubagentSession(
+        normalizeSubagentSession(record, safeSessionId),
+    );
     if (!safeSessionId || normalized === null) {
         return false;
     }
@@ -270,11 +305,11 @@ export function rememberNormalModeSubagentFromBackgroundTask(sessionId, payload,
     if (!safeSessionId || !isSubagentBackgroundTask(payload)) {
         return false;
     }
-    const normalized = normalizeSubagentSession({
+    const normalized = coerceParentStoppedSubagentSession(normalizeSubagentSession({
         ...payload,
         status: backgroundTaskStatusForEvent(payload, eventType),
         updated_at: payload?.updated_at || payload?.updatedAt || new Date().toISOString(),
-    }, safeSessionId);
+    }, safeSessionId));
     if (normalized === null) {
         return false;
     }
@@ -290,13 +325,14 @@ export function updateNormalModeSubagentSessionStatus(sessionId, instanceId, sta
     if (!safeSessionId || !safeInstanceId) {
         return;
     }
+    const normalizedStatus = normalizeSubagentRunStatus(status);
     const current = getSessionSubagentSessions(safeSessionId);
     let changed = false;
     let nextStatus = '';
     const next = current.map(item => (
         item.instanceId === safeInstanceId
             ? (() => {
-                nextStatus = String(status || item.status || 'idle');
+                nextStatus = normalizedStatus || item.status || 'idle';
                 if (item.status === nextStatus && item.runStatus === nextStatus) {
                     return item;
                 }
@@ -309,11 +345,141 @@ export function updateNormalModeSubagentSessionStatus(sessionId, instanceId, sta
             })()
             : item
     ));
+    const active = getActiveSubagentSession();
+    if (
+        active
+        && active.sessionId === safeSessionId
+        && active.instanceId === safeInstanceId
+        && (active.status !== normalizedStatus || active.runStatus !== normalizedStatus)
+    ) {
+        state.activeSubagentSession = {
+            ...active,
+            status: normalizedStatus,
+            runStatus: normalizedStatus,
+        };
+        syncSubagentSessionViewChrome(state.activeSubagentSession);
+    }
     if (!changed) {
+        if (active && active.sessionId === safeSessionId && active.instanceId === safeInstanceId) {
+            emitSubagentSessionStatusChanged(safeSessionId, safeInstanceId, normalizedStatus);
+        }
         return;
     }
     applySessionSubagentRecords(safeSessionId, next, { emitChange: false });
-    emitSubagentSessionStatusChanged(safeSessionId, safeInstanceId, nextStatus);
+    emitSubagentSessionStatusChanged(safeSessionId, safeInstanceId, nextStatus || normalizedStatus);
+}
+
+export function updateNormalModeSubagentSessionStatusByRunId(sessionId, runId, status) {
+    const safeRunId = String(runId || '').trim();
+    if (!safeRunId) {
+        return false;
+    }
+    const match = getNormalModeSubagentSessionByRunId(sessionId, safeRunId);
+    if (!match) {
+        return false;
+    }
+    updateNormalModeSubagentSessionStatus(
+        match.sessionId || sessionId,
+        match.instanceId,
+        status,
+    );
+    return true;
+}
+
+export function applySubagentSessionStatusEvent(payload, eventMeta = null) {
+    const safeSessionId = String(
+        payload?.parent_session_id
+        || payload?.parentSessionId
+        || payload?.session_id
+        || payload?.sessionId
+        || eventMeta?.session_id
+        || eventMeta?.sessionId
+        || state.currentSessionId
+        || '',
+    ).trim();
+    if (!safeSessionId || !payload || typeof payload !== 'object') {
+        return false;
+    }
+    const normalized = coerceParentStoppedSubagentSession(normalizeSubagentSession({
+        ...payload,
+        session_id: safeSessionId,
+        run_id: payload.subagent_run_id || payload.subagentRunId || payload.run_id || payload.runId,
+        status: payload.status || payload.run_status || payload.runStatus || 'idle',
+        run_status: payload.run_status || payload.runStatus || payload.status || 'idle',
+        updated_at: payload.updated_at || payload.updatedAt || new Date().toISOString(),
+    }, safeSessionId));
+    if (normalized === null) {
+        return false;
+    }
+    const current = getSessionSubagentSessions(safeSessionId);
+    const nextRecord = mergeSubagentSessionStatusRecord(current, normalized, payload);
+    const next = upsertSubagentSessionRecord(current, nextRecord);
+    applySessionSubagentRecords(safeSessionId, next, { emitChange: false });
+    emitSubagentSessionStatusChanged(
+        safeSessionId,
+        nextRecord.instanceId,
+        nextRecord.status,
+    );
+    updateRecentParentStopCandidateFromStatusEvent(
+        safeSessionId,
+        nextRecord,
+        payload,
+        eventMeta,
+    );
+    scheduleSubagentSessionStatusRefresh(safeSessionId);
+    return true;
+}
+
+export function markNormalModeSubagentSessionsStoppedForParent(sessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId) {
+        return [];
+    }
+    parentStoppedSessionIds.add(safeSessionId);
+    const recentlyStopped = collectRecentParentStopCandidateInstanceIds(safeSessionId);
+    const changed = updateNormalModeSubagentSessionsMatching(
+        safeSessionId,
+        item => isRunningSubagentSessionStatus(item.status),
+        'stopped',
+    );
+    const stoppedByParent = new Set([
+        ...(parentStoppedSubagentInstanceIdsBySession.get(safeSessionId) || []),
+        ...recentlyStopped,
+        ...changed,
+    ]);
+    parentStoppedSubagentInstanceIdsBySession.set(safeSessionId, stoppedByParent);
+    return Array.from(stoppedByParent);
+}
+
+export function clearNormalModeSubagentParentStopState(sessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId) {
+        return;
+    }
+    parentStoppedSessionIds.delete(safeSessionId);
+    parentStoppedSubagentInstanceIdsBySession.delete(safeSessionId);
+    recentParentStopCandidateTimestampsBySession.delete(safeSessionId);
+}
+
+export function markNormalModeSubagentSessionsRunningForParent(sessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId) {
+        return [];
+    }
+    const stoppedByParent = parentStoppedSubagentInstanceIdsBySession.get(safeSessionId);
+    const changed = updateNormalModeSubagentSessionsMatching(
+        safeSessionId,
+        item => (
+            isStoppedSubagentSessionStatus(item.status)
+            && (
+                stoppedByParent === undefined
+                || stoppedByParent.has(item.instanceId)
+            )
+        ),
+        'running',
+    );
+    clearNormalModeSubagentParentStopState(safeSessionId);
+    return changed;
 }
 
 export function removeSessionSubagent(sessionId, instanceId) {
@@ -340,9 +506,73 @@ export function removeSessionSubagent(sessionId, instanceId) {
     return removed;
 }
 
+function updateNormalModeSubagentSessionsMatching(sessionId, predicate, status) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId || typeof predicate !== 'function') {
+        return [];
+    }
+    const normalizedStatus = normalizeSubagentRunStatus(status);
+    const current = getSessionSubagentSessions(safeSessionId);
+    const changedInstanceIds = [];
+    const next = current.map(item => {
+        if (!predicate(item)) {
+            return item;
+        }
+        if (item.status === normalizedStatus && item.runStatus === normalizedStatus) {
+            return item;
+        }
+        changedInstanceIds.push(item.instanceId);
+        return {
+            ...item,
+            status: normalizedStatus,
+            runStatus: normalizedStatus,
+        };
+    });
+    const active = getActiveSubagentSession();
+    const activeShouldChange = !!(
+        active
+        && active.sessionId === safeSessionId
+        && predicate(active)
+        && (active.status !== normalizedStatus || active.runStatus !== normalizedStatus)
+    );
+    if (
+        activeShouldChange
+        || (
+            active
+            && active.sessionId === safeSessionId
+            && changedInstanceIds.includes(active.instanceId)
+        )
+    ) {
+        state.activeSubagentSession = {
+            ...active,
+            status: normalizedStatus,
+            runStatus: normalizedStatus,
+        };
+        syncSubagentSessionViewChrome(state.activeSubagentSession);
+    }
+    if (changedInstanceIds.length === 0) {
+        if (activeShouldChange) {
+            emitSubagentSessionStatusChanged(safeSessionId, active.instanceId, normalizedStatus);
+            return [active.instanceId];
+        }
+        return [];
+    }
+    applySessionSubagentRecords(safeSessionId, next, { emitChange: false });
+    changedInstanceIds.forEach(instanceId => {
+        emitSubagentSessionStatusChanged(safeSessionId, instanceId, normalizedStatus);
+    });
+    if (activeShouldChange && !changedInstanceIds.includes(active.instanceId)) {
+        emitSubagentSessionStatusChanged(safeSessionId, active.instanceId, normalizedStatus);
+        changedInstanceIds.push(active.instanceId);
+    }
+    return changedInstanceIds;
+}
+
 export async function openSubagentSession(sessionId, record) {
     const safeSessionId = String(sessionId || '').trim();
-    const normalized = normalizeSubagentSession(record, safeSessionId);
+    const normalized = coerceParentStoppedSubagentSession(
+        normalizeSubagentSession(record, safeSessionId),
+    );
     if (!safeSessionId || normalized === null) {
         return;
     }
@@ -514,6 +744,116 @@ function normalizeSubagentSessions(payload, sessionId) {
         .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
 }
 
+function coerceParentStoppedSubagentSession(record) {
+    if (!record || typeof record !== 'object') {
+        return record;
+    }
+    const safeSessionId = String(record.sessionId || record.session_id || '').trim();
+    if (!parentStoppedSessionIds.has(safeSessionId)) {
+        return record;
+    }
+    if (
+        !isRunningSubagentSessionStatus(record.status)
+        && !isRunningSubagentSessionStatus(record.runStatus || record.run_status)
+    ) {
+        return record;
+    }
+    rememberParentStoppedSubagentInstance(safeSessionId, record.instanceId || record.instance_id);
+    return {
+        ...record,
+        status: 'stopped',
+        runStatus: 'stopped',
+    };
+}
+
+function rememberParentStoppedSubagentInstance(sessionId, instanceId) {
+    const safeSessionId = String(sessionId || '').trim();
+    const safeInstanceId = String(instanceId || '').trim();
+    if (!safeSessionId || !safeInstanceId) {
+        return;
+    }
+    const current = parentStoppedSubagentInstanceIdsBySession.get(safeSessionId) || new Set();
+    current.add(safeInstanceId);
+    parentStoppedSubagentInstanceIdsBySession.set(safeSessionId, current);
+}
+
+function rememberRecentParentStopCandidate(sessionId, instanceId, status) {
+    const safeSessionId = String(sessionId || '').trim();
+    const safeInstanceId = String(instanceId || '').trim();
+    if (!safeSessionId || !safeInstanceId) {
+        return;
+    }
+    const normalizedStatus = normalizeSubagentRunStatus(status);
+    const current = recentParentStopCandidateTimestampsBySession.get(safeSessionId) || new Map();
+    if (isStoppedSubagentSessionStatus(normalizedStatus)) {
+        current.set(safeInstanceId, Date.now());
+        recentParentStopCandidateTimestampsBySession.set(safeSessionId, current);
+        return;
+    }
+    if (current.delete(safeInstanceId) && current.size === 0) {
+        recentParentStopCandidateTimestampsBySession.delete(safeSessionId);
+    }
+}
+
+function updateRecentParentStopCandidateFromStatusEvent(sessionId, record, payload, eventMeta) {
+    const safeSessionId = String(sessionId || '').trim();
+    const safeInstanceId = String(record?.instanceId || '').trim();
+    if (!safeSessionId || !safeInstanceId) {
+        return;
+    }
+    if (shouldTrackParentStopCandidate(record, payload, eventMeta)) {
+        rememberRecentParentStopCandidate(safeSessionId, safeInstanceId, record.status);
+        return;
+    }
+    rememberRecentParentStopCandidate(safeSessionId, safeInstanceId, '');
+}
+
+function shouldTrackParentStopCandidate(record, payload, eventMeta) {
+    if (!isStoppedSubagentSessionStatus(record?.status)) {
+        return false;
+    }
+    if (!(payload?.parent_stop_candidate || payload?.parentStopCandidate)) {
+        return false;
+    }
+    const eventRunId = String(
+        payload?.parent_run_id
+        || payload?.parentRunId
+        || eventMeta?.run_id
+        || eventMeta?.trace_id
+        || '',
+    ).trim();
+    const subagentRunId = String(
+        record?.runId
+        || payload?.subagent_run_id
+        || payload?.subagentRunId
+        || payload?.run_id
+        || payload?.runId
+        || '',
+    ).trim();
+    return !!(eventRunId && subagentRunId && eventRunId !== subagentRunId);
+}
+
+function collectRecentParentStopCandidateInstanceIds(sessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    const current = recentParentStopCandidateTimestampsBySession.get(safeSessionId);
+    if (!current) {
+        return [];
+    }
+    const cutoff = Date.now() - RECENT_PARENT_STOP_CANDIDATE_WINDOW_MS;
+    const recent = [];
+    for (const [instanceId, timestamp] of current.entries()) {
+        if (timestamp >= cutoff) {
+            recent.push(instanceId);
+            continue;
+        }
+        current.delete(instanceId);
+    }
+    if (current.size === 0) {
+        recentParentStopCandidateTimestampsBySession.delete(safeSessionId);
+    }
+    return recent;
+}
+
 function normalizeSubagentSession(record, sessionId) {
     if (!record || typeof record !== 'object') {
         return null;
@@ -601,6 +941,18 @@ function normalizeSubagentRunStatus(status) {
     return safeStatus;
 }
 
+function isRunningSubagentSessionStatus(status) {
+    return ['running', 'queued', 'starting', 'pending'].includes(
+        normalizeSubagentRunStatus(status),
+    );
+}
+
+function isStoppedSubagentSessionStatus(status) {
+    return ['stopped', 'cancelled', 'canceled'].includes(
+        normalizeSubagentRunStatus(status),
+    );
+}
+
 function upsertSubagentSessionRecord(current, nextRecord) {
     const next = [...current];
     const index = next.findIndex(item => item.instanceId === nextRecord.instanceId);
@@ -614,6 +966,36 @@ function upsertSubagentSessionRecord(current, nextRecord) {
     }
     next.sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
     return next;
+}
+
+function mergeSubagentSessionStatusRecord(current, normalized, payload) {
+    const existing = current.find(item => (
+        item.instanceId === normalized.instanceId
+        || (normalized.runId && item.runId === normalized.runId)
+    ));
+    if (!existing) {
+        return normalized;
+    }
+    return {
+        ...existing,
+        ...normalized,
+        conversationId: hasSubagentSessionPayloadField(payload, 'conversation_id', 'conversationId')
+            ? normalized.conversationId
+            : existing.conversationId,
+        checkpointEventId: hasSubagentSessionPayloadField(payload, 'checkpoint_event_id', 'checkpointEventId')
+            ? normalized.checkpointEventId
+            : existing.checkpointEventId,
+        lastEventId: hasSubagentSessionPayloadField(payload, 'last_event_id', 'lastEventId')
+            ? normalized.lastEventId
+            : existing.lastEventId,
+    };
+}
+
+function hasSubagentSessionPayloadField(payload, ...keys) {
+    if (!payload || typeof payload !== 'object') {
+        return false;
+    }
+    return keys.some(key => Object.prototype.hasOwnProperty.call(payload, key));
 }
 
 function shortInstanceId(instanceId) {
@@ -659,6 +1041,31 @@ function cancelTerminalRefreshForInstance(instanceId) {
         clearTimeout(timerId);
     }
     terminalRefreshTimers.delete(safeInstanceId);
+}
+
+function scheduleSubagentSessionStatusRefresh(sessionId) {
+    const safeSessionId = String(sessionId || '').trim();
+    if (!safeSessionId) {
+        return;
+    }
+    const existing = statusRefreshTimers.get(safeSessionId);
+    if (existing) {
+        clearTimeout(existing);
+    }
+    const timerId = setTimeout(() => {
+        statusRefreshTimers.delete(safeSessionId);
+        void ensureSessionSubagents(safeSessionId, {
+            force: true,
+            emitLoadingEvents: false,
+        }).then(() => {
+            emitSubagentSessionsChanged({
+                forceRefresh: false,
+                reason: 'status',
+                sessionId: safeSessionId,
+            });
+        });
+    }, 500);
+    statusRefreshTimers.set(safeSessionId, timerId);
 }
 
 function isStillActiveSubagentRender(active, requestId) {

--- a/frontend/dist/js/core/eventRouter/humanEvents.js
+++ b/frontend/dist/js/core/eventRouter/humanEvents.js
@@ -13,6 +13,7 @@ import {
     showGateCard,
 } from '../../components/agentPanel.js';
 import { markSubagentStatus } from '../../components/subagentRail.js';
+import { updateNormalModeSubagentSessionStatus } from '../../components/subagentSessions.js';
 
 export function handleSubagentGate(payload) {
     showGateCard(payload.instance_id, payload.role_id, {
@@ -29,26 +30,38 @@ export function handleGateResolved(payload, instanceId) {
     sysLog(`Gate resolved: ${payload.action}`, 'log-info');
 }
 
-export function handleSubagentStopped(payload) {
-    markSubagentStatus(payload.instance_id, 'stopped');
+export function handleSubagentStopped(payload, eventMeta = null) {
+    const instanceId = payload.instance_id;
+    const runId = String(
+        eventMeta?.run_id
+        || eventMeta?.trace_id
+        || payload.run_id
+        || state.activeRunId
+        || '',
+    ).trim();
+    markSubagentStatus(instanceId, 'stopped');
+    updateNormalModeSubagentSessionStatus(state.currentSessionId, instanceId, 'stopped');
     state.pausedSubagent = {
-        runId: state.activeRunId,
-        instanceId: payload.instance_id,
+        runId,
+        instanceId,
         roleId: payload.role_id,
         taskId: payload.task_id || null,
     };
-    markPausedSubagent(payload);
+    markPausedSubagent({ ...payload, run_id: runId });
     sysLog(
         `Subagent paused: ${payload.role_id || payload.instance_id}. Send follow-up in subagent panel.`,
         'log-info',
     );
 }
 
-export function handleSubagentResumed(payload) {
-    markSubagentStatus(payload.instance_id, 'running');
-    if (state.pausedSubagent && state.pausedSubagent.instanceId === payload.instance_id) {
+export function handleSubagentResumed(payload, eventMeta = null) {
+    void eventMeta;
+    const instanceId = payload.instance_id;
+    markSubagentStatus(instanceId, 'running');
+    updateNormalModeSubagentSessionStatus(state.currentSessionId, instanceId, 'running');
+    if (state.pausedSubagent && state.pausedSubagent.instanceId === instanceId) {
         state.pausedSubagent = null;
     }
-    clearPausedSubagent(payload.instance_id);
+    clearPausedSubagent(instanceId);
     sysLog(`Subagent resumed: ${payload.role_id || payload.instance_id}`, 'log-info');
 }

--- a/frontend/dist/js/core/eventRouter/index.js
+++ b/frontend/dist/js/core/eventRouter/index.js
@@ -7,7 +7,10 @@ import {
     isDisplayableBackgroundTaskPayload,
     scheduleRecoveryContinuityRefresh,
 } from '../../app/recovery.js';
-import { rememberNormalModeSubagentFromBackgroundTask } from '../../components/subagentSessions.js';
+import {
+    applySubagentSessionStatusEvent,
+    rememberNormalModeSubagentFromBackgroundTask,
+} from '../../components/subagentSessions.js';
 import {
     appendStreamInjectionMarker,
     applyStreamOverlayEvent,
@@ -37,6 +40,7 @@ import {
     handleRunFailed,
     handleRunStopped,
     handleRunStarted,
+    handleSubagentRunActive,
     handleSubagentRunTerminal,
     handleThinkingDelta,
     handleThinkingFinished,
@@ -108,8 +112,15 @@ export function routeEvent(evType, payload, eventMeta) {
             state.taskStatusMap[taskId] = 'completed';
         }
     }
+    if (evType === 'subagent_session_status_changed') {
+        applySubagentSessionStatusEvent(payload, eventMeta);
+        clearSeenRunEventsForTerminal(evType, eventRunId);
+        return;
+    }
     if (isSubagentRun) {
-        if (evType === 'model_step_started') {
+        if (evType === 'run_started' || evType === 'run_resumed') {
+            handleSubagentRunActive(instanceId, eventMeta, roleId);
+        } else if (evType === 'model_step_started') {
             handleModelStepStarted(eventMeta, instanceId, roleId);
         } else if (evType === 'text_delta') {
             handleTextDelta(payload, eventMeta, instanceId, roleId);
@@ -149,7 +160,7 @@ export function routeEvent(evType, payload, eventMeta) {
         handleRunStarted(eventMeta);
         roundsTimeline.syncRoundTodoVisibility?.();
     } else if (evType === 'run_resumed') {
-        handleRunStarted(eventMeta);
+        handleRunStarted(eventMeta, { resumeSubagents: true });
         roundsTimeline.syncRoundTodoVisibility?.();
     } else if (evType === 'model_step_started') {
         handleModelStepStarted(eventMeta, instanceId, roleId);
@@ -203,15 +214,13 @@ export function routeEvent(evType, payload, eventMeta) {
     } else if (evType === 'subagent_gate') {
         handleSubagentGate(payload);
     } else if (evType === 'subagent_stopped') {
-        handleSubagentStopped(payload);
+        handleSubagentStopped(payload, eventMeta);
     } else if (evType === 'subagent_resumed') {
-        handleSubagentResumed(payload);
+        handleSubagentResumed(payload, eventMeta);
     } else if (evType === 'gate_resolved') {
         handleGateResolved(payload, instanceId);
     } else if (backgroundTaskEvent) {
-        if (displayableBackgroundTaskEvent) {
-            handleBackgroundTaskEvent(evType, payload, eventMeta);
-        }
+        handleBackgroundTaskEvent(evType, payload, eventMeta);
         return;
     } else if (evType === 'token_usage') {
         scheduleSessionTokenUsageRefresh({ immediate: false });
@@ -309,7 +318,9 @@ function handleBackgroundTaskEvent(evType, payload, eventMeta) {
         return;
     }
     rememberNormalModeSubagentFromBackgroundTask(sessionId, payload, evType);
-    applyBackgroundTaskEvent(payload, eventMeta, evType);
+    if (isDisplayableBackgroundTaskPayload(payload)) {
+        applyBackgroundTaskEvent(payload, eventMeta, evType);
+    }
 }
 
 function isDuplicateRunEvent(runId, eventId) {
@@ -404,6 +415,7 @@ function scheduleContinuityRefreshForEvent(evType) {
         || evType === 'user_question_answered'
         || evType === 'subagent_stopped'
         || evType === 'subagent_resumed'
+        || evType === 'subagent_session_status_changed'
         || evType === 'notification_requested'
         || evType === 'gate_resolved'
     ) {

--- a/frontend/dist/js/core/eventRouter/runEvents.js
+++ b/frontend/dist/js/core/eventRouter/runEvents.js
@@ -27,12 +27,17 @@ import {
     rememberLiveSubagent,
 } from '../../components/subagentRail.js';
 import {
+    clearNormalModeSubagentParentStopState,
     getActiveSubagentSession,
     getActiveSubagentSessionStreamContainer,
+    getNormalModeSubagentSessionByRunId,
+    markNormalModeSubagentSessionsRunningForParent,
+    markNormalModeSubagentSessionsStoppedForParent,
     rememberNormalModeSubagentSession,
     renderActiveSubagentSession,
     settleActiveSubagentSessionAfterTerminal,
     updateNormalModeSubagentSessionStatus,
+    updateNormalModeSubagentSessionStatusByRunId,
 } from '../../components/subagentSessions.js';
 import { els } from '../../utils/dom.js';
 import { sysLog } from '../../utils/logger.js';
@@ -62,9 +67,14 @@ import { markSessionTerminalRunViewed } from '../api.js';
 const TERMINAL_VIEW_RETRY_DELAY_MS = 250;
 const TERMINAL_VIEW_MAX_ATTEMPTS = 3;
 
-export function handleRunStarted(eventMeta) {
+export function handleRunStarted(eventMeta, { resumeSubagents = false } = {}) {
     sysLog(`Run started (trace: ${eventMeta?.trace_id})`);
     const runId = eventMeta?.run_id || eventMeta?.trace_id || state.activeRunId;
+    if (resumeSubagents) {
+        markNormalModeSubagentSessionsRunningForParent(state.currentSessionId);
+    } else {
+        clearNormalModeSubagentParentStopState(state.currentSessionId);
+    }
     if (runId) {
         markRunStreamConnected(runId, { phase: 'running' });
     }
@@ -431,22 +441,45 @@ export function handleModelStepFinished(eventMeta, instanceId, roleIdOverride = 
 }
 
 export function handleSubagentRunTerminal(instanceId, status, eventMeta = null, roleIdOverride = '') {
-    const safeInstanceId = String(instanceId || '').trim();
-    if (!safeInstanceId) {
+    const runId = String(eventMeta?.run_id || eventMeta?.trace_id || '').trim();
+    const safeInstanceId = resolveNormalModeSubagentInstanceId(instanceId, runId);
+    if (!safeInstanceId && !runId) {
         return;
     }
     const roleId = String(roleIdOverride || state.instanceRoleMap?.[safeInstanceId] || '').trim();
-    const runId = String(eventMeta?.run_id || eventMeta?.trace_id || '').trim();
-    finalizeStream(safeInstanceId, roleId, { runId });
+    if (safeInstanceId) {
+        finalizeStream(safeInstanceId, roleId, { runId });
+    }
     reconcileTerminalRunStreamState(runId);
-    updateNormalModeSubagentSessionStatus(state.currentSessionId, safeInstanceId, status);
-    markSubagentStatus(safeInstanceId, status);
+    updateNormalModeSubagentRunStatus(runId, safeInstanceId, status);
+    if (safeInstanceId) {
+        markSubagentStatus(safeInstanceId, status);
+    }
     if (getActiveSubagentSession()?.instanceId === safeInstanceId) {
         settleActiveSubagentSessionAfterTerminal(safeInstanceId);
     }
     if (state.activeAgentInstanceId === safeInstanceId) {
         state.activeAgentInstanceId = null;
         state.activeAgentRoleId = null;
+    }
+}
+
+export function handleSubagentRunActive(instanceId, eventMeta = null, roleIdOverride = '') {
+    const runId = String(eventMeta?.run_id || eventMeta?.trace_id || '').trim();
+    const safeInstanceId = resolveNormalModeSubagentInstanceId(instanceId, runId);
+    const roleId = String(roleIdOverride || state.instanceRoleMap?.[safeInstanceId] || '').trim();
+    if (safeInstanceId && roleId) {
+        rememberNormalModeSubagentSession(state.currentSessionId, {
+            instance_id: safeInstanceId,
+            role_id: roleId,
+            run_id: runId,
+            status: 'running',
+        });
+    } else {
+        updateNormalModeSubagentRunStatus(runId, safeInstanceId, 'running');
+    }
+    if (safeInstanceId) {
+        markSubagentStatus(safeInstanceId, 'running');
     }
 }
 
@@ -491,6 +524,7 @@ export function handleRunStopped(eventMeta, payload) {
     sysLog(`Run stopped: ${payload?.reason || 'stopped_by_user'}`, 'log-info');
     const runId = eventMeta?.run_id || eventMeta?.trace_id || state.activeRunId || '';
     clearLlmRetryStatus(runId);
+    markNormalModeSubagentSessionsStoppedForParent(state.currentSessionId);
     if (state.activeAgentInstanceId) {
         markSubagentStatus(state.activeAgentInstanceId, 'stopped');
     }
@@ -519,7 +553,6 @@ export function handleRunStopped(eventMeta, payload) {
     finalizeStream('primary', getRunPrimaryRoleId(runId), { runId });
     reconcileTerminalRunStreamState(runId);
     clearRunPrimaryRole(runId);
-    markCurrentSessionTerminalViewed(eventMeta);
 }
 
 export function handleRunFailed(eventMeta, payload) {
@@ -763,6 +796,24 @@ function isNormalModeSubagentRun(runId, roleId) {
         && safeRoleId
         && !isRunPrimaryRoleId(safeRoleId, safeRunId)
     );
+}
+
+function resolveNormalModeSubagentInstanceId(instanceId, runId) {
+    const safeInstanceId = String(instanceId || '').trim();
+    if (safeInstanceId) {
+        return safeInstanceId;
+    }
+    const match = getNormalModeSubagentSessionByRunId(state.currentSessionId, runId);
+    return String(match?.instanceId || '').trim();
+}
+
+function updateNormalModeSubagentRunStatus(runId, instanceId, status) {
+    const safeInstanceId = String(instanceId || '').trim();
+    if (safeInstanceId) {
+        updateNormalModeSubagentSessionStatus(state.currentSessionId, safeInstanceId, status);
+        return;
+    }
+    updateNormalModeSubagentSessionStatusByRunId(state.currentSessionId, runId, status);
 }
 
 function escapeLogLabel(value) {

--- a/frontend/dist/js/core/stream.js
+++ b/frontend/dist/js/core/stream.js
@@ -10,6 +10,9 @@ import {
 } from './api.js';
 import { refreshVisibleContextIndicators } from '../components/contextIndicators.js';
 import { renderRuntimeInjectQueue } from '../components/runtimeInjectQueue.js';
+import {
+    markNormalModeSubagentSessionsStoppedForParent,
+} from '../components/subagentSessions.js';
 import { refreshSessionTopologyControls } from '../app/prompt.js';
 import { scheduleSessionsRefresh } from '../components/sidebar.js';
 import { els } from '../utils/dom.js';
@@ -1911,8 +1914,15 @@ async function finalizeStopAndSyncRecovery(runId, sessionId) {
     if (!safeRunId) return;
 
     endStream();
+    applyLocalStoppedSubagentSnapshot(safeSessionId);
     await applyLocalStoppedSnapshot(safeRunId, safeSessionId);
     await syncRecoveryAfterStopRequest(safeRunId, safeSessionId);
+}
+
+function applyLocalStoppedSubagentSnapshot(sessionId) {
+    const safeSessionId = String(sessionId || state.currentSessionId || '').trim();
+    if (!safeSessionId) return;
+    markNormalModeSubagentSessionsStoppedForParent(safeSessionId);
 }
 
 async function applyLocalStoppedSnapshot(runId, sessionId) {

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timezone
 import logging
 from collections.abc import Awaitable, Callable
@@ -52,7 +53,11 @@ from relay_teams.sessions.runs.run_models import (
 )
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
+    RunRuntimeRecord,
     RunRuntimeStatus,
+)
+from relay_teams.sessions.runs.subagent_lifecycle import (
+    mark_subagent_terminal_records,
 )
 from relay_teams.sessions.session_models import SessionMode
 from relay_teams.workspace import WorkspaceHandle
@@ -304,6 +309,7 @@ class BackgroundTaskService:
         self._synchronous_subagent_runtimes: dict[
             str, _ManagedSynchronousSubagentRuntime
         ] = {}
+        self._parent_stop_subagent_run_ids: set[str] = set()
         if self._background_task_manager is not None:
             self._background_task_manager.set_completion_listener(
                 self._handle_background_task_completion
@@ -539,6 +545,10 @@ class BackgroundTaskService:
                 event_type=RunEventType.BACKGROUND_TASK_STARTED,
                 record=record,
             )
+            await self._publish_subagent_session_status_event(
+                record=record,
+                status=BackgroundTaskStatus.RUNNING,
+            )
         except Exception:
             worker_task.cancel()
             await asyncio.gather(worker_task, return_exceptions=True)
@@ -611,6 +621,11 @@ class BackgroundTaskService:
                 session_id=session_id,
                 prepared=prepared,
             )
+            record = await self._repository.get_async(background_task_id) or record
+            await self._publish_subagent_session_status_event(
+                record=record,
+                status=BackgroundTaskStatus.RUNNING,
+            )
         except Exception as exc:
             await self._finalize_subagent_launch_failure(
                 background_task_id=background_task_id,
@@ -652,18 +667,21 @@ class BackgroundTaskService:
             parent_run_id=normalized_parent_run_id,
             subagent_run_id=normalized_run_id,
         )
-        if record is not None and record.is_active:
-            finalized_record = (
-                await self._finalize_active_synchronous_record_from_terminal_task(
-                    record
+        if record is not None:
+            if record.is_active:
+                finalized_record = (
+                    await self._finalize_active_synchronous_record_from_terminal_task(
+                        record
+                    )
                 )
-            )
-            if finalized_record is not None:
-                return await self._synchronous_subagent_result_from_record(
-                    parent_run_id=normalized_parent_run_id,
-                    subagent_run_id=normalized_run_id,
-                )
-            return await self._resume_synchronous_subagent_record(record)
+                if finalized_record is not None:
+                    return await self._synchronous_subagent_result_from_record(
+                        parent_run_id=normalized_parent_run_id,
+                        subagent_run_id=normalized_run_id,
+                    )
+                return await self._resume_synchronous_subagent_record(record)
+            if record.status == BackgroundTaskStatus.STOPPED:
+                return await self._resume_synchronous_subagent_record(record)
         return await self._synchronous_subagent_result_from_record(
             parent_run_id=normalized_parent_run_id,
             subagent_run_id=normalized_run_id,
@@ -673,6 +691,8 @@ class BackgroundTaskService:
         self,
         record: BackgroundTaskRecord,
     ) -> SynchronousSubagentResult:
+        if not record.is_active:
+            record = await self._reactivate_synchronous_subagent_record(record)
         prepared = self._prepared_launch_from_synchronous_record(record)
         if prepared.suppress_hooks:
             self._prime_subagent_hook_snapshot(subagent_run_id=prepared.subagent_run_id)
@@ -712,6 +732,101 @@ class BackgroundTaskService:
             prepared=prepared,
             launch_prompt=launch_prompt,
         )
+
+    async def _reactivate_synchronous_subagent_record(
+        self,
+        record: BackgroundTaskRecord,
+    ) -> BackgroundTaskRecord:
+        updated_at = datetime.now(tz=timezone.utc)
+        updated = await self._repository.upsert_async(
+            record.model_copy(
+                update={
+                    "status": BackgroundTaskStatus.RUNNING,
+                    "exit_code": None,
+                    "recent_output": (),
+                    "output_excerpt": "",
+                    "updated_at": updated_at,
+                    "completed_at": None,
+                    "completion_notified_at": None,
+                }
+            )
+        )
+        await self._publish_subagent_session_status_event(
+            record=updated,
+            status=BackgroundTaskStatus.RUNNING,
+        )
+        return updated
+
+    async def _publish_subagent_session_status_event(
+        self,
+        *,
+        record: BackgroundTaskRecord,
+        status: BackgroundTaskStatus,
+    ) -> None:
+        if record.kind != BackgroundTaskKind.SUBAGENT:
+            return
+        subagent_run_id = str(record.subagent_run_id or "").strip()
+        instance_id = str(record.subagent_instance_id or "").strip()
+        role_id = str(record.subagent_role_id or "").strip()
+        if not subagent_run_id or not instance_id or not role_id:
+            return
+        parent_stop_candidate = (
+            status == BackgroundTaskStatus.STOPPED
+            and subagent_run_id in self._parent_stop_subagent_run_ids
+        )
+        if status != BackgroundTaskStatus.RUNNING:
+            self._parent_stop_subagent_run_ids.discard(subagent_run_id)
+        status_value = status.value
+        run_phase = "subagent_running"
+        if status == BackgroundTaskStatus.STOPPED:
+            run_phase = "idle"
+        elif status in {BackgroundTaskStatus.COMPLETED, BackgroundTaskStatus.FAILED}:
+            run_phase = "terminal"
+        payload = {
+            "parent_session_id": record.session_id,
+            "parent_run_id": record.run_id,
+            "session_id": record.session_id,
+            "run_id": subagent_run_id,
+            "background_task_id": record.background_task_id,
+            "subagent_run_id": subagent_run_id,
+            "subagent_instance_id": instance_id,
+            "subagent_role_id": role_id,
+            "subagent_task_id": record.subagent_task_id or "",
+            "instance_id": instance_id,
+            "role_id": role_id,
+            "task_id": record.subagent_task_id or "",
+            "title": record.title,
+            "status": status_value,
+            "run_status": status_value,
+            "run_phase": run_phase,
+            "parent_stop_candidate": parent_stop_candidate,
+            "updated_at": record.updated_at.isoformat(),
+        }
+        try:
+            await self._publish_background_task_event_async(
+                event_type=RunEventType.SUBAGENT_SESSION_STATUS_CHANGED,
+                record=record.model_copy(
+                    update={
+                        "run_id": subagent_run_id,
+                        "instance_id": instance_id,
+                        "role_id": role_id,
+                    }
+                ),
+                payload_json=json.dumps(payload),
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task.subagent_session_status_event_skipped",
+                message="Failed to publish subagent session status event",
+                payload={
+                    "background_task_id": record.background_task_id,
+                    "subagent_run_id": record.subagent_run_id,
+                    "status": status.value,
+                },
+                exc_info=exc,
+            )
 
     @staticmethod
     def _prepared_launch_from_synchronous_record(
@@ -783,12 +898,21 @@ class BackgroundTaskService:
             status=status,
             output=output,
         )
+        await self._publish_subagent_session_status_event(
+            record=finalized,
+            status=status,
+        )
         subagent_run_id = str(record.subagent_run_id or "").strip()
         if subagent_run_id:
-            self._finalize_subagent_run_runtime(
+            await asyncio.to_thread(
+                self._finalize_subagent_run_runtime,
                 subagent_run_id=subagent_run_id,
+                session_id=record.session_id,
+                task_id=record.subagent_task_id,
+                instance_id=record.subagent_instance_id,
                 status=status,
                 output=output,
+                preserve_resume_state=status == BackgroundTaskStatus.STOPPED,
             )
         return finalized
 
@@ -847,16 +971,24 @@ class BackgroundTaskService:
                     + "\n\n"
                     + f"Subagent stop hook failed: {stop_hook_error}"
                 ).strip()
-            await self._finalize_synchronous_subagent_record(
+            record = await self._finalize_synchronous_subagent_record(
                 background_task_id=background_task_id,
                 status=final_status,
                 output=final_output,
             )
+            await self._publish_subagent_session_status_event(
+                record=record,
+                status=final_status,
+            )
             await asyncio.to_thread(
                 self._finalize_subagent_run_runtime,
                 subagent_run_id=prepared.subagent_run_id,
+                session_id=session_id,
+                task_id=prepared.subagent_task.task_id,
+                instance_id=prepared.subagent_instance.instance_id,
                 status=final_status,
                 output=final_output,
+                preserve_resume_state=final_status == BackgroundTaskStatus.STOPPED,
             )
             if hook_error is not None:
                 raise hook_error
@@ -917,6 +1049,7 @@ class BackgroundTaskService:
             subagent_run_id=prepared.subagent_run_id,
             result_holder=result_holder,
         )
+
         self._synchronous_subagent_runtimes[prepared.subagent_run_id] = managed_runtime
         run_control_manager.register_run_task(
             run_id=prepared.subagent_run_id,
@@ -926,6 +1059,14 @@ class BackgroundTaskService:
         try:
             await asyncio.shield(worker_task)
         except asyncio.CancelledError:
+            parent_stop_requested = run_control_manager.is_run_stop_requested(
+                parent_run_id
+            )
+            child_stop_requested = run_control_manager.is_run_stop_requested(
+                prepared.subagent_run_id
+            )
+            if parent_stop_requested and not child_stop_requested:
+                self._parent_stop_subagent_run_ids.add(prepared.subagent_run_id)
             run_control_manager.request_run_stop(prepared.subagent_run_id)
             await asyncio.gather(worker_task, return_exceptions=True)
             raise
@@ -1114,6 +1255,9 @@ class BackgroundTaskService:
             await asyncio.to_thread(
                 self._finalize_subagent_run_runtime,
                 subagent_run_id=subagent_run_id,
+                session_id=record.session_id,
+                task_id=record.subagent_task_id,
+                instance_id=record.subagent_instance_id,
                 status=status,
                 output=summarized_output,
             )
@@ -1128,6 +1272,10 @@ class BackgroundTaskService:
                 else RunEventType.BACKGROUND_TASK_COMPLETED
             ),
             record=record,
+        )
+        await self._publish_subagent_session_status_event(
+            record=record,
+            status=status,
         )
         await self._execute_subagent_stop_hooks(
             record=record,
@@ -1145,11 +1293,6 @@ class BackgroundTaskService:
         output: str,
         synchronous: bool,
     ) -> BackgroundTaskRecord:
-        await asyncio.to_thread(
-            self._mark_subagent_launch_entities_failed,
-            prepared=prepared,
-            output=output,
-        )
         if synchronous:
             record = await self._finalize_synchronous_subagent_record(
                 background_task_id=background_task_id,
@@ -1178,57 +1321,20 @@ class BackgroundTaskService:
                 event_type=RunEventType.BACKGROUND_TASK_COMPLETED,
                 record=record,
             )
+        await self._publish_subagent_session_status_event(
+            record=record,
+            status=BackgroundTaskStatus.FAILED,
+        )
         await asyncio.to_thread(
             self._finalize_subagent_run_runtime,
             subagent_run_id=prepared.subagent_run_id,
+            session_id=prepared.subagent_task.session_id,
+            task_id=prepared.subagent_task.task_id,
+            instance_id=prepared.subagent_instance.instance_id,
             status=BackgroundTaskStatus.FAILED,
             output=output,
         )
         return record
-
-    def _mark_subagent_launch_entities_failed(
-        self,
-        *,
-        prepared: _PreparedSubagentLaunch,
-        output: str,
-    ) -> None:
-        summarized_output = output.strip()
-        try:
-            self._require_task_repo().update_status(
-                prepared.subagent_task.task_id,
-                TaskStatus.FAILED,
-                assigned_instance_id=prepared.subagent_instance.instance_id,
-                error_message=summarized_output,
-            )
-        except Exception as exc:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="background_task.subagent_launch_task_mark_failed_skipped",
-                message="Failed to mark subagent task failed during launch cleanup",
-                payload={
-                    "subagent_run_id": prepared.subagent_run_id,
-                    "subagent_task_id": prepared.subagent_task.task_id,
-                },
-                exc_info=exc,
-            )
-        try:
-            self._require_agent_repo().mark_status(
-                prepared.subagent_instance.instance_id,
-                InstanceStatus.FAILED,
-            )
-        except Exception as exc:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="background_task.subagent_launch_instance_mark_failed_skipped",
-                message="Failed to mark subagent instance failed during launch cleanup",
-                payload={
-                    "subagent_run_id": prepared.subagent_run_id,
-                    "subagent_instance_id": prepared.subagent_instance.instance_id,
-                },
-                exc_info=exc,
-            )
 
     @staticmethod
     def _build_synchronous_subagent_record(
@@ -1504,6 +1610,7 @@ class BackgroundTaskService:
         *,
         event_type: RunEventType,
         record: BackgroundTaskRecord,
+        payload_json: str | None = None,
     ) -> None:
         if self._run_event_hub is None:
             return
@@ -1516,7 +1623,7 @@ class BackgroundTaskService:
                 instance_id=record.instance_id,
                 role_id=record.role_id,
                 event_type=event_type,
-                payload_json=record.model_dump_json(),
+                payload_json=payload_json or record.model_dump_json(),
             )
         )
 
@@ -1525,6 +1632,7 @@ class BackgroundTaskService:
         *,
         event_type: RunEventType,
         record: BackgroundTaskRecord,
+        payload_json: str | None = None,
     ) -> None:
         if self._run_event_hub is None:
             return
@@ -1538,7 +1646,7 @@ class BackgroundTaskService:
                 instance_id=record.instance_id,
                 role_id=record.role_id,
                 event_type=event_type,
-                payload_json=record.model_dump_json(),
+                payload_json=payload_json or record.model_dump_json(),
             ),
         )
 
@@ -1938,53 +2046,81 @@ class BackgroundTaskService:
         self,
         *,
         subagent_run_id: str,
+        session_id: str | None = None,
+        task_id: str | None = None,
+        instance_id: str | None = None,
         status: BackgroundTaskStatus,
         output: str,
+        preserve_resume_state: bool = False,
     ) -> None:
-        if self._hook_service is not None:
+        should_cleanup_resume_state = not preserve_resume_state
+        if should_cleanup_resume_state and self._hook_service is not None:
             self._hook_service.clear_run(subagent_run_id)
         runtime_role_resolver = self._get_runtime_role_resolver()
-        if runtime_role_resolver is not None:
+        if should_cleanup_resume_state and runtime_role_resolver is not None:
             runtime_role_resolver.cleanup_run(run_id=subagent_run_id)
         run_runtime_repo = self._run_runtime_repo
         if run_runtime_repo is None:
+            self._sync_terminal_subagent_entities(
+                subagent_run_id=subagent_run_id,
+                session_id=session_id or "",
+                task_id=task_id,
+                instance_id=instance_id,
+                status=status,
+                output=output,
+                update_run_runtime=None,
+            )
             return
         runtime = run_runtime_repo.get(subagent_run_id)
         if runtime is None:
-            return
-        if status == BackgroundTaskStatus.COMPLETED:
-            run_runtime_repo.update(
-                subagent_run_id,
-                status=RunRuntimeStatus.COMPLETED,
-                phase=RunRuntimePhase.TERMINAL,
-                active_instance_id=None,
-                active_task_id=None,
-                active_role_id=None,
-                active_subagent_instance_id=None,
-                last_error=None,
+            self._sync_terminal_subagent_entities(
+                subagent_run_id=subagent_run_id,
+                session_id=session_id or "",
+                task_id=task_id,
+                instance_id=instance_id,
+                status=status,
+                output=output,
+                update_run_runtime=None,
             )
             return
-        if status == BackgroundTaskStatus.STOPPED:
-            run_runtime_repo.update(
-                subagent_run_id,
-                status=RunRuntimeStatus.STOPPED,
-                phase=RunRuntimePhase.IDLE,
-                active_instance_id=None,
-                active_task_id=None,
-                active_role_id=None,
-                active_subagent_instance_id=None,
-                last_error="Task stopped by user",
-            )
-            return
-        run_runtime_repo.update(
-            subagent_run_id,
-            status=RunRuntimeStatus.FAILED,
-            phase=RunRuntimePhase.TERMINAL,
-            active_instance_id=None,
-            active_task_id=None,
-            active_role_id=None,
-            active_subagent_instance_id=None,
-            last_error=output or "Task failed",
+        runtime_record = cast(RunRuntimeRecord, runtime)
+        self._sync_terminal_subagent_entities(
+            subagent_run_id=subagent_run_id,
+            session_id=session_id or runtime_record.session_id,
+            task_id=task_id or runtime_record.active_task_id,
+            instance_id=instance_id or runtime_record.active_subagent_instance_id,
+            status=status,
+            output=output,
+            update_run_runtime=run_runtime_repo.update,
+        )
+
+    def _sync_terminal_subagent_entities(
+        self,
+        *,
+        subagent_run_id: str,
+        session_id: str,
+        task_id: str | None,
+        instance_id: str | None,
+        status: BackgroundTaskStatus,
+        output: str,
+        update_run_runtime: Callable[..., object] | None,
+    ) -> None:
+        task_update: Callable[..., object] | None = None
+        instance_update: Callable[[str, InstanceStatus], object] | None = None
+        if self._task_repo is not None:
+            task_update = self._task_repo.update_status
+        if self._agent_repo is not None:
+            instance_update = self._agent_repo.mark_status
+        mark_subagent_terminal_records(
+            update_task_status=task_update,
+            mark_instance_status=instance_update,
+            update_run_runtime=update_run_runtime,
+            subagent_run_id=subagent_run_id,
+            session_id=session_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            status=status,
+            output=output,
         )
 
 

--- a/src/relay_teams/sessions/runs/enums.py
+++ b/src/relay_teams/sessions/runs/enums.py
@@ -58,6 +58,7 @@ class RunEventType(str, Enum):
     USER_QUESTION_REQUESTED = "user_question_requested"
     USER_QUESTION_ANSWERED = "user_question_answered"
     NOTIFICATION_REQUESTED = "notification_requested"
+    SUBAGENT_SESSION_STATUS_CHANGED = "subagent_session_status_changed"
     SUBAGENT_STOPPED = "subagent_stopped"
     SUBAGENT_RESUMED = "subagent_resumed"
     RUN_STOPPED = "run_stopped"

--- a/src/relay_teams/sessions/runs/run_control_manager.py
+++ b/src/relay_teams/sessions/runs/run_control_manager.py
@@ -22,6 +22,9 @@ from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeRepository,
     RunRuntimeStatus,
 )
+from relay_teams.sessions.runs.subagent_lifecycle import (
+    mark_subagent_resumed_records,
+)
 from relay_teams.agents.tasks.enums import TaskStatus
 from relay_teams.agents.tasks.events import EventEnvelope, EventType
 from relay_teams.agents.tasks.models import TaskEnvelope
@@ -627,13 +630,6 @@ class RunControlManager:
             )
 
         task_id = self._find_task_for_instance(run_id=run_id, instance_id=instance_id)
-        if task_id:
-            self._require_task_repo().update_status(
-                task_id=task_id,
-                status=TaskStatus.ASSIGNED,
-                assigned_instance_id=instance_id,
-            )
-
         self._require_message_repo().append_user_prompt_if_missing(
             session_id=record.session_id,
             workspace_id=record.workspace_id,
@@ -660,18 +656,19 @@ class RunControlManager:
         self.release_paused_subagent(
             session_id=record.session_id, instance_id=instance_id
         )
-        self._require_agent_repo().mark_status(instance_id, InstanceStatus.IDLE)
-        if self._run_runtime_repo is not None:
-            self._run_runtime_repo.update(
-                run_id,
-                status=RunRuntimeStatus.RUNNING,
-                phase=RunRuntimePhase.SUBAGENT_RUNNING,
-                active_instance_id=instance_id,
-                active_task_id=task_id,
-                active_role_id=record.role_id,
-                active_subagent_instance_id=instance_id,
-                last_error=None,
-            )
+        mark_subagent_resumed_records(
+            update_task_status=self._require_task_repo().update_status,
+            mark_instance_status=self._require_agent_repo().mark_status,
+            update_run_runtime=(
+                self._run_runtime_repo.update
+                if self._run_runtime_repo is not None
+                else None
+            ),
+            run_id=run_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=record.role_id,
+        )
 
         self._require_run_event_hub().publish(
             RunEvent(

--- a/src/relay_teams/sessions/runs/subagent_lifecycle.py
+++ b/src/relay_teams/sessions/runs/subagent_lifecycle.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from pydantic import BaseModel, ConfigDict
+from relay_teams.agents.instances.enums import InstanceStatus
+from relay_teams.agents.tasks.enums import TaskStatus
+from relay_teams.logger import get_logger, log_event
+from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskStatus
+from relay_teams.sessions.runs.run_runtime_repo import (
+    RunRuntimePhase,
+    RunRuntimeStatus,
+)
+
+LOGGER = get_logger(__name__)
+
+
+class SubagentLifecycleTerminalState(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    task_status: TaskStatus
+    instance_status: InstanceStatus
+    run_status: RunRuntimeStatus
+    run_phase: RunRuntimePhase
+    last_error: str | None
+    task_result: str | None
+    task_error: str | None
+
+
+def terminal_state_for_background_status(
+    status: BackgroundTaskStatus,
+    *,
+    output: str,
+) -> SubagentLifecycleTerminalState:
+    summarized_output = output.strip()
+    if status == BackgroundTaskStatus.COMPLETED:
+        return SubagentLifecycleTerminalState(
+            task_status=TaskStatus.COMPLETED,
+            instance_status=InstanceStatus.COMPLETED,
+            run_status=RunRuntimeStatus.COMPLETED,
+            run_phase=RunRuntimePhase.TERMINAL,
+            last_error=None,
+            task_result=summarized_output,
+            task_error=None,
+        )
+    if status == BackgroundTaskStatus.STOPPED:
+        return SubagentLifecycleTerminalState(
+            task_status=TaskStatus.STOPPED,
+            instance_status=InstanceStatus.STOPPED,
+            run_status=RunRuntimeStatus.STOPPED,
+            run_phase=RunRuntimePhase.IDLE,
+            last_error="Task stopped by user",
+            task_result=None,
+            task_error="Task stopped by user",
+        )
+    return SubagentLifecycleTerminalState(
+        task_status=TaskStatus.FAILED,
+        instance_status=InstanceStatus.FAILED,
+        run_status=RunRuntimeStatus.FAILED,
+        run_phase=RunRuntimePhase.TERMINAL,
+        last_error=summarized_output or "Task failed",
+        task_result=None,
+        task_error=summarized_output or "Task failed",
+    )
+
+
+def mark_subagent_terminal_records(
+    *,
+    update_task_status: Callable[..., object] | None,
+    mark_instance_status: Callable[[str, InstanceStatus], object] | None,
+    update_run_runtime: Callable[..., object] | None,
+    subagent_run_id: str,
+    session_id: str,
+    task_id: str | None,
+    instance_id: str | None,
+    status: BackgroundTaskStatus,
+    output: str,
+) -> None:
+    terminal = terminal_state_for_background_status(status, output=output)
+    if task_id and update_task_status is not None:
+        try:
+            update_task_status(
+                task_id,
+                terminal.task_status,
+                assigned_instance_id=instance_id,
+                result=terminal.task_result,
+                error_message=terminal.task_error,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="subagent_lifecycle.task_terminal_update_skipped",
+                message="Failed to synchronize terminal subagent task status",
+                payload={
+                    "subagent_run_id": subagent_run_id,
+                    "session_id": session_id,
+                    "task_id": task_id,
+                    "status": status.value,
+                },
+                exc_info=exc,
+            )
+    if instance_id and mark_instance_status is not None:
+        try:
+            mark_instance_status(instance_id, terminal.instance_status)
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="subagent_lifecycle.instance_terminal_update_skipped",
+                message="Failed to synchronize terminal subagent instance status",
+                payload={
+                    "subagent_run_id": subagent_run_id,
+                    "session_id": session_id,
+                    "instance_id": instance_id,
+                    "status": status.value,
+                },
+                exc_info=exc,
+            )
+    if update_run_runtime is not None:
+        try:
+            update_run_runtime(
+                subagent_run_id,
+                status=terminal.run_status,
+                phase=terminal.run_phase,
+                active_instance_id=None,
+                active_task_id=None,
+                active_role_id=None,
+                active_subagent_instance_id=None,
+                last_error=terminal.last_error,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="subagent_lifecycle.runtime_terminal_update_skipped",
+                message="Failed to synchronize terminal subagent runtime status",
+                payload={
+                    "subagent_run_id": subagent_run_id,
+                    "session_id": session_id,
+                    "status": status.value,
+                },
+                exc_info=exc,
+            )
+
+
+def mark_subagent_resumed_records(
+    *,
+    update_task_status: Callable[..., object] | None,
+    mark_instance_status: Callable[[str, InstanceStatus], object] | None,
+    update_run_runtime: Callable[..., object] | None,
+    run_id: str,
+    task_id: str | None,
+    instance_id: str,
+    role_id: str,
+) -> None:
+    if task_id and update_task_status is not None:
+        update_task_status(
+            task_id,
+            TaskStatus.ASSIGNED,
+            assigned_instance_id=instance_id,
+        )
+    if mark_instance_status is not None:
+        mark_instance_status(instance_id, InstanceStatus.RUNNING)
+    if update_run_runtime is not None:
+        update_run_runtime(
+            run_id,
+            status=RunRuntimeStatus.RUNNING,
+            phase=RunRuntimePhase.SUBAGENT_RUNNING,
+            active_instance_id=instance_id,
+            active_task_id=task_id,
+            active_role_id=role_id,
+            active_subagent_instance_id=instance_id,
+            last_error=None,
+        )

--- a/src/relay_teams/sessions/session_rounds_projection.py
+++ b/src/relay_teams/sessions/session_rounds_projection.py
@@ -742,6 +742,7 @@ def _project_tool_messages_from_events(
     pending_by_identity: dict[tuple[str, str, str, str], list[tuple[str, int]]] = (
         defaultdict(list)
     )
+    stopped_run_ids = _stopped_run_ids_from_events(session_events)
     sorted_session_events = sorted(
         session_events,
         key=lambda item: str(item.get("occurred_at") or ""),
@@ -800,7 +801,14 @@ def _project_tool_messages_from_events(
         for record_key in tool_call_keys:
             call = calls_by_key.get(record_key)
             result = results_by_key.get(record_key)
-            if call is None or result is None:
+            if call is None:
+                continue
+            if result is None:
+                if _should_project_unmatched_tool_call(
+                    call,
+                    stopped_run_ids=stopped_run_ids,
+                ):
+                    projected_by_run[run_id].append(_event_tool_call_message(call))
                 continue
             call_tool_name = str(call.get("tool_name") or "")
             result_tool_name = str(result.get("tool_name") or "")
@@ -813,6 +821,30 @@ def _project_tool_messages_from_events(
             projected_by_run[run_id].append(_event_tool_call_message(call))
             projected_by_run[run_id].append(_event_tool_result_message(result))
     return dict(projected_by_run)
+
+
+def _stopped_run_ids_from_events(
+    session_events: list[dict[str, object]],
+) -> set[str]:
+    stopped_run_ids: set[str] = set()
+    for event in session_events:
+        if str(event.get("event_type") or "") != RunEventType.RUN_STOPPED.value:
+            continue
+        run_id = str(event.get("trace_id") or event.get("run_id") or "").strip()
+        if run_id:
+            stopped_run_ids.add(run_id)
+    return stopped_run_ids
+
+
+def _should_project_unmatched_tool_call(
+    call: dict[str, object],
+    *,
+    stopped_run_ids: set[str],
+) -> bool:
+    run_id = str(call.get("run_id") or "").strip()
+    if run_id not in stopped_run_ids:
+        return False
+    return str(call.get("tool_name") or "").strip() == "spawn_subagent"
 
 
 def _event_tool_call_message(record: dict[str, object]) -> dict[str, object]:

--- a/tests/integration_tests/browser/test_browser_smoke.py
+++ b/tests/integration_tests/browser/test_browser_smoke.py
@@ -2398,7 +2398,13 @@ def _api_path(integration_env: IntegrationEnvironment, url: str) -> str:
 def _open_web_settings_panel(
     page: Page, integration_env: IntegrationEnvironment
 ) -> None:
-    page.locator("#settings-btn").click()
+    settings_btn = page.locator("#settings-btn")
+    expect(settings_btn).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
+    page.wait_for_function(
+        "() => typeof document.getElementById('settings-btn')?.onclick === 'function'",
+        timeout=_WAIT_TIMEOUT_MS,
+    )
+    settings_btn.click()
     expect(page.locator("#settings-modal")).to_be_visible(timeout=_WAIT_TIMEOUT_MS)
     with page.expect_response(
         lambda response: (

--- a/tests/unit_tests/agent_runtimes/test_cli_client.py
+++ b/tests/unit_tests/agent_runtimes/test_cli_client.py
@@ -246,6 +246,8 @@ for raw_line in sys.stdin:
         raise SystemExit(0)
 """
 
+_CLI_SUBPROCESS_TEST_TIMEOUT_SECONDS = 20
+
 
 def _build_cli_agent(
     command: str,
@@ -307,6 +309,7 @@ class _TerminateTimeoutProcess:
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(_CLI_SUBPROCESS_TEST_TIMEOUT_SECONDS)
 async def test_probe_cli_agent_initializes_stdio_json_rpc_runtime() -> None:
     result = await probe_cli_agent(
         _build_cli_agent(sys.executable, ("-c", _JSON_RPC_RUNTIME_SCRIPT))
@@ -328,6 +331,7 @@ async def test_probe_cli_agent_reports_missing_command(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(_CLI_SUBPROCESS_TEST_TIMEOUT_SECONDS)
 async def test_probe_cli_agent_resolves_relative_command_from_runtime_cwd(
     tmp_path: Path,
 ) -> None:
@@ -350,6 +354,7 @@ async def test_probe_cli_agent_resolves_relative_command_from_runtime_cwd(
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(_CLI_SUBPROCESS_TEST_TIMEOUT_SECONDS)
 async def test_probe_cli_agent_uses_transport_env_for_command_lookup(
     tmp_path: Path,
 ) -> None:
@@ -373,6 +378,7 @@ async def test_probe_cli_agent_uses_transport_env_for_command_lookup(
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(_CLI_SUBPROCESS_TEST_TIMEOUT_SECONDS)
 async def test_run_cli_agent_prompt_uses_thread_turn_json_rpc(tmp_path: Path) -> None:
     result = await run_cli_agent_prompt(
         config=_build_cli_agent(sys.executable, ("-c", _JSON_RPC_RUNTIME_SCRIPT)),
@@ -385,6 +391,7 @@ async def test_run_cli_agent_prompt_uses_thread_turn_json_rpc(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(_CLI_SUBPROCESS_TEST_TIMEOUT_SECONDS)
 async def test_run_cli_agent_prompt_uses_completed_item_fallback(
     tmp_path: Path,
 ) -> None:
@@ -402,6 +409,7 @@ async def test_run_cli_agent_prompt_uses_completed_item_fallback(
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(_CLI_SUBPROCESS_TEST_TIMEOUT_SECONDS)
 async def test_run_cli_agent_prompt_raises_when_runtime_closes_during_turn(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/frontend/test_agent_panel_reflection_button_ui.py
+++ b/tests/unit_tests/frontend/test_agent_panel_reflection_button_ui.py
@@ -215,6 +215,48 @@ console.log(JSON.stringify({ initialTabState, initialPaneState, afterClickTabSta
             assert pane_info["hidden"] is True
 
 
+def test_stop_button_uses_main_scope_for_active_subagent_run(tmp_path: Path) -> None:
+    payload = _run_panel_factory_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { createPanel } = await import('./panelFactory.mjs');
+const { state } = await import('./mockState.mjs');
+const { calls } = await import('./mockApi.mjs');
+
+state.currentSessionId = 'session-1';
+state.activeRunId = 'parent-run-1';
+globalThis.__activeSubagentSession = {
+    sessionId: 'session-1',
+    instanceId: 'inst-1',
+    runId: 'subagent-run-1',
+    status: 'running',
+    runStatus: 'running',
+};
+
+const panel = createPanel('inst-1', 'writer', () => undefined);
+await panel.panelEl.querySelector('.agent-panel-stop').onclick();
+
+globalThis.__activeSubagentSession = null;
+state.activeRunId = 'parent-run-2';
+const parentScopedPanel = createPanel('inst-2', 'writer', () => undefined);
+await parentScopedPanel.panelEl.querySelector('.agent-panel-stop').onclick();
+
+console.log(JSON.stringify({
+    stopRun: calls.stopRun,
+    pausedSubagent: state.pausedSubagent,
+}));
+""".strip(),
+    )
+
+    assert payload["stopRun"] == [
+        ["subagent-run-1", {"scope": "main"}],
+        ["parent-run-2", {"scope": "subagent", "instanceId": "inst-2"}],
+    ]
+    paused_subagent = cast(dict[str, object], payload["pausedSubagent"])
+    assert paused_subagent["runId"] == "parent-run-2"
+    assert paused_subagent["instanceId"] == "inst-2"
+
+
 def _run_panel_factory_script(tmp_path: Path, runner_source: str) -> dict[str, object]:
     repo_root = Path(__file__).resolve().parents[3]
     source_path = (
@@ -239,6 +281,7 @@ def _run_panel_factory_script(tmp_path: Path, runner_source: str) -> dict[str, o
         "../../utils/logger.js": "./mockLogger.mjs",
         "./dom.js": "./mockDom.mjs",
         "./history.js": "./mockHistory.mjs",
+        "../subagentSessions.js": "./mockSubagentSessions.mjs",
         "../subagentRail.js": "./mockSubagentRail.mjs",
     }
     source_text = source_path.read_text(encoding="utf-8")
@@ -251,13 +294,15 @@ def _run_panel_factory_script(tmp_path: Path, runner_source: str) -> dict[str, o
 export const calls = {
     updateAgentReflection: [],
     deleteAgentReflection: [],
+    stopRun: [],
 };
 
 export async function injectSubagentMessage() {
     return undefined;
 }
 
-export async function stopRun() {
+export async function stopRun(runId, options = {}) {
+    calls.stopRun.push([runId, options]);
     return undefined;
 }
 
@@ -408,6 +453,22 @@ export const calls = { refreshSubagentRail: 0 };
 
 export async function refreshSubagentRail() {
     calls.refreshSubagentRail += 1;
+    return undefined;
+}
+
+export function markSubagentStatus() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSubagentSessions.mjs").write_text(
+        """
+export function getActiveSubagentSession() {
+    return globalThis.__activeSubagentSession || null;
+}
+
+export function updateNormalModeSubagentSessionStatus() {
     return undefined;
 }
 """.strip(),

--- a/tests/unit_tests/frontend/test_run_events_ui.py
+++ b/tests/unit_tests/frontend/test_run_events_ui.py
@@ -121,6 +121,141 @@ console.log(JSON.stringify({
     assert payload["viewedCalls"] == ["session-1"]
 
 
+def test_run_stopped_keeps_terminal_run_unviewed_for_resume_context(
+    tmp_path: Path,
+) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleRunStopped } = await import('./runEvents.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+state.activeRunId = 'run-1';
+
+handleRunStopped({ run_id: 'run-1', session_id: 'session-1' }, {});
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    viewedCalls: globalThis.__markSessionTerminalRunViewedCalls,
+    stoppedCalls: globalThis.__markNormalModeSubagentSessionsStoppedForParentCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["viewedCalls"] == []
+    assert payload["stoppedCalls"] == ["session-1"]
+
+
+def test_run_started_does_not_reactivate_stopped_subagent_sessions(
+    tmp_path: Path,
+) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleRunStarted } = await import('./runEvents.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+state.activeRunId = 'run-1';
+
+handleRunStarted({ run_id: 'run-1', session_id: 'session-1' });
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    clearedCalls: globalThis.__clearNormalModeSubagentParentStopStateCalls,
+    runningCalls: globalThis.__markNormalModeSubagentSessionsRunningForParentCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["clearedCalls"] == ["session-1"]
+    assert payload["runningCalls"] == []
+
+
+def test_run_resumed_reactivates_parent_stopped_subagent_sessions(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+state.activeRunId = 'run-1';
+
+routeEvent('run_resumed', {}, { run_id: 'run-1', session_id: 'session-1' });
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    calls: globalThis.__runEventCalls.filter(call => call.name === 'handleRunStarted'),
+}));
+""".strip(),
+    )
+
+    assert payload["calls"] == [
+        {
+            "name": "handleRunStarted",
+            "args": [
+                {"run_id": "run-1", "session_id": "session-1"},
+                {"resumeSubagents": True},
+            ],
+        }
+    ]
+
+
+def test_subagent_session_status_event_routes_to_subagent_session_cache(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+routeEvent('subagent_session_status_changed', {
+    parent_session_id: 'session-1',
+    parent_run_id: 'run-1',
+    subagent_run_id: 'subagent_run_1',
+    subagent_instance_id: 'inst-sub-1',
+    subagent_role_id: 'Explorer',
+    status: 'stopped',
+}, {
+    run_id: 'run-1',
+    session_id: 'session-1',
+    event_id: 'evt-1',
+});
+
+console.log(JSON.stringify({
+    statusEvents: globalThis.__subagentSessionStatusEvents,
+    backgroundEvents: globalThis.__applyBackgroundTaskEventCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["statusEvents"] == [
+        {
+            "payload": {
+                "parent_session_id": "session-1",
+                "parent_run_id": "run-1",
+                "subagent_run_id": "subagent_run_1",
+                "subagent_instance_id": "inst-sub-1",
+                "subagent_role_id": "Explorer",
+                "status": "stopped",
+            },
+            "eventMeta": {
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "event_id": "evt-1",
+            },
+        }
+    ]
+    assert payload["backgroundEvents"] == []
+
+
 def test_terminal_run_event_marks_parent_session_when_subagent_view_is_open(
     tmp_path: Path,
 ) -> None:
@@ -510,6 +645,57 @@ console.log(JSON.stringify({
     assert payload["subagentCalls"] == []
 
 
+def test_route_event_updates_foreground_subagent_background_task_status(
+    tmp_path: Path,
+) -> None:
+    payload = _run_event_router_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { routeEvent } = await import('./eventRouterIndex.mjs');
+
+routeEvent('background_task_stopped', {
+    background_task_id: 'foreground-subagent-1',
+    run_id: 'run-1',
+    session_id: 'session-1',
+    kind: 'subagent',
+    execution_mode: 'foreground',
+    subagent_run_id: 'subagent_run_deadbeef',
+    subagent_instance_id: 'writer-1',
+    subagent_role_id: 'writer',
+    status: 'stopped',
+}, { run_id: 'run-1', trace_id: 'run-1', session_id: 'session-1' });
+
+await Promise.resolve();
+
+console.log(JSON.stringify({
+    recoveryCalls: globalThis.__scheduleRecoveryContinuityRefreshCalls,
+    backgroundCalls: globalThis.__applyBackgroundTaskEventCalls,
+    subagentCalls: globalThis.__normalModeSubagentEvents,
+}));
+""".strip(),
+    )
+
+    assert payload["recoveryCalls"] == []
+    assert payload["backgroundCalls"] == []
+    assert payload["subagentCalls"] == [
+        {
+            "sessionId": "session-1",
+            "payload": {
+                "background_task_id": "foreground-subagent-1",
+                "run_id": "run-1",
+                "session_id": "session-1",
+                "kind": "subagent",
+                "execution_mode": "foreground",
+                "subagent_run_id": "subagent_run_deadbeef",
+                "subagent_instance_id": "writer-1",
+                "subagent_role_id": "writer",
+                "status": "stopped",
+            },
+            "eventType": "background_task_stopped",
+        }
+    ]
+
+
 def test_handle_subagent_run_terminal_finalizes_with_run_id(
     tmp_path: Path,
 ) -> None:
@@ -592,6 +778,89 @@ console.log(JSON.stringify({
         }
     ]
     assert payload["settleCalls"] == ["writer-1"]
+
+
+def test_handle_subagent_run_terminal_resolves_active_child_session_by_run_id(
+    tmp_path: Path,
+) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleSubagentRunTerminal } = await import('./runEvents.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+globalThis.__activeSubagentSession = {
+    sessionId: 'session-1',
+    instanceId: 'writer-1',
+    roleId: 'writer',
+    runId: 'subagent_run_deadbeef',
+};
+
+handleSubagentRunTerminal(
+    '',
+    'stopped',
+    { run_id: 'subagent_run_deadbeef', trace_id: 'subagent_run_deadbeef' },
+    '',
+);
+
+console.log(JSON.stringify({
+    statusCalls: globalThis.__updateNormalModeSubagentSessionStatusCalls,
+    statusByRunCalls: globalThis.__updateNormalModeSubagentSessionStatusByRunIdCalls,
+    settleCalls: globalThis.__settleActiveSubagentSessionAfterTerminalCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["statusCalls"] == [
+        {
+            "sessionId": "session-1",
+            "instanceId": "writer-1",
+            "status": "stopped",
+        }
+    ]
+    assert payload["statusByRunCalls"] == []
+    assert payload["settleCalls"] == ["writer-1"]
+
+
+def test_handle_subagent_run_active_resolves_active_child_session_by_run_id(
+    tmp_path: Path,
+) -> None:
+    payload = _run_run_events_script(
+        tmp_path=tmp_path,
+        runner_source="""
+const { handleSubagentRunActive } = await import('./runEvents.mjs');
+const { state } = await import('./mockState.mjs');
+
+state.currentSessionId = 'session-1';
+globalThis.__activeSubagentSession = {
+    sessionId: 'session-1',
+    instanceId: 'writer-1',
+    roleId: 'writer',
+    runId: 'subagent_run_deadbeef',
+};
+
+handleSubagentRunActive(
+    '',
+    { run_id: 'subagent_run_deadbeef', trace_id: 'subagent_run_deadbeef' },
+    '',
+);
+
+console.log(JSON.stringify({
+    statusCalls: globalThis.__updateNormalModeSubagentSessionStatusCalls,
+    statusByRunCalls: globalThis.__updateNormalModeSubagentSessionStatusByRunIdCalls,
+}));
+""".strip(),
+    )
+
+    assert payload["statusCalls"] == [
+        {
+            "sessionId": "session-1",
+            "instanceId": "writer-1",
+            "status": "running",
+        }
+    ]
+    assert payload["statusByRunCalls"] == []
 
 
 def test_handle_fallback_logs_escape_profile_labels(tmp_path: Path) -> None:
@@ -842,6 +1111,26 @@ export function getActiveSubagentSessionStreamContainer() {
     return globalThis.__activeSubagentSessionStreamContainer || null;
 }
 
+export function getNormalModeSubagentSessionByRunId(sessionId, runId) {
+    const active = globalThis.__activeSubagentSession || null;
+    if (active && active.sessionId === sessionId && active.runId === runId) {
+        return active;
+    }
+    return null;
+}
+
+export function clearNormalModeSubagentParentStopState(sessionId) {
+    globalThis.__clearNormalModeSubagentParentStopStateCalls.push(sessionId);
+}
+
+export function markNormalModeSubagentSessionsRunningForParent(sessionId) {
+    globalThis.__markNormalModeSubagentSessionsRunningForParentCalls.push(sessionId);
+}
+
+export function markNormalModeSubagentSessionsStoppedForParent(sessionId) {
+    globalThis.__markNormalModeSubagentSessionsStoppedForParentCalls.push(sessionId);
+}
+
 export function rememberNormalModeSubagentSession(sessionId, record) {
     globalThis.__rememberNormalModeSubagentSessionCalls.push({ sessionId, record });
 }
@@ -858,6 +1147,14 @@ export function updateNormalModeSubagentSessionStatus(sessionId, instanceId, sta
     globalThis.__updateNormalModeSubagentSessionStatusCalls.push({
         sessionId,
         instanceId,
+        status,
+    });
+}
+
+export function updateNormalModeSubagentSessionStatusByRunId(sessionId, runId, status) {
+    globalThis.__updateNormalModeSubagentSessionStatusByRunIdCalls.push({
+        sessionId,
+        runId,
         status,
     });
 }
@@ -983,6 +1280,10 @@ globalThis.__openAgentPanelCalls = [];
 globalThis.__rememberNormalModeSubagentSessionCalls = [];
 globalThis.__renderActiveSubagentSessionCalls = [];
 globalThis.__updateNormalModeSubagentSessionStatusCalls = [];
+globalThis.__updateNormalModeSubagentSessionStatusByRunIdCalls = [];
+globalThis.__clearNormalModeSubagentParentStopStateCalls = [];
+globalThis.__markNormalModeSubagentSessionsRunningForParentCalls = [];
+globalThis.__markNormalModeSubagentSessionsStoppedForParentCalls = [];
 globalThis.__finalizeStreamCalls = [];
 globalThis.__reconcileTerminalRunStreamStateCalls = [];
 globalThis.__settleActiveSubagentSessionAfterTerminalCalls = [];
@@ -1077,7 +1378,16 @@ export function applyBackgroundTaskEvent(payload, eventMeta = null, eventType = 
 }
 
 export function isDisplayableBackgroundTaskPayload(payload) {
-    return payload?.execution_mode === 'background' || payload?.kind === 'subagent';
+    const executionMode = String(payload?.execution_mode || payload?.executionMode || '').trim();
+    if (executionMode === 'foreground') {
+        return false;
+    }
+    if (executionMode === 'background') {
+        return true;
+    }
+    const kind = String(payload?.kind || '').trim();
+    const subagentRunId = String(payload?.subagent_run_id || payload?.subagentRunId || '').trim();
+    return kind === 'subagent' || subagentRunId.startsWith('subagent_run_');
 }
 """.strip(),
         encoding="utf-8",
@@ -1093,7 +1403,18 @@ export function scheduleSessionTokenUsageRefresh(options) {
     (tmp_path / "mockSubagentSessions.mjs").write_text(
         """
 export function rememberNormalModeSubagentFromBackgroundTask(sessionId, payload, eventType) {
+    const kind = String(payload?.kind || '').trim();
+    const subagentRunId = String(payload?.subagent_run_id || payload?.subagentRunId || '').trim();
+    if (kind !== 'subagent' && !subagentRunId.startsWith('subagent_run_')) {
+        return false;
+    }
     globalThis.__normalModeSubagentEvents.push({ sessionId, payload, eventType });
+    return true;
+}
+
+export function applySubagentSessionStatusEvent(payload, eventMeta = null) {
+    globalThis.__subagentSessionStatusEvents.push({ payload, eventMeta });
+    return true;
 }
 """.strip(),
         encoding="utf-8",
@@ -1168,6 +1489,7 @@ export function handleRunCompleted(...args) { pushCall('handleRunCompleted', arg
 export function handleRunFailed(...args) { pushCall('handleRunFailed', args); }
 export function handleRunStarted(...args) { pushCall('handleRunStarted', args); }
 export function handleRunStopped(...args) { pushCall('handleRunStopped', args); }
+export function handleSubagentRunActive(...args) { pushCall('handleSubagentRunActive', args); }
 export function handleSubagentRunTerminal(...args) { pushCall('handleSubagentRunTerminal', args); }
 export function handleThinkingDelta(...args) { pushCall('handleThinkingDelta', args); }
 export function handleThinkingFinished(...args) { pushCall('handleThinkingFinished', args); }
@@ -1218,6 +1540,7 @@ globalThis.__scheduleRecoveryContinuityRefreshCalls = [];
 globalThis.__scheduleSessionTokenUsageRefreshCalls = [];
 globalThis.__runEventCalls = [];
 globalThis.__normalModeSubagentEvents = [];
+globalThis.__subagentSessionStatusEvents = [];
 globalThis.__applyBackgroundTaskEventCalls = [];
 
 {runner_source}

--- a/tests/unit_tests/frontend/test_subagent_sessions_ui.py
+++ b/tests/unit_tests/frontend/test_subagent_sessions_ui.py
@@ -40,8 +40,9 @@ export async function fetchAgentMessages() {
     ];
 }
 
-export async function fetchSessionSubagents() {
-    return [];
+export async function fetchSessionSubagents(sessionId) {
+    globalThis.__fetchSessionSubagentsCalls.push(sessionId);
+    return globalThis.__fetchSessionSubagentsPayload || [];
 }
 """.strip(),
         encoding="utf-8",
@@ -1247,6 +1248,8 @@ export function sysLog() {
         """
 globalThis.__events = [];
 globalThis.__syncCalls = [];
+globalThis.__fetchSessionSubagentsCalls = [];
+globalThis.__fetchSessionSubagentsPayload = [];
 globalThis.CustomEvent = class CustomEvent {
     constructor(type, options = {}) {
         this.type = type;
@@ -1255,9 +1258,16 @@ globalThis.CustomEvent = class CustomEvent {
 };
 
 const {
+    applySubagentSessionStatusEvent,
+    clearNormalModeSubagentParentStopState,
+    getSessionSubagentSessions,
+    markNormalModeSubagentSessionsRunningForParent,
+    markNormalModeSubagentSessionsStoppedForParent,
+    openSubagentSession,
     replaceSessionSubagents,
     updateNormalModeSubagentSessionStatus,
 } = await import("./subagentSessions.mjs");
+const { state } = await import("./mockState.mjs");
 
 replaceSessionSubagents("session-1", [
     {
@@ -1266,6 +1276,9 @@ replaceSessionSubagents("session-1", [
         run_id: "subagent_run_1",
         status: "running",
         run_status: "running",
+        conversation_id: "conversation-1",
+        checkpoint_event_id: 9,
+        last_event_id: 12,
     },
 ], { emitChange: false });
 globalThis.__events = [];
@@ -1278,6 +1291,8 @@ replaceSessionSubagents("session-1", [
         status: "completed",
         run_status: "completed",
         run_phase: "finished",
+        conversation_id: "conversation-1",
+        checkpoint_event_id: 9,
         last_event_id: 12,
     },
 ], { emitChange: true });
@@ -1286,10 +1301,193 @@ globalThis.__events = [];
 
 updateNormalModeSubagentSessionStatus("session-1", "inst-sub-1", "failed");
 updateNormalModeSubagentSessionStatus("session-1", "inst-sub-1", "failed");
+const directEvents = [...globalThis.__events];
+globalThis.__events = [];
+
+replaceSessionSubagents("session-1", [
+    {
+        instance_id: "inst-sub-1",
+        role_id: "Explorer",
+        run_id: "subagent_run_1",
+        status: "running",
+        run_status: "running",
+        conversation_id: "conversation-1",
+        checkpoint_event_id: 9,
+        last_event_id: 12,
+    },
+], { emitChange: false });
+markNormalModeSubagentSessionsStoppedForParent("session-1");
+markNormalModeSubagentSessionsRunningForParent("session-1");
+const parentEvents = [...globalThis.__events];
+globalThis.__events = [];
+
+applySubagentSessionStatusEvent({
+    parent_session_id: "session-1",
+    parent_run_id: "run-1",
+    subagent_run_id: "subagent_run_1",
+    subagent_instance_id: "inst-sub-1",
+    subagent_role_id: "Explorer",
+    title: "Explore",
+    status: "stopped",
+    run_status: "stopped",
+    updated_at: "2026-05-09T00:00:00Z",
+}, { run_id: "run-1", session_id: "session-1" });
+const statusEventRecords = getSessionSubagentSessions("session-1");
+const statusEventEvents = [...globalThis.__events];
+globalThis.__events = [];
+
+markNormalModeSubagentSessionsStoppedForParent("session-2");
+replaceSessionSubagents("session-2", [
+    {
+        instance_id: "inst-sub-2",
+        role_id: "Explorer",
+        run_id: "subagent_run_2",
+        status: "running",
+        run_status: "running",
+    },
+], { emitChange: false });
+const unloadedParentStopRecords = getSessionSubagentSessions("session-2");
+await openSubagentSession("session-2", {
+    instance_id: "inst-sub-3",
+    role_id: "Explorer",
+    run_id: "subagent_run_3",
+    status: "running",
+    run_status: "running",
+});
+const openedDuringParentStop = state.activeSubagentSession;
+markNormalModeSubagentSessionsRunningForParent("session-2");
+const resumedAfterUnloadedParentStopRecords = getSessionSubagentSessions("session-2");
+const openedAfterParentResume = state.activeSubagentSession;
+
+markNormalModeSubagentSessionsStoppedForParent("session-3");
+clearNormalModeSubagentParentStopState("session-3");
+replaceSessionSubagents("session-3", [
+    {
+        instance_id: "inst-sub-4",
+        role_id: "Explorer",
+        run_id: "subagent_run_4",
+        status: "running",
+        run_status: "running",
+    },
+], { emitChange: false });
+const freshRunRecordsAfterClear = getSessionSubagentSessions("session-3");
+
+replaceSessionSubagents("session-4", [
+    {
+        instance_id: "inst-sub-5",
+        role_id: "Explorer",
+        run_id: "subagent_run_5",
+        status: "stopped",
+        run_status: "stopped",
+    },
+], { emitChange: false });
+markNormalModeSubagentSessionsStoppedForParent("session-4");
+markNormalModeSubagentSessionsRunningForParent("session-4");
+const individuallyStoppedRecordsAfterParentResume = getSessionSubagentSessions("session-4");
+
+replaceSessionSubagents("session-5", [
+    {
+        instance_id: "inst-sub-6",
+        role_id: "Explorer",
+        run_id: "subagent_run_6",
+        status: "running",
+        run_status: "running",
+    },
+], { emitChange: false });
+applySubagentSessionStatusEvent({
+    parent_session_id: "session-5",
+    parent_run_id: "run-5",
+    subagent_run_id: "subagent_run_6",
+    subagent_instance_id: "inst-sub-6",
+    subagent_role_id: "Explorer",
+    title: "Explore",
+    status: "stopped",
+    run_status: "stopped",
+    parent_stop_candidate: true,
+    updated_at: "2026-05-09T00:00:00Z",
+}, { run_id: "run-5", session_id: "session-5" });
+markNormalModeSubagentSessionsStoppedForParent("session-5");
+markNormalModeSubagentSessionsRunningForParent("session-5");
+const parentStoppedStatusEventRecordsAfterResume = getSessionSubagentSessions("session-5");
+
+replaceSessionSubagents("session-6", [
+    {
+        instance_id: "inst-sub-7",
+        role_id: "Explorer",
+        run_id: "subagent_run_7",
+        status: "running",
+        run_status: "running",
+    },
+], { emitChange: false });
+applySubagentSessionStatusEvent({
+    parent_session_id: "session-6",
+    parent_run_id: "run-6",
+    subagent_run_id: "subagent_run_7",
+    subagent_instance_id: "inst-sub-7",
+    subagent_role_id: "Explorer",
+    title: "Explore",
+    status: "stopped",
+    run_status: "stopped",
+    parent_stop_candidate: true,
+    updated_at: "2026-05-09T00:00:01Z",
+}, { run_id: "subagent_run_7", session_id: "session-6" });
+markNormalModeSubagentSessionsStoppedForParent("session-6");
+markNormalModeSubagentSessionsRunningForParent("session-6");
+const parentStoppedChildRunStatusEventRecordsAfterResume = getSessionSubagentSessions("session-6");
+
+replaceSessionSubagents("session-7", [
+    {
+        instance_id: "inst-sub-8",
+        role_id: "Explorer",
+        run_id: "subagent_run_8",
+        status: "running",
+        run_status: "running",
+    },
+], { emitChange: false });
+applySubagentSessionStatusEvent({
+    parent_session_id: "session-7",
+    subagent_run_id: "subagent_run_8",
+    subagent_instance_id: "inst-sub-8",
+    subagent_role_id: "Explorer",
+    title: "Explore",
+    status: "stopped",
+    run_status: "stopped",
+    updated_at: "2026-05-09T00:00:02Z",
+}, { run_id: "subagent_run_8", session_id: "session-7" });
+markNormalModeSubagentSessionsStoppedForParent("session-7");
+markNormalModeSubagentSessionsRunningForParent("session-7");
+const independentlyStoppedStatusEventRecordsAfterParentResume = getSessionSubagentSessions("session-7");
+
+replaceSessionSubagents("session-8", [
+    {
+        instance_id: "inst-sub-9",
+        role_id: "Explorer",
+        run_id: "subagent_run_9",
+        status: "running",
+        run_status: "running",
+    },
+], { emitChange: false });
+markNormalModeSubagentSessionsStoppedForParent("session-8");
+markNormalModeSubagentSessionsStoppedForParent("session-8");
+markNormalModeSubagentSessionsRunningForParent("session-8");
+const repeatedParentStopRecordsAfterResume = getSessionSubagentSessions("session-8");
 
 console.log(JSON.stringify({
     replaceEvents,
-    events: globalThis.__events,
+    events: directEvents,
+    parentEvents,
+    statusEventRecords,
+    statusEventEvents,
+    unloadedParentStopRecords,
+    openedDuringParentStop,
+    resumedAfterUnloadedParentStopRecords,
+    openedAfterParentResume,
+    freshRunRecordsAfterClear,
+    individuallyStoppedRecordsAfterParentResume,
+    parentStoppedStatusEventRecordsAfterResume,
+    parentStoppedChildRunStatusEventRecordsAfterResume,
+    independentlyStoppedStatusEventRecordsAfterParentResume,
+    repeatedParentStopRecordsAfterResume,
     syncCalls: globalThis.__syncCalls,
 }));
 """.strip(),
@@ -1333,9 +1531,98 @@ console.log(JSON.stringify({
             },
         },
     ]
+    assert payload["parentEvents"] == [
+        {
+            "type": "agent-teams-subagent-session-status-changed",
+            "detail": {
+                "sessionId": "session-1",
+                "instanceId": "inst-sub-1",
+                "status": "stopped",
+            },
+        },
+        {
+            "type": "agent-teams-subagent-session-status-changed",
+            "detail": {
+                "sessionId": "session-1",
+                "instanceId": "inst-sub-1",
+                "status": "running",
+            },
+        },
+    ]
+    assert payload["statusEventEvents"] == [
+        {
+            "type": "agent-teams-subagent-session-status-changed",
+            "detail": {
+                "sessionId": "session-1",
+                "instanceId": "inst-sub-1",
+                "status": "stopped",
+            },
+        },
+    ]
+    assert payload["statusEventRecords"][0]["status"] == "stopped"
+    assert payload["statusEventRecords"][0]["runStatus"] == "stopped"
+    assert payload["statusEventRecords"][0]["conversationId"] == "conversation-1"
+    assert payload["statusEventRecords"][0]["checkpointEventId"] == 9
+    assert payload["statusEventRecords"][0]["lastEventId"] == 12
+    assert payload["unloadedParentStopRecords"][0]["status"] == "stopped"
+    assert payload["unloadedParentStopRecords"][0]["runStatus"] == "stopped"
+    assert payload["openedDuringParentStop"]["status"] == "stopped"
+    assert payload["openedDuringParentStop"]["runStatus"] == "stopped"
+    assert payload["resumedAfterUnloadedParentStopRecords"][0]["status"] == "running"
+    assert payload["resumedAfterUnloadedParentStopRecords"][0]["runStatus"] == "running"
+    assert payload["openedAfterParentResume"]["status"] == "running"
+    assert payload["openedAfterParentResume"]["runStatus"] == "running"
+    assert payload["freshRunRecordsAfterClear"][0]["status"] == "running"
+    assert payload["freshRunRecordsAfterClear"][0]["runStatus"] == "running"
+    assert (
+        payload["individuallyStoppedRecordsAfterParentResume"][0]["status"] == "stopped"
+    )
+    assert (
+        payload["individuallyStoppedRecordsAfterParentResume"][0]["runStatus"]
+        == "stopped"
+    )
+    assert (
+        payload["parentStoppedStatusEventRecordsAfterResume"][0]["status"] == "running"
+    )
+    assert (
+        payload["parentStoppedStatusEventRecordsAfterResume"][0]["runStatus"]
+        == "running"
+    )
+    assert (
+        payload["parentStoppedChildRunStatusEventRecordsAfterResume"][0]["status"]
+        == "running"
+    )
+    assert (
+        payload["parentStoppedChildRunStatusEventRecordsAfterResume"][0]["runStatus"]
+        == "running"
+    )
+    assert (
+        payload["independentlyStoppedStatusEventRecordsAfterParentResume"][0]["status"]
+        == "stopped"
+    )
+    assert (
+        payload["independentlyStoppedStatusEventRecordsAfterParentResume"][0][
+            "runStatus"
+        ]
+        == "stopped"
+    )
+    assert payload["repeatedParentStopRecordsAfterResume"][0]["status"] == "running"
+    assert payload["repeatedParentStopRecordsAfterResume"][0]["runStatus"] == "running"
+    assert {
+        "sessionId": "session-2",
+        "statuses": ["running"],
+    } in payload["syncCalls"]
+    assert {
+        "sessionId": "session-3",
+        "statuses": ["running"],
+    } in payload["syncCalls"]
+    assert {
+        "sessionId": "session-7",
+        "statuses": ["stopped"],
+    } in payload["syncCalls"]
     assert payload["syncCalls"][-1] == {
-        "sessionId": "session-1",
-        "statuses": ["failed"],
+        "sessionId": "session-8",
+        "statuses": ["running"],
     }
 
 

--- a/tests/unit_tests/frontend/test_subagent_streams_ui.py
+++ b/tests/unit_tests/frontend/test_subagent_streams_ui.py
@@ -109,6 +109,10 @@ export function refreshSessionTopologyControls() {
 export function replaceSessionSubagents() {
     return undefined;
 }
+
+export function markNormalModeSubagentSessionsStoppedForParent() {
+    return [];
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -370,6 +374,258 @@ console.log(JSON.stringify({
     assert payload["scheduleSessionsRefreshCalls"] == 0
 
 
+def test_stop_request_applies_local_stopped_subagent_snapshot(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_path = repo_root / "frontend" / "dist" / "js" / "core" / "stream.js"
+    module_under_test_path = tmp_path / "stream.mjs"
+    runner_path = tmp_path / "runner_stop_subagents.mjs"
+
+    source_text = (
+        source_path.read_text(encoding="utf-8")
+        .replace("./api.js", "./mockApi.mjs")
+        .replace("../components/contextIndicators.js", "./mockContextIndicators.mjs")
+        .replace("../app/prompt.js", "./mockPrompt.mjs")
+        .replace("../components/subagentSessions.js", "./mockSubagentSessions.mjs")
+        .replace("../components/sidebar.js", "./mockSidebar.mjs")
+        .replace("../app/recovery.js", "./mockRecovery.mjs")
+        .replace("../utils/dom.js", "./mockDom.mjs")
+        .replace("../utils/logger.js", "./mockLogger.mjs")
+        .replace("./eventRouter.js", "./mockEventRouter.mjs")
+        .replace("../components/messageRenderer.js", "./mockMessageRenderer.mjs")
+        .replace("../components/runtimeInjectQueue.js", "./mockRuntimeInjectQueue.mjs")
+        .replace("../utils/i18n.js", "./mockI18n.mjs")
+        .replace("./state.js", "./mockState.mjs")
+    )
+    module_under_test_path.write_text(source_text, encoding="utf-8")
+    _write_stream_runtime_inject_mocks(tmp_path)
+
+    (tmp_path / "mockApi.mjs").write_text(
+        """
+export async function fetchSessionSubagents() {
+    return [];
+}
+
+export async function fetchSessions() {
+    return [];
+}
+
+export async function sendUserPrompt() {
+    throw new Error("not used");
+}
+
+export async function stopRun(runId, options = {}) {
+    globalThis.__stopRunCalls.push({ runId, options });
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockContextIndicators.mjs").write_text(
+        """
+export function refreshVisibleContextIndicators() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockPrompt.mjs").write_text(
+        """
+export function refreshSessionTopologyControls() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSubagentSessions.mjs").write_text(
+        """
+export function markNormalModeSubagentSessionsStoppedForParent(sessionId) {
+    globalThis.__stoppedSubagentParentSessions.push(sessionId);
+    return ["inst-sub-1"];
+}
+
+export function replaceSessionSubagents() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockSidebar.mjs").write_text(
+        """
+export function scheduleSessionsRefresh() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockRecovery.mjs").write_text(
+        """
+export function applyRecoverySnapshot(snapshot) {
+    globalThis.__recoverySnapshots.push(snapshot);
+}
+
+export function scheduleRecoveryContinuityRefresh(options = {}) {
+    globalThis.__recoveryRefreshes.push(options);
+}
+
+export async function hydrateSessionView(sessionId, options = {}) {
+    globalThis.__hydrateSessionViewCalls.push({ sessionId, options });
+    return {
+        activeRun: {
+            run_id: "run-1",
+            status: "stopped",
+            phase: "stopped",
+            is_recoverable: true,
+        },
+    };
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockDom.mjs").write_text(
+        """
+export const els = {
+    sendBtn: { disabled: false, style: {}, setAttribute() {} },
+    promptInput: { disabled: false, dataset: {}, placeholder: "", getAttribute() { return this.placeholder || ""; }, setAttribute(name, value) { this[name] = value; }, focus() {} },
+    yoloToggle: { disabled: false },
+    thinkingModeToggle: { disabled: false },
+    thinkingEffortSelect: { disabled: false },
+    stopBtn: { style: {}, disabled: false },
+};
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockLogger.mjs").write_text(
+        """
+export function errorToPayload(error, extra = {}) {
+    return { error: String(error?.message || error || ''), ...extra };
+}
+
+export function logError() {
+    return undefined;
+}
+
+export function logInfo() {
+    return undefined;
+}
+
+export function logWarn() {
+    return undefined;
+}
+
+export function sysLog() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockEventRouter.mjs").write_text(
+        """
+export function routeEvent() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockMessageRenderer.mjs").write_text(
+        """
+export function clearRunStreamState(runId) {
+    globalThis.__clearedRunStreamStates.push(runId);
+}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mockState.mjs").write_text(
+        """
+export const state = {
+    currentSessionId: "session-1",
+    currentSessionMode: "normal",
+    activeSubagentSession: {
+        sessionId: "session-1",
+        instanceId: "inst-sub-1",
+        runId: "subagent_run_1",
+        status: "running",
+        runStatus: "running",
+    },
+    activeEventSource: { close() { globalThis.__activeEventSourceClosed = true; } },
+    activeRunId: "run-1",
+    isGenerating: true,
+    runPrimaryRoleMap: {},
+};
+
+export function getPrimaryRoleId() {
+    return "MainAgent";
+}
+
+export function getPrimaryRoleLabel() {
+    return "Main Agent";
+}
+
+export function getRunPrimaryRoleId() {
+    return "MainAgent";
+}
+
+export function getRunPrimaryRoleLabel() {
+    return "Main Agent";
+}
+
+export function setRunPrimaryRole() {
+    return undefined;
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runner_path.write_text(
+        """
+globalThis.__stopRunCalls = [];
+globalThis.__stoppedSubagentParentSessions = [];
+globalThis.__recoverySnapshots = [];
+globalThis.__recoveryRefreshes = [];
+globalThis.__hydrateSessionViewCalls = [];
+globalThis.__clearedRunStreamStates = [];
+
+const { requestStopCurrentRun } = await import("./stream.mjs");
+
+const stopped = await requestStopCurrentRun();
+
+console.log(JSON.stringify({
+    stopped,
+    stopRunCalls: globalThis.__stopRunCalls,
+    stoppedSubagentParentSessions: globalThis.__stoppedSubagentParentSessions,
+    recoverySnapshots: globalThis.__recoverySnapshots,
+    recoveryRefreshes: globalThis.__recoveryRefreshes,
+    hydrateSessionViewCalls: globalThis.__hydrateSessionViewCalls,
+    clearedRunStreamStates: globalThis.__clearedRunStreamStates,
+}));
+""".strip(),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(runner_path)],
+        capture_output=True,
+        check=False,
+        cwd=str(repo_root),
+        text=True,
+        timeout=3,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "Node runner failed:\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    payload = json.loads(completed.stdout)
+
+    assert payload["stopped"] is True
+    assert payload["stopRunCalls"] == [{"runId": "run-1", "options": {"scope": "main"}}]
+    assert payload["stoppedSubagentParentSessions"] == ["session-1"]
+    assert payload["recoverySnapshots"][0]["active_run"]["status"] == "stopped"
+    assert payload["recoveryRefreshes"][0]["reason"] == "stop-sync"
+    assert payload["hydrateSessionViewCalls"][0]["sessionId"] == "session-1"
+    assert payload["clearedRunStreamStates"] == ["run-1", "run-1"]
+
+
 def test_active_parent_run_keeps_normal_subagent_discovery_polling(
     tmp_path: Path,
 ) -> None:
@@ -446,6 +702,10 @@ export function replaceSessionSubagents(sessionId, payload) {
         sessionId,
         rowCount: Array.isArray(payload) ? payload.length : 0,
     });
+}
+
+export function markNormalModeSubagentSessionsStoppedForParent() {
+    return [];
 }
 """.strip(),
         encoding="utf-8",
@@ -742,6 +1002,10 @@ export async function hydrateSessionView(sessionId, options = {}) {
         """
 export function replaceSessionSubagents() {
     return undefined;
+}
+
+export function markNormalModeSubagentSessionsStoppedForParent() {
+    return [];
 }
 """.strip(),
         encoding="utf-8",
@@ -1088,6 +1352,10 @@ export function refreshSessionTopologyControls() {
         """
 export function replaceSessionSubagents() {
     return undefined;
+}
+
+export function markNormalModeSubagentSessionsStoppedForParent() {
+    return [];
 }
 """.strip(),
         encoding="utf-8",
@@ -1442,6 +1710,10 @@ export function refreshSessionTopologyControls() {
 export function replaceSessionSubagents() {
     return undefined;
 }
+
+export function markNormalModeSubagentSessionsStoppedForParent() {
+    return [];
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -1769,6 +2041,10 @@ export function refreshSessionTopologyControls() {
 export function replaceSessionSubagents() {
     return undefined;
 }
+
+export function markNormalModeSubagentSessionsStoppedForParent() {
+    return [];
+}
 """.strip(),
         encoding="utf-8",
     )
@@ -2091,6 +2367,10 @@ export function replaceSessionSubagents(sessionId, payload, options = {}) {
         runId: Array.isArray(payload) ? payload[0]?.run_id || null : null,
         emitChange: options.emitChange === true,
     });
+}
+
+export function markNormalModeSubagentSessionsStoppedForParent() {
+    return [];
 }
 """.strip(),
         encoding="utf-8",

--- a/tests/unit_tests/sessions/runs/background_tasks/test_service.py
+++ b/tests/unit_tests/sessions/runs/background_tasks/test_service.py
@@ -962,6 +962,17 @@ async def test_background_task_service_start_subagent_completes_and_persists_res
     assert runtime is not None
     assert runtime.status == RunRuntimeStatus.COMPLETED
     assert runtime.phase == RunRuntimePhase.TERMINAL
+    assert task_repo.status_updates[-1] == {
+        "task_id": updated.subagent_task_id,
+        "status": TaskStatus.COMPLETED,
+        "assigned_instance_id": updated.subagent_instance_id,
+        "result": "analysis complete",
+        "error_message": None,
+    }
+    assert agent_repo.status_updates[-1] == {
+        "instance_id": updated.subagent_instance_id,
+        "status": InstanceStatus.COMPLETED,
+    }
 
 
 @pytest.mark.asyncio
@@ -1011,7 +1022,39 @@ async def test_background_task_service_start_subagent_publishes_start_event_asyn
     assert completed is True
     assert [event.event_type for event in run_event_hub.events] == [
         RunEventType.BACKGROUND_TASK_STARTED,
+        RunEventType.SUBAGENT_SESSION_STATUS_CHANGED,
         RunEventType.BACKGROUND_TASK_COMPLETED,
+        RunEventType.SUBAGENT_SESSION_STATUS_CHANGED,
+    ]
+    status_events = [
+        event
+        for event in run_event_hub.events
+        if event.event_type == RunEventType.SUBAGENT_SESSION_STATUS_CHANGED
+    ]
+    assert [event.run_id for event in status_events] == [
+        started.subagent_run_id,
+        started.subagent_run_id,
+    ]
+    assert [event.trace_id for event in status_events] == [
+        started.subagent_run_id,
+        started.subagent_run_id,
+    ]
+    status_payloads = [json.loads(event.payload_json) for event in status_events]
+    assert [payload["status"] for payload in status_payloads] == [
+        "running",
+        "completed",
+    ]
+    assert [payload["run_id"] for payload in status_payloads] == [
+        started.subagent_run_id,
+        started.subagent_run_id,
+    ]
+    assert [payload["parent_run_id"] for payload in status_payloads] == [
+        "run-1",
+        "run-1",
+    ]
+    assert [payload["parent_stop_candidate"] for payload in status_payloads] == [
+        False,
+        False,
     ]
 
 
@@ -1847,6 +1890,297 @@ async def test_background_task_service_wait_for_subagent_run_reattaches_existing
 
 
 @pytest.mark.asyncio
+async def test_background_task_service_parent_cancel_stops_and_restarts_sync_subagent(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-sync-parent-cancel-restart.db"
+    )
+    runtime_repo = RunRuntimeRepository(
+        tmp_path / "background-task-service-subagent-sync-parent-cancel-restart.db"
+    )
+    gate = asyncio.Event()
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        ),
+        gate=gate,
+    )
+    run_control_manager = _FakeRunControlManager()
+    run_event_hub = _LoopGuardRunEventHub()
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=run_control_manager,
+        run_runtime_repo=runtime_repo,
+        run_event_hub=cast(RunEventHub, run_event_hub),
+    )
+
+    run_task = asyncio.create_task(
+        service.run_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests and summarize the cause.",
+        )
+    )
+    while not run_control_manager.registered_run_ids:
+        await asyncio.sleep(0)
+    subagent_run_id = run_control_manager.registered_run_ids[0]
+
+    _ = run_control_manager.request_run_stop("run-1")
+    run_task.cancel()
+    try:
+        _run_result = await run_task
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError(
+            f"Expected subagent run task cancellation, got {_run_result!r}"
+        )
+
+    persisted = repo.list_all()[0]
+    runtime = runtime_repo.get(subagent_run_id)
+    assert persisted.status == BackgroundTaskStatus.STOPPED
+    assert runtime is not None
+    assert runtime.status == RunRuntimeStatus.STOPPED
+    assert run_control_manager.unregistered_run_ids == [subagent_run_id]
+    assert (
+        run_event_hub.events[-1].event_type
+        == RunEventType.SUBAGENT_SESSION_STATUS_CHANGED
+    )
+    assert run_event_hub.events[-1].run_id == subagent_run_id
+    stopped_event_payload = json.loads(run_event_hub.events[-1].payload_json)
+    assert stopped_event_payload["run_id"] == subagent_run_id
+    assert stopped_event_payload["parent_run_id"] == "run-1"
+    assert stopped_event_payload["subagent_run_id"] == subagent_run_id
+    assert stopped_event_payload["status"] == BackgroundTaskStatus.STOPPED.value
+    assert stopped_event_payload["parent_stop_candidate"] is True
+
+    wait_task = asyncio.create_task(
+        service.wait_for_subagent_run(
+            parent_run_id="run-1",
+            subagent_run_id=subagent_run_id,
+        )
+    )
+    gate.set()
+    result = await wait_task
+
+    assert result.run_id == subagent_run_id
+    assert result.output == "analysis complete"
+    assert len(executor.calls) == 2
+    assert run_control_manager.registered_run_ids == [
+        subagent_run_id,
+        subagent_run_id,
+    ]
+    assert run_control_manager.unregistered_run_ids == [
+        subagent_run_id,
+        subagent_run_id,
+    ]
+    restarted = repo.get(persisted.background_task_id)
+    assert restarted is not None
+    assert restarted.status == BackgroundTaskStatus.COMPLETED
+    status_events = [
+        event
+        for event in run_event_hub.events
+        if event.event_type == RunEventType.SUBAGENT_SESSION_STATUS_CHANGED
+    ]
+    assert [event.run_id for event in status_events] == [
+        subagent_run_id,
+        subagent_run_id,
+        subagent_run_id,
+        subagent_run_id,
+    ]
+    status_payloads = [json.loads(event.payload_json) for event in status_events]
+    assert [event["status"] for event in status_payloads] == [
+        BackgroundTaskStatus.RUNNING.value,
+        BackgroundTaskStatus.STOPPED.value,
+        BackgroundTaskStatus.RUNNING.value,
+        BackgroundTaskStatus.COMPLETED.value,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_child_stop_does_not_mark_parent_stop_candidate(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-sync-child-stop.db"
+    )
+    runtime_repo = RunRuntimeRepository(
+        tmp_path / "background-task-service-subagent-sync-child-stop.db"
+    )
+    gate = asyncio.Event()
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        ),
+        gate=gate,
+    )
+    run_control_manager = _FakeRunControlManager()
+    run_event_hub = _LoopGuardRunEventHub()
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=run_control_manager,
+        run_runtime_repo=runtime_repo,
+        run_event_hub=cast(RunEventHub, run_event_hub),
+    )
+
+    run_task = asyncio.create_task(
+        service.run_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            subagent_role_id="Crafter",
+            title="Investigate failures",
+            prompt="Inspect the failing tests and summarize the cause.",
+        )
+    )
+    while not run_control_manager.registered_run_ids:
+        await asyncio.sleep(0)
+    subagent_run_id = run_control_manager.registered_run_ids[0]
+    while not executor.calls:
+        await asyncio.sleep(0)
+
+    _ = run_control_manager.request_run_stop(subagent_run_id)
+    try:
+        _run_result = await run_task
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError(
+            f"Expected stopped subagent run cancellation, got {_run_result!r}"
+        )
+
+    persisted = repo.list_all()[0]
+    runtime = runtime_repo.get(subagent_run_id)
+    assert persisted.status == BackgroundTaskStatus.STOPPED
+    assert runtime is not None
+    assert runtime.status == RunRuntimeStatus.STOPPED
+    assert run_control_manager.unregistered_run_ids == [subagent_run_id]
+    status_events = [
+        event
+        for event in run_event_hub.events
+        if event.event_type == RunEventType.SUBAGENT_SESSION_STATUS_CHANGED
+    ]
+    status_payloads = [json.loads(event.payload_json) for event in status_events]
+    assert [event["status"] for event in status_payloads] == [
+        BackgroundTaskStatus.RUNNING.value,
+        BackgroundTaskStatus.STOPPED.value,
+    ]
+    assert status_payloads[-1]["run_id"] == subagent_run_id
+    assert status_payloads[-1]["parent_run_id"] == "run-1"
+    assert status_payloads[-1]["parent_stop_candidate"] is False
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_wait_for_subagent_run_preserves_temp_role_for_stopped_record(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-sync-temp-role-resume.db"
+    )
+    runtime_repo = RunRuntimeRepository(
+        tmp_path / "background-task-service-subagent-sync-temp-role-resume.db"
+    )
+    runtime_role_resolver = RuntimeRoleResolver(
+        role_registry=RoleRegistry(),
+        temporary_role_repository=TemporaryRoleRepository(
+            tmp_path / "temporary-roles-stop-resume.db"
+        ),
+    )
+    gate = asyncio.Event()
+    executor = _FakeTaskExecutionService(
+        result=TaskExecutionResult(
+            output="analysis complete",
+            completion_reason=RunCompletionReason.ASSISTANT_RESPONSE,
+        ),
+        gate=gate,
+        runtime_role_resolver=runtime_role_resolver,
+    )
+    run_control_manager = _FakeRunControlManager()
+    role = RoleDefinition(
+        role_id="skill_team_review_analyst_12345678",
+        name="Analyst",
+        description="Collects evidence.",
+        version="1",
+        mode=RoleMode.SUBAGENT,
+        tools=("read",),
+        system_prompt="Analyze.",
+    )
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        task_execution_service=executor,
+        agent_repo=_FakeAgentRepo(),
+        task_repo=_FakeTaskRepo(),
+        run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
+        run_control_manager=run_control_manager,
+        run_runtime_repo=runtime_repo,
+    )
+
+    run_task = asyncio.create_task(
+        service.run_subagent(
+            run_id="run-1",
+            session_id="session-1",
+            workspace_id="workspace-1",
+            subagent_role_id=role.role_id,
+            subagent_role=role,
+            title="Investigate failures",
+            prompt="Inspect the failing tests and summarize the cause.",
+        )
+    )
+    while not run_control_manager.registered_run_ids:
+        await asyncio.sleep(0)
+    subagent_run_id = run_control_manager.registered_run_ids[0]
+
+    run_task.cancel()
+    try:
+        _run_result = await run_task
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError(
+            f"Expected subagent run task cancellation, got {_run_result!r}"
+        )
+
+    cloned_role = runtime_role_resolver.get_temporary_role(
+        run_id=subagent_run_id,
+        role_id=role.role_id,
+    )
+    assert cloned_role.role_id == role.role_id
+
+    wait_task = asyncio.create_task(
+        service.wait_for_subagent_run(
+            parent_run_id="run-1",
+            subagent_run_id=subagent_run_id,
+        )
+    )
+    gate.set()
+    result = await wait_task
+
+    assert result.run_id == subagent_run_id
+    with pytest.raises(KeyError, match="Unknown temporary role"):
+        runtime_role_resolver.get_temporary_role(
+            run_id=subagent_run_id,
+            role_id=role.role_id,
+        )
+
+
+@pytest.mark.asyncio
 async def test_background_task_service_wait_for_subagent_run_recovers_persisted_sync_result(
     tmp_path: Path,
 ) -> None:
@@ -2328,20 +2662,40 @@ async def test_background_task_service_stop_for_run_stops_subagent(
     runtime_repo = RunRuntimeRepository(
         tmp_path / "background-task-service-subagent-stop.db"
     )
+    runtime_role_resolver = RuntimeRoleResolver(
+        role_registry=RoleRegistry(),
+        temporary_role_repository=TemporaryRoleRepository(
+            tmp_path / "temporary-roles-background-stop.db"
+        ),
+    )
     gate = asyncio.Event()
     executor = _FakeTaskExecutionService(
         result=TaskExecutionResult(output="should not finish"),
         gate=gate,
+        runtime_role_resolver=runtime_role_resolver,
+    )
+    run_event_hub = _LoopGuardRunEventHub()
+    hook_service = _CapturingHookService()
+    role = RoleDefinition(
+        role_id="skill_team_review_analyst_12345678",
+        name="Analyst",
+        description="Collects evidence.",
+        version="1",
+        mode=RoleMode.SUBAGENT,
+        tools=("read",),
+        system_prompt="Analyze.",
     )
     service = BackgroundTaskService(
         background_task_manager=None,
         repository=repo,
+        run_event_hub=cast(RunEventHub, run_event_hub),
         task_execution_service=executor,
         agent_repo=_FakeAgentRepo(),
         task_repo=_FakeTaskRepo(),
         run_intent_repo=_FakeRunIntentRepo(_parent_intent()),
         run_control_manager=_FakeRunControlManager(),
         run_runtime_repo=runtime_repo,
+        hook_service=cast(HookService, hook_service),
     )
 
     started = await service.start_subagent(
@@ -2352,9 +2706,15 @@ async def test_background_task_service_stop_for_run_stops_subagent(
         tool_call_id="call-1",
         workspace_id="workspace-1",
         cwd=Path("C:/workspace"),
-        subagent_role_id="Crafter",
+        subagent_role_id=role.role_id,
+        subagent_role=role,
         title="Investigate failures",
         prompt="Inspect the failing tests and summarize the cause.",
+    )
+    assert started.subagent_run_id is not None
+    _ = runtime_role_resolver.get_temporary_role(
+        run_id=started.subagent_run_id,
+        role_id=role.role_id,
     )
     stopped = await service.stop_for_run(
         run_id="run-1",
@@ -2370,6 +2730,85 @@ async def test_background_task_service_stop_for_run_stops_subagent(
     assert runtime is not None
     assert runtime.status == RunRuntimeStatus.STOPPED
     assert runtime.phase == RunRuntimePhase.IDLE
+    assert hook_service.cleared == [started.subagent_run_id]
+    status_payloads = [
+        json.loads(event.payload_json)
+        for event in run_event_hub.events
+        if event.event_type == RunEventType.SUBAGENT_SESSION_STATUS_CHANGED
+    ]
+    assert status_payloads[-1]["parent_stop_candidate"] is False
+    with pytest.raises(KeyError, match="Unknown temporary role"):
+        runtime_role_resolver.get_temporary_role(
+            run_id=started.subagent_run_id,
+            role_id=role.role_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_background_task_service_stop_for_run_synchronizes_persisted_subagent_without_runtime(
+    tmp_path: Path,
+) -> None:
+    repo = BackgroundTaskRepository(
+        tmp_path / "background-task-service-subagent-persisted-stop.db"
+    )
+    runtime_repo = RunRuntimeRepository(
+        tmp_path / "background-task-service-subagent-persisted-stop.db"
+    )
+    agent_repo = _FakeAgentRepo()
+    task_repo = _FakeTaskRepo()
+    record = repo.upsert(
+        _build_record(
+            background_task_id="background-subagent-1",
+            status=BackgroundTaskStatus.RUNNING,
+        ).model_copy(
+            update={
+                "kind": BackgroundTaskKind.SUBAGENT,
+                "title": "Investigate failures",
+                "input_text": "Inspect the failing tests.",
+                "command": "subagent:Crafter",
+                "subagent_role_id": "Crafter",
+                "subagent_run_id": "subagent_run_persisted",
+                "subagent_task_id": "task-subagent-1",
+                "subagent_instance_id": "inst-subagent-1",
+            }
+        )
+    )
+    _ = runtime_repo.ensure(
+        run_id="subagent_run_persisted",
+        session_id="session-1",
+        root_task_id="task-subagent-1",
+        status=RunRuntimeStatus.RUNNING,
+        phase=RunRuntimePhase.SUBAGENT_RUNNING,
+    )
+    service = BackgroundTaskService(
+        background_task_manager=None,
+        repository=repo,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        run_control_manager=_FakeRunControlManager(),
+        run_runtime_repo=runtime_repo,
+    )
+
+    stopped = await service.stop_for_run(
+        run_id=record.run_id,
+        background_task_id=record.background_task_id,
+    )
+
+    runtime = runtime_repo.get("subagent_run_persisted")
+    assert stopped.status == BackgroundTaskStatus.STOPPED
+    assert runtime is not None
+    assert runtime.status == RunRuntimeStatus.STOPPED
+    assert task_repo.status_updates[-1] == {
+        "task_id": "task-subagent-1",
+        "status": TaskStatus.STOPPED,
+        "assigned_instance_id": "inst-subagent-1",
+        "result": None,
+        "error_message": "Task stopped by user",
+    }
+    assert agent_repo.status_updates[-1] == {
+        "instance_id": "inst-subagent-1",
+        "status": InstanceStatus.STOPPED,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_run_control_manager.py
+++ b/tests/unit_tests/sessions/runs/test_run_control_manager.py
@@ -901,6 +901,8 @@ def test_resume_subagent_with_message_uses_same_instance_after_restart(
     task_record = task_repo.get("task-1")
     assert task_record.status == TaskStatus.ASSIGNED
     assert task_record.assigned_instance_id == "inst-1"
+    agent_record = agent_repo.get_instance("inst-1")
+    assert agent_record.status == InstanceStatus.RUNNING
     runtime = run_runtime_repo.get("run-1")
     assert runtime is not None
     assert runtime.phase == RunRuntimePhase.SUBAGENT_RUNNING

--- a/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
+++ b/tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
@@ -709,6 +709,125 @@ def test_build_session_rounds_projects_missing_tool_pairs_from_events(
     assert parts[3]["is_error"] is True
 
 
+def test_build_session_rounds_projects_stopped_spawn_subagent_call_without_result(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "rounds_projection_stopped_spawn_subagent_call.db"
+    session_id = "session-1"
+    run_id = "run-1"
+    coordinator_instance_id = "inst-coordinator-1"
+
+    task_repo = TaskRepository(db_path)
+    agent_repo = AgentInstanceRepository(db_path)
+    run_runtime_repo = RunRuntimeRepository(db_path)
+
+    _ = task_repo.create(
+        TaskEnvelope(
+            task_id="task-root",
+            session_id=session_id,
+            parent_task_id=None,
+            trace_id=run_id,
+            role_id="Coordinator",
+            objective="call a subagent then stop",
+            verification=VerificationPlan(checklist=("non_empty_response",)),
+        )
+    )
+    agent_repo.upsert_instance(
+        run_id=run_id,
+        trace_id=run_id,
+        session_id=session_id,
+        instance_id=coordinator_instance_id,
+        role_id="Coordinator",
+        workspace_id="default",
+        status=InstanceStatus.STOPPED,
+    )
+    run_runtime_repo.ensure(
+        run_id=run_id,
+        session_id=session_id,
+        root_task_id="task-root",
+    )
+
+    events: list[dict[str, object]] = [
+        {
+            "trace_id": run_id,
+            "run_id": run_id,
+            "task_id": "task-root",
+            "event_type": RunEventType.TOOL_CALL.value,
+            "occurred_at": "2026-05-09T10:00:00+00:00",
+            "payload_json": json.dumps(
+                {
+                    "run_id": run_id,
+                    "tool_name": "spawn_subagent",
+                    "tool_call_id": "call-subagent",
+                    "args": {
+                        "role_id": "Explorer",
+                        "description": "Inspect the issue",
+                        "prompt": "Find the cause.",
+                        "background": False,
+                    },
+                    "role_id": "Coordinator",
+                    "instance_id": coordinator_instance_id,
+                }
+            ),
+        },
+        {
+            "trace_id": run_id,
+            "run_id": run_id,
+            "task_id": "task-root",
+            "event_type": RunEventType.TOOL_CALL.value,
+            "occurred_at": "2026-05-09T10:00:01+00:00",
+            "payload_json": json.dumps(
+                {
+                    "run_id": run_id,
+                    "tool_name": "shell",
+                    "tool_call_id": "call-shell",
+                    "args": {"command": "pwd"},
+                    "role_id": "Coordinator",
+                    "instance_id": coordinator_instance_id,
+                }
+            ),
+        },
+        {
+            "trace_id": run_id,
+            "run_id": run_id,
+            "task_id": "task-root",
+            "event_type": RunEventType.RUN_STOPPED.value,
+            "occurred_at": "2026-05-09T10:00:02+00:00",
+            "payload_json": json.dumps({"reason": "stopped_by_user"}),
+        },
+    ]
+
+    rounds = build_session_rounds(
+        session_id=session_id,
+        agent_repo=agent_repo,
+        task_repo=task_repo,
+        approval_tickets_by_run={},
+        run_runtime_repo=run_runtime_repo,
+        get_session_messages=lambda _session_id: [],
+        get_session_events=lambda _session_id: events,
+    )
+
+    round_item = next(item for item in rounds if item["run_id"] == run_id)
+    coordinator_messages = cast(
+        list[dict[str, object]], round_item["coordinator_messages"]
+    )
+    parts = [
+        cast(
+            dict[str, object],
+            cast(
+                list[dict[str, object]],
+                cast(dict[str, object], message["message"])["parts"],
+            )[0],
+        )
+        for message in coordinator_messages
+    ]
+
+    assert [part["part_kind"] for part in parts] == ["tool-call"]
+    assert parts[0]["tool_name"] == "spawn_subagent"
+    assert parts[0]["tool_call_id"] == "call-subagent"
+    assert cast(dict[str, object], parts[0]["args"])["role_id"] == "Explorer"
+
+
 def test_build_session_rounds_keeps_event_tool_pairs_scoped_by_run(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Centralize subagent lifecycle transitions for stop/resume/completion paths and persisted recovery fallback.
- Keep frontend normal-mode subagent sessions in sync when parent runs stop or resume, including active subagent pages and unloaded subagent lists.
- Preserve stopped-run subagent tool-call projection so the main conversation still shows subagent invocation context after cancellation.
- Keep parent-stop markers from leaking into later fresh runs, and defer stopped subagent temporary-role cleanup until the subagent reaches a true terminal state.

## Validation

```bash
uv run --extra dev pytest tests/unit_tests/frontend/test_subagent_streams_ui.py tests/unit_tests/frontend/test_subagent_sessions_ui.py tests/unit_tests/frontend/test_run_events_ui.py tests/unit_tests/sessions/runs/background_tasks/test_service.py tests/unit_tests/sessions/runs/test_run_control_manager.py tests/unit_tests/sessions/test_rounds_projection_message_role_fallback.py
```

Result: 135 passed.

Spec-compliance changed-file check for `src/relay_teams/sessions/runs/subagent_lifecycle.py`: passed.

Closes #751