### PR TITLE
Deliver system reminders to external runtimes

### DIFF
--- a/docs/modules/agent-runtimes/architecture.md
+++ b/docs/modules/agent-runtimes/architecture.md
@@ -92,6 +92,26 @@ runtime instances inside a Relay Teams run.
 Both live under `agent_runtimes` so orchestration no longer owns a separate A2A
 implementation.
 
+## System Reminder Delivery
+
+External runtimes participate in the same system-reminder delivery contract as
+the built-in provider runtime, but they do not own reminder policy.
+
+`sessions/runs/system_injection.py` owns reminder queue filtering, classifier
+disposition, redacted run events, and conversation-history persistence through
+`SystemInjectionConsumer`. `agent_runtimes.provider` only invokes that consumer
+before composing ACP, A2A, or CLI prompts. This lets queued startup reminders
+become the latest user prompt without teaching each protocol adapter how to
+classify or persist reminder messages.
+
+ACP host tools have one additional boundary. After a hosted Relay Teams tool
+returns, `agent_runtimes.host_tool_bridge` asks the same consumer for any
+boundary reminders addressed to the active runtime instance. If reminders are
+applied, the bridge preserves the original tool return value and appends the
+rendered reminder text to the tool result content. The external ACP agent then
+sees the guidance next to the host tool result, while reminder state, event
+redaction, and history writes remain centralized in sessions/runs.
+
 ## Complexity Guardrails
 
 - Do not introduce another planner or orchestration framework inside

--- a/docs/modules/prompt/system-prompt-layering.md
+++ b/docs/modules/prompt/system-prompt-layering.md
@@ -41,6 +41,10 @@
 这些消息进入会话历史或注入队列，由模型在下一次安全边界看到。这样可以避免为了短期
 运行时状态重写稳定 system prompt，同时保留完整的时间线可观测性。
 
+外部 ACP runtime 会把 role prompt 和 host-tool guidance 组装成 prompt 文本的稳定前缀，
+再把当前任务消息放在 `## User Prompt` 后面。启动边界消费到的 `<system-reminder>` 只会
+成为 `## User Prompt` 内容，不得插入 `## Role Prompt` 或 host-tool guidance 之间。
+
 ## 稳定前缀规则
 
 为了保护 KV cache，下面内容不得因为 workspace、SSH profile、日期或 run 状态改变而移动或重写：

--- a/docs/modules/reminders/system-reminders-design.md
+++ b/docs/modules/reminders/system-reminders-design.md
@@ -72,8 +72,43 @@ reminder contract:
 - `enqueue_only` wakes an already-active loop at the next safe boundary.
 - `append_and_enqueue` also persists the reminder into conversation history before
   retrying a completion attempt.
+- `SystemInjectionConsumer` drains queued internal system reminders, applies the
+  injection classifier, emits redacted `INJECTION_APPLIED` events, and persists
+  applied reminders into conversation history when a message repository is
+  available.
 
-## 4. V1 Policies
+The consumer is intentionally owned by `sessions/runs` instead of provider or
+external runtime modules. Runtime adapters may choose the safe moment to call it,
+but they do not own reminder policy, marker detection, queue filtering, event
+redaction, or history persistence.
+
+## 4. Delivery Boundaries
+
+Built-in local provider execution and external agent runtimes consume the same
+queued reminder primitive at protocol-safe boundaries.
+
+Local provider execution:
+
+- drains startup reminders before building the next prompt turn
+- drains boundary reminders after tool execution and before the next model step
+- applies final-answer classification so guidance reminders can be discarded once
+  an answer is already ready
+
+External ACP, A2A, and CLI runtimes:
+
+- drain startup reminders before prompt composition so a queued
+  `<system-reminder>` becomes the latest conversation user prompt
+- include every applied startup reminder in the outbound prompt text when more
+  than one reminder is drained at the same prompt boundary
+- keep non-reminder injections queued for the normal user follow-up path
+
+External ACP host tools also drain boundary reminders after the hosted Relay
+Teams tool finishes. The bridge returns the original structured tool result and
+adds the rendered reminder text to the tool result content so the external ACP
+agent sees the guidance immediately after the host tool response. This keeps
+tool execution, reminder policy, and ACP protocol formatting separated.
+
+## 5. V1 Policies
 
 Tool failure:
 
@@ -105,14 +140,14 @@ Context pressure:
 - triggered after compaction is applied
 - reminds the agent that old tool output may no longer be available verbatim
 
-## 5. Public Interfaces
+## 6. Public Interfaces
 
 No new `/api/*`, CLI, SDK, or database schema is introduced.
 
 Reminder state is stored through `SharedStateRepository` with run-scoped keys under
 the session scope. The schema is private to `relay_teams.reminders`.
 
-## 6. Testing
+## 7. Testing
 
 The feature is covered by focused unit tests for:
 
@@ -121,4 +156,7 @@ The feature is covered by focused unit tests for:
 - persisted reminder state recovery
 - service-to-injection behavior
 - shared system injection sink behavior
+- shared system injection consumer behavior
+- external runtime prompt-start reminder delivery
+- external ACP host-tool boundary reminder delivery
 - root task retry when incomplete todos block completion

--- a/src/relay_teams/agent_runtimes/host_tool_bridge.py
+++ b/src/relay_teams/agent_runtimes/host_tool_bridge.py
@@ -51,6 +51,7 @@ from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
+from relay_teams.sessions.runs.system_injection import SystemInjectionConsumer
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
@@ -531,10 +532,38 @@ class ExternalAcpHostToolBridge:
             )
             if inspect.isawaitable(validation_result):
                 _ = await validation_result
-        return await tool.function_schema.call(
+        result = await tool.function_schema.call(
             dict(validated_arguments),
             ctx,
         )
+        reminder_content = await self._apply_tool_boundary_system_reminders(request)
+        return _append_system_reminder_content(result, reminder_content)
+
+    async def _apply_tool_boundary_system_reminders(
+        self,
+        request: LLMRequest,
+    ) -> tuple[str, ...]:
+        injection_manager = getattr(self, "_injection_manager", None)
+        if not isinstance(injection_manager, RunInjectionManager):
+            return ()
+        consumer = SystemInjectionConsumer(
+            injection_manager=injection_manager,
+            run_event_hub=self._run_event_hub,
+            message_repo=self._message_repo,
+        )
+        applied = await consumer.apply_boundary_system_reminders_async(
+            session_id=request.session_id,
+            run_id=request.run_id,
+            trace_id=request.trace_id,
+            task_id=request.task_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            workspace_id=request.workspace_id,
+            conversation_id=request.conversation_id
+            or build_conversation_id(request.session_id, request.role_id),
+            restart_scope="external_host_tool_boundary",
+        )
+        return applied.content
 
     async def _build_tool_deps_async(self, *, request: LLMRequest) -> ToolDeps:
         resolved_conversation_id = request.conversation_id or build_conversation_id(
@@ -620,6 +649,38 @@ class ExternalAcpHostToolBridge:
         if model_config is None:
             return ModelCapabilities()
         return model_config.capabilities
+
+
+def _append_system_reminder_content(
+    result: object,
+    reminder_content: tuple[str, ...],
+) -> object:
+    reminder_text = "\n\n".join(
+        text for text in reminder_content if text.strip()
+    ).strip()
+    if not reminder_text:
+        return result
+    if isinstance(result, ToolReturn):
+        return ToolReturn(
+            return_value=result.return_value,
+            content=_merge_tool_return_content(result.content, reminder_text),
+            metadata=result.metadata,
+        )
+    return ToolReturn(return_value=result, content=reminder_text)
+
+
+def _merge_tool_return_content(
+    content: str | Sequence[UserContent] | None,
+    reminder_text: str,
+) -> str | tuple[UserContent, ...]:
+    if content is None:
+        return reminder_text
+    if isinstance(content, str):
+        existing = content.rstrip()
+        if not existing:
+            return reminder_text
+        return f"{existing}\n\n{reminder_text}"
+    return *content, reminder_text
 
 
 class _HostedFastMcpTool(FastMcpTool):

--- a/src/relay_teams/agent_runtimes/provider.py
+++ b/src/relay_teams/agent_runtimes/provider.py
@@ -65,12 +65,14 @@ from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.sessions.runs.enums import RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
+from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_models import RunEvent
+from relay_teams.sessions.runs.system_injection import SystemInjectionConsumer
 from relay_teams.tools.runtime.context import (
     GatewaySessionLookupLike,
     XiaolubanNotifyServiceLike,
 )
-from relay_teams.workspace import WorkspaceManager
+from relay_teams.workspace import WorkspaceManager, build_conversation_id
 
 if TYPE_CHECKING:
     from relay_teams.agents.execution.message_repository import MessageRepository
@@ -91,7 +93,6 @@ if TYPE_CHECKING:
     from relay_teams.roles.role_registry import RoleRegistry
     from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
     from relay_teams.sessions.runs.event_log import EventLog
-    from relay_teams.sessions.runs.injection_queue import RunInjectionManager
     from relay_teams.sessions.runs.run_control_manager import RunControlManager
     from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
     from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
@@ -269,24 +270,38 @@ class AgentRuntimeSessionManager:
         async with lock:
             agent = self._config_service.resolve_runtime_agent(agent_id)
             if agent.protocol == ExternalAgentProtocol.A2A:
+                prompt_start_content = await self._apply_prompt_start_system_reminders(
+                    request
+                )
                 return await self._prompt_a2a(
                     agent=agent,
                     role=role,
                     request=request,
+                    prompt_start_content=prompt_start_content,
                 )
             if agent.protocol == ExternalAgentProtocol.CLI:
+                prompt_start_content = await self._apply_prompt_start_system_reminders(
+                    request
+                )
                 return await self._prompt_cli(
                     agent=agent,
                     role=role,
                     request=request,
+                    prompt_start_content=prompt_start_content,
                 )
+            prompt_start_content = await self._apply_prompt_start_system_reminders(
+                request
+            )
             handle = await self._ensure_conversation(
                 key=key,
                 agent=agent,
                 role=role,
                 request=request,
             )
-            prompt_text = self._resolve_external_user_prompt(request)
+            prompt_text = self._resolve_external_user_prompt(
+                request,
+                prompt_start_content=prompt_start_content,
+            )
             state = _ActivePromptState(request=request)
             handle.active_prompt = state
             handle.host_tool_bridge.bind_active_request(request)
@@ -370,14 +385,41 @@ class AgentRuntimeSessionManager:
                 )
             return output
 
+    async def _apply_prompt_start_system_reminders(
+        self, request: LLMRequest
+    ) -> tuple[str, ...]:
+        if not isinstance(self._injection_manager, RunInjectionManager):
+            return ()
+        consumer = SystemInjectionConsumer(
+            injection_manager=self._injection_manager,
+            run_event_hub=self._run_event_hub,
+            message_repo=self._message_repo,
+        )
+        applied = await consumer.apply_startup_system_reminders_async(
+            session_id=request.session_id,
+            run_id=request.run_id,
+            trace_id=request.trace_id,
+            task_id=request.task_id,
+            instance_id=request.instance_id,
+            role_id=request.role_id,
+            workspace_id=request.workspace_id,
+            conversation_id=_resolved_conversation_id(request),
+            restart_scope="external_prompt_start",
+        )
+        return applied.content
+
     async def _prompt_a2a(
         self,
         *,
         agent: ExternalAgentConfig,
         role: RoleDefinition,
         request: LLMRequest,
+        prompt_start_content: tuple[str, ...],
     ) -> str:
-        prompt_text = self._resolve_external_user_prompt(request)
+        prompt_text = self._resolve_external_user_prompt(
+            request,
+            prompt_start_content=prompt_start_content,
+        )
         workspace = await self._resolve_workspace_async(request)
         workspace_path = workspace.resolve_workdir()
 
@@ -424,8 +466,12 @@ class AgentRuntimeSessionManager:
         agent: ExternalAgentConfig,
         role: RoleDefinition,
         request: LLMRequest,
+        prompt_start_content: tuple[str, ...],
     ) -> str:
-        prompt_text = self._resolve_external_user_prompt(request)
+        prompt_text = self._resolve_external_user_prompt(
+            request,
+            prompt_start_content=prompt_start_content,
+        )
         workspace = await self._resolve_workspace_async(request)
         workspace_path = workspace.resolve_workdir()
 
@@ -1294,10 +1340,20 @@ class AgentRuntimeSessionManager:
             ),
         )
 
-    def _resolve_external_user_prompt(self, request: LLMRequest) -> str:
+    def _resolve_external_user_prompt(
+        self,
+        request: LLMRequest,
+        *,
+        prompt_start_content: tuple[str, ...] = (),
+    ) -> str:
+        prompt_start_text = "\n\n".join(
+            text.strip() for text in prompt_start_content if text.strip()
+        ).strip()
+        if prompt_start_text:
+            return prompt_start_text
         prompt_text = _extract_latest_user_prompt(
             self._message_repo.get_history_for_conversation_task(
-                request.conversation_id,
+                _resolved_conversation_id(request),
                 request.task_id,
             )
         )
@@ -1318,7 +1374,7 @@ class AgentRuntimeSessionManager:
         self._message_repo.append(
             session_id=request.session_id,
             workspace_id=request.workspace_id,
-            conversation_id=request.conversation_id,
+            conversation_id=_resolved_conversation_id(request),
             agent_role_id=request.role_id,
             instance_id=request.instance_id,
             task_id=request.task_id,
@@ -1393,6 +1449,13 @@ class _ActivePromptState:
 
 def _conversation_key(*, session_id: str, role_id: str, agent_id: str) -> str:
     return f"{session_id}:{role_id}:{agent_id}"
+
+
+def _resolved_conversation_id(request: LLMRequest) -> str:
+    return request.conversation_id or build_conversation_id(
+        request.session_id,
+        request.role_id,
+    )
 
 
 def _is_opencode_agent(agent: ExternalAgentConfig) -> bool:
@@ -1941,6 +2004,23 @@ def _compose_external_prompt(
     user_prompt: str,
     include_host_tool_guidance: bool,
 ) -> str:
+    stable_prefix = _compose_external_prompt_stable_prefix(
+        system_prompt=system_prompt,
+        include_host_tool_guidance=include_host_tool_guidance,
+    )
+    return "\n\n".join(
+        (
+            stable_prefix,
+            f"## User Prompt\n{user_prompt.strip()}",
+        )
+    )
+
+
+def _compose_external_prompt_stable_prefix(
+    *,
+    system_prompt: str,
+    include_host_tool_guidance: bool,
+) -> str:
     sections = [
         f"## Role Prompt\n{system_prompt.strip()}",
     ]
@@ -1951,7 +2031,6 @@ def _compose_external_prompt(
             "tasks, approvals, or skills, prefer the `agent_teams_*` host tools "
             "over similarly named native tools."
         )
-    sections.append(f"## User Prompt\n{user_prompt.strip()}")
     return "\n\n".join(section for section in sections if section.strip())
 
 

--- a/src/relay_teams/sessions/runs/injection_queue.py
+++ b/src/relay_teams/sessions/runs/injection_queue.py
@@ -152,6 +152,16 @@ class RunInjectionManager:
     def drain_system_reminders_at_start(
         self, run_id: str, recipient_instance_id: str
     ) -> tuple[InjectionMessage, ...]:
+        return self._drain_system_reminders(run_id, recipient_instance_id)
+
+    def drain_system_reminders_at_boundary(
+        self, run_id: str, recipient_instance_id: str
+    ) -> tuple[InjectionMessage, ...]:
+        return self._drain_system_reminders(run_id, recipient_instance_id)
+
+    def _drain_system_reminders(
+        self, run_id: str, recipient_instance_id: str
+    ) -> tuple[InjectionMessage, ...]:
         with self._lock:
             queue = self._queues.get(run_id, {}).get(recipient_instance_id, [])
             if not queue:

--- a/src/relay_teams/sessions/runs/system_injection.py
+++ b/src/relay_teams/sessions/runs/system_injection.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+from json import dumps, loads
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, JsonValue
 
 from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.media import user_prompt_content_to_text
 from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.event_stream import RunEventHub, publish_run_event_async
 from relay_teams.sessions.runs.injection_classification import (
+    INJECTION_CLASSIFIER,
+    InjectionBoundaryContext,
+    InjectionDisposition,
     public_injection_payload_json,
 )
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
@@ -372,3 +377,181 @@ class SystemInjectionSink:
             ),
         )
         return record
+
+
+class AppliedSystemInjection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    messages: tuple[InjectionMessage, ...] = ()
+    content: tuple[str, ...] = ()
+
+    @property
+    def applied(self) -> bool:
+        return bool(self.messages)
+
+
+class SystemInjectionConsumer:
+    def __init__(
+        self,
+        *,
+        injection_manager: RunInjectionManager,
+        run_event_hub: RunEventHub,
+        message_repo: MessageRepository | None = None,
+    ) -> None:
+        self._injection_manager = injection_manager
+        self._run_event_hub = run_event_hub
+        self._message_repo = message_repo
+
+    async def apply_startup_system_reminders_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        restart_scope: str,
+    ) -> AppliedSystemInjection:
+        messages = self._injection_manager.drain_system_reminders_at_start(
+            run_id,
+            instance_id,
+        )
+        return await self._apply_messages_async(
+            messages=messages,
+            session_id=session_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            restart_scope=restart_scope,
+            final_answer_ready=False,
+        )
+
+    async def apply_boundary_system_reminders_async(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        restart_scope: str,
+        final_answer_ready: bool = False,
+    ) -> AppliedSystemInjection:
+        messages = self._injection_manager.drain_system_reminders_at_boundary(
+            run_id,
+            instance_id,
+        )
+        return await self._apply_messages_async(
+            messages=messages,
+            session_id=session_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            task_id=task_id,
+            instance_id=instance_id,
+            role_id=role_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            restart_scope=restart_scope,
+            final_answer_ready=final_answer_ready,
+        )
+
+    async def _apply_messages_async(
+        self,
+        *,
+        messages: tuple[InjectionMessage, ...],
+        session_id: str,
+        run_id: str,
+        trace_id: str,
+        task_id: str,
+        instance_id: str,
+        role_id: str,
+        workspace_id: str,
+        conversation_id: str,
+        restart_scope: str,
+        final_answer_ready: bool,
+    ) -> AppliedSystemInjection:
+        if not messages:
+            return AppliedSystemInjection()
+        boundary_context = InjectionBoundaryContext(
+            final_answer_ready=final_answer_ready,
+        )
+        applied = tuple(
+            message
+            for message in messages
+            if INJECTION_CLASSIFIER.disposition(
+                message,
+                context=boundary_context,
+            )
+            == InjectionDisposition.APPLY
+        )
+        if not applied:
+            return AppliedSystemInjection()
+        content: list[str] = []
+        for message in applied:
+            await publish_run_event_async(
+                self._run_event_hub,
+                RunEvent(
+                    session_id=session_id,
+                    run_id=run_id,
+                    trace_id=trace_id,
+                    task_id=task_id,
+                    instance_id=instance_id,
+                    role_id=role_id,
+                    event_type=RunEventType.INJECTION_APPLIED,
+                    payload_json=_applied_injection_payload_json(
+                        message,
+                        restart_scope=restart_scope,
+                    ),
+                ),
+            )
+            if self._message_repo is not None:
+                _ = await self._message_repo.append_user_prompt_if_missing_async(
+                    session_id=session_id,
+                    workspace_id=workspace_id,
+                    conversation_id=conversation_id,
+                    agent_role_id=role_id,
+                    instance_id=instance_id,
+                    task_id=task_id,
+                    trace_id=trace_id,
+                    content=message.content,
+                )
+            text = user_prompt_content_to_text(message.content).strip()
+            if text:
+                content.append(text)
+        return AppliedSystemInjection(messages=applied, content=tuple(content))
+
+
+def _applied_injection_payload_json(
+    message: InjectionMessage,
+    *,
+    restart_scope: str,
+) -> str:
+    raw_payload = loads(public_injection_payload_json(message))
+    payload = (
+        {str(key): value for key, value in raw_payload.items()}
+        if isinstance(raw_payload, dict)
+        else {}
+    )
+    payload["interrupted_current_step"] = False
+    payload["restart_scope"] = restart_scope
+    payload["supersedes_pending_tool_calls"] = False
+    payload["applied_injection_ids"] = [message.injection_id]
+    return dumps(_json_payload(payload), ensure_ascii=False)
+
+
+def _json_payload(payload: dict[str, object]) -> dict[str, JsonValue]:
+    return {
+        key: value
+        for key, value in payload.items()
+        if isinstance(value, str | int | float | bool | list | dict) or value is None
+    }

--- a/tests/unit_tests/agent_runtimes/test_host_tool_bridge.py
+++ b/tests/unit_tests/agent_runtimes/test_host_tool_bridge.py
@@ -16,7 +16,13 @@ from relay_teams.providers.model_config import (
     ProviderType,
 )
 from relay_teams.providers.provider_contracts import LLMRequest
+from relay_teams.reminders import render_system_reminder
+from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 from relay_teams.roles.role_models import RoleDefinition
+from relay_teams.sessions.runs.enums import InjectionSource
+from relay_teams.sessions.runs.event_stream import RunEventHub
+from relay_teams.sessions.runs.injection_queue import RunInjectionManager
+from relay_teams.sessions.runs.run_models import RunEvent
 
 
 class _PublicTool:
@@ -43,6 +49,27 @@ class _MissingRunIntentRepo:
 class _FakeToolApprovalPolicy:
     def with_yolo(self, _yolo: bool) -> "_FakeToolApprovalPolicy":
         return self
+
+
+class _CapturingRunEventHub:
+    def __init__(self) -> None:
+        self.events: list[RunEvent] = []
+
+    def publish(self, event: RunEvent) -> int:
+        self.events.append(event)
+        return 0
+
+
+class _FakeMessageRepo:
+    def __init__(self) -> None:
+        self.appended_user_prompts: list[dict[str, object]] = []
+
+    async def append_user_prompt_if_missing_async(
+        self,
+        **kwargs: object,
+    ) -> bool:
+        self.appended_user_prompts.append(kwargs)
+        return True
 
 
 class _FakeWorkspaceManager:
@@ -504,6 +531,171 @@ async def test_run_hosted_tool_invokes_async_args_validator(
         "items": ["one"],
         "flag": True,
     }
+
+
+@pytest.mark.asyncio
+async def test_run_hosted_tool_appends_boundary_system_reminder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = LLMRequest(
+        run_id="run-1",
+        trace_id="trace-1",
+        task_id="task-1",
+        session_id="session-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        instance_id="instance-1",
+        role_id="main-agent",
+        system_prompt="system",
+        user_prompt="hello",
+    )
+    role = RoleDefinition(
+        role_id="main-agent",
+        name="Main Agent",
+        description="Handles ACP prompts",
+        version="1.0.0",
+        system_prompt="You are a helpful assistant.",
+    )
+    function_schema = _FakeFunctionSchema()
+    tool = cast(
+        host_tool_bridge_module.PydanticTool[host_tool_bridge_module.ToolDeps],
+        _FakeRuntimeTool(function_schema),
+    )
+    definition = host_tool_bridge_module.HostedToolDefinition(
+        source="builtin",
+        exposed_name="agent_teams_builtin_sample",
+        raw_name="sample",
+        description="Sample tool",
+        input_schema={},
+        tool=tool,
+    )
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    reminder = render_system_reminder("Inspect the tool failure before continuing.")
+    _ = injection_manager.enqueue(
+        "run-1",
+        "instance-1",
+        InjectionSource.SYSTEM,
+        reminder,
+        visibility="internal",
+        internal_kind="tool_failure",
+        internal_delivery_mode=SystemReminderDeliveryMode.GUIDANCE.value,
+        internal_issue_key="tool_failure:sample:tool_error",
+    )
+    event_hub = _CapturingRunEventHub()
+    message_repo = _FakeMessageRepo()
+    bridge = object.__new__(host_tool_bridge_module.ExternalAcpHostToolBridge)
+    bridge.__dict__.update(
+        {
+            "_active_request": request,
+            "_role": role,
+            "_context_model": cast(host_tool_bridge_module.Model, object()),
+            "_injection_manager": injection_manager,
+            "_run_event_hub": cast(RunEventHub, event_hub),
+            "_message_repo": message_repo,
+        }
+    )
+
+    async def fake_build_tool_deps_async(
+        *,
+        request: LLMRequest,
+    ) -> host_tool_bridge_module.ToolDeps:
+        _ = request
+        return cast(host_tool_bridge_module.ToolDeps, object())
+
+    monkeypatch.setattr(
+        bridge,
+        "_build_tool_deps_async",
+        fake_build_tool_deps_async,
+    )
+
+    result = await bridge.run_hosted_tool(
+        definition=definition,
+        arguments={"value": "input"},
+    )
+
+    assert isinstance(result, ToolReturn)
+    assert result.return_value == {"called": "input"}
+    assert result.content == reminder
+    assert message_repo.appended_user_prompts[0]["content"] == reminder
+    assert "Inspect the tool failure" not in event_hub.events[0].payload_json
+    assert (
+        injection_manager.drain_system_reminders_at_boundary("run-1", "instance-1")
+        == ()
+    )
+
+
+def test_append_system_reminder_content_preserves_existing_tool_return() -> None:
+    result = ToolReturn(
+        return_value={"called": "input"},
+        content="existing output",
+        metadata={"source": "tool"},
+    )
+
+    merged = host_tool_bridge_module._append_system_reminder_content(
+        result,
+        ("Inspect the tool failure before continuing.",),
+    )
+
+    assert isinstance(merged, ToolReturn)
+    assert merged.return_value == {"called": "input"}
+    assert merged.content == (
+        "existing output\n\nInspect the tool failure before continuing."
+    )
+    assert merged.metadata == {"source": "tool"}
+
+
+def test_append_system_reminder_content_handles_empty_tool_return_content() -> None:
+    result = ToolReturn(return_value={"called": "input"}, content="")
+
+    merged = host_tool_bridge_module._append_system_reminder_content(
+        result,
+        ("Inspect the tool failure before continuing.",),
+    )
+
+    assert isinstance(merged, ToolReturn)
+    assert merged.return_value == {"called": "input"}
+    assert merged.content == "Inspect the tool failure before continuing."
+
+
+def test_append_system_reminder_content_handles_missing_tool_return_content() -> None:
+    result = ToolReturn(return_value={"called": "input"}, content=None)
+
+    merged = host_tool_bridge_module._append_system_reminder_content(
+        result,
+        ("Inspect the tool failure before continuing.",),
+    )
+
+    assert isinstance(merged, ToolReturn)
+    assert merged.return_value == {"called": "input"}
+    assert merged.content == "Inspect the tool failure before continuing."
+
+
+def test_append_system_reminder_content_handles_sequence_tool_return_content() -> None:
+    result = ToolReturn(return_value={"called": "input"}, content=("existing output",))
+
+    merged = host_tool_bridge_module._append_system_reminder_content(
+        result,
+        ("Inspect the tool failure before continuing.",),
+    )
+
+    assert isinstance(merged, ToolReturn)
+    assert merged.return_value == {"called": "input"}
+    assert merged.content == (
+        "existing output",
+        "Inspect the tool failure before continuing.",
+    )
+
+
+def test_append_system_reminder_content_returns_original_without_reminder() -> None:
+    result = {"called": "input"}
+
+    merged = host_tool_bridge_module._append_system_reminder_content(
+        result,
+        ("   ",),
+    )
+
+    assert merged is result
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agent_runtimes/test_provider.py
+++ b/tests/unit_tests/agent_runtimes/test_provider.py
@@ -51,15 +51,18 @@ from relay_teams.providers.model_config import (
     SamplingConfig,
 )
 from relay_teams.providers.provider_contracts import LLMRequest
+from relay_teams.reminders import render_system_reminder
+from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
-from relay_teams.sessions.runs.enums import RunEventType
+from relay_teams.sessions.runs.enums import InjectionSource, RunEventType
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
+from relay_teams.sessions.runs.run_models import RunEvent
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.skills.skill_registry import SkillRegistry
 from relay_teams.gateway.im.service import ImToolService
@@ -67,7 +70,8 @@ from relay_teams.tools.registry import ToolRegistry
 from relay_teams.tools.runtime.approval_state import ToolApprovalManager
 from relay_teams.tools.runtime.policy import ToolApprovalPolicy
 from relay_teams.tools.runtime.approval_ticket_repo import ApprovalTicketRepository
-from relay_teams.workspace import WorkspaceManager
+from relay_teams.media import UserPromptContent
+from relay_teams.workspace import WorkspaceManager, build_conversation_id
 
 _ActivePromptState = provider_module._ActivePromptState
 _annotate_external_computer_tool_result = (
@@ -136,6 +140,25 @@ class _FakeMessageRepo:
 
     def append(self, **kwargs: object) -> None:
         self.append_calls.append(kwargs)
+
+    async def append_user_prompt_if_missing_async(
+        self,
+        *,
+        content: UserPromptContent,
+        **kwargs: object,
+    ) -> bool:
+        self.append_calls.append({"content": content, **kwargs})
+        self._history.append(ModelRequest(parts=[UserPromptPart(content=content)]))
+        return True
+
+
+class _CapturingRunEventHub:
+    def __init__(self) -> None:
+        self.events: list[RunEvent] = []
+
+    def publish(self, event: RunEvent) -> int:
+        self.events.append(event)
+        return 0
 
 
 class _FakeWorkspaceHandle:
@@ -519,23 +542,27 @@ def _build_manager(
     config_dir: Path,
     tool_approval_policy: ToolApprovalPolicy | None = None,
     agent: ExternalAgentConfig | None = None,
+    injection_manager: RunInjectionManager | None = None,
+    message_repo: _FakeMessageRepo | None = None,
+    run_event_hub: RunEventHub | None = None,
     resolve_model_config: (
         Callable[[RoleDefinition, LLMRequest], ModelEndpointConfig | None] | None
     ) = None,
 ) -> AgentRuntimeSessionManager:
+    resolved_message_repo = message_repo or _FakeMessageRepo(prompt_text)
     return AgentRuntimeSessionManager(
         config_dir=config_dir,
         config_service=cast(
             ExternalAgentConfigService, _FakeConfigService(agent or _build_agent())
         ),
         session_repo=cast(ExternalAgentSessionRepository, _FakeSessionRepo()),
-        message_repo=cast(MessageRepository, _FakeMessageRepo(prompt_text)),
-        run_event_hub=RunEventHub(),
+        message_repo=cast(MessageRepository, resolved_message_repo),
+        run_event_hub=run_event_hub or RunEventHub(),
         workspace_manager=cast(WorkspaceManager, _FakeWorkspaceManager(workdir)),
         task_repo=cast(TaskRepository, object()),
         shared_store=cast(SharedStateRepository, object()),
         event_bus=cast(EventLog, object()),
-        injection_manager=cast(RunInjectionManager, object()),
+        injection_manager=injection_manager or cast(RunInjectionManager, object()),
         agent_repo=cast(AgentInstanceRepository, object()),
         approval_ticket_repo=cast(ApprovalTicketRepository, object()),
         user_question_repo=None,
@@ -691,6 +718,112 @@ async def test_external_acp_prompt_includes_system_prompt_and_host_server(
     assert "## User Prompt" in prompt_text
     assert "Summarize the architecture." in prompt_text
     assert bridge.active_request is None
+
+
+def test_external_prompt_keeps_system_reminder_out_of_stable_prefix() -> None:
+    reminder = render_system_reminder("Finish the pending todo first.")
+
+    stable_prefix = provider_module._compose_external_prompt_stable_prefix(
+        system_prompt="Provider system prompt text.",
+        include_host_tool_guidance=True,
+    )
+    prompt_text = provider_module._compose_external_prompt(
+        system_prompt="Provider system prompt text.",
+        user_prompt=reminder,
+        include_host_tool_guidance=True,
+    )
+
+    assert prompt_text.startswith(stable_prefix)
+    assert "Provider system prompt text." in stable_prefix
+    assert "## Host Tools" in stable_prefix
+    assert "## User Prompt" not in stable_prefix
+    assert reminder not in stable_prefix
+    assert prompt_text.endswith(f"## User Prompt\n{reminder}")
+
+
+@pytest.mark.asyncio
+async def test_external_acp_prompt_applies_startup_system_reminder(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    transport = _RequestCapturingTransport()
+    captured: dict[str, object] = {}
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    event_hub = _CapturingRunEventHub()
+    message_repo = _FakeMessageRepo("Original task prompt.")
+    reminder = render_system_reminder("Finish the pending todo first.")
+    second_reminder = render_system_reminder("Review the recent tool failure.")
+    _ = injection_manager.enqueue(
+        "run-1",
+        "instance-1",
+        InjectionSource.SYSTEM,
+        reminder,
+        visibility="internal",
+        internal_kind="incomplete_todos",
+        internal_delivery_mode=SystemReminderDeliveryMode.COMPLETION_GUARD.value,
+        internal_issue_key="incomplete_todos:retry:1",
+    )
+    _ = injection_manager.enqueue(
+        "run-1",
+        "instance-1",
+        InjectionSource.SYSTEM,
+        second_reminder,
+        visibility="internal",
+        internal_kind="tool_failure",
+        internal_delivery_mode=SystemReminderDeliveryMode.GUIDANCE.value,
+        internal_issue_key="tool_failure:sample:tool_error",
+    )
+    manager = _build_manager(
+        prompt_text="Original task prompt.",
+        workdir=tmp_path,
+        config_dir=tmp_path / "config",
+        injection_manager=injection_manager,
+        message_repo=message_repo,
+        run_event_hub=cast(RunEventHub, event_hub),
+    )
+    _install_transport_builder(
+        monkeypatch=monkeypatch,
+        transport=transport,
+        captured=captured,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_create_host_tool_bridge",
+        lambda: _FakeHostToolBridge(has_tools=False),
+    )
+    request = _build_request().model_copy(update={"conversation_id": ""})
+
+    output = await manager.prompt(
+        agent_id="agent-1",
+        role=_build_role(),
+        request=request,
+    )
+
+    prompt_payload = transport.requests[2][1]
+    prompt_parts = cast(list[dict[str, object]], prompt_payload["prompt"])
+    prompt_text = str(prompt_parts[0]["text"])
+    applied_events = [
+        event
+        for event in event_hub.events
+        if event.event_type == RunEventType.INJECTION_APPLIED
+    ]
+    applied_payload = json.loads(applied_events[0].payload_json)
+    conversation_ids = {
+        str(call["conversation_id"]) for call in message_repo.append_calls
+    }
+    assert output == "External agent output."
+    assert reminder in prompt_text
+    assert second_reminder in prompt_text
+    assert prompt_text.startswith("## Role Prompt\nProvider system prompt text.")
+    assert prompt_text.endswith(f"## User Prompt\n{reminder}\n\n{second_reminder}")
+    assert conversation_ids == {build_conversation_id("session-1", "spec_coder")}
+    assert len(applied_events) == 2
+    assert "Finish the pending todo first" not in applied_events[0].payload_json
+    assert "Review the recent tool failure" not in applied_events[1].payload_json
+    assert applied_payload["content_redacted"] is True
+    assert applied_payload["restart_scope"] == "external_prompt_start"
+    assert injection_manager.drain_at_boundary("run-1", "instance-1") == ()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/sessions/runs/test_system_injection_sink.py
+++ b/tests/unit_tests/sessions/runs/test_system_injection_sink.py
@@ -4,13 +4,17 @@ from pathlib import Path
 import json
 from typing import cast
 
+import pytest
 from relay_teams.agents.execution.message_repository import MessageRepository
 from relay_teams.reminders import render_system_reminder
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.enums import InjectionSource
 from relay_teams.sessions.runs.run_models import RunEvent
-from relay_teams.sessions.runs.system_injection import SystemInjectionSink
+from relay_teams.sessions.runs.system_injection import (
+    SystemInjectionConsumer,
+    SystemInjectionSink,
+)
 from relay_teams.reminders.delivery import SystemReminderDeliveryMode
 
 
@@ -216,3 +220,132 @@ def test_enqueue_only_redacts_internal_system_reminder_events() -> None:
     assert payload["internal_kind"] == "read_only_streak"
     assert "<system-reminder>" not in event_hub.events[0].payload_json
     assert "Do not leak this body" not in event_hub.events[0].payload_json
+
+
+@pytest.mark.asyncio
+async def test_consumer_applies_only_system_reminders_and_redacts_events(
+    tmp_path: Path,
+) -> None:
+    message_repo = MessageRepository(tmp_path / "messages.db")
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    event_hub = _CapturingRunEventHub()
+    reminder = render_system_reminder("Inspect the failed tool result.")
+    _ = injection_manager.enqueue(
+        "run-1",
+        "inst-1",
+        InjectionSource.USER,
+        "regular follow-up",
+    )
+    _ = injection_manager.enqueue(
+        "run-1",
+        "inst-1",
+        InjectionSource.SYSTEM,
+        reminder,
+        visibility="internal",
+        internal_kind="tool_failure",
+        internal_delivery_mode=SystemReminderDeliveryMode.GUIDANCE.value,
+        internal_issue_key="tool_failure:read:file_missing",
+    )
+    consumer = SystemInjectionConsumer(
+        injection_manager=injection_manager,
+        run_event_hub=cast(RunEventHub, event_hub),
+        message_repo=message_repo,
+    )
+
+    applied = await consumer.apply_boundary_system_reminders_async(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="trace-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        restart_scope="external_host_tool_boundary",
+    )
+
+    payload = json.loads(event_hub.events[0].payload_json)
+    history = message_repo.get_history_for_conversation("conversation-1")
+    remaining = injection_manager.drain_at_boundary("run-1", "inst-1")
+    assert applied.content == (reminder,)
+    assert len(history) == 1
+    assert payload["content_redacted"] is True
+    assert payload["restart_scope"] == "external_host_tool_boundary"
+    assert "<system-reminder>" not in event_hub.events[0].payload_json
+    assert "Inspect the failed tool result" not in event_hub.events[0].payload_json
+    assert len(remaining) == 1
+    assert remaining[0].content == "regular follow-up"
+
+
+@pytest.mark.asyncio
+async def test_consumer_returns_noop_when_no_system_reminders(
+    tmp_path: Path,
+) -> None:
+    message_repo = MessageRepository(tmp_path / "messages.db")
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    event_hub = _CapturingRunEventHub()
+    consumer = SystemInjectionConsumer(
+        injection_manager=injection_manager,
+        run_event_hub=cast(RunEventHub, event_hub),
+        message_repo=message_repo,
+    )
+
+    applied = await consumer.apply_startup_system_reminders_async(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="trace-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        restart_scope="external_prompt_start",
+    )
+
+    assert applied.applied is False
+    assert event_hub.events == []
+    assert message_repo.get_history_for_conversation("conversation-1") == []
+
+
+@pytest.mark.asyncio
+async def test_consumer_discards_guidance_reminders_when_final_answer_is_ready(
+    tmp_path: Path,
+) -> None:
+    message_repo = MessageRepository(tmp_path / "messages.db")
+    injection_manager = RunInjectionManager()
+    injection_manager.activate("run-1")
+    event_hub = _CapturingRunEventHub()
+    _ = injection_manager.enqueue(
+        "run-1",
+        "inst-1",
+        InjectionSource.SYSTEM,
+        render_system_reminder("Move toward an answer."),
+        visibility="internal",
+        internal_kind="read_only_streak",
+        internal_delivery_mode=SystemReminderDeliveryMode.GUIDANCE.value,
+        internal_issue_key="read_only_streak",
+    )
+    consumer = SystemInjectionConsumer(
+        injection_manager=injection_manager,
+        run_event_hub=cast(RunEventHub, event_hub),
+        message_repo=message_repo,
+    )
+
+    applied = await consumer.apply_boundary_system_reminders_async(
+        session_id="session-1",
+        run_id="run-1",
+        trace_id="trace-1",
+        task_id="task-1",
+        instance_id="inst-1",
+        role_id="role-1",
+        workspace_id="workspace-1",
+        conversation_id="conversation-1",
+        restart_scope="external_prompt_boundary",
+        final_answer_ready=True,
+    )
+
+    assert applied.applied is False
+    assert event_hub.events == []
+    assert message_repo.get_history_for_conversation("conversation-1") == []


### PR DESCRIPTION
Closes #774

## Summary
- add a shared SystemInjectionConsumer that drains internal system reminders, applies classifier disposition, emits redacted application events, and persists applied reminders to conversation history
- consume startup reminders before ACP/A2A/CLI prompt composition and consume ACP host-tool boundary reminders after hosted tool execution
- keep external prompt stable prefixes explicit so `<system-reminder>` content only appears under `## User Prompt`
- preserve every startup reminder drained at the same boundary instead of only the latest persisted user message
- document the reminder/runtime boundaries and add focused unit coverage for consumer, external prompt-start, ACP host-tool delivery, and prompt-prefix behavior

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests/browser/test_browser_smoke.py::test_browser_web_settings_complex_fallback_roundtrip
- local changed-line diff-cover slice: 100%
- GitHub Actions for PR #775: all checks passing