### PR TITLE
Apply formal specs during verification

### DIFF
--- a/docs/core/api-design.md
+++ b/docs/core/api-design.md
@@ -2081,6 +2081,12 @@ Response fields:
 
 Returns the latest normalized evidence bundle stored on the task envelope. If verification has not produced evidence yet, the endpoint returns `404`.
 
+During verification, the backend builds an effective verification plan from the
+stored task plan plus any bound `TaskSpec.formal_verification` found on the task
+envelope or rehydrated from `spec_artifact_id`. Spec-derived formal checks are
+deduplicated against explicit `formal_checks`, and the evidence bundle formal
+flags reflect the effective plan.
+
 Response fields:
 - `task_id`
 - `spec_artifact_id`

--- a/docs/modules/agents/formal-task-spec-lifecycle.md
+++ b/docs/modules/agents/formal-task-spec-lifecycle.md
@@ -128,6 +128,14 @@ provide an explicit plan:
 - `strictness` mirrors `TaskSpec.strictness`.
 - `formal_checks` includes the optional `TaskSpec.formal_verification` plan.
 
+Verification also re-resolves the bound task spec at validation time. If a task
+has `TaskSpec.formal_verification` on the envelope, or only a bound
+`spec_artifact_id` that can be rehydrated, the formal plan is appended to the
+effective verification plan unless an identical explicit formal check is already
+present. This keeps existing and updated spec-bearing tasks inside the same
+formal proof/replay path even when their stored `VerificationPlan` predates the
+formal spec binding.
+
 Verification output is normalized into `VerificationEvidenceBundle`:
 
 - `items` capture task-result context, file, command, scoped event, and formal

--- a/src/relay_teams/agents/orchestration/verification.py
+++ b/src/relay_teams/agents/orchestration/verification.py
@@ -20,6 +20,7 @@ from relay_teams.agents.tasks.models import (
     FormalVerificationPlan,
     SemanticEvaluationRequest,
     SemanticEvaluationResult,
+    TaskSpec,
     VerificationCheckResult,
     VerificationCommand,
     VerificationEvidenceBundle,
@@ -273,9 +274,16 @@ def verify_task(
         event_type = EventType.VERIFICATION_FAILED
         evidence_bundle = None
     else:
+        verification_plan = _effective_verification_plan(
+            task_repo=task_repo,
+            task_id=task.envelope.task_id,
+            base_plan=task.envelope.verification,
+            spec=task.envelope.spec,
+            spec_artifact_id=task.envelope.spec_artifact_id,
+        )
         plan_run = _run_verification_plan(
             task_id=task.envelope.task_id,
-            plan=task.envelope.verification,
+            plan=verification_plan,
             result=task.result,
             event_bus=event_bus,
             trace_id=task.envelope.trace_id,
@@ -308,7 +316,7 @@ def verify_task(
                 "spec_source_task_id": task.envelope.spec_source_task_id,
                 "formal_verification_required": any(
                     formal_plan.required
-                    for formal_plan in task.envelope.verification.formal_checks
+                    for formal_plan in verification_plan.formal_checks
                 ),
                 "formal_verification_passed": None
                 if not required_formal_checks
@@ -369,6 +377,87 @@ def verify_task(
         latest_task.envelope.model_copy(update={"evidence_bundle": evidence_bundle}),
     )
     return verification
+
+
+def _effective_verification_plan(
+    *,
+    task_repo: TaskRepository,
+    task_id: str,
+    base_plan: VerificationPlan,
+    spec: TaskSpec | None,
+    spec_artifact_id: str | None,
+) -> VerificationPlan:
+    task_spec = _resolve_verification_task_spec(
+        task_repo=task_repo,
+        task_id=task_id,
+        spec=spec,
+        spec_artifact_id=spec_artifact_id,
+    )
+    if task_spec is None or task_spec.formal_verification is None:
+        return base_plan
+    if _formal_plan_exists(
+        formal_checks=base_plan.formal_checks,
+        formal_plan=task_spec.formal_verification,
+    ):
+        return base_plan
+    return base_plan.model_copy(
+        update={
+            "formal_checks": (
+                *base_plan.formal_checks,
+                task_spec.formal_verification,
+            )
+        }
+    )
+
+
+def _resolve_verification_task_spec(
+    *,
+    task_repo: TaskRepository,
+    task_id: str,
+    spec: TaskSpec | None,
+    spec_artifact_id: str | None,
+) -> TaskSpec | None:
+    if spec is not None:
+        return spec
+    if spec_artifact_id is None:
+        return None
+    try:
+        artifact = task_repo.get_spec_artifact(spec_artifact_id)
+    except KeyError as exc:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="verification.spec_artifact_missing",
+            message="Task verification could not resolve bound spec artifact.",
+            payload={
+                "task_id": task_id,
+                "spec_artifact_id": spec_artifact_id,
+                "error": str(exc),
+            },
+        )
+        return None
+    if artifact.task_id != task_id:
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="verification.spec_artifact_task_mismatch",
+            message="Task verification ignored a spec artifact bound to another task.",
+            payload={
+                "task_id": task_id,
+                "spec_artifact_id": spec_artifact_id,
+                "artifact_task_id": artifact.task_id,
+            },
+        )
+        return None
+    return artifact.spec
+
+
+def _formal_plan_exists(
+    *,
+    formal_checks: tuple[FormalVerificationPlan, ...],
+    formal_plan: FormalVerificationPlan,
+) -> bool:
+    return any(candidate == formal_plan for candidate in formal_checks)
 
 
 def _run_verification_plan(

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -27,6 +27,7 @@ from relay_teams.agents.tasks.models import (
     SemanticEvaluationRequest,
     SemanticEvaluationResult,
     TaskEnvelope,
+    TaskSpec,
     VerificationCheckResult,
     VerificationCommand,
     VerificationEvidenceBundle,
@@ -680,6 +681,343 @@ def test_verify_task_runs_formal_verification_profile(tmp_path: Path) -> None:
         if check.layer == VerificationLayer.FORMAL
     ]
     assert len(formal_checks) == 2
+    assert result.report.evidence_bundle.formal_verification_required is True
+    assert result.report.evidence_bundle.formal_verification_passed is True
+
+
+def test_verify_task_applies_formal_verification_from_task_spec(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_spec_formal.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    proof = workspace / "spec-model.tla"
+    proof.write_text("---- MODULE spec_model ----", encoding="utf-8")
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-spec-formal",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Return formal evidence from spec",
+        verification=VerificationPlan(),
+        spec=TaskSpec(
+            summary="Formal spec",
+            formal_verification=FormalVerificationPlan(
+                spec_language=FormalVerificationLanguage.TLA_PLUS,
+                tool_profile=FormalVerificationToolProfile.TLC,
+                properties=("Spec invariant holds",),
+                proof_artifacts=(Path("spec-model.tla"),),
+            ),
+        ),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        allowed_tools=("shell",),
+        tool_approval_policy=YOLO_TOOL_APPROVAL_POLICY,
+        workspace_root=workspace,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    formal_checks = tuple(
+        check
+        for check in result.report.checks
+        if check.layer == VerificationLayer.FORMAL
+    )
+    assert len(formal_checks) == 1
+    assert formal_checks[0].name.endswith(":proof_artifact:spec-model.tla")
+    assert result.report.evidence_bundle.formal_verification_required is True
+    assert result.report.evidence_bundle.formal_verification_passed is True
+
+
+def test_verify_task_rehydrates_formal_verification_from_spec_artifact(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_spec_artifact_formal.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    proof = workspace / "artifact-model.tla"
+    proof.write_text("---- MODULE artifact_model ----", encoding="utf-8")
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-artifact-formal",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Return formal evidence from artifact",
+        verification=VerificationPlan(),
+        spec=TaskSpec(
+            summary="Artifact spec",
+            formal_verification=FormalVerificationPlan(
+                spec_language=FormalVerificationLanguage.TLA_PLUS,
+                tool_profile=FormalVerificationToolProfile.TLC,
+                properties=("Artifact invariant holds",),
+                proof_artifacts=(Path("artifact-model.tla"),),
+            ),
+        ),
+    )
+    created = task_repo.create(task)
+    artifact_id = created.envelope.spec_artifact_id
+    assert artifact_id is not None
+    artifact_only_envelope = created.envelope.model_copy(
+        update={"spec": None, "spec_artifact_id": artifact_id}
+    )
+    task_repo._conn.execute(
+        "UPDATE tasks SET envelope_json=? WHERE task_id=?",
+        (artifact_only_envelope.model_dump_json(), task.task_id),
+    )
+    task_repo._conn.commit()
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        allowed_tools=("shell",),
+        tool_approval_policy=YOLO_TOOL_APPROVAL_POLICY,
+        workspace_root=workspace,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    formal_checks = tuple(
+        check
+        for check in result.report.checks
+        if check.layer == VerificationLayer.FORMAL
+    )
+    assert len(formal_checks) == 1
+    assert formal_checks[0].name.endswith(":proof_artifact:artifact-model.tla")
+    assert result.report.evidence_bundle.spec_artifact_id == artifact_id
+    assert result.report.evidence_bundle.formal_verification_required is True
+    assert result.report.evidence_bundle.formal_verification_passed is True
+
+
+def test_verify_task_ignores_spec_artifact_from_another_task(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_spec_artifact_mismatch.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    foreign_proof = workspace / "foreign-model.tla"
+    foreign_proof.write_text("---- MODULE foreign_model ----", encoding="utf-8")
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    source_task = TaskEnvelope(
+        task_id="task-source-formal",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Own a formal spec artifact",
+        verification=VerificationPlan(),
+        spec=TaskSpec(
+            summary="Foreign formal spec",
+            formal_verification=FormalVerificationPlan(
+                spec_language=FormalVerificationLanguage.TLA_PLUS,
+                tool_profile=FormalVerificationToolProfile.TLC,
+                properties=("Foreign invariant holds",),
+                proof_artifacts=(Path("foreign-model.tla"),),
+            ),
+        ),
+    )
+    source = task_repo.create(source_task)
+    artifact_id = source.envelope.spec_artifact_id
+    assert artifact_id is not None
+    target_task = TaskEnvelope(
+        task_id="task-target-with-stale-artifact",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Ignore stale artifact binding",
+        verification=VerificationPlan(),
+    )
+    _ = task_repo.create(target_task)
+    target_with_foreign_artifact = target_task.model_copy(
+        update={"spec_artifact_id": artifact_id}
+    )
+    task_repo._conn.execute(
+        "UPDATE tasks SET envelope_json=? WHERE task_id=?",
+        (target_with_foreign_artifact.model_dump_json(), target_task.task_id),
+    )
+    task_repo._conn.commit()
+    task_repo.update_status(target_task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        target_task.task_id,
+        allowed_tools=("shell",),
+        tool_approval_policy=YOLO_TOOL_APPROVAL_POLICY,
+        workspace_root=workspace,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    assert not any(
+        check.layer == VerificationLayer.FORMAL for check in result.report.checks
+    )
+    assert result.report.evidence_bundle.formal_verification_required is False
+    assert result.report.evidence_bundle.formal_verification_passed is None
+
+
+def test_verify_task_ignores_missing_spec_artifact_binding(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_missing_spec_artifact.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    task = TaskEnvelope(
+        task_id="task-missing-artifact",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Ignore missing artifact binding",
+        verification=VerificationPlan(),
+    )
+    _ = task_repo.create(task)
+    task_with_missing_artifact = task.model_copy(
+        update={"spec_artifact_id": "spec-missing"}
+    )
+    task_repo._conn.execute(
+        "UPDATE tasks SET envelope_json=? WHERE task_id=?",
+        (task_with_missing_artifact.model_dump_json(), task.task_id),
+    )
+    task_repo._conn.commit()
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        allowed_tools=("shell",),
+        tool_approval_policy=YOLO_TOOL_APPROVAL_POLICY,
+        workspace_root=workspace,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    assert not any(
+        check.layer == VerificationLayer.FORMAL for check in result.report.checks
+    )
+    assert result.report.evidence_bundle.formal_verification_required is False
+    assert result.report.evidence_bundle.formal_verification_passed is None
+
+
+def test_verify_task_does_not_duplicate_spec_formal_verification(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_spec_formal_duplicate.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    proof = workspace / "duplicate-model.tla"
+    proof.write_text("---- MODULE duplicate_model ----", encoding="utf-8")
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    formal_plan = FormalVerificationPlan(
+        spec_language=FormalVerificationLanguage.TLA_PLUS,
+        tool_profile=FormalVerificationToolProfile.TLC,
+        properties=("Duplicate invariant holds",),
+        proof_artifacts=(Path("duplicate-model.tla"),),
+    )
+    task = TaskEnvelope(
+        task_id="task-duplicate-formal",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Return formal evidence once",
+        verification=VerificationPlan(formal_checks=(formal_plan,)),
+        spec=TaskSpec(summary="Duplicate spec", formal_verification=formal_plan),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        allowed_tools=("shell",),
+        tool_approval_policy=YOLO_TOOL_APPROVAL_POLICY,
+        workspace_root=workspace,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    formal_checks = tuple(
+        check
+        for check in result.report.checks
+        if check.layer == VerificationLayer.FORMAL
+    )
+    assert len(formal_checks) == 1
+    assert formal_checks[0].name.endswith(":proof_artifact:duplicate-model.tla")
+
+
+def test_verify_task_preserves_explicit_formal_checks_with_spec_formal_plan(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "verification_spec_formal_merge.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    spec_proof = workspace / "spec-proof.tla"
+    explicit_proof = workspace / "explicit-proof.tla"
+    spec_proof.write_text("---- MODULE spec_proof ----", encoding="utf-8")
+    explicit_proof.write_text("---- MODULE explicit_proof ----", encoding="utf-8")
+    task_repo = TaskRepository(db_path)
+    event_log = EventLog(db_path)
+    spec_formal_plan = FormalVerificationPlan(
+        spec_language=FormalVerificationLanguage.TLA_PLUS,
+        tool_profile=FormalVerificationToolProfile.TLC,
+        properties=("Spec proof holds",),
+        proof_artifacts=(Path("spec-proof.tla"),),
+    )
+    explicit_formal_plan = FormalVerificationPlan(
+        spec_language=FormalVerificationLanguage.ALLOY,
+        tool_profile=FormalVerificationToolProfile.ALLOY_ANALYZER,
+        properties=("Explicit proof holds",),
+        proof_artifacts=(Path("explicit-proof.tla"),),
+    )
+    task = TaskEnvelope(
+        task_id="task-merge-formal",
+        session_id="session-1",
+        trace_id="run-1",
+        objective="Return merged formal evidence",
+        verification=VerificationPlan(formal_checks=(explicit_formal_plan,)),
+        spec=TaskSpec(summary="Spec proof", formal_verification=spec_formal_plan),
+    )
+    _ = task_repo.create(task)
+    task_repo.update_status(task.task_id, TaskStatus.COMPLETED, result="done")
+
+    result = verify_task(
+        task_repo,
+        event_log,
+        task.task_id,
+        allowed_tools=("shell",),
+        tool_approval_policy=YOLO_TOOL_APPROVAL_POLICY,
+        workspace_root=workspace,
+    )
+
+    assert result.passed is True
+    assert result.report is not None
+    assert result.report.evidence_bundle is not None
+    formal_check_names = tuple(
+        check.name
+        for check in result.report.checks
+        if check.layer == VerificationLayer.FORMAL
+    )
+    assert len(formal_check_names) == 2
+    assert any(
+        name.endswith(":proof_artifact:spec-proof.tla") for name in formal_check_names
+    )
+    assert any(
+        name.endswith(":proof_artifact:explicit-proof.tla")
+        for name in formal_check_names
+    )
     assert result.report.evidence_bundle.formal_verification_required is True
     assert result.report.evidence_bundle.formal_verification_passed is True
 


### PR DESCRIPTION
## Summary

- Rehydrate the task spec during verification and append bound `TaskSpec.formal_verification` to the effective verification plan when needed.
- Preserve explicit formal checks and avoid duplicating identical spec-derived formal plans.
- Guard artifact-only rehydration so missing or stale cross-task `spec_artifact_id` bindings are ignored and logged before any formal checks run.
- Keep evidence bundle formal flags based on the effective formal checks, including artifact-only spec bindings.
- Document the validation-time formal spec behavior.

Closes #776

## Verification

- `uv run --extra dev ruff check --fix`
- `uv run --extra dev ruff format --no-cache --force-exclude`
- `uv run --extra dev basedpyright` -> 0 errors
- `uv run --extra dev pytest -q tests/unit_tests/agents/orchestration/test_verification.py` -> 51 passed
- `uv run --extra dev pytest -q tests/unit_tests` -> 6446 passed, 5 skipped
- `uv run --extra dev pytest -q tests/unit_tests --cov=src/relay_teams --cov=src/relay_teams_evals --cov-report=xml:coverage.xml` -> 6458 passed, 5 skipped
- `uv run --extra dev diff-cover coverage.xml --config-file pyproject.toml --diff-file .tmp/diff-cover-copy-aware.diff` -> 100% diff coverage
- `PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests --basetemp .pytest-tmp/integration-review-fix` -> 127 passed, 8 skipped, 1 warning