### PR TITLE
Unify agent runtime memory context management

### DIFF
--- a/docs/design/fe1-memory-bank.md
+++ b/docs/design/fe1-memory-bank.md
@@ -2,9 +2,9 @@
 
 > **Feature ID**: FE-1
 > **Name**: Cross-Run Memory Bank
-> **Status**: Spec -- Ready for Implementation
+> **Status**: Implemented foundation -- runtime wiring in progress
 > **Created**: 2026-05-04
-> **Updated**: 2026-05-04
+> **Updated**: 2026-05-09
 > **Strictness**: high
 
 ---
@@ -26,8 +26,13 @@ Build a three-tier, six-operation Memory Bank that:
 - Persists structured memory entries across Runs, Sessions, and workspaces
 - Integrates with the existing FTS5 retrieval infrastructure via `RetrievalScopeKind.MEMORY`
 - Automatically consolidates working memory at Run/Task completion via existing hook events
-- Replaces the flat markdown blob with typed, tagged, versioned entries while maintaining backward compatibility with the existing reflection memory injection layer
+- Makes typed, tagged, versioned entries the primary long-term memory path while maintaining backward compatibility with the existing reflection memory injection layer
 - Provides REST API endpoints and CLI commands for memory management
+
+The legacy `role_memories` table remains a migration bridge for reflection
+summaries, session projections, and older subagent refresh flows. New runtime
+memory behavior should use Memory Bank entries in `memory_entries`; new features
+should not add capabilities to the legacy markdown blob.
 
 ### 1.3 Academic Foundation
 

--- a/docs/modules/agent-runtimes/architecture.md
+++ b/docs/modules/agent-runtimes/architecture.md
@@ -19,6 +19,36 @@ Every role turn follows the same sequence:
 5. Persist normalized run events, messages, runtime prompt snapshots, tool
    snapshots, status transitions, and final output.
 
+Memory and context-window management are session-runtime concerns, not adapter
+concerns. Before dispatch reaches the local provider, ACP, A2A, or CLI adapter,
+the shared prompt path must prepare the role prompt and history in this order:
+
+```text
+resolve role
+-> inject legacy reflection memory when still available
+-> inject Memory Bank project memory
+-> load session history
+-> prune to a safe tool-call boundary
+-> inject existing compaction summary
+-> compute full prompt budget
+-> microcompact old tool results in the live prompt view
+-> run full rolling-summary compaction when still over budget
+-> repair provider-replayable history
+-> dispatch to runtime adapter
+```
+
+`MemoryBankService` is the long-term memory system for the unified runtime. It
+owns three tiers, Working, Medium-term, and Persistent, and the six memory
+operations: consolidation, updating, indexing, forgetting, retrieval, and
+condensation. `role_memories` remains only a legacy reflection-memory
+compatibility layer during migration.
+
+`ConversationMicrocompactService` and `ConversationCompactionService` are short
+term session context controls. Microcompact changes only the prompt view sent to
+the runtime. Full compaction writes session history markers, hides old messages,
+and injects the rolling summary on later turns. Neither one replaces Memory
+Bank, and Memory Bank does not replace context compaction.
+
 The router selects one adapter:
 
 - local: the existing Relay Teams provider chain

--- a/docs/modules/memory/role-workspace-memory-design.md
+++ b/docs/modules/memory/role-workspace-memory-design.md
@@ -53,9 +53,20 @@ application bootstrap choice, not the workspace model itself.
 
 Memory is no longer part of the workspace module.
 
-It lives under `src/relay_teams/roles/` and uses one database table:
+The current runtime has two durable memory stores during migration:
 
 - `role_memories`
+- `memory_entries`
+
+`memory_entries` is the primary long-term Memory Bank. It stores typed entries
+across three tiers, Working, Medium-term, and Persistent, and supports the six
+memory operations: consolidation, updating, indexing, forgetting, retrieval, and
+condensation.
+
+`role_memories` is the legacy reflection-memory compatibility layer. It stores a
+single bounded markdown summary for older prompt injection, session projection,
+and subagent reflection refresh flows. New long-term memory capabilities should
+target Memory Bank instead of expanding `role_memories`.
 
 Scope rules:
 
@@ -85,9 +96,24 @@ The compaction entry point must depend on a replaceable strategy interface so fu
 Runtime dependencies are split cleanly:
 
 - `workspace`: execution boundary and filesystem access
-- `role_memory`: durable reflection memory access
+- `memory_bank`: structured long-term memory access
+- `role_memory`: legacy durable reflection memory access
 
-Prompt assembly pulls role memory from `roles.memory_service` and shared runtime state from `shared_state`. It no longer loads durable memory through `workspace`.
+Prompt assembly pulls Memory Bank entries through `MemoryBankService`, legacy
+reflection memory through `roles.memory_service`, and shared runtime state from
+`shared_state`. It no longer loads durable memory through `workspace`.
+
+All agent runtime protocols consume the same prepared session prompt. Local,
+ACP, A2A, and CLI runtimes should receive already-injected memory sections and
+already-compacted session history rather than reimplementing memory or context
+compression in protocol adapters.
+
+Prompt memory sections have separate meanings:
+
+- `## Project Memory`: Memory Bank Medium-term and Persistent entries.
+- `## Reflection Memory`: legacy `role_memories` markdown summary.
+- Compaction summary: short-term session history summary from full context
+  compaction, not durable project memory.
 
 ## 7. Removed Pieces
 
@@ -107,5 +133,6 @@ If you are reading older code or earlier design notes, note these incompatible c
 
 - role configs must use `memory_profile`; `workspace_profile` is no longer accepted
 - `memory_profile` only contains `enabled`
-- role durable memory lives in `role_memories`
+- primary long-term memory lives in `memory_entries`
+- legacy reflection memory still lives in `role_memories` until migration is complete
 - `role_daily_memories` has been removed

--- a/docs/modules/sessions/session-context-compaction-design.md
+++ b/docs/modules/sessions/session-context-compaction-design.md
@@ -172,8 +172,26 @@ load conversation history
 -> call model
 ```
 
-对应入口位于 `src/relay_teams/agents/execution/llm_session.py` 中的 `_prepare_prompt_context(...)`。
-真正的每轮迭代重建则统一走 `_build_agent_iteration_context(...)`。
+对应入口位于 `src/relay_teams/agents/execution/session_prompt.py` 中的
+`_prepare_prompt_context(...)`，具体历史准备由
+`src/relay_teams/agents/execution/prompt_history.py` 执行。真正的每轮迭代重建
+统一走 `_build_agent_iteration_context(...)`。
+
+这条链路属于 session runtime，而不是某个 provider 或外部 runtime
+adapter。local provider、ACP、A2A、CLI runtime 都应消费同一份已经准备好的
+prompt/history：
+
+- 长期 memory 在进入历史压缩前完成注入。
+- `microcompact` 和 full compaction 对所有 runtime 一致生效。
+- 协议 adapter 不直接从 message repository 拼接未压缩历史。
+- adapter 只负责协议传输、事件归一化和 host-tool 桥接。
+
+长期 memory 与短期压缩的职责保持分离：
+
+- Memory Bank 负责跨 run/session 的 Working、Medium-term、Persistent 记忆。
+- legacy reflection memory 只是迁移期 markdown summary 兼容层。
+- `microcompact` 只治理当前 prompt view。
+- full compaction 只治理当前 session transcript 和 rolling summary。
 
 ## 6. 关键设计
 

--- a/src/relay_teams/agent_runtimes/host_tool_bridge.py
+++ b/src/relay_teams/agent_runtimes/host_tool_bridge.py
@@ -53,7 +53,7 @@ from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.system_injection import SystemInjectionConsumer
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.sessions.runs.user_question_manager import UserQuestionManager

--- a/src/relay_teams/agent_runtimes/provider.py
+++ b/src/relay_teams/agent_runtimes/provider.py
@@ -91,7 +91,7 @@ if TYPE_CHECKING:
     from relay_teams.persistence.shared_state_repo import SharedStateRepository
     from relay_teams.roles.memory_service import RoleMemoryService
     from relay_teams.roles.role_registry import RoleRegistry
-    from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+    from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
     from relay_teams.sessions.runs.event_log import EventLog
     from relay_teams.sessions.runs.run_control_manager import RunControlManager
     from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository

--- a/src/relay_teams/agents/execution/agent_llm_session.py
+++ b/src/relay_teams/agents/execution/agent_llm_session.py
@@ -60,7 +60,7 @@ from relay_teams.providers.token_usage_repo import TokenUsageRepository
 from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager

--- a/src/relay_teams/agents/execution/session_mixin_base.py
+++ b/src/relay_teams/agents/execution/session_mixin_base.py
@@ -68,7 +68,7 @@ from relay_teams.providers.provider_contracts import LLMRequest
 from relay_teams.providers.token_usage_repo import TokenUsageRepository
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager

--- a/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
@@ -44,6 +44,7 @@ from relay_teams.hooks import HookService
 from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.media import MediaAssetService
+from relay_teams.memory.service import MemoryBankService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.reminders import ReminderDecision
 from relay_teams.reminders.service import SystemReminderService
@@ -113,6 +114,7 @@ class ExecutionHarness(BaseModel):
     mcp_registry: McpRegistry
     run_control_manager: object | None = None
     role_memory_service: RoleMemoryService | None = None
+    memory_bank_service: MemoryBankService | None = None
     memory_event_handler: MemoryEventHandler | None = None
     run_intent_repo: RunIntentRepository | None = None
     media_asset_service: MediaAssetService | None = None
@@ -142,6 +144,7 @@ class ExecutionHarness(BaseModel):
             tool_harness=self._tool_harness(),
             skill_runtime_service=self.skill_runtime_service,
             role_memory_service=self.role_memory_service,
+            memory_bank_service=self.memory_bank_service,
             runtime_role_resolver=self.runtime_role_resolver,
             run_intent_repo=self.run_intent_repo,
             media_asset_service=self.media_asset_service,
@@ -663,6 +666,7 @@ class ExecutionHarness(BaseModel):
         return await TaskPromptHarness.model_construct(
             role_registry=self.role_registry,
             role_memory_service=self.role_memory_service,
+            memory_bank_service=self.memory_bank_service,
         ).role_with_memory_async(role=role, role_id=role_id, workspace_id=workspace_id)
 
     async def prepare_runtime_snapshot(

--- a/src/relay_teams/agents/orchestration/harnesses/prompt_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/prompt_harness.py
@@ -28,6 +28,7 @@ from relay_teams.agents.execution.user_prompts import (
 from relay_teams.agents.orchestration.harnesses.tool_harness import TaskToolHarness
 from relay_teams.agents.tasks.models import TaskEnvelope
 from relay_teams.media import MediaAssetService, merge_user_prompt_content
+from relay_teams.memory.service import MemoryBankService
 from relay_teams.persistence.scope_models import ScopeRef, ScopeType
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.roles.memory_injection import build_role_with_memory_async
@@ -68,6 +69,7 @@ class TaskPromptHarness(BaseModel):
     tool_harness: TaskToolHarness
     skill_runtime_service: object | None = None
     role_memory_service: RoleMemoryService | None = None
+    memory_bank_service: MemoryBankService | None = None
     runtime_role_resolver: RuntimeRoleResolver | None = None
     run_intent_repo: RunIntentRepository | None = None
     media_asset_service: MediaAssetService | None = None
@@ -101,6 +103,7 @@ class TaskPromptHarness(BaseModel):
         return await build_role_with_memory_async(
             role_registry=self.role_registry,
             role_memory_service=self.role_memory_service,
+            memory_bank_service=self.memory_bank_service,
             role=role,
             role_id=role_id,
             workspace_id=workspace_id,

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -54,6 +54,7 @@ from relay_teams.hooks import HookService
 from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.media import MediaAssetService
+from relay_teams.memory.service import MemoryBankService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.reminders.service import SystemReminderService
 from relay_teams.memory.event_handler import MemoryEventHandler
@@ -131,6 +132,7 @@ class TaskExecutionService(BaseModel):
     injection_manager: RunInjectionManager | None = None
     run_control_manager: RunControlManager | None = None
     role_memory_service: RoleMemoryService | None = None
+    memory_bank_service: MemoryBankService | None = None
     memory_event_handler: MemoryEventHandler | None = None
     runtime_role_resolver: RuntimeRoleResolver | None = None
     run_intent_repo: RunIntentRepository | None = None
@@ -163,6 +165,7 @@ class TaskExecutionService(BaseModel):
             mcp_registry=getattr(self, "mcp_registry", None),
             run_control_manager=getattr(self, "run_control_manager", None),
             role_memory_service=getattr(self, "role_memory_service", None),
+            memory_bank_service=getattr(self, "memory_bank_service", None),
             memory_event_handler=getattr(self, "memory_event_handler", None),
             run_intent_repo=getattr(self, "run_intent_repo", None),
             media_asset_service=getattr(self, "media_asset_service", None),

--- a/src/relay_teams/agents/orchestration/task_execution_service_factory.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service_factory.py
@@ -8,6 +8,7 @@ from relay_teams.agents.execution.prompt_instructions import PromptInstructionRe
 from relay_teams.agents.execution.system_prompts import RuntimePromptBuilder
 from relay_teams.agents.orchestration.task_execution_service import TaskExecutionService
 from relay_teams.media import MediaAssetService
+from relay_teams.memory.service import MemoryBankService
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.providers.provider_contracts import LLMProvider
@@ -64,6 +65,7 @@ def create_task_execution_service(
     injection_manager: RunInjectionManager,
     run_control_manager: RunControlManager,
     role_memory_service: RoleMemoryService | None = None,
+    memory_bank_service: MemoryBankService | None = None,
     runtime_role_resolver: RuntimeRoleResolver | None = None,
     hook_service: HookService | None = None,
     todo_service: TodoService | None = None,
@@ -102,6 +104,7 @@ def create_task_execution_service(
         injection_manager=injection_manager,
         run_control_manager=run_control_manager,
         role_memory_service=role_memory_service,
+        memory_bank_service=memory_bank_service,
         runtime_role_resolver=runtime_role_resolver,
         run_intent_repo=run_intent_repo,
         media_asset_service=media_asset_service,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -197,11 +197,11 @@ from relay_teams.sessions.runs.background_tasks.manager import (
 from relay_teams.sessions.runs.background_tasks.command_runtime import (
     kill_process_tree_by_pid,
 )
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
 from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskKind
 from relay_teams.sessions.runs.background_tasks.repository import (
     BackgroundTaskRepository,
 )
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.sessions.runs.run_state_repo import RunStateRepository
@@ -1248,6 +1248,7 @@ class ServerContainer:
             injection_manager=self.injection_manager,
             run_control_manager=self.run_control_manager,
             role_memory_service=self.role_memory_service,
+            memory_bank_service=self.memory_bank_service,
             memory_event_handler=self.memory_event_handler,
             runtime_role_resolver=self.runtime_role_resolver,
             hook_service=self.hook_service,

--- a/src/relay_teams/providers/openai_compatible.py
+++ b/src/relay_teams/providers/openai_compatible.py
@@ -59,7 +59,7 @@ from relay_teams.providers.token_usage_repo import TokenUsageRepository
 from relay_teams.reminders.service import SystemReminderService
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.event_log import EventLog
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager

--- a/src/relay_teams/providers/provider_factory.py
+++ b/src/relay_teams/providers/provider_factory.py
@@ -56,7 +56,7 @@ from relay_teams.sessions.session_history_marker_repository import (
     SessionHistoryMarkerRepository,
 )
 from relay_teams.sessions.runs.run_intent_repo import RunIntentRepository
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.run_runtime_repo import RunRuntimeRepository
 from relay_teams.sessions.runs.user_question_manager import UserQuestionManager
 from relay_teams.sessions.runs.user_question_repository import UserQuestionRepository

--- a/src/relay_teams/sessions/runs/background_tasks/service.py
+++ b/src/relay_teams/sessions/runs/background_tasks/service.py
@@ -56,9 +56,6 @@ from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimeRecord,
     RunRuntimeStatus,
 )
-from relay_teams.sessions.runs.subagent_lifecycle import (
-    mark_subagent_terminal_records,
-)
 from relay_teams.sessions.session_models import SessionMode
 from relay_teams.workspace import WorkspaceHandle
 from relay_teams.workspace.ids import build_instance_conversation_id
@@ -96,6 +93,135 @@ class BackgroundTaskCompletionSink(Protocol):
         message: str,
     ) -> None:
         pass
+
+
+class _SubagentLifecycleTerminalState(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    task_status: TaskStatus
+    instance_status: InstanceStatus
+    run_status: RunRuntimeStatus
+    run_phase: RunRuntimePhase
+    last_error: str | None
+    task_result: str | None
+    task_error: str | None
+
+
+def _terminal_state_for_background_status(
+    status: BackgroundTaskStatus,
+    *,
+    output: str,
+) -> _SubagentLifecycleTerminalState:
+    summarized_output = output.strip()
+    if status == BackgroundTaskStatus.COMPLETED:
+        return _SubagentLifecycleTerminalState(
+            task_status=TaskStatus.COMPLETED,
+            instance_status=InstanceStatus.COMPLETED,
+            run_status=RunRuntimeStatus.COMPLETED,
+            run_phase=RunRuntimePhase.TERMINAL,
+            last_error=None,
+            task_result=summarized_output,
+            task_error=None,
+        )
+    if status == BackgroundTaskStatus.STOPPED:
+        return _SubagentLifecycleTerminalState(
+            task_status=TaskStatus.STOPPED,
+            instance_status=InstanceStatus.STOPPED,
+            run_status=RunRuntimeStatus.STOPPED,
+            run_phase=RunRuntimePhase.IDLE,
+            last_error="Task stopped by user",
+            task_result=None,
+            task_error="Task stopped by user",
+        )
+    return _SubagentLifecycleTerminalState(
+        task_status=TaskStatus.FAILED,
+        instance_status=InstanceStatus.FAILED,
+        run_status=RunRuntimeStatus.FAILED,
+        run_phase=RunRuntimePhase.TERMINAL,
+        last_error=summarized_output or "Task failed",
+        task_result=None,
+        task_error=summarized_output or "Task failed",
+    )
+
+
+def _mark_subagent_terminal_records(
+    *,
+    update_task_status: Callable[..., object] | None,
+    mark_instance_status: Callable[[str, InstanceStatus], object] | None,
+    update_run_runtime: Callable[..., object] | None,
+    subagent_run_id: str,
+    session_id: str,
+    task_id: str | None,
+    instance_id: str | None,
+    status: BackgroundTaskStatus,
+    output: str,
+) -> None:
+    terminal = _terminal_state_for_background_status(status, output=output)
+    if task_id and update_task_status is not None:
+        try:
+            update_task_status(
+                task_id,
+                terminal.task_status,
+                assigned_instance_id=instance_id,
+                result=terminal.task_result,
+                error_message=terminal.task_error,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task_service.task_terminal_update_skipped",
+                message="Failed to synchronize terminal subagent task status",
+                payload={
+                    "subagent_run_id": subagent_run_id,
+                    "session_id": session_id,
+                    "task_id": task_id,
+                    "status": status.value,
+                },
+                exc_info=exc,
+            )
+    if instance_id and mark_instance_status is not None:
+        try:
+            mark_instance_status(instance_id, terminal.instance_status)
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task_service.instance_terminal_update_skipped",
+                message="Failed to synchronize terminal subagent instance status",
+                payload={
+                    "subagent_run_id": subagent_run_id,
+                    "session_id": session_id,
+                    "instance_id": instance_id,
+                    "status": status.value,
+                },
+                exc_info=exc,
+            )
+    if update_run_runtime is not None:
+        try:
+            update_run_runtime(
+                subagent_run_id,
+                status=terminal.run_status,
+                phase=terminal.run_phase,
+                active_instance_id=None,
+                active_task_id=None,
+                active_role_id=None,
+                active_subagent_instance_id=None,
+                last_error=terminal.last_error,
+            )
+        except Exception as exc:
+            log_event(
+                LOGGER,
+                logging.WARNING,
+                event="background_task_service.runtime_terminal_update_skipped",
+                message="Failed to synchronize terminal subagent runtime status",
+                payload={
+                    "subagent_run_id": subagent_run_id,
+                    "session_id": session_id,
+                    "status": status.value,
+                },
+                exc_info=exc,
+            )
 
 
 @runtime_checkable
@@ -2111,7 +2237,7 @@ class BackgroundTaskService:
             task_update = self._task_repo.update_status
         if self._agent_repo is not None:
             instance_update = self._agent_repo.mark_status
-        mark_subagent_terminal_records(
+        _mark_subagent_terminal_records(
             update_task_status=task_update,
             mark_instance_status=instance_update,
             update_run_runtime=update_run_runtime,

--- a/src/relay_teams/sessions/runs/subagent_lifecycle.py
+++ b/src/relay_teams/sessions/runs/subagent_lifecycle.py
@@ -1,149 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 
-from pydantic import BaseModel, ConfigDict
 from relay_teams.agents.instances.enums import InstanceStatus
 from relay_teams.agents.tasks.enums import TaskStatus
-from relay_teams.logger import get_logger, log_event
-from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskStatus
 from relay_teams.sessions.runs.run_runtime_repo import (
     RunRuntimePhase,
     RunRuntimeStatus,
 )
-
-LOGGER = get_logger(__name__)
-
-
-class SubagentLifecycleTerminalState(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    task_status: TaskStatus
-    instance_status: InstanceStatus
-    run_status: RunRuntimeStatus
-    run_phase: RunRuntimePhase
-    last_error: str | None
-    task_result: str | None
-    task_error: str | None
-
-
-def terminal_state_for_background_status(
-    status: BackgroundTaskStatus,
-    *,
-    output: str,
-) -> SubagentLifecycleTerminalState:
-    summarized_output = output.strip()
-    if status == BackgroundTaskStatus.COMPLETED:
-        return SubagentLifecycleTerminalState(
-            task_status=TaskStatus.COMPLETED,
-            instance_status=InstanceStatus.COMPLETED,
-            run_status=RunRuntimeStatus.COMPLETED,
-            run_phase=RunRuntimePhase.TERMINAL,
-            last_error=None,
-            task_result=summarized_output,
-            task_error=None,
-        )
-    if status == BackgroundTaskStatus.STOPPED:
-        return SubagentLifecycleTerminalState(
-            task_status=TaskStatus.STOPPED,
-            instance_status=InstanceStatus.STOPPED,
-            run_status=RunRuntimeStatus.STOPPED,
-            run_phase=RunRuntimePhase.IDLE,
-            last_error="Task stopped by user",
-            task_result=None,
-            task_error="Task stopped by user",
-        )
-    return SubagentLifecycleTerminalState(
-        task_status=TaskStatus.FAILED,
-        instance_status=InstanceStatus.FAILED,
-        run_status=RunRuntimeStatus.FAILED,
-        run_phase=RunRuntimePhase.TERMINAL,
-        last_error=summarized_output or "Task failed",
-        task_result=None,
-        task_error=summarized_output or "Task failed",
-    )
-
-
-def mark_subagent_terminal_records(
-    *,
-    update_task_status: Callable[..., object] | None,
-    mark_instance_status: Callable[[str, InstanceStatus], object] | None,
-    update_run_runtime: Callable[..., object] | None,
-    subagent_run_id: str,
-    session_id: str,
-    task_id: str | None,
-    instance_id: str | None,
-    status: BackgroundTaskStatus,
-    output: str,
-) -> None:
-    terminal = terminal_state_for_background_status(status, output=output)
-    if task_id and update_task_status is not None:
-        try:
-            update_task_status(
-                task_id,
-                terminal.task_status,
-                assigned_instance_id=instance_id,
-                result=terminal.task_result,
-                error_message=terminal.task_error,
-            )
-        except Exception as exc:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="subagent_lifecycle.task_terminal_update_skipped",
-                message="Failed to synchronize terminal subagent task status",
-                payload={
-                    "subagent_run_id": subagent_run_id,
-                    "session_id": session_id,
-                    "task_id": task_id,
-                    "status": status.value,
-                },
-                exc_info=exc,
-            )
-    if instance_id and mark_instance_status is not None:
-        try:
-            mark_instance_status(instance_id, terminal.instance_status)
-        except Exception as exc:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="subagent_lifecycle.instance_terminal_update_skipped",
-                message="Failed to synchronize terminal subagent instance status",
-                payload={
-                    "subagent_run_id": subagent_run_id,
-                    "session_id": session_id,
-                    "instance_id": instance_id,
-                    "status": status.value,
-                },
-                exc_info=exc,
-            )
-    if update_run_runtime is not None:
-        try:
-            update_run_runtime(
-                subagent_run_id,
-                status=terminal.run_status,
-                phase=terminal.run_phase,
-                active_instance_id=None,
-                active_task_id=None,
-                active_role_id=None,
-                active_subagent_instance_id=None,
-                last_error=terminal.last_error,
-            )
-        except Exception as exc:
-            log_event(
-                LOGGER,
-                logging.WARNING,
-                event="subagent_lifecycle.runtime_terminal_update_skipped",
-                message="Failed to synchronize terminal subagent runtime status",
-                payload={
-                    "subagent_run_id": subagent_run_id,
-                    "session_id": session_id,
-                    "status": status.value,
-                },
-                exc_info=exc,
-            )
 
 
 def mark_subagent_resumed_records(

--- a/src/relay_teams/tools/runtime/context.py
+++ b/src/relay_teams/tools/runtime/context.py
@@ -31,7 +31,7 @@ from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.roles.runtime_role_resolver import RuntimeRoleResolver
 from relay_teams.sessions.runs.event_log import EventLog
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager
 from relay_teams.sessions.runs.run_control_manager import RunControlManager

--- a/src/relay_teams/tools/workspace_tools/background_task_tool_support.py
+++ b/src/relay_teams/tools/workspace_tools/background_task_tool_support.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.background_tasks.models import BackgroundTaskRecord
 from relay_teams.sessions.runs.background_tasks.projection import (
     build_background_task_result_payload,

--- a/tests/unit_tests/agents/orchestration/test_task_execution_service.py
+++ b/tests/unit_tests/agents/orchestration/test_task_execution_service.py
@@ -13,6 +13,7 @@ from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelRequest, UserPromptPart
 
 from relay_teams.agents.execution.message_repository import MessageRepository
+from relay_teams.agents.execution.system_prompts import PromptBuildInput
 from relay_teams.agents.execution.system_prompts import RuntimePromptBuilder
 from relay_teams.agents.execution.system_prompts import RuntimePromptSections
 from relay_teams.agent_runtimes.instances.enums import InstanceStatus
@@ -36,6 +37,16 @@ from relay_teams.media import (
 )
 from relay_teams.mcp.mcp_models import McpToolSchema
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.memory.models import (
+    CreateMemoryEntryRequest,
+    MemoryContent,
+    MemoryEntryKind,
+    MemoryScope,
+    MemorySourceKind,
+    MemoryTier,
+)
+from relay_teams.memory.repository import MemoryBankRepository
+from relay_teams.memory.service import MemoryBankService
 from relay_teams.persistence import close_live_sqlite_repositories_async
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
 from relay_teams.reminders import ReminderStateRepository
@@ -199,11 +210,11 @@ class _CapturingHookService:
 
 
 class _StaticPromptBuilder(RuntimePromptBuilder):
-    async def build_sections(self, data: object) -> RuntimePromptSections:
-        _ = data
+    async def build_sections(self, data: PromptBuildInput) -> RuntimePromptSections:
+        prompt = data.role.system_prompt
         return RuntimePromptSections(
-            prompt="You are the time role.",
-            base_instructions="You are the time role.",
+            prompt=prompt,
+            base_instructions=prompt,
         )
 
 
@@ -290,6 +301,7 @@ def _build_service(
     db_path: Path,
     provider: object,
     artifact_repo: TaskArtifactRepository | None = None,
+    memory_bank_service: MemoryBankService | None = None,
 ) -> tuple[
     TaskExecutionService,
     TaskRepository,
@@ -334,6 +346,7 @@ def _build_service(
         mcp_registry=McpRegistry(),
         run_intent_repo=RunIntentRepository(db_path),
         artifact_repo=artifact_repo,
+        memory_bank_service=memory_bank_service,
     )
     return service, task_repo, agent_repo, message_repo
 
@@ -487,6 +500,53 @@ async def test_execute_omits_objective_when_task_history_exists(
 
     assert result.output == "ok"
     assert provider.prompts == [None]
+
+
+@pytest.mark.asyncio
+async def test_execute_injects_memory_bank_project_memory(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "task_execution_service_memory_bank.db"
+    memory_bank_service = MemoryBankService(
+        repository=MemoryBankRepository(tmp_path / "memory_bank.db")
+    )
+    _ = await memory_bank_service.create_entry_async(
+        CreateMemoryEntryRequest(
+            tier=MemoryTier.PERSISTENT,
+            scope=MemoryScope.WORKSPACE,
+            workspace_id="default",
+            role_id="time",
+            kind=MemoryEntryKind.CONSTRAINT,
+            content=MemoryContent(
+                title="Runtime memory must follow session context",
+                body="Agent runtime prompts include the shared project memory bank.",
+            ),
+            source=MemorySourceKind.MANUAL,
+        )
+    )
+    provider = _CapturingProvider()
+    service, task_repo, agent_repo, message_repo = _build_service(
+        db_path,
+        provider,
+        memory_bank_service=memory_bank_service,
+    )
+    task, instance_id = _seed_task(
+        task_repo=task_repo,
+        agent_repo=agent_repo,
+        message_repo=message_repo,
+    )
+
+    result = await service.execute(
+        instance_id=instance_id,
+        role_id="time",
+        task=task,
+    )
+
+    assert result.output == "ok"
+    assert provider.system_prompts
+    system_prompt = provider.system_prompts[0]
+    assert "## Project Memory" in system_prompt
+    assert "Runtime memory must follow session context" in system_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/providers/test_provider_factory.py
+++ b/tests/unit_tests/providers/test_provider_factory.py
@@ -29,7 +29,7 @@ from relay_teams.providers.model_fallback import LlmFallbackMiddleware
 from relay_teams.providers.provider_factory import create_provider_factory
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
-from relay_teams.sessions.runs.background_tasks import BackgroundTaskService
+from relay_teams.sessions.runs.background_tasks.service import BackgroundTaskService
 from relay_teams.sessions.runs.run_control_manager import RunControlManager
 from relay_teams.sessions.runs.event_stream import RunEventHub
 from relay_teams.sessions.runs.injection_queue import RunInjectionManager


### PR DESCRIPTION
## Summary
- wire MemoryBankService through task prompt/runtime assembly so agent runtime prompts receive Project Memory entries
- document Memory Bank, legacy reflection memory, microcompact, and full compaction responsibilities under session runtime
- move background-task terminal sync into the background task service to avoid package import cycles while keeping public service exports

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- PLAYWRIGHT_BROWSERS_PATH=/home/steven/.cache/ms-playwright uv run --extra dev pytest -q tests/integration_tests

Closes #781