### PR TITLE
Implement MCP runtime schema loader

### DIFF
--- a/src/relay_teams/agent_runtimes/clients/cli.py
+++ b/src/relay_teams/agent_runtimes/clients/cli.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 import os
+from collections.abc import Mapping
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
@@ -102,8 +103,13 @@ async def probe_cli_agent(
             env=runtime_env,
         ):
             raise CliAgentError(f"CLI command not found: {command}")
+        resolved_command = _resolve_cli_command(
+            command,
+            runtime_cwd=probe_cwd,
+            env=runtime_env,
+        )
         client = _StdioCliJsonRpcClient(
-            command=command,
+            command=resolved_command or command,
             args=_build_command_args(transport=transport),
             runtime_cwd=probe_cwd,
             transport=transport,
@@ -118,7 +124,7 @@ async def probe_cli_agent(
             message="External CLI agent runtime is reachable over stdio JSON-RPC.",
             protocol=ExternalAgentProtocol.CLI,
             protocol_version_text="stdio-jsonrpc",
-            agent_name=Path(command).name,
+            agent_name=Path(resolved_command or command).name,
             agent_version=user_agent,
         )
     except Exception as exc:
@@ -198,23 +204,40 @@ def _cli_command_exists(
     runtime_cwd: Path | None = None,
     env: dict[str, str] | None = None,
 ) -> bool:
+    return _resolve_cli_command(command, runtime_cwd=runtime_cwd, env=env) is not None
+
+
+def _resolve_cli_command(
+    command: str,
+    *,
+    runtime_cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> str | None:
+    lookup_env = env or os.environ
     if "/" in command or "\\" in command:
         candidate = Path(command)
         if not candidate.is_absolute() and runtime_cwd is not None:
             candidate = runtime_cwd / candidate
-        return _executable_path_exists(candidate)
-    lookup_env = env or os.environ
+        return _resolve_executable_path(candidate, env=lookup_env)
     for directory in os.get_exec_path(lookup_env):
         candidate = Path(directory) / command
-        if _executable_path_exists(candidate):
-            return True
-        if os.name == "nt":
-            for suffix in lookup_env.get("PATHEXT", "").split(";"):
-                if suffix and _executable_path_exists(
-                    Path(directory) / f"{command}{suffix}"
-                ):
-                    return True
-    return False
+        resolved = _resolve_executable_path(candidate, env=lookup_env)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _resolve_executable_path(path: Path, *, env: Mapping[str, str]) -> str | None:
+    if _executable_path_exists(path):
+        return str(path)
+    if os.name != "nt" or path.suffix:
+        return None
+    for suffix in env.get("PATHEXT", "").split(";"):
+        if suffix:
+            candidate = path.with_name(f"{path.name}{suffix}")
+            if _executable_path_exists(candidate):
+                return str(candidate)
+    return None
 
 
 def _executable_path_exists(path: Path) -> bool:
@@ -554,8 +577,13 @@ class _StdioCliJsonRpcClient:
         if self._process is not None and self._process.returncode is None:
             return
         env = _runtime_env(self._transport)
-        self._process = await asyncio.create_subprocess_exec(
+        command = _resolve_cli_command(
             self._command,
+            runtime_cwd=self._runtime_cwd,
+            env=env,
+        )
+        self._process = await asyncio.create_subprocess_exec(
+            command or self._command,
             *self._args,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,

--- a/src/relay_teams/agents/execution/spec_checkpoint.py
+++ b/src/relay_teams/agents/execution/spec_checkpoint.py
@@ -221,11 +221,13 @@ def render_spec_checkpoint(
         lines.extend(
             _format_nested_items(
                 "Proof Artifacts",
-                tuple(str(path) for path in formal.proof_artifacts),
+                tuple(path.as_posix() for path in formal.proof_artifacts),
             )
         )
         if formal.counterexample_path is not None:
-            lines.append(f"  - Counterexample Path: {formal.counterexample_path}")
+            lines.append(
+                f"  - Counterexample Path: {formal.counterexample_path.as_posix()}"
+            )
         if formal.replay_command is not None:
             lines.append(
                 "  - Replay Command: " + " ".join(formal.replay_command.command)

--- a/src/relay_teams/agents/execution/system_prompts.py
+++ b/src/relay_teams/agents/execution/system_prompts.py
@@ -36,6 +36,7 @@ from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_models import McpDiscoveryStatus
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_contracts import build_role_contract_prompt
 from relay_teams.roles.role_registry import (
@@ -605,6 +606,7 @@ async def build_runtime_system_prompt(
     runtime_role_resolver: RuntimeRoleResolver | None = None,
     mcp_registry: McpRegistry | None = None,
     mcp_discovery_service: McpDiscoveryService | None = None,
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None = None,
     instruction_resolver: PromptInstructionResolver | None = None,
     hook_service: RuntimePromptHookService | None = None,
     run_event_hub: RunEventHub | None = None,
@@ -615,6 +617,7 @@ async def build_runtime_system_prompt(
         runtime_role_resolver=runtime_role_resolver,
         mcp_registry=mcp_registry,
         mcp_discovery_service=mcp_discovery_service,
+        runtime_mcp_schema_loader=runtime_mcp_schema_loader,
         instruction_resolver=instruction_resolver,
         hook_service=hook_service,
         run_event_hub=run_event_hub,
@@ -629,6 +632,7 @@ async def build_runtime_system_prompt_result(
     runtime_role_resolver: RuntimeRoleResolver | None = None,
     mcp_registry: McpRegistry | None = None,
     mcp_discovery_service: McpDiscoveryService | None = None,
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None = None,
     instruction_resolver: PromptInstructionResolver | None = None,
     hook_service: RuntimePromptHookService | None = None,
     run_event_hub: RunEventHub | None = None,
@@ -709,6 +713,7 @@ async def build_runtime_system_prompt_result(
         runtime_role_resolver=runtime_role_resolver,
         mcp_registry=mcp_registry,
         mcp_discovery_service=mcp_discovery_service,
+        runtime_mcp_schema_loader=runtime_mcp_schema_loader,
         run_id=data.task.trace_id if data.task is not None else None,
         allowed_role_ids=topology.allowed_role_ids if topology is not None else (),
     )
@@ -742,6 +747,7 @@ async def build_available_roles_prompt(
     runtime_role_resolver: RuntimeRoleResolver | None = None,
     mcp_registry: McpRegistry,
     mcp_discovery_service: McpDiscoveryService | None = None,
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None = None,
     run_id: str | None = None,
     allowed_role_ids: tuple[str, ...] = (),
 ) -> str:
@@ -779,6 +785,7 @@ async def build_available_roles_prompt(
                 ),
                 mcp_registry=mcp_registry,
                 mcp_discovery_service=mcp_discovery_service,
+                runtime_mcp_schema_loader=runtime_mcp_schema_loader,
             )
             for role in roles
         ]
@@ -960,11 +967,13 @@ async def _build_available_role_block(
     role_source: str,
     mcp_registry: McpRegistry,
     mcp_discovery_service: McpDiscoveryService | None,
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None,
 ) -> str:
     mcp_tools = await _list_role_mcp_tools(
         role=role,
         mcp_registry=mcp_registry,
         mcp_discovery_service=mcp_discovery_service,
+        runtime_mcp_schema_loader=runtime_mcp_schema_loader,
     )
     runtime_tools = runtime_tools_for_role(
         role_registry=role_registry,
@@ -988,6 +997,7 @@ async def _list_role_mcp_tools(
     role: RoleDefinition,
     mcp_registry: McpRegistry,
     mcp_discovery_service: McpDiscoveryService | None,
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None,
 ) -> tuple[str, ...]:
     resolved_server_names = mcp_registry.resolve_server_names(
         role.mcp_servers,
@@ -997,16 +1007,13 @@ async def _list_role_mcp_tools(
     if not resolved_server_names:
         return ()
     if mcp_discovery_service is None:
-        live_tool_groups = await asyncio.gather(
-            *(
-                mcp_registry.list_tools(server_name)
-                for server_name in resolved_server_names
-            )
-        )
+        loader = runtime_mcp_schema_loader or RuntimeMcpSchemaLoader(mcp_registry)
+        schema_load = await loader.load_many(resolved_server_names)
         return tuple(
-            tool_name
-            for tool_group in live_tool_groups
-            for tool_name in _tool_names(tool_group)
+            schema.name
+            for result in schema_load.results
+            if result.ok
+            for schema in result.schemas
         )
     return tuple(
         tool_name
@@ -1151,6 +1158,7 @@ class RuntimePromptBuilder(BaseModel):
     runtime_role_resolver: RuntimeRoleResolver | None = None
     mcp_registry: McpRegistry | None = None
     mcp_discovery_service: McpDiscoveryService | None = None
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None = None
     instruction_resolver: PromptInstructionResolver | None = None
     hook_service: RuntimePromptHookService | None = None
     run_event_hub: RunEventHub | None = None
@@ -1169,6 +1177,7 @@ class RuntimePromptBuilder(BaseModel):
             runtime_role_resolver=self.runtime_role_resolver,
             mcp_registry=self.mcp_registry,
             mcp_discovery_service=self.mcp_discovery_service,
+            runtime_mcp_schema_loader=self.runtime_mcp_schema_loader,
             instruction_resolver=self.instruction_resolver,
             hook_service=self.hook_service,
             run_event_hub=self.run_event_hub,

--- a/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/execution_harness.py
@@ -43,6 +43,7 @@ from relay_teams.agents.tasks.task_repository import TaskRepository
 from relay_teams.hooks import HookService
 from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.media import MediaAssetService
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
@@ -112,6 +113,7 @@ class ExecutionHarness(BaseModel):
     skill_registry: object
     skill_runtime_service: object | None = None
     mcp_registry: McpRegistry
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None = None
     run_control_manager: object | None = None
     role_memory_service: RoleMemoryService | None = None
     memory_bank_service: MemoryBankService | None = None
@@ -132,6 +134,7 @@ class ExecutionHarness(BaseModel):
             tool_registry=self.tool_registry,
             skill_registry=self.skill_registry,
             mcp_registry=self.mcp_registry,
+            runtime_mcp_schema_loader=self.runtime_mcp_schema_loader,
         )
 
     def _prompt_harness(self) -> TaskPromptHarness:

--- a/src/relay_teams/agents/orchestration/harnesses/tool_harness.py
+++ b/src/relay_teams/agents/orchestration/harnesses/tool_harness.py
@@ -18,6 +18,7 @@ from relay_teams.agent_runtimes.instances.models import (
 from relay_teams.agents.tasks.models import TaskEnvelope
 from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.roles.runtime_tools import runtime_tools_for_role
@@ -34,6 +35,7 @@ class TaskToolHarness(BaseModel):
     tool_registry: object
     skill_registry: object
     mcp_registry: McpRegistry
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None = None
 
     async def build_runtime_tools_snapshot(
         self,
@@ -110,19 +112,20 @@ class TaskToolHarness(BaseModel):
                     local_tools.append(entry)
 
         mcp_tools: list[RuntimeToolSnapshotEntry] = []
-        for server_name in self.mcp_registry.resolve_server_names(
+        resolved_server_names = self.mcp_registry.resolve_server_names(
             role.mcp_servers,
             strict=False,
             consumer=(
                 "agents.orchestration.harnesses.tool_harness"
                 ".build_runtime_tools_snapshot"
             ),
-        ):
-            try:
-                server_tool_schemas = await self.mcp_registry.list_tool_schemas(
-                    server_name
-                )
-            except Exception as exc:
+        )
+        loader = self.runtime_mcp_schema_loader or RuntimeMcpSchemaLoader(
+            self.mcp_registry
+        )
+        schema_load = await loader.load_many(resolved_server_names)
+        for result in schema_load.results:
+            if not result.ok:
                 log_event(
                     LOGGER,
                     logging.WARNING,
@@ -131,11 +134,13 @@ class TaskToolHarness(BaseModel):
                         "Failed to inspect MCP tools for runtime snapshot; "
                         "continuing without this MCP server"
                     ),
-                    payload={"server_name": server_name},
-                    exc_info=exc,
+                    payload={
+                        "server_name": result.server_name,
+                        "error": result.error or "",
+                    },
                 )
                 continue
-            for tool in server_tool_schemas:
+            for tool in result.schemas:
                 mcp_tools.append(
                     self.tool_entry_from_definition(
                         source="mcp",
@@ -145,7 +150,7 @@ class TaskToolHarness(BaseModel):
                         strict=None,
                         sequential=False,
                         parameters_json_schema=tool.input_schema,
-                        server_name=server_name,
+                        server_name=result.server_name,
                     )
                 )
 

--- a/src/relay_teams/agents/orchestration/task_execution_service.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service.py
@@ -53,6 +53,7 @@ from relay_teams.agents.tasks.wakeup_models import AgentWakeupEntry
 from relay_teams.hooks import HookService
 from relay_teams.logger import get_logger, log_event
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.media import MediaAssetService
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.persistence.shared_state_repo import SharedStateRepository
@@ -129,6 +130,7 @@ class TaskExecutionService(BaseModel):
     skill_registry: object
     skill_runtime_service: object | None = None
     mcp_registry: McpRegistry
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None = None
     injection_manager: RunInjectionManager | None = None
     run_control_manager: RunControlManager | None = None
     role_memory_service: RoleMemoryService | None = None
@@ -163,6 +165,11 @@ class TaskExecutionService(BaseModel):
             skill_registry=getattr(self, "skill_registry", None),
             skill_runtime_service=getattr(self, "skill_runtime_service", None),
             mcp_registry=getattr(self, "mcp_registry", None),
+            runtime_mcp_schema_loader=getattr(
+                self,
+                "runtime_mcp_schema_loader",
+                None,
+            ),
             run_control_manager=getattr(self, "run_control_manager", None),
             role_memory_service=getattr(self, "role_memory_service", None),
             memory_bank_service=getattr(self, "memory_bank_service", None),

--- a/src/relay_teams/agents/orchestration/task_execution_service_factory.py
+++ b/src/relay_teams/agents/orchestration/task_execution_service_factory.py
@@ -11,6 +11,7 @@ from relay_teams.media import MediaAssetService
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.providers.provider_contracts import LLMProvider
 from relay_teams.roles.memory_service import RoleMemoryService
 from relay_teams.roles.role_models import RoleDefinition
@@ -62,6 +63,7 @@ def create_task_execution_service(
     skill_runtime_service: SkillRuntimeService | None,
     mcp_registry: McpRegistry,
     mcp_discovery_service: McpDiscoveryService | None,
+    runtime_mcp_schema_loader: RuntimeMcpSchemaLoader | None = None,
     injection_manager: RunInjectionManager,
     run_control_manager: RunControlManager,
     role_memory_service: RoleMemoryService | None = None,
@@ -95,12 +97,14 @@ def create_task_execution_service(
             hook_service=hook_service,
             run_event_hub=run_event_hub,
             mcp_discovery_service=mcp_discovery_service,
+            runtime_mcp_schema_loader=runtime_mcp_schema_loader,
         ),
         provider_factory=provider_factory,
         tool_registry=tool_registry,
         skill_registry=skill_registry,
         skill_runtime_service=skill_runtime_service,
         mcp_registry=mcp_registry,
+        runtime_mcp_schema_loader=runtime_mcp_schema_loader,
         injection_manager=injection_manager,
         run_control_manager=run_control_manager,
         role_memory_service=role_memory_service,

--- a/src/relay_teams/interfaces/server/container.py
+++ b/src/relay_teams/interfaces/server/container.py
@@ -110,6 +110,7 @@ from relay_teams.mcp.mcp_config_watcher import McpConfigFileWatcher
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.mcp.mcp_service import McpService
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.metrics import (
     AggregateStoreSink,
     DEFAULT_DEFINITIONS,
@@ -420,12 +421,14 @@ class ServerContainer:
         self.mcp_discovery_service: McpDiscoveryService = McpDiscoveryService(
             self.mcp_registry
         )
+        self.runtime_mcp_schema_loader = RuntimeMcpSchemaLoader(self.mcp_registry)
         self.mcp_service: McpService = McpService(
             registry=self.mcp_registry,
             config_manager=self.mcp_config_manager,
             on_registry_changed=self.replace_mcp_registry,
             extra_specs=self._plugin_mcp_specs,
             discovery_service=self.mcp_discovery_service,
+            runtime_schema_loader=self.runtime_mcp_schema_loader,
         )
         self.command_registry: CommandRegistry = CommandRegistry(
             app_config_dir=app_config_dir,
@@ -812,6 +815,7 @@ class ServerContainer:
                 role_registry=self.role_registry,
                 mcp_registry=self.mcp_registry,
                 mcp_discovery_service=self.mcp_discovery_service,
+                runtime_mcp_schema_loader=self.runtime_mcp_schema_loader,
                 instruction_resolver=PromptInstructionResolver(
                     app_config_dir=runtime.paths.config_dir,
                     instructions=runtime.prompt_instructions.instructions,
@@ -1260,6 +1264,7 @@ class ServerContainer:
             skill_runtime_service=self.skill_runtime_service,
             mcp_registry=self.mcp_registry,
             mcp_discovery_service=self.mcp_discovery_service,
+            runtime_mcp_schema_loader=self.runtime_mcp_schema_loader,
             injection_manager=self.injection_manager,
             run_control_manager=self.run_control_manager,
             role_memory_service=self.role_memory_service,
@@ -1497,6 +1502,7 @@ class ServerContainer:
 
     def replace_mcp_registry(self, mcp_registry: McpRegistry) -> None:
         self.mcp_registry = mcp_registry
+        self.runtime_mcp_schema_loader.replace_registry(mcp_registry)
         self.mcp_service.replace_registry(mcp_registry)
         self._refresh_coordinator_runtime()
 
@@ -1507,6 +1513,7 @@ class ServerContainer:
             role_registry=self.role_registry,
             mcp_registry=self.mcp_registry,
             mcp_discovery_service=self.mcp_discovery_service,
+            runtime_mcp_schema_loader=self.runtime_mcp_schema_loader,
             instruction_resolver=PromptInstructionResolver(
                 app_config_dir=self.runtime.paths.config_dir,
                 instructions=self.runtime.prompt_instructions.instructions,

--- a/src/relay_teams/interfaces/server/deps.py
+++ b/src/relay_teams/interfaces/server/deps.py
@@ -41,6 +41,7 @@ from relay_teams.mcp.config_reload_service import McpConfigReloadService
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
 from relay_teams.mcp.mcp_service import McpService
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.media import MediaAssetService
 from relay_teams.memory.service import MemoryBankService
 from relay_teams.metrics import MetricsService
@@ -190,6 +191,10 @@ def get_mcp_registry(request: Request) -> McpRegistry:
 
 def get_mcp_discovery_service(request: Request) -> McpDiscoveryService:
     return get_container(request).mcp_discovery_service
+
+
+def get_runtime_mcp_schema_loader(request: Request) -> RuntimeMcpSchemaLoader:
+    return get_container(request).runtime_mcp_schema_loader
 
 
 def get_proxy_config_service(request: Request) -> ProxyConfigService:

--- a/src/relay_teams/interfaces/server/routers/mcp.py
+++ b/src/relay_teams/interfaces/server/routers/mcp.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
+from threading import Lock
+import time
+
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
 
 from relay_teams.interfaces.server.deps import get_mcp_service
 from relay_teams.mcp.mcp_models import (
@@ -17,6 +22,17 @@ from relay_teams.mcp.mcp_models import (
 from relay_teams.mcp.mcp_service import McpService
 
 router = APIRouter(prefix="/mcp", tags=["MCP"])
+_TOOLS_ROUTE_CACHE_SECONDS = 0.25
+_TOOLS_ROUTE_LOCK = Lock()
+_TOOLS_ROUTE_CACHE: dict[str, "_CachedToolsRouteResult"] = {}
+_TOOLS_ROUTE_IN_FLIGHT: dict[str, asyncio.Task[McpServerToolsSummary]] = {}
+
+
+class _CachedToolsRouteResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    summary: McpServerToolsSummary
+    expires_at: float
 
 
 @router.get("/servers")
@@ -90,9 +106,11 @@ async def list_mcp_server_tools(
     service: McpService = Depends(get_mcp_service),
 ) -> McpServerToolsSummary:
     try:
-        return await service.list_server_tools(server_name)
+        return await _list_mcp_server_tools_with_route_guard(server_name, service)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @router.post("/servers/{server_name}/tools:refresh")
@@ -104,6 +122,8 @@ async def refresh_mcp_server_tools(
         return service.refresh_server_tools(server_name)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @router.post("/servers/{server_name}/test")
@@ -115,3 +135,44 @@ async def test_mcp_server_connection(
         return await service.test_server_connection(server_name)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+async def _list_mcp_server_tools_with_route_guard(
+    server_name: str,
+    service: McpService,
+) -> McpServerToolsSummary:
+    normalized_name = server_name.strip()
+    loop = asyncio.get_running_loop()
+    task_to_await: asyncio.Task[McpServerToolsSummary] | None = None
+    created_task: asyncio.Task[McpServerToolsSummary] | None = None
+    with _TOOLS_ROUTE_LOCK:
+        cached = _TOOLS_ROUTE_CACHE.get(normalized_name)
+        if cached is not None:
+            if cached.expires_at > time.monotonic():
+                return cached.summary
+            del _TOOLS_ROUTE_CACHE[normalized_name]
+        existing_task = _TOOLS_ROUTE_IN_FLIGHT.get(normalized_name)
+        if existing_task is not None:
+            if existing_task.done():
+                del _TOOLS_ROUTE_IN_FLIGHT[normalized_name]
+            elif existing_task.get_loop() == loop:
+                task_to_await = existing_task
+        if task_to_await is None:
+            created_task = loop.create_task(service.list_server_tools(server_name))
+            _TOOLS_ROUTE_IN_FLIGHT[normalized_name] = created_task
+            task_to_await = created_task
+
+    try:
+        summary = await asyncio.shield(task_to_await)
+    finally:
+        if created_task is not None:
+            with _TOOLS_ROUTE_LOCK:
+                if _TOOLS_ROUTE_IN_FLIGHT.get(normalized_name) is created_task:
+                    del _TOOLS_ROUTE_IN_FLIGHT[normalized_name]
+    if created_task is not None:
+        with _TOOLS_ROUTE_LOCK:
+            _TOOLS_ROUTE_CACHE[normalized_name] = _CachedToolsRouteResult(
+                summary=summary,
+                expires_at=time.monotonic() + _TOOLS_ROUTE_CACHE_SECONDS,
+            )
+    return summary

--- a/src/relay_teams/interfaces/server/routers/prompts.py
+++ b/src/relay_teams/interfaces/server/routers/prompts.py
@@ -12,6 +12,7 @@ from relay_teams.interfaces.server.deps import (
     get_mcp_discovery_service,
     get_mcp_registry,
     get_role_registry,
+    get_runtime_mcp_schema_loader,
     get_skill_registry,
     get_skill_runtime_service,
     get_tool_registry,
@@ -28,6 +29,7 @@ from relay_teams.agents.execution.system_prompts import (
 )
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.paths import get_app_config_dir
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
@@ -103,6 +105,9 @@ async def preview_prompts(
     mcp_discovery_service: Annotated[
         McpDiscoveryService, Depends(get_mcp_discovery_service)
     ],
+    runtime_mcp_schema_loader: Annotated[
+        RuntimeMcpSchemaLoader, Depends(get_runtime_mcp_schema_loader)
+    ],
     skill_registry: Annotated[SkillRegistry, Depends(get_skill_registry)],
     skill_runtime_service: Annotated[
         SkillRuntimeService, Depends(get_skill_runtime_service)
@@ -168,6 +173,7 @@ async def preview_prompts(
         role_registry=role_registry,
         mcp_registry=mcp_registry,
         mcp_discovery_service=mcp_discovery_service,
+        runtime_mcp_schema_loader=runtime_mcp_schema_loader,
         instruction_resolver=PromptInstructionResolver(
             app_config_dir=get_app_config_dir()
         ),

--- a/src/relay_teams/mcp/__init__.py
+++ b/src/relay_teams/mcp/__init__.py
@@ -9,6 +9,7 @@ from relay_teams.mcp.mcp_models import (
     McpServerToolsSummary,
     McpToolInfo,
 )
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 
 __all__ = [
     "McpConfigScope",
@@ -17,4 +18,5 @@ __all__ = [
     "McpServerSummary",
     "McpServerToolsSummary",
     "McpToolInfo",
+    "RuntimeMcpSchemaLoader",
 ]

--- a/src/relay_teams/mcp/mcp_service.py
+++ b/src/relay_teams/mcp/mcp_service.py
@@ -19,8 +19,10 @@ from relay_teams.mcp.mcp_models import (
     McpServerSummary,
     McpServerToolsSummary,
     McpServerUpdateRequest,
+    McpToolInfo,
 )
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 
 from relay_teams.trace import trace_span
 
@@ -36,6 +38,7 @@ class McpService:
         on_registry_changed: Callable[[McpRegistry], None] | None = None,
         extra_specs: tuple[McpServerSpec, ...] = (),
         discovery_service: McpDiscoveryService | None = None,
+        runtime_schema_loader: RuntimeMcpSchemaLoader | None = None,
     ) -> None:
         self._registry: McpRegistry = registry
         self._config_manager: McpConfigManager | None = config_manager
@@ -44,11 +47,14 @@ class McpService:
         )
         self._extra_specs: tuple[McpServerSpec, ...] = extra_specs
         self._discovery_service: McpDiscoveryService | None = discovery_service
+        self._runtime_schema_loader = runtime_schema_loader
 
     def replace_registry(self, registry: McpRegistry) -> None:
         self._registry = registry
         if self._discovery_service is not None:
             self._discovery_service.replace_registry(registry)
+        if self._runtime_schema_loader is not None:
+            self._runtime_schema_loader.replace_registry(registry)
 
     def replace_extra_specs(self, extra_specs: tuple[McpServerSpec, ...]) -> None:
         self._extra_specs = extra_specs
@@ -139,7 +145,23 @@ class McpService:
                     enabled=spec.enabled,
                     status=McpDiscoveryStatus.DISABLED,
                 )
-            tools = await self._registry.list_tools(name)
+            loader = self._runtime_schema_loader or RuntimeMcpSchemaLoader(
+                self._registry
+            )
+            result = await loader.load_server(spec.name)
+            if not result.ok:
+                return McpServerToolsSummary(
+                    server=spec.name,
+                    source=spec.source,
+                    transport=_detect_transport(spec.server_config),
+                    enabled=spec.enabled,
+                    status=McpDiscoveryStatus.FAILED,
+                    error=result.error,
+                )
+            tools = tuple(
+                McpToolInfo(name=schema.name, description=schema.description)
+                for schema in result.schemas
+            )
             return McpServerToolsSummary(
                 server=spec.name,
                 source=spec.source,
@@ -160,6 +182,8 @@ class McpService:
             if self._discovery_service is not None:
                 return self._discovery_service.refresh_server(name)
             spec = self._registry.get_spec(name)
+            if self._runtime_schema_loader is not None:
+                self._runtime_schema_loader.invalidate_server(spec.name)
             return McpServerToolsSummary(
                 server=spec.name,
                 source=spec.source,

--- a/src/relay_teams/mcp/runtime_schema_loader.py
+++ b/src/relay_teams/mcp/runtime_schema_loader.py
@@ -1,0 +1,466 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from enum import Enum
+import logging
+import os
+from threading import Lock
+import time
+
+from pydantic import BaseModel, ConfigDict
+
+from relay_teams.logger import get_logger, log_event
+from relay_teams.mcp.mcp_models import McpToolSchema
+from relay_teams.mcp.mcp_registry import McpRegistry
+
+LOGGER = get_logger(__name__)
+
+RUNTIME_MCP_SCHEMA_CACHE_TTL_MS_ENV = "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_CACHE_TTL_MS"
+RUNTIME_MCP_SCHEMA_FAILED_TTL_MS_ENV = "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_FAILED_TTL_MS"
+RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS_ENV = (
+    "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS"
+)
+RUNTIME_MCP_SCHEMA_MAX_CONCURRENCY_ENV = (
+    "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_MAX_CONCURRENCY"
+)
+RUNTIME_MCP_SCHEMA_GLOBAL_FAILURE_THRESHOLD_ENV = (
+    "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_GLOBAL_FAILURE_THRESHOLD"
+)
+RUNTIME_MCP_SCHEMA_GLOBAL_COOLDOWN_MS_ENV = (
+    "RELAY_TEAMS_RUNTIME_MCP_SCHEMA_GLOBAL_COOLDOWN_MS"
+)
+
+DEFAULT_RUNTIME_MCP_SCHEMA_CACHE_TTL_MS = 30_000
+DEFAULT_RUNTIME_MCP_SCHEMA_FAILED_TTL_MS = 60_000
+DEFAULT_RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS = 1_500
+DEFAULT_RUNTIME_MCP_SCHEMA_MAX_CONCURRENCY = 3
+DEFAULT_RUNTIME_MCP_SCHEMA_GLOBAL_FAILURE_THRESHOLD = 3
+DEFAULT_RUNTIME_MCP_SCHEMA_GLOBAL_COOLDOWN_MS = 2_000
+
+
+class RuntimeMcpSchemaStatus(str, Enum):
+    LOADED = "loaded"
+    CACHE_HIT = "cache_hit"
+    FAILED = "failed"
+    SERVER_COOLDOWN = "server_cooldown"
+    GLOBAL_COOLDOWN = "global_cooldown"
+
+
+class RuntimeMcpServerSchemaResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    server_name: str
+    status: RuntimeMcpSchemaStatus
+    schemas: tuple[McpToolSchema, ...] = ()
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status in (
+            RuntimeMcpSchemaStatus.LOADED,
+            RuntimeMcpSchemaStatus.CACHE_HIT,
+        )
+
+
+class RuntimeMcpSchemaLoadResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    results: tuple[RuntimeMcpServerSchemaResult, ...]
+    schemas_by_server: dict[str, tuple[McpToolSchema, ...]]
+
+    @property
+    def loaded_count(self) -> int:
+        return sum(1 for result in self.results if result.ok)
+
+    @property
+    def skipped_count(self) -> int:
+        return len(self.results) - self.loaded_count
+
+
+class _CachedRuntimeMcpSchemas(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schemas: tuple[McpToolSchema, ...]
+    expires_at: float
+
+
+class _RuntimeMcpServerFailure(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    error: str
+    failed_until: float
+
+
+class RuntimeMcpSchemaLoader:
+    def __init__(
+        self,
+        registry: McpRegistry,
+        *,
+        cache_ttl_seconds: float | None = None,
+        failure_ttl_seconds: float | None = None,
+        server_timeout_seconds: float | None = None,
+        max_concurrency: int | None = None,
+        global_failure_threshold: int | None = None,
+        global_cooldown_seconds: float | None = None,
+    ) -> None:
+        self._registry = registry
+        self._cache_ttl_seconds = (
+            cache_ttl_seconds
+            if cache_ttl_seconds is not None
+            else _positive_int_env(
+                RUNTIME_MCP_SCHEMA_CACHE_TTL_MS_ENV,
+                DEFAULT_RUNTIME_MCP_SCHEMA_CACHE_TTL_MS,
+            )
+            / 1000.0
+        )
+        self._failure_ttl_seconds = (
+            failure_ttl_seconds
+            if failure_ttl_seconds is not None
+            else _positive_int_env(
+                RUNTIME_MCP_SCHEMA_FAILED_TTL_MS_ENV,
+                DEFAULT_RUNTIME_MCP_SCHEMA_FAILED_TTL_MS,
+            )
+            / 1000.0
+        )
+        self._server_timeout_seconds = (
+            server_timeout_seconds
+            if server_timeout_seconds is not None
+            else _positive_int_env(
+                RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS_ENV,
+                DEFAULT_RUNTIME_MCP_SCHEMA_SERVER_TIMEOUT_MS,
+            )
+            / 1000.0
+        )
+        resolved_max_concurrency = (
+            max_concurrency
+            if max_concurrency is not None
+            else _positive_int_env(
+                RUNTIME_MCP_SCHEMA_MAX_CONCURRENCY_ENV,
+                DEFAULT_RUNTIME_MCP_SCHEMA_MAX_CONCURRENCY,
+            )
+        )
+        self._global_failure_threshold = (
+            global_failure_threshold
+            if global_failure_threshold is not None
+            else _positive_int_env(
+                RUNTIME_MCP_SCHEMA_GLOBAL_FAILURE_THRESHOLD_ENV,
+                DEFAULT_RUNTIME_MCP_SCHEMA_GLOBAL_FAILURE_THRESHOLD,
+            )
+        )
+        self._global_cooldown_seconds = (
+            global_cooldown_seconds
+            if global_cooldown_seconds is not None
+            else _positive_int_env(
+                RUNTIME_MCP_SCHEMA_GLOBAL_COOLDOWN_MS_ENV,
+                DEFAULT_RUNTIME_MCP_SCHEMA_GLOBAL_COOLDOWN_MS,
+            )
+            / 1000.0
+        )
+        self._semaphore = asyncio.Semaphore(max(1, resolved_max_concurrency))
+        self._lock = Lock()
+        self._cache: dict[str, _CachedRuntimeMcpSchemas] = {}
+        self._failures: dict[str, _RuntimeMcpServerFailure] = {}
+        self._in_flight: dict[str, asyncio.Task[RuntimeMcpServerSchemaResult]] = {}
+        self._consecutive_failure_count = 0
+        self._global_cooldown_until = 0.0
+        self._registry_generation = 0
+
+    def replace_registry(self, registry: McpRegistry) -> None:
+        with self._lock:
+            self._registry = registry
+            self._registry_generation += 1
+            self._cache.clear()
+            self._failures.clear()
+            self._in_flight.clear()
+            self._consecutive_failure_count = 0
+            self._global_cooldown_until = 0.0
+
+    def invalidate_server(self, server_name: str) -> None:
+        normalized_name = server_name.strip()
+        with self._lock:
+            if normalized_name in self._cache:
+                del self._cache[normalized_name]
+            if normalized_name in self._failures:
+                del self._failures[normalized_name]
+
+    async def load_many(
+        self,
+        server_names: tuple[str, ...],
+        *,
+        force: bool = False,
+    ) -> RuntimeMcpSchemaLoadResult:
+        results = await asyncio.gather(
+            *(
+                self.load_server(server_name, force=force)
+                for server_name in server_names
+            )
+        )
+        schemas_by_server = {
+            result.server_name: result.schemas for result in results if result.ok
+        }
+        load_result = RuntimeMcpSchemaLoadResult(
+            results=tuple(results),
+            schemas_by_server=schemas_by_server,
+        )
+        self._log_load_result(load_result)
+        return load_result
+
+    async def load_server(
+        self,
+        server_name: str,
+        *,
+        force: bool = False,
+    ) -> RuntimeMcpServerSchemaResult:
+        normalized_name = server_name.strip()
+        if not normalized_name:
+            return RuntimeMcpServerSchemaResult(
+                server_name=server_name,
+                status=RuntimeMcpSchemaStatus.FAILED,
+                error="MCP server name is empty",
+            )
+        current_loop = asyncio.get_running_loop()
+        task_to_await: asyncio.Task[RuntimeMcpServerSchemaResult] | None = None
+        created_task: asyncio.Task[RuntimeMcpServerSchemaResult] | None = None
+        with self._lock:
+            registry = self._registry
+            registry_generation = self._registry_generation
+            if not force:
+                cached_result = self._cached_result_locked(normalized_name)
+                if cached_result is not None:
+                    return cached_result
+                cooldown_result = self._cooldown_result_locked(normalized_name)
+                if cooldown_result is not None:
+                    return cooldown_result
+            existing_task = self._in_flight.get(normalized_name)
+            if existing_task is not None:
+                if existing_task.done():
+                    del self._in_flight[normalized_name]
+                elif existing_task.get_loop() == current_loop:
+                    task_to_await = existing_task
+            if task_to_await is None:
+                created_task = current_loop.create_task(
+                    self._load_uncached_server(
+                        normalized_name,
+                        registry=registry,
+                        registry_generation=registry_generation,
+                    )
+                )
+                self._in_flight[normalized_name] = created_task
+                task_to_await = created_task
+
+        try:
+            return await asyncio.shield(task_to_await)
+        finally:
+            if created_task is not None:
+                with self._lock:
+                    if self._in_flight.get(normalized_name) is created_task:
+                        del self._in_flight[normalized_name]
+
+    async def _load_uncached_server(
+        self,
+        server_name: str,
+        *,
+        registry: McpRegistry,
+        registry_generation: int,
+    ) -> RuntimeMcpServerSchemaResult:
+        try:
+            async with self._semaphore:
+                with self._lock:
+                    global_cooldown_result = self._global_cooldown_result_locked(
+                        server_name
+                    )
+                    if global_cooldown_result is not None:
+                        return global_cooldown_result
+                schemas = await asyncio.wait_for(
+                    registry.list_tool_schemas(server_name),
+                    timeout=self._server_timeout_seconds,
+                )
+        except TimeoutError as exc:
+            return self._remember_failure(
+                server_name,
+                "timed out",
+                exc,
+                registry=registry,
+                registry_generation=registry_generation,
+            )
+        except Exception as exc:
+            return self._remember_failure(
+                server_name,
+                _exception_message(exc),
+                exc,
+                registry=registry,
+                registry_generation=registry_generation,
+            )
+
+        now = time.monotonic()
+        with self._lock:
+            if (
+                registry_generation != self._registry_generation
+                or registry is not self._registry
+            ):
+                return RuntimeMcpServerSchemaResult(
+                    server_name=server_name,
+                    status=RuntimeMcpSchemaStatus.FAILED,
+                    error=(
+                        f"MCP server {server_name} schema load was discarded "
+                        "because the MCP registry was replaced"
+                    ),
+                )
+            self._cache[server_name] = _CachedRuntimeMcpSchemas(
+                schemas=schemas,
+                expires_at=now + self._cache_ttl_seconds,
+            )
+            if server_name in self._failures:
+                del self._failures[server_name]
+            self._consecutive_failure_count = 0
+            self._global_cooldown_until = 0.0
+        registry.mark_server_runtime_available(server_name)
+        return RuntimeMcpServerSchemaResult(
+            server_name=server_name,
+            status=RuntimeMcpSchemaStatus.LOADED,
+            schemas=schemas,
+        )
+
+    def _remember_failure(
+        self,
+        server_name: str,
+        error: str,
+        exc: Exception,
+        *,
+        registry: McpRegistry,
+        registry_generation: int,
+    ) -> RuntimeMcpServerSchemaResult:
+        now = time.monotonic()
+        failed_until = now + self._failure_ttl_seconds
+        with self._lock:
+            if (
+                registry_generation != self._registry_generation
+                or registry is not self._registry
+            ):
+                return RuntimeMcpServerSchemaResult(
+                    server_name=server_name,
+                    status=RuntimeMcpSchemaStatus.FAILED,
+                    error=(
+                        f"MCP server {server_name} schema load was discarded "
+                        "because the MCP registry was replaced"
+                    ),
+                )
+            if server_name in self._cache:
+                del self._cache[server_name]
+            self._failures[server_name] = _RuntimeMcpServerFailure(
+                error=_format_server_error(server_name, error),
+                failed_until=failed_until,
+            )
+            self._consecutive_failure_count += 1
+            if self._consecutive_failure_count >= self._global_failure_threshold:
+                self._global_cooldown_until = now + self._global_cooldown_seconds
+        registry.mark_server_runtime_failed(server_name)
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="mcp.runtime_schema_loader.failed",
+            message="MCP runtime schema load failed",
+            payload={"server_name": server_name, "error": error},
+            exc_info=exc,
+        )
+        return RuntimeMcpServerSchemaResult(
+            server_name=server_name,
+            status=RuntimeMcpSchemaStatus.FAILED,
+            error=_format_server_error(server_name, error),
+        )
+
+    def _cached_result_locked(
+        self,
+        server_name: str,
+    ) -> RuntimeMcpServerSchemaResult | None:
+        cached = self._cache.get(server_name)
+        if cached is None:
+            return None
+        if cached.expires_at <= time.monotonic():
+            del self._cache[server_name]
+            return None
+        return RuntimeMcpServerSchemaResult(
+            server_name=server_name,
+            status=RuntimeMcpSchemaStatus.CACHE_HIT,
+            schemas=cached.schemas,
+        )
+
+    def _cooldown_result_locked(
+        self,
+        server_name: str,
+    ) -> RuntimeMcpServerSchemaResult | None:
+        global_cooldown_result = self._global_cooldown_result_locked(server_name)
+        if global_cooldown_result is not None:
+            return global_cooldown_result
+        now = time.monotonic()
+        failure = self._failures.get(server_name)
+        if failure is None:
+            return None
+        if failure.failed_until <= now:
+            del self._failures[server_name]
+            return None
+        return RuntimeMcpServerSchemaResult(
+            server_name=server_name,
+            status=RuntimeMcpSchemaStatus.SERVER_COOLDOWN,
+            error=f"MCP server {server_name} is in failure cooldown: {failure.error}",
+        )
+
+    def _global_cooldown_result_locked(
+        self,
+        server_name: str,
+    ) -> RuntimeMcpServerSchemaResult | None:
+        now = time.monotonic()
+        if self._global_cooldown_until > now:
+            return RuntimeMcpServerSchemaResult(
+                server_name=server_name,
+                status=RuntimeMcpSchemaStatus.GLOBAL_COOLDOWN,
+                error=(
+                    "MCP schema loading is in global cooldown after repeated "
+                    f"failures; skipped server {server_name}"
+                ),
+            )
+        return None
+
+    @staticmethod
+    def _log_load_result(result: RuntimeMcpSchemaLoadResult) -> None:
+        if result.skipped_count == 0:
+            return
+        log_event(
+            LOGGER,
+            logging.WARNING,
+            event="mcp.runtime_schema_loader.degraded",
+            message="Runtime MCP schema load skipped unavailable servers",
+            payload={
+                "loaded_count": result.loaded_count,
+                "skipped_count": result.skipped_count,
+                "skipped_server_names": [
+                    entry.server_name for entry in result.results if not entry.ok
+                ],
+            },
+        )
+
+
+def _format_server_error(server_name: str, error: str) -> str:
+    stripped_error = error.strip()
+    if not stripped_error:
+        stripped_error = "unknown error"
+    return f"MCP server {server_name} schema load failed: {stripped_error}"
+
+
+def _exception_message(exc: Exception) -> str:
+    message = str(exc).strip()
+    if message:
+        return message
+    return exc.__class__.__name__
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        parsed = int(raw_value.strip())
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default

--- a/src/relay_teams/net/clawhub_connectivity.py
+++ b/src/relay_teams/net/clawhub_connectivity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime, timezone
 import os
+from os import pathsep
 from pathlib import Path
 from time import perf_counter
 import subprocess
@@ -462,7 +463,7 @@ def _prepend_to_path(existing_path: str | None, directory: Path) -> str:
     path_parts = [str(directory)]
     if existing_path:
         path_parts.append(existing_path)
-    return ":".join(path_parts)
+    return pathsep.join(path_parts)
 
 
 def _read_clawhub_version(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,12 +44,31 @@ _ensure_installed_mcp_package()
 
 
 def pytest_configure(config: pytest.Config) -> None:
+    _configure_windows_asyncio_policy()
     config.addinivalue_line(
         "markers",
         "asyncio: mark a test function to run in an asyncio event loop",
     )
 
 
+def _configure_windows_asyncio_policy() -> None:
+    if sys.platform != "win32":
+        return
+    from asyncio import WindowsProactorEventLoopPolicy
+
+    asyncio.set_event_loop_policy(WindowsProactorEventLoopPolicy())
+
+
+@pytest.fixture
+def event_loop_policy() -> asyncio.AbstractEventLoopPolicy:
+    if sys.platform != "win32":
+        return asyncio.get_event_loop_policy()
+    from asyncio import WindowsProactorEventLoopPolicy
+
+    return WindowsProactorEventLoopPolicy()
+
+
+@pytest.hookimpl(tryfirst=True)
 def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
     marker = pyfuncitem.get_closest_marker("asyncio")
     if marker is None:
@@ -68,6 +87,7 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
         finally:
             await _close_live_sqlite_repos_in_current_loop()
 
+    _configure_windows_asyncio_policy()
     asyncio.run(_run_test_with_sqlite_cleanup())
     return True
 

--- a/tests/unit_tests/agent_runtimes/test_cli_client.py
+++ b/tests/unit_tests/agent_runtimes/test_cli_client.py
@@ -263,6 +263,24 @@ def _build_cli_agent(
     )
 
 
+def _write_json_rpc_runtime_executable(path: Path) -> Path:
+    if os.name == "nt":
+        script_path = path.with_suffix(".py")
+        script_path.write_text(_JSON_RPC_RUNTIME_SCRIPT, encoding="utf-8")
+        command_path = path.with_suffix(".cmd")
+        command_path.write_text(
+            f'@echo off\r\n"{sys.executable}" "%~dp0{script_path.name}"\r\n',
+            encoding="utf-8",
+        )
+        return command_path
+    path.write_text(
+        f"#!{sys.executable}\n{_JSON_RPC_RUNTIME_SCRIPT}",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
 class _NotificationClient:
     def __init__(self, notifications: list[_CliJsonRpcNotification]) -> None:
         self._notifications = notifications
@@ -337,20 +355,15 @@ async def test_probe_cli_agent_resolves_relative_command_from_runtime_cwd(
 ) -> None:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    executable = bin_dir / "runtime-agent"
-    executable.write_text(
-        f"#!{sys.executable}\n{_JSON_RPC_RUNTIME_SCRIPT}",
-        encoding="utf-8",
-    )
-    executable.chmod(0o755)
+    executable = _write_json_rpc_runtime_executable(bin_dir / "runtime-agent")
 
     result = await probe_cli_agent(
-        _build_cli_agent("./bin/runtime-agent", ()),
+        _build_cli_agent(f"./bin/{executable.name}", ()),
         runtime_cwd=tmp_path,
     )
 
     assert result.ok is True
-    assert result.agent_name == "runtime-agent"
+    assert result.agent_name == executable.name
 
 
 @pytest.mark.asyncio
@@ -358,23 +371,18 @@ async def test_probe_cli_agent_resolves_relative_command_from_runtime_cwd(
 async def test_probe_cli_agent_uses_transport_env_for_command_lookup(
     tmp_path: Path,
 ) -> None:
-    executable = tmp_path / "runtime-agent"
-    executable.write_text(
-        f"#!{sys.executable}\n{_JSON_RPC_RUNTIME_SCRIPT}",
-        encoding="utf-8",
-    )
-    executable.chmod(0o755)
+    executable = _write_json_rpc_runtime_executable(tmp_path / "runtime-agent")
 
     result = await probe_cli_agent(
         _build_cli_agent(
-            "runtime-agent",
+            executable.name,
             (),
             env=(ExternalAgentSecretBinding(name="PATH", value=str(tmp_path)),),
         )
     )
 
     assert result.ok is True
-    assert result.agent_name == "runtime-agent"
+    assert result.agent_name == executable.name
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/agents/execution/test_prompts.py
+++ b/tests/unit_tests/agents/execution/test_prompts.py
@@ -21,8 +21,14 @@ from relay_teams.agents.execution.user_prompts import (
 from relay_teams.agents.tasks.models import TaskEnvelope, VerificationPlan
 from relay_teams.hooks import HookDecisionBundle, HookDecisionType, HookEventName
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
-from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec, McpToolInfo
+from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
+    McpServerSpec,
+    McpToolInfo,
+    McpToolSchema,
+)
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.secrets import AppSecretStore
 from relay_teams.roles.role_models import RoleDefinition, RoleMode
 from relay_teams.roles.role_contracts import (
@@ -222,10 +228,30 @@ class _FakeMcpRegistry(McpRegistry):
         assert name == "docs"
         return (McpToolInfo(name="docs_search", description="Search docs"),)
 
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        assert name == "docs"
+        return (
+            McpToolSchema(
+                name="docs_search",
+                description="Search docs",
+                input_schema={"type": "object"},
+            ),
+        )
+
 
 class _NoRealtimeMcpRegistry(_FakeMcpRegistry):
     async def list_tools(self, name: str) -> tuple[McpToolInfo, ...]:
         raise AssertionError("prompt building should not connect to MCP servers")
+
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        raise AssertionError("prompt building should not connect to MCP servers")
+
+
+class _SlowSchemaMcpRegistry(_FakeMcpRegistry):
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        assert name == "docs"
+        await asyncio.sleep(1)
+        return ()
 
 
 def _ready_fake_mcp_discovery(registry: McpRegistry) -> McpDiscoveryService:
@@ -539,6 +565,38 @@ def test_runtime_system_prompt_lists_mcp_tools_live_without_discovery_service() 
     )
 
     assert "- MCP Tools: docs_search" in prompt
+
+
+def test_runtime_system_prompt_skips_slow_live_mcp_without_discovery_service() -> None:
+    registry = _coordinator_registry()
+    mcp_registry = _SlowSchemaMcpRegistry()
+
+    prompt = asyncio.run(
+        system_prompts.build_runtime_system_prompt(
+            system_prompts.RuntimePromptBuildInput(
+                role=_role("Coordinator"),
+                task=_task(),
+                topology=RunTopologySnapshot(
+                    session_mode=SessionMode.ORCHESTRATION,
+                    main_agent_role_id="MainAgent",
+                    normal_root_role_id="MainAgent",
+                    coordinator_role_id="Coordinator",
+                    orchestration_preset_id="default",
+                    orchestration_prompt="Delegate by capability and finalize yourself.",
+                    allowed_role_ids=("writer_agent",),
+                ),
+                shared_state_snapshot=(),
+            ),
+            role_registry=registry,
+            mcp_registry=mcp_registry,
+            runtime_mcp_schema_loader=RuntimeMcpSchemaLoader(
+                mcp_registry,
+                server_timeout_seconds=0.01,
+            ),
+        )
+    )
+
+    assert "- MCP Tools: none" in prompt
 
 
 def test_runtime_system_prompt_includes_run_temporary_roles_in_available_roles(

--- a/tests/unit_tests/agents/orchestration/test_orphan_recovery.py
+++ b/tests/unit_tests/agents/orchestration/test_orphan_recovery.py
@@ -58,7 +58,11 @@ def _make_orphan_task_record(
 def wakeup_repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        yield AgentWakeupRepository(db_path)
+        repo = AgentWakeupRepository(db_path)
+        try:
+            yield repo
+        finally:
+            repo.close()
 
 
 class TestOrphanRecovery:

--- a/tests/unit_tests/agents/orchestration/test_stale_task_sweeper.py
+++ b/tests/unit_tests/agents/orchestration/test_stale_task_sweeper.py
@@ -59,7 +59,11 @@ def _make_task_record(
 def wakeup_repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        yield AgentWakeupRepository(db_path)
+        repo = AgentWakeupRepository(db_path)
+        try:
+            yield repo
+        finally:
+            repo.close()
 
 
 class TestStaleTaskSweeper:

--- a/tests/unit_tests/agents/orchestration/test_verification.py
+++ b/tests/unit_tests/agents/orchestration/test_verification.py
@@ -2266,7 +2266,7 @@ def test_resolve_command_cwd_returns_none_when_no_cwd_and_no_workspace() -> None
 def test_resolve_command_cwd_resolves_custom_cwd() -> None:
     cmd = VerificationCommand(command=("echo", "hi"), cwd=Path("subdir"))
     result = verification_module._resolve_command_cwd(cmd, workspace_root=Path("/ws"))
-    assert result == Path("/ws/subdir")
+    assert result == Path("/ws/subdir").resolve()
 
 
 def test_wrap_cross_evaluation_evaluator_returns_none_when_no_evaluator() -> None:

--- a/tests/unit_tests/agents/orchestration/test_wakeup_auto_enqueue.py
+++ b/tests/unit_tests/agents/orchestration/test_wakeup_auto_enqueue.py
@@ -99,7 +99,11 @@ def _make_task_record(
 def wakeup_repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        yield AgentWakeupRepository(db_path)
+        repo = AgentWakeupRepository(db_path)
+        try:
+            yield repo
+        finally:
+            repo.close()
 
 
 # ── coalesce_and_enqueue tests ───────────────────────────────────────

--- a/tests/unit_tests/agents/orchestration/test_wakeup_dispatcher.py
+++ b/tests/unit_tests/agents/orchestration/test_wakeup_dispatcher.py
@@ -60,7 +60,11 @@ def _make_task_record(
 def wakeup_repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        yield AgentWakeupRepository(db_path)
+        repo = AgentWakeupRepository(db_path)
+        try:
+            yield repo
+        finally:
+            repo.close()
 
 
 class TestWakeupDispatcher:

--- a/tests/unit_tests/agents/tasks/test_agent_wakeup_repository.py
+++ b/tests/unit_tests/agents/tasks/test_agent_wakeup_repository.py
@@ -17,7 +17,11 @@ from relay_teams.agents.tasks.wakeup_models import AgentWakeupEntry
 def repo() -> Generator[AgentWakeupRepository, None, None]:
     with TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test_wakeups.db"
-        yield AgentWakeupRepository(db_path)
+        repository = AgentWakeupRepository(db_path)
+        try:
+            yield repository
+        finally:
+            repository.close()
 
 
 def _make_entry(**overrides: object) -> AgentWakeupEntry:
@@ -120,12 +124,19 @@ class TestAgentWakeupRepository:
         with TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test_reopen.db"
             repo1 = AgentWakeupRepository(db_path)
-            entry = _make_entry()
-            await repo1.enqueue_async(entry)
+            repo2: AgentWakeupRepository | None = None
+            try:
+                entry = _make_entry()
+                await repo1.enqueue_async(entry)
+                await repo1.close_async()
 
-            repo2 = AgentWakeupRepository(db_path)
-            count = await repo2.count_pending_async()
-            assert count == 1
+                repo2 = AgentWakeupRepository(db_path)
+                count = await repo2.count_pending_async()
+                assert count == 1
+            finally:
+                if repo2 is not None:
+                    await repo2.close_async()
+                await repo1.close_async()
 
     @pytest.mark.asyncio
     async def test_claim_next_pending_returns_none_when_empty(

--- a/tests/unit_tests/interfaces/server/test_mcp_router.py
+++ b/tests/unit_tests/interfaces/server/test_mcp_router.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
+from typing import cast
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -18,6 +21,7 @@ from relay_teams.mcp.mcp_models import (
     McpServerUpdateRequest,
     McpToolInfo,
 )
+from relay_teams.mcp.mcp_service import McpService
 
 
 class _FakeMcpService:
@@ -135,6 +139,12 @@ def _create_test_client(fake_service: object) -> TestClient:
     app.include_router(mcp.router, prefix="/api")
     app.dependency_overrides[get_mcp_service] = lambda: fake_service
     return TestClient(app)
+
+
+def _clear_route_guard_state() -> None:
+    with mcp._TOOLS_ROUTE_LOCK:
+        mcp._TOOLS_ROUTE_CACHE.clear()
+        mcp._TOOLS_ROUTE_IN_FLIGHT.clear()
 
 
 def test_list_mcp_servers() -> None:
@@ -380,6 +390,7 @@ def test_update_mcp_server_config_returns_503_when_unavailable() -> None:
 
 
 def test_list_mcp_server_tools() -> None:
+    _clear_route_guard_state()
     client = _create_test_client(_FakeMcpService())
 
     response = client.get("/api/mcp/servers/filesystem/tools")
@@ -397,7 +408,80 @@ def test_list_mcp_server_tools() -> None:
     }
 
 
+def test_list_mcp_server_tools_route_guard_reuses_short_interval_result() -> None:
+    _clear_route_guard_state()
+
+    class _CountingService(_FakeMcpService):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def list_server_tools(self, name: str) -> McpServerToolsSummary:
+            self.calls += 1
+            return await super().list_server_tools(name)
+
+    service = _CountingService()
+
+    first = asyncio.run(
+        mcp._list_mcp_server_tools_with_route_guard(
+            "filesystem",
+            cast(McpService, service),
+        )
+    )
+    second = asyncio.run(
+        mcp._list_mcp_server_tools_with_route_guard(
+            "filesystem",
+            cast(McpService, service),
+        )
+    )
+
+    assert first.server == "filesystem"
+    assert second.server == "filesystem"
+    assert service.calls == 1
+
+
+def test_list_mcp_server_tools_route_guard_shares_concurrent_request() -> None:
+    _clear_route_guard_state()
+
+    class _BlockingService(_FakeMcpService):
+        def __init__(self) -> None:
+            self.calls = 0
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def list_server_tools(self, name: str) -> McpServerToolsSummary:
+            self.calls += 1
+            self.entered.set()
+            await self.release.wait()
+            return await super().list_server_tools(name)
+
+    async def run_guarded_calls(service: _BlockingService) -> None:
+        first_task = asyncio.create_task(
+            mcp._list_mcp_server_tools_with_route_guard(
+                "filesystem",
+                cast(McpService, service),
+            )
+        )
+        second_task = asyncio.create_task(
+            mcp._list_mcp_server_tools_with_route_guard(
+                "filesystem",
+                cast(McpService, service),
+            )
+        )
+        await asyncio.wait_for(service.entered.wait(), timeout=1)
+        service.release.set()
+        first, second = await asyncio.gather(first_task, second_task)
+        assert first.server == "filesystem"
+        assert second.server == "filesystem"
+
+    service = _BlockingService()
+
+    asyncio.run(run_guarded_calls(service))
+
+    assert service.calls == 1
+
+
 def test_refresh_mcp_server_tools() -> None:
+    _clear_route_guard_state()
     client = _create_test_client(_FakeMcpService())
 
     response = client.post("/api/mcp/servers/filesystem/tools:refresh")

--- a/tests/unit_tests/interfaces/server/test_prompts_router.py
+++ b/tests/unit_tests/interfaces/server/test_prompts_router.py
@@ -13,6 +13,7 @@ from relay_teams.interfaces.server.deps import (
     get_mcp_discovery_service,
     get_mcp_registry,
     get_role_registry,
+    get_runtime_mcp_schema_loader,
     get_skill_registry,
     get_skill_runtime_service,
     get_tool_registry,
@@ -21,8 +22,14 @@ from relay_teams.interfaces.server.deps import (
 )
 from relay_teams.interfaces.server.routers import prompts
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
-from relay_teams.mcp.mcp_models import McpConfigScope, McpServerSpec, McpToolInfo
+from relay_teams.mcp.mcp_models import (
+    McpConfigScope,
+    McpServerSpec,
+    McpToolInfo,
+    McpToolSchema,
+)
 from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.roles.role_models import RoleDefinition
 from relay_teams.roles.role_registry import RoleRegistry
 from relay_teams.skills.skill_models import SkillInstructionEntry
@@ -271,6 +278,21 @@ class _FakeMcpRegistry(McpRegistry):
             McpToolInfo(name="docs_search_docs", description="Search docs"),
         )
 
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        assert name == "docs"
+        return (
+            McpToolSchema(
+                name="docs_read_file",
+                description="Read a file",
+                input_schema={"type": "object"},
+            ),
+            McpToolSchema(
+                name="docs_search_docs",
+                description="Search docs",
+                input_schema={"type": "object"},
+            ),
+        )
+
 
 def _build_mcp_discovery_service() -> McpDiscoveryService:
     service = McpDiscoveryService(_FakeMcpRegistry())
@@ -282,6 +304,10 @@ def _build_mcp_discovery_service() -> McpDiscoveryService:
         ),
     )
     return service
+
+
+def _build_runtime_mcp_schema_loader() -> RuntimeMcpSchemaLoader:
+    return RuntimeMcpSchemaLoader(_FakeMcpRegistry())
 
 
 def _create_client(
@@ -299,6 +325,9 @@ def _create_client(
     app.dependency_overrides[get_tool_registry] = _build_tool_registry
     app.dependency_overrides[get_mcp_registry] = _FakeMcpRegistry
     app.dependency_overrides[get_mcp_discovery_service] = _build_mcp_discovery_service
+    app.dependency_overrides[get_runtime_mcp_schema_loader] = (
+        _build_runtime_mcp_schema_loader
+    )
     app.dependency_overrides[get_skill_registry] = _FakeSkillRegistry
     app.dependency_overrides[get_skill_runtime_service] = lambda: (
         resolved_skill_runtime_service
@@ -306,7 +335,7 @@ def _create_client(
     app.dependency_overrides[get_workspace_service] = lambda: _FakeWorkspaceService(
         {"preview-workspace"}
     )
-    app.dependency_overrides[get_workspace_manager] = lambda: _FakeWorkspaceManager()
+    app.dependency_overrides[get_workspace_manager] = _FakeWorkspaceManager
     return TestClient(app)
 
 
@@ -425,6 +454,9 @@ def test_prompts_preview_uses_workspace_execution_root_when_workspace_is_provide
     app.dependency_overrides[get_tool_registry] = _build_tool_registry
     app.dependency_overrides[get_mcp_registry] = _FakeMcpRegistry
     app.dependency_overrides[get_mcp_discovery_service] = _build_mcp_discovery_service
+    app.dependency_overrides[get_runtime_mcp_schema_loader] = (
+        _build_runtime_mcp_schema_loader
+    )
     app.dependency_overrides[get_skill_registry] = _FakeSkillRegistry
     app.dependency_overrides[get_skill_runtime_service] = _FakeSkillRuntimeService
     app.dependency_overrides[get_workspace_service] = lambda: workspace_service
@@ -474,6 +506,9 @@ def test_prompts_preview_includes_project_instruction_files(tmp_path: Path) -> N
     app.dependency_overrides[get_tool_registry] = _build_tool_registry
     app.dependency_overrides[get_mcp_registry] = _FakeMcpRegistry
     app.dependency_overrides[get_mcp_discovery_service] = _build_mcp_discovery_service
+    app.dependency_overrides[get_runtime_mcp_schema_loader] = (
+        _build_runtime_mcp_schema_loader
+    )
     app.dependency_overrides[get_skill_registry] = _FakeSkillRegistry
     app.dependency_overrides[get_skill_runtime_service] = _FakeSkillRuntimeService
     app.dependency_overrides[get_workspace_service] = lambda: workspace_service

--- a/tests/unit_tests/mcp/test_mcp_service.py
+++ b/tests/unit_tests/mcp/test_mcp_service.py
@@ -20,10 +20,12 @@ from relay_teams.mcp.mcp_models import (
     McpServerUpdateRequest,
     McpServerSpec,
     McpToolInfo,
+    McpToolSchema,
 )
 from relay_teams.mcp.mcp_discovery_service import McpDiscoveryService
 from relay_teams.mcp.mcp_registry import McpRegistry, build_mcp_server
 from relay_teams.mcp.mcp_service import McpService
+from relay_teams.mcp.runtime_schema_loader import RuntimeMcpSchemaLoader
 from relay_teams.trace import get_trace_context
 
 
@@ -231,11 +233,17 @@ async def test_list_server_tools_without_discovery_service_lists_live_tools(
         )
     )
 
-    async def fake_list_tools(name: str) -> tuple[McpToolInfo, ...]:
+    async def fake_list_tool_schemas(name: str) -> tuple[McpToolSchema, ...]:
         assert name == "filesystem"
-        return (McpToolInfo(name="filesystem_read_file", description="Read a file"),)
+        return (
+            McpToolSchema(
+                name="filesystem_read_file",
+                description="Read a file",
+                input_schema={"type": "object"},
+            ),
+        )
 
-    monkeypatch.setattr(registry, "list_tools", fake_list_tools)
+    monkeypatch.setattr(registry, "list_tool_schemas", fake_list_tool_schemas)
     service = McpService(registry=registry)
 
     summary = await service.list_server_tools("filesystem")
@@ -243,6 +251,75 @@ async def test_list_server_tools_without_discovery_service_lists_live_tools(
     assert summary.server == "filesystem"
     assert summary.status == McpDiscoveryStatus.READY
     assert [tool.name for tool in summary.tools] == ["filesystem_read_file"]
+
+
+@pytest.mark.asyncio
+async def test_list_server_tools_uses_runtime_schema_loader_cache(monkeypatch) -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+    calls = 0
+
+    async def fake_list_tool_schemas(name: str) -> tuple[McpToolSchema, ...]:
+        nonlocal calls
+        assert name == "filesystem"
+        calls += 1
+        return (
+            McpToolSchema(
+                name="filesystem_read_file",
+                description="Read a file",
+                input_schema={"type": "object"},
+            ),
+        )
+
+    monkeypatch.setattr(registry, "list_tool_schemas", fake_list_tool_schemas)
+    loader = RuntimeMcpSchemaLoader(registry, cache_ttl_seconds=60.0)
+    service = McpService(registry=registry, runtime_schema_loader=loader)
+
+    first = await service.list_server_tools("filesystem")
+    second = await service.list_server_tools("filesystem")
+
+    assert first.status == McpDiscoveryStatus.READY
+    assert second.status == McpDiscoveryStatus.READY
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_list_server_tools_returns_failed_summary_during_loader_cooldown(
+    monkeypatch,
+) -> None:
+    registry = McpRegistry(
+        (
+            McpServerSpec(
+                name="filesystem",
+                config={"mcpServers": {"filesystem": {"command": "npx"}}},
+                server_config={"command": "npx"},
+                source=McpConfigScope.APP,
+            ),
+        )
+    )
+
+    async def fake_list_tool_schemas(_name: str) -> tuple[McpToolSchema, ...]:
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(registry, "list_tool_schemas", fake_list_tool_schemas)
+    loader = RuntimeMcpSchemaLoader(registry, failure_ttl_seconds=60.0)
+    service = McpService(registry=registry, runtime_schema_loader=loader)
+
+    first = await service.list_server_tools("filesystem")
+    second = await service.list_server_tools("filesystem")
+
+    assert first.status == McpDiscoveryStatus.FAILED
+    assert second.status == McpDiscoveryStatus.FAILED
+    assert "filesystem" in (second.error or "")
+    assert "cooldown" in (second.error or "")
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/mcp/test_runtime_schema_loader.py
+++ b/tests/unit_tests/mcp/test_runtime_schema_loader.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from relay_teams.mcp.mcp_models import McpToolSchema
+from relay_teams.mcp.mcp_registry import McpRegistry
+from relay_teams.mcp.runtime_schema_loader import (
+    RuntimeMcpSchemaLoader,
+    RuntimeMcpSchemaStatus,
+)
+
+
+class _ConfigurableSchemaRegistry(McpRegistry):
+    def __init__(self, *, tool_suffix: str = "search") -> None:
+        super().__init__(())
+        self.calls: dict[str, int] = {}
+        self.release: asyncio.Event | None = None
+        self.fail_names: set[str] = set()
+        self.client_error_names: set[str] = set()
+        self.sleep_seconds = 0.0
+        self.tool_suffix = tool_suffix
+
+    async def list_tool_schemas(self, name: str) -> tuple[McpToolSchema, ...]:
+        self.calls[name] = self.calls.get(name, 0) + 1
+        if self.release is not None:
+            await self.release.wait()
+        if self.sleep_seconds > 0:
+            await asyncio.sleep(self.sleep_seconds)
+        if name in self.client_error_names:
+            raise _ClientTransportError(f"{name} transport unavailable")
+        if name in self.fail_names:
+            raise RuntimeError(f"{name} offline")
+        return (
+            McpToolSchema(
+                name=f"{name}_{self.tool_suffix}",
+                description="Search",
+                input_schema={"type": "object"},
+            ),
+        )
+
+
+class _ClientTransportError(Exception):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_does_not_call_registry_again() -> None:
+    registry = _ConfigurableSchemaRegistry()
+    loader = RuntimeMcpSchemaLoader(registry, cache_ttl_seconds=60.0)
+
+    first = await loader.load_server("docs")
+    second = await loader.load_server("docs")
+
+    assert first.status == RuntimeMcpSchemaStatus.LOADED
+    assert second.status == RuntimeMcpSchemaStatus.CACHE_HIT
+    assert registry.calls == {"docs": 1}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_server_load_shares_in_flight_probe() -> None:
+    registry = _ConfigurableSchemaRegistry()
+    registry.release = asyncio.Event()
+    loader = RuntimeMcpSchemaLoader(registry, cache_ttl_seconds=60.0)
+
+    first_task = asyncio.create_task(loader.load_server("docs"))
+    second_task = asyncio.create_task(loader.load_server("docs"))
+    await asyncio.sleep(0)
+    registry.release.set()
+
+    first, second = await asyncio.gather(first_task, second_task)
+
+    assert first.ok is True
+    assert second.ok is True
+    assert registry.calls == {"docs": 1}
+
+
+@pytest.mark.asyncio
+async def test_timeout_enters_server_failure_ttl_and_fast_fails() -> None:
+    registry = _ConfigurableSchemaRegistry()
+    registry.sleep_seconds = 1.0
+    loader = RuntimeMcpSchemaLoader(
+        registry,
+        failure_ttl_seconds=60.0,
+        server_timeout_seconds=0.01,
+    )
+
+    first = await loader.load_server("slow")
+    registry.sleep_seconds = 0.0
+    second = await loader.load_server("slow")
+
+    assert first.status == RuntimeMcpSchemaStatus.FAILED
+    assert second.status == RuntimeMcpSchemaStatus.SERVER_COOLDOWN
+    assert "slow" in (second.error or "")
+    assert "cooldown" in (second.error or "")
+    assert registry.calls == {"slow": 1}
+
+
+@pytest.mark.asyncio
+async def test_consecutive_failures_trigger_global_cooldown() -> None:
+    registry = _ConfigurableSchemaRegistry()
+    registry.fail_names.update({"one", "two"})
+    loader = RuntimeMcpSchemaLoader(
+        registry,
+        global_failure_threshold=2,
+        global_cooldown_seconds=60.0,
+    )
+
+    _ = await loader.load_many(("one", "two"))
+    skipped = await loader.load_server("three")
+
+    assert skipped.status == RuntimeMcpSchemaStatus.GLOBAL_COOLDOWN
+    assert "three" in (skipped.error or "")
+    assert "global cooldown" in (skipped.error or "")
+    assert registry.calls == {"one": 1, "two": 1}
+
+
+@pytest.mark.asyncio
+async def test_queued_loads_honor_global_cooldown_after_semaphore_wait() -> None:
+    registry = _ConfigurableSchemaRegistry()
+    registry.fail_names.update({"one", "two"})
+    loader = RuntimeMcpSchemaLoader(
+        registry,
+        max_concurrency=1,
+        global_failure_threshold=1,
+        global_cooldown_seconds=60.0,
+    )
+
+    result = await loader.load_many(("one", "two"))
+
+    statuses = {entry.server_name: entry.status for entry in result.results}
+    assert statuses == {
+        "one": RuntimeMcpSchemaStatus.FAILED,
+        "two": RuntimeMcpSchemaStatus.GLOBAL_COOLDOWN,
+    }
+    assert registry.calls == {"one": 1}
+
+
+@pytest.mark.asyncio
+async def test_server_recovers_after_failure_ttl() -> None:
+    registry = _ConfigurableSchemaRegistry()
+    registry.fail_names.add("docs")
+    loader = RuntimeMcpSchemaLoader(registry, failure_ttl_seconds=0.01)
+
+    first = await loader.load_server("docs")
+    await asyncio.sleep(0.02)
+    registry.fail_names.clear()
+    second = await loader.load_server("docs")
+
+    assert first.status == RuntimeMcpSchemaStatus.FAILED
+    assert second.status == RuntimeMcpSchemaStatus.LOADED
+    assert [schema.name for schema in second.schemas] == ["docs_search"]
+    assert registry.calls == {"docs": 2}
+
+
+@pytest.mark.asyncio
+async def test_replace_registry_clears_failure_state() -> None:
+    broken_registry = _ConfigurableSchemaRegistry()
+    broken_registry.fail_names.add("docs")
+    loader = RuntimeMcpSchemaLoader(broken_registry, failure_ttl_seconds=60.0)
+    first = await loader.load_server("docs")
+
+    recovered_registry = _ConfigurableSchemaRegistry()
+    loader.replace_registry(recovered_registry)
+    second = await loader.load_server("docs")
+
+    assert first.status == RuntimeMcpSchemaStatus.FAILED
+    assert second.status == RuntimeMcpSchemaStatus.LOADED
+    assert broken_registry.calls == {"docs": 1}
+    assert recovered_registry.calls == {"docs": 1}
+
+
+@pytest.mark.asyncio
+async def test_client_transport_error_returns_failed_result() -> None:
+    registry = _ConfigurableSchemaRegistry()
+    registry.client_error_names.add("remote")
+    loader = RuntimeMcpSchemaLoader(registry)
+
+    result = await loader.load_many(("remote",))
+
+    assert result.skipped_count == 1
+    assert result.results[0].status == RuntimeMcpSchemaStatus.FAILED
+    assert "remote transport unavailable" in (result.results[0].error or "")
+    assert registry.calls == {"remote": 1}
+
+
+@pytest.mark.asyncio
+async def test_replace_registry_discards_stale_in_flight_result() -> None:
+    stale_registry = _ConfigurableSchemaRegistry(tool_suffix="stale")
+    stale_registry.release = asyncio.Event()
+    loader = RuntimeMcpSchemaLoader(stale_registry, cache_ttl_seconds=60.0)
+
+    stale_task = asyncio.create_task(loader.load_server("docs"))
+    await asyncio.sleep(0)
+    fresh_registry = _ConfigurableSchemaRegistry(tool_suffix="fresh")
+    loader.replace_registry(fresh_registry)
+    stale_registry.release.set()
+
+    stale_result = await stale_task
+    fresh_result = await loader.load_server("docs")
+    cached_result = await loader.load_server("docs")
+
+    assert stale_result.status == RuntimeMcpSchemaStatus.FAILED
+    assert "registry was replaced" in (stale_result.error or "")
+    assert [schema.name for schema in fresh_result.schemas] == ["docs_fresh"]
+    assert [schema.name for schema in cached_result.schemas] == ["docs_fresh"]
+    assert stale_registry.calls == {"docs": 1}
+    assert fresh_registry.calls == {"docs": 1}


### PR DESCRIPTION
## Summary
- Add a shared runtime MCP schema loader with per-server cache, failure TTL, in-flight coalescing, global concurrency limiting, and short global cooldown after repeated failures.
- Wire the loader through MCP service, runtime prompt fallback, task runtime tools snapshots, server container, and MCP tool-list routes.
- Add route-level MCP tools request coalescing/short caching and broaden tests for loader, service, router, runtime snapshot, and prompt fallback behavior.

## Validation
- uv run --extra dev ruff check --fix
- uv run --extra dev ruff format --no-cache --force-exclude
- uv run --extra dev basedpyright
- uv run --extra dev pytest -q tests/unit_tests
- uv run --extra dev pytest -q tests/integration_tests

Fixes #788